### PR TITLE
Improve export filenames with session context

### DIFF
--- a/prompts/20260408-improve-export-filenames.md
+++ b/prompts/20260408-improve-export-filenames.md
@@ -1,0 +1,19 @@
+---
+session: "improve-export-filenames"
+timestamp: "2026-04-08T18:53:00Z"
+model: claude-opus-4-6
+tools: []
+---
+
+## Human
+
+Improve export filenames — currently everything downloads as "model.extension". Use session name, add date/unit suffixes, DRY up the download logic, embed metadata in file headers.
+
+## Changes
+
+- `src/export/download.ts` (new): Shared `getExportFilename()` (session name + version + date + units), `getExportTitle()` for file metadata, `downloadBlob()` helper.
+- `src/export/gltf.ts`: Use shared download utilities, accept optional `customName` param.
+- `src/export/stl.ts`: Use shared download utilities, session name in STL header.
+- `src/export/obj.ts`: Use shared download utilities, session name in OBJ comment.
+- `src/export/threemf.ts`: Use shared download utilities, session name in 3MF XML metadata.
+- `src/main.ts`: Console API export methods accept optional filename override.

--- a/src/export/download.ts
+++ b/src/export/download.ts
@@ -1,0 +1,77 @@
+// Shared export download utilities — filename generation + blob download
+
+import { getState } from '../storage/sessionManager';
+import { getUnits } from '../geometry/units';
+
+/**
+ * Build a descriptive export filename from session context.
+ *
+ * Priority: customName > session name (+ version label) > "model"
+ * Always appends date, optional unit suffix, and extension.
+ */
+export function getExportFilename(extension: string, customName?: string): string {
+  let base: string;
+
+  if (customName) {
+    base = customName;
+  } else {
+    const state = getState();
+    if (state.session?.name) {
+      base = state.session.name;
+      if (state.currentVersion?.label) {
+        base += `_${state.currentVersion.label}`;
+      }
+    } else {
+      base = 'model';
+    }
+  }
+
+  // Sanitize: keep alphanumeric, spaces, hyphens, underscores
+  base = base.replace(/[^a-zA-Z0-9 _-]/g, '');
+  // Collapse whitespace to hyphens
+  base = base.replace(/\s+/g, '-');
+  // Collapse consecutive hyphens/underscores
+  base = base.replace(/[-_]{2,}/g, '-');
+  // Trim leading/trailing hyphens
+  base = base.replace(/^[-_]+|[-_]+$/g, '');
+  // Truncate
+  base = base.slice(0, 80);
+  // Fallback if sanitization emptied it
+  if (!base) base = 'model';
+
+  // Date suffix
+  const now = new Date();
+  const date = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+
+  // Unit suffix
+  const unit = getUnits();
+  const unitSuffix = unit !== 'unitless' ? `_${unit}` : '';
+
+  return `${base}_${date}${unitSuffix}.${extension}`;
+}
+
+/**
+ * Get a human-readable export name for embedding in file metadata (headers, comments).
+ * Returns session name if active, otherwise "mAInifold Export".
+ */
+export function getExportTitle(): string {
+  const state = getState();
+  if (state.session?.name) {
+    let title = state.session.name;
+    if (state.currentVersion?.label) {
+      title += ` — ${state.currentVersion.label}`;
+    }
+    return title;
+  }
+  return 'mAInifold Export';
+}
+
+/** Trigger a browser download for a Blob. */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/export/gltf.ts
+++ b/src/export/gltf.ts
@@ -1,8 +1,9 @@
 import { getScene } from '../renderer/viewport';
 import { getPhantomGroup } from '../renderer/phantomGeometry';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
+import { downloadBlob, getExportFilename } from './download';
 
