### PR TITLE
Improve editor error diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",
+        "@codemirror/lint": "^6.9.5",
         "@codemirror/state": "^6.5.4",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.39.16",
@@ -79,6 +80,7 @@
       "version": "6.9.5",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
       "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/lint": "^6.9.5",
     "@codemirror/state": "^6.5.4",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.39.16",

--- a/prompts/20260424-editor-error-diagnostics.md
+++ b/prompts/20260424-editor-error-diagnostics.md
@@ -1,0 +1,54 @@
+---
+session: "editor-error-diagnostics"
+timestamp: "2026-04-24T18:40:00Z"
+model: gpt-5-codex
+tools: [codex-cli, playwright]
+---
+
+## Human
+
+User noted that syntax errors currently appear only as a small message
+above the editor, making it hard to tell where the error is or how to fix
+it. After an investigation, user asked to create a branch from the latest
+`staging`, implement the recommendation, and open a PR for deployment
+testing.
+
+## Approach
+
+Added structured source diagnostics alongside the existing string error
+messages so existing console API callers keep working while the editor can
+show precise locations:
+
+- `SourceDiagnostic` type on engine validation/run results
+- JS syntax diagnostics derived from the CodeMirror JavaScript parser
+- OpenSCAD diagnostics parsed from compiler stderr line references
+- runtime diagnostics with hints, but no misleading editor marker when no
+  source location is available
+
+## UI
+
+Integrated `@codemirror/lint` in the editor:
+
+- lint gutter markers
+- red inline ranges for located errors
+- automatic reveal/selection of the first diagnostic after a failed run
+- diagnostics clear on edit or successful run
+
+Added an editor error panel under the editor header with a short summary,
+location, full error output, and a focused hint. The compact status label
+now shows summaries like `Syntax error on line 2:11` instead of the full
+truncated exception.
+
+## Verification
+
+Validated with:
+
+- `npm run build`
+- `git diff --check`
+- Playwright browser checks for:
+  - JavaScript syntax errors showing a line/column, panel, gutter marker,
+    inline range, and API diagnostics
+  - successful JavaScript run clearing the panel and diagnostics
+  - no editor marker for non-located runtime errors
+  - OpenSCAD syntax errors returning line diagnostics and showing editor
+    markers/panel output

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -4,11 +4,14 @@ import { javascript } from '@codemirror/lang-javascript';
 import { StreamLanguage } from '@codemirror/language';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { basicSetup } from 'codemirror';
+import { lintGutter, setDiagnostics, type Diagnostic } from '@codemirror/lint';
+import type { SourceDiagnostic } from '../geometry/types';
 
 export type EditorLanguage = 'manifold-js' | 'scad';
 
 let editorView: EditorView | null = null;
 let debounceTimer: number | null = null;
+let activeDiagnostics: Diagnostic[] = [];
 const languageCompartment = new Compartment();
 
 // Minimal OpenSCAD StreamLanguage — keyword/builtin/comment/string/number coloring.
@@ -57,6 +60,55 @@ function languageExt(lang: EditorLanguage): Extension {
   return lang === 'scad' ? scadLanguage : javascript();
 }
 
