### PR TITLE
Add forkVersion + unify loadVersion API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -762,7 +762,11 @@ await mainifold.closeSession()
 
 // Version navigation
 await mainifold.listVersions()        // → [{id, index, label, timestamp, status}]
-await mainifold.loadVersion(2)        // Load version by index
+await mainifold.loadVersion(2)        // Load by index (number) or id (string)
+                                      // → {id, index, label, code, geometryData} or {error}
+await mainifold.forkVersion(2, code => code.replace('h = 10', 'h = 20'), "v2a - taller", { isManifold: true })
+                                      // Load parent + apply transform + validate + save in one call
+                                      // → {passed?, parent, geometry, version, diff, galleryUrl} or {error}
 await mainifold.navigateVersion('prev')
 await mainifold.navigateVersion('next')
 await mainifold.saveVersion("label")  // Save current state as version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -762,11 +762,11 @@ await mainifold.closeSession()
 
 // Version navigation
 await mainifold.listVersions()        // → [{id, index, label, timestamp, status}]
-await mainifold.loadVersion(2)        // Load by index (number) or id (string)
-                                      // → {id, index, label, code, geometryData} or {error}
-await mainifold.forkVersion(2, code => code.replace('h = 10', 'h = 20'), "v2a - taller", { isManifold: true })
-                                      // Load parent + apply transform + validate + save in one call
-                                      // → {passed?, parent, geometry, version, diff, galleryUrl} or {error}
+await mainifold.loadVersion({ index: 2 })   // or { id: "Kx3Pq9mA2wEr" } from listVersions()
+                                             // → {id, index, label, code, geometryData} or {error}
+await mainifold.forkVersion({ index: 2 }, code => code.replace('h = 10', 'h = 20'), "v2a - taller", { isManifold: true })
+                                             // Load parent + apply transform + validate + save in one call
+                                             // → {passed?, parent, geometry, version, diff, galleryUrl} or {error}
 await mainifold.navigateVersion('prev')
 await mainifold.navigateVersion('next')
 await mainifold.saveVersion("label")  // Save current state as version