-export async function exportGLB(): Promise<void> {
+export async function exportGLB(customName?: string): Promise<void> {
   const scene = getScene();
   const exporter = new GLTFExporter();
 
@@ -17,14 +18,5 @@ export async function exportGLB(): Promise<void> {
   if (phantom) phantom.visible = wasVisible;
 
   const blob = new Blob([result as ArrayBuffer], { type: 'model/gltf-binary' });
-  downloadBlob(blob, 'model.glb');
-}
-
-function downloadBlob(blob: Blob, filename: string) {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
+  downloadBlob(blob, getExportFilename('glb', customName));
 }

--- a/src/export/obj.ts
+++ b/src/export/obj.ts
@@ -1,9 +1,10 @@
 import type { MeshData } from '../geometry/types';
+import { downloadBlob, getExportFilename, getExportTitle } from './download';
 
-export function exportOBJ(meshData: MeshData): void {
+export function exportOBJ(meshData: MeshData, customName?: string): void {
   const { vertProperties, triVerts, numVert, numTri, numProp } = meshData;
 
-  const lines: string[] = ['# mAInifold OBJ Export'];
+  const lines: string[] = [`# ${getExportTitle()}`];
 
   // Vertices
   for (let i = 0; i < numVert; i++) {
@@ -22,10 +23,5 @@ export function exportOBJ(meshData: MeshData): void {
   }
 
   const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'model.obj';
-  a.click();
-  URL.revokeObjectURL(url);
+  downloadBlob(blob, getExportFilename('obj', customName));
 }

--- a/src/export/stl.ts
+++ b/src/export/stl.ts
@@ -1,6 +1,7 @@
 import type { MeshData } from '../geometry/types';
+import { downloadBlob, getExportFilename, getExportTitle } from './download';
 
-export function exportSTL(meshData: MeshData): void {
+export function exportSTL(meshData: MeshData, customName?: string): void {
   const { vertProperties, triVerts, numTri, numProp } = meshData;
 
   // Binary STL format
@@ -10,9 +11,9 @@ export function exportSTL(meshData: MeshData): void {
   const buffer = new ArrayBuffer(bufferSize);
   const view = new DataView(buffer);
 
-  // Header (80 bytes, can be anything)
-  const header = 'mAInifold STL Export';
-  for (let i = 0; i < header.length && i < 80; i++) {
+  // Header (80 bytes) — include session name if available
+  const header = getExportTitle();
+  for (let i = 0; i < Math.min(header.length, 80); i++) {
     view.setUint8(i, header.charCodeAt(i));
   }
 
@@ -69,10 +70,5 @@ export function exportSTL(meshData: MeshData): void {
   }
 
   const blob = new Blob([buffer], { type: 'application/octet-stream' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'model.stl';
-  a.click();
-  URL.revokeObjectURL(url);
+  downloadBlob(blob, getExportFilename('stl', customName));
 }

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -1,7 +1,8 @@
 import type { MeshData } from '../geometry/types';
 import { get3MFUnitString } from '../geometry/units';
+import { downloadBlob, getExportFilename, getExportTitle } from './download';
 
-export function export3MF(meshData: MeshData): void {
+export function export3MF(meshData: MeshData, customName?: string): void {
   const { vertProperties, triVerts, numVert, numTri, numProp } = meshData;
 
   // Build vertices XML
@@ -22,8 +23,13 @@ export function export3MF(meshData: MeshData): void {
     triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
   }
 
+  // Escape XML special chars in title
+  const title = getExportTitle().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
   const modelXml = `<?xml version="1.0" encoding="UTF-8"?>
 <model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <metadata name="Title">${title}</metadata>
+  <metadata name="Application">mAInifold</metadata>
   <resources>
     <object id="1" type="model">
       <mesh>
@@ -60,12 +66,7 @@ ${triangles.join('\n')}
   ]);
 
   const blob = new Blob([zip], { type: 'application/vnd.ms-package.3dmanufacturing' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'model.3mf';
-  a.click();
-  URL.revokeObjectURL(url);
+  downloadBlob(blob, getExportFilename('3mf', customName));
 }
 
 // Minimal ZIP builder — no compression (STORE method), sufficient for 3MF

--- a/src/main.ts
+++ b/src/main.ts
@@ -694,24 +694,24 @@ async function main() {
       return getModule();
     },
 
-    /** Export current model as GLB download */
-    async exportGLB() {
-      await exportGLB();
+    /** Export current model as GLB download. Optional filename override. */
+    async exportGLB(filename?: string) {
+      await exportGLB(filename);
     },
 
-    /** Export current model as STL download */
-    exportSTL() {
-      if (currentMeshData) exportSTL(currentMeshData);
+    /** Export current model as STL download. Optional filename override. */
+    exportSTL(filename?: string) {
+      if (currentMeshData) exportSTL(currentMeshData, filename);
     },
 
-    /** Export current model as OBJ download */
-    exportOBJ() {
-      if (currentMeshData) exportOBJ(currentMeshData);
+    /** Export current model as OBJ download. Optional filename override. */
+    exportOBJ(filename?: string) {
+      if (currentMeshData) exportOBJ(currentMeshData, filename);
     },
 
-    /** Export current model as 3MF download */
-    export3MF() {
-      if (currentMeshData) export3MF(currentMeshData);
+    /** Export current model as 3MF download. Optional filename override. */
+    export3MF(filename?: string) {
+      if (currentMeshData) export3MF(currentMeshData, filename);
     },
 
     /** Validate code without rendering. Returns { valid, error? } */


### PR DESCRIPTION
## Summary

- Export filenames now use the active session name + version label + date + unit suffix instead of hardcoded `model.<ext>` (e.g., `Walkway-shield_v2-added-teeth_2026-04-08_mm.stl`)
- Extracted shared `downloadBlob()` and `getExportFilename()` utilities into `src/export/download.ts`, removing duplicated download logic from all 4 export modules
- File metadata now includes session context: STL binary header, OBJ comment line, and 3MF XML `<metadata>` elements
- Console API export methods (`mainifold.exportGLB()`, etc.) accept an optional filename override for programmatic use

## Test plan

- [ ] Export without a session active — filename should be `model_<date>.<ext>`
- [ ] Export with a session + version active — filename should include session name and version label
- [ ] Set units to `mm`, export — filename should end with `_mm.<ext>`
- [ ] Call `mainifold.exportGLB("custom-name")` via console — should use custom name
- [ ] Open exported OBJ in text editor — first line should show session name
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)