### PR TITLE
Add XYZ orientation gizmo, bounding box dimensions, drag-to-measure, and camera lock

### DIFF
--- a/prompts/20260424-viewport-gizmo-dimensions-measure.md
+++ b/prompts/20260424-viewport-gizmo-dimensions-measure.md
@@ -1,0 +1,42 @@
+---
+session: "viewport-gizmo-dimensions-measure"
+timestamp: "2026-04-24T15:30:00Z"
+model: claude-opus-4-6
+tools: [claude-code, playwright-mcp]
+---
+
+## Human
+
+Add an XYZ orientation gizmo to the interactive viewport, bounding box
+dimension annotations, drag-to-measure tool, and camera lock controls.
+
+## Key Changes
+
+1. **XYZ Orientation Gizmo** — Three.js ViewHelper in the upper-right corner
+   showing colored X/Y/Z axes with labels. Click any axis to snap the camera
+   to that view with smooth animation. Z-up-correct view targets for all 6
+   axes. Fixed ViewHelper's autoClear bug that was blanking the main render.
+
+2. **Bounding Box Dimensions** — Extension lines, dimension lines, tick marks,
+   and labeled values for X/Y/Z extents. On by default, toggleable via the
+   📐 button. Updates automatically when the model changes.
+
+3. **Drag-to-Measure** — Reworked from click-click to press-drag-release.
+   Live dashed line + distance label during drag. Click to dismiss. Refactored
+   measureOverlay.ts for efficient in-place updates during drag (no
+   create/destroy per frame).
+
+4. **Camera Lock Controls** — Measure mode now locks camera rotation while
+   active. Added dedicated 🔓/🔒 toggle button for manual orbit lock.
+   Central orbit lock system in viewport.ts with multiple independent lock
+   sources (measure, user, gizmo animation).
+
+## Files
+
+- `src/renderer/orientationGizmo.ts` (new)
+- `src/renderer/dimensionLines.ts` (new)
+- `src/renderer/measureOverlay.ts` (reworked)
+- `src/renderer/viewport.ts` (modified)
+- `src/ui/layout.ts` (modified)
+- `src/ui/measureTool.ts` (reworked)
+- `src/main.ts` (modified)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import './style.css';
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, type Language } from './geometry/engine';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
-import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera } from './renderer/viewport';
+import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, setDimensionsVisible, isDimensionsVisible } from './renderer/viewport';
 import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, renderSliceSVG, setReferenceImages as _setRefImages, clearReferenceImages as _clearRefImages, getReferenceImages as _getRefImages, type ReferenceImages } from './renderer/multiview';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage } from './editor/codeEditor';
@@ -924,8 +924,10 @@ async function main() {
   // Wire up clip controls
   initClipControls(clipControls);
 
-  // Wire up measure toggle
+  // Wire up viewport overlay buttons
+  initDimensionsToggle(clipControls);
   initMeasureToggle(clipControls);
+  initOrbitLockToggle(clipControls);
 
   editorReady = true;
   editorReadyResolve();
@@ -2074,18 +2076,21 @@ async function main() {
 
     // === Phase 5: Measuring Tool ===
 
-    /** Toggle interactive measure mode — click two points to measure distance */
+    /** Toggle interactive measure mode — click two points to measure distance.
+     *  Also locks camera rotation while measuring. */
     measureMode(enabled?: boolean): void {
       assertBoolean(enabled, 'measureMode(enabled)', { optional: true });
       const state = getMeasureState();
       if (enabled === undefined) {
         // Toggle
-        if (state.active) deactivateMeasure();
-        else activateMeasure();
+        if (state.active) { deactivateMeasure(); setMeasureLock(false); }
+        else { activateMeasure(); setMeasureLock(true); }
       } else if (enabled) {
         activateMeasure();
+        setMeasureLock(true);
       } else {
         deactivateMeasure();
+        setMeasureLock(false);
       }
     },
 
@@ -2307,11 +2312,44 @@ async function main() {
       const state = getMeasureState();
       if (state.active) {
         deactivateMeasure();
+        setMeasureLock(false);
         measureBtn.className = inactiveClass;
       } else {
         activateMeasure();
+        setMeasureLock(true);
         measureBtn.className = activeClass;
       }
+    });
+  }
+
+  function initDimensionsToggle(container: HTMLElement) {
+    const dimBtn = container.querySelector('#dimensions-toggle') as HTMLButtonElement;
+    if (!dimBtn) return;
+
+    const inactiveClass = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+    const activeClass = 'px-2 py-1 rounded text-xs bg-blue-500/20 backdrop-blur text-blue-400 hover:bg-blue-500/30 transition-colors border border-blue-500/30';
+
+    dimBtn.addEventListener('click', () => {
+      const nowVisible = !isDimensionsVisible();
+      setDimensionsVisible(nowVisible);
+      dimBtn.className = nowVisible ? activeClass : inactiveClass;
+      dimBtn.title = nowVisible ? 'Hide bounding box dimensions' : 'Show bounding box dimensions';
+    });
+  }
+
+  function initOrbitLockToggle(container: HTMLElement) {
+    const lockBtn = container.querySelector('#orbit-lock-toggle') as HTMLButtonElement;
+    if (!lockBtn) return;
+
+    const inactiveClass = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+    const activeClass = 'px-2 py-1 rounded text-xs bg-amber-500/20 backdrop-blur text-amber-400 hover:bg-amber-500/30 transition-colors border border-amber-500/30';
+
+    lockBtn.addEventListener('click', () => {
+      const locked = !isUserOrbitLocked();
+      setUserOrbitLock(locked);
+      lockBtn.className = locked ? activeClass : inactiveClass;
+      lockBtn.textContent = locked ? '\uD83D\uDD12' : '\uD83D\uDD13';
+      lockBtn.title = locked ? 'Unlock camera rotation' : 'Lock camera rotation';
     });
   }
 }

