### PR TITLE
Add session JSON + raw code exports with format descriptions

### DIFF
--- a/prompts/20260427-export-import-improvements.md
+++ b/prompts/20260427-export-import-improvements.md
@@ -1,0 +1,34 @@
+---
+session: "export-import-improvements"
+timestamp: "2026-04-27T18:00:00Z"
+model: claude-opus-4-7
+tools: [Read, Edit, Write, Bash, Grep, Glob, chrome-devtools]
+---
+
+## Human
+
+I have an export option for STL, 3mf, etc. but the option to export the
+current session as JSON so it can be imported into another user's session
+isn't there, which makes it harder to find. Add it there, plus a raw
+export option for the text.
+
+Also annotate each format with what it does — OBJ is the only one that
+imports into Bambu with both color and geometry (color is "coming soon",
+assume we have it). STL has no color. 3MF is generic, probably doesn't
+import with color. GLB doesn't import to Bambu, least preferred.
+
+## Changes
+
+- `src/export/session.ts` (new): `exportSessionJSON()` and `exportRawCode()`
+  helpers wrapping the existing `exportSession` serializer + `downloadBlob`.
+- `src/ui/toolbar.ts`: Restructured export dropdown into two sections
+  (3D model / Project) with one-line descriptions on every item.
+  3D formats reordered by Bambu Studio compatibility:
+  OBJ (recommended) → 3MF → STL → GLB. Added Session (.partwright.json)
+  and Code (raw) under Project. Replaced `createDropdownItem` with
+  `createDescribedItem` + `createSectionHeader` + `createDivider`.
+- `src/main.ts`: Wired `onExportSessionJSON` and `onExportRawCode`
+  callbacks. Raw code uses the active language for filename extension
+  (.js / .scad).
+- `src/ui/sessionList.ts`: Per-row Export button now calls
+  `exportSessionJSON(sessionId)` so both call sites stay in sync.

