### PR TITLE
Add diff view for comparing code between versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",
+        "@codemirror/merge": "^6.12.1",
         "@codemirror/state": "^6.5.4",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.39.16",
@@ -83,6 +84,19 @@
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
         "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/merge": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.12.1.tgz",
+      "integrity": "sha512-GA8hBq2T+IFM0sb5fk8CunTrqOulA3zurJmHtzcU15EMnL8aYpVINfJ5bkfd53M4ikwoew4Y1ydtSaAlk6+B1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/highlight": "^1.0.0",
+        "style-mod": "^4.1.0"
       }
     },
     "node_modules/@codemirror/search": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/merge": "^6.12.1",
     "@codemirror/state": "^6.5.4",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.39.16",

--- a/prompts/20260424-diff-view.md
+++ b/prompts/20260424-diff-view.md
@@ -1,0 +1,32 @@
+---
+session: "diff-view"
+timestamp: "2026-04-24T18:35:00Z"
+model: claude-opus-4-6
+tools: [claude-code, playwright-mcp]
+---
+
+## Human
+
+Add a "diff view" tab to compare code between two session versions.
+
+## Key Changes
+
+1. **New dependency** — Added `@codemirror/merge` for side-by-side code diff
+   with synchronized scrolling, syntax highlighting, and change gutters.
+
+2. **New module `src/ui/diffView.ts`** — Version selector dropdowns, MergeView
+   instance (read-only, both panes), geometry stat delta chips (volume, surface
+   area, components, genus, dimensions with percentage changes), swap button,
+   and load-to-editor actions.
+
+3. **Layout updates** — Added `'diff'` to `TabName` union, new `diffContainer`
+   in `LayoutElements`, tab button between Gallery and Notes, editor pane
+   hidden when diff tab is active.
+
+4. **URL state** — `?diff` query parameter for the diff tab, consistent with
+   existing `?gallery` and `?notes` patterns. All URL read/write locations
+   updated (layout.ts switchTab, sessionManager.ts updateURL, main.ts
+   shouldShowLanding, getViewState).
+
+5. **Console API** — `setView('diff')` and `getViewState()` updated to support
+   the new tab.

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { createNotFoundPage } from './ui/notFound';
 import { initViewsPanel, updateMultiView } from './ui/panels';
 import { createSessionBar } from './ui/sessionBar';
 import { createGalleryView, refreshGallery } from './ui/gallery';
+import { createDiffView, refreshDiff } from './ui/diffView';
 import { createNotesView, refreshNotes } from './ui/notes';
 import { initSessionList, showSessionList } from './ui/sessionList';
 import { exportGLB } from './export/gltf';
@@ -572,7 +573,7 @@ function shouldShowLanding(): boolean {
   const params = new URLSearchParams(window.location.search);
   // Landing if at root path AND no query params that indicate a specific view
   const isRootPath = path === '/' || path === '';
-  return isRootPath && !params.has('view') && !params.has('session') && !params.has('gallery') && !params.has('notes');
+  return isRootPath && !params.has('view') && !params.has('session') && !params.has('gallery') && !params.has('diff') && !params.has('notes');
 }
 
 function shouldShowHelp(): boolean {
@@ -705,7 +706,7 @@ async function main() {
   });
 
   // Create layout
-  const { editorContainer, viewportPane, viewsContainer, elevationsContainer, galleryContainer, notesContainer, statusBar, clipControls, switchTab } = createLayout(editorUI);
+  const { editorContainer, viewportPane, viewsContainer, elevationsContainer, galleryContainer, diffContainer, notesContainer, statusBar, clipControls, switchTab } = createLayout(editorUI);
 
   // Init views panel
   initViewsPanel(viewsContainer);
@@ -717,12 +718,20 @@ async function main() {
     switchTab('interactive');
   });
 
+  // Init diff view
+  createDiffView(diffContainer, (code: string) => {
+    setValue(code);
+    runCode(code);
+    switchTab('interactive');
+  });
+
   // Init notes panel
   createNotesView(notesContainer);
 
   // Refresh gallery/notes whenever their tabs are selected
   window.addEventListener('tab-switched', ((e: CustomEvent) => {
     if (e.detail.tab === 'gallery') refreshGallery();
+    if (e.detail.tab === 'diff') refreshDiff();
     if (e.detail.tab === 'notes') refreshNotes();
   }) as EventListener);
 