--- a/src/renderer/dimensionLines.ts
+++ b/src/renderer/dimensionLines.ts
@@ -1,0 +1,179 @@
+// Bounding box dimension annotations — shows X, Y, Z extent with lines and labels
+import * as THREE from 'three';
+import { formatDimension } from '../geometry/units';
+
+let dimensionGroup: THREE.Group | null = null;
+let parentScene: THREE.Scene | null = null;
+let visible = true;
+let currentMaxDim = 1;
+
+export function initDimensionLines(scene: THREE.Scene): void {
+  parentScene = scene;
+  dimensionGroup = new THREE.Group();
+  dimensionGroup.name = 'dimension-lines';
+  scene.add(dimensionGroup);
+}
+
+export function setDimensionsVisible(v: boolean): void {
+  visible = v;
+  if (dimensionGroup) dimensionGroup.visible = v;
+}
+
+export function isDimensionsVisible(): boolean {
+  return visible;
+}
+
+export function updateDimensionLines(box: THREE.Box3): void {
+  clearGroup();
+  if (!dimensionGroup || !visible) return;
+
+  const min = box.min;
+  const max = box.max;
+  const size = box.getSize(new THREE.Vector3());
+
+  if (size.x === 0 && size.y === 0 && size.z === 0) return;
+
+  currentMaxDim = Math.max(size.x, size.y, size.z);
+  const off = currentMaxDim * 0.15; // offset from model to dimension line
+
+  // Layout: three dimension lines meeting at corner (max.x + off, min.y - off, min.z - off)
+  // X runs left, Y runs back, Z runs up — visible from default isometric view
+
+  // X dimension — bottom front edge, offset in -Y and -Z
+  if (size.x > 0.001) {
+    const dy = min.y - off;
+    const dz = min.z - off;
+    // Extension lines from model corners to dimension line
+    addExtLine(new THREE.Vector3(min.x, min.y, min.z), new THREE.Vector3(min.x, dy, dz));
+    addExtLine(new THREE.Vector3(max.x, min.y, min.z), new THREE.Vector3(max.x, dy, dz));
+    // Dimension line
+    addDimLine(new THREE.Vector3(min.x, dy, dz), new THREE.Vector3(max.x, dy, dz));
+    // Label
+    addLabel(new THREE.Vector3((min.x + max.x) / 2, dy, dz), formatDimension(size.x));
+  }
+
+  // Y dimension — bottom right edge, offset in +X and -Z
+  if (size.y > 0.001) {
+    const dx = max.x + off;
+    const dz = min.z - off;
+    addExtLine(new THREE.Vector3(max.x, min.y, min.z), new THREE.Vector3(dx, min.y, dz));
+    addExtLine(new THREE.Vector3(max.x, max.y, min.z), new THREE.Vector3(dx, max.y, dz));
+    addDimLine(new THREE.Vector3(dx, min.y, dz), new THREE.Vector3(dx, max.y, dz));
+    addLabel(new THREE.Vector3(dx, (min.y + max.y) / 2, dz), formatDimension(size.y));
+  }
+
+  // Z dimension — right front vertical, offset in +X and -Y
+  if (size.z > 0.001) {
+    const dx = max.x + off;
+    const dy = min.y - off;
+    addExtLine(new THREE.Vector3(max.x, min.y, min.z), new THREE.Vector3(dx, dy, min.z));
+    addExtLine(new THREE.Vector3(max.x, min.y, max.z), new THREE.Vector3(dx, dy, max.z));
+    addDimLine(new THREE.Vector3(dx, dy, min.z), new THREE.Vector3(dx, dy, max.z));
+    addLabel(new THREE.Vector3(dx, dy, (min.z + max.z) / 2), formatDimension(size.z));
+  }
+}
+
+function addExtLine(from: THREE.Vector3, to: THREE.Vector3): void {
+  if (!dimensionGroup) return;
+  const geo = new THREE.BufferGeometry().setFromPoints([from, to]);
+  const mat = new THREE.LineBasicMaterial({ color: 0x888888, transparent: true, opacity: 0.25, depthTest: false });
+  const line = new THREE.Line(geo, mat);
+  line.renderOrder = 100;
+  dimensionGroup.add(line);
+}
+
+function addDimLine(from: THREE.Vector3, to: THREE.Vector3): void {
+  if (!dimensionGroup) return;
+  const geo = new THREE.BufferGeometry().setFromPoints([from, to]);
+  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa, transparent: true, opacity: 0.5, depthTest: false });
+  const line = new THREE.Line(geo, mat);
+  line.renderOrder = 100;
+  dimensionGroup.add(line);
+
+  // Tick marks at each end — small perpendicular lines
+  const dir = new THREE.Vector3().subVectors(to, from).normalize();
+  const tick = currentMaxDim * 0.025;
+
+  // Pick a perpendicular direction for the tick
+  const up = new THREE.Vector3(0, 0, 1);
+  let perp = new THREE.Vector3().crossVectors(dir, up);
+  if (perp.lengthSq() < 0.001) {
+    perp = new THREE.Vector3().crossVectors(dir, new THREE.Vector3(0, 1, 0));
+  }
+  perp.normalize().multiplyScalar(tick);
+
+  for (const pt of [from, to]) {
+    const tGeo = new THREE.BufferGeometry().setFromPoints([
+      pt.clone().add(perp),
+      pt.clone().sub(perp),
+    ]);
+    const tMat = new THREE.LineBasicMaterial({ color: 0xaaaaaa, transparent: true, opacity: 0.5, depthTest: false });
+    const tLine = new THREE.Line(tGeo, tMat);
+    tLine.renderOrder = 100;
+    dimensionGroup.add(tLine);
+  }
+}
+
+function addLabel(position: THREE.Vector3, text: string): void {
+  if (!dimensionGroup) return;
+
+  const canvas = document.createElement('canvas');
+  const size = 128;
+  canvas.width = size;
+  canvas.height = size / 2;
+  const ctx = canvas.getContext('2d')!;
+
+  // Background pill
+  ctx.fillStyle = 'rgba(30, 30, 50, 0.6)';
+  const pad = 6;
+  ctx.font = 'bold 22px system-ui, sans-serif';
+  const tw = ctx.measureText(text).width;
+  const rx = (size - tw) / 2 - pad;
+  const ry = size / 4 - 14;
+  const rw = tw + pad * 2;
+  const rh = 28;
+  ctx.beginPath();
+  ctx.roundRect(rx, ry, rw, rh, 4);
+  ctx.fill();
+
+  // Text
+  ctx.fillStyle = '#cccccc';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, size / 2, size / 4);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  const mat = new THREE.SpriteMaterial({ map: texture, transparent: true, depthTest: false });
+  const sprite = new THREE.Sprite(mat);
+  sprite.position.copy(position);
+
+  const scale = currentMaxDim * 0.07;
+  sprite.scale.set(scale * 2, scale, 1);
+  sprite.renderOrder = 101;
+  dimensionGroup.add(sprite);
+}
+
+function clearGroup(): void {
+  if (!dimensionGroup) return;
+  while (dimensionGroup.children.length > 0) {
+    const child = dimensionGroup.children[0];
+    dimensionGroup.remove(child);
+    if (child instanceof THREE.Line) {
+      child.geometry.dispose();
+      (child.material as THREE.Material).dispose();
+    } else if (child instanceof THREE.Sprite) {
+      child.material.map?.dispose();
+      child.material.dispose();
+    }
+  }
+}
+
+export function disposeDimensionLines(): void {
+  clearGroup();
+  if (dimensionGroup && parentScene) {
+    parentScene.remove(dimensionGroup);
+  }
+  dimensionGroup = null;
+  parentScene = null;
+}