+function clampOffset(offset: number, docLength: number): number {
+  if (!Number.isFinite(offset)) return 0;
+  return Math.max(0, Math.min(docLength, Math.trunc(offset)));
+}
+
+function offsetFromLineColumn(doc: string, line?: number, column?: number): number {
+  if (!line) return 0;
+  const targetLine = Math.max(1, Math.trunc(line));
+  let currentLine = 1;
+  let lineStart = 0;
+
+  for (let i = 0; i < doc.length && currentLine < targetLine; i++) {
+    if (doc.charCodeAt(i) === 10) {
+      currentLine++;
+      lineStart = i + 1;
+    }
+  }
+
+  if (currentLine !== targetLine) return doc.length;
+  const lineEnd = doc.indexOf('\n', lineStart);
+  const end = lineEnd === -1 ? doc.length : lineEnd;
+  const colOffset = Math.max(0, Math.trunc(column ?? 1) - 1);
+  return Math.min(lineStart + colOffset, end);
+}
+
+function toEditorDiagnostic(input: SourceDiagnostic, doc: string): Diagnostic {
+  const from = input.from !== undefined
+    ? clampOffset(input.from, doc.length)
+    : offsetFromLineColumn(doc, input.line, input.column);
+  const to = input.to !== undefined
+    ? clampOffset(input.to, doc.length)
+    : input.endLine !== undefined
+      ? offsetFromLineColumn(doc, input.endLine, input.endColumn)
+      : Math.min(doc.length, from + 1);
+  const message = input.hint ? `${input.message}\nHint: ${input.hint}` : input.message;
+
+  return {
+    from,
+    to: Math.max(from, to),
+    severity: input.severity,
+    source: input.source,
+    message,
+  };
+}
+
+function hasEditorLocation(input: SourceDiagnostic): boolean {
+  return input.from !== undefined || input.line !== undefined;
+}
+
 export function initEditor(
   container: HTMLElement,
   initialCode: string,
@@ -68,9 +120,13 @@ export function initEditor(
     extensions: [
       basicSetup,
       languageCompartment.of(languageExt(initialLanguage)),
+      lintGutter(),
       oneDark,
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
+          if (activeDiagnostics.length > 0) {
+            window.queueMicrotask(() => clearEditorDiagnostics());
+          }
           if (debounceTimer !== null) clearTimeout(debounceTimer);
           debounceTimer = window.setTimeout(() => {
             onChange(getValue());
@@ -81,6 +137,7 @@ export function initEditor(
         '&': { height: '100%', fontSize: '13px' },
         '.cm-scroller': { overflow: 'auto' },
         '.cm-content': { fontFamily: 'monospace' },
+        '.cm-lint-marker-error': { cursor: 'help' },
       }),
     ],
   });
@@ -109,4 +166,29 @@ export function setValue(code: string): void {
   editorView.dispatch({
     changes: { from: 0, to: editorView.state.doc.length, insert: code },
   });
+}
+
+export function setEditorDiagnostics(diagnostics: SourceDiagnostic[]): void {
+  if (!editorView) return;
+  const doc = editorView.state.doc.toString();
+  activeDiagnostics = diagnostics
+    .filter(hasEditorLocation)
+    .map(d => toEditorDiagnostic(d, doc));
+  editorView.dispatch(setDiagnostics(editorView.state, activeDiagnostics));
+}
+
+export function clearEditorDiagnostics(): void {
+  if (!editorView || activeDiagnostics.length === 0) return;
+  activeDiagnostics = [];
+  editorView.dispatch(setDiagnostics(editorView.state, []));
+}
+
+export function revealFirstDiagnostic(): void {
+  if (!editorView || activeDiagnostics.length === 0) return;
+  const first = activeDiagnostics[0];
+  editorView.dispatch({
+    selection: { anchor: first.from, head: first.to },
+    effects: EditorView.scrollIntoView(first.from, { y: 'center' }),
+  });
+  editorView.focus();
 }

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -1,4 +1,5 @@
 import type { Engine, MeshResult, ValidateResult } from './types';
+import { javaScriptSyntaxDiagnostics, runtimeDiagnostic } from '../sourceDiagnostics';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let manifoldModule: any = null;
@@ -49,10 +50,12 @@ export const manifoldJsEngine: Engine = {
       result = fn(api);
 
       if (!result || typeof result.getMesh !== 'function') {
+        const error = 'Code must return a Manifold object. Did you forget to `return` the final Manifold? See /ai.md#before-you-start';
         return {
           mesh: null,
           manifold: null,
-          error: 'Code must return a Manifold object. Did you forget to `return` the final Manifold? See /ai.md#before-you-start',
+          error,
+          diagnostics: runtimeDiagnostic(error, 'Add a final `return` statement that returns the Manifold you want to render.', 'JavaScript'),
         };
       }
 
@@ -70,21 +73,29 @@ export const manifoldJsEngine: Engine = {
       };
     } catch (e: unknown) {
       let msg = e instanceof Error ? e.message : String(e);
+      const isSyntaxError = e instanceof SyntaxError;
+      let hint: string | undefined;
 
       // Enhance common WASM error messages with actionable hints
       if (msg.includes('BindingError') && msg.includes('deleted object')) {
-        msg += '\n💡 Hint: A Manifold or CrossSection was used after being deleted. Avoid calling .delete() on objects you still need, or store intermediate results before cleanup.';
+        hint = 'A Manifold or CrossSection was used after being deleted. Avoid calling .delete() on objects you still need, or store intermediate results before cleanup.';
       } else if (msg.includes('function _Cylinder called with')) {
-        msg += '\n💡 Hint: Manifold.cylinder(height, radiusLow, radiusHigh?, segments?) — check argument count and order.';
+        hint = 'Manifold.cylinder(height, radiusLow, radiusHigh?, segments?) — check argument count and order.';
       } else if (msg.includes('function _Cube called with')) {
-        msg += '\n💡 Hint: Manifold.cube([x, y, z], center?) — first arg must be an array of 3 numbers.';
+        hint = 'Manifold.cube([x, y, z], center?) — first arg must be an array of 3 numbers.';
       } else if (msg.includes('Missing field')) {
-        msg += '\n💡 Hint: You may have passed an array where an object was expected, or vice versa. Check the API signature.';
+        hint = 'You may have passed an array where an object was expected, or vice versa. Check the API signature.';
       } else if (msg.includes('unreachable') || msg.includes('RuntimeError')) {
-        msg += '\n💡 Hint: WASM runtime error — likely caused by degenerate geometry (zero-area face, self-intersection, or invalid boolean). Try simplifying the operation or checking input dimensions.';
+        hint = 'WASM runtime error — likely caused by degenerate geometry, a self-intersection, or an invalid boolean. Try simplifying the operation or checking input dimensions.';
       }
 
-      return { mesh: null, manifold: null, error: msg };
+      if (hint) msg += `\nHint: ${hint}`;
+      return {
+        mesh: null,
+        manifold: null,
+        error: msg,
+        diagnostics: isSyntaxError ? javaScriptSyntaxDiagnostics(jsCode, msg, e) : runtimeDiagnostic(msg, hint, 'JavaScript'),
+      };
     }
   },
 
