### PR TITLE
Persist active language to session on switch

### DIFF
--- a/prompts/20260427-fix-session-language-persist.md
+++ b/prompts/20260427-fix-session-language-persist.md
@@ -1,0 +1,40 @@
+---
+session: "fix-session-language-persist"
+timestamp: "2026-04-27T11:00:00Z"
+model: claude-opus-4-7
+tools: []
+---
+
+## Human
+
+I had AI build a SCAD model that rendered fine, but reopening the saved
+session threw a JavaScript syntax error — the editor was in JS mode trying
+to parse SCAD code. The thumbnail showed the correct render, so the engine
+was clearly in SCAD mode at save time. How could the language metadata
+have ended up wrong?
+
+## Assistant
+
+### Root cause
+
+`createSession` snapshots `getActiveLanguage()` at creation time and stores
+it on the session record. `switchLanguage` updates the engine, editor, and
+toolbar but never writes the new language back to the active session row.
+So the bug flow is:
+
+1. AI opens `/editor?view=ai` — default `manifold-js`.
+2. AI calls `createSession()` — session stored with `language: undefined`
+   (treated as `manifold-js`).
+3. AI calls `setActiveLanguage('scad')` → `switchLanguage('scad')`. Engine
+   switches, but the session row is never updated.
+4. AI calls `runAndSave(scadCode, ...)` — runs through SCAD engine, saves
+   version with SCAD code, captures correct thumbnail.
+5. User reopens — load path reads `session.language ?? 'manifold-js'`,
+   gets `'manifold-js'`, parses SCAD as JS → SyntaxError.
+
+### Fix
+
+Added `setSessionLanguage(id, lang)` in `sessionManager.ts` that calls
+`updateSession` and refreshes in-memory state. `switchLanguage` in
+`main.ts` now invokes it for the active session after the engine is ready.
+Sessions now stay in sync with the active engine across language switches.

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ import {
   listSessions,
   deleteSession,
   renameSession,
+  setSessionLanguage,
   saveVersion,
   navigateVersion,
   loadVersion as loadVersionFromStore,
@@ -1256,6 +1257,12 @@ async function main() {
       setStatus(statusBar, 'error', `Failed to load ${lang}: ${e instanceof Error ? e.message : String(e)}`);
       throw e;
     }
+    // Persist the language to the active session so reopening it loads in the
+    // correct mode. Without this, sessions created before a language switch
+    // keep their stale language field and reload in the wrong engine, parsing
+    // SCAD code as JS (or vice versa).
+    const sid = getState().session?.id;
+    if (sid) await setSessionLanguage(sid, lang);
     setStatus(statusBar, 'ready', 'Ready');
   }
 

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -169,6 +169,14 @@ export async function renameSession(id: string, newName: string): Promise<void> 
   }
 }
 
+export async function setSessionLanguage(id: string, language: 'manifold-js' | 'scad'): Promise<void> {
+  await dbUpdateSession(id, { language, updated: Date.now() });
+  if (currentState.session?.id === id) {
+    currentState.session = { ...currentState.session, language, updated: Date.now() };
+    notify();
+  }
+}
+
 // === Version operations ===
 
 export async function saveVersion(


### PR DESCRIPTION
## Summary

- Fixes a bug where AI-built SCAD sessions would reload as JS and throw a syntax error, even though the saved render looked correct.
- `switchLanguage` now writes the new language back to the active session record so new sessions and switched sessions stay in sync with the engine.
- Adds a `setSessionLanguage(id, lang)` helper in `sessionManager` that updates IndexedDB and the in-memory state in one place.

## Root cause

`createSession` snapshots `getActiveLanguage()` at creation time. `switchLanguage` updated the engine, editor, and toolbar — but never the session row. An AI agent that called \`createSession()\` in default JS mode, then switched to SCAD, would write SCAD code to versions while the session record still claimed \`language: 'manifold-js'\`. Render worked at save time (engine was in SCAD), but every load path reads \`session.language ?? 'manifold-js'\`, so reopening parsed SCAD as JS.

## Test plan

- [ ] Open \`/editor?view=ai\`, run \`await partwright.createSession('scad-test')\`
- [ ] Run \`await partwright.setActiveLanguage('scad')\`
- [ ] Run \`await partwright.runAndSave('cube([10,10,10]);', 'v1')\` — verify it renders
- [ ] Refresh the page (or open the session from the landing page) — editor should restore in SCAD mode, no syntax error
- [ ] Sanity check: a JS-only session (no language switch) still loads as JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)