### PR TITLE
Annotations: include in JSON export + panel info hint

### DIFF
--- a/prompts/20260427-annotations-export-and-info.md
+++ b/prompts/20260427-annotations-export-and-info.md
@@ -1,0 +1,59 @@
+---
+session: "annotations-export-and-info"
+timestamp: "2026-04-27T21:30:00Z"
+model: claude-opus-4-7
+tools: ["Read", "Edit", "Grep", "Bash", "chrome-devtools"]
+---
+
+## Human
+
+I recently merged an annotation feature into the staging branch (make sure
+your worktree branch is based on staging). I want to make sure that the
+annotate menu has an info message indicating to the user that annotations
+can be used to help indicate specific improvements to AIs working on a
+model. Also, do annotations get exported in the json export. If not,
+ensure that they do. Test the implementation and create a PR when complete.
+
+## Assistant
+
+### Audit
+
+Annotations were stored only in module-level state in `annotations.ts`
+(no persistence layer) and the `exportSession()` schema in
+`storage/sessionManager.ts` did not reference them — so JSON exports
+silently dropped any user markup. The Annotate panel had per-control
+tooltips but no overall message explaining the AI-feedback intent.
+
+### Changes
+
+- **annotations.ts** — added a `SerializedAnnotation` POJO type, plus
+  `serializeAll()` / `loadFromSerialized()` helpers that convert
+  `THREE.Vector3` points and anchors to/from `{x, y, z}` plain objects.
+  Camera and plane fields were already JSON-friendly.
+- **sessionManager.ts** — bumped `SCHEMA_VERSION` to `1.2`. Added an
+  optional top-level `annotations` field on `ExportedSession`.
+  `exportSession()` snapshots the in-memory store *only when exporting
+  the currently active session* (annotations aren't really
+  session-scoped today; this keeps a backup-export of session B from
+  inheriting session A's annotations). `importSession()` calls
+  `loadFromSerialized()` after the session-state notify so any UI
+  listeners pick up the restored marks.
+- **annotateUI.ts** — added a small pink info banner at the top of
+  the picker panel: "Annotations are saved with this session and
+  exported in the JSON. Use them to point out specific improvements
+  for an AI working on the model."
+
+### Verification
+
+`npm run build` clean. Drove the app via chrome-devtools MCP at
+`/editor?view=ai`:
+
+- Confirmed banner renders in the panel.
+- `addTextAnnotation` → `exportSession` returns `partwright: '1.2'`
+  with the annotation attached and `THREE.Vector3` correctly
+  serialized to `{x, y, z}`.
+- `clearAnnotations` then re-`importSession` restored the same
+  annotation by id (round-trip).
+- Exporting an inactive session by id returned no `annotations`
+  field (intentional cross-session bleed prevention).
+- No console errors.

--- a/src/annotations/annotateUI.ts
+++ b/src/annotations/annotateUI.ts
@@ -186,6 +186,12 @@ function createPickerPanel(): HTMLElement {
   panel.className = 'hidden absolute top-10 right-2 z-20 bg-zinc-800/95 backdrop-blur border border-zinc-600/60 rounded-lg p-2.5 shadow-xl';
   panel.style.minWidth = '220px';
 
+  // Info banner — explains the purpose of annotations to the user.
+  const info = document.createElement('div');
+  info.className = 'mb-2 p-2 rounded bg-pink-500/10 border border-pink-400/30 text-[10px] text-pink-200 leading-snug';
+  info.textContent = 'Annotations are saved with this session and exported in the JSON. Use them to point out specific improvements for an AI working on the model.';
+  panel.appendChild(info);
+
   // Sub-mode tabs
   const tabsRow = document.createElement('div');
   tabsRow.className = 'flex items-center gap-1.5 mb-2';

--- a/src/annotations/annotations.ts
+++ b/src/annotations/annotations.ts
@@ -29,6 +29,29 @@ export interface TextAnnotation {
 
 export type Annotation = StrokeAnnotation | TextAnnotation;
 
+/** JSON-serializable form of an annotation. THREE.Vector3 fields become
+ *  plain `{x, y, z}` objects; everything else is already POJO-friendly. */
+export type SerializedAnnotation =
+  | {
+      type: 'stroke';
+      id: string;
+      points: { x: number; y: number; z: number }[];
+      color: [number, number, number];
+      width: number;
+      camera: SessionCamera;
+      plane: SessionPlane;
+    }
+  | {
+      type: 'text';
+      id: string;
+      anchor: { x: number; y: number; z: number };
+      text: string;
+      color: [number, number, number];
+      fontSizePx: number;
+      camera: SessionCamera;
+      plane: SessionPlane;
+    };
+
 let annotations: Annotation[] = [];
 const listeners: Array<() => void> = [];
 
@@ -115,6 +138,61 @@ export function clearTexts(): void {
 export function clearAll(): void {
   if (annotations.length === 0) return;
   annotations = [];
+  notify();
+}
+
+/** Snapshot all annotations as JSON-serializable plain objects. */
+export function serializeAll(): SerializedAnnotation[] {
+  return annotations.map((a): SerializedAnnotation => {
+    if (a.type === 'stroke') {
+      return {
+        type: 'stroke',
+        id: a.id,
+        points: a.points.map(p => ({ x: p.x, y: p.y, z: p.z })),
+        color: a.color,
+        width: a.width,
+        camera: a.camera,
+        plane: a.plane,
+      };
+    }
+    return {
+      type: 'text',
+      id: a.id,
+      anchor: { x: a.anchor.x, y: a.anchor.y, z: a.anchor.z },
+      text: a.text,
+      color: a.color,
+      fontSizePx: a.fontSizePx,
+      camera: a.camera,
+      plane: a.plane,
+    };
+  });
+}
+
+/** Replace all in-memory annotations with the given serialized snapshot. */
+export function loadFromSerialized(serialized: SerializedAnnotation[]): void {
+  annotations = serialized.map((s): Annotation => {
+    if (s.type === 'stroke') {
+      return {
+        type: 'stroke',
+        id: s.id,
+        points: s.points.map(p => new THREE.Vector3(p.x, p.y, p.z)),
+        color: s.color,
+        width: s.width,
+        camera: s.camera,
+        plane: s.plane,
+      };
+    }
+    return {
+      type: 'text',
+      id: s.id,
+      anchor: new THREE.Vector3(s.anchor.x, s.anchor.y, s.anchor.z),
+      text: s.text,
+      color: s.color,
+      fontSizePx: s.fontSizePx,
+      camera: s.camera,
+      plane: s.plane,
+    };
+  });
   notify();
 }
 

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -23,6 +23,11 @@ import {
   type ReferenceImagesData,
 } from './db';
 import type { SerializedColorRegion } from '../color/regions';
+import {
+  serializeAll as serializeAnnotations,
+  loadFromSerialized as loadAnnotations,
+  type SerializedAnnotation,
+} from '../annotations/annotations';
 
 /**
  * Current schema version for `.partwright.json` exports.
@@ -37,8 +42,11 @@ import type { SerializedColorRegion } from '../color/regions';
  *  - `1.1` — color regions promoted to an explicit `versions[].colorRegions` field. The
  *           legacy nested location is still written for backward compatibility with
  *           pre-1.1 readers, and read as a fallback when the explicit field is absent.
+ *  - `1.2` — annotations (freehand strokes + pinned text labels) included at the top
+ *           level. Snapshots the in-memory annotation store at export time and is
+ *           restored on import. Older readers ignore the field.
  */
-export const SCHEMA_VERSION = '1.1';
+export const SCHEMA_VERSION = '1.2';
 
 const CURRENT_MAJOR = 1;
 
@@ -63,6 +71,14 @@ export interface ExportedSession {
     colorRegions?: SerializedColorRegion[];
   }[];
   notes?: { text: string; timestamp: number }[];
+  /**
+   * Freehand strokes and pinned text labels drawn on the model to communicate
+   * intent to AI agents working on it. Only included when exporting the
+   * currently active session (annotations live in transient module state and
+   * are not associated with non-active sessions).
+   * @since 1.2
+   */
+  annotations?: SerializedAnnotation[];
 }
 
 interface SchemaVersionInfo {
@@ -520,6 +536,12 @@ export async function exportSession(sessionId?: string): Promise<ExportedSession
   const versions = await dbListVersions(id);
   const notes = await dbListNotes(id);
 
+  // Annotations live in transient module state, not in the database. Only attach
+  // them when the export target is the currently active session — exporting an
+  // inactive session shouldn't pick up annotations belonging to a different model.
+  const isActive = currentState.session?.id === id;
+  const annotations = isActive ? serializeAnnotations() : [];
+
   return {
     partwright: SCHEMA_VERSION,
     session: { name: session.name, created: session.created, updated: session.updated, referenceImages: session.referenceImages ?? null, ...(session.language ? { language: session.language } : {}) },
@@ -536,6 +558,7 @@ export async function exportSession(sessionId?: string): Promise<ExportedSession
       };
     }),
     ...(notes.length > 0 ? { notes: notes.map(n => ({ text: n.text, timestamp: n.timestamp })) } : {}),
+    ...(annotations.length > 0 ? { annotations } : {}),
   };
 }
 
