### PR TITLE
Close annotate/paint/measure menus on Escape

### DIFF
--- a/prompts/20260427-escape-closes-popups.md
+++ b/prompts/20260427-escape-closes-popups.md
@@ -41,3 +41,16 @@ fires any events that should be fired properly upon then closing)?
   the global handler won't fire while a label is being typed — the
   input's own cancel flow runs unchanged.
 - Verified `npm run build` succeeds with no TypeScript errors.
+
+## Follow-up — TDZ fix
+
+After the user reported Escape didn't close the popups (and that paint
+didn't re-render until the code was edited), browser console showed
+`Cannot access 'closeMeasureIfActive' before initialization`. The `let`
+binding was declared lower in the same enclosing function than the
+`initMeasureToggle` call site, so assigning to it from inside that
+function hit the temporal dead zone. The thrown ReferenceError aborted
+the rest of the init flow, which is why `setOnRegionPainted(...)` —
+the callback that re-renders on paint — never ran. Moved the `let`
+declaration above the `initMeasureToggle()` call. Verified in Chrome:
+escape now closes annotate, paint, and measure menus.

--- a/prompts/20260427-escape-closes-popups.md
+++ b/prompts/20260427-escape-closes-popups.md
@@ -1,0 +1,43 @@
+---
+session: "escape-closes-popups"
+timestamp: "2026-04-27T21:40:00Z"
+model: claude-opus-4-7
+tools: [Read, Edit, Bash, Grep]
+---
+
+## Human
+
+make sure your worktree is based on the staging branch. Then, I noticed
+that when annotation that I noticed that hitting escape key did not hide
+the annotation menu (and perhaps other sub menu popups from other things
+like painting). Can you make sure that the esc key closes them (and
+fires any events that should be fired properly upon then closing)?
+
+## Changes
+
+- `src/annotations/annotateUI.ts`: Added `closeMenu()` and
+  `isAnnotateOpen()` exports. `closeMenu()` mirrors the close branch of
+  `toggleAnnotateMode()` so the same teardown runs — `onActiveChange`
+  callbacks fire (panel hides, button styling resets) and the session
+  plane outline tears down via `hidePlaneOutline()` + `endSessionPlane()`.
+- `src/color/paintUI.ts`: Added `isPaintOpen()` export. The existing
+  `forceDeactivate()` already handles the close-and-fire-events flow.
+- `src/main.ts`: Refactored `initMeasureToggle` to expose a reusable
+  `closeMeasureIfActive()` closure that deactivates measure, releases
+  the orbit lock, and resets the button class. Added
+  `initEscapeMenuClose()` — a single document-level keydown handler
+  that on Escape:
+  - Bails when typing in INPUT/TEXTAREA/contenteditable (e.g. editor,
+    text-annotation input, session name field).
+  - Defers to select-mode's existing deselect-on-Escape when an
+    annotation is selected (one Escape deselects, the next closes).
+  - Otherwise closes any open annotate, paint, and measure menus.
+
+## Notes
+
+- Worktree was 21 commits behind `staging`; merged `origin/staging` in
+  before making changes.
+- Text-mode's input handler calls `e.stopPropagation()` on Escape, so
+  the global handler won't fire while a label is being typed — the
+  input's own cancel flow runs unchanged.
+- Verified `npm run build` succeeds with no TypeScript errors.

--- a/prompts/20260427-escape-closes-popups.md
+++ b/prompts/20260427-escape-closes-popups.md
@@ -42,6 +42,14 @@ fires any events that should be fired properly upon then closing)?
   input's own cancel flow runs unchanged.
 - Verified `npm run build` succeeds with no TypeScript errors.
 
+## Follow-up — extend to cross-section
+
+User asked for Escape to also close the cross-section view. Added a
+`getClipState().enabled` check to the global handler that calls
+`setClipping(false)` + `syncClipUI()` so the toggle button reverts and
+the slider group hides — same teardown that the toolbar click does.
+Verified in Chrome.
+
 ## Follow-up — TDZ fix
 
 After the user reported Escape didn't close the popups (and that paint

--- a/src/annotations/annotateUI.ts
+++ b/src/annotations/annotateUI.ts
@@ -416,3 +416,20 @@ function rgbToHex(color: [number, number, number]): string {
 export function forceDeactivate(): void {
   if (isPenActive()) deactivatePen();
 }
+
+/** Returns true if any annotate sub-mode (pen/text/select) is active. */
+export function isAnnotateOpen(): boolean {
+  return isAnyActive();
+}
+
+/** Close the annotate menu and tear down the session plane.
+ *  Mirrors the close branch of the toolbar toggle so the same teardown
+ *  events fire (mode-active callbacks, panel hide, plane outline cleanup). */
+export function closeMenu(): void {
+  if (!isAnyActive()) return;
+  deactivatePen();
+  deactivateText();
+  deactivateSelect();
+  hidePlaneOutline();
+  endSessionPlane();
+}

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -222,3 +222,8 @@ export function forceDeactivate(): void {
     pickerPanel?.classList.add('hidden');
   }
 }
