### PR TITLE
Fix export menu — 3MF first, correct color descriptions

### DIFF
--- a/prompts/20260428-export-menu-labels.md
+++ b/prompts/20260428-export-menu-labels.md
@@ -1,0 +1,16 @@
+---
+session: "export-menu-labels"
+timestamp: "2026-04-28T10:45:00Z"
+model: claude-opus-4-6
+tools: []
+---
+
+## Human
+
+Fix export menu labels — remove "recommended" badge from OBJ, correct 3MF description that incorrectly says colors are not preserved, and move 3MF to first position.
+
+## Assistant
+
+### Key decisions
+
+Updated the export dropdown in toolbar.ts. 3MF is now first (native Bambu Studio format with per-face colors via m:colorgroup). Removed "recommended" badge from OBJ. Corrected 3MF description from "color regions are not preserved on Bambu import" to "Geometry + color. Native format for Bambu Studio multi-color prints." Added ZIP extraction hint to OBJ description. Updated GLB description for clarity.

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -204,26 +204,25 @@ export function createToolbar(
   dropdown.id = 'export-dropdown';
   dropdown.className = 'absolute right-0 top-full mt-1 bg-zinc-800 border border-zinc-600 rounded shadow-lg py-1 hidden z-20 w-72 max-h-[80vh] overflow-y-auto';
 
-  // Section: 3D model formats — ordered by Bambu Studio compatibility
+  // Section: 3D model formats
   dropdown.appendChild(createSectionHeader('3D model'));
-
-  const objOpt = createDescribedItem(
-    'OBJ',
-    'Geometry + color. Best for Bambu Studio multi-color prints.',
-    'recommended',
-  );
-  objOpt.addEventListener('click', () => {
-    dropdown.classList.add('hidden');
-    callbacks.onExportOBJ();
-  });
 
   const threemfOpt = createDescribedItem(
     '3MF',
-    'Generic 3D format. Geometry only — color regions are not preserved on Bambu import.',
+    'Geometry + color. Native format for Bambu Studio multi-color prints.',
   );
   threemfOpt.addEventListener('click', () => {
     dropdown.classList.add('hidden');
     callbacks.onExport3MF();
+  });
+
+  const objOpt = createDescribedItem(
+    'OBJ',
+    'Geometry + color via MTL. Extract ZIP before importing into slicer.',
+  );
+  objOpt.addEventListener('click', () => {
+    dropdown.classList.add('hidden');
+    callbacks.onExportOBJ();
   });
 
   const stlOpt = createDescribedItem(
@@ -237,15 +236,15 @@ export function createToolbar(
 
   const glbOpt = createDescribedItem(
     'GLB',
-    'Web/preview format with materials. Does not import into Bambu Studio.',
+    'Web/preview format with vertex colors. Not supported by slicers.',
   );
   glbOpt.addEventListener('click', () => {
     dropdown.classList.add('hidden');
     callbacks.onExportGLB();
   });
 
-  dropdown.appendChild(objOpt);
   dropdown.appendChild(threemfOpt);
+  dropdown.appendChild(objOpt);
   dropdown.appendChild(stlOpt);
   dropdown.appendChild(glbOpt);
 


### PR DESCRIPTION
## Summary

- Moves 3MF to first position in the export dropdown (native Bambu Studio format with per-face color support)
- Removes "recommended" badge from OBJ
- Fixes 3MF description: was "color regions are not preserved on Bambu import" — now "Geometry + color. Native format for Bambu Studio multi-color prints."
- Adds ZIP extraction hint to OBJ description
- Clarifies GLB description

## Test plan

- [ ] Export dropdown shows 3MF first, then OBJ, STL, GLB
- [ ] No "recommended" badge on any format
- [ ] Descriptions are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)