### PR TITLE
Fix browser history navigation

### DIFF
--- a/prompts/20260424-browser-history-navigation.md
+++ b/prompts/20260424-browser-history-navigation.md
@@ -1,0 +1,33 @@
+---
+session: "browser-history-navigation"
+timestamp: "2026-04-24T18:11:55Z"
+model: gpt-5-codex
+tools: [codex, playwright]
+---
+
+## Human
+
+The browser back button did not work correctly. Moving from `/` to the editor
+overwrote the root history entry, and switching editor sections such as
+Interactive to Gallery also overwrote the current entry instead of allowing
+Back to restore the previous view. The request was to research as needed,
+make the changes, confirm they work, and create a PR.
+
+## Approach
+
+Changed tab navigation to push history entries for user-visible view changes
+while still allowing internal URL synchronization to opt out during `popstate`.
+Added route synchronization in `main.ts` so browser Back/Forward re-applies the
+page and editor tab represented by the URL instead of only changing the address
+bar.
+
+Kept automatic session/version URL writes as replacements so session creation,
+saving, and version updates do not flood browser history. Also removed a stale
+gallery URL helper and stopped session URL updates from deleting tab-owned
+parameters.
+
+Verified with Playwright in a real Chromium window because headless Chromium in
+this environment could not create a WebGL context. Smoke checks covered:
+root to editor then browser Back to root, Interactive to Gallery then browser
+Back to Interactive, help route Back behavior, landing-page session tile loading,
+AI-view deep linking, and `npm run build`.

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCamer
 import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, renderSliceSVG, setReferenceImages as _setRefImages, clearReferenceImages as _clearRefImages, getReferenceImages as _getRefImages, type ReferenceImages } from './renderer/multiview';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage } from './editor/codeEditor';
-import { createLayout } from './ui/layout';
+import { createLayout, type TabName } from './ui/layout';
 import { createToolbar, isAutoRun, setToolbarLanguage } from './ui/toolbar';
 import { createLandingPage } from './ui/landing';
 import { createHelpPage } from './ui/help';