--- a/prompts/20260421-version-forking-api.md
+++ b/prompts/20260421-version-forking-api.md
@@ -1,0 +1,77 @@
+---
+session: "version-forking-api"
+timestamp: "2026-04-21T16:00:00Z"
+model: claude-opus-4-6
+tools: [claude-code]
+---
+
+## Human
+
+A browser-based AI session regressed mid-iteration: while producing a
+v11a/v12a/v13a branch, it lost parts of the parent design. The agent's
+post-mortem blamed `getCode()` returning stale content after
+`loadVersion(id)` and asked for either a version return shape that
+includes code or a one-shot fork helper. User asked for an assessment
+plus a proposal.
+
+## Assessment
+
+Traced the flow. The immediate trigger was almost certainly an argument
+mismatch: `loadVersion` accepts a 1-based **index**, but `listVersions()`
+returns `id` as the first field and the agent's message literally says
+"loadVersion(id)". Passing a string id to `getVersionByIndex` returns
+null, so `loadVersion` returns null and never calls `setValue` — the
+editor buffer (v13) stays put, and `getCode()` returns that buffer.
+CodeMirror's `dispatch` is synchronous, so there's no read-after-write
+race.
+
+That's the root cause, but the design issues behind it are real:
+1. `loadVersion(index)` is ambiguous given `listVersions()[].id` is first.
+2. `loadVersion` doesn't return code/geometryData, forcing a separate
+   `getCode()` — vulnerable to the Chrome extension's content filter
+   that blocks JS-like strings.
+3. No atomic fork primitive, so parallel branches (v11a, v11b...)
+   require a 4-step chain with silent-failure surface area at each step.
+
+## Decisions
+
+- Return `{error: "..."}` on failure, not throw — matches the
+  convention used by `sliceAtZ`, `modifyAndTest`, `getSessionContext`,
+  `help()`. Keep `id` out of the error branch so truthy checks on
+  `result.id` still work as success tests.
+- Accept either `number` (index) or `string` (id) via runtime type
+  dispatch in `loadVersion` and `forkVersion`, rather than introducing
+  separate `loadVersionById` methods. Error messages call out which
+  kind of arg was received.
+- `forkVersion` re-uses the existing `runAndSave` pattern (validate in
+  isolation, commit atomically, return diff + galleryUrl), adding a
+  `parent` field so the agent sees which version was forked even on
+  assertion failure.
+- `peekVersion` (read-only lookup that doesn't mutate current-version
+  state) added to sessionManager so `forkVersion` can read the parent
+  without moving the session pointer before save.
+- Cross-session id lookups are rejected in `loadVersion`/`peekVersion`
+  to avoid an agent accidentally loading a version from a different
+  session by id.
+
+## Changes
+
+- `src/storage/db.ts`: Add `getVersionById(id)` for id-based lookup.
+- `src/storage/sessionManager.ts`: Rename `loadVersionByIndex` ->
+  `loadVersion(target: number | string)`; add `peekVersion` for
+  state-free reads.
+- `src/main.ts`: `loadVersion` now returns
+  `{id, index, label, code, geometryData}` or `{error}`; new
+  `forkVersion(target, transformFn, label?, assertions?)` that loads +
+  transforms + validates + saves in one call; `help()` entries updated.
+- `src/ui/gallery.ts`: Import rename to match new sessionManager API.
+- `public/ai.md`: New "Forking a prior version" section; updated
+  console API block; two new "Common agent mistakes" bullets
+  (index-vs-id gotcha, don't hand-chain load/getCode/save).
+- `CLAUDE.md`: Version navigation block documents both new shapes.
+
+## Workflow
+
+Branched off `origin/staging` (at merge commit `8953386` for PR #17),
+not off `main`, per project convention that all work goes through
+staging first.

--- a/prompts/20260421-version-forking-api.md
+++ b/prompts/20260421-version-forking-api.md
@@ -39,10 +39,17 @@ That's the root cause, but the design issues behind it are real:
   convention used by `sliceAtZ`, `modifyAndTest`, `getSessionContext`,
   `help()`. Keep `id` out of the error branch so truthy checks on
   `result.id` still work as success tests.
-- Accept either `number` (index) or `string` (id) via runtime type
-  dispatch in `loadVersion` and `forkVersion`, rather than introducing
-  separate `loadVersionById` methods. Error messages call out which
-  kind of arg was received.
+- Public `loadVersion` and `forkVersion` take an object arg with
+  exactly one of `{ index: number }` or `{ id: string }`. Initial
+  proposal used runtime `typeof` dispatch on a bare `number | string`
+  param; switched to object args after the user flagged that dual-type
+  params read as a code smell even when `typeof` mechanically separates
+  them. Object args are self-documenting (`{index: 2}` vs
+  `{id: "..."}`), reject both-set / neither-set at the boundary, and
+  keep forkVersion's call site readable. Internal sessionManager
+  helpers (`loadVersion`, `peekVersion`) still accept the looser
+  `number | string` — the object-arg unwrapping happens at the public
+  boundary only.
 - `forkVersion` re-uses the existing `runAndSave` pattern (validate in
   isolation, commit atomically, return diff + galleryUrl), adding a
   `parent` field so the agent sees which version was forked even on

--- a/public/ai.md
+++ b/public/ai.md
@@ -34,6 +34,8 @@ mAInifold is a browser-based parametric CAD tool powered by manifold-3d (WASM). 
 - **Skipping visual verification** -- stats alone can't catch visual defects. After structural changes, screenshot the Elevations tab or use `renderView()`.
 - **Flush boolean placement** -- shapes must overlap by at least 0.5 units to union correctly. Merely touching at a face produces disconnected components.
 - **Not reading session context before modifying** -- when opening an existing session, always call `getSessionContext()` first and read the notes/version history before making changes. See [Resuming a session](#resuming-a-session).
+- **Branching off a prior version by hand** -- don't chain `loadVersion` -> `getCode` -> modify -> `runAndSave`. A silent failure (wrong arg, blocked return value, stale buffer) can drop parts of the parent. Use [`forkVersion(indexOrId, transformFn, label, assertions?)`](#forking-a-prior-version) instead -- it loads the parent's code server-side, applies your transform, validates, and saves atomically.
+- **Passing an id where an index is expected (or vice versa)** -- `loadVersion` and `forkVersion` both accept either, but older code assumed numeric index only. If you see `{ error: "No version found with ..." }`, check `listVersions()` and confirm whether you're passing `.index` or `.id`.
 
 ## How to use this tool
 
@@ -82,7 +84,8 @@ await mainifold.runAndSave(code, label?, assertions?) // Assert+save in one call
 await mainifold.createSessionWithVersions(name, [{code, label},...]) // Batch create
 await mainifold.saveVersion(label?)     // Save current state as version
 await mainifold.listVersions()          // -> [{id, index, label, timestamp, status}]
-await mainifold.loadVersion(index)      // Load specific version
+await mainifold.loadVersion(indexOrId)  // Load version into editor -> {id, index, label, code, geometryData} or {error}
+await mainifold.forkVersion(indexOrId, transformFn, label?, assertions?) // Load + modify + validate + save in one call
 mainifold.getGalleryUrl()               // -> URL for gallery view (human review)
 mainifold.getSessionUrl()               // -> URL for this session
 await mainifold.listSessions()          // -> [{id, name, updated}]
@@ -351,6 +354,36 @@ const r = await mainifold.runAndSave(code, "v2 - added towers", {
 // r.diff         = { volume: { from, to, delta }, componentCount: ..., ... }
 // r.galleryUrl   = gallery URL for human review
 ```
+
+### Forking a prior version
+
+When iterating on a design, the common flow is *load a previous version, tweak it, save as a new version*.
+Doing that across separate `loadVersion` -> `getCode` -> modify -> `runAndSave` calls is fragile: if any
+step fails silently (wrong arg type, a client-side content filter on `getCode`, etc.) you can end up saving
+a regression without noticing. `forkVersion` collapses the whole chain into one server-side call:
+
+```js
+const r = await mainifold.forkVersion(
+  11,                                  // index (from listVersions()[].index) or id string
+  code => code.replace('towerH = 28', 'towerH = 35'),
+  "v11a - taller towers",              // label for the new version
+  { isManifold: true, maxComponents: 1 } // optional assertions (validated before saving)
+);
+// On success:
+//   r.passed       = true (only when assertions provided)
+//   r.parent       = { id, index, label } of the version you forked from
+//   r.geometry     = full geometry stats
+//   r.version      = { id, index, label } of the newly saved version
+//   r.diff         = stat diff vs. the previous current version
+//   r.galleryUrl   = gallery URL for human review
+// On failure:
+//   r.error        = "No version found with index ..." / "transformFn threw: ..." / etc.
+//   r.passed=false + r.failures=[...] if assertions didn't pass (nothing saved)
+```
+
+`target` accepts either the numeric `index` or the string `id` from `listVersions()`. Use whichever you
+have — the function dispatches on type. This is the recommended way to build parallel branches
+(v11a, v11b, ...) off a shared parent without a load/read/modify/save round-trip chain.
 
 ### Modify and test
 

--- a/public/ai.md
+++ b/public/ai.md
@@ -34,8 +34,8 @@ mAInifold is a browser-based parametric CAD tool powered by manifold-3d (WASM). 
 - **Skipping visual verification** -- stats alone can't catch visual defects. After structural changes, screenshot the Elevations tab or use `renderView()`.
 - **Flush boolean placement** -- shapes must overlap by at least 0.5 units to union correctly. Merely touching at a face produces disconnected components.
 - **Not reading session context before modifying** -- when opening an existing session, always call `getSessionContext()` first and read the notes/version history before making changes. See [Resuming a session](#resuming-a-session).
-- **Branching off a prior version by hand** -- don't chain `loadVersion` -> `getCode` -> modify -> `runAndSave`. A silent failure (wrong arg, blocked return value, stale buffer) can drop parts of the parent. Use [`forkVersion(indexOrId, transformFn, label, assertions?)`](#forking-a-prior-version) instead -- it loads the parent's code server-side, applies your transform, validates, and saves atomically.
-- **Passing an id where an index is expected (or vice versa)** -- `loadVersion` and `forkVersion` both accept either, but older code assumed numeric index only. If you see `{ error: "No version found with ..." }`, check `listVersions()` and confirm whether you're passing `.index` or `.id`.
+- **Branching off a prior version by hand** -- don't chain `loadVersion` -> `getCode` -> modify -> `runAndSave`. A silent failure (blocked return value, stale buffer) can drop parts of the parent. Use [`forkVersion({index} | {id}, transformFn, label, assertions?)`](#forking-a-prior-version) instead -- it loads the parent's code server-side, applies your transform, validates, and saves atomically.
+- **Passing a bare index or id instead of `{index}` / `{id}`** -- `loadVersion` and `forkVersion` take an object with exactly one of `{index: number}` or `{id: string}`, e.g. `loadVersion({index: 2})` or `loadVersion({id: "Kx3Pq9mA2wEr"})`. Bare `loadVersion(2)` will return `{error: "...target must be { index: number } or { id: string }..."}`.
 
 ## How to use this tool
 
@@ -84,8 +84,8 @@ await mainifold.runAndSave(code, label?, assertions?) // Assert+save in one call
 await mainifold.createSessionWithVersions(name, [{code, label},...]) // Batch create
 await mainifold.saveVersion(label?)     // Save current state as version
 await mainifold.listVersions()          // -> [{id, index, label, timestamp, status}]
-await mainifold.loadVersion(indexOrId)  // Load version into editor -> {id, index, label, code, geometryData} or {error}
-await mainifold.forkVersion(indexOrId, transformFn, label?, assertions?) // Load + modify + validate + save in one call
+await mainifold.loadVersion({index} | {id})  // Load version into editor -> {id, index, label, code, geometryData} or {error}
+await mainifold.forkVersion({index} | {id}, transformFn, label?, assertions?) // Load + modify + validate + save in one call
 mainifold.getGalleryUrl()               // -> URL for gallery view (human review)
 mainifold.getSessionUrl()               // -> URL for this session
 await mainifold.listSessions()          // -> [{id, name, updated}]
@@ -364,7 +364,7 @@ a regression without noticing. `forkVersion` collapses the whole chain into one 
 
 ```js
 const r = await mainifold.forkVersion(
-  11,                                  // index (from listVersions()[].index) or id string
+  { index: 11 },                       // or { id: "Kx3Pq9mA2wEr" } from listVersions()
   code => code.replace('towerH = 28', 'towerH = 35'),
   "v11a - taller towers",              // label for the new version
   { isManifold: true, maxComponents: 1 } // optional assertions (validated before saving)
@@ -381,9 +381,10 @@ const r = await mainifold.forkVersion(
 //   r.passed=false + r.failures=[...] if assertions didn't pass (nothing saved)
 ```
 
-`target` accepts either the numeric `index` or the string `id` from `listVersions()`. Use whichever you
-have — the function dispatches on type. This is the recommended way to build parallel branches
-(v11a, v11b, ...) off a shared parent without a load/read/modify/save round-trip chain.
+`target` is an object with exactly one of `{ index }` (numeric, 1-based) or `{ id }` (string from
+`listVersions()[].id`). The two are never mixed, so there's no ambiguity about which field is being
+looked up. This is the recommended way to build parallel branches (v11a, v11b, ...) off a shared
+parent without a load/read/modify/save round-trip chain.
 
 ### Modify and test
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,8 @@ import {
   renameSession,
   saveVersion,
   navigateVersion,
-  loadVersionByIndex,
+  loadVersion as loadVersionFromStore,
+  peekVersion,
   listCurrentVersions,
   getState,
   getSessionUrl,
@@ -992,14 +993,30 @@ async function main() {
       }));
     },
 
-    /** Load a specific version by index */
-    async loadVersion(index: number) {
-      const version = await loadVersionByIndex(index);
-      if (version) {
-        setValue(version.code);
-        runCodeSync(version.code);
+    /** Load a version into the editor by index (number, 1-based from listVersions()[].index)
+     *  or id (string, from listVersions()[].id). Returns the loaded version's code and stats,
+     *  or { error } if not found. */
+    async loadVersion(target: number | string) {
+      if (target === undefined || target === null || (typeof target !== 'number' && typeof target !== 'string')) {
+        return { error: 'loadVersion(target): target must be a number (index) or string (id) from listVersions()' };
       }
-      return version ? { id: version.id, index: version.index, label: version.label } : null;
+      if (!getState().session) {
+        return { error: 'No active session. Call openSession(id) or createSession() first.' };
+      }
+      const version = await loadVersionFromStore(target);
+      if (!version) {
+        const kind = typeof target === 'number' ? 'index' : 'id';
+        return { error: `No version found with ${kind} "${target}" in the active session. Use listVersions() to see valid ${kind}s.` };
+      }
+      setValue(version.code);
+      runCodeSync(version.code);
+      return {
+        id: version.id,
+        index: version.index,
+        label: version.label,
+        code: version.code,
+        geometryData: version.geometryData,
+      };
     },
 
     /** Navigate to previous or next version */
@@ -1050,6 +1067,82 @@ async function main() {
 
       return {
         ...(assertions ? { passed: true } : {}),
+        geometry: newGeoData,
+        version: version ? { id: version.id, index: version.index, label: version.label } : null,
+        diff,
+        galleryUrl: getGalleryUrl(),
+      };
+    },
+
+    /** Fork a prior version: load its code, apply transformFn, validate, and save as a new version.
+     *  target: index (number) or id (string) from listVersions().
+     *  transformFn: (code: string) => string — modifies the parent's code. Return the full new code.
+     *  Eliminates the load + getCode + modify + save round-trip chain.
+     *  Returns { error } if the parent isn't found or transformFn throws.
+     *  Returns { passed, failures } without saving if assertions fail.
+     *  On success: { passed?, parent, geometry, version, diff, galleryUrl }. */
+    async forkVersion(
+      target: number | string,
+      transformFn: (code: string) => string,
+      label?: string,
+      assertions?: GeometryAssertions,
+    ) {
+      if (target === undefined || target === null || (typeof target !== 'number' && typeof target !== 'string')) {
+        return { error: 'forkVersion(target, transformFn): target must be a number (index) or string (id) from listVersions()' };
+      }
+      if (typeof transformFn !== 'function') {
+        return { error: 'forkVersion(target, transformFn): transformFn must be a function (code: string) => string' };
+      }
+      if (!getState().session) {
+        return { error: 'No active session. Call openSession(id) or createSession() first.' };
+      }
+
+      const parent = await peekVersion(target);
+      if (!parent) {
+        const kind = typeof target === 'number' ? 'index' : 'id';
+        return { error: `No version found with ${kind} "${target}" in the active session. Use listVersions() to see valid ${kind}s.` };
+      }
+
+      let newCode: string;
+      try {
+        newCode = transformFn(parent.code);
+      } catch (e: unknown) {
+        return { error: `transformFn threw: ${e instanceof Error ? e.message : String(e)}`, parent: { id: parent.id, index: parent.index, label: parent.label } };
+      }
+      if (typeof newCode !== 'string') {
+        return { error: `transformFn must return a string; got ${typeof newCode}`, parent: { id: parent.id, index: parent.index, label: parent.label } };
+      }
+
+      // Validate in isolation before committing anything.
+      const { geometryData: testData, manifold: testManifold } = executeIsolated(newCode);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      try { (testManifold as any)?.delete?.(); } catch { /* ignore */ }
+      if (testData.status === 'error') {
+        return { passed: false, failures: [testData.error as string], geometry: testData, parent: { id: parent.id, index: parent.index, label: parent.label }, version: null, diff: null, galleryUrl: getGalleryUrl() };
+      }
+      if (assertions) {
+        const failures = checkAssertions(testData, assertions);
+        if (failures.length > 0) {
+          return { passed: false, failures, geometry: testData, parent: { id: parent.id, index: parent.index, label: parent.label }, version: null, diff: null, galleryUrl: getGalleryUrl() };
+        }
+      }
+
+      // Commit: update editor, run, save.
+      const prevGeoData = getState().currentVersion?.geometryData as Record<string, unknown> | null;
+      setValue(newCode);
+      runCodeSync(newCode);
+      const newGeoData = JSON.parse(geometryDataEl.textContent || '{}');
+      const thumbnail = await captureThumbnail();
+      const version = await saveVersion(newCode, getGeometryDataObj(), thumbnail, label, assertions?.notes);
+
+      let diff = null;
+      if (prevGeoData && prevGeoData.status === 'ok' && newGeoData.status === 'ok') {
+        diff = computeStatDiff(prevGeoData, newGeoData);
+      }
+
+      return {
+        ...(assertions ? { passed: true } : {}),
+        parent: { id: parent.id, index: parent.index, label: parent.label },
         geometry: newGeoData,
         version: version ? { id: version.id, index: version.index, label: version.label } : null,
         diff,
@@ -1558,7 +1651,8 @@ async function main() {
         'runAndSave':      { signature: 'await runAndSave(code, label?, assertions?) -- Assert + save version in one call', docs: '/ai.md#assert--save-in-one-call' },
         'saveVersion':     { signature: 'await saveVersion(label?) -- Save current state as version', docs: '/ai.md#console-api--windowmainifold' },
         'listVersions':    { signature: 'await listVersions() -- List all versions in session', docs: '/ai.md#console-api--windowmainifold' },
-        'loadVersion':     { signature: 'await loadVersion(index) -- Load specific version', docs: '/ai.md#console-api--windowmainifold' },
+        'loadVersion':     { signature: 'await loadVersion(indexOrId) -- Load version into editor -> {id, index, label, code, geometryData} or {error}', docs: '/ai.md#console-api--windowmainifold' },
+        'forkVersion':     { signature: 'await forkVersion(indexOrId, transformFn, label?, assertions?) -- Load + modify + validate + save in one call', docs: '/ai.md#forking-a-prior-version' },
         'openSession':     { signature: 'await openSession(id) -- Open existing session', docs: '/ai.md#resuming-a-session' },
         'listSessions':    { signature: 'await listSessions() -- List all sessions', docs: '/ai.md#console-api--windowmainifold' },
         'getSessionContext': { signature: 'await getSessionContext() -- Get full session context (for resuming)', docs: '/ai.md#resuming-a-session' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -348,6 +348,37 @@ function getGeometryDataObj(): Record<string, unknown> | null {
   }
 }
 
+/** Validate a { index } | { id } version-target arg. Returns a parsed descriptor
+ *  or { error } with a caller-aware message. Exactly one of index/id must be set. */
+function parseVersionTarget(
+  target: unknown,
+  caller: string,
+): { kind: 'index'; value: number } | { kind: 'id'; value: string } | { error: string } {
+  const usage = `${caller}(target, ...): target must be { index: number } or { id: string } from listVersions()`;
+  if (target === null || typeof target !== 'object') {
+    return { error: usage };
+  }
+  const { index, id } = target as { index?: unknown; id?: unknown };
+  const hasIndex = index !== undefined;
+  const hasId = id !== undefined;
+  if (hasIndex && hasId) {
+    return { error: `${caller}: pass either { index } or { id }, not both.` };
+  }
+  if (!hasIndex && !hasId) {
+    return { error: usage };
+  }
+  if (hasIndex) {
+    if (typeof index !== 'number' || !Number.isFinite(index)) {
+      return { error: `${caller}: target.index must be a finite number (got ${typeof index}).` };
+    }
+    return { kind: 'index', value: index };
+  }
+  if (typeof id !== 'string' || id.length === 0) {
+    return { error: `${caller}: target.id must be a non-empty string (got ${typeof id}).` };
+  }
+  return { kind: 'id', value: id };
+}
+
 // Determine which page to show based on URL path and query params
 function shouldShowLanding(): boolean {
   const path = window.location.pathname;
@@ -993,20 +1024,18 @@ async function main() {
       }));
     },
 
-    /** Load a version into the editor by index (number, 1-based from listVersions()[].index)
-     *  or id (string, from listVersions()[].id). Returns the loaded version's code and stats,
-     *  or { error } if not found. */
-    async loadVersion(target: number | string) {
-      if (target === undefined || target === null || (typeof target !== 'number' && typeof target !== 'string')) {
-        return { error: 'loadVersion(target): target must be a number (index) or string (id) from listVersions()' };
-      }
+    /** Load a version into the editor. Pass { index } or { id } from listVersions().
+     *  Returns the loaded version's code and stats, or { error } if not found. */
+    async loadVersion(target: { index?: number; id?: string }) {
+      const parsed = parseVersionTarget(target, 'loadVersion');
+      if ('error' in parsed) return parsed;
       if (!getState().session) {
         return { error: 'No active session. Call openSession(id) or createSession() first.' };
       }
-      const version = await loadVersionFromStore(target);
+      const version = await loadVersionFromStore(parsed.value);
       if (!version) {
-        const kind = typeof target === 'number' ? 'index' : 'id';
-        return { error: `No version found with ${kind} "${target}" in the active session. Use listVersions() to see valid ${kind}s.` };
+        const kind = parsed.kind;
+        return { error: `No version found with ${kind} "${parsed.value}" in the active session. Use listVersions() to see valid ${kind}s.` };
       }
       setValue(version.code);
       runCodeSync(version.code);
@@ -1075,21 +1104,20 @@ async function main() {
     },
 
     /** Fork a prior version: load its code, apply transformFn, validate, and save as a new version.
-     *  target: index (number) or id (string) from listVersions().
+     *  target: { index } or { id } from listVersions().
      *  transformFn: (code: string) => string — modifies the parent's code. Return the full new code.
      *  Eliminates the load + getCode + modify + save round-trip chain.
      *  Returns { error } if the parent isn't found or transformFn throws.
      *  Returns { passed, failures } without saving if assertions fail.
      *  On success: { passed?, parent, geometry, version, diff, galleryUrl }. */
     async forkVersion(
-      target: number | string,
+      target: { index?: number; id?: string },
       transformFn: (code: string) => string,
       label?: string,
       assertions?: GeometryAssertions,
     ) {
-      if (target === undefined || target === null || (typeof target !== 'number' && typeof target !== 'string')) {
-        return { error: 'forkVersion(target, transformFn): target must be a number (index) or string (id) from listVersions()' };
-      }
+      const parsed = parseVersionTarget(target, 'forkVersion');
+      if ('error' in parsed) return parsed;
       if (typeof transformFn !== 'function') {
         return { error: 'forkVersion(target, transformFn): transformFn must be a function (code: string) => string' };
       }
@@ -1097,7 +1125,7 @@ async function main() {
         return { error: 'No active session. Call openSession(id) or createSession() first.' };
       }
 
-      const parent = await peekVersion(target);
+      const parent = await peekVersion(parsed.value);
       if (!parent) {
         const kind = typeof target === 'number' ? 'index' : 'id';
         return { error: `No version found with ${kind} "${target}" in the active session. Use listVersions() to see valid ${kind}s.` };
@@ -1651,8 +1679,8 @@ async function main() {
         'runAndSave':      { signature: 'await runAndSave(code, label?, assertions?) -- Assert + save version in one call', docs: '/ai.md#assert--save-in-one-call' },
         'saveVersion':     { signature: 'await saveVersion(label?) -- Save current state as version', docs: '/ai.md#console-api--windowmainifold' },
         'listVersions':    { signature: 'await listVersions() -- List all versions in session', docs: '/ai.md#console-api--windowmainifold' },
-        'loadVersion':     { signature: 'await loadVersion(indexOrId) -- Load version into editor -> {id, index, label, code, geometryData} or {error}', docs: '/ai.md#console-api--windowmainifold' },
-        'forkVersion':     { signature: 'await forkVersion(indexOrId, transformFn, label?, assertions?) -- Load + modify + validate + save in one call', docs: '/ai.md#forking-a-prior-version' },
+        'loadVersion':     { signature: 'await loadVersion({index} | {id}) -- Load version into editor -> {id, index, label, code, geometryData} or {error}', docs: '/ai.md#console-api--windowmainifold' },
+        'forkVersion':     { signature: 'await forkVersion({index} | {id}, transformFn, label?, assertions?) -- Load + modify + validate + save in one call', docs: '/ai.md#forking-a-prior-version' },
         'openSession':     { signature: 'await openSession(id) -- Open existing session', docs: '/ai.md#resuming-a-session' },
         'listSessions':    { signature: 'await listSessions() -- List all sessions', docs: '/ai.md#console-api--windowmainifold' },
         'getSessionContext': { signature: 'await getSessionContext() -- Get full session context (for resuming)', docs: '/ai.md#resuming-a-session' },

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -214,6 +214,11 @@ export async function getVersionByIndex(sessionId: string, index: number): Promi
   return reqToPromise(idx.get([sessionId, index])) as Promise<Version | null>;
 }
 
+export async function getVersionById(id: string): Promise<Version | null> {
+  const store = await tx('versions', 'readonly');
+  return reqToPromise(store.get(id)) as Promise<Version | null>;
+}
+
 export async function getVersionCount(sessionId: string): Promise<number> {
   const store = await tx('versions', 'readonly');
   const index = store.index('sessionId');

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -9,6 +9,7 @@ import {
   listVersions as dbListVersions,
   getLatestVersion,
   getVersionByIndex,
+  getVersionById,
   getVersionCount,
   clearAllData,
   updateSession as dbUpdateSession,
@@ -209,10 +210,28 @@ export async function navigateVersion(direction: 'prev' | 'next'): Promise<Versi
   return version;
 }
 
-export async function loadVersionByIndex(index: number): Promise<Version | null> {
+/** Look up a version by index (number) or id (string) without mutating current state. */
+export async function peekVersion(target: number | string): Promise<Version | null> {
+  if (!currentState.session) return null;
+  if (typeof target === 'number') {
+    return getVersionByIndex(currentState.session.id, target);
+  }
+  const v = await getVersionById(target);
+  return v && v.sessionId === currentState.session.id ? v : null;
+}
+
+/** Load a version by index (number) or id (string). */
+export async function loadVersion(target: number | string): Promise<Version | null> {
   if (!currentState.session) return null;
 
-  const version = await getVersionByIndex(currentState.session.id, index);
+  let version: Version | null = null;
+  if (typeof target === 'number') {
+    version = await getVersionByIndex(currentState.session.id, target);
+  } else {
+    const v = await getVersionById(target);
+    // Reject versions from other sessions to avoid cross-session pollution.
+    if (v && v.sessionId === currentState.session.id) version = v;
+  }
   if (!version) return null;
 
   currentState = { ...currentState, currentVersion: version };

--- a/src/ui/gallery.ts
+++ b/src/ui/gallery.ts
@@ -1,6 +1,6 @@
 // Gallery view — grid of version thumbnails for comparing iterations
 
-import { listCurrentVersions, loadVersionByIndex, getReferenceImagesFromSession, type Version, type ReferenceImagesData } from '../storage/sessionManager';
+import { listCurrentVersions, loadVersion, getReferenceImagesFromSession, type Version, type ReferenceImagesData } from '../storage/sessionManager';
 
 let galleryEl: HTMLElement | null = null;
 let onLoadCode: ((code: string) => void) | null = null;
@@ -106,7 +106,7 @@ function createTile(version: Version): HTMLElement {
   const tile = document.createElement('div');
   tile.className = 'bg-zinc-800 rounded-lg overflow-hidden cursor-pointer hover:ring-2 hover:ring-blue-500 transition-all group';
   tile.addEventListener('click', async () => {
-    const v = await loadVersionByIndex(version.index);
+    const v = await loadVersion(version.index);
     if (v && onLoadCode) onLoadCode(v.code);
   });
 


### PR DESCRIPTION
## Summary

- Adds `forkVersion(target, transformFn, label?, assertions?)` — loads parent + applies transform + validates in isolation + saves atomically in one call. Eliminates the load→getCode→modify→save chain that caused a recent iteration regression where an agent silently lost parts of the parent design.
- Updates `loadVersion` to return `{id, index, label, code, geometryData}` on success (previously returned only the first three) or `{error: "..."}` on failure — matches the existing error convention used by `sliceAtZ`, `modifyAndTest`, `getSessionContext`, `help()`.
- Both methods take an object-arg target: `{ index: number }` or `{ id: string }`. Self-documenting at the call site and impossible to confuse the two. Rejects both-set / neither-set at the boundary.
- New "Common agent mistakes" bullets in ai.md covering the hand-chain anti-pattern and the target-arg shape.

## Context

An agent running a parallel-branch workflow (v11 → v11a → v12a → v13a) reported `getCode()` returning stale content after `loadVersion(id)`. Traced it: the agent passed a string id to an index-only parameter, `getVersionByIndex` returned null, `loadVersion` returned null without updating the editor, and `getCode()` returned the untouched v13 buffer. The agent then rewrote from scratch and lost detail. This PR fixes both the ambiguous signature and the root design issue (no atomic fork primitive).

Full prompt log: `prompts/20260421-version-forking-api.md`.

## Usage

```js
// Load a version into the editor
await mainifold.loadVersion({ index: 11 });
await mainifold.loadVersion({ id: "Kx3Pq9mA2wEr" });
// -> { id, index, label, code, geometryData }  or  { error: "..." }

// Fork a parent into a new branch in one atomic call
await mainifold.forkVersion(
  { index: 11 },
  code => code.replace('towerH = 28', 'towerH = 35'),
  "v11a - taller towers",
  { isManifold: true, maxComponents: 1 }  // optional assertions
);
// -> { passed?, parent, geometry, version, diff, galleryUrl }  or  { error } / { passed: false, failures }
```

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] `await mainifold.loadVersion({ index: 1 })` loads v1 and returns `{code, geometryData, ...}`
- [ ] `await mainifold.loadVersion({ id: "<id-from-listVersions>" })` loads by id
- [ ] `await mainifold.loadVersion({ index: 999 })` returns `{error: "No version found with index..."}`
- [ ] `await mainifold.loadVersion({ id: "foo" })` (id not in session) returns `{error}`
- [ ] `await mainifold.loadVersion(2)` (bare number — not supported) returns `{error: "...target must be { index: number } or { id: string }..."}`
- [ ] `await mainifold.loadVersion({ index: 1, id: "x" })` rejects both-set
- [ ] `await mainifold.loadVersion({})` rejects neither-set
- [ ] `await mainifold.forkVersion({ index: 1 }, c => c.replace('10', '20'), "v1a")` creates a new version with transformed code
- [ ] `await mainifold.forkVersion({ index: 1 }, () => "garbage", "bad", { isManifold: true })` returns `{passed: false, failures: [...]}` and does NOT save
- [ ] Gallery tile click still loads versions (sanity: the rename didn't break the UI path)
- [ ] `mainifold.help('forkVersion')` prints the new signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)