@@ -94,7 +105,12 @@ export const manifoldJsEngine: Engine = {
       new Function('api', `"use strict";\n${jsCode}`);
       return { valid: true };
     } catch (e) {
-      return { valid: false, error: e instanceof Error ? e.message : String(e) };
+      const error = e instanceof Error ? e.message : String(e);
+      return {
+        valid: false,
+        error,
+        diagnostics: e instanceof SyntaxError ? javaScriptSyntaxDiagnostics(jsCode, error, e) : runtimeDiagnostic(error, undefined, 'JavaScript'),
+      };
     }
   },
 };

--- a/src/geometry/engines/openscad.ts
+++ b/src/geometry/engines/openscad.ts
@@ -1,6 +1,7 @@
 import type { Engine, MeshResult, ValidateResult } from './types';
 import { parseBinarySTLToMeshGL } from './scadToManifold';
 import { getManifoldModule, manifoldJsEngine } from './manifoldJs';
+import { scadDiagnostics } from '../sourceDiagnostics';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CreateOpenSCAD = (opts: any) => Promise<any>;
@@ -105,7 +106,8 @@ export const openscadEngine: Engine = {
  *  and round-trips through Manifold.ofMesh(). */
 export async function runScadAsync(source: string): Promise<MeshResult> {
   if (!createFn) {
-    return { mesh: null, manifold: null, error: 'OpenSCAD engine not initialized.' };
+    const error = 'OpenSCAD engine not initialized.';
+    return { mesh: null, manifold: null, error, diagnostics: scadDiagnostics(source, error) };
   }
 
   let instance: any;
@@ -113,7 +115,8 @@ export async function runScadAsync(source: string): Promise<MeshResult> {
   try {
     ({ instance, stderr } = await createInstance());
   } catch (e) {
-    return { mesh: null, manifold: null, error: `Failed to create OpenSCAD instance: ${e instanceof Error ? e.message : String(e)}` };
+    const error = `Failed to create OpenSCAD instance: ${e instanceof Error ? e.message : String(e)}`;
+    return { mesh: null, manifold: null, error, diagnostics: scadDiagnostics(source, error) };
   }
 
   try {
@@ -127,10 +130,12 @@ export async function runScadAsync(source: string): Promise<MeshResult> {
     ]);
 
     if (exitCode !== 0) {
+      const error = `OpenSCAD exited with code ${exitCode}\n${formatStderr(stderr)}`;
       return {
         mesh: null,
         manifold: null,
-        error: `OpenSCAD exited with code ${exitCode}\n${formatStderr(stderr)}`,
+        error,
+        diagnostics: scadDiagnostics(source, error),
       };
     }
 
@@ -139,19 +144,23 @@ export async function runScadAsync(source: string): Promise<MeshResult> {
       const raw = instance.FS.readFile('/out.stl');
       stlBytes = raw instanceof Uint8Array ? raw : new Uint8Array(raw);
     } catch (e) {
+      const error = `OpenSCAD did not produce output: ${e instanceof Error ? e.message : String(e)}\n${formatStderr(stderr)}`;
       return {
         mesh: null,
         manifold: null,
-        error: `OpenSCAD did not produce output: ${e instanceof Error ? e.message : String(e)}\n${formatStderr(stderr)}`,
+        error,
+        diagnostics: scadDiagnostics(source, error),
       };
     }
 
     const mesh = parseBinarySTLToMeshGL(stlBytes);
     if (!mesh || mesh.numTri === 0) {
+      const error = `OpenSCAD produced empty or invalid STL output.\n${formatStderr(stderr)}`;
       return {
         mesh: null,
         manifold: null,
-        error: `OpenSCAD produced empty or invalid STL output.\n${formatStderr(stderr)}`,
+        error,
+        diagnostics: scadDiagnostics(source, error),
       };
     }
 
@@ -176,24 +185,30 @@ export async function runScadAsync(source: string): Promise<MeshResult> {
     } else {
       msg = e instanceof Error ? e.message : String(e);
     }
+    const error = `OpenSCAD: ${msg}\n${formatStderr(stderr)}`;
     return {
       mesh: null,
       manifold: null,
-      error: `OpenSCAD: ${msg}\n${formatStderr(stderr)}`,
+      error,
+      diagnostics: scadDiagnostics(source, error),
     };
   }
 }
 
 /** Async validate — creates a fresh instance, compiles to AST (fast path). */
 export async function validateScadAsync(source: string): Promise<ValidateResult> {
-  if (!createFn) return { valid: false, error: 'OpenSCAD not initialized' };
+  if (!createFn) {
+    const error = 'OpenSCAD not initialized';
+    return { valid: false, error, diagnostics: scadDiagnostics(source, error) };
+  }
 
   let instance: any;
   let stderr: string[];
   try {
     ({ instance, stderr } = await createInstance());
   } catch (e) {
-    return { valid: false, error: `Failed to create OpenSCAD instance: ${e instanceof Error ? e.message : String(e)}` };
+    const error = `Failed to create OpenSCAD instance: ${e instanceof Error ? e.message : String(e)}`;
+    return { valid: false, error, diagnostics: scadDiagnostics(source, error) };
   }
 
   try {
@@ -204,8 +219,10 @@ export async function validateScadAsync(source: string): Promise<ValidateResult>
       '/v.scad',
     ]);
     if (code === 0) return { valid: true };
-    return { valid: false, error: formatStderr(stderr) };
+    const error = formatStderr(stderr);
+    return { valid: false, error, diagnostics: scadDiagnostics(source, error) };
   } catch (e) {
-    return { valid: false, error: e instanceof Error ? e.message : String(e) };
+    const error = e instanceof Error ? e.message : String(e);
+    return { valid: false, error, diagnostics: scadDiagnostics(source, error) };
   }
 }

