### PR TITLE
Annotate + Paint: add redo, plus undo/redo/hide/clear for paint

### DIFF
--- a/prompts/20260428-annotate-paint-undo-redo-hide.md
+++ b/prompts/20260428-annotate-paint-undo-redo-hide.md
@@ -1,0 +1,70 @@
+---
+session: "annotate-paint-undo-redo-hide"
+timestamp: "2026-04-28T00:00:00Z"
+model: claude-opus-4-7
+tools: ["Read", "Edit", "Write", "Bash", "Grep", "Glob"]
+---
+
+## Human
+
+(1) The annotate panel has Undo but no Redo — accidentally undoing loses
+the stroke for good. Add a Redo button. Base the worktree off `staging`.
+
+(2) The paint panel has no undo/redo/hide. Add the same action row to
+paint that annotate now has: visibility toggle, undo, redo, clear.
+
+## Assistant
+
+### Key decisions
+
+- **Per-feature redo stacks, not a global history.** The annotate redo
+  stack only tracks strokes; the paint redo stack only tracks regions.
+  Mixing them would mean one feature's mutations could resurrect the
+  other's state, which would surprise the user.
+- **Redo stack clears on any non-undo mutation** (new add, clear,
+  remove-by-id, deserialize). This keeps redo from re-adding state into
+  a context where the user wouldn't expect it — e.g. paint a region,
+  undo, paint a different region, then redo would have stitched a stale
+  region into the timeline.
+- **Visibility is a viewport-only concern.** Exports
+  (`hasColorRegions() ? applyTriColors(...) : ...`) keep their colors
+  regardless of the Hide button so the user can toggle paint off
+  without losing it from saved files. A new
+  `applyTriColorsIfVisible()` is the viewport-side variant; the
+  original `applyTriColors()` is reserved for export sites.
+- **No new top-level toolbar buttons.** All four actions live inside
+  the existing picker panels — same pattern annotate already
+  established. Buttons grey out when there's nothing to act on so
+  users get visual feedback without state guessing.
+
+### Architecture
+
+- `src/annotations/annotations.ts` — added `strokeRedoStack`,
+  `redoLastStroke()`, `canRedoStroke()`, `onRedoChange()`. Existing
+  mutation paths (`addStroke`, `addText`, `removeAnnotationById`,
+  `clearStrokes`, `clearTexts`, `clearAll`, `removeLastAnnotation`,
+  `loadFromSerialized`) all call `clearRedoStack()`.
+- `src/annotations/annotateUI.ts` — Redo button next to Undo, wired to
+  `onRedoChange` for enabled-state toggling.
+- `src/color/regions.ts` — symmetric design: `regionRedoStack`,
+  `removeLastRegion()`, `redoLastRegion()`, `canRedoRegion()`,
+  `onRedoChange()`, plus a visibility flag with `isVisible()`,
+  `setVisible()`, `onVisibilityChange()`. New
+  `applyTriColorsIfVisible(mesh)` short-circuits to the unmodified
+  mesh when paint is hidden.
+- `src/color/paintUI.ts` — new action row at the bottom of the picker
+  panel: Hide/Show, Undo paint, Redo paint, Clear. Subscribes to
+  `onRegionsChange`, `onRedoChange`, and `onVisibilityChange` to keep
+  button states in sync.
+- `src/main.ts` — viewport call sites (line 471, 1298, 1311, 1321,
+  2517, 2885) now use `applyTriColorsIfVisible`. Export call sites
+  (870, 1502) keep `applyTriColors` so 3MF/STL/etc. always include
+  paint. New `onPaintVisibilityChange` listener re-renders the
+  viewport, multiview, and elevations on toggle.
+
+### Verification
+
+- `npm run build` clean (one type error caught & fixed: an unused
+  `isPaintVisible` import after refactoring).
+- Couldn't drive Chrome DevTools MCP (server not connectable from this
+  environment), so left the in-browser exercise to the user.

--- a/src/annotations/annotateUI.ts
+++ b/src/annotations/annotateUI.ts
@@ -1,5 +1,5 @@
 // Annotate UI — toggle button, sub-mode (pen/text/select) selector, color