--- a/src/export/session.ts
+++ b/src/export/session.ts
@@ -1,0 +1,39 @@
+// Session JSON + raw code exports
+
+import { exportSession, getState } from '../storage/sessionManager';
+import { downloadBlob } from './download';
+
+/** Sanitize a session name into a filename-safe slug. Falls back to "session". */
+function slugify(name: string): string {
+  const slug = name
+    .replace(/[^a-zA-Z0-9_-]+/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 80);
+  return slug || 'session';
+}
+
+/**
+ * Export the current (or specified) session as a `.partwright.json` file.
+ * Returns true if a download was triggered, false if no session was available.
+ */
+export async function exportSessionJSON(sessionId?: string): Promise<boolean> {
+  const data = await exportSession(sessionId);
+  if (!data) return false;
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  downloadBlob(blob, `${slugify(data.session.name)}.partwright.json`);
+  return true;
+}
+
+/**
+ * Export the editor's current code as a plain `.js` or `.scad` file.
+ * Uses the active session/version for the filename when available.
+ */
+export function exportRawCode(code: string, language: 'manifold-js' | 'scad'): void {
+  const ext = language === 'scad' ? 'scad' : 'js';
+  const state = getState();
+  let base = state.session?.name ?? 'code';
+  if (state.currentVersion?.label) base += `_${state.currentVersion.label}`;
+  const blob = new Blob([code], { type: 'text/plain' });
+  downloadBlob(blob, `${slugify(base)}.${ext}`);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { exportGLB } from './export/gltf';
 import { exportSTL } from './export/stl';
 import { exportOBJ } from './export/obj';
 import { export3MF } from './export/threemf';
+import { exportSessionJSON, exportRawCode } from './export/session';
 import type { MeshData, SourceDiagnostic } from './geometry/types';
 import { analyzeZProfile, type ZProfile } from './geometry/profileAnalysis';
 import { probeAtXY, probeRay, measureDistance, type ProbeResult, type GeneralRayResult } from './geometry/rayCast';
@@ -744,6 +745,13 @@ async function main() {
     },
     onExport3MF: () => {
       if (currentMeshData) export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData);
+    },
+    onExportSessionJSON: async () => {
+      const ok = await exportSessionJSON();
+      if (!ok) alert('No active session to export. Save a version first.');
+    },
+    onExportRawCode: () => {
+      exportRawCode(getValue(), getActiveLanguage());
     },
     onExampleSelect: async (entry: ExampleEntry) => {
       // Auto-switch engine + editor mode if the example uses a different language.

--- a/src/ui/sessionList.ts
+++ b/src/ui/sessionList.ts
@@ -5,12 +5,12 @@ import {
   createSession,
   deleteSession,
   openSession,
-  exportSession,
   importSession,
   clearAllSessions,
   type Session,
   type ExportedSession,
 } from '../storage/sessionManager';
+import { exportSessionJSON } from '../export/session';
 import { getVersionCount } from '../storage/db';
 
 let modalEl: HTMLElement | null = null;
@@ -182,14 +182,7 @@ async function createSessionRow(session: Session): Promise<HTMLElement> {
   expBtn.textContent = 'Export';
   expBtn.addEventListener('click', async (e) => {
     e.stopPropagation();
-    const data = await exportSession(session.id);
-    if (!data) return;
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `${session.name.replace(/[^a-zA-Z0-9_-]/g, '_')}.partwright.json`;
-    link.click();
-    URL.revokeObjectURL(link.href);
+    await exportSessionJSON(session.id);
   });
   row.appendChild(expBtn);
 

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -12,6 +12,8 @@ export interface ToolbarCallbacks {
   onExportSTL: () => void;
   onExportOBJ: () => void;
   onExport3MF: () => void;
+  onExportSessionJSON: () => void;
+  onExportRawCode: () => void;
   onExampleSelect: (entry: ExampleEntry) => void;
   onLanguageSwitch: (lang: 'manifold-js' | 'scad') => void;
 }
@@ -171,36 +173,78 @@ export function createToolbar(
 
   const dropdown = document.createElement('div');
   dropdown.id = 'export-dropdown';
-  dropdown.className = 'absolute right-0 top-full mt-1 bg-zinc-800 border border-zinc-600 rounded shadow-lg py-1 hidden z-20 min-w-32';
+  dropdown.className = 'absolute right-0 top-full mt-1 bg-zinc-800 border border-zinc-600 rounded shadow-lg py-1 hidden z-20 w-72 max-h-[80vh] overflow-y-auto';
 
-  const glbOpt = createDropdownItem('GLB (recommended)');
-  glbOpt.addEventListener('click', () => {
-    dropdown.classList.add('hidden');
-    callbacks.onExportGLB();
-  });
+  // Section: 3D model formats — ordered by Bambu Studio compatibility
+  dropdown.appendChild(createSectionHeader('3D model'));
 
-  const stlOpt = createDropdownItem('STL');
-  stlOpt.addEventListener('click', () => {
-    dropdown.classList.add('hidden');
-    callbacks.onExportSTL();
-  });
-
-  const objOpt = createDropdownItem('OBJ');
+  const objOpt = createDescribedItem(
+    'OBJ',
+    'Geometry + color. Best for Bambu Studio multi-color prints.',
+    'recommended',
+  );
   objOpt.addEventListener('click', () => {
     dropdown.classList.add('hidden');
     callbacks.onExportOBJ();
   });
 
-  const threemfOpt = createDropdownItem('3MF');
+  const threemfOpt = createDescribedItem(
+    '3MF',
+    'Generic 3D format. Geometry only — color regions are not preserved on Bambu import.',
+  );
   threemfOpt.addEventListener('click', () => {
     dropdown.classList.add('hidden');
     callbacks.onExport3MF();
   });
 
-  dropdown.appendChild(glbOpt);
-  dropdown.appendChild(stlOpt);
+  const stlOpt = createDescribedItem(
+    'STL',
+    'Geometry only, no color. Universal slicer support.',
+  );
+  stlOpt.addEventListener('click', () => {
+    dropdown.classList.add('hidden');
+    callbacks.onExportSTL();
+  });
+
+  const glbOpt = createDescribedItem(
+    'GLB',
+    'Web/preview format with materials. Does not import into Bambu Studio.',
+  );
+  glbOpt.addEventListener('click', () => {
+    dropdown.classList.add('hidden');
+    callbacks.onExportGLB();
+  });
+
   dropdown.appendChild(objOpt);
   dropdown.appendChild(threemfOpt);
+  dropdown.appendChild(stlOpt);
+  dropdown.appendChild(glbOpt);
+
+  // Section: project / source — for sharing between users or working with the code directly
+  dropdown.appendChild(createDivider());
+  dropdown.appendChild(createSectionHeader('Project'));
+
+  const sessionOpt = createDescribedItem(
+    'Session (.partwright.json)',
+    'All versions, notes, and reference images. Another Partwright user can import this.',
+  );
+  sessionOpt.addEventListener('click', () => {
+    dropdown.classList.add('hidden');
+    callbacks.onExportSessionJSON();
+  });
+
+  const codeOpt = createDescribedItem(
+    'Code (raw)',
+    'Just the editor source as plain .js or .scad text.',
+  );
+  codeOpt.addEventListener('click', () => {
+    dropdown.classList.add('hidden');
+    callbacks.onExportRawCode();
+  });
+
+  dropdown.appendChild(sessionOpt);
+  dropdown.appendChild(codeOpt);
+
   exportWrapper.appendChild(dropdown);
 
   btnExport.addEventListener('click', () => {
@@ -254,9 +298,44 @@ function createButton(id: string, text: string): HTMLButtonElement {
   return btn;
 }
 
-function createDropdownItem(text: string): HTMLButtonElement {
+function createDescribedItem(label: string, description: string, badge?: string): HTMLButtonElement {
   const btn = document.createElement('button');
-  btn.className = 'block w-full text-left px-3 py-1.5 text-xs text-zinc-300 hover:bg-zinc-700';
-  btn.textContent = text;
+  btn.className = 'block w-full text-left px-3 py-1.5 hover:bg-zinc-700 transition-colors';
+
+  const top = document.createElement('div');
+  top.className = 'flex items-center gap-1.5';
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'text-xs text-zinc-200 font-medium';
+  labelEl.textContent = label;
+  top.appendChild(labelEl);
+
+  if (badge) {
+    const badgeEl = document.createElement('span');
+    badgeEl.className = 'text-[9px] uppercase tracking-wide text-emerald-400 border border-emerald-400/30 rounded px-1 py-px';
+    badgeEl.textContent = badge;
+    top.appendChild(badgeEl);
+  }
+
+  btn.appendChild(top);
+
+  const descEl = document.createElement('div');
+  descEl.className = 'text-[10px] text-zinc-500 leading-tight mt-0.5';
+  descEl.textContent = description;
+  btn.appendChild(descEl);
+
   return btn;
+}
+
+function createSectionHeader(text: string): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'px-3 pt-1 pb-0.5 text-[10px] uppercase tracking-wider text-zinc-500 font-semibold';
+  el.textContent = text;
+  return el;
+}
+
+function createDivider(): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'my-1 border-t border-zinc-700';
+  return el;
 }


### PR DESCRIPTION
## Summary

- Adds **Session (.partwright.json)** and **Code (raw)** options to the toolbar Export dropdown — previously the JSON share-export was buried inside the Sessions modal.
- Annotates every export option with a one-line description of what each format preserves and which slicers it imports into.
- Reorders the 3D model formats by Bambu Studio compatibility: **OBJ (recommended)** → 3MF → STL → GLB.
- Per-row Export button in the Sessions modal now reuses the new `exportSessionJSON` helper so both call sites stay in sync.

## Test plan

- [x] `npm run build` passes
- [x] Dropdown opens and shows 6 options across two sections
- [x] OBJ / 3MF / STL still trigger downloads with correct filenames
- [x] **Session (.partwright.json)** downloads valid JSON containing `partwright: "1.0"`, the session, and all versions
- [x] **Code (raw)** downloads a `.js` (or `.scad`) text file with the editor's current source
- [ ] Manually import a downloaded `.partwright.json` via Sessions → Import to confirm round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)