--- a/src/renderer/measureOverlay.ts
+++ b/src/renderer/measureOverlay.ts
@@ -6,6 +6,11 @@ let measureGroup: THREE.Group | null = null;
 let labelEl: HTMLElement | null = null;
 let camera: THREE.PerspectiveCamera | null = null;
 let renderer: THREE.WebGLRenderer | null = null;
+// Retained references for efficient updates during drag
+let lineObj: THREE.Line | null = null;
+let sphere1: THREE.Mesh | null = null;
+let sphere2: THREE.Mesh | null = null;
+let storedP1: THREE.Vector3 | null = null;
 
 export function initMeasureOverlay(
   scene: THREE.Scene,
@@ -20,18 +25,27 @@ export function initMeasureOverlay(
   scene.add(measureGroup);
 }
 
-export function showMeasurement(
-  p1: THREE.Vector3,
-  p2: THREE.Vector3,
-  distance: number,
-  container: HTMLElement,
-): void {
+/** Create the measurement visual for point 1 (start of drag). */
+export function startMeasurement(p1: THREE.Vector3, container: HTMLElement): void {
   clearMeasurement();
   if (!measureGroup || !camera || !renderer) return;
+  storedP1 = p1.clone();
 
-  // Dashed line between points
-  const points = [p1, p2];
-  const geometry = new THREE.BufferGeometry().setFromPoints(points);
+  const sphereGeo = new THREE.SphereGeometry(0.15, 8, 8);
+  const sphereMat = new THREE.MeshBasicMaterial({ color: 0xffdd00, depthTest: false });
+
+  sphere1 = new THREE.Mesh(sphereGeo, sphereMat);
+  sphere1.position.copy(p1);
+  sphere1.renderOrder = 999;
+  measureGroup.add(sphere1);
+
+  sphere2 = new THREE.Mesh(sphereGeo.clone(), sphereMat.clone());
+  sphere2.position.copy(p1);
+  sphere2.renderOrder = 999;
+  measureGroup.add(sphere2);
+
+  // Dashed line (initially zero-length)
+  const geometry = new THREE.BufferGeometry().setFromPoints([p1, p1]);
   const material = new THREE.LineDashedMaterial({
     color: 0xffdd00,
     dashSize: 0.5,
@@ -39,33 +53,56 @@ export function showMeasurement(
     depthTest: false,
     linewidth: 2,
   });
-  const line = new THREE.Line(geometry, material);
-  line.computeLineDistances();
-  line.renderOrder = 999;
-  measureGroup.add(line);
+  lineObj = new THREE.Line(geometry, material);
+  lineObj.computeLineDistances();
+  lineObj.renderOrder = 999;
+  measureGroup.add(lineObj);
 
-  // Small spheres at endpoints
-  const sphereGeo = new THREE.SphereGeometry(0.15, 8, 8);
-  const sphereMat = new THREE.MeshBasicMaterial({ color: 0xffdd00, depthTest: false });
-  const s1 = new THREE.Mesh(sphereGeo, sphereMat);
-  s1.position.copy(p1);
-  s1.renderOrder = 999;
-  measureGroup.add(s1);
-  const s2 = new THREE.Mesh(sphereGeo, sphereMat);
-  s2.position.copy(p2);
-  s2.renderOrder = 999;
-  measureGroup.add(s2);
-
-  // HTML label positioned at midpoint
+  // Label (initially hidden)
   labelEl = document.createElement('div');
   labelEl.className = 'absolute pointer-events-none px-2 py-1 rounded text-xs font-mono font-bold z-50';
-  labelEl.style.cssText = 'background: rgba(255,221,0,0.9); color: #1a1a2e; transform: translate(-50%, -100%); white-space: nowrap;';
-  labelEl.textContent = formatDimension(distance);
+  labelEl.style.cssText = 'background: rgba(255,221,0,0.9); color: #1a1a2e; transform: translate(-50%, -100%); white-space: nowrap; display: none;';
   container.style.position = 'relative';
   container.appendChild(labelEl);
+}
 
-  // Position label in screen space
-  updateLabelPosition(p1, p2);
+/** Update the measurement target (point 2) during drag. Fast — no allocation. */
+export function updateMeasurementTarget(p2: THREE.Vector3, distance: number): void {
+  if (!lineObj || !sphere2 || !storedP1 || !camera || !renderer || !labelEl) return;
+
+  // Update sphere position
+  sphere2.position.copy(p2);
+
+  // Update line geometry
+  const positions = lineObj.geometry.attributes.position as THREE.BufferAttribute;
+  positions.setXYZ(1, p2.x, p2.y, p2.z);
+  positions.needsUpdate = true;
+  lineObj.geometry.computeBoundingSphere();
+  lineObj.computeLineDistances();
+
+  // Update label
+  labelEl.textContent = formatDimension(distance);
+  labelEl.style.display = '';
+
+  // Position label in screen space at midpoint
+  const mid = new THREE.Vector3().addVectors(storedP1, p2).multiplyScalar(0.5);
+  const projected = mid.clone().project(camera);
+  const canvas = renderer.domElement;
+  const x = (projected.x * 0.5 + 0.5) * canvas.clientWidth;
+  const y = (-projected.y * 0.5 + 0.5) * canvas.clientHeight;
+  labelEl.style.left = `${x}px`;
+  labelEl.style.top = `${y}px`;
+}
+
+/** Show a complete measurement (legacy — used for finalized state). */
+export function showMeasurement(
+  p1: THREE.Vector3,
+  p2: THREE.Vector3,
+  distance: number,
+  container: HTMLElement,
+): void {
+  startMeasurement(p1, container);
+  updateMeasurementTarget(p2, distance);
 }
 
 export function updateLabelPosition(p1?: THREE.Vector3, p2?: THREE.Vector3): void {
@@ -101,4 +138,8 @@ export function clearMeasurement(): void {
     labelEl.remove();
     labelEl = null;
   }
+  lineObj = null;
+  sphere1 = null;
+  sphere2 = null;
+  storedP1 = null;
 }

--- a/src/renderer/orientationGizmo.ts
+++ b/src/renderer/orientationGizmo.ts
@@ -1,0 +1,190 @@
+// Orientation gizmo — XYZ axes indicator in the viewport corner
+// Uses Three.js ViewHelper for the visual, with custom click-to-snap for Z-up
+
+import * as THREE from 'three';
+import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
+import type { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+let viewHelper: ViewHelper | null = null;
+let mainCamera: THREE.PerspectiveCamera | null = null;
+let mainControls: OrbitControls | null = null;
+let canvasEl: HTMLElement | null = null;
+
+// Snap-to-view animation state
+let snapAnimating = false;
+const snapStartPos = new THREE.Vector3();
+const snapTargetPos = new THREE.Vector3();
+const snapStartUp = new THREE.Vector3();
+const snapTargetUp = new THREE.Vector3();
+let snapProgress = 0;
+const SNAP_DURATION = 0.4; // seconds
+
+const GIZMO_SIZE = 128;
+const GIZMO_MARGIN = 8;
+const HIT_RADIUS = 0.4; // in orthographic units (-2 to 2 range)
+
+// Z-up view orientations: camera direction from target, camera up vector.
+// Top/bottom use a tiny Y offset to avoid degenerate lookAt when view dir is parallel to camera.up.
+const VIEW_TARGETS: Record<string, { dir: [number, number, number]; up: [number, number, number] }> = {
+  posX: { dir: [1, 0, 0], up: [0, 0, 1] },
+  negX: { dir: [-1, 0, 0], up: [0, 0, 1] },
+  posY: { dir: [0, 1, 0], up: [0, 0, 1] },
+  negY: { dir: [0, -1, 0], up: [0, 0, 1] },
+  posZ: { dir: [0, -0.001, 1], up: [0, 0, 1] },
+  negZ: { dir: [0, 0.001, -1], up: [0, 0, 1] },
+};
+
+// Axis endpoint base positions (unit vectors in gizmo space)
+const AXIS_ENDPOINTS: [string, number, number, number][] = [
+  ['posX', 1, 0, 0], ['posY', 0, 1, 0], ['posZ', 0, 0, 1],
+  ['negX', -1, 0, 0], ['negY', 0, -1, 0], ['negZ', 0, 0, -1],
+];
+
+let gizmoCursorActive = false;
+
+export function initOrientationGizmo(
+  camera: THREE.PerspectiveCamera,
+  canvas: HTMLElement,
+  controls: OrbitControls,
+): void {
+  mainCamera = camera;
+  mainControls = controls;
+  canvasEl = canvas;
+
+  viewHelper = new ViewHelper(camera, canvas);
+  viewHelper.setLabels('X', 'Y', 'Z');
+  viewHelper.setLabelStyle('18px system-ui', '#ffffff', 14);
+  viewHelper.location = { top: GIZMO_MARGIN, right: GIZMO_MARGIN, bottom: 0, left: null };
+
+  // Fix negative axis sprites: default black is invisible on the dark viewport background
+  viewHelper.children.forEach(child => {
+    if (child instanceof THREE.Sprite && child.userData.type?.startsWith('neg')) {
+      child.material.dispose();
+      if (child.material.map) child.material.map.dispose();
+      const c = document.createElement('canvas');
+      c.width = 64;
+      c.height = 64;
+      const ctx = c.getContext('2d')!;
+      ctx.beginPath();
+      ctx.arc(32, 32, 14, 0, Math.PI * 2);
+      ctx.fillStyle = '#666666';
+      ctx.fill();
+      const tex = new THREE.CanvasTexture(c);
+      tex.colorSpace = THREE.SRGBColorSpace;
+      child.material = new THREE.SpriteMaterial({ map: tex, toneMapped: false, opacity: 0.4 });
+    }
+  });
+
+  canvas.addEventListener('click', onGizmoClick);
+  canvas.addEventListener('pointermove', onGizmoPointerMove);
+}
+
+/** Hit-test gizmo axis endpoints. Returns axis type or null. */
+function hitTestGizmo(clientX: number, clientY: number): string | null {
+  if (!canvasEl || !mainCamera) return null;
+
+  const rect = canvasEl.getBoundingClientRect();
+  const gizmoLeft = rect.right - GIZMO_SIZE - GIZMO_MARGIN;
+  const gizmoTop = rect.top + GIZMO_MARGIN;
+
+  const localX = clientX - gizmoLeft;
+  const localY = clientY - gizmoTop;
+  if (localX < 0 || localX > GIZMO_SIZE || localY < 0 || localY > GIZMO_SIZE) return null;
+
+  // Convert to gizmo's orthographic space (-2 to 2)
+  const orthoX = (localX / GIZMO_SIZE) * 4 - 2;
+  const orthoY = -((localY / GIZMO_SIZE) * 4 - 2);
+
+  const q = mainCamera.quaternion.clone().invert();
+  let best: string | null = null;
+  let bestZ = -Infinity;
+
+  for (const [type, x, y, z] of AXIS_ENDPOINTS) {
+    const pos = new THREE.Vector3(x, y, z).applyQuaternion(q);
+    const dx = orthoX - pos.x;
+    const dy = orthoY - pos.y;
+    if (Math.sqrt(dx * dx + dy * dy) < HIT_RADIUS && pos.z > bestZ) {
+      best = type;
+      bestZ = pos.z;
+    }
+  }
+
+  return best;
+}
+
+function onGizmoClick(event: MouseEvent): void {
+  if (!mainCamera || !mainControls || snapAnimating) return;
+
+  const axis = hitTestGizmo(event.clientX, event.clientY);
+  if (!axis) return;
+
+  const target = VIEW_TARGETS[axis];
+  if (!target) return;
+
+  const distance = mainCamera.position.distanceTo(mainControls.target);
+  const dir = new THREE.Vector3(...target.dir).normalize();
+
+  snapStartPos.copy(mainCamera.position);
+  snapTargetPos.copy(dir).multiplyScalar(distance).add(mainControls.target);
+  snapStartUp.copy(mainCamera.up);
+  snapTargetUp.set(...target.up);
+  snapProgress = 0;
+  snapAnimating = true;
+}
+
+function onGizmoPointerMove(event: PointerEvent): void {
+  if (!canvasEl) return;
+  const overAxis = !snapAnimating && hitTestGizmo(event.clientX, event.clientY) !== null;
+  if (overAxis && !gizmoCursorActive) {
+    canvasEl.style.cursor = 'pointer';
+    gizmoCursorActive = true;
+  } else if (!overAxis && gizmoCursorActive) {
+    canvasEl.style.cursor = '';
+    gizmoCursorActive = false;
+  }
+}
+
+export function renderGizmo(renderer: THREE.WebGLRenderer): void {
+  if (!viewHelper) return;
+  // Disable autoClear so ViewHelper's internal renderer.render() doesn't
+  // wipe the main scene that was already drawn this frame.
+  const saved = renderer.autoClear;
+  renderer.autoClear = false;
+  viewHelper.render(renderer);
+  renderer.autoClear = saved;
+}
+
+export function updateGizmo(delta: number): void {
+  if (!snapAnimating || !mainCamera || !mainControls) return;
+
+  snapProgress = Math.min(1, snapProgress + delta / SNAP_DURATION);
+  const t = snapProgress * snapProgress * (3 - 2 * snapProgress); // smoothstep
+
+  mainCamera.position.lerpVectors(snapStartPos, snapTargetPos, t);
+  mainCamera.up.lerpVectors(snapStartUp, snapTargetUp, t).normalize();
+  mainCamera.lookAt(mainControls.target);
+
+  if (snapProgress >= 1) {
+    snapAnimating = false;
+  }
+}
+
+export function isGizmoAnimating(): boolean {
+  return snapAnimating;
+}
+
+export function disposeGizmo(): void {
+  if (canvasEl) {
+    canvasEl.removeEventListener('click', onGizmoClick);
+    canvasEl.removeEventListener('pointermove', onGizmoPointerMove);
+    if (gizmoCursorActive) {
+      canvasEl.style.cursor = '';
+      gizmoCursorActive = false;
+    }
+  }
+  viewHelper?.dispose();
+  viewHelper = null;
+  mainCamera = null;
+  mainControls = null;
+  canvasEl = null;
+}

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -4,6 +4,8 @@ import type { MeshData } from '../geometry/types';
 import { createDefaultMaterial, createWireframeMaterial } from './materials';
 import { initPhantomGroup } from './phantomGeometry';
 import { initMeasureOverlay } from './measureOverlay';
+import { initOrientationGizmo, renderGizmo, updateGizmo, disposeGizmo, isGizmoAnimating } from './orientationGizmo';
+import { initDimensionLines, updateDimensionLines, disposeDimensionLines } from './dimensionLines';
 
 let renderer: THREE.WebGLRenderer;
 let camera: THREE.PerspectiveCamera;
@@ -11,6 +13,10 @@ let scene: THREE.Scene;
 let controls: OrbitControls;
 let meshGroup: THREE.Group;
 let animationId: number;
+
+// Orbit lock state — orbit is disabled when any lock source is active
+let measureLock = false;
+let userLock = false;
 
 // Clipping plane state
 const clipPlane = new THREE.Plane(new THREE.Vector3(0, 0, -1), 0); // clips above Z
@@ -81,6 +87,12 @@ export function initViewport(container: HTMLElement): {
   // Measure overlay group
   initMeasureOverlay(scene, camera, renderer);
 
+  // Orientation gizmo (XYZ axes indicator)
+  initOrientationGizmo(camera, canvas, controls);
+
+  // Bounding box dimension annotations
+  initDimensionLines(scene);
+
   // ResizeObserver
   const observer = new ResizeObserver(entries => {
     const { width, height } = entries[0].contentRect;
@@ -92,10 +104,15 @@ export function initViewport(container: HTMLElement): {
   observer.observe(container);
 
   // Animate
+  const clock = new THREE.Clock();
   function animate() {
     animationId = requestAnimationFrame(animate);
+    const delta = clock.getDelta();
+    updateGizmo(delta);
+    controls.enabled = !measureLock && !userLock && !isGizmoAnimating();
     controls.update();
     renderer.render(scene, camera);
+    renderGizmo(renderer);
   }
   animate();
 
@@ -148,6 +165,9 @@ export function updateMesh(meshData: MeshData): void {
 
   // Update model bounds for clip slider
   modelBounds = { min: box.min.z, max: box.max.z };
+
+  // Update bounding box dimension annotations
+  updateDimensionLines(box);
 
   controls.target.copy(center);
   camera.position.set(
@@ -304,8 +324,32 @@ export function getMeshGroup(): THREE.Group {
   return meshGroup;
 }
 
+// === Orbit lock API ===
+
+function syncOrbitEnabled(): void {
+  controls.enabled = !measureLock && !userLock && !isGizmoAnimating();
+}
+
+export function setMeasureLock(locked: boolean): void {
+  measureLock = locked;
+  syncOrbitEnabled();
+}
+
+export function setUserOrbitLock(locked: boolean): void {
+  userLock = locked;
+  syncOrbitEnabled();
+}
+
+export function isUserOrbitLocked(): boolean {
+  return userLock;
+}
+
+export { setDimensionsVisible, isDimensionsVisible } from './dimensionLines';
+
 export function dispose(): void {
   cancelAnimationFrame(animationId);
+  disposeGizmo();
+  disposeDimensionLines();
   controls.dispose();
   renderer.dispose();
 }

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -222,6 +222,22 @@ function createClipControls(): HTMLElement {
   container.id = 'clip-controls';
   container.className = 'absolute top-2 right-2 z-10 flex items-center gap-2';
 
+  // Dimensions toggle (on by default)
+  const dimBtn = document.createElement('button');
+  dimBtn.id = 'dimensions-toggle';
+  dimBtn.className = 'px-2 py-1 rounded text-xs bg-blue-500/20 backdrop-blur text-blue-400 hover:bg-blue-500/30 transition-colors border border-blue-500/30';
+  dimBtn.textContent = '\uD83D\uDCCF';
+  dimBtn.title = 'Toggle bounding box dimensions';
+  container.appendChild(dimBtn);
+
+  // Orbit lock toggle
+  const lockBtn = document.createElement('button');
+  lockBtn.id = 'orbit-lock-toggle';
+  lockBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  lockBtn.textContent = '\uD83D\uDD13';
+  lockBtn.title = 'Lock camera rotation';
+  container.appendChild(lockBtn);
+
   // Measure toggle button
   const measureBtn = document.createElement('button');
   measureBtn.id = 'measure-toggle';

--- a/src/ui/measureTool.ts
+++ b/src/ui/measureTool.ts
@@ -1,7 +1,7 @@
-// Interactive measuring tool — click two points on model to measure distance
+// Interactive measuring tool — drag between two points on model to measure distance
 import * as THREE from 'three';
 import { measureDistance } from '../geometry/rayCast';
-import { showMeasurement, clearMeasurement, updateLabelPosition } from '../renderer/measureOverlay';
+import { startMeasurement, updateMeasurementTarget, clearMeasurement, updateLabelPosition } from '../renderer/measureOverlay';
 
 export interface MeasureState {
   active: boolean;
@@ -10,7 +10,7 @@ export interface MeasureState {
   distance: number | null;
 }
 
-type MeasureMode = 'inactive' | 'awaiting_p1' | 'awaiting_p2' | 'displaying';
+type MeasureMode = 'inactive' | 'ready' | 'dragging' | 'displaying';
 
 let mode: MeasureMode = 'inactive';
 let point1: THREE.Vector3 | null = null;
@@ -21,7 +21,12 @@ let meshGroup: THREE.Group;
 let cam: THREE.PerspectiveCamera;
 let viewportContainer: HTMLElement;
 let canvas: HTMLCanvasElement;
+
+let downHandler: ((e: PointerEvent) => void) | null = null;
+let moveHandler: ((e: PointerEvent) => void) | null = null;
+let upHandler: ((e: PointerEvent) => void) | null = null;
 let clickHandler: ((e: MouseEvent) => void) | null = null;
+let dragEndTime = 0; // suppress the click event that trails a drag's pointerup
 
 export function initMeasureTool(
   canvasEl: HTMLCanvasElement,
@@ -37,13 +42,12 @@ export function initMeasureTool(
 
 export function activate(): void {
   if (mode !== 'inactive') return;
-  mode = 'awaiting_p1';
-  point1 = null;
-  point2 = null;
-  currentDistance = null;
+  mode = 'ready';
   canvas.style.cursor = 'crosshair';
 
+  downHandler = handlePointerDown;
   clickHandler = handleClick;
+  canvas.addEventListener('pointerdown', downHandler);
   canvas.addEventListener('click', clickHandler);
 }
 
@@ -54,16 +58,12 @@ export function deactivate(): void {
   currentDistance = null;
   canvas.style.cursor = '';
   clearMeasurement();
-
-  if (clickHandler) {
-    canvas.removeEventListener('click', clickHandler);
-    clickHandler = null;
-  }
+  removeListeners();
 }
 
 export function clear(): void {
   if (mode === 'displaying') {
-    mode = 'awaiting_p1';
+    mode = 'ready';
     point1 = null;
     point2 = null;
     currentDistance = null;
@@ -87,39 +87,109 @@ export function refreshLabel(): void {
   }
 }
 
-function handleClick(e: MouseEvent): void {
-  if (mode === 'displaying') {
-    // Clear and restart
-    clear();
-    return;
-  }
-
+function raycastModel(e: PointerEvent | MouseEvent): THREE.Vector3 | null {
   const rect = canvas.getBoundingClientRect();
   const mouse = new THREE.Vector2(
     ((e.clientX - rect.left) / rect.width) * 2 - 1,
     -((e.clientY - rect.top) / rect.height) * 2 + 1,
   );
-
   const raycaster = new THREE.Raycaster();
   raycaster.setFromCamera(mouse, cam);
-
   const intersections = raycaster.intersectObjects(meshGroup.children, true);
-  if (intersections.length === 0) return;
+  return intersections.length > 0 ? intersections[0].point.clone() : null;
+}
 
-  const hit = intersections[0].point;
+function handlePointerDown(e: PointerEvent): void {
+  if (mode === 'displaying') return; // click handler will clear it
+  if (mode !== 'ready') return;
 
-  if (mode === 'awaiting_p1') {
-    point1 = hit.clone();
-    mode = 'awaiting_p2';
-  } else if (mode === 'awaiting_p2' && point1) {
-    point2 = hit.clone();
+  const hit = raycastModel(e);
+  if (!hit) return;
+
+  point1 = hit;
+  point2 = null;
+  currentDistance = null;
+  mode = 'dragging';
+
+  startMeasurement(point1, viewportContainer);
+
+  // Add drag listeners
+  moveHandler = handlePointerMove;
+  upHandler = handlePointerUp;
+  canvas.addEventListener('pointermove', moveHandler);
+  canvas.addEventListener('pointerup', upHandler);
+
+  e.preventDefault();
+}
+
+function handlePointerMove(e: PointerEvent): void {
+  if (mode !== 'dragging' || !point1) return;
+
+  const hit = raycastModel(e);
+  if (hit) {
+    point2 = hit;
     currentDistance = measureDistance(
       [point1.x, point1.y, point1.z],
       [point2.x, point2.y, point2.z],
     );
+    updateMeasurementTarget(point2, currentDistance);
+  }
+}
+
+function handlePointerUp(e: PointerEvent): void {
+  if (mode !== 'dragging' || !point1) {
+    endDrag(e);
+    return;
+  }
+
+  // Try raycast at release point; fall back to last known point2 from drag
+  const hit = raycastModel(e) || point2;
+  if (hit && point1.distanceTo(hit) > 0.01) {
+    // Finalize measurement
+    point2 = hit;
+    currentDistance = measureDistance(
+      [point1.x, point1.y, point1.z],
+      [point2.x, point2.y, point2.z],
+    );
+    updateMeasurementTarget(point2, currentDistance);
     mode = 'displaying';
     canvas.style.cursor = '';
-
-    showMeasurement(point1, point2, currentDistance, viewportContainer);
+    dragEndTime = Date.now();
+  } else {
+    // Drag was too short or missed model — cancel
+    clearMeasurement();
+    point1 = null;
+    point2 = null;
+    currentDistance = null;
+    mode = 'ready';
+    canvas.style.cursor = 'crosshair';
   }
+
+  endDrag(e);
+}
+
+function handleClick(_e: MouseEvent): void {
+  // Ignore the click event that immediately follows a drag's pointerup
+  if (Date.now() - dragEndTime < 200) return;
+  if (mode === 'displaying') {
+    clear();
+  }
+}
+
+function endDrag(_e: PointerEvent): void {
+  if (moveHandler) canvas.removeEventListener('pointermove', moveHandler);
+  if (upHandler) canvas.removeEventListener('pointerup', upHandler);
+  moveHandler = null;
+  upHandler = null;
+}
+
+function removeListeners(): void {
+  if (downHandler) canvas.removeEventListener('pointerdown', downHandler);
+  if (clickHandler) canvas.removeEventListener('click', clickHandler);
+  if (moveHandler) canvas.removeEventListener('pointermove', moveHandler);
+  if (upHandler) canvas.removeEventListener('pointerup', upHandler);
+  downHandler = null;
+  clickHandler = null;
+  moveHandler = null;
+  upHandler = null;
 }


### PR DESCRIPTION
## Summary

- **XYZ orientation gizmo** in the viewport corner (Three.js ViewHelper) — shows colored X/Y/Z axes with labels that rotate with the camera. Click any axis to snap to that view with smooth 0.4s animation. Z-up-correct targets for all 6 axes.
- **Bounding box dimension annotations** — extension lines, dimension lines, tick marks, and labeled X/Y/Z values. On by default, toggleable via 📐 button. Auto-updates when the model changes.
- **Drag-to-measure** — reworked from click-click to press-drag-release. Live dashed line + distance label during drag. Click to dismiss. Refactored overlay for efficient in-place updates.
- **Camera lock controls** — Measure mode now locks camera rotation while active. Added 🔓/🔒 toggle button for manual orbit lock. Central lock system supports multiple independent lock sources.
- **Bug fix** — ViewHelper's internal `renderer.render()` was auto-clearing the framebuffer, blanking the main scene. Fixed by disabling autoClear around the gizmo render.

## New files
- `src/renderer/orientationGizmo.ts` — gizmo module
- `src/renderer/dimensionLines.ts` — dimension annotations

## Test plan
- [ ] Model renders correctly in Interactive viewport (was broken by autoClear bug, now fixed)
- [ ] XYZ gizmo visible in upper-right, rotates with camera orbit
- [ ] Click X/Y/Z axis labels to snap camera to that view
- [ ] Bounding box dimensions visible by default, toggle off/on with 📐 button
- [ ] Dimension values update when loading different models/examples
- [ ] Drag on model surface in Measure mode shows live distance line
- [ ] Release drag finalizes measurement, click anywhere to dismiss
- [ ] 🔓 button locks/unlocks camera rotation independently
- [ ] Camera stays locked during Measure mode, unlocks when toggled off
- [ ] `npm run build` succeeds with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)