### PR TITLE
Add security docs, CSP header, and deploy audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ src/
 
 Requires `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers for SharedArrayBuffer / WASM threads (configured in `vite.config.ts`).
 
+## Security
+
+mAInifold is designed to be controlled by AI agents, which means you're trusting the app not to embed hidden instructions that trick your AI into doing something harmful. See [SECURITY.md](SECURITY.md) for the full trust model, what the app can and can't do, and how to verify it yourself.
+
+**TL;DR:** No backend, no outbound network requests, no analytics, no hidden DOM instructions, 7 well-known dependencies, enforced Content Security Policy.
+
 ## Coordinate system
 
 Right-handed, Z-up. The XY plane is the ground, Z points up. Units are arbitrary — use consistent scale.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Model
+
+mAInifold is a client-side CAD tool designed to be controlled by AI agents. This document explains the security properties of the app so you can make an informed decision about running it with your AI.
+
+## Threat model: AI prompt injection
+
+When you point an AI agent (Claude, GPT, etc.) at a web app, the app becomes an attack surface. A malicious app could embed hidden instructions in the DOM, invisible text, or API responses to trick your AI into:
+
+- Exfiltrating data from your system
+- Running destructive commands
+- Making unauthorized API calls
+
+### Why mAInifold is safe
+
+**No backend, no network.** The app runs entirely in your browser. There are no servers, no API calls, no telemetry, no analytics. The Content Security Policy enforces `connect-src 'self'` — the app literally cannot make outbound network requests.
+
+**No hidden instructions.** The only AI-facing content is [`/ai.md`](public/ai.md), explicitly linked via `<link rel="ai-instructions">` in index.html. You can read it yourself — it contains only API documentation for the geometry engine. There are no hidden DOM elements, invisible text, data attributes, or encoded payloads containing instructions.
+
+**Minimal dependencies.** The app has 7 runtime dependencies, all well-known open source libraries:
+
+| Package | Purpose |
+|---------|---------|
+| `manifold-3d` | WASM geometry engine |
+| `three` | 3D rendering |
+| `codemirror` + plugins | Code editor |
+| `tailwindcss` | CSS styling |
+
+There are no network libraries, no analytics SDKs, no ad frameworks.
+
+**Content Security Policy.** The CSP header blocks:
+- Inline scripts (`<script>alert(1)</script>`)
+- External script loading (`<script src="evil.com/...">`)
+- Outbound network requests (`fetch("evil.com/...")`)
+- External font/image loading (fingerprinting vectors)
+
+**Geometry data is numbers only.** The `#geometry-data` DOM element (read by AI agents for model stats) contains only computed numerical values — vertex counts, volumes, bounding boxes. User code never appears in this element.
+
+## Code execution model
+
+The geometry editor executes user-written JavaScript via `new Function('api', code)`. This is **not a security sandbox** — it's equivalent to `eval()` with strict mode. User code can access `window`, `document`, and browser APIs.
+
+This is by design: mAInifold is a code editor, like CodePen or JSFiddle. You should only run code you trust, just as you would in a browser dev console.
+
+The `api` parameter provides only geometry primitives (`Manifold`, `CrossSection`, etc.) — no browser APIs are passed in. But the sandbox boundary is convention, not enforcement.
+
+## How to verify
+
+If you want to audit the app yourself:
+
+1. **Read the source.** The app is ~3,000 lines of TypeScript. Start with `index.html`, `src/main.ts`, and `public/ai.md`.
+2. **Check the CSP.** Open DevTools → Network → look at response headers for `Content-Security-Policy`.
+3. **Search for hidden text.** In DevTools Console: `document.querySelectorAll('[style*="display:none"], [style*="visibility:hidden"], [aria-hidden]')` — should return only the `#geometry-data` stats element.
+4. **Monitor network.** Open DevTools → Network tab. The app makes zero outbound requests after initial page load.
+5. **Review dependencies.** `npm ls --depth=0` shows all direct dependencies. `npm audit` checks for known vulnerabilities.
+
+## Reporting vulnerabilities
+
+If you find a security issue, please open a GitHub issue or contact the maintainer directly.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self'; worker-src 'self' blob:; font-src 'self'" />
   <title>mAInifold</title>
   <link rel="stylesheet" href="/src/style.css" />
   <script src="coi-serviceworker.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2205,9 +2205,10 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2471,9 +2472,10 @@
       "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA=="
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "deploy": "npm audit --audit-level=high && tsc && vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/prompts/20260408-security-review-and-csp.md
+++ b/prompts/20260408-security-review-and-csp.md
@@ -1,0 +1,19 @@
+---
+session: "security-review-and-csp"
+timestamp: "2026-04-08T20:30:00Z"
+model: claude-opus-4-6
+tools: []
+---
+
+## Human
+
+Security review focused on AI prompt injection risks (the app is "bring your own AI" and users should trust it won't embed hidden instructions), followed by a broader security audit.
+
+## Changes
+
+- `SECURITY.md`: New file documenting the AI prompt injection trust model, code execution model (`new Function` is not a sandbox), and how users can verify safety themselves.
+- `README.md`: Added Security section linking to SECURITY.md.
+- `index.html`: Added Content-Security-Policy meta tag blocking external scripts, outbound requests, and inline script injection.
+- `vite.config.ts`: Added CSP header for dev server.
+- `package.json`: Added `npm run deploy` command that runs `npm audit --audit-level=high` before `tsc && vite build`.
+- `package-lock.json`: Updated vite 6.4.1 -> 6.4.2 and picomatch 4.0.3 -> 4.0.4 to fix 2 high-severity vulnerabilities (path traversal, websocket arbitrary file read).

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     headers: {
       'Cross-Origin-Opener-Policy': 'same-origin',
       'Cross-Origin-Embedder-Policy': 'require-corp',
+      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self'; worker-src 'self' blob:; font-src 'self'",
     },
     fs: {
       // Relax strict fs access for WASM files in node_modules


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` documenting the AI prompt injection trust model — explains why the app is safe for "bring your own AI" use, how the code execution model works, and how users can verify it themselves
- Add Content-Security-Policy header (both in `vite.config.ts` for dev and `index.html` meta tag for production) blocking external scripts, outbound requests, and inline script injection
- Add `npm run deploy` command: `npm audit --audit-level=high && tsc && vite build` — fails the build on high/critical dependency vulnerabilities (update Cloudflare build command from `npm run build` to `npm run deploy`)
- Link Security section from README
- Fix 2 high-severity Vite vulnerabilities via `npm audit fix` (path traversal + websocket arbitrary file read)

## Test plan
- [ ] `npm run deploy` succeeds locally
- [ ] `npm run dev` still works (CSP doesn't break WASM, styles, thumbnails)
- [ ] Verify CSP header appears in browser DevTools Network tab
- [ ] Verify no console errors from CSP violations during normal use
- [ ] Read SECURITY.md for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)