### PR TITLE
Improve AI agent discoverability of window.mainifold API

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,13 @@
   <link rel="ai-instructions" href="ai.md" type="text/markdown" />
 </head>
 <body class="bg-zinc-900 w-screen h-screen overflow-hidden">
+  <div id="ai-agent-readme" hidden aria-hidden="true" data-agent-instructions="true">
+    AGENT INSTRUCTIONS: Do NOT drive this app with clicks or keystrokes.
+    Use the programmatic API at window.mainifold — call help() for a method list.
+    Full docs: /ai.md
+    Quickstart: await mainifold.createSession("name"), then await mainifold.runAndSave(code, label, {isManifold:true, maxComponents:1}).
+    Code must end with: return manifoldObject;
+  </div>
   <div id="app" class="flex flex-col h-screen w-screen">
     <!-- Splash screen — visible until JS mounts, then removed -->
     <div id="loading-splash" style="display:flex;align-items:center;justify-content:center;flex-direction:column;height:100vh;width:100vw;background:#18181b;gap:24px">

--- a/index.html
+++ b/index.html
@@ -50,14 +50,11 @@
   <link rel="stylesheet" href="/src/style.css" />
   <script src="coi-serviceworker.js"></script>
   <link rel="ai-instructions" href="ai.md" type="text/markdown" />
+  <meta name="ai-instructions" content="See /llms.txt" />
 </head>
 <body class="bg-zinc-900 w-screen h-screen overflow-hidden">
-  <div id="ai-agent-readme" hidden aria-hidden="true" data-agent-instructions="true">
-    AGENT INSTRUCTIONS: Do NOT drive this app with clicks or keystrokes.
-    Use the programmatic API at window.mainifold — call help() for a method list.
-    Full docs: /ai.md
-    Quickstart: await mainifold.createSession("name"), then await mainifold.runAndSave(code, label, {isManifold:true, maxComponents:1}).
-    Code must end with: return manifoldObject;
+  <div id="ai-agent-readme" hidden aria-hidden="true">
+    AI agents: this app is designed for programmatic use. See /llms.txt and /ai.md.
   </div>
   <div id="app" class="flex flex-col h-screen w-screen">
     <!-- Splash screen — visible until JS mounts, then removed -->

--- a/prompts/20260417-agent-discoverability.md
+++ b/prompts/20260417-agent-discoverability.md
@@ -7,13 +7,22 @@ tools: [claude-code]
 
 ## Human
 
-Evaluated feedback from a previous AI agent session about API discoverability issues. The agent proposed 12 changes; I assessed which were worthwhile vs over-engineered and implemented the 5 highest-impact ones.
+Evaluated feedback from two AI agent sessions about API discoverability issues. First agent proposed 12 changes; assessed which were worthwhile and implemented 5. Second agent (Chrome-based, security-conscious) tested the result and gave further feedback: the banner triggered security caution because it mixed a signpost with behavioral commands, and several documentation polish issues.
 
 ## Changes
 
-- `index.html`: Add hidden `#ai-agent-readme` div as first child of `<body>` — DOM-snapshot tools surface it immediately
-- `public/ai.md`: Add "Before you start" TL;DR section and "Common agent mistakes" list at top of file
-- `src/main.ts`: Add `mainifold.help(method?)` self-documenting method with per-method lookup
-- `src/main.ts`: Seed new sessions with a `[WORKFLOW]` note via `createSession()` so resuming agents see conventions
-- `public/llms.txt`: New file following llms.txt convention, pointing to `/ai.md`
-- `public/robots.txt`: Add comment directing AI agents to `/ai.md` and `/llms.txt`
+### Initial commit
+- `index.html`: Add hidden `#ai-agent-readme` div as first child of `<body>`
+- `public/ai.md`: Add "Before you start" TL;DR section and "Common agent mistakes" list
+- `src/main.ts`: Add `mainifold.help(method?)` self-documenting method
+- `src/main.ts`: Seed new sessions with a `[WORKFLOW]` note
+- `public/llms.txt`: New file following llms.txt convention
+- `public/robots.txt`: Add comment directing AI agents to docs
+
+### Follow-up commit (agent feedback)
+- `index.html`: Shrink banner to pure signpost (no commands), add `<meta name="ai-instructions">` tag
+- `public/llms.txt`: Expand with quickstart code block and ## Docs section
+- `public/ai.md`: Restructure top with intro + table of contents, replace hardcoded ports with relative paths, replace non-ASCII chars with ASCII equivalents, add sandbox environment docs, add `notes` to assertions spec, flag photo-to-model tooling as optional, demote #geometry-data DOM reading, add "not reading session context" to common mistakes
+- `src/main.ts`: `help()` now returns structured object (not just string), console greeter replaced with concise `console.info`, add UI-input warning toast+console.warn when `?view=ai` is set and agent clicks/types
+- `vite.config.ts`: Add middleware to serve .md/.txt with charset=utf-8
+- `public/_headers`: Add Content-Type charset rules for .md and .txt files in production

--- a/prompts/20260417-agent-discoverability.md
+++ b/prompts/20260417-agent-discoverability.md
@@ -7,11 +7,11 @@ tools: [claude-code]
 
 ## Human
 
-Evaluated feedback from two AI agent sessions about API discoverability issues. First agent proposed 12 changes; assessed which were worthwhile and implemented 5. Second agent (Chrome-based, security-conscious) tested the result and gave further feedback: the banner triggered security caution because it mixed a signpost with behavioral commands, and several documentation polish issues.
+Evaluated feedback from two AI agent sessions about API discoverability issues. First agent proposed 12 changes; assessed which were worthwhile and implemented 5. Second agent (Chrome-based, security-conscious) tested the result and gave further feedback across two rounds.
 
 ## Changes
 
-### Initial commit
+### Commit 1: Initial discoverability
 - `index.html`: Add hidden `#ai-agent-readme` div as first child of `<body>`
 - `public/ai.md`: Add "Before you start" TL;DR section and "Common agent mistakes" list
 - `src/main.ts`: Add `mainifold.help(method?)` self-documenting method
@@ -19,10 +19,14 @@ Evaluated feedback from two AI agent sessions about API discoverability issues. 
 - `public/llms.txt`: New file following llms.txt convention
 - `public/robots.txt`: Add comment directing AI agents to docs
 
-### Follow-up commit (agent feedback)
-- `index.html`: Shrink banner to pure signpost (no commands), add `<meta name="ai-instructions">` tag
+### Commit 2: Refinement (security-conscious agent feedback)
+- `index.html`: Shrink banner to pure signpost, add `<meta name="ai-instructions">` tag
 - `public/llms.txt`: Expand with quickstart code block and ## Docs section
-- `public/ai.md`: Restructure top with intro + table of contents, replace hardcoded ports with relative paths, replace non-ASCII chars with ASCII equivalents, add sandbox environment docs, add `notes` to assertions spec, flag photo-to-model tooling as optional, demote #geometry-data DOM reading, add "not reading session context" to common mistakes
-- `src/main.ts`: `help()` now returns structured object (not just string), console greeter replaced with concise `console.info`, add UI-input warning toast+console.warn when `?view=ai` is set and agent clicks/types
-- `vite.config.ts`: Add middleware to serve .md/.txt with charset=utf-8
-- `public/_headers`: Add Content-Type charset rules for .md and .txt files in production
+- `public/ai.md`: Restructure top, fix encoding, fix ports, add sandbox docs, add notes to assertions, flag optional tooling, demote #geometry-data, add session-context mistake
+- `src/main.ts`: `help()` returns structured object, console.info one-liner, UI-input warning
+- `vite.config.ts`: Middleware for .md/.txt charset=utf-8
+- `public/_headers`: Content-Type charset rules for production
+
+### Commit 3: Final polish (second round of agent feedback)
+- `public/ai.md`: Fix numbering gap (4->6) in Stat-Based Verification, normalize heading case to sentence case throughout, add "Resuming a session" to TOC
+- `src/main.ts`: `help()` method entries now include docs anchors (`{signature, docs}` objects instead of flat strings), per-method lookup returns signature + docs link

--- a/prompts/20260417-agent-discoverability.md
+++ b/prompts/20260417-agent-discoverability.md
@@ -7,26 +7,30 @@ tools: [claude-code]
 
 ## Human
 
-Evaluated feedback from two AI agent sessions about API discoverability issues. First agent proposed 12 changes; assessed which were worthwhile and implemented 5. Second agent (Chrome-based, security-conscious) tested the result and gave further feedback across two rounds.
+An AI agent (via browser extension) had a poor session -- it drove the app with clicks/keystrokes instead of using the `window.mainifold` programmatic API. That agent produced a 12-point improvement spec. The user asked me to evaluate it objectively, then implement the worthwhile changes and create a PR.
+
+A second AI agent (Chrome-based, security-conscious) then tested the result and gave a second round of feedback: the DOM banner triggered prompt-injection caution because it mixed behavioral commands with the signpost, and the docs had encoding, consistency, and content gaps.
+
+A third round of feedback from the same agent addressed final polish: numbering gaps, heading case inconsistency, and adding docs anchors to `help()` output.
 
 ## Changes
 