+
+/** True if the paint menu is open (paint mode is active). */
+export function isPaintOpen(): boolean {
+  return isActive();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3006,6 +3006,7 @@ async function main() {
       if (isAnnotateOpen()) { closeAnnotateMenu(); closed = true; }
       if (isPaintOpen()) { closePaintMenu(); closed = true; }
       if (closeMeasureIfActive()) closed = true;
+      if (getClipState().enabled) { setClipping(false); syncClipUI(); closed = true; }
       if (closed) e.preventDefault();
     });
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,9 +29,10 @@ import { setUnits as _setUnits, getUnits as _getUnits, type UnitSystem } from '.
 import { initMeasureTool, activate as activateMeasure, deactivate as deactivateMeasure, getState as getMeasureState } from './ui/measureTool';
 import { maybeStartTour, resetTour, startTour } from './ui/tour';
 import { initTheme } from './ui/theme';
-import { initPaintUI } from './color/paintUI';
+import { initPaintUI, isPaintOpen, forceDeactivate as closePaintMenu } from './color/paintUI';
 import { updatePaintMesh, setOnRegionPainted, isActive as isPaintActive } from './color/paintMode';
-import { initAnnotateUI } from './annotations/annotateUI';
+import { initAnnotateUI, isAnnotateOpen, closeMenu as closeAnnotateMenu } from './annotations/annotateUI';
+import { isActive as isSelectActive, getSelectedId as getSelectedAnnotationId } from './annotations/selectMode';
 import {
   getStrokes as getAnnotationStrokes,
   getTexts as getAnnotationTexts,
@@ -1241,6 +1242,7 @@ async function main() {
   initPaintUI(clipControls);
   initMeasureToggle(clipControls);
   initOrbitLockToggle(clipControls);
+  initEscapeMenuClose();
 
   // Initialize editor lock
   initEditorLock(editorContainer);
@@ -2957,6 +2959,8 @@ async function main() {
     }
   }
 
+  let closeMeasureIfActive: () => boolean = () => false;
+
   function initMeasureToggle(container: HTMLElement) {
     const measureBtn = container.querySelector('#measure-toggle') as HTMLButtonElement;
     if (!measureBtn) return;
@@ -2964,17 +2968,43 @@ async function main() {
     const inactiveClass = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
     const activeClass = 'px-2 py-1 rounded text-xs bg-blue-500/20 backdrop-blur text-blue-400 hover:bg-blue-500/30 transition-colors border border-blue-500/30';
 
+    function close(): boolean {
+      if (!getMeasureState().active) return false;
+      deactivateMeasure();
+      setMeasureLock(false);
+      measureBtn.className = inactiveClass;
+      return true;
+    }
+
+    closeMeasureIfActive = close;
+
     measureBtn.addEventListener('click', () => {
-      const state = getMeasureState();
-      if (state.active) {
-        deactivateMeasure();
-        setMeasureLock(false);
-        measureBtn.className = inactiveClass;
+      if (getMeasureState().active) {
+        close();
       } else {
         activateMeasure();
         setMeasureLock(true);
         measureBtn.className = activeClass;
       }
+    });
+  }
+
+  function initEscapeMenuClose() {
+    document.addEventListener('keydown', (e) => {
+      if (e.key !== 'Escape') return;
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+        return;
+      }
+      // Let select-mode handle Escape first when an annotation is selected
+      // (it deselects). A subsequent Escape will close the menu.
+      if (isSelectActive() && getSelectedAnnotationId()) return;
+
+      let closed = false;
+      if (isAnnotateOpen()) { closeAnnotateMenu(); closed = true; }
+      if (isPaintOpen()) { closePaintMenu(); closed = true; }
+      if (closeMeasureIfActive()) closed = true;
+      if (closed) e.preventDefault();
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1240,6 +1240,10 @@ async function main() {
   initDimensionsToggle(clipControls);
   initAnnotateUI(clipControls);
   initPaintUI(clipControls);
+  // Declared before initMeasureToggle is called so the assignment inside it
+  // doesn't hit a let-TDZ error (the same `let` lower in this function is
+  // hoisted to a binding, but only initialized when execution reaches it).
+  let closeMeasureIfActive: () => boolean = () => false;
   initMeasureToggle(clipControls);
   initOrbitLockToggle(clipControls);
   initEscapeMenuClose();
@@ -2958,8 +2962,6 @@ async function main() {
       }
     }
   }
-
-  let closeMeasureIfActive: () => boolean = () => false;
 
   function initMeasureToggle(container: HTMLElement) {
     const measureBtn = container.querySelector('#measure-toggle') as HTMLButtonElement;


### PR DESCRIPTION
## Summary
- Pressing Esc now properly closes the annotate, paint, and measure popup menus, firing existing teardown events (session-plane cleanup, `onActiveChange` callbacks, button-state reset).
- Adds `closeMenu()` / `isAnnotateOpen()` to annotateUI and `isPaintOpen()` to paintUI; refactors the measure toggle in `main.ts` to expose a reusable close helper.
- New `initEscapeMenuClose()` document-level keydown handler defers to select-mode's deselect-on-Escape (so one Esc deselects, the next closes) and to text-mode's input cancel (the input stops propagation).

## Test plan
- [ ] Open annotate menu (any sub-mode: pen/text/select), press Esc — menu closes, button returns to inactive state, session plane outline tears down.
- [ ] In select sub-mode with an annotation selected, press Esc — annotation deselects but menu stays open. Press Esc again — menu closes.
- [ ] In text sub-mode while typing a label, press Esc — input cancels (existing behavior); menu stays open.
- [ ] Open paint menu, press Esc — menu closes, paint mode deactivates, button returns to inactive state.
- [ ] Activate measure tool, press Esc — measure deactivates, orbit lock releases, button returns to inactive state.
- [ ] Press Esc with focus in the code editor or session-name input — no popups affected.
- [ ] `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)