### PR TITLE
Toolbar Import button with drag-and-drop (closes #37)

### DIFF
--- a/prompts/20260427-toolbar-import-button.md
+++ b/prompts/20260427-toolbar-import-button.md
@@ -1,0 +1,32 @@
+---
+session: "toolbar-import-button"
+timestamp: "2026-04-27T19:00:00Z"
+model: claude-opus-4-7
+tools: [Read, Edit, Bash, Grep, chrome-devtools]
+---
+
+## Human
+
+Implement #37: surface Import in the toolbar (mirror of Export). Accept
+.partwright.json (existing import path), raw .js / .scad (new session in
+matching language), and drag-and-drop onto the editor. Confirm before
+clobbering an active unsaved session.
+
+## Changes
+
+- `src/ui/toolbar.ts`: Added `↑ Import` button before the Export wrapper,
+  with a hidden file input accepting `.partwright.json,.json,.js,.scad`.
+  New `onImportFile: (file: File) => void | Promise<void>` callback in
+  `ToolbarCallbacks`. Exported `IMPORT_ACCEPT` constant for reuse.
+- `src/main.ts`:
+  - New `handleImportFile(file)` function that branches on extension.
+    JSON path validates the `partwright`/`mainifold` brand, calls
+    `importSession()` with `runCodeSync + captureThumbnail` for thumbnail
+    regen, then `openSession()` + `loadVersionIntoEditor()`.
+    Raw code path switches language by extension, `createSession()`
+    with the file basename as the session name, then `setValue() +
+    runCodeSync()`.
+  - Confirms via `showInlineConfirm` when an active session has versions.
+  - Document-level `dragover`/`drop` listeners route importable files
+    through the same `handleImportFile` so users can drop anywhere on
+    the editor.

--- a/src/main.ts
+++ b/src/main.ts
@@ -753,6 +753,77 @@ async function main() {
   const defaultExampleKey = Object.keys(examples).find(k => k.includes('basic_shapes')) ?? Object.keys(examples)[0];
   const defaultCode = examples[defaultExampleKey]?.code ?? '// Write your manifold code here\nconst { Manifold } = api;\nreturn Manifold.cube([5,5,5], true);';
 
+  // Import a .partwright.json session, or a raw .js / .scad file, into a new session.
+  async function handleImportFile(file: File): Promise<void> {
+    const lowerName = file.name.toLowerCase();
+
+    // Confirm before clobbering an active session
+    const cur = getState();
+    if (cur.session && cur.versionCount > 0) {
+      const ok = await showInlineConfirm(
+        editorUI,
+        `Open "${file.name}" as a new session? Your current session will be kept.`,
+      );
+      if (!ok) return;
+    }
+
+    try {
+      if (lowerName.endsWith('.json')) {
+        const text = await file.text();
+        let data: ExportedSession;
+        try {
+          data = JSON.parse(text) as ExportedSession;
+        } catch {
+          alert(`Could not parse "${file.name}" as JSON.`);
+          return;
+        }
+        if ((!data.partwright && !data.mainifold) || !data.session || !Array.isArray(data.versions)) {
+          alert(`"${file.name}" doesn't look like a Partwright session file.`);
+          return;
+        }
+        const session = await importSession(data, async (code) => {
+          await runCodeSync(code);
+          return captureThumbnail();
+        });
+        const version = await openSession(session.id);
+        if (version) await loadVersionIntoEditor(version);
+      } else if (lowerName.endsWith('.js') || lowerName.endsWith('.scad')) {
+        const code = await file.text();
+        const lang: Language = lowerName.endsWith('.scad') ? 'scad' : 'manifold-js';
+        if (lang !== getActiveLanguage()) await switchLanguage(lang);
+        const sessionName = file.name.replace(/\.(js|scad)$/i, '');
+        await createSession(sessionName, lang);
+        setValue(code);
+        await runCodeSync(code);
+      } else {
+        alert(`Unsupported file type: ${file.name}\n\nSupported: .partwright.json, .js, .scad`);
+      }
+    } catch (e) {
+      alert(`Failed to import "${file.name}": ${(e as Error).message}`);
+    }
+  }
+
+  // Document-level drag-and-drop import
+  function isImportableFile(file: File): boolean {
+    const n = file.name.toLowerCase();
+    return n.endsWith('.json') || n.endsWith('.js') || n.endsWith('.scad');
+  }
+
+  document.addEventListener('dragover', (e) => {
+    if (!e.dataTransfer || e.dataTransfer.types.indexOf('Files') === -1) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  });
+
+  document.addEventListener('drop', async (e) => {
+    const files = e.dataTransfer?.files;
+    if (!files || files.length === 0) return;
+    const first = Array.from(files).find(isImportableFile);
+    if (!first) return;
+    e.preventDefault();
+    await handleImportFile(first);
+  });
+
   // Create toolbar
   createToolbar(editorUI, examples, {
     onRun: () => runCode(),
@@ -768,6 +839,7 @@ async function main() {
     onExport3MF: () => {
       if (currentMeshData) export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData);
     },
+    onImportFile: handleImportFile,
     onExampleSelect: async (entry: ExampleEntry) => {
       // Auto-switch engine + editor mode if the example uses a different language.
       if (entry.language !== getActiveLanguage()) {

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -12,9 +12,13 @@ export interface ToolbarCallbacks {
   onExportSTL: () => void;
   onExportOBJ: () => void;
   onExport3MF: () => void;
+  onImportFile: (file: File) => void | Promise<void>;
   onExampleSelect: (entry: ExampleEntry) => void;
   onLanguageSwitch: (lang: 'manifold-js' | 'scad') => void;
 }
+
+/** File extensions accepted by the Import button and drag-and-drop. */
+export const IMPORT_ACCEPT = '.partwright.json,.json,.js,.scad';
 
 let _autoRun = true;
 let _onAutoRunChange: ((on: boolean) => void) | null = null;
@@ -161,9 +165,28 @@ export function createToolbar(
   });
   toolbar.appendChild(select);
 
+  // Import button — file picker accepting .partwright.json / .js / .scad
+  const btnImport = createButton('btn-import', '\u2191 Import');
+  btnImport.title = 'Import a .partwright.json session, or a .js / .scad file';
+  btnImport.classList.add('ml-2');
+
+  const importInput = document.createElement('input');
+  importInput.type = 'file';
+  importInput.accept = IMPORT_ACCEPT;
+  importInput.className = 'hidden';
+  importInput.addEventListener('change', async () => {
+    const file = importInput.files?.[0];
+    if (file) await callbacks.onImportFile(file);
+    importInput.value = '';
+  });
+
+  btnImport.addEventListener('click', () => importInput.click());
+  toolbar.appendChild(btnImport);
+  toolbar.appendChild(importInput);
+
   // Export dropdown
   const exportWrapper = document.createElement('div');
-  exportWrapper.className = 'relative ml-2';
+  exportWrapper.className = 'relative ml-1';
   exportWrapper.id = 'export-wrapper';
 
   const btnExport = createButton('btn-export', '\u2193 Export');


### PR DESCRIPTION
Closes #37.

## Summary

- Adds an `↑ Import` button to the toolbar paired with `↓ Export`. Same prominence as Export — Import is no longer buried in Sessions….
- Accepts three file types via the picker:
  - `.partwright.json` — full session round-trip (versions, notes, reference images) via existing `importSession()`.
  - `.js` — creates a new session in **manifold-js** with the file basename as the session name.
  - `.scad` — creates a new session in **SCAD** (auto-switches the editor language).
- Drag-and-drop the same file types anywhere on the editor and they import via the same flow.
- Confirms before opening if the active session already has saved versions.

## Files

- `src/ui/toolbar.ts` — new button, hidden file input, `onImportFile` in `ToolbarCallbacks`.
- `src/main.ts` — `handleImportFile()` (extension branching, validation, session creation) plus document-level `dragover`/`drop` listeners.

## Test plan

- [x] `npm run build` passes
- [x] Click Import → pick `.partwright.json` → new session appears with all versions
- [x] Click Import → pick `.js` → new session created, code in editor, runs
- [x] Click Import → pick `.scad` → language auto-switches to SCAD, new session created
- [x] Drag-and-drop a `.partwright.json` onto the editor → imports
- [x] Confirm prompt appears when active session has versions; Cancel aborts
- [ ] Manually try a malformed `.json` file → user-visible error, no crash
- [ ] Manually try a `.txt` file → "Unsupported file type" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)