### PR TITLE
Fix TDZ error that blocked first render after WASM load

### DIFF
--- a/prompts/20260427-fix-wasm-load-rerender.md
+++ b/prompts/20260427-fix-wasm-load-rerender.md
@@ -13,6 +13,8 @@ When I hard refresh a page I see "Loading WASM" but I don't think it refreshes a
 
 ### Key decisions
 
-Root cause was a TDZ error: `let _running = false` in `main.ts` was declared mid-function (after `await syncEditorFromURL()`). On hard refresh, `syncEditorFromURL → loadVersionIntoEditor → runCodeSync` references `_running` before its declaration line executes, throwing "Cannot access '_running' before initialization". The unhandled rejection escaped to `main().catch`, leaving the status bar stuck on "Loading WASM..." and the model never rendered.
+Two related bugs in `main.ts → syncEditorFromURL`:
 
-Fix: hoisted the `let _running = false;` declaration to the top of `main()` next to other state vars (`engineOk`, `editorReady`, etc.) so async callbacks fired during initial load can safely reference it.
+1. When `?session=<id>` references a session that doesn't exist in IndexedDB (or has no saved versions), `openSession` returns null. The original code only handled the success branch and the no-session-id branch, leaving this case to fall through with no `runCode` call and no status update — so "Loading WASM..." stayed forever and the viewport was empty. Fix: when `openSession` returns null, fall through to create a fresh session if needed and run defaults.
+
+2. `let _running = false` was declared mid-function (after `await syncEditorFromURL()`). In dev (non-minified), `syncEditorFromURL → loadVersionIntoEditor → runCodeSync` references `_running` before its declaration line executes, throwing TDZ. Fix: hoisted the declaration to the top of `main()` next to other state vars.

--- a/prompts/20260427-fix-wasm-load-rerender.md
+++ b/prompts/20260427-fix-wasm-load-rerender.md
@@ -1,0 +1,18 @@
+---
+session: "fix-wasm-load-rerender"
+timestamp: "2026-04-27T19:34:00Z"
+model: claude-opus-4-7
+tools: [chrome-devtools]
+---
+
+## Human
+
+When I hard refresh a page I see "Loading WASM" but I don't think it refreshes and re-renders the model when the wasm load is complete. Base your worktree off staging and investigate. If you think you understand this issue and can fix it, make a PR with the fix.
+
+## Assistant
+
+### Key decisions
+
+Root cause was a TDZ error: `let _running = false` in `main.ts` was declared mid-function (after `await syncEditorFromURL()`). On hard refresh, `syncEditorFromURL → loadVersionIntoEditor → runCodeSync` references `_running` before its declaration line executes, throwing "Cannot access '_running' before initialization". The unhandled rejection escaped to `main().catch`, leaving the status bar stuck on "Loading WASM..." and the model never rendered.
+
+Fix: hoisted the `let _running = false;` declaration to the top of `main()` next to other state vars (`engineOk`, `editorReady`, etc.) so async callbacks fired during initial load can safely reference it.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1048,13 +1048,23 @@ async function main() {
         if (version) {
           await loadVersionIntoEditor(version);
           if (tab === 'gallery') refreshGallery();
+          return;
         }
+        // openSession returned null — either the session ID in the URL
+        // doesn't exist in IndexedDB (e.g. a stale bookmark, or a URL
+        // shared from another browser/device), or the session exists
+        // but has no saved versions. Fall through to create a fresh
+        // session if needed and run defaults, so the viewport renders
+        // and the status doesn't stay stuck on "Loading WASM...".
+      } else {
+        return;
       }
-    } else if (!getState().session) {
-      await createSession();
-      setStatus(statusBar, 'ready', 'Ready');
-      runCode(defaultCode);
     }
+    if (!getState().session) {
+      await createSession();
+    }
+    setStatus(statusBar, 'ready', 'Ready');
+    runCode(defaultCode);
   }
 
   async function syncRouteFromURL() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -898,6 +898,9 @@ async function main() {
   let engineOk = false;
   let helpHasAppBackTarget = false;
   let notFoundEl: HTMLElement | null = null;
+  // Declared early so async callbacks (e.g. runCodeSync triggered during
+  // initial syncEditorFromURL) don't hit a TDZ error before this point.
+  let _running = false;
 
   async function ensureEditorReady() {
     if (!editorReady) await editorReadyPromise;
@@ -1260,7 +1263,8 @@ async function main() {
   }
 
   // === Execution state ===
-  let _running = false;
+  // (`_running` is declared at the top of main() so async callbacks fired
+  // during initial load don't hit a Temporal Dead Zone error.)
 
   async function executeIsolated(code: string, lang?: Language) {
     const t0 = performance.now();


### PR DESCRIPTION
## Summary

After hard refresh, the status bar stayed stuck on "Loading WASM..." and the model never rendered until the user manually edited the code.

### Root cause

In `syncEditorFromURL` (`src/main.ts`), when the URL contains `?session=<id>` and `openSession(id)` returns `null` — either because the session doesn't exist in IndexedDB (stale bookmark, URL shared from a different browser/device, session was deleted) or because the session exists but has no saved versions — the original branching only handled the success case and the no-session-id case:

```js
if (sessionId) {
  if (needsSessionLoad || ...) {
    const version = await openSession(sessionId, ...);
    if (version) { /* load + render */ }
    // else: fell through with no runCode, no setStatus
  }
} else if (!getState().session) {
  await createSession();
  setStatus(statusBar, 'ready', 'Ready');
  runCode(defaultCode);
}
```

So when `openSession` returned null, neither path ran `runCode` or updated the status — leaving "Loading WASM..." forever and an empty viewport. Editing later fired the editor's onChange callback (in auto-run mode) which called `runCode`, finally clearing the bad state.

### Fix

When `openSession` returns null, fall through to create a fresh session if needed and run the default code, so the viewport always renders and the status always transitions to "Ready".

This commit also includes a smaller related fix: `let _running = false` was declared mid-function, so in dev (non-minified) any code path that called `runCodeSync` before that line was reached threw a TDZ error. Hoisted the declaration to the top of `main()` next to the other state vars. (In production builds, terser tends to combine the let-declarations at the top of the function so this rarely fires there, but the hoist is correct in either case.)

## Test plan

- [x] Hard refresh `/editor?session=NONEXISTENT` → status transitions to "Ready", a fresh session is created, default code renders
- [x] Hard refresh `/editor?session=<existing-id>&v=1` → existing session loads, saved code renders, URL preserved
- [x] Hard refresh `/editor` (no session) → auto-creates session, default code renders
- [x] Hard refresh `/editor?view=ai&session=<existing-id>&v=1` → AI Views tab, all 4 isometric views render
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)