--- a/src/geometry/engines/types.ts
+++ b/src/geometry/engines/types.ts
@@ -1,4 +1,4 @@
-import type { MeshData, MeshResult } from '../types';
+import type { MeshData, MeshResult, SourceDiagnostic } from '../types';
 
 export type Language = 'manifold-js' | 'scad';
 
@@ -11,6 +11,7 @@ export function isLanguage(v: unknown): v is Language {
 export interface ValidateResult {
   valid: boolean;
   error?: string;
+  diagnostics?: SourceDiagnostic[];
 }
 
 export interface Engine {
@@ -26,4 +27,4 @@ export interface Engine {
   validate(source: string): ValidateResult;
 }
 
-export type { MeshData, MeshResult };
+export type { MeshData, MeshResult, SourceDiagnostic };

--- a/src/geometry/sourceDiagnostics.ts
+++ b/src/geometry/sourceDiagnostics.ts
@@ -1,0 +1,178 @@
+import { javascriptLanguage } from '@codemirror/lang-javascript';
+import type { SourceDiagnostic } from './types';
+
+const MAX_SYNTAX_DIAGNOSTICS = 5;
+
+interface ErrorWithLocation extends Error {
+  lineNumber?: number;
+  columnNumber?: number;
+}
+
+function clampOffset(source: string, offset: number): number {
+  if (!Number.isFinite(offset)) return 0;
+  return Math.max(0, Math.min(source.length, Math.trunc(offset)));
+}
+
+export function offsetToLocation(source: string, offset: number): { line: number; column: number } {
+  const target = clampOffset(source, offset);
+  let line = 1;
+  let lineStart = 0;
+  for (let i = 0; i < target; i++) {
+    if (source.charCodeAt(i) === 10) {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, column: target - lineStart + 1 };
+}
+
+export function lineRange(source: string, line: number, column = 1): { from: number; to: number } {
+  const targetLine = Math.max(1, Math.trunc(line || 1));
+  let currentLine = 1;
+  let lineStart = 0;
+
+  for (let i = 0; i < source.length && currentLine < targetLine; i++) {
+    if (source.charCodeAt(i) === 10) {
+      currentLine++;
+      lineStart = i + 1;
+    }
+  }
+
+  if (currentLine !== targetLine) {
+    return { from: source.length, to: source.length };
+  }
+
+  let lineEnd = source.indexOf('\n', lineStart);
+  if (lineEnd === -1) lineEnd = source.length;
+
+  const from = clampOffset(source, lineStart + Math.max(0, Math.trunc(column || 1) - 1));
+  return { from: Math.min(from, lineEnd), to: Math.max(Math.min(lineEnd, from + 1), from) };
+}
+
+function expandRange(source: string, from: number, to: number): { from: number; to: number } {
+  const start = clampOffset(source, from);
+  const end = clampOffset(source, to);
+  if (end > start) return { from: start, to: end };
+  if (start < source.length && source[start] !== '\n') return { from: start, to: start + 1 };
+  if (start > 0) return { from: start - 1, to: start };
+  return { from: start, to: start };
+}
+
+function syntaxHint(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('unexpected token') || lower.includes('unexpected identifier')) {
+    return 'Check just before this location for a missing comma, operator, value, or closing delimiter.';
+  }
+  if (lower.includes('missing )') || lower.includes('unexpected end')) {
+    return 'Check for an unclosed parenthesis, bracket, brace, string, or template literal above this line.';
+  }
+  if (lower.includes('invalid or unexpected token')) {
+    return 'Check for an extra character, a bad quote, or an unterminated string.';
+  }
+  if (lower.includes('strict mode')) {
+    return 'The editor code runs as a strict JavaScript function body.';
+  }
+  return 'Fix the highlighted syntax, then run the model again.';
+}
+
+function firstUsefulLine(message: string): string {
+  const lines = message
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line && !line.includes('Could not initialize localization'));
+  return lines.find(line => /^ERROR\b/i.test(line)) ?? lines[0] ?? message;
+}
+
+export function javaScriptSyntaxDiagnostics(source: string, message: string, error?: unknown): SourceDiagnostic[] {
+  const diagnostics: SourceDiagnostic[] = [];
+  const tree = javascriptLanguage.parser.parse(source);
+
+  tree.cursor().iterate((node) => {
+    if (!node.type.isError || diagnostics.length >= MAX_SYNTAX_DIAGNOSTICS) return;
+    const { from, to } = expandRange(source, node.from, node.to);
+    const loc = offsetToLocation(source, from);
+    const endLoc = offsetToLocation(source, to);
+    diagnostics.push({
+      message: diagnostics.length === 0 ? message : 'Additional syntax issue near this location.',
+      severity: 'error',
+      source: 'JavaScript',
+      hint: syntaxHint(message),
+      from,
+      to,
+      line: loc.line,
+      column: loc.column,
+      endLine: endLoc.line,
+      endColumn: endLoc.column,
+    });
+  });
+
+  if (diagnostics.length > 0) return diagnostics;
+
+  const locatedError = error instanceof Error ? error as ErrorWithLocation : null;
+  if (locatedError?.lineNumber) {
+    // The Function constructor prepends `"use strict";\n`, so browser-provided
+    // line numbers for that generated body are one line higher than user code.
+    const line = Math.max(1, locatedError.lineNumber - 1);
+    const column = Math.max(1, locatedError.columnNumber ?? 1);
+    const { from, to } = lineRange(source, line, column);
+    const loc = offsetToLocation(source, from);
+    return [{
+      message,
+      severity: 'error',
+      source: 'JavaScript',
+      hint: syntaxHint(message),
+      from,
+      to,
+      line: loc.line,
+      column: loc.column,
+    }];
+  }
+
+  return [{
+    message,
+    severity: 'error',
+    source: 'JavaScript',
+    hint: syntaxHint(message),
+  }];
+}
+
+export function scadDiagnostics(source: string, message: string): SourceDiagnostic[] {
+  const lineMatch = message.match(/\bline\s+(\d+)(?:\s*,\s*column\s+(\d+))?/i);
+  const line = lineMatch ? Number(lineMatch[1]) : undefined;
+  const column = lineMatch?.[2] ? Number(lineMatch[2]) : 1;
+  const diagnosticMessage = firstUsefulLine(message);
+
+  if (!line) {
+    return [{
+      message: diagnosticMessage,
+      severity: 'error',
+      source: 'OpenSCAD',
+      hint: 'Check the OpenSCAD error output and the most recent edit.',
+    }];
+  }
+
+  const { from, to } = lineRange(source, line, column);
+  const loc = offsetToLocation(source, from);
+  const endLoc = offsetToLocation(source, to);
+  return [{
+    message: diagnosticMessage,
+    severity: 'error',
+    source: 'OpenSCAD',
+    hint: 'Check this line and the line above it for missing punctuation or an unclosed delimiter.',
+    from,
+    to,
+    line: loc.line,
+    column: loc.column,
+    endLine: endLoc.line,
+    endColumn: endLoc.column,
+  }];
+}
+
+export function runtimeDiagnostic(message: string, hint?: string, source = 'Runtime'): SourceDiagnostic[] {
+  return [{
+    message,
+    severity: 'error',
+    source,
+    hint,
+  }];
+}

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -6,10 +6,26 @@ export interface MeshData {
   numProp: number;
 }
 
+export type DiagnosticSeverity = 'error' | 'warning' | 'info' | 'hint';
+
+export interface SourceDiagnostic {
+  message: string;
+  severity: DiagnosticSeverity;
+  source?: string;
+  hint?: string;
+  from?: number;
+  to?: number;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+}
+
 export interface MeshResult {
   mesh: MeshData | null;
   manifold: unknown | null;
   error: string | null;
+  diagnostics?: SourceDiagnostic[];
 }
 
 export interface CrossSectionResult {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
 import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, setDimensionsVisible, isDimensionsVisible } from './renderer/viewport';
 import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, renderSliceSVG, setReferenceImages as _setRefImages, clearReferenceImages as _clearRefImages, getReferenceImages as _getRefImages, type ReferenceImages } from './renderer/multiview';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
