### PR TITLE
Improve agent discoverability: redirects, agentHints, error links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ const ctx = await mainifold.getSessionContext();
 // ctx.versions   — [{index, label, timestamp, notes?, geometrySummary: {volume, boundingBox, ...}}]
 // ctx.notes      — [{id, text, timestamp}]
 // ctx.currentVersion — {index, label}
+// ctx.agentHints — {apiDocsUrl, recommendedEntrypoint, codeMustReturnManifold, recentErrors}
 ```
 
 Read the notes and version history before making changes. The notes tell you what was required, what was tried, what feedback was given, and what measurements matter. Continue the note-logging pattern as you work.
@@ -784,7 +785,8 @@ const ctx = await mainifold.getSessionContext()
 // → { session: {id, name, created, updated},
 //     versions: [{index, label, timestamp, notes?, geometrySummary: {volume, surfaceArea, boundingBox, ...}}],
 //     notes: [{id, text, timestamp}],
-//     currentVersion: {index, label}, versionCount }
+//     currentVersion: {index, label}, versionCount,
+//     agentHints: {apiDocsUrl, recommendedEntrypoint, codeMustReturnManifold, recentErrors} }
 
 // Version notes — attach design rationale to a specific version
 await mainifold.runAndSave(code, "v2 - thicker walls", {

--- a/prompts/20260418-agent-discoverability-followup.md
+++ b/prompts/20260418-agent-discoverability-followup.md
@@ -1,0 +1,31 @@
+---
+session: "agent-discoverability-followup"
+timestamp: "2026-04-18T21:15:00Z"
+model: claude-opus-4-6
+tools: [claude-code]
+---
+
+## Human
+
+The modeler AI provided a 12-point feedback document on agent discoverability gaps. Most items were already addressed by PR #16. The user asked me to evaluate the feedback, then implement the remaining worthwhile improvements.
+
+## Assessment
+
+Of the 12 proposed changes, 8 were already implemented. Three were recommended:
+1. Add /ai, /agent, /api redirects to /ai.md
+2. Add agentHints field to getSessionContext() with recentErrors tracking
+3. Improve the "must return a Manifold" error message with a docs link
+
+Three were rejected:
+- Auto-return bare expressions (risky AST rewriting)
+- Expose raw CodeMirror view (invites the behavior we're preventing)
+- ?agent=1 query param with UI dimming (over-engineered, ?view=ai already exists)
+
+## Changes
+
+- `public/_redirects`: Add /ai, /agent, /api -> /ai.md 301 redirects
+- `src/storage/sessionManager.ts`: Add error ring buffer (last 5 errors) and agentHints field to SessionContext type and getSessionContext() return value
+- `src/main.ts`: Import recordError, call it on execution failures in executeIsolated() and runCodeSync()
+- `src/geometry/engine.ts`: Append "/ai.md#before-you-start" link to missing-return error message
+- `public/ai.md`: Document agentHints in API reference and resuming-a-session sections
+- `CLAUDE.md`: Document agentHints in getSessionContext() examples

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,4 @@
+/ai /ai.md 301
+/agent /ai.md 301
+/api /ai.md 301
 /* /index.html 200

--- a/public/ai.md
+++ b/public/ai.md
@@ -96,7 +96,8 @@ await mainifold.updateSessionNote(noteId, text) // Edit a note
 await mainifold.deleteSessionNote(noteId)       // Remove a note
 
 // Session context -- get everything in one call (for resuming sessions)
-await mainifold.getSessionContext()     // -> {session, versions[], notes[], currentVersion, versionCount}
+await mainifold.getSessionContext()     // -> {session, versions[], notes[], currentVersion, versionCount, agentHints}
+// agentHints: {apiDocsUrl, recommendedEntrypoint, codeMustReturnManifold, recentErrors[]}
 ```
 
 ## Geometry data
@@ -434,6 +435,8 @@ const ctx = await mainifold.getSessionContext();
 // ctx.notes      -- [{id, text, timestamp}]  (all session notes)
 // ctx.currentVersion -- {index, label}
 // ctx.versionCount