-### Commit 1: Initial discoverability
-- `index.html`: Add hidden `#ai-agent-readme` div as first child of `<body>`
-- `public/ai.md`: Add "Before you start" TL;DR section and "Common agent mistakes" list
-- `src/main.ts`: Add `mainifold.help(method?)` self-documenting method
-- `src/main.ts`: Seed new sessions with a `[WORKFLOW]` note
-- `public/llms.txt`: New file following llms.txt convention
-- `public/robots.txt`: Add comment directing AI agents to docs
+### Commit 1: Initial discoverability (c096dc4)
+- `index.html`: Add hidden `#ai-agent-readme` div as first child of `<body>` with API instructions
+- `public/ai.md`: Add "Before you start" TL;DR section and "Common agent mistakes" list at top
+- `src/main.ts`: Add `mainifold.help(method?)` self-documenting method returning a string
+- `src/main.ts`: Seed new sessions with a `[WORKFLOW]` note via `createSession()`
+- `public/llms.txt`: New file following llms.txt convention, pointing to `/ai.md`
+- `public/robots.txt`: Add comment directing AI agents to `/ai.md` and `/llms.txt`
 
-### Commit 2: Refinement (security-conscious agent feedback)
-- `index.html`: Shrink banner to pure signpost, add `<meta name="ai-instructions">` tag
-- `public/llms.txt`: Expand with quickstart code block and ## Docs section
-- `public/ai.md`: Restructure top, fix encoding, fix ports, add sandbox docs, add notes to assertions, flag optional tooling, demote #geometry-data, add session-context mistake
-- `src/main.ts`: `help()` returns structured object, console.info one-liner, UI-input warning
-- `vite.config.ts`: Middleware for .md/.txt charset=utf-8
-- `public/_headers`: Content-Type charset rules for production
+### Commit 2: Refinement from security-conscious agent (362a73c)
+- `index.html`: Shrink banner to pure signpost (no API names/commands/code), add `<meta name="ai-instructions">` tag
+- `public/llms.txt`: Expand with quickstart code block and `## Docs` section
+- `public/ai.md`: Restructure top with intro paragraph + table of contents before checklist; replace hardcoded `localhost:5173` with relative paths; replace non-ASCII chars (em-dashes, arrows) with ASCII equivalents; add sandbox environment documentation; add `notes` to assertions spec; flag photo-to-model tooling as optional; demote `#geometry-data` DOM reading below `getGeometryData()`; add "not reading session context" to common mistakes
+- `src/main.ts`: `help()` changed to return structured object (`{app, docs, constraints, quickstart, methods}`); verbose console.log greeter replaced with single `console.info` line; add UI-input warning (toast + console.warn) when `?view=ai` is set and agent clicks/types
+- `vite.config.ts`: Add Vite middleware plugin to serve `.md`/`.txt` with `charset=utf-8`
+- `public/_headers`: Add Content-Type charset rules for `.md` and `.txt` in Cloudflare Pages production
 
-### Commit 3: Final polish (second round of agent feedback)
-- `public/ai.md`: Fix numbering gap (4->6) in Stat-Based Verification, normalize heading case to sentence case throughout, add "Resuming a session" to TOC
-- `src/main.ts`: `help()` method entries now include docs anchors (`{signature, docs}` objects instead of flat strings), per-method lookup returns signature + docs link
+### Commit 3: Final polish (0745003)
+- `public/ai.md`: Fix numbering gap (4 -> 6, now 1-5) in "Stat-based verification" list; normalize all section headings to sentence case; add "Resuming a session" to table of contents
+- `src/main.ts`: `help()` method entries changed from flat strings to `{signature, docs}` objects with anchors to relevant `/ai.md` sections; `help('methodName')` returns `{method, signature, docs}`

--- a/prompts/20260417-agent-discoverability.md
+++ b/prompts/20260417-agent-discoverability.md
@@ -1,0 +1,19 @@
+---
+session: "agent-discoverability"
+timestamp: "2026-04-17T23:20:00Z"
+model: claude-opus-4-6
+tools: [claude-code]
+---
+
+## Human
+
+Evaluated feedback from a previous AI agent session about API discoverability issues. The agent proposed 12 changes; I assessed which were worthwhile vs over-engineered and implemented the 5 highest-impact ones.
+
+## Changes
+
+- `index.html`: Add hidden `#ai-agent-readme` div as first child of `<body>` — DOM-snapshot tools surface it immediately
+- `public/ai.md`: Add "Before you start" TL;DR section and "Common agent mistakes" list at top of file
+- `src/main.ts`: Add `mainifold.help(method?)` self-documenting method with per-method lookup
+- `src/main.ts`: Seed new sessions with a `[WORKFLOW]` note via `createSession()` so resuming agents see conventions
+- `public/llms.txt`: New file following llms.txt convention, pointing to `/ai.md`
+- `public/robots.txt`: Add comment directing AI agents to `/ai.md` and `/llms.txt`

