### PR TITLE
Remove trufflehog pre-commit hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,8 +3,6 @@ pre-commit:
   commands:
     gitleaks:
       run: gitleaks protect --staged --verbose --redact
-    trufflehog:
-      run: trufflehog git file://. --since-commit HEAD --only-verified --fail
     prompt-log:
       run: |
         # Skip if only prompt files are being committed

--- a/prompts/20260408-remove-trufflehog.md
+++ b/prompts/20260408-remove-trufflehog.md
@@ -1,0 +1,14 @@
+---
+session: "remove-trufflehog"
+timestamp: "2026-04-08T20:39:00Z"
+model: claude-opus-4-6
+tools: []
+---
+
+## Human
+
+Remove trufflehog pre-commit hook — it was supposed to have been removed already and it breaks in git worktrees.
+
+## Changes
+
+- `lefthook.yml`: Removed the `trufflehog` command from pre-commit hooks. Gitleaks remains for secret scanning.


### PR DESCRIPTION
## Summary
- Remove trufflehog from `lefthook.yml` pre-commit hooks
- Gitleaks remains and covers secret scanning
- Trufflehog breaks in git worktrees (can't parse `.git` file when it's a worktree pointer rather than a directory)

## Test plan
- [ ] Commits succeed without trufflehog errors
- [ ] Gitleaks still runs on pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)