### PR TITLE
Sync docs with recent features (color regions, diff tab, exports)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ The app uses path-based routing for top-level pages and query parameters for vie
 - `?view=ai` — AI Views tab
 - `?view=elevations` — Elevations tab
 - `?gallery` — Gallery tab
+- `?diff` — Diff tab (side-by-side code + stat comparison between two versions)
 - `?notes` — Notes tab
 - `?session=<id>` — Active session
 - `?session=<id>&v=3` — Specific version

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Built on [manifold-3d](https://github.com/elalish/manifold) (fast WASM boolean e
 - **Session & versioning** — Save multiple design variations, then open a gallery view to compare them side-by-side. Ideal for AI workflows that generate N variations for human review.
 - **Multi-view rendering** — Interactive 3D viewport plus a 4-panel isometric grid (alternating cube corners, every face visible in 2+ views).
 - **Cross-sections** — Slice geometry at any Z height, inspect the 2D profile as SVG.
-- **Export** — GLB and STL download.
+- **Color regions** — Paint coplanar face regions with the in-app paint mode or the `paintRegion` console API; colors flow through GLB and 3MF exports for multi-material slicing.
+- **Export** — GLB, STL, OBJ, and 3MF download. GLB and 3MF carry per-region colors when present.
 
 ## Quick start
 
@@ -90,13 +91,20 @@ partwright.getGeometryData()     // Current model stats (volume, bbox, genus, ..
 partwright.getCode()             // Read editor contents
 partwright.setCode(code)         // Write to editor
 partwright.sliceAtZ(z)           // Cross-section at height z
-partwright.exportGLB()           // Download GLB
+partwright.exportGLB()           // Download GLB (carries vertex colors)
 partwright.exportSTL()           // Download STL
+partwright.exportOBJ()           // Download OBJ
+partwright.export3MF()           // Download 3MF (carries per-region materials)
 
 // Sessions — save/compare design iterations
 await partwright.createSession("Gear variations")
 await partwright.runAndSave(code, "v1 - basic")
 partwright.getGalleryUrl()       // URL for gallery view
+
+// Color regions — tag coplanar faces with a color (see /ai.md#color-regions)
+partwright.paintRegion({ point: [10,0,5], normal: [0,0,1], color: [1,0,0] })
+partwright.listRegions()
+partwright.clearColors()
 ```
 
 Geometry stats are also always available as JSON in `#geometry-data` for DOM scraping.
@@ -147,8 +155,11 @@ src/
   ui/layout.ts            Split-pane layout
   ui/toolbar.ts           Top toolbar with examples dropdown
   ui/panels.ts            View tab wiring
-  export/gltf.ts          GLB export
+  export/gltf.ts          GLB export (with vertex colors)
   export/stl.ts           STL export
+  export/obj.ts           OBJ export
+  export/threemf.ts       3MF export (per-region basematerials + pid)
+  color/                  Paint mode, coplanar flood-fill, region persistence
 ```
 
 Requires `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers for SharedArrayBuffer / WASM threads (configured in `vite.config.ts`).

--- a/prompts/20260427-docs-sync-recent-features.md
+++ b/prompts/20260427-docs-sync-recent-features.md
@@ -1,0 +1,54 @@
+---
+session: "docs-sync-recent-features"
+timestamp: "2026-04-27T20:00:00Z"
+model: claude-opus-4-7
+tools: [Read, Edit, Grep, Glob, Bash]
+---
+
+## Human
+
+Ensure your working tree branch is based off the staging branch. Then,
+review our current docs (help, README, ai.md, etc.) and create a PR with
+any updates that might be needed based on recent work that did not update
+those files.
+
+## Changes
+
+Audited recent commits on `staging` (color regions, diff view tab,
+toolbar import button, grid plane toggle, editor diagnostics, browser
+history fix, viewport gizmo) against `README.md`, `CLAUDE.md`,
+`AGENTS.md` (symlink to CLAUDE.md), `GEMINI.md` (symlink), and
+`public/ai.md`. Found three concrete drift points:
+
+1. **Color regions API was undocumented in `public/ai.md`.**
+   `partwright.help('paintRegion')` already pointed to
+   `/ai.md#color-regions`, but that anchor didn't exist.
+2. **`?diff` URL parameter was missing from the Query Parameters table**
+   in CLAUDE.md (and so AGENTS.md / GEMINI.md via the symlink).
+3. **README export/architecture sections were stale** — listed only GLB
+   and STL, and the architecture tree was missing `obj.ts`,
+   `threemf.ts`, and `color/`.
+
+Files touched:
+
+- `public/ai.md`: Added `## Color regions` section (new TOC entry +
+  anchor), and added `paintRegion` / `listRegions` / `clearColors` to
+  the Console API listing.
+- `CLAUDE.md`: Added `?diff` to the Query Parameters table. Picked up
+  by AGENTS.md and GEMINI.md automatically (both are symlinks to
+  CLAUDE.md).
+- `README.md`: Added a "Color regions" feature bullet, updated Export
+  bullet to all four formats, added `exportOBJ` / `export3MF` /
+  `paintRegion` etc. to the Console API code block, and added
+  `obj.ts` / `threemf.ts` / `color/` to the architecture tree.
+
+No code changes; help page (`src/ui/help.ts`) intentionally not
+expanded — paint mode and diff view are accessible from the UI and a
+guided tour, and the help page is meant as a friendly overview rather
+than a full feature reference.
+
+## Verification
+
+- `git diff --stat` shows only the three doc files modified.
+- Manually re-checked `partwright.help('paintRegion')` references:
+  the new anchor `#color-regions` exists in `public/ai.md`.

--- a/public/ai.md
+++ b/public/ai.md
@@ -16,6 +16,7 @@ Partwright is a browser-based parametric CAD tool with two modeling engines: **m
 - [Writing OpenSCAD code](#writing-openscad-code)
 - [Common pitfalls for boolean operations](#common-pitfalls-for-boolean-operations)
 - [Print-safe geometry](#print-safe-geometry)
+- [Color regions](#color-regions)
 - [Reference images](#reference-images)
 - [Photo-to-model workflow](#photo-to-model-workflow) (optional tooling)
 - [Iteration workflow](#iteration-workflow)
@@ -159,6 +160,11 @@ partwright.getSessionUrl()               // -> URL for this session
 await partwright.listSessions()          // -> [{id, name, updated}]
 await partwright.openSession(id)         // Open existing session
 await partwright.clearAllSessions()      // Delete all sessions & versions
+
+// Color regions -- tag coplanar face regions with a color (see #color-regions)
+partwright.paintRegion({point, normal, color, name?, tolerance?}) // -> {id, name, triangles} or {error}
+partwright.listRegions()                 // -> [{id, name, color, source, triangles, order}, ...]
+partwright.clearColors()                 // Remove all regions
 
 // Notes -- track design context, decisions, and measurements
 await partwright.addSessionNote(text)    // -> {id, text, timestamp}
@@ -379,6 +385,34 @@ if (problems.length) {
 ```
 
 Or batch it with `query({ sliceAt: [zMax - 2, zMax - 1.8, ..., zMax - 0.2] })` and check each slice's `area`. If any layer below the actual geometry end falls under threshold, redesign the top to terminate with a flat plateau instead of a near-point taper.
+
+## Color regions
+
+Color regions tag a coplanar set of triangles with an RGB color. Regions are persisted on the saved version, ride through GLB and 3MF exports, and show as swatch badges in the gallery. They do **not** modify the geometry -- the underlying mesh, volume, manifoldness, etc. are unchanged.
+
+```js
+// Paint the face that contains [10, 0, 5] with normal [0, 0, 1] (top face) bright red.
+const r = partwright.paintRegion({
+  point:  [10, 0, 5],
+  normal: [0, 0, 1],
+  color:  [1, 0, 0],         // RGB in 0..1
+  name:   "Top",             // optional, defaults to "Region N"
+  tolerance: 0.9995,         // optional cosine threshold for coplanarity (default 0.9995)
+});
+// r = { id, name, triangles } on success, or { error } if no matching face found
+
+partwright.listRegions()    // [{ id, name, color, source, triangles, order }, ...]
+partwright.clearColors()    // remove all regions
+```
+
+**How face matching works.** `paintRegion` flood-fills outward from the seed triangle, including any neighbor whose normal is within `tolerance` of the seed's. Pick `point` slightly inside the model surface and pass the outward-pointing `normal` -- the seed resolver looks for the triangle whose plane the point lies on and whose normal aligns with yours.
+
+**Editor lock.** When color regions exist, the editor is locked (the model can't be re-run, because new geometry would invalidate the saved triangle indices). To edit code, the user clicks "Unlock to edit" in the UI. Agents that need to iterate on the geometry should call `clearColors()` first, or fork a new uncolored version with `forkVersion`.
+
+**Export behavior.**
+- `exportGLB()` -- vertex colors flow through automatically.
+- `export3MF()` -- regions become `<basematerials>` entries with per-triangle `pid` attributes (compatible with PrusaSlicer / Bambu Studio multi-material slicing).
+- `exportSTL()` and `exportOBJ()` -- formats don't carry color, so colors are dropped.
 
 ## Reference images
 


### PR DESCRIPTION
## Summary

Audited recent commits on `staging` against the docs and found three drift points where shipped features weren't reflected:

- **Color regions API was undocumented in `public/ai.md`.** `partwright.help('paintRegion')` already pointed to `/ai.md#color-regions`, but the anchor didn't exist. Added a full section covering `paintRegion`, `listRegions`, `clearColors`, the editor lock, and per-format export behavior. Also added the three methods to the Console API listing.
- **`?diff` URL parameter was missing** from CLAUDE.md's Query Parameters table. Added it. AGENTS.md and GEMINI.md inherit it (symlinks to CLAUDE.md).
- **README export/architecture sections were stale.** Listed only GLB/STL and was missing OBJ/3MF/color export. Updated the features bullets, the Console API code block, and the architecture tree (`obj.ts`, `threemf.ts`, `color/`).

No source changes — docs only. The help page (`src/ui/help.ts`) was intentionally left alone since it's a friendly overview rather than a feature reference, and paint mode is reachable via the guided tour.

## Test plan

- [x] `npm run build` passes
- [x] `partwright.help('paintRegion')` link target now exists in `public/ai.md`
- [ ] Render `public/ai.md` on the deployed preview and confirm the new TOC entry / `#color-regions` anchor work
- [ ] Skim README on the GitHub UI for any rendering issues in the updated bullet list / code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)