--- a/public/_headers
+++ b/public/_headers
@@ -2,3 +2,9 @@
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self'; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'
+
+/*.md
+  Content-Type: text/markdown; charset=utf-8
+
+/*.txt
+  Content-Type: text/plain; charset=utf-8

--- a/public/ai.md
+++ b/public/ai.md
@@ -1,5 +1,22 @@
 # mAInifold — AI Agent Instructions
 
+## Before you start
+
+1. **Use `window.mainifold`** — that's the programmatic API. Do NOT drive the app with clicks, keystrokes, or DOM manipulation.
+2. **Code must end with `return manifoldObject;`** — a bare trailing expression won't work.
+3. **Use `runAndSave(code, label, {isManifold: true, maxComponents: 1})`** to validate and commit a version.
+4. **Log decisions with `addSessionNote("[PREFIX] ...")`** — prefixes: `[REQUIREMENT]`, `[DECISION]`, `[FEEDBACK]`, `[MEASUREMENT]`, `[ATTEMPT]`, `[TODO]`.
+
+### Common agent mistakes
+
+- **Driving the UI with clicks/keystrokes** — CodeMirror's auto-close-brackets will corrupt your code. Use `mainifold.setCode()` and `mainifold.run()` instead.
+- **Forgetting `return`** — code runs in `new Function()`, so a trailing expression is NOT automatically returned. You must write `return Manifold.cube(...)`.
+- **Skipping sessions** — always create a session (`createSession`) and save versions (`runAndSave`) so the user can review your work in the gallery.
+- **Skipping visual verification** — stats alone can't catch visual defects. After structural changes, screenshot the Elevations tab or use `renderView()`.
+- **Flush boolean placement** — shapes must overlap by at least 0.5 units to union correctly. Merely touching at a face produces disconnected components.
+
+---
+
 Browser-based parametric CAD tool powered by manifold-3d (WASM). Write JavaScript that constructs 3D geometry, returns a Manifold object, and it renders live.
 
 **Coordinate system:** Right-handed, Z-up. XY plane is the ground. Units are arbitrary.

--- a/public/ai.md
+++ b/public/ai.md
@@ -17,6 +17,7 @@ mAInifold is a browser-based parametric CAD tool powered by manifold-3d (WASM). 
 - [Iteration workflow](#iteration-workflow)
 - [Visual verification](#visual-verification)
 - [Stat-based verification](#stat-based-verification)
+- [Resuming a session](#resuming-a-session)
 
 ## Before you start
 
@@ -191,7 +192,7 @@ Queries:    .area()  .isEmpty()  .numVert()  .numContour()  .bounds()
 Output:     .toPolygons()  .decompose()  .delete()
 ```
 
-## Common Pitfalls for Boolean Operations
+## Common pitfalls for boolean operations
 
 ### Always use volumetric overlap, never flush placement
 Shapes that merely touch at a face will NOT union correctly -- they stay as separate components. Offset joining geometry by at least 0.5 units along the joining axis.
@@ -228,7 +229,7 @@ const r = await mainifold.runAndExplain(code);
 // ]
 ```
 
-## Reference Images
+## Reference images
 
 Load reference photos to compare against your model's elevations:
 ```js
@@ -251,7 +252,7 @@ mainifold.getReferenceImages()  // -> {front?, right?, ...} or null
 
 When reference images are loaded, the Elevations tab shows each model view side-by-side with the corresponding reference image. This enables direct visual comparison for accuracy.
 
-## Photo-to-Model Workflow
+## Photo-to-model workflow
 
 > **Optional tooling.** This workflow uses `scripts/generate-views.js` and Gemini, which may not be installed in every environment. If unavailable, skip the analysis step and supply reference images manually via `setReferenceImages()`.
 
@@ -298,7 +299,7 @@ Switch to Elevations tab and compare model silhouette against reference at each 
 Add features in order of visual impact: roof -> porch -> windows/doors -> trim details.
 After each addition, verify the relevant elevation matches the reference.
 
-## Iteration Workflow
+## Iteration workflow
 
 ### Testing without side effects
 
@@ -451,7 +452,7 @@ Read the notes and version history before making changes. The notes tell you:
 5. Use `query({sliceAt: [...], decompose: true})` for follow-up inspection without re-running
 6. Repeat. Gallery URL is in `#geometry-data` or the `runAndSave` return value.
 
-## Visual Verification
+## Visual verification
 
 **CRITICAL: Stats alone cannot catch visual defects.** A roof can be mangled, a spire twisted,
 or proportions wrong -- all while volume, componentCount, and genus look correct. After every
@@ -484,10 +485,10 @@ const s = mainifold.sliceAtZVisual(10);  // returns {svg, area, contours}
 - `?view=elevations` -- Front, Right, Back, Left, Top orthographic + 1 isometric (6 views)
 - Use Elevations for shape verification, AI Views for overall appearance.
 
-## Stat-Based Verification
+## Stat-based verification
 
 1. Read `#geometry-data` -- check `status:"ok"`, volume, dimensions, componentCount, isManifold
 2. Check `crossSections` quartiles (z25/z50/z75) for expected profile
 3. Use `mainifold.sliceAtZ(z)` for specific heights
 4. Use `mainifold.validate(code)` for quick syntax checks
-6. Use `mainifold.runAndAssert(code, assertions)` for structured validation
+5. Use `mainifold.runAndAssert(code, assertions)` for structured validation

--- a/public/ai.md
+++ b/public/ai.md
@@ -1,90 +1,108 @@
-# mAInifold — AI Agent Instructions
+# mAInifold -- AI Agent Instructions
 
-## Before you start
-
-1. **Use `window.mainifold`** — that's the programmatic API. Do NOT drive the app with clicks, keystrokes, or DOM manipulation.
-2. **Code must end with `return manifoldObject;`** — a bare trailing expression won't work.
-3. **Use `runAndSave(code, label, {isManifold: true, maxComponents: 1})`** to validate and commit a version.
-4. **Log decisions with `addSessionNote("[PREFIX] ...")`** — prefixes: `[REQUIREMENT]`, `[DECISION]`, `[FEEDBACK]`, `[MEASUREMENT]`, `[ATTEMPT]`, `[TODO]`.
-
-### Common agent mistakes
-
-- **Driving the UI with clicks/keystrokes** — CodeMirror's auto-close-brackets will corrupt your code. Use `mainifold.setCode()` and `mainifold.run()` instead.
-- **Forgetting `return`** — code runs in `new Function()`, so a trailing expression is NOT automatically returned. You must write `return Manifold.cube(...)`.
-- **Skipping sessions** — always create a session (`createSession`) and save versions (`runAndSave`) so the user can review your work in the gallery.
-- **Skipping visual verification** — stats alone can't catch visual defects. After structural changes, screenshot the Elevations tab or use `renderView()`.
-- **Flush boolean placement** — shapes must overlap by at least 0.5 units to union correctly. Merely touching at a face produces disconnected components.
-
----
-
-Browser-based parametric CAD tool powered by manifold-3d (WASM). Write JavaScript that constructs 3D geometry, returns a Manifold object, and it renders live.
+mAInifold is a browser-based parametric CAD tool powered by manifold-3d (WASM). You write JavaScript that constructs 3D geometry and returns a `Manifold` object, which renders live. All interaction is via the `window.mainifold` programmatic API -- do not drive the app through clicks or keystrokes.
 
 **Coordinate system:** Right-handed, Z-up. XY plane is the ground. Units are arbitrary.
 
+## Contents
+
+- [Before you start](#before-you-start)
+- [Common agent mistakes](#common-agent-mistakes)
+- [Console API -- window.mainifold](#console-api--windowmainifold)
+- [Geometry data](#geometry-data)
+- [Writing model code](#writing-model-code)
+- [Common pitfalls for boolean operations](#common-pitfalls-for-boolean-operations)
+- [Reference images](#reference-images)
+- [Photo-to-model workflow](#photo-to-model-workflow) (optional tooling)
+- [Iteration workflow](#iteration-workflow)
+- [Visual verification](#visual-verification)
+- [Stat-based verification](#stat-based-verification)
+
+## Before you start
+
+1. **Use `window.mainifold`** -- that's the programmatic API. Do NOT drive the app with clicks, keystrokes, or DOM manipulation.
+2. **Code must end with `return manifoldObject;`** -- a bare trailing expression won't work.
+3. **Use `runAndSave(code, label, {isManifold: true, maxComponents: 1})`** to validate and commit a version.
+4. **Log decisions with `addSessionNote("[PREFIX] ...")`** -- prefixes: `[REQUIREMENT]`, `[DECISION]`, `[FEEDBACK]`, `[MEASUREMENT]`, `[ATTEMPT]`, `[TODO]`.
+
+## Common agent mistakes
+
+- **Driving the UI with clicks/keystrokes** -- CodeMirror's auto-close-brackets will corrupt your code. Use `mainifold.setCode()` and `mainifold.run()` instead.
+- **Forgetting `return`** -- code runs in `new Function()`, so a trailing expression is NOT automatically returned. You must write `return Manifold.cube(...)`.
+- **Skipping sessions** -- always create a session (`createSession`) and save versions (`runAndSave`) so the user can review your work in the gallery.
+- **Skipping visual verification** -- stats alone can't catch visual defects. After structural changes, screenshot the Elevations tab or use `renderView()`.
+- **Flush boolean placement** -- shapes must overlap by at least 0.5 units to union correctly. Merely touching at a face produces disconnected components.
+- **Not reading session context before modifying** -- when opening an existing session, always call `getSessionContext()` first and read the notes/version history before making changes. See [Resuming a session](#resuming-a-session).
+
 ## How to use this tool
 
-1. Navigate with `?view=ai` to see 4 isometric views (e.g. `http://localhost:5173/editor?view=ai`)
+1. Navigate with `?view=ai` to see 4 isometric views (e.g. `/editor?view=ai`)
 2. Use `window.mainifold` in the browser console to interact programmatically
-3. Read `document.getElementById("geometry-data").textContent` for structured stats (JSON)
+3. Call `mainifold.help()` for a full method list, or `mainifold.help('methodName')` for a specific method
+4. Use `mainifold.getGeometryData()` to read current geometry stats programmatically
 
-## Console API — window.mainifold
+## Console API -- window.mainifold
 
 ```js
 mainifold.run(code?)          // Run code, update views, return geometry stats
 mainifold.getGeometryData()   // Current stats (same as #geometry-data)
-mainifold.validate(code)      // Check code without rendering → {valid, error?}
+mainifold.validate(code)      // Check code without rendering -> {valid, error?}
 mainifold.getCode()           // Read editor contents
 mainifold.setCode(code)       // Set editor contents (no auto-run)
-mainifold.sliceAtZ(z)         // Cross-section → {polygons, svg, boundingBox, area}
-mainifold.getBoundingBox()    // → {min:[x,y,z], max:[x,y,z]}
+mainifold.sliceAtZ(z)         // Cross-section -> {polygons, svg, boundingBox, area}
+mainifold.getBoundingBox()    // -> {min:[x,y,z], max:[x,y,z]}
 mainifold.getModule()         // Raw manifold-3d WASM module
-mainifold.toggleClip(on?)     // Toggle 3D clipping plane → {enabled, z, min, max}
-mainifold.setClipZ(z)         // Set clip height → {enabled, z, min, max}
-mainifold.getClipState()      // → {enabled, z, min, max}
+mainifold.toggleClip(on?)     // Toggle 3D clipping plane -> {enabled, z, min, max}
+mainifold.setClipZ(z)         // Set clip height -> {enabled, z, min, max}
+mainifold.getClipState()      // -> {enabled, z, min, max}
 await mainifold.exportGLB()   // Download GLB
 mainifold.exportSTL()         // Download STL
 mainifold.exportOBJ()         // Download OBJ
 mainifold.export3MF()         // Download 3MF
 
-// Isolated execution — test code without changing editor/viewport state
-await mainifold.runIsolated(code)       // → {geometryData, thumbnail}
-await mainifold.runAndAssert(code, assertions) // → {passed, failures?, stats}
-await mainifold.runAndExplain(code)     // → {stats, components[], hints[]} (debug disconnects)
+// Isolated execution -- test code without changing editor/viewport state
+await mainifold.runIsolated(code)       // -> {geometryData, thumbnail}
+await mainifold.runAndAssert(code, assertions) // -> {passed, failures?, stats}
+await mainifold.runAndExplain(code)     // -> {stats, components[], hints[]} (debug disconnects)
 await mainifold.modifyAndTest(patchFn, assertions?) // Modify current code + test in isolation
 mainifold.query({sliceAt?, decompose?, boundingBox?}) // Multi-query current geometry in one call
-mainifold.renderView({elevation?, azimuth?, ortho?, size?}) // Render from any angle → data URL
-mainifold.sliceAtZVisual(z)            // Cross-section SVG at height z → {svg, area, contours}
-mainifold.isRunning()                   // → boolean (is code executing?)
+mainifold.renderView({elevation?, azimuth?, ortho?, size?}) // Render from any angle -> data URL
+mainifold.sliceAtZVisual(z)            // Cross-section SVG at height z -> {svg, area, contours}
+mainifold.isRunning()                   // -> boolean (is code executing?)
 
-// Reference images — compare model against photos
+// Reference images -- compare model against photos
 mainifold.setReferenceImages({front?, right?, back?, left?, top?, perspective?})
 mainifold.clearReferenceImages()
 mainifold.getReferenceImages()
 
-// Sessions — save/compare design iterations
-await mainifold.createSession(name?)    // → {id, url, galleryUrl}
-await mainifold.runAndSave(code, label?, assertions?) // Assert+save in one call → {passed?, geometry, version, diff, galleryUrl}
+// Sessions -- save/compare design iterations
+await mainifold.createSession(name?)    // -> {id, url, galleryUrl}
+await mainifold.runAndSave(code, label?, assertions?) // Assert+save in one call -> {passed?, geometry, version, diff, galleryUrl}
 await mainifold.createSessionWithVersions(name, [{code, label},...]) // Batch create
 await mainifold.saveVersion(label?)     // Save current state as version
-await mainifold.listVersions()          // → [{id, index, label, timestamp, status}]
+await mainifold.listVersions()          // -> [{id, index, label, timestamp, status}]
 await mainifold.loadVersion(index)      // Load specific version
-mainifold.getGalleryUrl()               // → URL for gallery view (human review)
-mainifold.getSessionUrl()               // → URL for this session
-await mainifold.listSessions()          // → [{id, name, updated}]
+mainifold.getGalleryUrl()               // -> URL for gallery view (human review)
+mainifold.getSessionUrl()               // -> URL for this session
+await mainifold.listSessions()          // -> [{id, name, updated}]
 await mainifold.openSession(id)         // Open existing session
 await mainifold.clearAllSessions()      // Delete all sessions & versions
 
-// Notes — track design context, decisions, and measurements
-await mainifold.addSessionNote(text)    // → {id, text, timestamp}
-await mainifold.listSessionNotes()      // → [{id, text, timestamp}, ...]
+// Notes -- track design context, decisions, and measurements
+await mainifold.addSessionNote(text)    // -> {id, text, timestamp}
+await mainifold.listSessionNotes()      // -> [{id, text, timestamp}, ...]
 await mainifold.updateSessionNote(noteId, text) // Edit a note
 await mainifold.deleteSessionNote(noteId)       // Remove a note
 
-// Session context — get everything in one call (for resuming sessions)
-await mainifold.getSessionContext()     // → {session, versions[], notes[], currentVersion, versionCount}
+// Session context -- get everything in one call (for resuming sessions)
+await mainifold.getSessionContext()     // -> {session, versions[], notes[], currentVersion, versionCount}
 ```
 
-## #geometry-data schema
+## Geometry data
+
+**Preferred:** Use `mainifold.getGeometryData()` to read current geometry stats programmatically.
+
+**Fallback** (if `window.mainifold` is not yet initialized): read `document.getElementById("geometry-data").textContent` -- it contains the same JSON.
 
 ```json
 {
@@ -107,31 +125,33 @@ await mainifold.getSessionContext()     // → {session, versions[], notes[], cu
 On error: `{"status":"error","error":"...","executionTimeMs":2,"codeHash":"..."}`
 
 ### Common errors
-- `Code must return a Manifold object` → forgot `return` statement
-- `function _Cylinder called with N arguments` → wrong arg count
-- Geometry looks wrong → check `isManifold` and `componentCount` (failed booleans = extra components)
+- `Code must return a Manifold object` -- forgot `return` statement
+- `function _Cylinder called with N arguments` -- wrong arg count
+- Geometry looks wrong -- check `isManifold` and `componentCount` (failed booleans = extra components)
 
 ## Writing model code
 
-Code runs in a sandbox via `new Function('api', code)`. All transforms return new immutable Manifold instances — chaining works.
+Code runs in a sandbox via `new Function('api', code)`. All transforms return new immutable Manifold instances -- chaining works.
 
 ```js
-const { Manifold, CrossSection } = api;
+const { Manifold, CrossSection, setCircularSegments } = api;
 // MUST return a Manifold object
 ```
+
+**Sandbox environment:** The `api` object provides `Manifold`, `CrossSection`, and `setCircularSegments`. Standard JavaScript globals (`Math`, `Array`, `Object`, `JSON`, `Date`, `console`, etc.) are available. There is no DOM access, no `fetch`/network, no `require`/`import`, and no file I/O. Do not attempt to load external libraries or make HTTP requests in model code.
 
 ### Primitive origins and orientations
 
 ```
-cube([x,y,z])         → spans [0,0,0] to [x,y,z]. center=true → centered at origin
-sphere(r, n?)         → centered at origin
-cylinder(h,rLo,rHi?,n?) → Z-axis, base z=0, top z=h. rHi=0 for cone
-tetrahedron()          → vertices at [1,1,1],[1,-1,-1],[-1,1,-1],[-1,-1,1]. Scale to size.
+cube([x,y,z])         -> spans [0,0,0] to [x,y,z]. center=true -> centered at origin
+sphere(r, n?)         -> centered at origin
+cylinder(h,rLo,rHi?,n?) -> Z-axis, base z=0, top z=h. rHi=0 for cone
+tetrahedron()          -> vertices at [1,1,1],[1,-1,-1],[-1,1,-1],[-1,-1,1]. Scale to size.
 extrude(cs, h, nDiv?, twist?, scaleTop?, center?)
-  → along Z, z=0 to z=h. twist=degrees, scaleTop=number or [x,y] (0 for cone point)
+  -> along Z, z=0 to z=h. twist=degrees, scaleTop=number or [x,y] (0 for cone point)
 revolve(cs, n?, degrees?)
-  → around Y axis, then remaps so result is Z-up.
-    Profile X=radial distance, Y=height → after revolve, Y becomes Z automatically.
+  -> around Y axis, then remaps so result is Z-up.
+    Profile X=radial distance, Y=height -> after revolve, Y becomes Z automatically.
     Only positive-X side used. degrees defaults to 360.
 Segments guide: 6-8 low-poly, 32-48 smooth, 64+ high quality
 ```
@@ -149,20 +169,20 @@ CrossSection: square, circle, ofPolygons (CCW outer, CW holes),
 
 ```
 Booleans:   .add(other)  .subtract(other)  .intersect(other)  .hull()
-Transforms: .translate([x,y,z])  .rotate([rx,ry,rz]) (degrees, applied X→Y→Z)
+Transforms: .translate([x,y,z])  .rotate([rx,ry,rz]) (degrees, applied X->Y->Z)
             .scale(s) or .scale([x,y,z])  .mirror([nx,ny,nz]) (plane normal)
             .warp(fn)  .transform(mat4x3)
 Mesh ops:   .refine(n)  .simplify()  .smoothOut()  .calculateNormals(idx, angle?)
 Queries:    .volume()  .surfaceArea()  .genus()  .numVert()  .numTri()  .isEmpty()
             .boundingBox()  .status() (0=valid)  .decompose()
 Slicing:    .slice(z)  .project()  .trimByPlane(n,off)  .splitByPlane(n,off)
-Output:     .getMesh() → {vertProperties, triVerts, numVert, numTri, numProp}
+Output:     .getMesh() -> {vertProperties, triVerts, numVert, numTri, numProp}
 ```
 
 ### CrossSection instance methods
 
 ```
-2D→3D:      .extrude(h, nDiv?, twist?, scaleTop?, center?)  .revolve(n?, degrees?)
+2D->3D:      .extrude(h, nDiv?, twist?, scaleTop?, center?)  .revolve(n?, degrees?)
 Transforms: .translate([x,y])  .rotate(degrees)  .scale(s or [x,y])
             .mirror([nx,ny])  .warp(fn)  .transform(mat3)
 Booleans:   .add(other)  .subtract(other)  .intersect(other)  .hull()
@@ -174,12 +194,12 @@ Output:     .toPolygons()  .decompose()  .delete()
 ## Common Pitfalls for Boolean Operations
 
 ### Always use volumetric overlap, never flush placement
-Shapes that merely touch at a face will NOT union correctly — they stay as separate components. Offset joining geometry by at least 0.5 units along the joining axis.
+Shapes that merely touch at a face will NOT union correctly -- they stay as separate components. Offset joining geometry by at least 0.5 units along the joining axis.
 ```js
-// BAD — merlon sits exactly on wall top, stays disconnected
+// BAD -- merlon sits exactly on wall top, stays disconnected
 merlon.translate([x, y, wallTopZ])
 
-// GOOD — merlon overlaps 0.5 units into wall body
+// GOOD -- merlon overlaps 0.5 units into wall body
 merlon.translate([x, y, wallTopZ - 0.5])
 ```
 
@@ -192,7 +212,7 @@ Manifold.cylinder(spireH, 11, 0, 24).translate([0, 0, keepH - 0.5])
 ```
 
 ### Flag poles on cone tips need to start inside the cone body
-A cylinder placed at the exact tip of a cone (where radius = 0) has nothing to union with. Start the pole 1–2 units below the tip so it overlaps solid cone geometry.
+A cylinder placed at the exact tip of a cone (where radius = 0) has nothing to union with. Start the pole 1-2 units below the tip so it overlaps solid cone geometry.
 
 ### Debugging disconnected components
 When `componentCount > 1`, use `runAndExplain(code)` to identify which pieces are floating:
@@ -203,8 +223,8 @@ const r = await mainifold.runAndExplain(code);
 //   { index: 1, volume: 12,    centroid: [29, 29, 26], boundingBox: {...} },
 // ]
 // r.hints = [
-//   "1 tiny disconnected component(s) detected — likely floating attachments...",
-//   "Components 0 and 1 share a face or near-touch (gap: 0.00) — need volumetric overlap"
+//   "1 tiny disconnected component(s) detected -- likely floating attachments...",
+//   "Components 0 and 1 share a face or near-touch (gap: 0.00) -- need volumetric overlap"
 // ]
 ```
 
@@ -226,16 +246,18 @@ mainifold.setReferenceImages({
 mainifold.clearReferenceImages()
 
 // Get current reference image state
-mainifold.getReferenceImages()  // → {front?, right?, ...} or null
+mainifold.getReferenceImages()  // -> {front?, right?, ...} or null
 ```
 
 When reference images are loaded, the Elevations tab shows each model view side-by-side with the corresponding reference image. This enables direct visual comparison for accuracy.
 
 ## Photo-to-Model Workflow
 
+> **Optional tooling.** This workflow uses `scripts/generate-views.js` and Gemini, which may not be installed in every environment. If unavailable, skip the analysis step and supply reference images manually via `setReferenceImages()`.
+
 To recreate a building or object from a photo:
 
-### 1. Analyze the reference
+### 1. Analyze the reference (optional helper)
 Use `scripts/generate-views.js` to extract structural analysis:
 ```bash
 node scripts/generate-views.js /path/to/photo.jpg
@@ -256,7 +278,7 @@ mainifold.setReferenceImages({ front: frontDataUrl, right: rightDataUrl, ... })
 ### 3. Build major masses first
 Start with the largest geometric volumes and get proportions right before adding detail:
 ```js
-// Decompose into: main body → wings → roof → porch → details
+// Decompose into: main body -> wings -> roof -> porch -> details
 // Build each mass, validate proportions against reference
 const r = await mainifold.runAndAssert(code, {
   isManifold: true, maxComponents: 1,
@@ -273,7 +295,7 @@ Switch to Elevations tab and compare model silhouette against reference at each 
 - Porch depth and column spacing
 
 ### 5. Iterate on details
-Add features in order of visual impact: roof → porch → windows/doors → trim details.
+Add features in order of visual impact: roof -> porch -> windows/doors -> trim details.
 After each addition, verify the relevant elevation matches the reference.
 
 ## Iteration Workflow
@@ -287,7 +309,7 @@ const r = await mainifold.runIsolated(code);
 // r.thumbnail = data:image/png base64 string (4 isometric views)
 ```
 
-### Assertions — structured validation
+### Assertions -- structured validation
 
 Check geometry against expectations in one call:
 ```js
@@ -297,13 +319,14 @@ const r = await mainifold.runAndAssert(code, {
   isManifold: true,     // must be valid manifold
   maxComponents: 1,     // detect failed booleans
   genus: 0,             // exact topological genus (0 = solid, N = N holes)
-  minGenus: 1,          // genus range — useful when exact count is unpredictable
+  minGenus: 1,          // genus range -- useful when exact count is unpredictable
   maxGenus: 20,
   minBounds: [10,10,5], // minimum bounding box dimensions [X,Y,Z]
   maxBounds: [50,50,30],
   minTriangles: 100,    // mesh complexity bounds
   maxTriangles: 50000,
-  boundsRatio: { widthToDepth: [1.2, 1.8], widthToHeight: [1.5, 2.5] }  // proportion ranges
+  boundsRatio: { widthToDepth: [1.2, 1.8], widthToHeight: [1.5, 2.5] },  // proportion ranges
+  notes: "Design rationale or context for this version",  // optional: attached to saved version
 });
 // r.passed = true/false
 // r.failures = ["volume 500.0 < minVolume 1000"] (only if failed)
@@ -312,7 +335,7 @@ const r = await mainifold.runAndAssert(code, {
 
 ### Assert + save in one call
 
-`runAndSave` accepts optional assertions. If provided, validates in isolation first — fails fast
+`runAndSave` accepts optional assertions. If provided, validates in isolation first -- fails fast
 without saving if assertions don't pass. On success, saves the version and returns stat diff:
 ```js
 const r = await mainifold.runAndSave(code, "v2 - added towers", {
@@ -367,10 +390,10 @@ const r = await mainifold.createSessionWithVersions("Castle", [
 ]);
 // r.session = {id, name}
 // r.versions = [{version, geometry}, ...]
-// r.galleryUrl = "http://localhost:5173/editor?session=abc&gallery"
+// r.galleryUrl = "/editor?session=abc&gallery"
 ```
 
-### Session notes — tracking design context
+### Session notes -- tracking design context
 
 Use session notes to build a persistent record of the design story. This enables any agent (or human) resuming the session later to understand what happened and why.
 
@@ -405,10 +428,10 @@ When opening a session you haven't worked on (or returning after time away), **a
 ```js
 await mainifold.openSession(sessionId);
 const ctx = await mainifold.getSessionContext();
-// ctx.session    — {id, name, created, updated}
-// ctx.versions   — [{index, label, timestamp, notes?, geometrySummary: {volume, boundingBox, ...}}]
-// ctx.notes      — [{id, text, timestamp}]  (all session notes)
-// ctx.currentVersion — {index, label}
+// ctx.session    -- {id, name, created, updated}
+// ctx.versions   -- [{index, label, timestamp, notes?, geometrySummary: {volume, boundingBox, ...}}]
+// ctx.notes      -- [{id, text, timestamp}]  (all session notes)
+// ctx.currentVersion -- {index, label}
 // ctx.versionCount
 ```
 
@@ -422,19 +445,19 @@ Read the notes and version history before making changes. The notes tell you:
 ### Recommended iteration pattern
 
 1. Write initial code, assert+save in one call: `runAndSave(code, "v1 - base", {isManifold: true, maxComponents: 1})`
-2. **Visually verify** — switch to Elevations tab (`?view=elevations`) and screenshot. Check Front/Side views.
-3. Modify code, test with `modifyAndTest(patchFn)` or `runIsolated(code)` — no side effects
-4. When satisfied, save: `runAndSave(modifiedCode, "v2 - improvements", assertions)` — check the diff
+2. **Visually verify** -- switch to Elevations tab (`?view=elevations`) and screenshot. Check Front/Side views.
+3. Modify code, test with `modifyAndTest(patchFn)` or `runIsolated(code)` -- no side effects
+4. When satisfied, save: `runAndSave(modifiedCode, "v2 - improvements", assertions)` -- check the diff
 5. Use `query({sliceAt: [...], decompose: true})` for follow-up inspection without re-running
 6. Repeat. Gallery URL is in `#geometry-data` or the `runAndSave` return value.
 
 ## Visual Verification
 
 **CRITICAL: Stats alone cannot catch visual defects.** A roof can be mangled, a spire twisted,
-or proportions wrong — all while volume, componentCount, and genus look correct. After every
+or proportions wrong -- all while volume, componentCount, and genus look correct. After every
 structural change:
 
-1. **Check the Elevations tab** (`?view=elevations`) — shows Front, Right, Back, Left, Top views.
+1. **Check the Elevations tab** (`?view=elevations`) -- shows Front, Right, Back, Left, Top views.
    Side elevations immediately reveal roof profiles, wall alignment, and symmetry issues that
    isometric views can hide.
 2. **Use `renderView()` for specific angles:**
@@ -450,20 +473,20 @@ const s = mainifold.sliceAtZVisual(10);  // returns {svg, area, contours}
 // svg = visual rendering of the cross-section profile at z=10
 ```
 4. **Feature-specific checks:**
-   - Added a roof? Check side elevation — should be a clean triangle/gable profile.
-   - Cut a door/window? Check front elevation — opening should be visible.
-   - Added a tower? Check top-down — should be circular, properly positioned.
-   - Made something hollow? Slice at mid-height — should show wall ring, not solid fill.
+   - Added a roof? Check side elevation -- should be a clean triangle/gable profile.
+   - Cut a door/window? Check front elevation -- opening should be visible.
+   - Added a tower? Check top-down -- should be circular, properly positioned.
+   - Made something hollow? Slice at mid-height -- should show wall ring, not solid fill.
 
 ### View tabs
 
-- `?view=ai` — 4 isometric views (alternating cube corners)
-- `?view=elevations` — Front, Right, Back, Left, Top orthographic + 1 isometric (6 views)
+- `?view=ai` -- 4 isometric views (alternating cube corners)
+- `?view=elevations` -- Front, Right, Back, Left, Top orthographic + 1 isometric (6 views)
 - Use Elevations for shape verification, AI Views for overall appearance.
 
 ## Stat-Based Verification
 
-1. Read `#geometry-data` — check `status:"ok"`, volume, dimensions, componentCount, isManifold
+1. Read `#geometry-data` -- check `status:"ok"`, volume, dimensions, componentCount, isManifold
 2. Check `crossSections` quartiles (z25/z50/z75) for expected profile
 3. Use `mainifold.sliceAtZ(z)` for specific heights
 4. Use `mainifold.validate(code)` for quick syntax checks

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,7 @@
+# mAInifold
+
+> AI-driven parametric CAD in the browser. Programmatic API at window.mainifold.
+
+## Docs
+
+- [AI Agent Instructions](/ai.md): Full API reference, workflow guide, and common pitfalls

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,7 +1,19 @@
 # mAInifold
 
-> AI-driven parametric CAD in the browser. Programmatic API at window.mainifold.
+> AI-driven parametric CAD in the browser. All interaction is via the `window.mainifold` JavaScript API.
+
+## Quickstart
+
+```js
+mainifold.help()                        // List all available methods
+await mainifold.createSession("name")   // Start a named session
+await mainifold.runAndSave(code, "v1 - description", {
+  isManifold: true, maxComponents: 1    // Validate before saving
+})
+// Code must end with: return <Manifold object>;
+```
 
 ## Docs
 
-- [AI Agent Instructions](/ai.md): Full API reference, workflow guide, and common pitfalls
+- [Full API reference and workflow guide](/ai.md)
+- `mainifold.help()` in the browser console for live method discovery

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
 
+# AI agents: see /ai.md for programmatic API docs, /llms.txt for summary
 Sitemap: https://mainifold.pages.dev/sitemap.xml

--- a/src/main.ts
+++ b/src/main.ts
@@ -903,6 +903,12 @@ async function main() {
     /** Create a new session and make it active */
     async createSession(name?: string) {
       const session = await createSession(name);
+      await addSessionNote(
+        '[WORKFLOW] Drive this app via window.mainifold (see /ai.md). ' +
+        'Use runAndSave(code, label, assertions) for iterations; ' +
+        'addSessionNote with [REQUIREMENT]/[DECISION]/[MEASUREMENT]/[FEEDBACK]/[ATTEMPT]/[TODO] prefixes; ' +
+        'getSessionContext() when resuming.',
+      );
       return { id: session.id, url: getSessionUrl(), galleryUrl: getGalleryUrl() };
     },
 