@@ -1994,6 +2003,7 @@ async function main() {
       const params = new URLSearchParams(window.location.search);
       let tab = 'interactive';
       if (params.has('gallery')) tab = 'gallery';
+      else if (params.has('diff')) tab = 'diff';
       else if (params.has('notes')) tab = 'notes';
       else if (params.get('view') === 'ai') tab = 'ai';
       else if (params.get('view') === 'elevations') tab = 'elevations';
@@ -2001,8 +2011,8 @@ async function main() {
     },
 
     /** Programmatic tab switching */
-    setView(tab: 'interactive' | 'ai' | 'elevations' | 'gallery' | 'notes'): void {
-      assertEnum(tab, ['interactive', 'ai', 'elevations', 'gallery', 'notes'] as const, 'setView(tab)');
+    setView(tab: 'interactive' | 'ai' | 'elevations' | 'gallery' | 'diff' | 'notes'): void {
+      assertEnum(tab, ['interactive', 'ai', 'elevations', 'gallery', 'diff', 'notes'] as const, 'setView(tab)');
       switchTab(tab);
     },
 
@@ -2146,7 +2156,7 @@ async function main() {
         'analyzeProfile':  { signature: 'analyzeProfile(sampleCount?) -- Z-profile feature summary', docs: '/ai.md#console-api--windowpartwright' },
         'measureAt':       { signature: 'measureAt([x,y]) -- Ray-cast probe at XY -> {hits, thickness, topZ, bottomZ}', docs: '/ai.md#console-api--windowpartwright' },
         // View
-        'setView':         { signature: 'setView(tab) -- Switch tab: "interactive", "ai", "elevations", "gallery"', docs: '/ai.md#view-tabs' },
+        'setView':         { signature: 'setView(tab) -- Switch tab: "interactive", "ai", "elevations", "gallery", "diff"', docs: '/ai.md#view-tabs' },
         'getViewState':    { signature: 'getViewState() -- Current tab and camera state', docs: '/ai.md#view-tabs' },
         // Export
         'exportGLB':       { signature: 'await exportGLB() -- Download GLB file', docs: '/ai.md#console-api--windowpartwright' },

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -85,6 +85,7 @@ function updateURL() {
     params.delete('session');
     params.delete('v');
     params.delete('gallery');
+    params.delete('diff');
   }
   const qs = params.toString().replace(/=(?=&|$)/g, '');
   const newUrl = qs

--- a/src/ui/diffView.ts
+++ b/src/ui/diffView.ts
@@ -1,0 +1,278 @@
+// Diff view — side-by-side code comparison between two session versions
+
+import { MergeView } from '@codemirror/merge';
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { javascript } from '@codemirror/lang-javascript';
+import { oneDark } from '@codemirror/theme-one-dark';
+import { basicSetup } from 'codemirror';
+import { listCurrentVersions, type Version } from '../storage/sessionManager';
+
+let diffEl: HTMLElement | null = null;
+let mergeView: MergeView | null = null;
+let onLoadCode: ((code: string) => void) | null = null;
+
+export function createDiffView(container: HTMLElement, loadCode: (code: string) => void): void {
+  diffEl = container;
+  onLoadCode = loadCode;
+
+  window.addEventListener('session-changed', () => {
+    // Destroy stale merge view when session changes
+    destroyMergeView();
+    if (diffEl && !diffEl.classList.contains('hidden')) refreshDiff();
+  });
+}
+
+export async function refreshDiff(): Promise<void> {
+  if (!diffEl) return;
+
+  const versions = await listCurrentVersions();
+
+  // Clear everything except the merge view (which we manage separately)
+  destroyMergeView();
+  diffEl.innerHTML = '';
+
+  if (versions.length < 2) {
+    const empty = document.createElement('div');
+    empty.className = 'flex items-center justify-center h-full text-zinc-500 text-sm';
+    empty.textContent = versions.length === 0
+      ? 'No versions saved yet. Save at least 2 versions to compare.'
+      : 'Only 1 version saved. Save another version to compare.';
+    diffEl.appendChild(empty);
+    return;
+  }
+
+  // Build the UI
+  const wrapper = document.createElement('div');
+  wrapper.className = 'flex flex-col h-full';
+
+  // --- Controls bar ---
+  const controls = document.createElement('div');
+  controls.className = 'flex items-center gap-3 px-4 py-2 bg-zinc-800 border-b border-zinc-700 shrink-0 flex-wrap';
+
+  const labelA = document.createElement('span');
+  labelA.className = 'text-xs text-zinc-400 font-mono';
+  labelA.textContent = 'From:';
+
+  const selectA = createVersionSelect(versions, versions.length - 2);
+
+  const labelB = document.createElement('span');
+  labelB.className = 'text-xs text-zinc-400 font-mono';
+  labelB.textContent = 'To:';
+
+  const selectB = createVersionSelect(versions, versions.length - 1);
+
+  const swapBtn = document.createElement('button');
+  swapBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-700 text-zinc-300 hover:bg-zinc-600 transition-colors';
+  swapBtn.textContent = '\u21C4 Swap';
+  swapBtn.title = 'Swap left and right versions';
+  swapBtn.addEventListener('click', () => {
+    const tmp = selectA.value;
+    selectA.value = selectB.value;
+    selectB.value = tmp;
+    renderDiff(versions, parseInt(selectA.value), parseInt(selectB.value), mergeContainer, statsContainer);
+  });
+
+  const loadLeftBtn = document.createElement('button');
+  loadLeftBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-700 text-zinc-300 hover:bg-zinc-600 transition-colors ml-auto';
+  loadLeftBtn.textContent = 'Load Left';
+  loadLeftBtn.title = 'Load the left version into the editor';
+  loadLeftBtn.addEventListener('click', () => {
+    const v = versions.find(v => v.index === parseInt(selectA.value));
+    if (v && onLoadCode) onLoadCode(v.code);
+  });
+
+  const loadRightBtn = document.createElement('button');
+  loadRightBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-700 text-zinc-300 hover:bg-zinc-600 transition-colors';
+  loadRightBtn.textContent = 'Load Right';
+  loadRightBtn.title = 'Load the right version into the editor';
+  loadRightBtn.addEventListener('click', () => {
+    const v = versions.find(v => v.index === parseInt(selectB.value));
+    if (v && onLoadCode) onLoadCode(v.code);
+  });
+
+  controls.appendChild(labelA);
+  controls.appendChild(selectA);
+  controls.appendChild(labelB);
+  controls.appendChild(selectB);
+  controls.appendChild(swapBtn);
+  controls.appendChild(loadLeftBtn);
+  controls.appendChild(loadRightBtn);
+
+  // --- Stats delta bar ---
+  const statsContainer = document.createElement('div');
+  statsContainer.className = 'px-4 py-2 bg-zinc-850 border-b border-zinc-700 shrink-0';
+
+  // --- Merge view container ---
+  const mergeContainer = document.createElement('div');
+  mergeContainer.className = 'flex-1 min-h-0 overflow-auto';
+
+  wrapper.appendChild(controls);
+  wrapper.appendChild(statsContainer);
+  wrapper.appendChild(mergeContainer);
+  diffEl.appendChild(wrapper);
+
+  // Wire up select changes
+  const onSelectChange = () => {
+    renderDiff(versions, parseInt(selectA.value), parseInt(selectB.value), mergeContainer, statsContainer);
+  };
+  selectA.addEventListener('change', onSelectChange);
+  selectB.addEventListener('change', onSelectChange);
+
+  // Initial render
+  renderDiff(versions, parseInt(selectA.value), parseInt(selectB.value), mergeContainer, statsContainer);
+}
+
+function createVersionSelect(versions: Version[], selectedIdx: number): HTMLSelectElement {
+  const select = document.createElement('select');
+  select.className = 'bg-zinc-700 text-zinc-200 text-xs font-mono rounded px-2 py-1 border border-zinc-600 focus:border-blue-500 focus:outline-none';
+
+  for (const v of versions) {
+    const opt = document.createElement('option');
+    opt.value = String(v.index);
+    opt.textContent = `v${v.index} — ${v.label}`;
+    if (v.index === versions[selectedIdx]?.index) opt.selected = true;
+    select.appendChild(opt);
+  }
+
+  return select;
+}
+
+function renderDiff(
+  versions: Version[],
+  indexA: number,
+  indexB: number,
+  mergeContainer: HTMLElement,
+  statsContainer: HTMLElement,
+): void {
+  const vA = versions.find(v => v.index === indexA);
+  const vB = versions.find(v => v.index === indexB);
+  if (!vA || !vB) return;
+
+  // Render stats delta
+  renderStatsDelta(vA, vB, statsContainer);
+
+  // Destroy previous merge view
+  destroyMergeView();
+  mergeContainer.innerHTML = '';
+
+  const readOnlyExt = EditorState.readOnly.of(true);
+  const themeExt = EditorView.theme({
+    '&': { height: '100%', fontSize: '13px' },
+    '.cm-scroller': { overflow: 'auto' },
+    '.cm-content': { fontFamily: 'monospace' },
+  });
+
+  mergeView = new MergeView({
+    a: {
+      doc: vA.code,
+      extensions: [basicSetup, javascript(), oneDark, readOnlyExt, themeExt],
+    },
+    b: {
+      doc: vB.code,
+      extensions: [basicSetup, javascript(), oneDark, readOnlyExt, themeExt],
+    },
+    parent: mergeContainer,
+    highlightChanges: true,
+    gutter: true,
+    collapseUnchanged: { margin: 3, minSize: 6 },
+  });
+
+  // Style the merge view container
+  mergeView.dom.style.height = '100%';
+  mergeView.dom.style.overflow = 'auto';
+}
+
+function renderStatsDelta(vA: Version, vB: Version, container: HTMLElement): void {
+  container.innerHTML = '';
+
+  const gdA = vA.geometryData;
+  const gdB = vB.geometryData;
+
+  if (!gdA || !gdB || gdA.status !== 'ok' || gdB.status !== 'ok') {
+    const msg = document.createElement('div');
+    msg.className = 'text-xs text-zinc-500 font-mono';
+    if (!gdA && !gdB) {
+      msg.textContent = 'No geometry data for either version.';
+    } else if (gdA?.status === 'error' || gdB?.status === 'error') {
+      msg.textContent = 'One or both versions had geometry errors.';
+    } else {
+      msg.textContent = 'Geometry data unavailable for comparison.';
+    }
+    container.appendChild(msg);
+    return;
+  }
+
+  const row = document.createElement('div');
+  row.className = 'flex items-center gap-4 flex-wrap';
+
+  // Compare numeric fields
+  const fields: { key: string; label: string; decimals: number }[] = [
+    { key: 'volume', label: 'Volume', decimals: 1 },
+    { key: 'surfaceArea', label: 'Surface Area', decimals: 1 },
+    { key: 'componentCount', label: 'Components', decimals: 0 },
+    { key: 'genus', label: 'Genus', decimals: 0 },
+  ];
+
+  for (const { key, label, decimals } of fields) {
+    const a = gdA[key] as number | undefined;
+    const b = gdB[key] as number | undefined;
+    if (a === undefined || b === undefined) continue;
+
+    const delta = b - a;
+    const pct = a !== 0 ? ((delta / a) * 100) : null;
+
+    const chip = document.createElement('span');
+    chip.className = 'text-xs font-mono px-2 py-0.5 rounded';
+
+    const valStr = `${a.toFixed(decimals)} \u2192 ${b.toFixed(decimals)}`;
+
+    if (delta === 0) {
+      chip.className += ' bg-zinc-700/50 text-zinc-400';
+      chip.textContent = `${label}: ${valStr}`;
+    } else {
+      const sign = delta > 0 ? '+' : '';
+      const pctStr = pct !== null ? ` (${sign}${pct.toFixed(1)}%)` : '';
+      chip.className += delta > 0 ? ' bg-emerald-900/40 text-emerald-400' : ' bg-red-900/40 text-red-400';
+      chip.textContent = `${label}: ${valStr} ${sign}${delta.toFixed(decimals)}${pctStr}`;
+    }
+
+    row.appendChild(chip);
+  }
+
+  // Bounding box dimensions
+  const bbA = gdA.boundingBox as { dimensions?: number[] } | undefined;
+  const bbB = gdB.boundingBox as { dimensions?: number[] } | undefined;
+  if (bbA?.dimensions && bbB?.dimensions) {
+    const dA = bbA.dimensions;
+    const dB = bbB.dimensions;
+    const chip = document.createElement('span');
+    chip.className = 'text-xs font-mono px-2 py-0.5 rounded bg-zinc-700/50 text-zinc-400';
+    chip.textContent = `Dims: ${fmtDims(dA)} \u2192 ${fmtDims(dB)}`;
+    row.appendChild(chip);
+  }
+
+  // Manifold status
+  const imA = gdA.isManifold as boolean | undefined;
+  const imB = gdB.isManifold as boolean | undefined;
+  if (imA !== undefined && imB !== undefined && imA !== imB) {
+    const chip = document.createElement('span');
+    chip.className = 'text-xs font-mono px-2 py-0.5 rounded';
+    chip.className += imB ? ' bg-emerald-900/40 text-emerald-400' : ' bg-red-900/40 text-red-400';
+    chip.textContent = `Manifold: ${imA} \u2192 ${imB}`;
+    row.appendChild(chip);
+  }
+
+  container.appendChild(row);
+}
+
+function fmtDims(d: number[]): string {
+  return `${d[0].toFixed(0)}\u00D7${d[1].toFixed(0)}\u00D7${d[2].toFixed(0)}`;
+}
+
+function destroyMergeView(): void {
+  if (mergeView) {
+    mergeView.destroy();
+    mergeView = null;
+  }
+}

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,4 +1,4 @@
-export type TabName = 'interactive' | 'ai' | 'elevations' | 'gallery' | 'notes';
+export type TabName = 'interactive' | 'ai' | 'elevations' | 'gallery' | 'diff' | 'notes';
 
 export interface LayoutElements {
   editorPane: HTMLElement;
@@ -7,6 +7,7 @@ export interface LayoutElements {
   viewsContainer: HTMLElement;
   elevationsContainer: HTMLElement;
   galleryContainer: HTMLElement;
+  diffContainer: HTMLElement;
   notesContainer: HTMLElement;
   statusBar: HTMLElement;
   clipControls: HTMLElement;
@@ -65,6 +66,8 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   tabElevations.title = 'Orthographic views with optional reference image overlay';
   const tabGallery = createTab('Gallery', false);
   tabGallery.title = 'Compare saved versions side-by-side';
+  const tabDiff = createTab('Diff', false);
+  tabDiff.title = 'Compare code between two versions';
   const tabNotes = createTab('Notes', false);
   tabNotes.title = 'Session notes and design decisions log';
 
@@ -89,6 +92,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   tabBar.appendChild(tabAI);
   tabBar.appendChild(tabElevations);
   tabBar.appendChild(tabGallery);
+  tabBar.appendChild(tabDiff);
   tabBar.appendChild(tabNotes);
   tabBar.appendChild(viewActions);
 
@@ -113,16 +117,20 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   galleryContainer.id = 'gallery-container';
   galleryContainer.className = 'flex-1 min-h-0 overflow-auto bg-zinc-900 hidden p-4';
 
+  const diffContainer = document.createElement('div');
+  diffContainer.id = 'diff-container';
+  diffContainer.className = 'flex-1 min-h-0 overflow-hidden bg-zinc-900 hidden';
+
   const notesContainer = document.createElement('div');
   notesContainer.id = 'notes-container';
   notesContainer.className = 'flex-1 min-h-0 overflow-auto bg-zinc-900 hidden p-4 flex flex-col';
 
-  const allTabs = [tabInteractive, tabAI, tabElevations, tabGallery, tabNotes];
-  const allPanes = [viewportPane, viewsContainer, elevationsContainer, galleryContainer, notesContainer];
+  const allTabs = [tabInteractive, tabAI, tabElevations, tabGallery, tabDiff, tabNotes];
+  const allPanes = [viewportPane, viewsContainer, elevationsContainer, galleryContainer, diffContainer, notesContainer];
 
   // Shared tab activation logic (DOM toggling, editor visibility, events)
   function applyTab(tab: TabName) {
-    const idx = tab === 'interactive' ? 0 : tab === 'ai' ? 1 : tab === 'elevations' ? 2 : tab === 'gallery' ? 3 : 4;
+    const idx = tab === 'interactive' ? 0 : tab === 'ai' ? 1 : tab === 'elevations' ? 2 : tab === 'gallery' ? 3 : tab === 'diff' ? 4 : 5;
     for (let i = 0; i < allPanes.length; i++) {
       if (i === idx) {
         allPanes[i].classList.remove('hidden');
@@ -133,7 +141,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
       }
     }
     viewActions.classList.toggle('hidden', tab !== 'ai' && tab !== 'elevations');
-    const hideEditor = tab === 'ai' || tab === 'elevations';
+    const hideEditor = tab === 'ai' || tab === 'elevations' || tab === 'diff';
     editorPane.classList.toggle('hidden', hideEditor);
     splitter.classList.toggle('hidden', hideEditor);
     window.dispatchEvent(new CustomEvent('tab-switched', { detail: { tab } }));
@@ -149,22 +157,32 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
     if (tab === 'ai') {
       params.set('view', 'ai');
       params.delete('gallery');
+      params.delete('diff');
       params.delete('notes');
     } else if (tab === 'elevations') {
       params.set('view', 'elevations');
       params.delete('gallery');
+      params.delete('diff');
       params.delete('notes');
     } else if (tab === 'gallery') {
       params.set('gallery', '');
       params.delete('view');
+      params.delete('diff');
+      params.delete('notes');
+    } else if (tab === 'diff') {
+      params.set('diff', '');
+      params.delete('view');
+      params.delete('gallery');
       params.delete('notes');
     } else if (tab === 'notes') {
       params.set('notes', '');
       params.delete('view');
       params.delete('gallery');
+      params.delete('diff');
     } else {
       params.delete('view');
       params.delete('gallery');
+      params.delete('diff');
       params.delete('notes');
     }
     const newUrl = params.toString()
@@ -177,12 +195,15 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   tabAI.addEventListener('click', () => switchTab('ai'));
   tabElevations.addEventListener('click', () => switchTab('elevations'));
   tabGallery.addEventListener('click', () => switchTab('gallery'));
+  tabDiff.addEventListener('click', () => switchTab('diff'));
   tabNotes.addEventListener('click', () => switchTab('notes'));
 
   // Restore tab from URL on initial load (without re-writing the URL)
   const initParams = new URLSearchParams(window.location.search);
   if (initParams.has('notes')) {
     applyTab('notes');
+  } else if (initParams.has('diff')) {
+    applyTab('diff');
   } else if (initParams.has('gallery')) {
     applyTab('gallery');
   } else if (initParams.get('view') === 'elevations') {
@@ -196,6 +217,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   rightPane.appendChild(viewsContainer);
   rightPane.appendChild(elevationsContainer);
   rightPane.appendChild(galleryContainer);
+  rightPane.appendChild(diffContainer);
   rightPane.appendChild(notesContainer);
 
   main.appendChild(editorPane);
@@ -204,7 +226,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
 
   appContainer.appendChild(main);
 
-  return { editorPane, editorContainer, viewportPane, viewsContainer, elevationsContainer, galleryContainer, notesContainer, statusBar, clipControls, switchTab };
+  return { editorPane, editorContainer, viewportPane, viewsContainer, elevationsContainer, galleryContainer, diffContainer, notesContainer, statusBar, clipControls, switchTab };
 }
 
 function createTab(label: string, active: boolean): HTMLButtonElement {


### PR DESCRIPTION
## Summary
- Adds a **Diff** tab (between Gallery and Notes) for side-by-side code comparison between any two session versions
- Uses `@codemirror/merge` for synchronized scrolling, syntax highlighting, and change gutters
- Shows geometry stat deltas (volume, surface area, components, genus, dimensions) with color-coded percentage changes
- Includes version selector dropdowns, swap button, and load-to-editor actions
- Full URL state support (`?diff` param) and console API integration (`setView('diff')`, `getViewState()`)

## Test plan
- [ ] Open editor, save 2+ versions, click Diff tab — should show side-by-side code diff with stat deltas
- [ ] Change version selectors — diff and stats should update
- [ ] Click Swap — versions should reverse, stats show inverted deltas
- [ ] Click Load Left / Load Right — should load that version's code into editor and switch to Interactive
- [ ] Navigate to `?diff` URL directly — should open diff tab on load
- [ ] `partwright.setView('diff')` / `partwright.getViewState()` — should work from console
- [ ] With <2 versions — should show helpful empty state message
- [ ] `npm run build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)