### PR TITLE
Add toggleable grid plane below model

### DIFF
--- a/prompts/20260424-grid-plane-toggle.md
+++ b/prompts/20260424-grid-plane-toggle.md
@@ -1,0 +1,19 @@
+---
+session: "grid-plane-toggle"
+timestamp: "2026-04-24T19:00:00Z"
+model: claude-opus-4-6
+tools: [claude-code]
+---
+
+## Human
+
+Add a toggleable grid plane to the viewport, hidden by default, positioned
+below the model at its bounding box minimum Z.
+
+## Key Changes
+
+- `src/renderer/viewport.ts`: Store grid reference at module level, default
+  to hidden, position at `box.min.z` on each mesh update, export
+  `setGridVisible`/`isGridVisible` API
+- `src/ui/layout.ts`: Add grid toggle button (▦) in viewport overlay controls
+- `src/main.ts`: Wire up grid toggle button with active/inactive styling

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import './style.css';
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, type Language } from './geometry/engine';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
-import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, setDimensionsVisible, isDimensionsVisible } from './renderer/viewport';
+import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible } from './renderer/viewport';
 import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, renderSliceSVG, setReferenceImages as _setRefImages, clearReferenceImages as _clearRefImages, getReferenceImages as _getRefImages, type ReferenceImages } from './renderer/multiview';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage } from './editor/codeEditor';
@@ -927,6 +927,7 @@ async function main() {
   initClipControls(clipControls);
 
   // Wire up viewport overlay buttons
+  initGridToggle(clipControls);
   initDimensionsToggle(clipControls);
   initMeasureToggle(clipControls);
   initOrbitLockToggle(clipControls);
@@ -2324,6 +2325,21 @@ async function main() {
         setMeasureLock(true);
         measureBtn.className = activeClass;
       }
+    });
+  }
+
+  function initGridToggle(container: HTMLElement) {
+    const gridBtn = container.querySelector('#grid-toggle') as HTMLButtonElement;
+    if (!gridBtn) return;
+
+    const inactiveClass = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+    const activeClass = 'px-2 py-1 rounded text-xs bg-blue-500/20 backdrop-blur text-blue-400 hover:bg-blue-500/30 transition-colors border border-blue-500/30';
+
+    gridBtn.addEventListener('click', () => {
+      const nowVisible = !isGridVisible();
+      setGridVisible(nowVisible);
+      gridBtn.className = nowVisible ? activeClass : inactiveClass;
+      gridBtn.title = nowVisible ? 'Hide grid plane' : 'Show grid plane';
     });
   }
 

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -18,6 +18,9 @@ let animationId: number;
 let measureLock = false;
 let userLock = false;
 
+// Grid plane
+let grid: THREE.GridHelper;
+
 // Clipping plane state
 const clipPlane = new THREE.Plane(new THREE.Vector3(0, 0, -1), 0); // clips above Z
 let clippingEnabled = false;
@@ -73,9 +76,10 @@ export function initViewport(container: HTMLElement): {
   dir2.position.set(-10, 10, -5);
   scene.add(dir2);
 
-  // Grid on XY plane
-  const grid = new THREE.GridHelper(40, 40, 0x444444, 0x333333);
+  // Grid on XY plane (hidden by default)
+  grid = new THREE.GridHelper(40, 40, 0x444444, 0x333333);
   grid.rotation.x = Math.PI / 2;
+  grid.visible = false;
   scene.add(grid);
 
   meshGroup = new THREE.Group();
@@ -168,6 +172,9 @@ export function updateMesh(meshData: MeshData): void {
 
   // Update bounding box dimension annotations
   updateDimensionLines(box);
+
+  // Position grid at the bottom of the model
+  grid.position.z = box.min.z;
 
   controls.target.copy(center);
   camera.position.set(
@@ -345,6 +352,16 @@ export function isUserOrbitLocked(): boolean {
 }
 
 export { setDimensionsVisible, isDimensionsVisible } from './dimensionLines';
+
+// === Grid visibility API ===
+
+export function setGridVisible(visible: boolean): void {
+  grid.visible = visible;
+}
+
+export function isGridVisible(): boolean {
+  return grid.visible;
+}
 
 export function dispose(): void {
   cancelAnimationFrame(animationId);

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -222,6 +222,14 @@ function createClipControls(): HTMLElement {
   container.id = 'clip-controls';
   container.className = 'absolute top-2 right-2 z-10 flex items-center gap-2';
 
+  // Grid toggle (off by default)
+  const gridBtn = document.createElement('button');
+  gridBtn.id = 'grid-toggle';
+  gridBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  gridBtn.textContent = '\u25A6';
+  gridBtn.title = 'Show grid plane';
+  container.appendChild(gridBtn);
+
   // Dimensions toggle (on by default)
   const dimBtn = document.createElement('button');
   dimBtn.id = 'dimensions-toggle';


### PR DESCRIPTION
## Summary
- Adds a grid plane toggle button (▦) to the viewport overlay controls
- Grid is hidden by default and can be toggled on/off
- When visible, the grid is positioned at the model's bounding box minimum Z, acting as a ground plane beneath the geometry
- Grid repositions automatically when the model changes

## Test plan
- [ ] Open the editor with a model loaded
- [ ] Verify grid is hidden by default
- [ ] Click the ▦ button — grid should appear below the model, button turns blue
- [ ] Click again — grid should disappear, button returns to gray
- [ ] Load different examples and toggle grid — should reposition at the bottom of each model
- [ ] Verify build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)