### PR TITLE
Make toolbar logo clickable to return home

### DIFF
--- a/prompts/20260427-clickable-logo.md
+++ b/prompts/20260427-clickable-logo.md
@@ -1,0 +1,34 @@
+---
+session: "clickable-logo"
+timestamp: "2026-04-27T19:15:00Z"
+model: claude-opus-4-7
+tools: [Read, Edit, Bash, Grep, chrome-devtools]
+---
+
+## Human
+
+If anyone ever clicks on the partwright icon and logo, it send them back to
+the main landing page of the app. set your working tree to be based off
+staging and implement that feature across all pages as applicable. Create a
+PR after you've implemented and tested.
+
+## Changes
+
+- `src/ui/toolbar.ts`: The toolbar logo (icon + "Partwright" wordmark) is
+  now a `<button>` instead of an inert `<div>`. Added `onGoHome` to
+  `ToolbarCallbacks` and wired the click handler. Added `aria-label`,
+  `title`, and a hover-opacity transition for affordance.
+- `src/main.ts`: `createToolbar` now passes `onGoHome` that pushes `/`
+  onto history and calls `syncRouteFromURL()` so the landing page is
+  shown without a full page reload.
+
+## Notes
+
+- The landing page already shows the logo within the hero, so no change
+  was needed there — clicking from landing would be a no-op.
+- The help page and 404 page do not display the logo, so nothing to wire
+  up there.
+- Verified via Chrome DevTools MCP: navigated to `/editor`, clicked the
+  logo, URL transitioned to `/` with the landing page visible. Browser
+  back navigation correctly returns to the editor with the prior session
+  still loaded. No console errors.

--- a/src/main.ts
+++ b/src/main.ts
@@ -826,6 +826,10 @@ async function main() {
 
   // Create toolbar
   createToolbar(editorUI, examples, {
+    onGoHome: () => {
+      updateAppHistory('/', 'push');
+      void syncRouteFromURL();
+    },
     onRun: () => runCode(),
     onExportGLB: async () => {
       try { await exportGLB(); } catch (e) { console.error('GLB export error:', e); }

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -15,6 +15,7 @@ export interface ToolbarCallbacks {
   onImportFile: (file: File) => void | Promise<void>;
   onExampleSelect: (entry: ExampleEntry) => void;
   onLanguageSwitch: (lang: 'manifold-js' | 'scad') => void;
+  onGoHome: () => void;
 }
 
 /** File extensions accepted by the Import button and drag-and-drop. */
@@ -57,10 +58,14 @@ export function createToolbar(
   const toolbar = document.createElement('div');
   toolbar.className = 'flex items-center gap-1 px-3 py-1.5 bg-zinc-900 border-b border-zinc-700 text-sm shrink-0';
 
-  // Logo
-  const logo = document.createElement('div');
-  logo.className = 'flex items-center gap-2 mr-4';
+  // Logo — clicking returns to the landing page
+  const logo = document.createElement('button');
+  logo.type = 'button';
+  logo.className = 'flex items-center gap-2 mr-4 bg-transparent border-0 p-0 cursor-pointer hover:opacity-80 transition-opacity';
+  logo.title = 'Back to home';
+  logo.setAttribute('aria-label', 'Partwright home');
   logo.innerHTML = `${partwrightMarkSvg(20)}<span class="text-zinc-100 font-semibold tracking-tight">Partwright</span>`;
+  logo.addEventListener('click', callbacks.onGoHome);
   toolbar.appendChild(logo);
 
   // Auto-run toggle + manual Run button


### PR DESCRIPTION
## Summary
- Editor toolbar logo (icon + "Partwright" wordmark) is now a button that navigates to the landing page (`/`) when clicked.
- Adds `onGoHome` to `ToolbarCallbacks`; wired in `main.ts` to push `/` onto history and re-sync the route without a full page reload.
- Landing page already renders the logo as part of the hero (no change needed); help and 404 pages don't display the logo.

## Test plan
- [x] `npm run build` succeeds with no TypeScript errors
- [x] Navigated to `/editor?session=<id>`, clicked the logo — URL becomes `/` and the landing page renders
- [x] Browser back returns to the editor with the prior session loaded
- [x] No console errors during navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)