@@ -596,5 +619,12 @@ export async function importSession(
   currentState = { session: refreshedSession, currentVersion: latest, versionCount: count };
   updateURL();
   notify();
+
+  // Restore annotations into the in-memory store. This replaces any existing
+  // annotations — the imported session is now the active context.
+  if (data.annotations && data.annotations.length > 0) {
+    loadAnnotations(data.annotations);
+  }
+
   return refreshedSession;
 }


### PR DESCRIPTION
## Summary
- Adds an info banner to the Annotate panel explaining that annotations are saved with the session and meant to communicate specific improvements to AIs working on the model.
- Bumps the session export schema to `1.2` and includes the in-memory annotations under a top-level `annotations` field. Restored on import.
- Annotations are only attached when exporting the *currently active* session, to avoid bleeding the current model's marks into a backup-export of an unrelated session.

## Test plan
- [x] `npm run build` clean (no TS errors).
- [x] Open `/editor?view=ai`, switch to Interactive, click Annotate — banner is visible at the top of the panel.
- [x] Programmatic round-trip via `window.partwright`: `addTextAnnotation` → `exportSession` returns `partwright: '1.2'` with the annotation under `annotations[0]` (Vector3 → `{x,y,z}`, color/camera/plane preserved).
- [x] `clearAnnotations` then re-`importSession` restores the same annotation by id.
- [x] `exportSession(<inactive id>)` omits the `annotations` field.
- [x] No console errors during the test flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)