@@ -1508,6 +1514,72 @@ async function main() {
     /** Programmatic measurement between two 3D points (no clicking needed) */
     measurePoints(p1: [number, number, number], p2: [number, number, number]): number {
       return measureDistance(p1, p2);
+    },
+
+    /** Self-documenting help — prints method list and returns summary string */
+    help(method?: string): string {
+      const methods: Record<string, string> = {
+        // Core
+        'run': 'run(code?) — Run code, update views, return geometry stats',
+        'getGeometryData': 'getGeometryData() — Current stats (same as #geometry-data)',
+        'validate': 'validate(code) — Check code without rendering → {valid, error?}',
+        'getCode': 'getCode() — Read editor contents',
+        'setCode': 'setCode(code) — Set editor contents (no auto-run)',
+        // Isolated execution
+        'runIsolated': 'await runIsolated(code) — Test code without side effects → {geometryData, thumbnail}',
+        'runAndAssert': 'await runAndAssert(code, assertions) — Validate geometry → {passed, failures?, stats}',
+        'runAndExplain': 'await runAndExplain(code) — Debug disconnected components → {stats, components[], hints[]}',
+        'modifyAndTest': 'await modifyAndTest(patchFn, assertions?) — Modify + test without committing',
+        'query': 'query({sliceAt?, decompose?, boundingBox?}) — Multi-query current geometry',
+        // Sessions
+        'createSession': 'await createSession(name?) — Create session → {id, url, galleryUrl}',
+        'runAndSave': 'await runAndSave(code, label?, assertions?) — Assert + save version in one call',
+        'saveVersion': 'await saveVersion(label?) — Save current state as version',
+        'listVersions': 'await listVersions() — List all versions in session',
+        'loadVersion': 'await loadVersion(index) — Load specific version',
+        'openSession': 'await openSession(id) — Open existing session',
+        'listSessions': 'await listSessions() — List all sessions',
+        'getSessionContext': 'await getSessionContext() — Get full session context (for resuming)',
+        'getGalleryUrl': 'getGalleryUrl() — URL for gallery view (human review)',
+        // Notes
+        'addSessionNote': 'await addSessionNote(text) — Add note with [PREFIX] tag',
+        'listSessionNotes': 'await listSessionNotes() — List all session notes',
+        // Inspection
+        'sliceAtZ': 'sliceAtZ(z) — Cross-section at height → {polygons, svg, area}',
+        'getBoundingBox': 'getBoundingBox() — → {min, max}',
+        'renderView': 'renderView({elevation?, azimuth?, ortho?, size?}) — Render from any angle → data URL',
+        'analyzeProfile': 'analyzeProfile(sampleCount?) — Z-profile feature summary',
+        'measureAt': 'measureAt([x,y]) — Ray-cast probe at XY → {hits, thickness, topZ, bottomZ}',
+        // View
+        'setView': 'setView(tab) — Switch tab: "interactive", "ai", "elevations", "gallery"',
+        'getViewState': 'getViewState() — Current tab and camera state',
+        // Export
+        'exportGLB': 'await exportGLB() — Download GLB file',
+        'exportSTL': 'exportSTL() — Download STL file',
+        'exportOBJ': 'exportOBJ() — Download OBJ file',
+        'export3MF': 'export3MF() — Download 3MF file',
+      };
+
+      if (method) {
+        const entry = methods[method];
+        if (entry) {
+          console.log(entry);
+          return entry;
+        }
+        return `Unknown method "${method}". Call help() for full list.`;
+      }
+
+      const lines = [
+        'mAInifold — AI-driven parametric CAD. Full docs: /ai.md',
+        '',
+        'IMPORTANT: Code must end with "return manifoldObject;"',
+        'Do NOT drive the UI with clicks/keystrokes — use this API.',
+        '',
+        ...Object.values(methods),
+      ];
+      const output = lines.join('\n');
+      console.log(output);
+      return output;
     },
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1538,57 +1538,55 @@ async function main() {
 
     /** Self-documenting help -- returns structured object and logs readable summary */
     help(method?: string): Record<string, unknown> {
-      const methods: Record<string, string> = {
+      const methods: Record<string, { signature: string; docs: string }> = {
         // Core
-        'run': 'run(code?) -- Run code, update views, return geometry stats',
-        'getGeometryData': 'getGeometryData() -- Current stats as JSON object',
-        'validate': 'validate(code) -- Check code without rendering -> {valid, error?}',
-        'getCode': 'getCode() -- Read editor contents',
-        'setCode': 'setCode(code) -- Set editor contents (no auto-run)',
+        'run':             { signature: 'run(code?) -- Run code, update views, return geometry stats', docs: '/ai.md#console-api--windowmainifold' },
+        'getGeometryData': { signature: 'getGeometryData() -- Current stats as JSON object', docs: '/ai.md#geometry-data' },
+        'validate':        { signature: 'validate(code) -- Check code without rendering -> {valid, error?}', docs: '/ai.md#console-api--windowmainifold' },
+        'getCode':         { signature: 'getCode() -- Read editor contents', docs: '/ai.md#console-api--windowmainifold' },
+        'setCode':         { signature: 'setCode(code) -- Set editor contents (no auto-run)', docs: '/ai.md#console-api--windowmainifold' },
         // Isolated execution
-        'runIsolated': 'await runIsolated(code) -- Test code without side effects -> {geometryData, thumbnail}',
-        'runAndAssert': 'await runAndAssert(code, assertions) -- Validate geometry -> {passed, failures?, stats}',
-        'runAndExplain': 'await runAndExplain(code) -- Debug disconnected components -> {stats, components[], hints[]}',
-        'modifyAndTest': 'await modifyAndTest(patchFn, assertions?) -- Modify + test without committing',
-        'query': 'query({sliceAt?, decompose?, boundingBox?}) -- Multi-query current geometry',
+        'runIsolated':     { signature: 'await runIsolated(code) -- Test without side effects -> {geometryData, thumbnail}', docs: '/ai.md#testing-without-side-effects' },
+        'runAndAssert':    { signature: 'await runAndAssert(code, assertions) -- Validate geometry -> {passed, failures?, stats}', docs: '/ai.md#assertions----structured-validation' },
+        'runAndExplain':   { signature: 'await runAndExplain(code) -- Debug disconnected components -> {stats, components[], hints[]}', docs: '/ai.md#debugging-disconnected-components' },
+        'modifyAndTest':   { signature: 'await modifyAndTest(patchFn, assertions?) -- Modify + test without committing', docs: '/ai.md#modify-and-test' },
+        'query':           { signature: 'query({sliceAt?, decompose?, boundingBox?}) -- Multi-query current geometry', docs: '/ai.md#multi-query-current-geometry' },
         // Sessions
-        'createSession': 'await createSession(name?) -- Create session -> {id, url, galleryUrl}',
-        'runAndSave': 'await runAndSave(code, label?, assertions?) -- Assert + save version in one call',
-        'saveVersion': 'await saveVersion(label?) -- Save current state as version',
-        'listVersions': 'await listVersions() -- List all versions in session',
-        'loadVersion': 'await loadVersion(index) -- Load specific version',
-        'openSession': 'await openSession(id) -- Open existing session',
-        'listSessions': 'await listSessions() -- List all sessions',
-        'getSessionContext': 'await getSessionContext() -- Get full session context (for resuming)',
-        'getGalleryUrl': 'getGalleryUrl() -- URL for gallery view (human review)',
+        'createSession':   { signature: 'await createSession(name?) -- Create session -> {id, url, galleryUrl}', docs: '/ai.md#console-api--windowmainifold' },
+        'runAndSave':      { signature: 'await runAndSave(code, label?, assertions?) -- Assert + save version in one call', docs: '/ai.md#assert--save-in-one-call' },
+        'saveVersion':     { signature: 'await saveVersion(label?) -- Save current state as version', docs: '/ai.md#console-api--windowmainifold' },
+        'listVersions':    { signature: 'await listVersions() -- List all versions in session', docs: '/ai.md#console-api--windowmainifold' },
+        'loadVersion':     { signature: 'await loadVersion(index) -- Load specific version', docs: '/ai.md#console-api--windowmainifold' },
+        'openSession':     { signature: 'await openSession(id) -- Open existing session', docs: '/ai.md#resuming-a-session' },
+        'listSessions':    { signature: 'await listSessions() -- List all sessions', docs: '/ai.md#console-api--windowmainifold' },
+        'getSessionContext': { signature: 'await getSessionContext() -- Get full session context (for resuming)', docs: '/ai.md#resuming-a-session' },
+        'getGalleryUrl':   { signature: 'getGalleryUrl() -- URL for gallery view (human review)', docs: '/ai.md#console-api--windowmainifold' },
         // Notes
-        'addSessionNote': 'await addSessionNote(text) -- Add note with [PREFIX] tag',
-        'listSessionNotes': 'await listSessionNotes() -- List all session notes',
+        'addSessionNote':  { signature: 'await addSessionNote(text) -- Add note with [PREFIX] tag', docs: '/ai.md#session-notes----tracking-design-context' },
+        'listSessionNotes': { signature: 'await listSessionNotes() -- List all session notes', docs: '/ai.md#session-notes----tracking-design-context' },
         // Inspection
-        'sliceAtZ': 'sliceAtZ(z) -- Cross-section at height -> {polygons, svg, area}',
-        'getBoundingBox': 'getBoundingBox() -- -> {min, max}',
-        'renderView': 'renderView({elevation?, azimuth?, ortho?, size?}) -- Render from any angle -> data URL',
-        'analyzeProfile': 'analyzeProfile(sampleCount?) -- Z-profile feature summary',
-        'measureAt': 'measureAt([x,y]) -- Ray-cast probe at XY -> {hits, thickness, topZ, bottomZ}',
+        'sliceAtZ':        { signature: 'sliceAtZ(z) -- Cross-section at height -> {polygons, svg, area}', docs: '/ai.md#console-api--windowmainifold' },
+        'getBoundingBox':  { signature: 'getBoundingBox() -- -> {min, max}', docs: '/ai.md#console-api--windowmainifold' },
+        'renderView':      { signature: 'renderView({elevation?, azimuth?, ortho?, size?}) -- Render from any angle -> data URL', docs: '/ai.md#visual-verification' },
+        'analyzeProfile':  { signature: 'analyzeProfile(sampleCount?) -- Z-profile feature summary', docs: '/ai.md#console-api--windowmainifold' },
+        'measureAt':       { signature: 'measureAt([x,y]) -- Ray-cast probe at XY -> {hits, thickness, topZ, bottomZ}', docs: '/ai.md#console-api--windowmainifold' },
         // View
-        'setView': 'setView(tab) -- Switch tab: "interactive", "ai", "elevations", "gallery"',
-        'getViewState': 'getViewState() -- Current tab and camera state',
+        'setView':         { signature: 'setView(tab) -- Switch tab: "interactive", "ai", "elevations", "gallery"', docs: '/ai.md#view-tabs' },
+        'getViewState':    { signature: 'getViewState() -- Current tab and camera state', docs: '/ai.md#view-tabs' },
         // Export
-        'exportGLB': 'await exportGLB() -- Download GLB file',
-        'exportSTL': 'exportSTL() -- Download STL file',
-        'exportOBJ': 'exportOBJ() -- Download OBJ file',
-        'export3MF': 'export3MF() -- Download 3MF file',
+        'exportGLB':       { signature: 'await exportGLB() -- Download GLB file', docs: '/ai.md#console-api--windowmainifold' },
+        'exportSTL':       { signature: 'exportSTL() -- Download STL file', docs: '/ai.md#console-api--windowmainifold' },
+        'exportOBJ':       { signature: 'exportOBJ() -- Download OBJ file', docs: '/ai.md#console-api--windowmainifold' },
+        'export3MF':       { signature: 'export3MF() -- Download 3MF file', docs: '/ai.md#console-api--windowmainifold' },
       };
 
       if (method) {
         const entry = methods[method];
         if (entry) {
-          console.log(entry);
-          return { method, description: entry };
+          console.log(`${entry.signature}\nDocs: ${entry.docs}`);
+          return { method, ...entry };
         }
-        const msg = `Unknown method "${method}". Call help() for full list.`;
-        console.log(msg);
-        return { error: msg };
+        return { error: `Unknown method "${method}". Call help() for full list.` };
       }
 
       const result = {
@@ -1618,7 +1616,7 @@ async function main() {
         '  await mainifold.runAndSave(code, "v1", {isManifold: true, maxComponents: 1})',
         '',
         'Methods:',
-        ...Object.values(methods).map(m => `  ${m}`),
+        ...Object.entries(methods).map(([, v]) => `  ${v.signature}`),
       ];
       console.log(lines.join('\n'));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -725,6 +725,26 @@ async function main() {
     }
   });
 
+  // Warn AI agents that try to drive the UI when ?view=ai is set
+  if (new URLSearchParams(window.location.search).get('view') === 'ai') {
+    let agentUIWarningShown = false;
+    const warnAgentUI = () => {
+      if (agentUIWarningShown) return;
+      agentUIWarningShown = true;
+      const msg = 'Detected UI-driven input. This app expects programmatic control from AI agents. Use window.mainifold.runAndSave() -- see /llms.txt';
+      console.warn(msg);
+      // Show a non-blocking toast
+      const toast = document.createElement('div');
+      toast.textContent = msg;
+      toast.style.cssText = 'position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:#451a03;color:#fbbf24;padding:8px 16px;border-radius:6px;font-size:13px;z-index:9999;max-width:600px;text-align:center;pointer-events:none;';
+      document.body.appendChild(toast);
+      setTimeout(() => toast.remove(), 8000);
+    };
+    // Listen on the editor and viewport containers
+    editorUI.addEventListener('keydown', warnAgentUI, { once: true });
+    editorUI.addEventListener('click', warnAgentUI, { once: true });
+  }
+
   // === Execution state ===
   let _running = false;
 
@@ -1516,105 +1536,100 @@ async function main() {
       return measureDistance(p1, p2);
     },
 
-    /** Self-documenting help — prints method list and returns summary string */
-    help(method?: string): string {
+    /** Self-documenting help -- returns structured object and logs readable summary */
+    help(method?: string): Record<string, unknown> {
       const methods: Record<string, string> = {
         // Core
-        'run': 'run(code?) — Run code, update views, return geometry stats',
-        'getGeometryData': 'getGeometryData() — Current stats (same as #geometry-data)',
-        'validate': 'validate(code) — Check code without rendering → {valid, error?}',
-        'getCode': 'getCode() — Read editor contents',
-        'setCode': 'setCode(code) — Set editor contents (no auto-run)',
+        'run': 'run(code?) -- Run code, update views, return geometry stats',
+        'getGeometryData': 'getGeometryData() -- Current stats as JSON object',
+        'validate': 'validate(code) -- Check code without rendering -> {valid, error?}',
+        'getCode': 'getCode() -- Read editor contents',
+        'setCode': 'setCode(code) -- Set editor contents (no auto-run)',
         // Isolated execution
-        'runIsolated': 'await runIsolated(code) — Test code without side effects → {geometryData, thumbnail}',
-        'runAndAssert': 'await runAndAssert(code, assertions) — Validate geometry → {passed, failures?, stats}',
-        'runAndExplain': 'await runAndExplain(code) — Debug disconnected components → {stats, components[], hints[]}',
-        'modifyAndTest': 'await modifyAndTest(patchFn, assertions?) — Modify + test without committing',
-        'query': 'query({sliceAt?, decompose?, boundingBox?}) — Multi-query current geometry',
+        'runIsolated': 'await runIsolated(code) -- Test code without side effects -> {geometryData, thumbnail}',
+        'runAndAssert': 'await runAndAssert(code, assertions) -- Validate geometry -> {passed, failures?, stats}',
+        'runAndExplain': 'await runAndExplain(code) -- Debug disconnected components -> {stats, components[], hints[]}',
+        'modifyAndTest': 'await modifyAndTest(patchFn, assertions?) -- Modify + test without committing',
+        'query': 'query({sliceAt?, decompose?, boundingBox?}) -- Multi-query current geometry',
         // Sessions
-        'createSession': 'await createSession(name?) — Create session → {id, url, galleryUrl}',
-        'runAndSave': 'await runAndSave(code, label?, assertions?) — Assert + save version in one call',
-        'saveVersion': 'await saveVersion(label?) — Save current state as version',
-        'listVersions': 'await listVersions() — List all versions in session',
-        'loadVersion': 'await loadVersion(index) — Load specific version',
-        'openSession': 'await openSession(id) — Open existing session',
-        'listSessions': 'await listSessions() — List all sessions',
-        'getSessionContext': 'await getSessionContext() — Get full session context (for resuming)',
-        'getGalleryUrl': 'getGalleryUrl() — URL for gallery view (human review)',
+        'createSession': 'await createSession(name?) -- Create session -> {id, url, galleryUrl}',
+        'runAndSave': 'await runAndSave(code, label?, assertions?) -- Assert + save version in one call',
+        'saveVersion': 'await saveVersion(label?) -- Save current state as version',
+        'listVersions': 'await listVersions() -- List all versions in session',
+        'loadVersion': 'await loadVersion(index) -- Load specific version',
+        'openSession': 'await openSession(id) -- Open existing session',
+        'listSessions': 'await listSessions() -- List all sessions',
+        'getSessionContext': 'await getSessionContext() -- Get full session context (for resuming)',
+        'getGalleryUrl': 'getGalleryUrl() -- URL for gallery view (human review)',
         // Notes
-        'addSessionNote': 'await addSessionNote(text) — Add note with [PREFIX] tag',
-        'listSessionNotes': 'await listSessionNotes() — List all session notes',
+        'addSessionNote': 'await addSessionNote(text) -- Add note with [PREFIX] tag',
+        'listSessionNotes': 'await listSessionNotes() -- List all session notes',
         // Inspection
-        'sliceAtZ': 'sliceAtZ(z) — Cross-section at height → {polygons, svg, area}',
-        'getBoundingBox': 'getBoundingBox() — → {min, max}',
-        'renderView': 'renderView({elevation?, azimuth?, ortho?, size?}) — Render from any angle → data URL',
-        'analyzeProfile': 'analyzeProfile(sampleCount?) — Z-profile feature summary',
-        'measureAt': 'measureAt([x,y]) — Ray-cast probe at XY → {hits, thickness, topZ, bottomZ}',
+        'sliceAtZ': 'sliceAtZ(z) -- Cross-section at height -> {polygons, svg, area}',
+        'getBoundingBox': 'getBoundingBox() -- -> {min, max}',
+        'renderView': 'renderView({elevation?, azimuth?, ortho?, size?}) -- Render from any angle -> data URL',
+        'analyzeProfile': 'analyzeProfile(sampleCount?) -- Z-profile feature summary',
+        'measureAt': 'measureAt([x,y]) -- Ray-cast probe at XY -> {hits, thickness, topZ, bottomZ}',
         // View
-        'setView': 'setView(tab) — Switch tab: "interactive", "ai", "elevations", "gallery"',
-        'getViewState': 'getViewState() — Current tab and camera state',
+        'setView': 'setView(tab) -- Switch tab: "interactive", "ai", "elevations", "gallery"',
+        'getViewState': 'getViewState() -- Current tab and camera state',
         // Export
-        'exportGLB': 'await exportGLB() — Download GLB file',
-        'exportSTL': 'exportSTL() — Download STL file',
-        'exportOBJ': 'exportOBJ() — Download OBJ file',
-        'export3MF': 'export3MF() — Download 3MF file',
+        'exportGLB': 'await exportGLB() -- Download GLB file',
+        'exportSTL': 'exportSTL() -- Download STL file',
+        'exportOBJ': 'exportOBJ() -- Download OBJ file',
+        'export3MF': 'export3MF() -- Download 3MF file',
       };
 
       if (method) {
         const entry = methods[method];
         if (entry) {
           console.log(entry);
-          return entry;
+          return { method, description: entry };
         }
-        return `Unknown method "${method}". Call help() for full list.`;
+        const msg = `Unknown method "${method}". Call help() for full list.`;
+        console.log(msg);
+        return { error: msg };
       }
 
+      const result = {
+        app: 'mAInifold -- AI-driven parametric CAD in the browser',
+        docs: '/ai.md',
+        constraints: {
+          codeMustReturn: 'Code must end with: return <Manifold object>;',
+          noUIAutomation: 'Do not drive the app with clicks or keystrokes. Use this API.',
+        },
+        quickstart: [
+          'mainifold.help()                        // You are here',
+          'await mainifold.createSession("name")   // Start a named session',
+          'await mainifold.runAndSave(code, "v1", {isManifold: true, maxComponents: 1})',
+        ],
+        methods,
+      };
+
+      // Also log a readable summary to the console
       const lines = [
-        'mAInifold — AI-driven parametric CAD. Full docs: /ai.md',
+        'mAInifold -- AI-driven parametric CAD. Full docs: /ai.md',
         '',
-        'IMPORTANT: Code must end with "return manifoldObject;"',
-        'Do NOT drive the UI with clicks/keystrokes — use this API.',
+        'Code must end with: return <Manifold object>;',
+        'Do not drive the UI with clicks/keystrokes -- use this API.',
         '',
-        ...Object.values(methods),
+        'Quickstart:',
+        '  await mainifold.createSession("name")',
+        '  await mainifold.runAndSave(code, "v1", {isManifold: true, maxComponents: 1})',
+        '',
+        'Methods:',
+        ...Object.values(methods).map(m => `  ${m}`),
       ];
-      const output = lines.join('\n');
-      console.log(output);
-      return output;
+      console.log(lines.join('\n'));
+
+      return result;
     },
   };
 
   (window as unknown as Record<string, unknown>).mainifold = mainifoldAPI;
 
   // Log API availability for AI agents
-  console.log(
-    '%c[mAInifold]%c Console API available at %cwindow.mainifold%c\n' +
-    'Methods: .run(code?), .getGeometryData(), .getCode(), .setCode(code),\n' +
-    '         .sliceAtZ(z), .getBoundingBox(), .validate(code),\n' +
-    '         .toggleClip(on?), .setClipZ(z), .getClipState(),\n' +
-    '         .getModule(), .exportGLB(), .exportSTL(), .exportOBJ(), .export3MF()\n' +
-    'Isolated: .runIsolated(code), .runAndAssert(code, assertions),\n' +
-    '          .runAndExplain(code), .isRunning()\n' +
-    'Intelligence: .analyzeProfile(), .analyzeProfileIsolated(code),\n' +
-    '              .measureAt([x,y]), .measureBetween(p1,p2), .probeRay(origin,dir),\n' +
-    '              .checkContainment()\n' +
-    'View: .getViewState(), .setView(tab), .setUnits(unit), .getUnits()\n' +
-    'Phantom: .setReferenceGeometry(code, opts?), .clearReferenceGeometry(),\n' +
-    '         .hasReferenceGeometry()\n' +
-    'Measure: .measureMode(enabled?), .getMeasurement(), .measurePoints(p1,p2)\n' +
-    'Sessions: .createSession(name?), .saveVersion(label?), .runAndSave(code, label?),\n' +
-    '          .createSessionWithVersions(name, [{code,label},...]),\n' +
-    '          .listSessions(), .openSession(id), .listVersions(), .loadVersion(idx),\n' +
-    '          .renameSession(name, id?), .getGalleryUrl(), .getSessionUrl(),\n' +
-    '          .getSessionState(), .getSessionContext(),\n' +
-    '          .exportSession(id?), .importSession(data), .clearAllSessions()\n' +
-    'Notes: .addSessionNote(text), .listSessionNotes(),\n' +
-    '       .updateSessionNote(noteId, text), .deleteSessionNote(noteId)\n' +
-    'Structured data: document.getElementById("geometry-data").textContent',
-    'color: #4ade80; font-weight: bold',
-    'color: inherit',
-    'color: #60a5fa; font-weight: bold',
-    'color: inherit',
-  );
+  console.info('mAInifold: AI agents should use window.mainifold -- start with mainifold.help(). See /llms.txt');
 
   // === Internal functions ===
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,27 @@
-import { defineConfig, type Plugin } from 'vite';
+import { defineConfig, type Plugin, type Connect } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
+
+// Set charset=utf-8 on .md and .txt files served from public/ during dev.
+// Prevents em-dashes and other UTF-8 chars from rendering as mojibake.
+function markdownCharset(): Plugin {
+  return {
+    name: 'markdown-charset',
+    configureServer(server) {
+      server.middlewares.use(((req: Connect.IncomingMessage, res, next) => {
+        if (req.url && /\.(md|txt)(\?|$)/.test(req.url)) {
+          const origSetHeader = res.setHeader.bind(res);
+          res.setHeader = (name: string, value: string | number | readonly string[]) => {
+            if (name.toLowerCase() === 'content-type' && typeof value === 'string' && !value.includes('charset')) {
+              return origSetHeader(name, value + '; charset=utf-8');
+            }
+            return origSetHeader(name, value);
+          };
+        }
+        next();
+      }) as Connect.NextHandleFunction);
+    },
+  };
+}
 
 // Resolve relative paths to absolute URLs at build time.
 // Checks SITE_URL (custom env var) then CF_PAGES_URL (Cloudflare Pages built-in).
@@ -31,7 +53,7 @@ function absoluteUrls(): Plugin {
 
 export default defineConfig({
   base: '/',
-  plugins: [tailwindcss(), absoluteUrls()],
+  plugins: [tailwindcss(), absoluteUrls(), markdownCharset()],
   optimizeDeps: {
     exclude: ['manifold-3d']
   },


### PR DESCRIPTION
## Summary

Improve AI agent discoverability so agents find and use the `window.mainifold` programmatic API instead of falling back to UI-driven automation. Based on feedback from two agent sessions.

### Commit 1: Initial discoverability
- Hidden `#ai-agent-readme` DOM banner so agents discover the API on first page observation
- "Before you start" TL;DR and "Common agent mistakes" at top of `ai.md`
- `mainifold.help(method?)` self-documenting method
- Seed new sessions with `[WORKFLOW]` note
- `llms.txt` and `robots.txt` AI comment

### Commit 2: Refinement from Chrome agent feedback
- **Shrink banner to pure signpost** -- separates "where to look" from "what to do" (avoids prompt-injection caution in security-conscious agents)
- **`<meta name="ai-instructions">`** tag in `<head>`
- **Expand `llms.txt`** with quickstart code block so agents can start working without a second hop
- **Restructure `ai.md`**: intro paragraph + table of contents first, then checklist and mistakes
- **`help()` returns structured object** (`{app, docs, quickstart, constraints, methods}`) -- capability discovery via API, not untrusted DOM
- **Concise `console.info`** one-liner replaces verbose console.log block
- **UI-input warning** when `?view=ai` is set: toast + `console.warn` on first click/keydown, fires once, doesn't block human use
- **Encoding fix**: serve `.md`/`.txt` with `charset=utf-8` (Vite middleware for dev, Cloudflare `_headers` for prod)
- **ai.md polish**: hardcoded ports -> relative paths, non-ASCII -> ASCII, sandbox environment documented, `notes` added to assertions spec, photo-to-model flagged as optional, `#geometry-data` demoted below `getGeometryData()`, "not reading session context" added to common mistakes

## Test plan

- [ ] `npm run build` passes
- [ ] Load `/editor?view=ai` -- inspect DOM, confirm `#ai-agent-readme` div contains only a signpost (no API names or code)
- [ ] `<meta name="ai-instructions">` present in page `<head>`
- [ ] Browser console shows single `console.info` line mentioning `window.mainifold` and `/llms.txt`
- [ ] `window.mainifold.help()` returns an object with `app`, `docs`, `quickstart`, `constraints`, `methods` keys
- [ ] `window.mainifold.help('runAndSave')` returns `{method, description}` object
- [ ] `await window.mainifold.createSession("test")` then `await mainifold.listSessionNotes()` shows `[WORKFLOW]` note
- [ ] Click in the editor while `?view=ai` is set -- toast appears with warning, console.warn logged, only fires once
- [ ] Manual use at `/editor` (no `?view=ai`) -- no toast or warning on clicks
- [ ] `/ai.md` renders without mojibake (no garbled em-dashes)
- [ ] `/ai.md` has intro + TOC before "Before you start" checklist
- [ ] `/ai.md` has no `localhost:5173` references (relative paths only)
- [ ] `/llms.txt` has quickstart code block and ## Docs section
- [ ] `/ai.md` assertions spec includes `notes` key
- [ ] Photo-to-model section has "Optional tooling" callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)