-import { initEditor, setValue, getValue, setLanguage as setEditorLanguage } from './editor/codeEditor';
+import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic } from './editor/codeEditor';
 import { createLayout } from './ui/layout';
 import { createToolbar, isAutoRun, setToolbarLanguage } from './ui/toolbar';
 import { createLandingPage } from './ui/landing';
@@ -19,7 +19,7 @@ import { exportGLB } from './export/gltf';
 import { exportSTL } from './export/stl';
 import { exportOBJ } from './export/obj';
 import { export3MF } from './export/threemf';
-import type { MeshData } from './geometry/types';
+import type { MeshData, SourceDiagnostic } from './geometry/types';
 import { analyzeZProfile, type ZProfile } from './geometry/profileAnalysis';
 import { probeAtXY, probeRay, measureDistance, type ProbeResult, type GeneralRayResult } from './geometry/rayCast';
 import { checkContainment, type ContainmentWarning } from './geometry/containmentCheck';
@@ -126,6 +126,57 @@ function simpleHash(str: string): string {
     h = ((h << 5) - h + str.charCodeAt(i)) | 0;
   }
   return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+function firstErrorLine(error: string): string {
+  return error
+    .split('\n')
+    .map(line => line.trim())
+    .find(Boolean) ?? error;
+}
+
+function summarizeDiagnostics(error: string, diagnostics: SourceDiagnostic[] = []): string {
+  const primary = diagnostics[0];
+  if (primary?.line) {
+    const label = primary.source === 'OpenSCAD' ? 'OpenSCAD error' : 'Syntax error';
+    return `${label} on line ${primary.line}${primary.column ? `:${primary.column}` : ''}`;
+  }
+
+  const summary = firstErrorLine(error);
+  return summary.length > 80 ? `${summary.slice(0, 77)}...` : summary;
+}
+
+function renderEditorError(panel: HTMLElement, error: string, diagnostics: SourceDiagnostic[] = []): void {
+  const primary = diagnostics[0];
+  const title = document.createElement('div');
+  title.className = 'font-semibold text-red-200';
+  title.textContent = summarizeDiagnostics(error, diagnostics);
+
+  const location = document.createElement('div');
+  location.className = 'mt-1 text-red-200/80';
+  location.textContent = primary?.line
+    ? `${primary.source ?? 'Error'} at line ${primary.line}${primary.column ? `, column ${primary.column}` : ''}`
+    : primary?.source ?? 'Error';
+
+  const details = document.createElement('pre');
+  details.className = 'mt-2 max-h-32 overflow-auto whitespace-pre-wrap font-mono text-[11px] leading-4 text-red-100/90';
+  details.textContent = error;
+
+  panel.replaceChildren(title, location, details);
+
+  if (primary?.hint) {
+    const hint = document.createElement('div');
+    hint.className = 'mt-2 text-red-100';
+    hint.textContent = `Hint: ${primary.hint}`;
+    panel.appendChild(hint);
+  }
+
+  panel.classList.remove('hidden');
+}
+
+function clearEditorErrorPanel(panel: HTMLElement): void {
+  panel.classList.add('hidden');
+  panel.replaceChildren();
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -705,7 +756,7 @@ async function main() {
   });
 
   // Create layout
