### PR TITLE
Add per-region face coloring (Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ After any changes that touch routing, Vite config, index.html, or initialization
 5. **AI agent bypass**: `http://localhost:5173/editor?view=ai` should skip the landing page and go straight to the editor with AI Views tab selected.
 6. **Session loading**: Click a session tile on the landing page — should load the session code in the editor, show the session name in the session bar, and update the URL to `/editor?session=<id>`.
 7. **Build**: `npm run build` should succeed with no TypeScript errors.
+8. **Paint mode**: Click the Paint button in the viewport overlay. A color picker panel should appear. Click a face on the model — it should paint the coplanar region in the selected color. The Paint button badge should show the region count.
+9. **Editor lock**: After painting a face, the editor should show a lock banner ("This version has color regions applied.") and become read-only. The run button should be disabled.
+10. **Unlock modal**: Click "Unlock to edit" — a modal should appear with two options (preserve/destructive). Clicking "Unlock editor" with the default "preserve" option should save the colored version and create a new uncolored version. The editor should unlock.
+11. **Gallery badges**: Colored versions in the gallery should show small color-swatch dots next to the version label.
+12. **Color export**: With color regions painted, export GLB — the file should carry vertex colors. Export 3MF — the file should include `<basematerials>` and per-triangle `pid` attributes.
 
 ## AI Agent Workflow & API Reference
 

--- a/prompts/20260424-color-regions-phase1.md
+++ b/prompts/20260424-color-regions-phase1.md
@@ -1,0 +1,42 @@
+---
+session: "color-regions-ph1"
+timestamp: "2026-04-24T16:00:00Z"
+model: claude-opus-4-6
+tools: [claude-in-chrome, browser-testing]
+---
+
+## Human
+
+Read .plans/coloring-proposal.md and proceed with phase 1.
+
+## Assistant
+
+### Key decisions
+
+**Phase 1 implementation** of per-region face coloring:
+
+1. **Data plumbing**: Extended `MeshData` with optional `triColors` (Uint8Array, RGB per triangle). Created `ColorRegionStore` (`src/color/regions.ts`) for managing in-memory color regions with spatial descriptors. Updated `meshGLToBufferGeometry` in both viewport and multiview to unindex geometry and set per-vertex color attributes when triColors present. Added `vertexColors` parameter to material factories.
+
+2. **Triangle adjacency + coplanar BFS** (`src/color/adjacency.ts`): Edge-key adjacency graph, BFS with normal-dot threshold for flood-filling coplanar faces, Moller-Trumbore raycaster for `resolveSeed` rehydration from spatial descriptors.
+
+3. **Face picking UX**: Three.js Raycaster-based face picker (`src/color/facePicker.ts`), paint mode controller with hover highlight overlay (`src/color/paintMode.ts`), color picker panel with 8 preset swatches + custom input (`src/color/paintUI.ts`). Paint button added to viewport overlay controls.
+
+4. **Editor lock + unlock modal** (`src/color/editorLock.ts`): CodeMirror read-only compartment, amber lock banner, modal with preserve-and-branch (default) vs destructive unlock paths.
+
+5. **Persistence & gallery badges**: Color regions serialized in version `geometryData.colorRegions`, rehydrated on version load via `resolveSeed` + BFS. Gallery tiles show color-swatch dots for colored versions.
+
+6. **Color exports**: 3MF extended with `<basematerials>` and per-triangle `pid` attributes. GLB carries vertex colors automatically via Three.js GLTFExporter. Export paths pass colored MeshData when regions exist.
+
+7. **Console API**: `paintRegion({point, normal, color})`, `listRegions()`, `clearColors()` added to `window.partwright`.
+
+### Files changed
+- `src/color/` (new directory): `regions.ts`, `adjacency.ts`, `facePicker.ts`, `paintMode.ts`, `paintUI.ts`, `editorLock.ts`
+- `src/geometry/types.ts`: Added `triColors` to MeshData
+- `src/renderer/viewport.ts`: Vertex color support in meshGLToBufferGeometry
+- `src/renderer/multiview.ts`: Vertex color support in all render paths
+- `src/renderer/materials.ts`: `vertexColors` parameter on material factories
+- `src/editor/codeEditor.ts`: Read-only compartment for editor locking
+- `src/export/threemf.ts`: basematerials + pid color export
+- `src/main.ts`: Paint mode wiring, color persistence, console API
+- `src/ui/gallery.ts`: Color swatch badges on version tiles
+- `CLAUDE.md`: Smoke test checklist for coloring

--- a/prompts/20260424-fix-3mf-color-export.md
+++ b/prompts/20260424-fix-3mf-color-export.md
@@ -1,0 +1,18 @@
+---
+session: "fix-3mf-colors"
+timestamp: "2026-04-24T16:45:00Z"
+model: claude-opus-4-6
+tools: [claude-in-chrome, browser-testing]
+---
+
+## Human
+
+3MF export doesn't preserve colors in viewers.
+
+## Assistant
+
+### Key decisions
+
+The 3MF XML was technically correct but most viewers need **every** triangle to have a material assignment (`pid` attribute), not just the painted ones. Unpainted triangles had no `pid` so viewers ignored the color data entirely.
+
+Fix: added a default base color (`#4a9eff`) at material index 0, assigned `pid="2" p1="0"` to all unpainted triangles, and set `pid="2" pindex="0"` on the `<object>` element as a fallback default. Now every triangle in a colored export has a material.

--- a/prompts/20260424-fix-paint-camera-reset.md
+++ b/prompts/20260424-fix-paint-camera-reset.md
@@ -1,0 +1,16 @@
+---
+session: "color-regions-ph1-fix"
+timestamp: "2026-04-24T16:27:00Z"
+model: claude-opus-4-6
+tools: [claude-in-chrome, browser-testing]
+---
+
+## Human
+
+Whenever I paint a surface the orientation flips back to some default initial position. Is it possible to prevent that?
+
+## Assistant
+
+### Key decisions
+
+Added `skipAutoFrame` option to `updateMesh()` in `viewport.ts`. All color-only update paths (paint, clear, unlock, rehydrate, console API) now pass `{ skipAutoFrame: true }` so the camera stays in its current orbit position. The auto-frame still runs on actual geometry changes (code execution).

--- a/prompts/20260424-fix-unlock-version-fork.md
+++ b/prompts/20260424-fix-unlock-version-fork.md
@@ -1,0 +1,23 @@
+---
+session: "fix-unlock-fork"
+timestamp: "2026-04-24T16:50:00Z"
+model: claude-opus-4-6
+tools: [claude-in-chrome, browser-testing]
+---
+
+## Human
+
+When I unlock a colored version, no new version is created. Expected v3 (uncolored) to appear after unlocking v2 (colored).
+
+## Assistant
+
+### Key decisions
+
+The issue was that `saveVersion` in sessionManager silently skips saves when the code is identical to the current version. Since the unlock fork creates two versions with the same code (one colored, one clean), both were being skipped.
+
+Fix: added `options?: { force?: boolean }` to `saveVersion` to bypass the duplicate-code check. The unlock handler now:
+1. Force-saves the colored version (v2) with colorRegions in geometryData
+2. Re-renders without colors
+3. Force-saves a clean uncolored version (v3) — this becomes the active version
+
+The user now sees the expected flow: v2 (colored, locked) preserved in gallery, v3 (uncolored, editable) active.

--- a/prompts/20260424-skip-duplicate-colored-save.md
+++ b/prompts/20260424-skip-duplicate-colored-save.md
@@ -1,0 +1,16 @@
+---
+session: "skip-dup-colored"
+timestamp: "2026-04-24T16:55:00Z"
+model: claude-opus-4-6
+tools: []
+---
+
+## Human
+
+Opening a past colored version and unlocking it creates a duplicate colored version. Skip the colored save if already persisted.
+
+## Assistant
+
+### Key decisions
+
+Check `currentVersion.geometryData.colorRegions` before saving. If the loaded version already has colorRegions persisted, skip the colored save and only create the new uncolored sibling.

--- a/src/color/adjacency.ts
+++ b/src/color/adjacency.ts
@@ -1,0 +1,233 @@
+// Triangle adjacency and coplanar region finding
+
+import type { MeshData } from '../geometry/types';
+
+export interface AdjacencyGraph {
+  /** For each triangle index, the list of adjacent triangle indices (sharing an edge). */
+  neighbors: Uint32Array[];
+  /** Triangle normals — 3 floats per triangle (nx, ny, nz). */
+  normals: Float32Array;
+}
+
+/** Create a canonical edge key from two vertex indices (order-independent). */
+function edgeKey(a: number, b: number): string {
+  return a < b ? `${a},${b}` : `${b},${a}`;
+}
+
+/** Build a triangle adjacency graph from mesh data.
+ *  O(numTri) with Map-based edge lookup. */
+export function buildAdjacency(mesh: MeshData): AdjacencyGraph {
+  const { triVerts, numTri, vertProperties, numProp } = mesh;
+
+  // Build edge → triangle list map
+  const edgeToTris = new Map<string, number[]>();
+
+  for (let t = 0; t < numTri; t++) {
+    const v0 = triVerts[t * 3];
+    const v1 = triVerts[t * 3 + 1];
+    const v2 = triVerts[t * 3 + 2];
+
+    for (const key of [edgeKey(v0, v1), edgeKey(v1, v2), edgeKey(v2, v0)]) {
+      let list = edgeToTris.get(key);
+      if (!list) {
+        list = [];
+        edgeToTris.set(key, list);
+      }
+      list.push(t);
+    }
+  }
+
+  // Build neighbor lists
+  const neighbors: Set<number>[] = new Array(numTri);
+  for (let i = 0; i < numTri; i++) neighbors[i] = new Set();
+
+  for (const tris of edgeToTris.values()) {
+    for (let i = 0; i < tris.length; i++) {
+      for (let j = i + 1; j < tris.length; j++) {
+        neighbors[tris[i]].add(tris[j]);
+        neighbors[tris[j]].add(tris[i]);
+      }
+    }
+  }
+
+  // Compute triangle normals
+  const normals = new Float32Array(numTri * 3);
+  for (let t = 0; t < numTri; t++) {
+    const v0 = triVerts[t * 3];
+    const v1 = triVerts[t * 3 + 1];
+    const v2 = triVerts[t * 3 + 2];
+
+    const ax = vertProperties[v1 * numProp] - vertProperties[v0 * numProp];
+    const ay = vertProperties[v1 * numProp + 1] - vertProperties[v0 * numProp + 1];
+    const az = vertProperties[v1 * numProp + 2] - vertProperties[v0 * numProp + 2];
+
+    const bx = vertProperties[v2 * numProp] - vertProperties[v0 * numProp];
+    const by = vertProperties[v2 * numProp + 1] - vertProperties[v0 * numProp + 1];
+    const bz = vertProperties[v2 * numProp + 2] - vertProperties[v0 * numProp + 2];
+
+    // Cross product
+    let nx = ay * bz - az * by;
+    let ny = az * bx - ax * bz;
+    let nz = ax * by - ay * bx;
+
+    // Normalize
+    const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+    if (len > 0) {
+      nx /= len;
+      ny /= len;
+      nz /= len;
+    }
+
+    normals[t * 3] = nx;
+    normals[t * 3 + 1] = ny;
+    normals[t * 3 + 2] = nz;
+  }
+
+  return {
+    neighbors: neighbors.map(s => new Uint32Array(s)),
+    normals,
+  };
+}
+
+/** BFS from a seed triangle, collecting all adjacent triangles whose normal is
+ *  within `normalTolerance` (dot product threshold, e.g. 0.9995) of the seed's normal.
+ *  Returns the set of triangle indices forming the coplanar region. */
+export function findCoplanarRegion(
+  seedTri: number,
+  adjacency: AdjacencyGraph,
+  normalTolerance = 0.9995,
+): Set<number> {
+  const { neighbors, normals } = adjacency;
+  const result = new Set<number>();
+
+  const seedNx = normals[seedTri * 3];
+  const seedNy = normals[seedTri * 3 + 1];
+  const seedNz = normals[seedTri * 3 + 2];
+
+  const queue = [seedTri];
+  result.add(seedTri);
+
+  while (queue.length > 0) {
+    const current = queue.pop()!;
+    const adj = neighbors[current];
+    for (let i = 0; i < adj.length; i++) {
+      const neighbor = adj[i];
+      if (result.has(neighbor)) continue;
+
+      const nx = normals[neighbor * 3];
+      const ny = normals[neighbor * 3 + 1];
+      const nz = normals[neighbor * 3 + 2];
+
+      const dot = seedNx * nx + seedNy * ny + seedNz * nz;
+      if (dot >= normalTolerance) {
+        result.add(neighbor);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Get the normal of a specific triangle. */
+export function getTriangleNormal(triIndex: number, adjacency: AdjacencyGraph): [number, number, number] {
+  return [
+    adjacency.normals[triIndex * 3],
+    adjacency.normals[triIndex * 3 + 1],
+    adjacency.normals[triIndex * 3 + 2],
+  ];
+}
+
+/** Get the centroid of a specific triangle. */
+export function getTriangleCentroid(triIndex: number, mesh: MeshData): [number, number, number] {
+  const { triVerts, vertProperties, numProp } = mesh;
+  const v0 = triVerts[triIndex * 3];
+  const v1 = triVerts[triIndex * 3 + 1];
+  const v2 = triVerts[triIndex * 3 + 2];
+
+  return [
+    (vertProperties[v0 * numProp] + vertProperties[v1 * numProp] + vertProperties[v2 * numProp]) / 3,
+    (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3,
+    (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3,
+  ];
+}
+
+/** Resolve a spatial seed descriptor back to a triangle index by raycasting
+ *  from seedPoint along -seedNormal into the mesh. Returns the first triangle
+ *  whose normal matches within tolerance, or -1 if none found. */
+export function resolveSeed(
+  seedPoint: [number, number, number],
+  seedNormal: [number, number, number],
+  mesh: MeshData,
+  adjacency: AdjacencyGraph,
+  normalTolerance = 0.9995,
+): number {
+  const { triVerts, vertProperties, numProp, numTri } = mesh;
+  const epsilon = 0.01;
+
+  // Ray origin: slightly above the surface along the normal
+  const ox = seedPoint[0] + seedNormal[0] * epsilon;
+  const oy = seedPoint[1] + seedNormal[1] * epsilon;
+  const oz = seedPoint[2] + seedNormal[2] * epsilon;
+
+  // Ray direction: into the surface
+  const dx = -seedNormal[0];
+  const dy = -seedNormal[1];
+  const dz = -seedNormal[2];
+
+  let bestT = Infinity;
+  let bestTri = -1;
+
+  for (let t = 0; t < numTri; t++) {
+    const v0i = triVerts[t * 3];
+    const v1i = triVerts[t * 3 + 1];
+    const v2i = triVerts[t * 3 + 2];
+
+    const p0x = vertProperties[v0i * numProp];
+    const p0y = vertProperties[v0i * numProp + 1];
+    const p0z = vertProperties[v0i * numProp + 2];
+    const p1x = vertProperties[v1i * numProp];
+    const p1y = vertProperties[v1i * numProp + 1];
+    const p1z = vertProperties[v1i * numProp + 2];
+    const p2x = vertProperties[v2i * numProp];
+    const p2y = vertProperties[v2i * numProp + 1];
+    const p2z = vertProperties[v2i * numProp + 2];
+
+    // Möller–Trumbore intersection
+    const e1x = p1x - p0x, e1y = p1y - p0y, e1z = p1z - p0z;
+    const e2x = p2x - p0x, e2y = p2y - p0y, e2z = p2z - p0z;
+
+    const hx = dy * e2z - dz * e2y;
+    const hy = dz * e2x - dx * e2z;
+    const hz = dx * e2y - dy * e2x;
+
+    const a = e1x * hx + e1y * hy + e1z * hz;
+    if (a > -1e-8 && a < 1e-8) continue;
+
+    const f = 1 / a;
+    const sx = ox - p0x, sy = oy - p0y, sz = oz - p0z;
+    const u = f * (sx * hx + sy * hy + sz * hz);
+    if (u < 0 || u > 1) continue;
+
+    const qx = sy * e1z - sz * e1y;
+    const qy = sz * e1x - sx * e1z;
+    const qz = sx * e1y - sy * e1x;
+    const v = f * (dx * qx + dy * qy + dz * qz);
+    if (v < 0 || u + v > 1) continue;
+
+    const tHit = f * (e2x * qx + e2y * qy + e2z * qz);
+    if (tHit > 0 && tHit < bestT) {
+      // Check normal tolerance
+      const nx = adjacency.normals[t * 3];
+      const ny = adjacency.normals[t * 3 + 1];
+      const nz = adjacency.normals[t * 3 + 2];
+      const dot = seedNormal[0] * nx + seedNormal[1] * ny + seedNormal[2] * nz;
+      if (dot >= normalTolerance) {
+        bestT = tHit;
+        bestTri = t;
+      }
+    }
+  }
+
+  return bestTri;
+}

--- a/src/color/editorLock.ts
+++ b/src/color/editorLock.ts
@@ -1,0 +1,239 @@
+// Editor lock — locks the code editor when the current version has color regions.
+// Provides lock overlay banner and unlock modal with preserve/destructive paths.
+
+import { setReadOnly } from '../editor/codeEditor';
+import { hasRegions, clearRegions, serialize as serializeRegions, type SerializedColorRegion } from './regions';
+
+let locked = false;
+let lockOverlay: HTMLElement | null = null;
+let editorContainer: HTMLElement | null = null;
+let runButton: HTMLElement | null = null;
+let autoRunButton: HTMLElement | null = null;
+
+// Callback to fork the current version (provided by main.ts)
+let onUnlockFork: ((colorRegions: SerializedColorRegion[]) => Promise<void>) | null = null;
+let onUnlockClear: (() => void) | null = null;
+
+export function setUnlockHandlers(
+  forkHandler: (colorRegions: SerializedColorRegion[]) => Promise<void>,
+  clearHandler: () => void,
+): void {
+  onUnlockFork = forkHandler;
+  onUnlockClear = clearHandler;
+}
+
+export function initEditorLock(container: HTMLElement): void {
+  editorContainer = container;
+  runButton = document.getElementById('btn-run');
+  autoRunButton = document.getElementById('btn-auto-run');
+}
+
+export function isLocked(): boolean {
+  return locked;
+}
+
+/** Sync lock state based on whether regions exist. Call after painting, loading, or clearing. */
+export function syncLockState(): void {
+  const shouldLock = hasRegions();
+  if (shouldLock === locked) return;
+
+  locked = shouldLock;
+  setReadOnly(locked);
+
+  if (locked) {
+    showLockOverlay();
+    disableRun();
+  } else {
+    hideLockOverlay();
+    enableRun();
+  }
+}
+
+function showLockOverlay(): void {
+  if (lockOverlay || !editorContainer) return;
+
+  lockOverlay = document.createElement('div');
+  lockOverlay.id = 'editor-lock-overlay';
+  lockOverlay.className = 'flex items-center justify-between px-3 py-1.5 bg-amber-900/60 border-b border-amber-500/40 text-xs text-amber-200 shrink-0';
+
+  const msg = document.createElement('span');
+  msg.innerHTML = '\uD83D\uDD12 This version has color regions applied.';
+
+  const unlockBtn = document.createElement('button');
+  unlockBtn.className = 'px-2 py-0.5 rounded text-xs bg-amber-500/20 hover:bg-amber-500/40 text-amber-100 border border-amber-500/40 transition-colors';
+  unlockBtn.textContent = 'Unlock to edit';
+  unlockBtn.addEventListener('click', showUnlockModal);
+
+  lockOverlay.appendChild(msg);
+  lockOverlay.appendChild(unlockBtn);
+
+  // Insert after the editor header (first child of editorContainer's parent)
+  const editorPane = editorContainer.parentElement;
+  if (editorPane) {
+    // Insert before the editor container
+    editorPane.insertBefore(lockOverlay, editorContainer);
+  }
+}
+
+function hideLockOverlay(): void {
+  if (lockOverlay) {
+    lockOverlay.remove();
+    lockOverlay = null;
+  }
+}
+
+function disableRun(): void {
+  if (runButton) {
+    (runButton as HTMLButtonElement).disabled = true;
+    runButton.classList.add('opacity-40', 'pointer-events-none');
+  }
+  if (autoRunButton) {
+    (autoRunButton as HTMLButtonElement).disabled = true;
+    autoRunButton.classList.add('opacity-40', 'pointer-events-none');
+  }
+}
+
+function enableRun(): void {
+  if (runButton) {
+    (runButton as HTMLButtonElement).disabled = false;
+    runButton.classList.remove('opacity-40', 'pointer-events-none');
+  }
+  if (autoRunButton) {
+    (autoRunButton as HTMLButtonElement).disabled = false;
+    autoRunButton.classList.remove('opacity-40', 'pointer-events-none');
+  }
+}
+
+function showUnlockModal(): void {
+  // Backdrop
+  const backdrop = document.createElement('div');
+  backdrop.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm';
+
+  const modal = document.createElement('div');
+  modal.className = 'bg-zinc-800 border border-zinc-600 rounded-xl shadow-2xl p-6 max-w-md w-full mx-4';
+
+  // Title
+  const title = document.createElement('h2');
+  title.className = 'text-base font-semibold text-zinc-100 mb-3';
+  title.textContent = 'Editing will create a new uncolored version';
+
+  // Explanation
+  const explanation = document.createElement('p');
+  explanation.className = 'text-sm text-zinc-400 mb-4 leading-relaxed';
+  explanation.textContent = 'This version has color regions applied. To edit the code, Partwright will create a new version with the same code but no colors. The colored version stays in your gallery.';
+
+  // Radio options
+  const optionsContainer = document.createElement('div');
+  optionsContainer.className = 'space-y-3 mb-5';
+
+  // Option 1: Preserve (default)
+  const opt1 = createRadioOption(
+    'unlock-mode',
+    'preserve',
+    true,
+    'Preserve this colored version and create a new version for editing',
+    'The colored version stays in your gallery. A new uncolored copy opens in the editor.',
+    'text-emerald-400',
+  );
+
+  // Option 2: Destructive
+  const opt2 = createRadioOption(
+    'unlock-mode',
+    'destructive',
+    false,
+    'Remove color regions from this version instead',
+    '\u26A0\uFE0F Color regions will be permanently removed. This cannot be undone.',
+    'text-red-400',
+  );
+
+  optionsContainer.appendChild(opt1.wrapper);
+  optionsContainer.appendChild(opt2.wrapper);
+
+  // Buttons
+  const btnRow = document.createElement('div');
+  btnRow.className = 'flex justify-end gap-2';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'px-4 py-2 rounded text-sm text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 transition-colors';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => backdrop.remove());
+
+  const confirmBtn = document.createElement('button');
+  confirmBtn.className = 'px-4 py-2 rounded text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors';
+  confirmBtn.textContent = 'Unlock editor';
+  confirmBtn.addEventListener('click', async () => {
+    const preserveRadio = opt1.wrapper.querySelector('input') as HTMLInputElement;
+    const preserve = preserveRadio.checked;
+
+    backdrop.remove();
+
+    if (preserve && onUnlockFork) {
+      const colorData = serializeRegions();
+      clearRegions();
+      syncLockState();
+      await onUnlockFork(colorData);
+    } else if (!preserve && onUnlockClear) {
+      clearRegions();
+      syncLockState();
+      onUnlockClear();
+    }
+  });
+
+  btnRow.appendChild(cancelBtn);
+  btnRow.appendChild(confirmBtn);
+
+  modal.appendChild(title);
+  modal.appendChild(explanation);
+  modal.appendChild(optionsContainer);
+  modal.appendChild(btnRow);
+  backdrop.appendChild(modal);
+
+  // Close on backdrop click
+  backdrop.addEventListener('click', (e) => {
+    if (e.target === backdrop) backdrop.remove();
+  });
+
+  // Close on Escape
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') { backdrop.remove(); document.removeEventListener('keydown', onKey); }
+  };
+  document.addEventListener('keydown', onKey);
+
+  document.body.appendChild(backdrop);
+}
+
+function createRadioOption(
+  name: string,
+  value: string,
+  checked: boolean,
+  label: string,
+  description: string,
+  labelColor: string,
+): { wrapper: HTMLElement } {
+  const wrapper = document.createElement('label');
+  wrapper.className = 'flex items-start gap-3 p-3 rounded-lg border border-zinc-600/50 hover:border-zinc-500 cursor-pointer transition-colors';
+
+  const radio = document.createElement('input');
+  radio.type = 'radio';
+  radio.name = name;
+  radio.value = value;
+  radio.checked = checked;
+  radio.className = 'mt-0.5 accent-blue-500';
+
+  const textDiv = document.createElement('div');
+  const labelEl = document.createElement('div');
+  labelEl.className = `text-sm font-medium ${labelColor}`;
+  labelEl.textContent = label;
+
+  const descEl = document.createElement('div');
+  descEl.className = 'text-xs text-zinc-500 mt-0.5';
+  descEl.textContent = description;
+
+  textDiv.appendChild(labelEl);
+  textDiv.appendChild(descEl);
+
+  wrapper.appendChild(radio);
+  wrapper.appendChild(textDiv);
+
+  return { wrapper };
+}

--- a/src/color/facePicker.ts
+++ b/src/color/facePicker.ts
@@ -1,0 +1,43 @@
+// Face picking — raycast from mouse position to find triangle index on the viewport mesh
+
+import * as THREE from 'three';
+import { getMeshGroup, getCamera, getRenderer } from '../renderer/viewport';
+
+export interface FacePickResult {
+  triangleIndex: number;
+  point: [number, number, number];
+  normal: [number, number, number];
+}
+
+const raycaster = new THREE.Raycaster();
+const mouse = new THREE.Vector2();
+
+/** Pick a face from a mouse event on the viewport canvas.
+ *  Returns null if no face was hit. */
+export function pickFace(event: MouseEvent): FacePickResult | null {
+  const canvas = getRenderer().domElement;
+  const rect = canvas.getBoundingClientRect();
+  mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+
+  const camera = getCamera();
+  raycaster.setFromCamera(mouse, camera);
+
+  const meshGroup = getMeshGroup();
+  // Only intersect the solid mesh (first child), not wireframe or cap
+  const solidMesh = meshGroup.children[0];
+  if (!(solidMesh instanceof THREE.Mesh)) return null;
+
+  const intersections = raycaster.intersectObject(solidMesh);
+  if (intersections.length === 0) return null;
+
+  const hit = intersections[0];
+  if (hit.faceIndex === undefined || hit.faceIndex === null) return null;
+  if (!hit.face) return null;
+
+  return {
+    triangleIndex: hit.faceIndex,
+    point: [hit.point.x, hit.point.y, hit.point.z],
+    normal: [hit.face.normal.x, hit.face.normal.y, hit.face.normal.z],
+  };
+}

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -1,0 +1,175 @@
+// Paint mode — coordinates face picking, hover preview, and color application
+
+import * as THREE from 'three';
+import type { MeshData } from '../geometry/types';
+import { pickFace } from './facePicker';
+import { buildAdjacency, findCoplanarRegion, getTriangleNormal, type AdjacencyGraph } from './adjacency';
+import { addRegion, getRegions } from './regions';
+import { getMeshGroup, getRenderer } from '../renderer/viewport';
+
+let active = false;
+let currentColor: [number, number, number] = [1, 0.2, 0.2]; // default red
+let adjacency: AdjacencyGraph | null = null;
+let currentMesh: MeshData | null = null;
+
+// Hover highlight state
+let highlightMesh: THREE.Mesh | null = null;
+let hoveredTriangles: Set<number> | null = null;
+
+// Callbacks
+let onRegionPainted: (() => void) | null = null;
+
+export function isActive(): boolean { return active; }
+
+export function setColor(color: [number, number, number]): void {
+  currentColor = color;
+}
+
+export function getColor(): [number, number, number] {
+  return currentColor;
+}
+
+export function setOnRegionPainted(fn: () => void): void {
+  onRegionPainted = fn;
+}
+
+/** Rebuild adjacency graph for a new mesh. Call this whenever updateMesh fires. */
+export function updatePaintMesh(mesh: MeshData): void {
+  currentMesh = mesh;
+  if (active) {
+    adjacency = buildAdjacency(mesh);
+  }
+  clearHighlight();
+}
+
+export function activate(): void {
+  if (active) return;
+  active = true;
+
+  if (currentMesh) {
+    adjacency = buildAdjacency(currentMesh);
+  }
+
+  const canvas = getRenderer().domElement;
+  canvas.addEventListener('mousemove', onMouseMove);
+  canvas.addEventListener('click', onClick);
+  canvas.style.cursor = 'crosshair';
+}
+
+export function deactivate(): void {
+  if (!active) return;
+  active = false;
+  adjacency = null;
+
+  const canvas = getRenderer().domElement;
+  canvas.removeEventListener('mousemove', onMouseMove);
+  canvas.removeEventListener('click', onClick);
+  canvas.style.cursor = '';
+  clearHighlight();
+}
+
+function onMouseMove(event: MouseEvent): void {
+  if (!adjacency || !currentMesh) return;
+
+  const result = pickFace(event);
+  if (!result) {
+    clearHighlight();
+    return;
+  }
+
+  const region = findCoplanarRegion(result.triangleIndex, adjacency);
+  if (hoveredTriangles && setsEqual(hoveredTriangles, region)) return;
+
+  hoveredTriangles = region;
+  showHighlight(region);
+}
+
+function onClick(event: MouseEvent): void {
+  if (!adjacency || !currentMesh) return;
+
+  const result = pickFace(event);
+  if (!result) return;
+
+  const region = findCoplanarRegion(result.triangleIndex, adjacency);
+  const normal = getTriangleNormal(result.triangleIndex, adjacency);
+
+  // Create a named region
+  const existingCount = getRegions().length;
+  const name = `Region ${existingCount + 1}`;
+
+  addRegion(
+    name,
+    [...currentColor] as [number, number, number],
+    'face-pick',
+    {
+      kind: 'coplanar',
+      seedPoint: result.point,
+      seedNormal: normal,
+      normalTolerance: 0.9995,
+    },
+    region,
+  );
+
+  clearHighlight();
+
+  if (onRegionPainted) onRegionPainted();
+}
+
+function showHighlight(triangles: Set<number>): void {
+  clearHighlight();
+  if (!currentMesh) return;
+
+  const { triVerts, vertProperties, numProp } = currentMesh;
+
+  // Build a geometry from just the highlighted triangles
+  const positions = new Float32Array(triangles.size * 9);
+  let idx = 0;
+
+  for (const t of triangles) {
+    const v0 = triVerts[t * 3];
+    const v1 = triVerts[t * 3 + 1];
+    const v2 = triVerts[t * 3 + 2];
+
+    for (const vi of [v0, v1, v2]) {
+      positions[idx++] = vertProperties[vi * numProp];
+      positions[idx++] = vertProperties[vi * numProp + 1];
+      positions[idx++] = vertProperties[vi * numProp + 2];
+    }
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geo.computeVertexNormals();
+
+  const mat = new THREE.MeshBasicMaterial({
+    color: new THREE.Color(currentColor[0], currentColor[1], currentColor[2]),
+    transparent: true,
+    opacity: 0.4,
+    side: THREE.DoubleSide,
+    depthTest: true,
+    depthWrite: false,
+    polygonOffset: true,
+    polygonOffsetFactor: -1,
+  });
+
+  highlightMesh = new THREE.Mesh(geo, mat);
+  highlightMesh.name = 'paint-hover';
+  highlightMesh.renderOrder = 999;
+  getMeshGroup().add(highlightMesh);
+}
+
+function clearHighlight(): void {
+  if (highlightMesh) {
+    getMeshGroup().remove(highlightMesh);
+    highlightMesh.geometry.dispose();
+    (highlightMesh.material as THREE.Material).dispose();
+    highlightMesh = null;
+  }
+  hoveredTriangles = null;
+}
+
+function setsEqual(a: Set<number>, b: Set<number>): boolean {
+  if (a.size !== b.size) return false;
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -1,0 +1,217 @@
+// Paint mode UI — button toggle, color picker, region count badge
+
+import { activate, deactivate, isActive, setColor } from './paintMode';
+import { getRegions, onChange as onRegionsChange } from './regions';
+
+const PRESET_COLORS: [number, number, number][] = [
+  [0.92, 0.26, 0.21], // red
+  [0.13, 0.59, 0.95], // blue
+  [0.30, 0.69, 0.31], // green
+  [1.00, 0.76, 0.03], // yellow
+  [0.61, 0.15, 0.69], // purple
+  [1.00, 0.60, 0.00], // orange
+  [0.00, 0.74, 0.83], // teal
+  [0.91, 0.12, 0.39], // pink
+];
+
+let paintBtn: HTMLButtonElement | null = null;
+let pickerPanel: HTMLElement | null = null;
+let regionCountBadge: HTMLElement | null = null;
+
+/** Initialize the paint UI inside the clip-controls overlay area. */
+export function initPaintUI(controlsContainer: HTMLElement): void {
+  // Paint toggle button
+  paintBtn = document.createElement('button');
+  paintBtn.id = 'paint-toggle';
+  paintBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  paintBtn.textContent = '\uD83C\uDFA8 Paint';
+  paintBtn.title = 'Paint color regions on model faces';
+
+  // Region count badge
+  regionCountBadge = document.createElement('span');
+  regionCountBadge.className = 'hidden ml-1 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-blue-500 text-white leading-none';
+  paintBtn.appendChild(regionCountBadge);
+
+  paintBtn.addEventListener('click', togglePaintMode);
+
+  // Insert before the measure toggle
+  const measureBtn = controlsContainer.querySelector('#measure-toggle');
+  if (measureBtn) {
+    controlsContainer.insertBefore(paintBtn, measureBtn);
+  } else {
+    controlsContainer.appendChild(paintBtn);
+  }
+
+  // Color picker panel (hidden by default)
+  pickerPanel = createPickerPanel();
+  controlsContainer.appendChild(pickerPanel);
+
+  // Update badge when regions change
+  onRegionsChange(updateBadge);
+  updateBadge();
+}
+
+function togglePaintMode(): void {
+  if (isActive()) {
+    deactivate();
+    updateButtonState(false);
+    pickerPanel?.classList.add('hidden');
+  } else {
+    activate();
+    updateButtonState(true);
+    pickerPanel?.classList.remove('hidden');
+  }
+}
+
+function updateButtonState(active: boolean): void {
+  if (!paintBtn) return;
+  if (active) {
+    paintBtn.className = 'px-2 py-1 rounded text-xs bg-blue-500/30 backdrop-blur text-blue-300 border border-blue-500/50 transition-colors';
+  } else {
+    paintBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  }
+}
+
+function updateBadge(): void {
+  if (!regionCountBadge) return;
+  const count = getRegions().length;
+  if (count > 0) {
+    regionCountBadge.textContent = String(count);
+    regionCountBadge.classList.remove('hidden');
+  } else {
+    regionCountBadge.classList.add('hidden');
+  }
+}
+
+function createPickerPanel(): HTMLElement {
+  const panel = document.createElement('div');
+  panel.id = 'paint-picker-panel';
+  panel.className = 'hidden absolute top-10 right-2 z-20 bg-zinc-800/95 backdrop-blur border border-zinc-600/60 rounded-lg p-2.5 shadow-xl';
+  panel.style.minWidth = '160px';
+
+  // Title
+  const title = document.createElement('div');
+  title.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1.5 font-medium';
+  title.textContent = 'Color';
+  panel.appendChild(title);
+
+  // Preset swatches grid
+  const grid = document.createElement('div');
+  grid.className = 'grid grid-cols-4 gap-1.5 mb-2';
+
+  for (const color of PRESET_COLORS) {
+    const swatch = document.createElement('button');
+    swatch.className = 'w-6 h-6 rounded border-2 border-transparent hover:border-white/50 transition-colors';
+    swatch.style.backgroundColor = rgbToCSS(color);
+    swatch.title = rgbToHex(color);
+
+    swatch.addEventListener('click', () => {
+      setColor(color);
+      updateActiveSwatch(grid, swatch);
+    });
+
+    grid.appendChild(swatch);
+  }
+
+  // Mark first swatch as active
+  const first = grid.children[0] as HTMLElement;
+  if (first) first.classList.add('border-white/80', 'ring-1', 'ring-white/30');
+
+  panel.appendChild(grid);
+
+  // Custom color input
+  const customRow = document.createElement('div');
+  customRow.className = 'flex items-center gap-1.5';
+
+  const colorInput = document.createElement('input');
+  colorInput.type = 'color';
+  colorInput.value = rgbToHex(PRESET_COLORS[0]);
+  colorInput.className = 'w-6 h-6 rounded cursor-pointer border-0 p-0 bg-transparent';
+  colorInput.title = 'Custom color';
+
+  colorInput.addEventListener('input', () => {
+    const hex = colorInput.value;
+    const r = parseInt(hex.slice(1, 3), 16) / 255;
+    const g = parseInt(hex.slice(3, 5), 16) / 255;
+    const b = parseInt(hex.slice(5, 7), 16) / 255;
+    setColor([r, g, b]);
+    // Clear active swatch borders
+    for (const child of Array.from(grid.children)) {
+      (child as HTMLElement).classList.remove('border-white/80', 'ring-1', 'ring-white/30');
+    }
+  });
+
+  const customLabel = document.createElement('span');
+  customLabel.className = 'text-[10px] text-zinc-500';
+  customLabel.textContent = 'Custom';
+
+  customRow.appendChild(colorInput);
+  customRow.appendChild(customLabel);
+  panel.appendChild(customRow);
+
+  // Region list (compact)
+  const regionList = document.createElement('div');
+  regionList.id = 'paint-region-list';
+  regionList.className = 'mt-2 border-t border-zinc-700 pt-2 max-h-32 overflow-y-auto';
+  panel.appendChild(regionList);
+
+  onRegionsChange(() => updateRegionList(regionList));
+
+  return panel;
+}
+
+function updateActiveSwatch(grid: HTMLElement, activeSwatch: HTMLElement): void {
+  for (const child of Array.from(grid.children)) {
+    (child as HTMLElement).classList.remove('border-white/80', 'ring-1', 'ring-white/30');
+  }
+  activeSwatch.classList.add('border-white/80', 'ring-1', 'ring-white/30');
+}
+
+function updateRegionList(container: HTMLElement): void {
+  const regions = getRegions();
+  container.innerHTML = '';
+
+  if (regions.length === 0) return;
+
+  for (const region of regions) {
+    const row = document.createElement('div');
+    row.className = 'flex items-center gap-1.5 py-0.5';
+
+    const dot = document.createElement('span');
+    dot.className = 'w-3 h-3 rounded-sm shrink-0';
+    dot.style.backgroundColor = rgbToCSS(region.color);
+
+    const label = document.createElement('span');
+    label.className = 'text-[11px] text-zinc-400 truncate flex-1';
+    label.textContent = region.name;
+
+    const count = document.createElement('span');
+    count.className = 'text-[10px] text-zinc-600';
+    count.textContent = `${region.triangles.size}\u25B3`;
+
+    row.appendChild(dot);
+    row.appendChild(label);
+    row.appendChild(count);
+    container.appendChild(row);
+  }
+}
+
+function rgbToCSS(color: [number, number, number]): string {
+  return `rgb(${Math.round(color[0] * 255)}, ${Math.round(color[1] * 255)}, ${Math.round(color[2] * 255)})`;
+}
+
+function rgbToHex(color: [number, number, number]): string {
+  const r = Math.round(color[0] * 255).toString(16).padStart(2, '0');
+  const g = Math.round(color[1] * 255).toString(16).padStart(2, '0');
+  const b = Math.round(color[2] * 255).toString(16).padStart(2, '0');
+  return `#${r}${g}${b}`;
+}
+
+/** Deactivate paint mode externally (e.g. when switching tabs). */
+export function forceDeactivate(): void {
+  if (isActive()) {
+    deactivate();
+    updateButtonState(false);
+    pickerPanel?.classList.add('hidden');
+  }
+}

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -1,0 +1,171 @@
+// ColorRegionStore — manages per-face color regions for the current mesh
+
+import type { MeshData } from '../geometry/types';
+
+export interface ColorRegion {
+  id: number;
+  name: string;
+  color: [number, number, number]; // RGB 0..1
+  source: 'face-pick' | 'slab' | 'subtree' | 'paintbrush';
+  descriptor: RegionDescriptor;
+  order: number;
+  triangles: Set<number>; // resolved triangle indices (transient, not persisted)
+}
+
+export type RegionDescriptor =
+  | { kind: 'coplanar'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; normalTolerance: number }
+  | { kind: 'slab'; axis: 'x' | 'y' | 'z'; min: number; max: number }
+  | { kind: 'triangles'; ids: number[] };
+
+export interface SerializedColorRegion {
+  id: number;
+  name: string;
+  color: [number, number, number];
+  source: ColorRegion['source'];
+  descriptor: RegionDescriptor;
+  order: number;
+}
+
+type ChangeListener = () => void;
+
+let regions: ColorRegion[] = [];
+let nextOrder = 1;
+const listeners: ChangeListener[] = [];
+
+function notify(): void {
+  for (const fn of listeners) fn();
+}
+
+export function onChange(fn: ChangeListener): void {
+  listeners.push(fn);
+}
+
+export function removeChangeListener(fn: ChangeListener): void {
+  const idx = listeners.indexOf(fn);
+  if (idx >= 0) listeners.splice(idx, 1);
+}
+
+export function getRegions(): readonly ColorRegion[] {
+  return regions;
+}
+
+export function hasRegions(): boolean {
+  return regions.length > 0;
+}
+
+export function addRegion(
+  name: string,
+  color: [number, number, number],
+  source: ColorRegion['source'],
+  descriptor: RegionDescriptor,
+  triangles: Set<number>,
+): ColorRegion {
+  const id = Date.now() + Math.floor(Math.random() * 1000);
+  const region: ColorRegion = {
+    id,
+    name,
+    color,
+    source,
+    descriptor,
+    order: nextOrder++,
+    triangles,
+  };
+  regions.push(region);
+  notify();
+  return region;
+}
+
+export function removeRegion(id: number): boolean {
+  const idx = regions.findIndex(r => r.id === id);
+  if (idx < 0) return false;
+  regions.splice(idx, 1);
+  notify();
+  return true;
+}
+
+export function updateRegionColor(id: number, color: [number, number, number]): void {
+  const region = regions.find(r => r.id === id);
+  if (region) {
+    region.color = color;
+    notify();
+  }
+}
+
+export function clearRegions(): void {
+  if (regions.length === 0) return;
+  regions = [];
+  nextOrder = 1;
+  notify();
+}
+
+/** Build triColors (Uint8Array, numTri*3 RGB) from current regions.
+ *  Higher-order regions win on overlap. Returns null if no regions. */
+export function buildTriColors(numTri: number): Uint8Array | null {
+  if (regions.length === 0) return null;
+
+  const buf = new Uint8Array(numTri * 3); // default 0,0,0 — will be ignored for unpainted tris
+
+  // Track which triangles are painted and with what priority
+  const triOrder = new Int32Array(numTri); // 0 = unpainted
+  triOrder.fill(0);
+
+  // Sort by order ascending so higher-order regions overwrite lower
+  const sorted = [...regions].sort((a, b) => a.order - b.order);
+
+  for (const region of sorted) {
+    const r = Math.round(region.color[0] * 255);
+    const g = Math.round(region.color[1] * 255);
+    const b = Math.round(region.color[2] * 255);
+    for (const tri of region.triangles) {
+      if (tri >= 0 && tri < numTri && region.order >= triOrder[tri]) {
+        buf[tri * 3] = r;
+        buf[tri * 3 + 1] = g;
+        buf[tri * 3 + 2] = b;
+        triOrder[tri] = region.order;
+      }
+    }
+  }
+
+  // Mark which triangles are painted (any with order > 0)
+  // We use a separate flag array to distinguish "painted black" from "unpainted"
+  const painted = new Uint8Array(numTri);
+  for (let i = 0; i < numTri; i++) {
+    if (triOrder[i] > 0) painted[i] = 1;
+  }
+
+  // Store the painted mask on the result for the renderer
+  (buf as Uint8Array & { _painted?: Uint8Array })._painted = painted;
+  return buf;
+}
+
+/** Which triangles are painted in a triColors buffer? */
+export function isPainted(triColors: Uint8Array, triIndex: number): boolean {
+  const painted = (triColors as Uint8Array & { _painted?: Uint8Array })._painted;
+  return painted ? painted[triIndex] === 1 : (triColors[triIndex * 3] !== 0 || triColors[triIndex * 3 + 1] !== 0 || triColors[triIndex * 3 + 2] !== 0);
+}
+
+export function serialize(): SerializedColorRegion[] {
+  return regions.map(r => ({
+    id: r.id,
+    name: r.name,
+    color: r.color,
+    source: r.source,
+    descriptor: r.descriptor,
+    order: r.order,
+  }));
+}
+
+export function deserialize(data: SerializedColorRegion[]): void {
+  regions = data.map(d => ({
+    ...d,
+    triangles: new Set<number>(),
+  }));
+  nextOrder = regions.reduce((max, r) => Math.max(max, r.order + 1), 1);
+}
+
+/** Apply triColors to a MeshData, returning a new object (non-destructive). */
+export function applyTriColors(mesh: MeshData): MeshData {
+  const triColors = buildTriColors(mesh.numTri);
+  if (!triColors) return mesh;
+  return { ...mesh, triColors };
+}

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -10,6 +10,7 @@ export type EditorLanguage = 'manifold-js' | 'scad';
 let editorView: EditorView | null = null;
 let debounceTimer: number | null = null;
 const languageCompartment = new Compartment();
+const readOnlyCompartment = new Compartment();
 
 // Minimal OpenSCAD StreamLanguage — keyword/builtin/comment/string/number coloring.
 const SCAD_KEYWORDS = new Set([
@@ -68,6 +69,7 @@ export function initEditor(
     extensions: [
       basicSetup,
       languageCompartment.of(languageExt(initialLanguage)),
+      readOnlyCompartment.of(EditorState.readOnly.of(false)),
       oneDark,
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
@@ -108,5 +110,12 @@ export function setValue(code: string): void {
   if (!editorView) return;
   editorView.dispatch({
     changes: { from: 0, to: editorView.state.doc.length, insert: code },
+  });
+}
+
+export function setReadOnly(readOnly: boolean): void {
+  if (!editorView) return;
+  editorView.dispatch({
+    effects: readOnlyCompartment.reconfigure(EditorState.readOnly.of(readOnly)),
   });
 }

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -15,10 +15,17 @@ export function export3MF(meshData: MeshData, customName?: string): void {
   }
 
   // Collect distinct colors for basematerials (if triColors present)
+  // Index 0 is always the default base color for unpainted triangles
+  const DEFAULT_COLOR = '#4a9eff';
   const colorMap = new Map<string, number>(); // hex -> material index
   const materialColors: string[] = [];
+  let hasColors = false;
 
   if (triColors) {
+    // Reserve index 0 for the default color
+    colorMap.set(DEFAULT_COLOR, 0);
+    materialColors.push(DEFAULT_COLOR);
+
     const painted = (triColors as Uint8Array & { _painted?: Uint8Array })._painted;
     for (let t = 0; t < numTri; t++) {
       const isPainted = painted ? painted[t] === 1 : (triColors[t * 3] !== 0 || triColors[t * 3 + 1] !== 0 || triColors[t * 3 + 2] !== 0);
@@ -32,12 +39,11 @@ export function export3MF(meshData: MeshData, customName?: string): void {
         colorMap.set(hex, materialColors.length);
         materialColors.push(hex);
       }
+      hasColors = true;
     }
   }
 
-  const hasColors = materialColors.length > 0;
-
-  // Build triangles XML
+  // Build triangles XML — when colors exist, every triangle gets a pid
   const triangles: string[] = [];
   for (let t = 0; t < numTri; t++) {
     const v1 = triVerts[t * 3];
@@ -52,10 +58,11 @@ export function export3MF(meshData: MeshData, customName?: string): void {
         const g = triColors[t * 3 + 1].toString(16).padStart(2, '0');
         const b = triColors[t * 3 + 2].toString(16).padStart(2, '0');
         const hex = `#${r}${g}${b}`;
-        const pid = colorMap.get(hex)!;
-        triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="2" p1="${pid}" />`);
+        const matIdx = colorMap.get(hex)!;
+        triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="2" p1="${matIdx}" />`);
       } else {
-        triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
+        // Unpainted triangles get the default base color
+        triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="2" p1="0" />`);
       }
     } else {
       triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
@@ -66,7 +73,7 @@ export function export3MF(meshData: MeshData, customName?: string): void {
   let basematerialsXml = '';
   if (hasColors) {
     const bases = materialColors.map((hex, i) =>
-      `      <base name="Color ${i + 1}" displaycolor="${hex}" />`
+      `      <base name="${i === 0 ? 'Default' : 'Color ' + i}" displaycolor="${hex}" />`
     ).join('\n');
     basematerialsXml = `
     <basematerials id="2">
@@ -85,7 +92,7 @@ ${bases}
   <metadata name="Title">${title}</metadata>
   <metadata name="Application">Partwright</metadata>
   <resources>${basematerialsXml}
-    <object id="1" type="model">
+    <object id="1" type="model"${hasColors ? ' pid="2" pindex="0"' : ''}>
       <mesh>
         <vertices>
 ${vertices.join('\n')}

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -3,7 +3,7 @@ import { get3MFUnitString } from '../geometry/units';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
 
 export function export3MF(meshData: MeshData, customName?: string): void {
-  const { vertProperties, triVerts, numVert, numTri, numProp } = meshData;
+  const { vertProperties, triVerts, numVert, numTri, numProp, triColors } = meshData;
 
   // Build vertices XML
   const vertices: string[] = [];
@@ -14,23 +14,77 @@ export function export3MF(meshData: MeshData, customName?: string): void {
     vertices.push(`          <vertex x="${x}" y="${y}" z="${z}" />`);
   }
 
+  // Collect distinct colors for basematerials (if triColors present)
+  const colorMap = new Map<string, number>(); // hex -> material index
+  const materialColors: string[] = [];
+
+  if (triColors) {
+    const painted = (triColors as Uint8Array & { _painted?: Uint8Array })._painted;
+    for (let t = 0; t < numTri; t++) {
+      const isPainted = painted ? painted[t] === 1 : (triColors[t * 3] !== 0 || triColors[t * 3 + 1] !== 0 || triColors[t * 3 + 2] !== 0);
+      if (!isPainted) continue;
+
+      const r = triColors[t * 3].toString(16).padStart(2, '0');
+      const g = triColors[t * 3 + 1].toString(16).padStart(2, '0');
+      const b = triColors[t * 3 + 2].toString(16).padStart(2, '0');
+      const hex = `#${r}${g}${b}`;
+      if (!colorMap.has(hex)) {
+        colorMap.set(hex, materialColors.length);
+        materialColors.push(hex);
+      }
+    }
+  }
+
+  const hasColors = materialColors.length > 0;
+
   // Build triangles XML
   const triangles: string[] = [];
   for (let t = 0; t < numTri; t++) {
     const v1 = triVerts[t * 3];
     const v2 = triVerts[t * 3 + 1];
     const v3 = triVerts[t * 3 + 2];
-    triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
+
+    if (hasColors && triColors) {
+      const painted = (triColors as Uint8Array & { _painted?: Uint8Array })._painted;
+      const isPainted = painted ? painted[t] === 1 : (triColors[t * 3] !== 0 || triColors[t * 3 + 1] !== 0 || triColors[t * 3 + 2] !== 0);
+      if (isPainted) {
+        const r = triColors[t * 3].toString(16).padStart(2, '0');
+        const g = triColors[t * 3 + 1].toString(16).padStart(2, '0');
+        const b = triColors[t * 3 + 2].toString(16).padStart(2, '0');
+        const hex = `#${r}${g}${b}`;
+        const pid = colorMap.get(hex)!;
+        triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="2" p1="${pid}" />`);
+      } else {
+        triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
+      }
+    } else {
+      triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
+    }
+  }
+
+  // Build basematerials XML block
+  let basematerialsXml = '';
+  if (hasColors) {
+    const bases = materialColors.map((hex, i) =>
+      `      <base name="Color ${i + 1}" displaycolor="${hex}" />`
+    ).join('\n');
+    basematerialsXml = `
+    <basematerials id="2">
+${bases}
+    </basematerials>`;
   }
 
   // Escape XML special chars in title
   const title = getExportTitle().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
+  // Add materials namespace if colors present
+  const nsAttr = hasColors ? ' xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"' : '';
+
   const modelXml = `<?xml version="1.0" encoding="UTF-8"?>
-<model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+<model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"${nsAttr}>
   <metadata name="Title">${title}</metadata>
   <metadata name="Application">Partwright</metadata>
-  <resources>
+  <resources>${basematerialsXml}
     <object id="1" type="model">
       <mesh>
         <vertices>

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -4,6 +4,7 @@ export interface MeshData {
   numVert: number;
   numTri: number;
   numProp: number;
+  triColors?: Uint8Array; // numTri * 3 (RGB per triangle), optional
 }
 
 export interface MeshResult {

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,11 @@ import { checkContainment, type ContainmentWarning } from './geometry/containmen
 import { setUnits as _setUnits, getUnits as _getUnits, type UnitSystem } from './geometry/units';
 import { initMeasureTool, activate as activateMeasure, deactivate as deactivateMeasure, getState as getMeasureState } from './ui/measureTool';
 import { maybeStartTour, resetTour, startTour } from './ui/tour';
+import { initPaintUI } from './color/paintUI';
+import { updatePaintMesh, setOnRegionPainted, isActive as isPaintActive } from './color/paintMode';
+import { applyTriColors, hasRegions as hasColorRegions, onChange as onColorRegionsChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, type SerializedColorRegion } from './color/regions';
+import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
+import { buildAdjacency, findCoplanarRegion, resolveSeed } from './color/adjacency';
 import {
   getSessionIdFromURL,
   getVersionFromURL,
@@ -354,6 +359,54 @@ function getGeometryDataObj(): Record<string, unknown> | null {
   }
 }
 
+/** Rehydrate color regions from a version's geometryData.
+ *  Rebuilds adjacency + BFS for coplanar descriptors against the current mesh. */
+function rehydrateColorRegions(geometryData: Record<string, unknown> | null): void {
+  clearRegions();
+
+  if (!geometryData || !currentMeshData) return;
+  const regions = geometryData.colorRegions as SerializedColorRegion[] | undefined;
+  if (!regions || regions.length === 0) return;
+
+  const mesh = currentMeshData;
+  const adjacency = buildAdjacency(mesh);
+
+  for (const region of regions) {
+    let triangles = new Set<number>();
+
+    if (region.descriptor.kind === 'coplanar') {
+      const { seedPoint, seedNormal, normalTolerance } = region.descriptor;
+      const seedTri = resolveSeed(seedPoint, seedNormal, mesh, adjacency, normalTolerance);
+      if (seedTri >= 0) {
+        triangles = findCoplanarRegion(seedTri, adjacency, normalTolerance);
+      }
+    } else if (region.descriptor.kind === 'triangles') {
+      triangles = new Set(region.descriptor.ids);
+    }
+
+    if (triangles.size > 0) {
+      addRegion(region.name, region.color, region.source, region.descriptor, triangles);
+    }
+  }
+
+  syncLockState();
+
+  // Re-render with colors if regions were rehydrated
+  if (hasColorRegions() && currentMeshData) {
+    const colored = applyTriColors(currentMeshData);
+    updateMesh(colored);
+  }
+}
+
+/** Include color regions in geometry data for saving. */
+function enrichGeometryDataWithColors(geoData: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!geoData) return geoData;
+  if (hasColorRegions()) {
+    geoData.colorRegions = serializeRegions();
+  }
+  return geoData;
+}
+
 // === Argument validation helpers ==========================================
 //
 // Runtime type/shape validation for the window.partwright API. The public API
@@ -638,7 +691,7 @@ async function main() {
       if (currentMeshData) exportOBJ(currentMeshData);
     },
     onExport3MF: () => {
-      if (currentMeshData) export3MF(currentMeshData);
+      if (currentMeshData) export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData);
     },
     onExampleSelect: async (entry: ExampleEntry) => {
       // Auto-switch engine + editor mode if the example uses a different language.
@@ -674,12 +727,16 @@ async function main() {
   createSessionBar(editorUI, {
     onSaveVersion: async () => ({
       code: getValue(),
-      geometryData: getGeometryDataObj(),
+      geometryData: enrichGeometryDataWithColors(getGeometryDataObj()),
       thumbnail: await captureThumbnail(),
     }),
-    onLoadVersion: (code: string) => {
+    onLoadVersion: async (code: string) => {
       setValue(code);
-      runCode(code);
+      await runCodeSync(code);
+      const loadedVersion = getState().currentVersion;
+      if (loadedVersion) {
+        rehydrateColorRegions(loadedVersion.geometryData);
+      }
     },
     onOpenGallery: () => {
       switchTab('gallery');
@@ -711,9 +768,14 @@ async function main() {
   initViewsPanel(viewsContainer);
 
   // Init gallery
-  createGalleryView(galleryContainer, (code: string) => {
+  createGalleryView(galleryContainer, async (code: string) => {
     setValue(code);
-    runCode(code);
+    await runCodeSync(code);
+    // Rehydrate color regions from the loaded version
+    const loadedVersion = getState().currentVersion;
+    if (loadedVersion) {
+      rehydrateColorRegions(loadedVersion.geometryData);
+    }
     switchTab('interactive');
   });
 
@@ -928,8 +990,61 @@ async function main() {
 
   // Wire up viewport overlay buttons
   initDimensionsToggle(clipControls);
+  initPaintUI(clipControls);
   initMeasureToggle(clipControls);
   initOrbitLockToggle(clipControls);
+
+  // Initialize editor lock
+  initEditorLock(editorContainer);
+
+  // Set up unlock handlers
+  setUnlockHandlers(
+    // Fork: save the colored version first, then create a new uncolored version
+    async (colorData) => {
+      // Save current version with color data if in a session
+      if (getState().session && currentMeshData) {
+        const code = getValue();
+        const geometryData = getGeometryDataObj() ?? {};
+        geometryData.colorRegions = colorData;
+        await saveVersion(code, geometryData, null, 'colored', undefined);
+      }
+      // Editor is now unlocked (clearRegions already called), re-render without colors
+      if (currentMeshData) {
+        updateMesh(currentMeshData);
+        updateMultiView(currentMeshData);
+        renderElevationsToContainer(elevationsContainer, currentMeshData);
+      }
+    },
+    // Clear: just re-render without colors (clearRegions already called)
+    () => {
+      if (currentMeshData) {
+        updateMesh(currentMeshData);
+        updateMultiView(currentMeshData);
+        renderElevationsToContainer(elevationsContainer, currentMeshData);
+      }
+    },
+  );
+
+  // When a color region is painted, re-render the mesh with colors and sync lock
+  setOnRegionPainted(() => {
+    if (currentMeshData) {
+      const colored = applyTriColors(currentMeshData);
+      updateMesh(colored);
+      updateMultiView(colored);
+      renderElevationsToContainer(elevationsContainer, colored);
+    }
+    syncLockState();
+  });
+
+  // Also listen for any region change (e.g. clear) to re-render
+  onColorRegionsChange(() => {
+    syncLockState();
+    if (!isPaintActive()) return; // only auto-refresh while paint mode is on
+    if (currentMeshData) {
+      const colored = applyTriColors(currentMeshData);
+      updateMesh(colored);
+    }
+  });
 
   editorReady = true;
   editorReadyResolve();
@@ -954,7 +1069,9 @@ async function main() {
           await ensureEngineReady(sessionLang);
         }
         setValue(version.code);
-        runCode(version.code);
+        await runCodeSync(version.code);
+        // Rehydrate color regions from loaded version
+        rehydrateColorRegions(version.geometryData);
         const refImages = await getReferenceImagesFromSession();
         if (refImages) {
           _setRefImages(refImages as ReferenceImages);
@@ -1123,7 +1240,7 @@ async function main() {
     /** Export current model as 3MF download. Optional filename override. */
     export3MF(filename?: string) {
       assertString(filename, 'export3MF(filename)', { optional: true });
-      if (currentMeshData) export3MF(currentMeshData, filename);
+      if (currentMeshData) export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData, filename);
     },
 
     /** Validate code without rendering. Returns { valid, error? } */
@@ -1314,7 +1431,7 @@ async function main() {
     async saveVersion(label?: string) {
       assertString(label, 'saveVersion(label)', { optional: true });
       const thumbnail = await captureThumbnail();
-      const version = await saveVersion(getValue(), getGeometryDataObj(), thumbnail, label);
+      const version = await saveVersion(getValue(), enrichGeometryDataWithColors(getGeometryDataObj()), thumbnail, label);
       return version ? { id: version.id, index: version.index, label: version.label } : null;
     },
 
@@ -1345,6 +1462,7 @@ async function main() {
       }
       setValue(version.code);
       await runCodeSync(version.code);
+      rehydrateColorRegions(version.geometryData);
       return {
         id: version.id,
         index: version.index,
@@ -1362,6 +1480,7 @@ async function main() {
       if (version) {
         setValue(version.code);
         await runCodeSync(version.code);
+        rehydrateColorRegions(version.geometryData);
       }
       return version ? { id: version.id, index: version.index, label: version.label } : null;
     },
@@ -1402,7 +1521,7 @@ async function main() {
       await runCodeSync(code);
       const newGeoData = JSON.parse(geometryDataEl.textContent || '{}');
       const thumbnail = await captureThumbnail();
-      const version = await saveVersion(code, getGeometryDataObj(), thumbnail, label, assertions?.notes);
+      const version = await saveVersion(code, enrichGeometryDataWithColors(getGeometryDataObj()), thumbnail, label, assertions?.notes);
 
       let diff = null;
       if (prevGeoData && prevGeoData.status === 'ok' && newGeoData.status === 'ok') {
@@ -2109,6 +2228,65 @@ async function main() {
       return measureDistance(p1, p2);
     },
 
+    // === Color Regions API ===
+
+    /** Paint a coplanar region by specifying a point and normal on the model surface.
+     *  Returns the created region or {error}. */
+    paintRegion(opts: { point: [number, number, number]; normal: [number, number, number]; color: [number, number, number]; name?: string; tolerance?: number }) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintRegion requires {point, normal, color}' };
+      const { point, normal, color, name, tolerance } = opts;
+      if (!Array.isArray(point) || point.length !== 3) return { error: 'point must be [x,y,z]' };
+      if (!Array.isArray(normal) || normal.length !== 3) return { error: 'normal must be [nx,ny,nz]' };
+      if (!Array.isArray(color) || color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+
+      const normalTolerance = tolerance ?? 0.9995;
+      const adjacency = buildAdjacency(currentMeshData);
+      const seedTri = resolveSeed(point as [number, number, number], normal as [number, number, number], currentMeshData, adjacency, normalTolerance);
+      if (seedTri < 0) return { error: 'No matching face found at the given point/normal' };
+
+      const triangles = findCoplanarRegion(seedTri, adjacency, normalTolerance);
+      const regionName = name ?? `Region ${getRegions().length + 1}`;
+      const region = addRegion(
+        regionName,
+        color as [number, number, number],
+        'face-pick',
+        { kind: 'coplanar', seedPoint: point as [number, number, number], seedNormal: normal as [number, number, number], normalTolerance },
+        triangles,
+      );
+
+      // Re-render with colors
+      const colored = applyTriColors(currentMeshData);
+      updateMesh(colored);
+      updateMultiView(colored);
+      syncLockState();
+
+      return { id: region.id, name: region.name, triangles: triangles.size };
+    },
+
+    /** List all color regions on the current geometry */
+    listRegions() {
+      return getRegions().map(r => ({
+        id: r.id,
+        name: r.name,
+        color: r.color,
+        source: r.source,
+        triangles: r.triangles.size,
+        order: r.order,
+      }));
+    },
+
+    /** Clear all color regions */
+    clearColors() {
+      clearRegions();
+      if (currentMeshData) {
+        updateMesh(currentMeshData);
+        updateMultiView(currentMeshData);
+      }
+      syncLockState();
+      return { cleared: true };
+    },
+
     /** Self-documenting help -- returns structured object and logs readable summary */
     help(method?: string): Record<string, unknown> {
       assertString(method, 'help(method)', { optional: true, allowEmpty: false });
@@ -2153,6 +2331,10 @@ async function main() {
         'exportSTL':       { signature: 'exportSTL() -- Download STL file', docs: '/ai.md#console-api--windowpartwright' },
         'exportOBJ':       { signature: 'exportOBJ() -- Download OBJ file', docs: '/ai.md#console-api--windowpartwright' },
         'export3MF':       { signature: 'export3MF() -- Download 3MF file', docs: '/ai.md#console-api--windowpartwright' },
+        // Color regions
+        'paintRegion':     { signature: 'paintRegion({point, normal, color, name?, tolerance?}) -- Paint coplanar face region', docs: '/ai.md#color-regions' },
+        'listRegions':     { signature: 'listRegions() -- List all color regions', docs: '/ai.md#color-regions' },
+        'clearColors':     { signature: 'clearColors() -- Remove all color regions', docs: '/ai.md#color-regions' },
       };
 
       if (method) {
@@ -2234,9 +2416,14 @@ async function main() {
     if (result.mesh) {
       currentMeshData = result.mesh;
       currentManifold = result.manifold;
-      updateMesh(result.mesh);
-      updateMultiView(result.mesh);
-      renderElevationsToContainer(elevationsContainer, result.mesh);
+
+      // Apply any existing color regions to the mesh
+      const displayMesh = hasColorRegions() ? applyTriColors(result.mesh) : result.mesh;
+      updateMesh(displayMesh);
+      updateMultiView(displayMesh);
+      renderElevationsToContainer(elevationsContainer, displayMesh);
+      updatePaintMesh(result.mesh); // always pass uncolored mesh for adjacency
+
       updateGeometryData(elapsed, src);
       syncClipSliderBounds();
       setStatus(statusBar, 'ready', 'Ready');

--- a/src/main.ts
+++ b/src/main.ts
@@ -999,16 +999,22 @@ async function main() {
 
   // Set up unlock handlers
   setUnlockHandlers(
-    // Fork: save the colored version, then create a new uncolored version
+    // Fork: save the colored version (if needed), then create a new uncolored version
     async (colorData) => {
       if (getState().session && currentMeshData) {
         const code = getValue();
-        const thumbnail = await captureThumbnail();
 
-        // 1. Save the colored version (force to bypass duplicate-code check)
-        const coloredGeoData = getGeometryDataObj() ?? {};
-        coloredGeoData.colorRegions = colorData;
-        await saveVersion(code, coloredGeoData, thumbnail, 'colored', undefined, { force: true });
+        // 1. Only save the colored version if it doesn't already have colorRegions persisted
+        const currentVersion = getState().currentVersion;
+        const alreadyPersisted = currentVersion?.geometryData &&
+          Array.isArray((currentVersion.geometryData as Record<string, unknown>).colorRegions);
+
+        if (!alreadyPersisted) {
+          const thumbnail = await captureThumbnail();
+          const coloredGeoData = getGeometryDataObj() ?? {};
+          coloredGeoData.colorRegions = colorData;
+          await saveVersion(code, coloredGeoData, thumbnail, 'colored', undefined, { force: true });
+        }
 
         // 2. Re-render without colors, then save an uncolored sibling
         updateMesh(currentMeshData, { skipAutoFrame: true });

--- a/src/main.ts
+++ b/src/main.ts
@@ -999,20 +999,33 @@ async function main() {
 
   // Set up unlock handlers
   setUnlockHandlers(
-    // Fork: save the colored version first, then create a new uncolored version
+    // Fork: save the colored version, then create a new uncolored version
     async (colorData) => {
-      // Save current version with color data if in a session
       if (getState().session && currentMeshData) {
         const code = getValue();
-        const geometryData = getGeometryDataObj() ?? {};
-        geometryData.colorRegions = colorData;
-        await saveVersion(code, geometryData, null, 'colored', undefined);
-      }
-      // Editor is now unlocked (clearRegions already called), re-render without colors
-      if (currentMeshData) {
+        const thumbnail = await captureThumbnail();
+
+        // 1. Save the colored version (force to bypass duplicate-code check)
+        const coloredGeoData = getGeometryDataObj() ?? {};
+        coloredGeoData.colorRegions = colorData;
+        await saveVersion(code, coloredGeoData, thumbnail, 'colored', undefined, { force: true });
+
+        // 2. Re-render without colors, then save an uncolored sibling
         updateMesh(currentMeshData, { skipAutoFrame: true });
         updateMultiView(currentMeshData);
         renderElevationsToContainer(elevationsContainer, currentMeshData);
+
+        const cleanGeoData = getGeometryDataObj() ?? {};
+        delete cleanGeoData.colorRegions;
+        const cleanThumb = await captureThumbnail();
+        await saveVersion(code, cleanGeoData, cleanThumb, undefined, undefined, { force: true });
+      } else {
+        // No session — just re-render without colors
+        if (currentMeshData) {
+          updateMesh(currentMeshData, { skipAutoFrame: true });
+          updateMultiView(currentMeshData);
+          renderElevationsToContainer(elevationsContainer, currentMeshData);
+        }
       }
     },
     // Clear: just re-render without colors (clearRegions already called)

--- a/src/main.ts
+++ b/src/main.ts
@@ -394,7 +394,7 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): vo
   // Re-render with colors if regions were rehydrated
   if (hasColorRegions() && currentMeshData) {
     const colored = applyTriColors(currentMeshData);
-    updateMesh(colored);
+    updateMesh(colored, { skipAutoFrame: true });
   }
 }
 
@@ -1010,7 +1010,7 @@ async function main() {
       }
       // Editor is now unlocked (clearRegions already called), re-render without colors
       if (currentMeshData) {
-        updateMesh(currentMeshData);
+        updateMesh(currentMeshData, { skipAutoFrame: true });
         updateMultiView(currentMeshData);
         renderElevationsToContainer(elevationsContainer, currentMeshData);
       }
@@ -1018,7 +1018,7 @@ async function main() {
     // Clear: just re-render without colors (clearRegions already called)
     () => {
       if (currentMeshData) {
-        updateMesh(currentMeshData);
+        updateMesh(currentMeshData, { skipAutoFrame: true });
         updateMultiView(currentMeshData);
         renderElevationsToContainer(elevationsContainer, currentMeshData);
       }
@@ -1029,7 +1029,7 @@ async function main() {
   setOnRegionPainted(() => {
     if (currentMeshData) {
       const colored = applyTriColors(currentMeshData);
-      updateMesh(colored);
+      updateMesh(colored, { skipAutoFrame: true });
       updateMultiView(colored);
       renderElevationsToContainer(elevationsContainer, colored);
     }
@@ -1042,7 +1042,7 @@ async function main() {
     if (!isPaintActive()) return; // only auto-refresh while paint mode is on
     if (currentMeshData) {
       const colored = applyTriColors(currentMeshData);
-      updateMesh(colored);
+      updateMesh(colored, { skipAutoFrame: true });
     }
   });
 
@@ -2257,7 +2257,7 @@ async function main() {
 
       // Re-render with colors
       const colored = applyTriColors(currentMeshData);
-      updateMesh(colored);
+      updateMesh(colored, { skipAutoFrame: true });
       updateMultiView(colored);
       syncLockState();
 
@@ -2280,7 +2280,7 @@ async function main() {
     clearColors() {
       clearRegions();
       if (currentMeshData) {
-        updateMesh(currentMeshData);
+        updateMesh(currentMeshData, { skipAutoFrame: true });
         updateMultiView(currentMeshData);
       }
       syncLockState();

--- a/src/renderer/materials.ts
+++ b/src/renderer/materials.ts
@@ -1,10 +1,11 @@
 import * as THREE from 'three';
 
-export function createDefaultMaterial(): THREE.MeshPhongMaterial {
+export function createDefaultMaterial(vertexColors = false): THREE.MeshPhongMaterial {
   return new THREE.MeshPhongMaterial({
-    color: 0x4a9eff,
+    color: vertexColors ? 0xffffff : 0x4a9eff,
     shininess: 40,
     side: THREE.DoubleSide,
+    vertexColors,
   });
 }
 
@@ -17,11 +18,12 @@ export function createWireframeMaterial(): THREE.MeshBasicMaterial {
   });
 }
 
-export function createWhiteMaterial(): THREE.MeshPhongMaterial {
+export function createWhiteMaterial(vertexColors = false): THREE.MeshPhongMaterial {
   return new THREE.MeshPhongMaterial({
     color: 0xffffff,
     shininess: 30,
     side: THREE.DoubleSide,
+    vertexColors,
   });
 }
 

--- a/src/renderer/multiview.ts
+++ b/src/renderer/multiview.ts
@@ -18,15 +18,56 @@ const VIEWS: ViewConfig[] = [
 
 function meshDataToGeometry(meshData: MeshData): THREE.BufferGeometry {
   const geometry = new THREE.BufferGeometry();
-  const positions = new Float32Array(meshData.numVert * 3);
-  for (let i = 0; i < meshData.numVert; i++) {
-    positions[i * 3] = meshData.vertProperties[i * meshData.numProp];
-    positions[i * 3 + 1] = meshData.vertProperties[i * meshData.numProp + 1];
-    positions[i * 3 + 2] = meshData.vertProperties[i * meshData.numProp + 2];
+
+  if (meshData.triColors) {
+    // Unindex to carry per-triangle colors as per-vertex attributes
+    const numTri = meshData.numTri;
+    const positions = new Float32Array(numTri * 3 * 3);
+    const colors = new Float32Array(numTri * 3 * 3);
+    const { vertProperties, triVerts, numProp, triColors } = meshData;
+
+    for (let t = 0; t < numTri; t++) {
+      const v0 = triVerts[t * 3];
+      const v1 = triVerts[t * 3 + 1];
+      const v2 = triVerts[t * 3 + 2];
+
+      for (let c = 0; c < 3; c++) {
+        positions[t * 9 + c] = vertProperties[v0 * numProp + c];
+        positions[t * 9 + 3 + c] = vertProperties[v1 * numProp + c];
+        positions[t * 9 + 6 + c] = vertProperties[v2 * numProp + c];
+      }
+
+      const r = triColors[t * 3] / 255;
+      const g = triColors[t * 3 + 1] / 255;
+      const b = triColors[t * 3 + 2] / 255;
+      const painted = (triColors as Uint8Array & { _painted?: Uint8Array })._painted;
+      const isPainted = painted ? painted[t] === 1 : (r !== 0 || g !== 0 || b !== 0);
+      const cr = isPainted ? r : 1;
+      const cg = isPainted ? g : 1;
+      const cb = isPainted ? b : 1;
+
+      for (let v = 0; v < 3; v++) {
+        colors[t * 9 + v * 3] = cr;
+        colors[t * 9 + v * 3 + 1] = cg;
+        colors[t * 9 + v * 3 + 2] = cb;
+      }
+    }
+
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    geometry.computeVertexNormals();
+  } else {
+    const positions = new Float32Array(meshData.numVert * 3);
+    for (let i = 0; i < meshData.numVert; i++) {
+      positions[i * 3] = meshData.vertProperties[i * meshData.numProp];
+      positions[i * 3 + 1] = meshData.vertProperties[i * meshData.numProp + 1];
+      positions[i * 3 + 2] = meshData.vertProperties[i * meshData.numProp + 2];
+    }
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setIndex(new THREE.BufferAttribute(meshData.triVerts, 1));
+    geometry.computeVertexNormals();
   }
-  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-  geometry.setIndex(new THREE.BufferAttribute(meshData.triVerts, 1));
-  geometry.computeVertexNormals();
+
   return geometry;
 }
 
@@ -67,7 +108,8 @@ export function renderViewsToContainer(container: HTMLElement, meshData: MeshDat
   dir2.position.set(-10, 10, -5);
   scene.add(dir2);
 
-  const solidMesh = new THREE.Mesh(geometry, createWhiteMaterial());
+  const hasColors = geometry.hasAttribute('color');
+  const solidMesh = new THREE.Mesh(geometry, createWhiteMaterial(hasColors));
   const wireMesh = new THREE.Mesh(geometry, createBlackWireframeMaterial());
   scene.add(solidMesh);
   scene.add(wireMesh);
@@ -126,6 +168,7 @@ export function renderViewsToContainer(container: HTMLElement, meshData: MeshDat
 export function renderCompositeCanvas(meshData: MeshData): HTMLCanvasElement {
   const geometry = meshDataToGeometry(meshData);
   const viewSize = 500;
+  const hasColors = geometry.hasAttribute('color');
 
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0xffffff);
@@ -136,7 +179,7 @@ export function renderCompositeCanvas(meshData: MeshData): HTMLCanvasElement {
   dir.position.set(10, -10, 15);
   scene.add(dir);
 
-  const solidMesh = new THREE.Mesh(geometry, createWhiteMaterial());
+  const solidMesh = new THREE.Mesh(geometry, createWhiteMaterial(hasColors));
   const wireMesh = new THREE.Mesh(geometry, createBlackWireframeMaterial());
   scene.add(solidMesh);
   scene.add(wireMesh);
@@ -246,7 +289,8 @@ function createElevationScene(geometry: THREE.BufferGeometry, bgColor: number): 
   const dir2 = new THREE.DirectionalLight(0xffffff, 0.3);
   dir2.position.set(-10, 10, -5);
   scene.add(dir2);
-  const solidMesh = new THREE.Mesh(geometry, createWhiteMaterial());
+  const hasColors = geometry.hasAttribute('color');
+  const solidMesh = new THREE.Mesh(geometry, createWhiteMaterial(hasColors));
   const wireMesh = new THREE.Mesh(geometry, createBlackWireframeMaterial());
   scene.add(solidMesh);
   scene.add(wireMesh);

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -119,7 +119,7 @@ export function initViewport(container: HTMLElement): {
   return { scene, camera, renderer };
 }
 
-export function updateMesh(meshData: MeshData): void {
+export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boolean }): void {
   // Clear previous
   while (meshGroup.children.length > 0) {
     const child = meshGroup.children[0];
@@ -158,29 +158,32 @@ export function updateMesh(meshData: MeshData): void {
     meshGroup.add(capMesh);
   }
 
-  // Auto-frame the camera
+  // Auto-frame the camera (skip when only colors changed)
   const box = new THREE.Box3().setFromObject(meshGroup);
-  const center = box.getCenter(new THREE.Vector3());
-  const size = box.getSize(new THREE.Vector3());
-  const maxDim = Math.max(size.x, size.y, size.z);
 
-  // Update model bounds for clip slider
-  modelBounds = { min: box.min.z, max: box.max.z };
+  if (!options?.skipAutoFrame) {
+    const center = box.getCenter(new THREE.Vector3());
+    const size = box.getSize(new THREE.Vector3());
+    const maxDim = Math.max(size.x, size.y, size.z);
 
-  // Update bounding box dimension annotations
-  updateDimensionLines(box);
+    // Update model bounds for clip slider
+    modelBounds = { min: box.min.z, max: box.max.z };
 
-  controls.target.copy(center);
-  camera.position.set(
-    center.x + maxDim * 1.2,
-    center.y - maxDim * 1.2,
-    center.z + maxDim * 1.2,
-  );
-  controls.update();
+    // Update bounding box dimension annotations
+    updateDimensionLines(box);
 
-  // Update clip plane position if clipping
-  if (clippingEnabled) {
-    updateClipPlaneVisual();
+    controls.target.copy(center);
+    camera.position.set(
+      center.x + maxDim * 1.2,
+      center.y - maxDim * 1.2,
+      center.z + maxDim * 1.2,
+    );
+    controls.update();
+
+    // Update clip plane position if clipping
+    if (clippingEnabled) {
+      updateClipPlaneVisual();
+    }
   }
 }
 

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -133,8 +133,9 @@ export function updateMesh(meshData: MeshData): void {
   }
 
   const geometry = meshGLToBufferGeometry(meshData);
+  const hasColors = geometry.hasAttribute('color');
 
-  const solidMat = createDefaultMaterial();
+  const solidMat = createDefaultMaterial(hasColors);
   const wireMat = createWireframeMaterial();
 
   // Apply clipping planes to materials
@@ -273,17 +274,64 @@ function removeClipPlaneVisual() {
 
 function meshGLToBufferGeometry(mesh: MeshData): THREE.BufferGeometry {
   const geometry = new THREE.BufferGeometry();
-  const positions = new Float32Array(mesh.numVert * 3);
 
-  for (let i = 0; i < mesh.numVert; i++) {
-    positions[i * 3] = mesh.vertProperties[i * mesh.numProp];
-    positions[i * 3 + 1] = mesh.vertProperties[i * mesh.numProp + 1];
-    positions[i * 3 + 2] = mesh.vertProperties[i * mesh.numProp + 2];
+  if (mesh.triColors) {
+    // With per-triangle colors, we must unindex (duplicate vertices per triangle)
+    // so each triangle's 3 vertices can carry that triangle's color.
+    const numTri = mesh.numTri;
+    const positions = new Float32Array(numTri * 3 * 3);
+    const colors = new Float32Array(numTri * 3 * 3);
+    const { vertProperties, triVerts, numProp, triColors } = mesh;
+
+    for (let t = 0; t < numTri; t++) {
+      const v0 = triVerts[t * 3];
+      const v1 = triVerts[t * 3 + 1];
+      const v2 = triVerts[t * 3 + 2];
+
+      // Positions
+      for (let c = 0; c < 3; c++) {
+        positions[t * 9 + c] = vertProperties[v0 * numProp + c];
+        positions[t * 9 + 3 + c] = vertProperties[v1 * numProp + c];
+        positions[t * 9 + 6 + c] = vertProperties[v2 * numProp + c];
+      }
+
+      // Colors (same for all 3 vertices of the triangle)
+      const r = triColors[t * 3] / 255;
+      const g = triColors[t * 3 + 1] / 255;
+      const b = triColors[t * 3 + 2] / 255;
+
+      // Check if this triangle is painted (has a color region)
+      const painted = (triColors as Uint8Array & { _painted?: Uint8Array })._painted;
+      const isPainted = painted ? painted[t] === 1 : (r !== 0 || g !== 0 || b !== 0);
+
+      // Unpainted triangles get the default blue (#4a9eff)
+      const cr = isPainted ? r : 0x4a / 255;
+      const cg = isPainted ? g : 0x9e / 255;
+      const cb = isPainted ? b : 0xff / 255;
+
+      for (let v = 0; v < 3; v++) {
+        colors[t * 9 + v * 3] = cr;
+        colors[t * 9 + v * 3 + 1] = cg;
+        colors[t * 9 + v * 3 + 2] = cb;
+      }
+    }
+
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    geometry.computeVertexNormals();
+  } else {
+    // No colors — use indexed geometry (original path)
+    const positions = new Float32Array(mesh.numVert * 3);
+    for (let i = 0; i < mesh.numVert; i++) {
+      positions[i * 3] = mesh.vertProperties[i * mesh.numProp];
+      positions[i * 3 + 1] = mesh.vertProperties[i * mesh.numProp + 1];
+      positions[i * 3 + 2] = mesh.vertProperties[i * mesh.numProp + 2];
+    }
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setIndex(new THREE.BufferAttribute(mesh.triVerts, 1));
+    geometry.computeVertexNormals();
   }
 
-  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-  geometry.setIndex(new THREE.BufferAttribute(mesh.triVerts, 1));
-  geometry.computeVertexNormals();
   return geometry;
 }
 

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -182,11 +182,12 @@ export async function saveVersion(
   thumbnail: Blob | null,
   label?: string,
   notes?: string,
+  options?: { force?: boolean },
 ): Promise<Version | null> {
   if (!currentState.session) return null;
 
-  // Skip if code is identical to the current version
-  if (currentState.currentVersion && currentState.currentVersion.code === code) {
+  // Skip if code is identical to the current version (unless forced)
+  if (!options?.force && currentState.currentVersion && currentState.currentVersion.code === code) {
     return null;
   }
 

--- a/src/ui/gallery.ts
+++ b/src/ui/gallery.ts
@@ -148,6 +148,33 @@ function createTile(version: Version): HTMLElement {
 
   info.appendChild(header);
 
+  // Color region badge — show swatch dots if version has color regions
+  if (version.geometryData) {
+    const colorRegions = (version.geometryData as Record<string, unknown>).colorRegions as
+      { color: [number, number, number] }[] | undefined;
+    if (colorRegions && colorRegions.length > 0) {
+      const badge = document.createElement('div');
+      badge.className = 'flex items-center gap-0.5 ml-1';
+      badge.title = `${colorRegions.length} color region${colorRegions.length > 1 ? 's' : ''}`;
+
+      const shown = colorRegions.slice(0, 3);
+      for (const region of shown) {
+        const dot = document.createElement('span');
+        dot.className = 'inline-block w-2.5 h-2.5 rounded-sm';
+        const [r, g, b] = region.color;
+        dot.style.backgroundColor = `rgb(${Math.round(r * 255)},${Math.round(g * 255)},${Math.round(b * 255)})`;
+        badge.appendChild(dot);
+      }
+      if (colorRegions.length > 3) {
+        const more = document.createElement('span');
+        more.className = 'text-[9px] text-zinc-500';
+        more.textContent = `+${colorRegions.length - 3}`;
+        badge.appendChild(more);
+      }
+      header.appendChild(badge);
+    }
+  }
+
   // Stats from geometryData
   if (version.geometryData) {
     const stats = document.createElement('div');


### PR DESCRIPTION
## Summary

- **Paint mode**: Click-to-paint coplanar face regions with 8 preset colors + custom picker. Hover preview highlights the region before committing. Camera stays in place when painting (no auto-frame reset).
- **Editor lock/unlock**: Colored versions lock the code editor. Unlock modal defaults to preserving the colored version and creating a new uncolored sibling for editing. Re-opening an already-saved colored version and unlocking skips the redundant save.
- **Persistence**: Color regions stored as spatial descriptors in `geometryData.colorRegions`, rehydrated on version load via raycast + BFS.
- **Gallery badges**: Colored versions show small color-swatch dots in the gallery.
- **Color exports**: GLB carries vertex colors automatically. 3MF extended with `<basematerials>` and per-triangle `pid` attributes (all triangles assigned a material for viewer compatibility).
- **Console API**: `paintRegion()`, `listRegions()`, `clearColors()` for programmatic use.

## Test plan

- [ ] Open editor, click Paint button — color picker appears
- [ ] Click a model face — coplanar region paints in selected color, camera stays in position
- [ ] Editor shows lock banner, code is read-only
- [ ] Click "Unlock to edit" — modal appears with preserve/destructive options
- [ ] Default unlock saves colored version (v2), creates uncolored copy (v3), editor shows v3
- [ ] Navigate back to v2 — colors rehydrate, lock banner appears
- [ ] Unlock v2 again — only creates one new uncolored version (no duplicate colored save)
- [ ] Load a colored version from gallery — colors rehydrate correctly
- [ ] Export GLB with colors — verify in 3D viewer
- [ ] Console: `partwright.paintRegion({point, normal, color})` works
- [ ] `npm run build` succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)