### PR TITLE
Add Notes step to guided tour and AI context hints

### DIFF
--- a/prompts/20260408-tour-notes-and-ai-context.md
+++ b/prompts/20260408-tour-notes-and-ai-context.md
@@ -1,0 +1,21 @@
+---
+session: "tour-notes-and-ai-context"
+timestamp: "2026-04-08T22:58:00Z"
+model: claude-opus-4-6
+tools: []
+---
+
+## Human
+
+Update the guided tour to include the Notes tab and add AI agent context
+to each step explaining how AI-driven design impacts that area.
+
+## Changes
+
+- `src/ui/tour.ts` — Added "Design Notes" step (8th step, targeting
+  `[data-tab="Notes"]`) explaining how to log requirements, decisions,
+  and feedback. Updated 6 existing steps with AI context: Code Editor
+  (AI writes code automatically), Live Rendering (API-driven renders),
+  3D Viewport (AI uses isometric/elevation views), Sessions (AI creates
+  sessions and versions), Gallery (AI generates gallery URLs), Reference
+  Images (minor wording tweak).

--- a/src/ui/tour.ts
+++ b/src/ui/tour.ts
@@ -13,37 +13,50 @@ const STEPS: TourStep[] = [
   {
     target: '#editor-container',
     title: 'Code Editor',
-    description: 'Write JavaScript to create 3D geometry using primitives, booleans, and transforms.',
+    description:
+      'Write JavaScript to create 3D geometry using primitives, booleans, and transforms. When an AI agent is driving, it writes and updates code here automatically.',
     placement: 'right',
   },
   {
     target: '#btn-auto-run',
     title: 'Live Rendering',
-    description: 'Code re-renders automatically as you type. Click to pause auto-render if your model gets complex.',
+    description:
+      'Code re-renders automatically as you type. Click to pause auto-render if your model gets complex. AI agents trigger renders via the console API without needing this button.',
     placement: 'bottom',
   },
   {
     target: '#viewport-container',
     title: '3D Viewport',
-    description: 'Orbit (drag), zoom (scroll), and pan (right-drag) to inspect your model from any angle.',
+    description:
+      'Orbit (drag), zoom (scroll), and pan (right-drag) to inspect your model from any angle. AI agents use the isometric views and elevation tabs for visual verification instead.',
     placement: 'left',
   },
   {
     target: '#session-bar',
     title: 'Sessions & Versions',
-    description: 'Create sessions to track iterations. Save versions and navigate between them.',
+    description:
+      'Create sessions to track iterations. Save versions and navigate between them. AI agents create sessions and save versions automatically as they iterate on your design.',
     placement: 'bottom',
   },
   {
     target: '#btn-ref-upload',
     title: 'Reference Images',
-    description: 'Upload reference photos for AI to match. Name files by angle (front.jpg, right.png) for multi-view comparison.',
+    description:
+      'Upload reference photos for AI to match. Name files by angle (front.jpg, right.png) for multi-view comparison in the Elevations tab.',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tab="Notes"]',
+    title: 'Design Notes',
+    description:
+      'Log requirements, decisions, feedback, and measurements alongside your design. AI agents write notes automatically to capture the design story — review them to see why each change was made.',
     placement: 'bottom',
   },
   {
     target: '[data-tab="Gallery"]',
     title: 'Compare Versions',
-    description: 'View saved versions side-by-side in the Gallery to track your design evolution.',
+    description:
+      'View saved versions and notes side-by-side in the Gallery to track your design evolution. AI agents generate a gallery URL so you can review all iterations at a glance.',
     placement: 'bottom',
   },
   {


### PR DESCRIPTION
## Summary
- Added a **Design Notes** step to the guided tour (now 8 steps), targeting the Notes tab — explains how to log requirements, decisions, feedback, and measurements
- Updated 6 existing tour step descriptions with AI agent context, explaining how AI-driven design impacts each area (code editor, rendering, viewport, sessions, gallery, reference images)

## Test plan
- [ ] Run `npm run dev`, open `http://localhost:5173` in a fresh browser (or clear `mainifold-tour-completed` from localStorage)
- [ ] Walk through all 8 tour steps — verify the new "Design Notes" step spotlights the Notes tab
- [ ] Confirm step counter shows `N / 8` (was 7)
- [ ] Verify AI context sentences read naturally in each tooltip
- [ ] Check that `?view=ai` still skips the tour

🤖 Generated with [Claude Code](https://claude.com/claude-code)