+// ctx.agentHints -- {apiDocsUrl, recommendedEntrypoint, codeMustReturnManifold, recentErrors}
+//   recentErrors: last 5 validation errors from this page session (helps avoid repeating mistakes)
 ```
 
 Read the notes and version history before making changes. The notes tell you:

--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -45,7 +45,7 @@ export function executeCode(jsCode: string): MeshResult {
       return {
         mesh: null,
         manifold: null,
-        error: 'Code must return a Manifold object. Did you forget to `return` the final Manifold?',
+        error: 'Code must return a Manifold object. Did you forget to `return` the final Manifold? See /ai.md#before-you-start',
       };
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,7 @@ import {
   deleteSessionNote,
   updateSessionNote,
   getSessionContext,
+  recordError,
   onStateChange,
   type ExportedSession,
   type ReferenceImagesData,
@@ -754,6 +755,7 @@ async function main() {
     const elapsed = Math.round(performance.now() - t0);
 
     if (result.error) {
+      recordError(result.error);
       return {
         geometryData: { status: 'error' as const, error: result.error, executionTimeMs: elapsed, codeHash: simpleHash(code) },
         meshData: null as MeshData | null,
@@ -1648,6 +1650,7 @@ async function main() {
     _running = false;
 
     if (result.error) {
+      recordError(result.error);
       setStatus(statusBar, 'error', result.error);
       geometryDataEl.textContent = JSON.stringify({ status: 'error', error: result.error, executionTimeMs: elapsed, codeHash: simpleHash(src) });
       return;

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -283,6 +283,20 @@ export async function updateSessionNote(noteId: string, text: string): Promise<v
   await dbUpdateNote(noteId, text);
 }
 
+// === Recent error tracking (for agentHints) ===
+
+const recentErrors: { error: string; timestamp: number }[] = [];
+const MAX_RECENT_ERRORS = 5;
+
+export function recordError(error: string): void {
+  recentErrors.push({ error, timestamp: Date.now() });
+  if (recentErrors.length > MAX_RECENT_ERRORS) recentErrors.shift();
+}
+
+export function getRecentErrors(): { error: string; timestamp: number }[] {
+  return [...recentErrors];
+}
+
 // === Session context (single call for AI agents) ===
 
 export interface SessionContext {
@@ -304,6 +318,12 @@ export interface SessionContext {
   notes: { id: string; text: string; timestamp: number }[];
   currentVersion: { index: number; label: string } | null;
   versionCount: number;
+  agentHints: {
+    apiDocsUrl: string;
+    recommendedEntrypoint: string;
+    codeMustReturnManifold: boolean;
+    recentErrors: { error: string; timestamp: number }[];
+  };
 }
 
 export async function getSessionContext(): Promise<SessionContext | null> {
@@ -343,6 +363,12 @@ export async function getSessionContext(): Promise<SessionContext | null> {
       ? { index: currentState.currentVersion.index, label: currentState.currentVersion.label }
       : null,
     versionCount: currentState.versionCount,
+    agentHints: {
+      apiDocsUrl: '/ai.md',
+      recommendedEntrypoint: 'runAndSave',
+      codeMustReturnManifold: true,
+      recentErrors: getRecentErrors(),
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #16 (agent discoverability). Implements three improvements from modeler AI feedback:

- **URL redirects**: `/ai`, `/agent`, `/api` all 301-redirect to `/ai.md` so agents probing standard paths find the docs
- **`agentHints` in `getSessionContext()`**: New field with `apiDocsUrl`, `recommendedEntrypoint`, `codeMustReturnManifold`, and `recentErrors` (ring buffer of last 5 validation errors) -- helps agents resuming sessions avoid repeating predecessor mistakes
- **Better error message**: The "must return a Manifold" error now includes a link to `/ai.md#before-you-start`

## Test plan

- [ ] `npm run build` passes
- [ ] Visit `/ai` in browser -- should redirect to `/ai.md`
- [ ] Run code without `return` statement -- error message includes `/ai.md#before-you-start`
- [ ] Create a session, trigger some errors, call `getSessionContext()` -- verify `agentHints.recentErrors` contains the errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)