@@ -29,7 +29,6 @@ import { maybeStartTour, resetTour, startTour } from './ui/tour';
 import {
   getSessionIdFromURL,
   getVersionFromURL,
-  isGalleryMode,
   openSession,
   createSession,
   closeSession,
@@ -584,6 +583,28 @@ function shouldShow404(): boolean {
   return path !== '/' && path !== '' && path !== '/help' && path !== '/editor';
 }
 
+function getTabFromURL(): TabName {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has('notes')) return 'notes';
+  if (params.has('gallery')) return 'gallery';
+  if (params.get('view') === 'elevations') return 'elevations';
+  if (params.get('view') === 'ai') return 'ai';
+  return 'interactive';
+}
+
+function currentURLPathAndSearch(): string {
+  return `${window.location.pathname}${window.location.search}`;
+}
+
+function updateAppHistory(url: string, mode: 'push' | 'replace'): void {
+  if (url === currentURLPathAndSearch()) return;
+  if (mode === 'push') {
+    window.history.pushState(null, '', url);
+  } else {
+    window.history.replaceState(null, '', url);
+  }
+}
+
 
 // Hide landing/help and show the editor UI
 function showEditorUI(landingEl: HTMLElement | null, helpEl: HTMLElement | null, editorUI: HTMLElement) {
@@ -747,52 +768,126 @@ async function main() {
   app.appendChild(editorUI);
   app.appendChild(overlayContainer);
 
+  let editorReady = false;
+  let editorReadyResolve: (() => void) = () => {};
+  const editorReadyPromise = new Promise<void>(resolve => { editorReadyResolve = resolve; });
+  let engineOk = false;
+  let helpHasAppBackTarget = false;
+  let notFoundEl: HTMLElement | null = null;
+
+  async function ensureEditorReady() {
+    if (!editorReady) await editorReadyPromise;
+  }
+
   // Helper to transition from landing/help to editor
   function transitionToEditor() {
     showEditorUI(landingEl, helpEl, editorUI);
+    if (notFoundEl) notFoundEl.classList.add('hidden');
     overlayContainer.classList.add('hidden');
     window.dispatchEvent(new Event('resize'));
   }
 
-  // Track whether user came from landing (for help back navigation)
-  let cameFromLanding = false;
+  async function loadVersionIntoEditor(version: { code: string }) {
+    const sessionLang = getState().session?.language ?? 'manifold-js';
+    if (sessionLang !== getActiveLanguage()) {
+      await switchLanguage(sessionLang);
+    }
+    setValue(version.code);
+    runCode(version.code);
+    const refImages = await getReferenceImagesFromSession();
+    if (refImages) {
+      _setRefImages(refImages as ReferenceImages);
+    } else {
+      _clearRefImages();
+    }
+  }
+
+  async function openEditorFromLanding() {
+    updateAppHistory('/editor', 'push');
+    transitionToEditor();
+    await ensureEditorReady();
+    if (window.location.pathname !== '/editor') return;
+    await createSession();
+    updateDocumentTitle({ page: 'editor' });
+    setStatus(statusBar, 'ready', 'Ready');
+    runCode(defaultCode);
+  }
+
+  async function openSessionFromLanding(sid: string) {
+    updateAppHistory(`/editor?session=${sid}`, 'push');
+    transitionToEditor();
+    await ensureEditorReady();
+    if (getSessionIdFromURL() !== sid) return;
+    const version = await openSession(sid);
+    if (version) {
+      await loadVersionIntoEditor(version);
+    }
+    updateDocumentTitle({ page: 'editor' });
+  }
+
+  async function ensureLandingPage() {
+    if (!landingEl) {
+      landingEl = await createLandingPage(overlayContainer, {
+        onOpenEditor: openEditorFromLanding,
+        onOpenHelp: () => showHelp(),
+        onOpenSession: openSessionFromLanding,
+      });
+    }
+    return landingEl;
+  }
+
+  async function showLandingPage() {
+    const page = await ensureLandingPage();
+    overlayContainer.classList.remove('hidden');
+    editorUI.classList.add('hidden');
+    helpEl?.classList.add('hidden');
+    notFoundEl?.classList.add('hidden');
+    page.classList.remove('hidden');
+    updateDocumentTitle({ page: 'landing' });
+  }
+
+  function showNotFoundPage() {
+    if (!notFoundEl) {
+      notFoundEl = createNotFoundPage(overlayContainer, {
+        onGoHome: () => {
+          updateAppHistory('/', 'push');
+          void syncRouteFromURL();
+        },
+      });
+    }
+    overlayContainer.classList.remove('hidden');
+    editorUI.classList.add('hidden');
+    landingEl?.classList.add('hidden');
+    helpEl?.classList.add('hidden');
+    notFoundEl.classList.remove('hidden');
+    updateDocumentTitle({ page: '404' });
+  }
 
   // Helper to show help page
-  function showHelp() {
-    cameFromLanding = landingEl != null && !landingEl.classList.contains('hidden');
+  function showHelp(options: { history?: 'push' | 'replace' | 'none' } = {}) {
+    const historyMode = options.history ?? 'push';
+    if (historyMode !== 'none') {
+      helpHasAppBackTarget = currentURLPathAndSearch() !== '/help';
+      updateAppHistory('/help', historyMode);
+    }
     if (!helpEl) {
       helpEl = createHelpPage(overlayContainer, {
         onBack: () => {
-          if (cameFromLanding && landingEl) {
-            // Go back to landing
-            helpEl?.classList.add('hidden');
-            landingEl.classList.remove('hidden');
-            window.history.replaceState(null, '', '/');
-            updateDocumentTitle({ page: 'landing' });
+          if (helpHasAppBackTarget) {
+            window.history.back();
           } else {
-            // Go back to editor — preserve session URL params
-            transitionToEditor();
-            const state = getState();
-            if (state.session) {
-              const params = new URLSearchParams();
-              params.set('session', state.session.id);
-              if (state.currentVersion) params.set('v', String(state.currentVersion.index));
-              window.history.replaceState(null, '', `/editor?${params}`);
-            } else {
-              window.history.replaceState(null, '', '/editor');
-            }
-            updateDocumentTitle({ page: 'editor' });
+            updateAppHistory('/editor', 'replace');
+            void syncEditorFromURL();
           }
         },
         onStartTour: async () => {
-          // Always go to editor (not landing), wait for it to be ready, then start tour
+          updateAppHistory('/editor', 'push');
           transitionToEditor();
           await ensureEditorReady();
           if (!getState().session) {
             await createSession();
             runCode(defaultCode);
           }
-          window.history.replaceState(null, '', '/editor');
           resetTour();
           startTour();
         },
@@ -801,10 +896,52 @@ async function main() {
     overlayContainer.classList.remove('hidden');
     editorUI.classList.add('hidden');
     if (landingEl) landingEl.classList.add('hidden');
+    if (notFoundEl) notFoundEl.classList.add('hidden');
     helpEl.classList.remove('hidden');
-    window.history.replaceState(null, '', '/help');
     updateDocumentTitle({ page: 'help' });
   }
+
+  async function syncEditorFromURL() {
+    transitionToEditor();
+    switchTab(getTabFromURL(), { history: 'none' });
+    updateDocumentTitle({ page: 'editor' });
+    await ensureEditorReady();
+    if (!engineOk) return;
+
+    const sessionId = getSessionIdFromURL();
+    if (sessionId) {
+      const versionIndex = getVersionFromURL();
+      const state = getState();
+      const needsSessionLoad = state.session?.id !== sessionId;
+      const needsVersionLoad = versionIndex !== null && state.currentVersion?.index !== versionIndex;
+      if (needsSessionLoad || needsVersionLoad) {
+        const version = await openSession(sessionId, versionIndex ?? undefined);
+        if (version) {
+          await loadVersionIntoEditor(version);
+        }
+      }
+    } else if (!getState().session) {
+      await createSession();
+      setStatus(statusBar, 'ready', 'Ready');
+      runCode(defaultCode);
+    }
+  }
+
+  async function syncRouteFromURL() {
+    if (shouldShowLanding()) {
+      await showLandingPage();
+    } else if (shouldShowHelp()) {
+      showHelp({ history: 'none' });
+    } else if (shouldShow404()) {
+      showNotFoundPage();
+    } else {
+      await syncEditorFromURL();
+    }
+  }
+
+  window.addEventListener('popstate', () => {
+    void syncRouteFromURL();
+  });
 
   // Expose showHelp for toolbar
   const windowRecord = window as unknown as Record<string, unknown>;
@@ -817,92 +954,14 @@ async function main() {
   const show404 = shouldShow404();
 
   if (showLanding) {
-    // Show landing page immediately — hide editor UI
-    editorUI.classList.add('hidden');
-    overlayContainer.classList.remove('hidden');
-    updateDocumentTitle({ page: 'landing' });
-    landingEl = await createLandingPage(overlayContainer, {
-      onOpenEditor: async () => {
-        transitionToEditor();
-        await ensureEditorReady();
-        await createSession();
-        updateDocumentTitle({ page: 'editor' });
-        setStatus(statusBar, 'ready', 'Ready');
-        runCode(defaultCode);
-      },
-      onOpenHelp: showHelp,
-      onOpenSession: async (sid) => {
-        transitionToEditor();
-        await ensureEditorReady();
-        const version = await openSession(sid);
-        if (version) {
-          // Restore session language
-          const sessionLang = getState().session?.language ?? 'manifold-js';
-          if (sessionLang !== getActiveLanguage()) {
-            await switchLanguage(sessionLang);
-          }
-          setValue(version.code);
-          runCode(version.code);
-          const refImages = await getReferenceImagesFromSession();
-          if (refImages) _setRefImages(refImages as ReferenceImages);
-        }
-        updateDocumentTitle({ page: 'editor' });
-        window.history.replaceState(null, '', `/editor?session=${sid}`);
-      },
-    });
+    await showLandingPage();
   } else if (showHelpPage) {
-    // Show help page immediately
-    editorUI.classList.add('hidden');
-    overlayContainer.classList.remove('hidden');
-    updateDocumentTitle({ page: 'help' });
-    helpEl = createHelpPage(overlayContainer, {
-      onBack: async () => {
-        helpEl?.classList.add('hidden');
-        transitionToEditor();
-        await ensureEditorReady();
-        if (!getState().session) {
-          await createSession();
-          runCode(defaultCode);
-        }
-        updateDocumentTitle({ page: 'editor' });
-      },
-      onStartTour: async () => {
-        helpEl?.classList.add('hidden');
-        transitionToEditor();
-        await ensureEditorReady();
-        if (!getState().session) {
-          await createSession();
-          runCode(defaultCode);
-        }
-        window.history.replaceState(null, '', '/editor');
-        resetTour();
-        startTour();
-      },
-    });
+    showHelp({ history: 'none' });
   } else if (show404) {
-    // Show 404 page — hide editor UI entirely
-    editorUI.classList.add('hidden');
-    overlayContainer.classList.remove('hidden');
-    updateDocumentTitle({ page: '404' });
-    createNotFoundPage(overlayContainer, {
-      onGoHome: () => {
-        window.location.href = '/';
-      },
-    });
-  }
-
-  // Init engine, viewport, editor (in background if landing/help is showing)
-  let editorReady = false;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let editorReadyResolve: (() => void) = () => {};
-  const editorReadyPromise = new Promise<void>(resolve => { editorReadyResolve = resolve; });
-
-  async function ensureEditorReady() {
-    if (!editorReady) await editorReadyPromise;
+    showNotFoundPage();
   }
 
   // Init geometry engine — wrapped in try/catch so editor/viewport still init on failure
-  let engineOk = false;
   setStatus(statusBar, 'loading', 'Loading WASM...');
   try {
     await initEngine();
@@ -941,38 +1000,7 @@ async function main() {
 
   // If not on landing/help/404, load session or default code now
   if (!showLanding && !showHelpPage && !show404 && engineOk) {
-    const sessionId = getSessionIdFromURL();
-    if (sessionId) {
-      const versionIndex = getVersionFromURL();
-      const version = await openSession(sessionId, versionIndex ?? undefined);
-      if (version) {
-        // Restore session language
-        const sessionLang = getState().session?.language ?? 'manifold-js';
-        if (sessionLang !== getActiveLanguage()) {
-          setActiveLanguage(sessionLang);
-          setEditorLanguage(sessionLang);
-          await ensureEngineReady(sessionLang);
-        }
-        setValue(version.code);
-        runCode(version.code);
-        const refImages = await getReferenceImagesFromSession();
-        if (refImages) {
-          _setRefImages(refImages as ReferenceImages);
-        }
-        if (isGalleryMode()) {
-          switchTab('gallery');
-          refreshGallery();
-        }
-      } else {
-        await createSession();
-        setStatus(statusBar, 'ready', 'Ready');
-        runCode(defaultCode);
-      }
-    } else {
-      await createSession();
-      setStatus(statusBar, 'ready', 'Ready');
-      runCode(defaultCode);
-    }
+    await syncEditorFromURL();
   }
 
   // Update document title when session state changes (create, open, close, rename)
@@ -1991,13 +2019,7 @@ async function main() {
 
     /** Get current view state — active tab, camera angle, zoom */
     getViewState(): { tab: string; camera: { azimuth: number; elevation: number; distance: number; target: [number, number, number] } } {
-      const params = new URLSearchParams(window.location.search);
-      let tab = 'interactive';
-      if (params.has('gallery')) tab = 'gallery';
-      else if (params.has('notes')) tab = 'notes';
-      else if (params.get('view') === 'ai') tab = 'ai';
-      else if (params.get('view') === 'elevations') tab = 'elevations';
-      return { tab, camera: getCameraState() };
+      return { tab: getTabFromURL(), camera: getCameraState() };
     },
 
     /** Programmatic tab switching */

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -84,7 +84,6 @@ function updateURL() {
   } else {
     params.delete('session');
     params.delete('v');
-    params.delete('gallery');
   }
   const qs = params.toString().replace(/=(?=&|$)/g, '');
   const newUrl = qs
@@ -100,10 +99,6 @@ export function getSessionIdFromURL(): string | null {
 export function getVersionFromURL(): number | null {
   const v = new URLSearchParams(window.location.search).get('v');
   return v ? parseInt(v, 10) : null;
-}
-
-export function isGalleryMode(): boolean {
-  return new URLSearchParams(window.location.search).has('gallery');
 }
 
 // === Session operations ===

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -10,7 +10,11 @@ export interface LayoutElements {
   notesContainer: HTMLElement;
   statusBar: HTMLElement;
   clipControls: HTMLElement;
-  switchTab: (tab: TabName) => void;
+  switchTab: (tab: TabName, options?: SwitchTabOptions) => void;
+}
+
+export interface SwitchTabOptions {
+  history?: 'push' | 'replace' | 'none';
 }
 
 export function createLayout(appContainer: HTMLElement): LayoutElements {
@@ -141,7 +145,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   }
 
   // Tab switching — updates URL to reflect current tab
-  function switchTab(tab: TabName) {
+  function switchTab(tab: TabName, options: SwitchTabOptions = {}) {
     applyTab(tab);
 
     const basePath = '/editor';
@@ -170,7 +174,15 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
     const newUrl = params.toString()
       ? `${basePath}?${params.toString().replace(/=(?=&|$)/g, '')}`
       : basePath;
-    window.history.replaceState(null, '', newUrl);
+    const currentUrl = `${window.location.pathname}${window.location.search}`;
+    const historyMode = options.history ?? 'push';
+    if (historyMode !== 'none' && newUrl !== currentUrl) {
+      if (historyMode === 'replace') {
+        window.history.replaceState(null, '', newUrl);
+      } else {
+        window.history.pushState(null, '', newUrl);
+      }
+    }
   }
 
   tabInteractive.addEventListener('click', () => switchTab('interactive'));


### PR DESCRIPTION
## Summary
- push browser history entries for editor tab/page navigation instead of replacing the current entry
- sync the rendered page and active editor tab from the URL on browser Back/Forward
- keep session/version URL updates as replacements and preserve tab-owned query params

## Verification
- npm run build
- Playwright smoke: / -> Open Editor -> browser Back returns to /
- Playwright smoke: Interactive -> Gallery -> browser Back returns to Interactive
- Playwright smoke: Help route Back, landing session tile loading, and /editor?view=ai deep link

Note: Playwright was run headful because headless Chromium in this environment could not create a WebGL context.