-  const { editorContainer, viewportPane, viewsContainer, elevationsContainer, galleryContainer, notesContainer, statusBar, clipControls, switchTab } = createLayout(editorUI);
+  const { editorContainer, editorErrorPanel, viewportPane, viewsContainer, elevationsContainer, galleryContainer, notesContainer, statusBar, clipControls, switchTab } = createLayout(editorUI);
 
   // Init views panel
   initViewsPanel(viewsContainer);
@@ -1042,7 +1093,13 @@ async function main() {
     if (result.error) {
       recordError(result.error);
       return {
-        geometryData: { status: 'error' as const, error: result.error, executionTimeMs: elapsed, codeHash: simpleHash(code) },
+        geometryData: {
+          status: 'error' as const,
+          error: result.error,
+          diagnostics: result.diagnostics ?? [],
+          executionTimeMs: elapsed,
+          codeHash: simpleHash(code),
+        },
         meshData: null as MeshData | null,
         manifold: null as unknown,
       };
@@ -1127,7 +1184,7 @@ async function main() {
     },
 
     /** Validate code without rendering. Returns { valid, error? } */
-    async validate(code: string, opts?: { language?: Language }): Promise<{ valid: boolean; error?: string }> {
+    async validate(code: string, opts?: { language?: Language }): Promise<{ valid: boolean; error?: string; diagnostics?: SourceDiagnostic[] }> {
       const check = guard(() => {
         assertString(code, 'validate(code)', { allowEmpty: false });
         if (opts !== undefined) {
@@ -1139,7 +1196,7 @@ async function main() {
       });
       if (typeof check === 'object' && check !== null && 'error' in check) return { valid: false, error: check.error };
       const r = await validateCodeAsync(code, opts?.language);
-      return r.valid ? { valid: true } : { valid: false, error: r.error };
+      return r.valid ? { valid: true } : { valid: false, error: r.error, diagnostics: r.diagnostics ?? [] };
     },
 
     /** Get active engine language */
@@ -2211,6 +2268,8 @@ async function main() {
   function runCode(code?: string) {
     const src = code ?? getValue();
     setStatus(statusBar, 'running', 'Running...');
+    clearEditorDiagnostics();
+    clearEditorErrorPanel(editorErrorPanel);
 
     requestAnimationFrame(async () => {
       await runCodeSync(src);
@@ -2226,12 +2285,24 @@ async function main() {
 
     if (result.error) {
       recordError(result.error);
-      setStatus(statusBar, 'error', result.error);
-      geometryDataEl.textContent = JSON.stringify({ status: 'error', error: result.error, executionTimeMs: elapsed, codeHash: simpleHash(src) });
+      const diagnostics = result.diagnostics ?? [];
+      setStatus(statusBar, 'error', summarizeDiagnostics(result.error, diagnostics));
+      setEditorDiagnostics(diagnostics);
+      renderEditorError(editorErrorPanel, result.error, diagnostics);
+      revealFirstDiagnostic();
+      geometryDataEl.textContent = JSON.stringify({
+        status: 'error',
+        error: result.error,
+        diagnostics,
+        executionTimeMs: elapsed,
+        codeHash: simpleHash(src),
+      });
       return;
     }
 
     if (result.mesh) {
+      clearEditorDiagnostics();
+      clearEditorErrorPanel(editorErrorPanel);
       currentMeshData = result.mesh;
       currentManifold = result.manifold;
       updateMesh(result.mesh);
@@ -2361,7 +2432,8 @@ async function main() {
 
 function setStatus(el: HTMLElement, state: 'ready' | 'running' | 'error' | 'loading', text: string) {
   el.textContent = text;
-  el.className = 'text-xs font-mono max-w-xs truncate ';
+  el.title = text;
+  el.className = 'text-xs font-mono max-w-[60%] truncate text-right ';
   switch (state) {
     case 'ready':
       el.className += 'text-emerald-400';

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -3,6 +3,7 @@ export type TabName = 'interactive' | 'ai' | 'elevations' | 'gallery' | 'notes';
 export interface LayoutElements {
   editorPane: HTMLElement;
   editorContainer: HTMLElement;
+  editorErrorPanel: HTMLElement;
   viewportPane: HTMLElement;
   viewsContainer: HTMLElement;
   elevationsContainer: HTMLElement;
@@ -38,6 +39,11 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   editorHeader.appendChild(statusBar);
 
   editorPane.appendChild(editorHeader);
+
+  const editorErrorPanel = document.createElement('div');
+  editorErrorPanel.id = 'editor-error-panel';
+  editorErrorPanel.className = 'hidden border-b border-red-500/30 bg-red-950/40 px-3 py-2 text-xs text-red-100';
+  editorPane.appendChild(editorErrorPanel);
 
   const editorContainer = document.createElement('div');
   editorContainer.id = 'editor-container';
@@ -204,7 +210,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
 
   appContainer.appendChild(main);
 
-  return { editorPane, editorContainer, viewportPane, viewsContainer, elevationsContainer, galleryContainer, notesContainer, statusBar, clipControls, switchTab };
+  return { editorPane, editorContainer, editorErrorPanel, viewportPane, viewsContainer, elevationsContainer, galleryContainer, notesContainer, statusBar, clipControls, switchTab };
 }
 
 function createTab(label: string, active: boolean): HTMLButtonElement {


### PR DESCRIPTION
## Summary
- Add structured source diagnostics to JS and OpenSCAD engine errors while preserving existing string error outputs.
- Show located errors in CodeMirror with lint gutter markers, inline ranges, and automatic reveal.
- Add an editor error panel with summary, location, full error text, and targeted hints; expose diagnostics through validate/run geometry data.

## Verification
- npm run build
- git diff --check
- Playwright browser checks for JS syntax errors, diagnostic clearing after successful run, non-located runtime errors, and OpenSCAD syntax diagnostics.