-// picker, width/font-size picker, restore-view, undo/clear actions, count badge.
+// picker, width/font-size picker, restore-view, undo/redo/clear actions, count badge.
 
 import {
   activate as activatePen,
@@ -28,7 +28,16 @@ import {
   onSelectionChange,
   restoreView as restoreSelectionView,
 } from './selectMode';
-import { getCount, onChange as onStrokesChange, removeLastStroke, clearStrokes, clearAll } from './annotations';
+import {
+  getCount,
+  onChange as onStrokesChange,
+  onRedoChange,
+  removeLastStroke,
+  redoLastStroke,
+  canRedoStroke,
+  clearStrokes,
+  clearAll,
+} from './annotations';
 import { setAnnotationsVisible, isAnnotationsVisible } from './annotationOverlay';
 import { endSession as endSessionPlane, hidePlaneOutline } from './sessionPlane';
 
@@ -67,6 +76,7 @@ let selectTabBtn: HTMLButtonElement | null = null;
 let widthRow: HTMLElement | null = null;
 let fontRow: HTMLElement | null = null;
 let restoreViewBtn: HTMLButtonElement | null = null;
+let redoBtn: HTMLButtonElement | null = null;
 let selectionInfo: HTMLElement | null = null;
 
 const inactiveBtnClass = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
@@ -98,6 +108,7 @@ export function initAnnotateUI(controlsContainer: HTMLElement): void {
   controlsContainer.appendChild(pickerPanel);
 
   onStrokesChange(updateCountBadge);
+  onRedoChange(updateRedoButton);
   onPenActiveChange(updatePanelState);
   onTextActiveChange(updatePanelState);
   onSelectActiveChange(updatePanelState);
@@ -105,6 +116,7 @@ export function initAnnotateUI(controlsContainer: HTMLElement): void {
   updateCountBadge();
   updatePanelState();
   updateSelectionInfo(null);
+  updateRedoButton();
 }
 
 function isAnyActive(): boolean {
@@ -167,6 +179,14 @@ function updateSelectionInfo(id: string | null): void {
     restoreViewBtn.disabled = true;
     restoreViewBtn.classList.add('opacity-40', 'cursor-not-allowed');
   }
+}
+
+function updateRedoButton(): void {
+  if (!redoBtn) return;
+  const can = canRedoStroke();
+  redoBtn.disabled = !can;
+  redoBtn.classList.toggle('opacity-40', !can);
+  redoBtn.classList.toggle('cursor-not-allowed', !can);
 }
 
 function updateCountBadge(): void {
@@ -338,7 +358,7 @@ function createPickerPanel(): HTMLElement {
   selectionInfo.textContent = 'Drag to move. Delete to remove. Esc to deselect.';
   panel.appendChild(selectionInfo);
 
-  // Action row: visibility, restore-view, undo, clear
+  // Action row: visibility, restore-view, undo, redo, clear
   const actions = document.createElement('div');
   actions.className = 'flex items-center gap-1.5 mt-2 pt-2 border-t border-zinc-700 flex-wrap';
 
@@ -370,6 +390,14 @@ function createPickerPanel(): HTMLElement {
   undoBtn.title = 'Remove the most recent freehand stroke';
   undoBtn.addEventListener('click', () => { removeLastStroke(); });
   actions.appendChild(undoBtn);
+
+  redoBtn = document.createElement('button');
+  redoBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors opacity-40 cursor-not-allowed';
+  redoBtn.textContent = 'Redo stroke';
+  redoBtn.title = 'Restore the most recently undone freehand stroke';
+  redoBtn.disabled = true;
+  redoBtn.addEventListener('click', () => { redoLastStroke(); });
+  actions.appendChild(redoBtn);
 
   const clearStrokesBtn = document.createElement('button');
   clearStrokesBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors';

--- a/src/annotations/annotations.ts
+++ b/src/annotations/annotations.ts
@@ -55,6 +55,13 @@ export type SerializedAnnotation =
 let annotations: Annotation[] = [];
 const listeners: Array<() => void> = [];
 
+// Redo stack — strokes that were removed via `removeLastStroke()`. Any other
+// mutation (new add, clear, specific delete, session load) drops the stack so
+// redo can never resurrect a stroke into a state where the user wouldn't
+// expect it.
+let strokeRedoStack: StrokeAnnotation[] = [];
+const redoListeners: Array<() => void> = [];
+
 export function getStrokes(): readonly StrokeAnnotation[] {
   return annotations.filter((a): a is StrokeAnnotation => a.type === 'stroke');
 }
@@ -73,11 +80,13 @@ export function getCount(): number {
 
 export function addStroke(stroke: StrokeAnnotation): void {
   annotations.push(stroke);
+  clearRedoStack();
   notify();
 }
 
 export function addText(text: TextAnnotation): void {
   annotations.push(text);
+  clearRedoStack();
   notify();
 }
 
@@ -102,6 +111,8 @@ export function removeLastStroke(): StrokeAnnotation | null {
     const a = annotations[i];
     if (a.type === 'stroke') {
       annotations.splice(i, 1);
+      strokeRedoStack.push(a);
+      notifyRedo();
       notify();
       return a;
     }
@@ -109,9 +120,26 @@ export function removeLastStroke(): StrokeAnnotation | null {
   return null;
 }
 
+/** Re-add the most recently undone stroke. Returns null if nothing to redo. */
+export function redoLastStroke(): StrokeAnnotation | null {
+  const stroke = strokeRedoStack.pop() ?? null;
+  if (!stroke) return null;
+  annotations.push(stroke);
+  notifyRedo();
+  notify();
+  return stroke;
+}
+
+export function canRedoStroke(): boolean {
+  return strokeRedoStack.length > 0;
+}
+
 export function removeLastAnnotation(): Annotation | null {
   const popped = annotations.pop() ?? null;
-  if (popped) notify();
+  if (popped) {
+    clearRedoStack();
+    notify();
+  }
   return popped;
 }
 
@@ -119,6 +147,7 @@ export function removeAnnotationById(id: string): Annotation | null {
   const i = annotations.findIndex(a => a.id === id);
   if (i < 0) return null;
   const [removed] = annotations.splice(i, 1);
+  clearRedoStack();
   notify();
   return removed;
 }
@@ -126,18 +155,25 @@ export function removeAnnotationById(id: string): Annotation | null {
 export function clearStrokes(): void {
   const before = annotations.length;
   annotations = annotations.filter(a => a.type !== 'stroke');
-  if (annotations.length !== before) notify();
+  if (annotations.length !== before) {
+    clearRedoStack();
+    notify();
+  }
 }
 
 export function clearTexts(): void {
   const before = annotations.length;
   annotations = annotations.filter(a => a.type !== 'text');
-  if (annotations.length !== before) notify();
+  if (annotations.length !== before) {
+    clearRedoStack();
+    notify();
+  }
 }
 
 export function clearAll(): void {
   if (annotations.length === 0) return;
   annotations = [];
+  clearRedoStack();
   notify();
 }
 
@@ -170,6 +206,7 @@ export function serializeAll(): SerializedAnnotation[] {
 
 /** Replace all in-memory annotations with the given serialized snapshot. */
 export function loadFromSerialized(serialized: SerializedAnnotation[]): void {
+  clearRedoStack();
   annotations = serialized.map((s): Annotation => {
     if (s.type === 'stroke') {
       return {
@@ -204,6 +241,24 @@ export function onChange(fn: () => void): () => void {
   };
 }
 
+export function onRedoChange(fn: () => void): () => void {
+  redoListeners.push(fn);
+  return () => {
+    const i = redoListeners.indexOf(fn);
+    if (i >= 0) redoListeners.splice(i, 1);
+  };
+}
+
 function notify(): void {
   for (const fn of listeners) fn();
+}
+
+function notifyRedo(): void {
+  for (const fn of redoListeners) fn();
+}
+
+function clearRedoStack(): void {
+  if (strokeRedoStack.length === 0) return;
+  strokeRedoStack = [];
+  notifyRedo();
 }

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -1,7 +1,19 @@
-// Paint mode UI — button toggle, color picker, region count badge
+// Paint mode UI — button toggle, color picker, region count badge,
+// undo/redo/hide/clear actions.
 
 import { activate, deactivate, isActive, setColor } from './paintMode';
-import { getRegions, onChange as onRegionsChange } from './regions';
+import {
+  getRegions,
+  onChange as onRegionsChange,
+  onRedoChange,
+  onVisibilityChange,
+  isVisible as isPaintVisible,
+  setVisible as setPaintVisible,
+  removeLastRegion,
+  redoLastRegion,
+  canRedoRegion,
+  clearRegions,
+} from './regions';
 import { forceDeactivate as forceDeactivateAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as forceDeactivateAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as forceDeactivateAnnotateSelect } from '../annotations/selectMode';
@@ -20,6 +32,9 @@ const PRESET_COLORS: [number, number, number][] = [
 let paintBtn: HTMLButtonElement | null = null;
 let pickerPanel: HTMLElement | null = null;
 let regionCountBadge: HTMLElement | null = null;
+let visibilityBtn: HTMLButtonElement | null = null;
+let undoBtn: HTMLButtonElement | null = null;
+let redoBtn: HTMLButtonElement | null = null;
 
 /** Initialize the paint UI inside the clip-controls overlay area. */
 export function initPaintUI(controlsContainer: HTMLElement): void {
@@ -49,9 +64,17 @@ export function initPaintUI(controlsContainer: HTMLElement): void {
   pickerPanel = createPickerPanel();
   controlsContainer.appendChild(pickerPanel);
 
-  // Update badge when regions change
-  onRegionsChange(updateBadge);
+  // Update badge + button states when regions / redo / visibility change
+  onRegionsChange(() => {
+    updateBadge();
+    updateUndoButton();
+  });
+  onRedoChange(updateRedoButton);
+  onVisibilityChange(updateVisibilityButton);
   updateBadge();
+  updateUndoButton();
+  updateRedoButton();
+  updateVisibilityButton();
 }
 
 function togglePaintMode(): void {
@@ -164,7 +187,63 @@ function createPickerPanel(): HTMLElement {
 
   onRegionsChange(() => updateRegionList(regionList));
 
+  // Action row: visibility, undo, redo, clear
+  const actions = document.createElement('div');
+  actions.className = 'flex items-center gap-1.5 mt-2 pt-2 border-t border-zinc-700 flex-wrap';
+
+  visibilityBtn = document.createElement('button');
+  visibilityBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors';
+  visibilityBtn.title = 'Toggle paint region visibility in viewport (exports keep colors regardless)';
+  visibilityBtn.addEventListener('click', () => { setPaintVisible(!isPaintVisible()); });
+  actions.appendChild(visibilityBtn);
+
+  undoBtn = document.createElement('button');
+  undoBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors opacity-40 cursor-not-allowed';
+  undoBtn.textContent = 'Undo paint';
+  undoBtn.title = 'Remove the most recent paint region';
+  undoBtn.disabled = true;
+  undoBtn.addEventListener('click', () => { removeLastRegion(); });
+  actions.appendChild(undoBtn);
+
+  redoBtn = document.createElement('button');
+  redoBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors opacity-40 cursor-not-allowed';
+  redoBtn.textContent = 'Redo paint';
+  redoBtn.title = 'Restore the most recently undone paint region';
+  redoBtn.disabled = true;
+  redoBtn.addEventListener('click', () => { redoLastRegion(); });
+  actions.appendChild(redoBtn);
+
+  const clearBtn = document.createElement('button');
+  clearBtn.className = 'px-2 py-1 rounded text-[10px] bg-red-700/60 text-red-200 hover:bg-red-600/60 transition-colors';
+  clearBtn.textContent = 'Clear';
+  clearBtn.title = 'Remove all paint regions';
+  clearBtn.addEventListener('click', () => { clearRegions(); });
+  actions.appendChild(clearBtn);
+
+  panel.appendChild(actions);
+
   return panel;
+}
+
+function updateVisibilityButton(): void {
+  if (!visibilityBtn) return;
+  visibilityBtn.textContent = isPaintVisible() ? 'Hide' : 'Show';
+}
+
+function updateUndoButton(): void {
+  if (!undoBtn) return;
+  const can = getRegions().length > 0;
+  undoBtn.disabled = !can;
+  undoBtn.classList.toggle('opacity-40', !can);
+  undoBtn.classList.toggle('cursor-not-allowed', !can);
+}
+
+function updateRedoButton(): void {
+  if (!redoBtn) return;
+  const can = canRedoRegion();
+  redoBtn.disabled = !can;
+  redoBtn.classList.toggle('opacity-40', !can);
+  redoBtn.classList.toggle('cursor-not-allowed', !can);
 }
 
 function updateActiveSwatch(grid: HTMLElement, activeSwatch: HTMLElement): void {

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -30,10 +30,32 @@ type ChangeListener = () => void;
 
 let regions: ColorRegion[] = [];
 let nextOrder = 1;
+let visible = true;
 const listeners: ChangeListener[] = [];
+const visibilityListeners: ChangeListener[] = [];
+const redoListeners: ChangeListener[] = [];
+
+// Redo stack — regions removed via `removeLastRegion()`. Any other mutation
+// (add, clear, deserialize) drops the stack so redo can never resurrect a
+// region into a state where the user wouldn't expect it.
+let regionRedoStack: ColorRegion[] = [];
 
 function notify(): void {
   for (const fn of listeners) fn();
+}
+
+function notifyVisibility(): void {
+  for (const fn of visibilityListeners) fn();
+}
+
+function notifyRedo(): void {
+  for (const fn of redoListeners) fn();
+}
+
+function clearRedoStack(): void {
+  if (regionRedoStack.length === 0) return;
+  regionRedoStack = [];
+  notifyRedo();
 }
 
 export function onChange(fn: ChangeListener): void {
@@ -43,6 +65,32 @@ export function onChange(fn: ChangeListener): void {
 export function removeChangeListener(fn: ChangeListener): void {
   const idx = listeners.indexOf(fn);
   if (idx >= 0) listeners.splice(idx, 1);
+}
+
+export function onVisibilityChange(fn: ChangeListener): () => void {
+  visibilityListeners.push(fn);
+  return () => {
+    const i = visibilityListeners.indexOf(fn);
+    if (i >= 0) visibilityListeners.splice(i, 1);
+  };
+}
+
+export function onRedoChange(fn: ChangeListener): () => void {
+  redoListeners.push(fn);
+  return () => {
+    const i = redoListeners.indexOf(fn);
+    if (i >= 0) redoListeners.splice(i, 1);
+  };
+}
+
+export function isVisible(): boolean {
+  return visible;
+}
+
+export function setVisible(v: boolean): void {
+  if (visible === v) return;
+  visible = v;
+  notifyVisibility();
 }
 
 export function getRegions(): readonly ColorRegion[] {
@@ -71,6 +119,7 @@ export function addRegion(
     triangles,
   };
   regions.push(region);
+  clearRedoStack();
   notify();
   return region;
 }
@@ -79,8 +128,33 @@ export function removeRegion(id: number): boolean {
   const idx = regions.findIndex(r => r.id === id);
   if (idx < 0) return false;
   regions.splice(idx, 1);
+  clearRedoStack();
   notify();
   return true;
+}
+
+/** Pop the most recently added region and push it onto the redo stack. */
+export function removeLastRegion(): ColorRegion | null {
+  if (regions.length === 0) return null;
+  const region = regions.pop()!;
+  regionRedoStack.push(region);
+  notifyRedo();
+  notify();
+  return region;
+}
+
+/** Pop the redo stack and re-add the region. Returns null if nothing to redo. */
+export function redoLastRegion(): ColorRegion | null {
+  const region = regionRedoStack.pop() ?? null;
+  if (!region) return null;
+  regions.push(region);
+  notifyRedo();
+  notify();
+  return region;
+}
+
+export function canRedoRegion(): boolean {
+  return regionRedoStack.length > 0;
 }
 
 export function updateRegionColor(id: number, color: [number, number, number]): void {
@@ -95,6 +169,7 @@ export function clearRegions(): void {
   if (regions.length === 0) return;
   regions = [];
   nextOrder = 1;
+  clearRedoStack();
   notify();
 }
 
@@ -161,6 +236,7 @@ export function deserialize(data: SerializedColorRegion[]): void {
     triangles: new Set<number>(),
   }));
   nextOrder = regions.reduce((max, r) => Math.max(max, r.order + 1), 1);
+  clearRedoStack();
 }
 
 /** Apply triColors to a MeshData, returning a new object (non-destructive). */
@@ -168,4 +244,12 @@ export function applyTriColors(mesh: MeshData): MeshData {
   const triColors = buildTriColors(mesh.numTri);
   if (!triColors) return mesh;
   return { ...mesh, triColors };
+}
+
+/** Same as `applyTriColors` but returns the mesh unchanged when paint
+ *  visibility is toggled off. Use this for viewport rendering; exports should
+ *  call `applyTriColors` directly so colors persist regardless of UI state. */
+export function applyTriColorsIfVisible(mesh: MeshData): MeshData {
+  if (!visible) return mesh;
+  return applyTriColors(mesh);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ import {
 import { setColor as setAnnotateColor, setWidth as setAnnotateWidth, getWidth as getAnnotateWidth } from './annotations/annotateMode';
 import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontSize as getAnnotateFontSize } from './annotations/textMode';
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
-import { applyTriColors, hasRegions as hasColorRegions, onChange as onColorRegionsChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, type SerializedColorRegion } from './color/regions';
+import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, type SerializedColorRegion } from './color/regions';
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
 import { buildAdjacency, findCoplanarRegion, resolveSeed } from './color/adjacency';
 import {
@@ -468,7 +468,7 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): vo
 
   // Re-render with colors if regions were rehydrated
   if (hasColorRegions() && currentMeshData) {
-    const colored = applyTriColors(currentMeshData);
+    const colored = applyTriColorsIfVisible(currentMeshData);
     updateMesh(colored, { skipAutoFrame: true });
   }
 }
@@ -1295,7 +1295,7 @@ async function main() {
   // When a color region is painted, re-render the mesh with colors and sync lock
   setOnRegionPainted(() => {
     if (currentMeshData) {
-      const colored = applyTriColors(currentMeshData);
+      const colored = applyTriColorsIfVisible(currentMeshData);
       updateMesh(colored, { skipAutoFrame: true });
       updateMultiView(colored);
       renderElevationsToContainer(elevationsContainer, colored);
@@ -1308,9 +1308,19 @@ async function main() {
     syncLockState();
     if (!isPaintActive()) return; // only auto-refresh while paint mode is on
     if (currentMeshData) {
-      const colored = applyTriColors(currentMeshData);
+      const colored = applyTriColorsIfVisible(currentMeshData);
       updateMesh(colored, { skipAutoFrame: true });
     }
+  });
+
+  // Toggling paint visibility re-renders the viewport, multiview, and elevations
+  // so colors disappear/reappear immediately. Exports remain colored regardless.
+  onPaintVisibilityChange(() => {
+    if (!currentMeshData) return;
+    const colored = applyTriColorsIfVisible(currentMeshData);
+    updateMesh(colored, { skipAutoFrame: true });
+    updateMultiView(colored);
+    renderElevationsToContainer(elevationsContainer, colored);
   });
 
   // When annotations change (stroke added/removed/cleared) or are toggled,
@@ -1318,7 +1328,7 @@ async function main() {
   // stay in sync with the live viewport.
   const refreshAnnotationDependentPanes = () => {
     if (!currentMeshData) return;
-    const meshForPanes = isPaintActive() ? applyTriColors(currentMeshData) : currentMeshData;
+    const meshForPanes = isPaintActive() ? applyTriColorsIfVisible(currentMeshData) : currentMeshData;
     updateMultiView(meshForPanes);
     renderElevationsToContainer(elevationsContainer, meshForPanes);
   };
@@ -2514,7 +2524,7 @@ async function main() {
       );
 
       // Re-render with colors
-      const colored = applyTriColors(currentMeshData);
+      const colored = applyTriColorsIfVisible(currentMeshData);
       updateMesh(colored, { skipAutoFrame: true });
       updateMultiView(colored);
       syncLockState();
@@ -2882,7 +2892,7 @@ async function main() {
       currentManifold = result.manifold;
 
       // Apply any existing color regions to the mesh
-      const displayMesh = hasColorRegions() ? applyTriColors(result.mesh) : result.mesh;
+      const displayMesh = hasColorRegions() ? applyTriColorsIfVisible(result.mesh) : result.mesh;
       updateMesh(displayMesh);
       updateMultiView(displayMesh);
       renderElevationsToContainer(elevationsContainer, displayMesh);


### PR DESCRIPTION
## Summary

- Adds **Redo stroke** to the annotate panel (Undo had no counterpart, so accidental undos were lossy)
- Adds **Hide/Show, Undo, Redo, Clear** to the paint panel (it previously had no history controls beyond regenerating from scratch)
- Paint visibility is viewport-only — exports always include colors regardless of the Hide button

## Implementation notes

- Per-feature redo stacks; both clear on any non-undo mutation so redo can never resurrect stale state.
- `applyTriColorsIfVisible()` is the new viewport-side helper; export sites keep `applyTriColors()` directly.
- New listeners: `onRedoChange`, `onPaintVisibilityChange`. The viewport, multiview, and elevations all re-render on visibility toggle.

## Test plan

- [ ] Annotate: draw two strokes, Undo twice, Redo twice — confirm strokes return in order
- [ ] Annotate: draw a stroke, Undo, draw a new stroke — confirm Redo button greys out
- [ ] Paint: paint two regions, Undo twice, Redo twice — confirm regions return
- [ ] Paint: paint a region, click Hide — viewport, multiview, and elevations should all blank the paint; click Show to bring it back
- [ ] Paint: paint a region, click Hide, export 3MF — exported file should still contain the paint colors
- [ ] Paint: Clear should empty both the viewport and the region list, and disable Undo/Redo

🤖 Generated with [Claude Code](https://claude.com/claude-code)