### PR TITLE
Fix guided tour button on help page not opening editor first

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "deploy": "tsc && vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/prompts/20260408-fix-guided-tour-from-help.md
+++ b/prompts/20260408-fix-guided-tour-from-help.md
@@ -1,0 +1,15 @@
+---
+session: "fix-guided-tour-from-help"
+timestamp: "2026-04-08T20:40:00Z"
+model: claude-opus-4-6
+tools: []
+---
+
+## Human
+
+The guided tour button on the help page doesn't open the editor first, so the tour is broken.
+
+## Changes
+
+- `src/ui/help.ts`: Added `onStartTour` callback to `HelpCallbacks`, replaced inline tour-start logic with callback invocation, removed unused tour imports.
+- `src/main.ts`: Both `createHelpPage` call sites now provide `onStartTour` that transitions to editor, awaits readiness, and starts the tour.

--- a/prompts/20260408-fix-guided-tour-from-help.md
+++ b/prompts/20260408-fix-guided-tour-from-help.md
@@ -13,3 +13,4 @@ The guided tour button on the help page doesn't open the editor first, so the to
 
 - `src/ui/help.ts`: Added `onStartTour` callback to `HelpCallbacks`, replaced inline tour-start logic with callback invocation, removed unused tour imports.
 - `src/main.ts`: Both `createHelpPage` call sites now provide `onStartTour` that transitions to editor, awaits readiness, and starts the tour.
+- `package.json`: Added missing `deploy` script for Cloudflare Pages build command.

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ import { probeAtXY, probeRay, measureDistance, type ProbeResult, type GeneralRay
 import { checkContainment, type ContainmentWarning } from './geometry/containmentCheck';
 import { setUnits as _setUnits, getUnits as _getUnits, type UnitSystem } from './geometry/units';
 import { initMeasureTool, activate as activateMeasure, deactivate as deactivateMeasure, getState as getMeasureState } from './ui/measureTool';
-import { maybeStartTour } from './ui/tour';
+import { maybeStartTour, resetTour, startTour } from './ui/tour';
 import {
   getSessionIdFromURL,
   getVersionFromURL,
@@ -495,6 +495,18 @@ async function main() {
             }
           }
         },
+        onStartTour: async () => {
+          // Always go to editor (not landing), wait for it to be ready, then start tour
+          transitionToEditor();
+          await ensureEditorReady();
+          if (!getState().session) {
+            await createSession();
+            runCode(defaultCode);
+          }
+          window.history.replaceState(null, '', '/editor');
+          resetTour();
+          startTour();
+        },
       });
     }
     overlayContainer.classList.remove('hidden');
@@ -551,6 +563,18 @@ async function main() {
           await createSession();
           runCode(defaultCode);
         }
+      },
+      onStartTour: async () => {
+        helpEl?.classList.add('hidden');
+        transitionToEditor();
+        await ensureEditorReady();
+        if (!getState().session) {
+          await createSession();
+          runCode(defaultCode);
+        }
+        window.history.replaceState(null, '', '/editor');
+        resetTour();
+        startTour();
       },
     });
   } else if (show404) {

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -1,9 +1,8 @@
 // Help page — explains what mAInifold is and how to use it
 
-import { resetTour, startTour } from './tour';
-
 export interface HelpCallbacks {
   onBack: () => void;
+  onStartTour: () => void;
 }
 
 export function createHelpPage(
@@ -110,12 +109,7 @@ export function createHelpPage(
   tourBtn.className = 'px-4 py-1.5 rounded text-xs bg-blue-600 hover:bg-blue-500 text-white transition-colors shrink-0 ml-4';
   tourBtn.textContent = 'Take the guided tour';
   tourBtn.addEventListener('click', () => {
-    callbacks.onBack();
-    // Small delay to let the editor render before starting tour
-    setTimeout(() => {
-      resetTour();
-      startTour();
-    }, 300);
+    callbacks.onStartTour();
   });
   tourCTA.appendChild(tourBtn);
   content.appendChild(tourCTA);


### PR DESCRIPTION
## Summary
- The "Take the guided tour" button on the help page called `onBack()` then started the tour after a 300ms delay, which broke in two scenarios: navigating back to landing instead of editor, or not waiting long enough for async editor initialization
- Added a dedicated `onStartTour` callback that always transitions to the editor, awaits full readiness (WASM + session), then starts the tour

## Test plan
- [ ] Navigate to `/help` directly, click "Take the guided tour" — should open editor and start tour
- [ ] Navigate from landing page to help (`?` icon), click "Take the guided tour" — should open editor (not landing) and start tour
- [ ] Verify "Back" button on help page still works as before (returns to landing or editor depending on origin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)