### PR TITLE
Add AI-friendly file I/O API and Recent Exports inbox

### DIFF
--- a/prompts/20260428-ai-friendly-file-io.md
+++ b/prompts/20260428-ai-friendly-file-io.md
@@ -143,3 +143,13 @@ UX:
     Recent Imports with source badge "JS".
   - Re-clicking a Recent Imports JSON entry replays the preview;
     Clear empties the list and hides the section.
+
+## Polish: close dropdowns on Escape
+
+User noticed the Export dropdown didn't close on Escape and asked for
+parity. (The Import side appeared to close on Escape only because the
+preview modal was handling the key.) Added a document-level keydown
+listener for each dropdown in `src/ui/toolbar.ts` that hides it when
+the user presses Escape while it is open. Smoke-checked in Playwright
+that both Export and Import dropdowns close as expected and that
+pressing Escape with no dropdown open is a no-op.

--- a/prompts/20260428-ai-friendly-file-io.md
+++ b/prompts/20260428-ai-friendly-file-io.md
@@ -1,0 +1,89 @@
+---
+session: "ai-friendly-file-io"
+timestamp: "2026-04-28T15:00:00Z"
+model: claude-opus-4-7
+tools: [Read, Edit, Write, Bash, Grep, Glob, playwright]
+---
+
+## Human
+
+When AIs work on file export and import features they struggle because
+they can't actually interact with the browser file picker. Same problem
+existed with reference images. Propose a solution that lets local AIs
+work with features that normally pop browser dialogs — stream/return file
+contents over the `window.partwright` API so the agent can save bytes
+itself, plus an export inbox so users can re-download recent exports.
+
+## Changes
+
+- `src/export/exportInbox.ts` (new): in-memory ring buffer (max 10) of
+  recent export blobs with `registerExport` / `listExports` /
+  `getExport` / `clearExports` / `onExportInboxChange`. Both the toolbar
+  and the AI API read from this same store, so an export the human
+  triggered remains downloadable and inspectable from agent code.
+
+- Exporters split into pure builders + thin downloaders:
+  - `src/export/gltf.ts`: new `buildGLB()` returning `{blob, filename, mimeType}`;
+    `exportGLB()` calls it then `downloadBlob(..., 'GLB')`. Defines the shared
+    `BuiltExport` interface re-used by the other builders.
+  - `src/export/stl.ts`: new `buildSTL()`; `exportSTL()` thin wrapper.
+  - `src/export/obj.ts`: new `buildOBJ()` — returns text/plain or
+    application/zip depending on whether color regions are painted.
+  - `src/export/threemf.ts`: new `build3MF()`.
+  - `src/export/session.ts`: new `buildSessionJSON()` (also returns
+    parsed `data`) and `buildRawCode()` (also returns `text` + `language`).
+
+- `src/export/download.ts`: `downloadBlob()` now takes a `source` label
+  and registers the blob in the inbox. New `{ register: false }` option
+  lets the Recent Exports re-download path avoid double-counting. Adds
+  `bytesToBase64()` / `blobToBase64()` helpers (chunked to avoid stack
+  overflow).
+
+- `src/ui/toolbar.ts`: new "Recent Exports" section in the Export
+  dropdown. Renders an entry per inbox blob with a source badge, filename,
+  size, and relative timestamp. Clicking re-downloads the same blob via
+  `downloadBlob(..., { register: false })`. Includes a "Clear" link and
+  hides the section when the inbox is empty. Subscribes to inbox changes
+  so the UI stays live; re-renders timestamps when the dropdown opens.
+
+- `src/main.ts`:
+  - New `partwrightAPI` methods that return file contents inline so AI
+    agents can bypass file dialogs:
+    - `exportGLBData()`, `exportSTLData()`, `exportOBJData()`,
+      `export3MFData()` — base64 (or text for plain OBJ).
+    - `exportSessionData()` — returns the parsed `.partwright.json` object.
+    - `exportCodeData()` — returns the editor source as text.
+    - `importSessionData(jsonObjectOrString)` — accept a parsed payload
+      directly; reuses the existing import pipeline by extracting
+      `importSessionPayload()` and `validateSessionPayload()` helpers
+      shared with `handleImportFile()`.
+    - `importCodeData(code, language, sessionName?)` — accept inline
+      source as a new session.
+    - `listRecentExports()` / `getRecentExport(id)` /
+      `downloadRecentExport(id)` / `clearRecentExports()`.
+  - Each `*Data()` method also registers the blob in the Recent Exports
+    inbox so agent-driven exports are visible in the toolbar.
+  - `help()` listings updated with all the new methods, pointing at the
+    new ai.md anchor.
+
+- `public/ai.md`: new "AI-friendly file I/O" section documenting the
+  whole pattern with examples; new TOC entry; quick-reference list in
+  the Console API block updated to call out the `*Data()` variants and
+  recommend them for agent flows.
+
+## Verification
+
+- `npm run build` clean, no TypeScript errors.
+- Playwright smoke test: hit `/editor?view=ai`, ran every new method on
+  the default cube. All 12 methods present. STL/OBJ/GLB/3MF/session/code
+  exports return correct mime types and sizes. GLB base64 starts with
+  `Z2xURg` (decodes to "glTF" magic). OBJ returns `text` (no colors
+  painted in the smoke session). Round-tripped a session via
+  `exportSessionData()` → `importSessionData()` and got a new sessionId.
+  Recent Exports list shows all entries with badges + relative times;
+  `downloadRecentExport(id)` triggered an actual browser download
+  without adding a duplicate inbox entry; `clearRecentExports()` empties
+  it and hides the toolbar section.
+- Bad-payload import paths return helpful `{error}` messages
+  ("payload missing partwright/mainifold brand…", "could not parse
+  string as JSON").

--- a/prompts/20260428-ai-friendly-file-io.md
+++ b/prompts/20260428-ai-friendly-file-io.md
@@ -87,3 +87,59 @@ itself, plus an export inbox so users can re-download recent exports.
 - Bad-payload import paths return helpful `{error}` messages
   ("payload missing partwright/mainifold brand…", "could not parse
   string as JSON").
+
+## Follow-up: Import dropdown + preview modal + Recent Imports
+
+After the initial review, expanded the import side to mirror the export
+UX:
+
+- `src/import/importInbox.ts` (new): in-memory ring buffer (max 10) of
+  imported file blobs with `registerImport` / `listImports` /
+  `getImport` / `clearImports` / `onImportInboxChange`, plus
+  `classifyImportSource(filename)` returning `'JSON' | 'JS' | 'SCAD'`.
+
+- `src/ui/importPreview.ts` (new): preview modal with
+  `summarizeSessionImport(data) -> SessionImportSummary` and
+  `showImportPreview(filename, summary)` returning `Promise<boolean>`.
+  The modal shows session name, schema version badge, version count,
+  language, notes, annotations, reference image sides, and last
+  updated timestamp before committing the import. Enter confirms;
+  Esc / overlay click / Cancel rejects.
+
+- `src/ui/toolbar.ts`: replaced the bare Import button with an
+  `import-wrapper` dropdown that holds a "Choose file…" entry (still
+  triggers the hidden `<input type="file">` so the OS picker
+  behaviour is unchanged for the user) plus a "Recent Imports"
+  section that renders inbox entries with a source badge, filename,
+  size, and relative timestamp. New `onImportInboxEntry` callback in
+  `ToolbarCallbacks`. Clear button empties the inbox.
+
+- `src/main.ts`:
+  - Extracted `importJSONFromText(filename, text)` which validates,
+    runs the preview modal, and commits.
+  - `handleImportFile()` now returns `boolean` (whether it
+    committed), routes JSON through the preview, and only adds to
+    the inbox if the import actually completed. The legacy
+    "Open as a new session?" confirm only runs for `.js` / `.scad`
+    now since the JSON preview already serves as confirmation.
+  - New `handleReimportInboxEntry(entry)` reuses the same paths for
+    Recent Imports re-clicks (preview for JSON, confirm-on-clobber
+    for JS/SCAD).
+
+- `window.partwright.importSessionData()` deliberately does **not**
+  show the preview — it's the programmatic entry point and the agent
+  has already decided.
+
+### Verification (follow-up)
+
+- `npm run build` clean.
+- Smoke test in Playwright on `/editor?view=ai`:
+  - Import button toggles the new dropdown (no immediate file picker).
+  - Synthetic File dispatched at the hidden input opens the preview
+    modal with correct stats; Cancel closes cleanly with no inbox
+    entry; Import commits and adds the entry with badge + size +
+    "just now".
+  - JS file path still uses the existing confirm modal and lands in
+    Recent Imports with source badge "JS".
+  - Re-clicking a Recent Imports JSON entry replays the preview;
+    Clear empties the list and hides the section.

--- a/public/ai.md
+++ b/public/ai.md
@@ -17,6 +17,7 @@ Partwright is a browser-based parametric CAD tool with two modeling engines: **m
 - [Common pitfalls for boolean operations](#common-pitfalls-for-boolean-operations)
 - [Print-safe geometry](#print-safe-geometry)
 - [Color regions](#color-regions)
+- [AI-friendly file I/O](#ai-friendly-file-io)
 - [Reference images](#reference-images)
 - [Photo-to-model workflow](#photo-to-model-workflow) (optional tooling)
 - [Iteration workflow](#iteration-workflow)
@@ -128,10 +129,23 @@ await partwright.setActiveLanguage(lang) // Switch engine + editor mode ('manifo
 partwright.toggleClip(on?)     // Toggle 3D clipping plane -> {enabled, z, min, max}
 partwright.setClipZ(z)         // Set clip height -> {enabled, z, min, max}
 partwright.getClipState()      // -> {enabled, z, min, max}
-await partwright.exportGLB()   // Download GLB
-partwright.exportSTL()         // Download STL
-partwright.exportOBJ()         // Download OBJ
-partwright.export3MF()         // Download 3MF
+await partwright.exportGLB()   // Download GLB (browser file dialog -- prefer exportGLBData() in agent flows)
+partwright.exportSTL()         // Download STL ("                                       exportSTLData() ")
+partwright.exportOBJ()         // Download OBJ ("                                       exportOBJData() ")
+partwright.export3MF()         // Download 3MF ("                                       export3MFData() ")
+// Agent-friendly variants -- bytes return inline, no file dialog. See AI-friendly file I/O.
+await partwright.exportGLBData()        // -> {filename, mimeType, base64, sizeBytes}
+await partwright.exportSTLData()
+await partwright.exportOBJData()        // text or base64 depending on whether colors are painted
+await partwright.export3MFData()
+await partwright.exportSessionData()    // -> {filename, mimeType, data, sizeBytes} (parsed JSON)
+partwright.exportCodeData()             // -> {filename, mimeType, language, text, sizeBytes}
+await partwright.importSessionData(parsedJson)         // -> {sessionId} or {error}
+await partwright.importCodeData(code, language, name?) // -> {sessionId}
+partwright.listRecentExports()                         // Recent Exports inbox
+await partwright.getRecentExport(id)
+partwright.downloadRecentExport(id)
+partwright.clearRecentExports()
 
 // Isolated execution -- test code without changing editor/viewport state
 await partwright.runIsolated(code)       // -> {geometryData, thumbnail}
@@ -414,6 +428,58 @@ partwright.clearColors()    // remove all regions
 - `exportGLB()` -- vertex colors flow through automatically.
 - `export3MF()` -- regions become `<basematerials>` entries with per-triangle `pid` attributes (compatible with PrusaSlicer / Bambu Studio multi-material slicing).
 - `exportSTL()` and `exportOBJ()` -- formats don't carry color, so colors are dropped.
+
+## AI-friendly file I/O
+
+The standard `exportGLB()` / `exportSTL()` / `exportOBJ()` / `export3MF()` methods trigger a browser download — the file goes to the user's Downloads folder, which an AI agent can't observe. Likewise, `Import` opens an OS file picker that an agent can't dismiss. Use the `*Data()` methods below instead: they return file contents over the API and skip the picker entirely.
+
+### Export — return bytes over the API
+```js
+// 3D model formats — binary blobs come back as base64
+const glb = await partwright.exportGLBData()
+// -> { filename: "model_2026-04-28.glb", mimeType: "model/gltf-binary", base64: "...", sizeBytes: 12345 }
+
+const stl = await partwright.exportSTLData()
+const tmf = await partwright.export3MFData()
+
+// OBJ is text-typed when the mesh has no painted color regions, otherwise a ZIP.
+// Inspect mimeType to tell which: "text/plain" -> use `text`, "application/zip" -> use `base64`.
+const obj = await partwright.exportOBJData()
+
+// Session JSON — returns the parsed object directly, no decoding needed
+const ses = await partwright.exportSessionData()
+// -> { filename: "...partwright.json", mimeType: "application/json", data: { partwright: "1.2", session: {...}, versions: [...] }, sizeBytes }
+
+// Editor source as text
+const src = await partwright.exportCodeData()
+// -> { filename, mimeType: "text/plain", language: "manifold-js", text, sizeBytes }
+```
+
+Each call also adds the export to the Recent Exports inbox so the user can re-download it from the toolbar's Export → Recent Exports list.
+
+### Import — supply the payload directly
+```js
+// Import a parsed .partwright.json (object or string) as a new active session
+const r = await partwright.importSessionData(parsedJson)
+// -> { sessionId } or { error }
+
+// Import raw source as a new session
+await partwright.importCodeData(code, 'manifold-js')           // optional sessionName arg
+await partwright.importCodeData(scadCode, 'scad', 'my-shape')
+```
+
+### Recent Exports inbox
+Every export — whether the human clicked Export or the agent called `*Data()` — is kept in a small in-memory ring buffer (last 10). The user sees them in the Export dropdown's "Recent Exports" section; agents can read them too.
+```js
+partwright.listRecentExports()
+// -> [{ id, filename, mimeType, source, sizeBytes, timestamp }, ...]   // newest first
+
+await partwright.getRecentExport(id)   // adds bytes (text or base64) to the metadata
+partwright.downloadRecentExport(id)    // re-trigger the browser download
+partwright.clearRecentExports()
+```
+
+This is also the easiest way to inspect what the user just exported manually: the bytes stay in memory until they're pushed out by newer exports.
 
 ## Reference images
 

--- a/src/export/download.ts
+++ b/src/export/download.ts
@@ -2,6 +2,7 @@
 
 import { getState } from '../storage/sessionManager';
 import { getUnits } from '../geometry/units';
+import { registerExport } from './exportInbox';
 
 /**
  * Build a descriptive export filename from session context.
@@ -66,12 +67,41 @@ export function getExportTitle(): string {
   return 'Partwright Export';
 }
 
-/** Trigger a browser download for a Blob. */
-export function downloadBlob(blob: Blob, filename: string): void {
+/**
+ * Trigger a browser download for a Blob and add the entry to the export inbox.
+ * `source` is a short label shown in the Recent Exports list (e.g. "GLB", "Session JSON").
+ * Pass `register: false` to download without recording (e.g. when re-downloading
+ * an existing inbox entry — we don't want to double-register it).
+ */
+export function downloadBlob(
+  blob: Blob,
+  filename: string,
+  source?: string,
+  options?: { register?: boolean },
+): void {
+  if (options?.register !== false && source) {
+    registerExport(blob, filename, source);
+  }
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
   a.download = filename;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+/** Encode an ArrayBuffer / Uint8Array as base64 without blowing the call stack. */
+export function bytesToBase64(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  const CHUNK = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + CHUNK)));
+  }
+  return btoa(binary);
+}
+
+/** Async-read a Blob as base64 (no data: prefix). */
+export async function blobToBase64(blob: Blob): Promise<string> {
+  return bytesToBase64(await blob.arrayBuffer());
 }

--- a/src/export/exportInbox.ts
+++ b/src/export/exportInbox.ts
@@ -1,0 +1,70 @@
+// Recent-exports inbox: an in-memory ring buffer of the last N export blobs the
+// app produced. Both the toolbar (Recent Exports list) and the AI console API
+// read from this — so an export the human triggered remains downloadable and
+// inspectable without re-running the geometry.
+
+const MAX_ENTRIES = 10;
+
+export interface ExportInboxEntry {
+  id: string;
+  blob: Blob;
+  filename: string;
+  mimeType: string;
+  source: string;
+  sizeBytes: number;
+  timestamp: number;
+}
+
+const entries: ExportInboxEntry[] = [];
+const listeners = new Set<() => void>();
+
+let nextSeq = 1;
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+/** Add an export to the inbox. Newest entries are at index 0. */
+export function registerExport(
+  blob: Blob,
+  filename: string,
+  source: string,
+  mimeType?: string,
+): ExportInboxEntry {
+  const entry: ExportInboxEntry = {
+    id: `exp_${Date.now().toString(36)}_${nextSeq++}`,
+    blob,
+    filename,
+    mimeType: mimeType ?? blob.type ?? 'application/octet-stream',
+    source,
+    sizeBytes: blob.size,
+    timestamp: Date.now(),
+  };
+  entries.unshift(entry);
+  while (entries.length > MAX_ENTRIES) entries.pop();
+  notify();
+  return entry;
+}
+
+/** Snapshot of the inbox, newest first. */
+export function listExports(): ExportInboxEntry[] {
+  return entries.slice();
+}
+
+/** Look up a single entry by id. */
+export function getExport(id: string): ExportInboxEntry | null {
+  return entries.find(e => e.id === id) ?? null;
+}
+
+/** Drop everything from the inbox (used by the toolbar Clear action). */
+export function clearExports(): void {
+  if (entries.length === 0) return;
+  entries.length = 0;
+  notify();
+}
+
+/** Subscribe to inbox changes. Returns an unsubscribe fn. */
+export function onExportInboxChange(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}

--- a/src/export/gltf.ts
+++ b/src/export/gltf.ts
@@ -3,7 +3,14 @@ import { getPhantomGroup } from '../renderer/phantomGeometry';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
 import { downloadBlob, getExportFilename } from './download';
 
-export async function exportGLB(customName?: string): Promise<void> {
+export interface BuiltExport {
+  blob: Blob;
+  filename: string;
+  mimeType: string;
+}
+
+/** Build the GLB blob for the current scene without triggering a download. */
+export async function buildGLB(customName?: string): Promise<BuiltExport> {
   const scene = getScene();
   const exporter = new GLTFExporter();
 
@@ -17,6 +24,12 @@ export async function exportGLB(customName?: string): Promise<void> {
   // Restore phantom visibility
   if (phantom) phantom.visible = wasVisible;
 
-  const blob = new Blob([result as ArrayBuffer], { type: 'model/gltf-binary' });
-  downloadBlob(blob, getExportFilename('glb', customName));
+  const mimeType = 'model/gltf-binary';
+  const blob = new Blob([result as ArrayBuffer], { type: mimeType });
+  return { blob, filename: getExportFilename('glb', customName), mimeType };
+}
+
+export async function exportGLB(customName?: string): Promise<void> {
+  const built = await buildGLB(customName);
+  downloadBlob(built.blob, built.filename, 'GLB');
 }

--- a/src/export/obj.ts
+++ b/src/export/obj.ts
@@ -1,5 +1,6 @@
 import type { MeshData } from '../geometry/types';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
+import type { BuiltExport } from './gltf';
 import { buildZip } from './zip';
 import { cleanMeshForExport, DEFAULT_COLOR_HEX, triColorHex, hasAnyPainted } from './meshClean';
 
@@ -8,7 +9,12 @@ function f6(v: number): string {
   return v.toFixed(6);
 }
 
-export function exportOBJ(meshData: MeshData, customName?: string): void {
+/**
+ * Build an OBJ export blob without triggering a download.
+ * If the mesh has painted color regions, the result is a ZIP bundling .obj + .mtl;
+ * otherwise it's a plain text .obj.
+ */
+export function buildOBJ(meshData: MeshData, customName?: string): BuiltExport {
   const { triVerts, triColors } = meshData;
   const title = getExportTitle();
 
@@ -67,21 +73,28 @@ export function exportOBJ(meshData: MeshData, customName?: string): void {
       { name: `${baseName}.mtl`, data: enc.encode(mtlLines.join('\n') + '\n') },
     ]);
 
-    const blob = new Blob([zip], { type: 'application/zip' });
-    downloadBlob(blob, `${baseName}.zip`);
-  } else {
-    // No colors — plain OBJ
-    for (let i = 0; i < numUniqueVerts; i++) {
-      lines.push(`v ${f6(uniquePositions[i * 3])} ${f6(uniquePositions[i * 3 + 1])} ${f6(uniquePositions[i * 3 + 2])}`);
-    }
-
-    for (const t of validTris) {
-      lines.push(`f ${fv(triVerts[t * 3])} ${fv(triVerts[t * 3 + 1])} ${fv(triVerts[t * 3 + 2])}`);
-    }
-
-    const blob = new Blob([lines.join('\n') + '\n'], { type: 'text/plain' });
-    downloadBlob(blob, getExportFilename('obj', customName));
+    const mimeType = 'application/zip';
+    const blob = new Blob([zip], { type: mimeType });
+    return { blob, filename: `${baseName}.zip`, mimeType };
   }
+
+  // No colors — plain OBJ
+  for (let i = 0; i < numUniqueVerts; i++) {
+    lines.push(`v ${f6(uniquePositions[i * 3])} ${f6(uniquePositions[i * 3 + 1])} ${f6(uniquePositions[i * 3 + 2])}`);
+  }
+
+  for (const t of validTris) {
+    lines.push(`f ${fv(triVerts[t * 3])} ${fv(triVerts[t * 3 + 1])} ${fv(triVerts[t * 3 + 2])}`);
+  }
+
+  const mimeType = 'text/plain';
+  const blob = new Blob([lines.join('\n') + '\n'], { type: mimeType });
+  return { blob, filename: getExportFilename('obj', customName), mimeType };
+}
+
+export function exportOBJ(meshData: MeshData, customName?: string): void {
+  const built = buildOBJ(meshData, customName);
+  downloadBlob(built.blob, built.filename, 'OBJ');
 }
 
 function matName(hex: string): string {

--- a/src/export/session.ts
+++ b/src/export/session.ts
@@ -1,7 +1,8 @@
 // Session JSON + raw code exports
 
-import { exportSession, getState } from '../storage/sessionManager';
+import { exportSession, getState, type ExportedSession } from '../storage/sessionManager';
 import { downloadBlob } from './download';
+import type { BuiltExport } from './gltf';
 
 /** Sanitize a session name into a filename-safe slug. Falls back to "session". */
 function slugify(name: string): string {
@@ -13,16 +14,56 @@ function slugify(name: string): string {
   return slug || 'session';
 }
 
+export interface BuiltSessionExport extends BuiltExport {
+  /** The parsed session data — convenient for AI callers that want the JSON directly. */
+  data: ExportedSession;
+}
+
+/** Build a `.partwright.json` blob for the current (or specified) session. */
+export async function buildSessionJSON(sessionId?: string): Promise<BuiltSessionExport | null> {
+  const data = await exportSession(sessionId);
+  if (!data) return null;
+  const mimeType = 'application/json';
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: mimeType });
+  return {
+    blob,
+    filename: `${slugify(data.session.name)}.partwright.json`,
+    mimeType,
+    data,
+  };
+}
+
 /**
  * Export the current (or specified) session as a `.partwright.json` file.
  * Returns true if a download was triggered, false if no session was available.
  */
 export async function exportSessionJSON(sessionId?: string): Promise<boolean> {
-  const data = await exportSession(sessionId);
-  if (!data) return false;
-  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-  downloadBlob(blob, `${slugify(data.session.name)}.partwright.json`);
+  const built = await buildSessionJSON(sessionId);
+  if (!built) return false;
+  downloadBlob(built.blob, built.filename, 'Session JSON');
   return true;
+}
+
+export interface BuiltCodeExport extends BuiltExport {
+  text: string;
+  language: 'manifold-js' | 'scad';
+}
+
+/** Build the raw code blob for the editor source. */
+export function buildRawCode(code: string, language: 'manifold-js' | 'scad'): BuiltCodeExport {
+  const ext = language === 'scad' ? 'scad' : 'js';
+  const state = getState();
+  let base = state.session?.name ?? 'code';
+  if (state.currentVersion?.label) base += `_${state.currentVersion.label}`;
+  const mimeType = 'text/plain';
+  const blob = new Blob([code], { type: mimeType });
+  return {
+    blob,
+    filename: `${slugify(base)}.${ext}`,
+    mimeType,
+    text: code,
+    language,
+  };
 }
 
 /**
@@ -30,10 +71,6 @@ export async function exportSessionJSON(sessionId?: string): Promise<boolean> {
  * Uses the active session/version for the filename when available.
  */
 export function exportRawCode(code: string, language: 'manifold-js' | 'scad'): void {
-  const ext = language === 'scad' ? 'scad' : 'js';
-  const state = getState();
-  let base = state.session?.name ?? 'code';
-  if (state.currentVersion?.label) base += `_${state.currentVersion.label}`;
-  const blob = new Blob([code], { type: 'text/plain' });
-  downloadBlob(blob, `${slugify(base)}.${ext}`);
+  const built = buildRawCode(code, language);
+  downloadBlob(built.blob, built.filename, 'Code');
 }

--- a/src/export/stl.ts
+++ b/src/export/stl.ts
@@ -1,7 +1,9 @@
 import type { MeshData } from '../geometry/types';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
+import type { BuiltExport } from './gltf';
 
-export function exportSTL(meshData: MeshData, customName?: string): void {
+/** Build the binary STL blob for a mesh without triggering a download. */
+export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
   const { vertProperties, triVerts, numTri, numProp } = meshData;
 
   // Binary STL format
@@ -69,6 +71,12 @@ export function exportSTL(meshData: MeshData, customName?: string): void {
     view.setUint16(offset, 0, true); offset += 2;
   }
 
-  const blob = new Blob([buffer], { type: 'application/octet-stream' });
-  downloadBlob(blob, getExportFilename('stl', customName));
+  const mimeType = 'application/octet-stream';
+  const blob = new Blob([buffer], { type: mimeType });
+  return { blob, filename: getExportFilename('stl', customName), mimeType };
+}
+
+export function exportSTL(meshData: MeshData, customName?: string): void {
+  const built = buildSTL(meshData, customName);
+  downloadBlob(built.blob, built.filename, 'STL');
 }

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -1,10 +1,12 @@
 import type { MeshData } from '../geometry/types';
 import { get3MFUnitString } from '../geometry/units';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
+import type { BuiltExport } from './gltf';
 import { buildZip } from './zip';
 import { cleanMeshForExport, DEFAULT_COLOR_HEX, triColorHex, hasAnyPainted } from './meshClean';
 
-export function export3MF(meshData: MeshData, customName?: string): void {
+/** Build a 3MF export blob without triggering a download. */
+export function build3MF(meshData: MeshData, customName?: string): BuiltExport {
   const { triVerts, triColors } = meshData;
 
   const { remap, uniquePositions, validTris } = cleanMeshForExport(meshData);
@@ -108,6 +110,12 @@ ${triangles.join('\n')}
     { name: '3D/3dmodel.model', data: new TextEncoder().encode(modelXml) },
   ]);
 
-  const blob = new Blob([zip], { type: 'application/vnd.ms-package.3dmanufacturing' });
-  downloadBlob(blob, getExportFilename('3mf', customName));
+  const mimeType = 'application/vnd.ms-package.3dmanufacturing';
+  const blob = new Blob([zip], { type: mimeType });
+  return { blob, filename: getExportFilename('3mf', customName), mimeType };
+}
+
+export function export3MF(meshData: MeshData, customName?: string): void {
+  const built = build3MF(meshData, customName);
+  downloadBlob(built.blob, built.filename, '3MF');
 }

--- a/src/import/importInbox.ts
+++ b/src/import/importInbox.ts
@@ -1,0 +1,74 @@
+// Recent-imports inbox: an in-memory ring buffer of the last N files the user
+// imported. Mirrors the Recent Exports inbox so the toolbar's Import dropdown
+// can offer one-click re-import. Holds the underlying Blob so a re-import does
+// not require the user to re-pick the file from disk.
+
+const MAX_ENTRIES = 10;
+
+export type ImportSource = 'JSON' | 'JS' | 'SCAD';
+
+export interface ImportInboxEntry {
+  id: string;
+  blob: Blob;
+  filename: string;
+  source: ImportSource;
+  sizeBytes: number;
+  timestamp: number;
+}
+
+const entries: ImportInboxEntry[] = [];
+const listeners = new Set<() => void>();
+
+let nextSeq = 1;
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+/** Add an entry to the inbox. Newest entries are at index 0. */
+export function registerImport(blob: Blob, filename: string, source: ImportSource): ImportInboxEntry {
+  const entry: ImportInboxEntry = {
+    id: `imp_${Date.now().toString(36)}_${nextSeq++}`,
+    blob,
+    filename,
+    source,
+    sizeBytes: blob.size,
+    timestamp: Date.now(),
+  };
+  entries.unshift(entry);
+  while (entries.length > MAX_ENTRIES) entries.pop();
+  notify();
+  return entry;
+}
+
+/** Snapshot of the inbox, newest first. */
+export function listImports(): ImportInboxEntry[] {
+  return entries.slice();
+}
+
+/** Look up a single entry by id. */
+export function getImport(id: string): ImportInboxEntry | null {
+  return entries.find(e => e.id === id) ?? null;
+}
+
+/** Drop everything from the inbox. */
+export function clearImports(): void {
+  if (entries.length === 0) return;
+  entries.length = 0;
+  notify();
+}
+
+/** Subscribe to inbox changes. Returns an unsubscribe fn. */
+export function onImportInboxChange(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+/** Source label for an import based on filename — used by the inbox + UI. */
+export function classifyImportSource(filename: string): ImportSource | null {
+  const lower = filename.toLowerCase();
+  if (lower.endsWith('.json')) return 'JSON';
+  if (lower.endsWith('.scad')) return 'SCAD';
+  if (lower.endsWith('.js')) return 'JS';
+  return null;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,12 @@ import {
   clearExports as clearInboxExports,
   registerExport as registerInboxExport,
 } from './export/exportInbox';
+import {
+  registerImport,
+  classifyImportSource,
+  type ImportInboxEntry,
+} from './import/importInbox';
+import { showImportPreview, summarizeSessionImport } from './ui/importPreview';
 import type { BuiltExport } from './export/gltf';
 
 /** Register a freshly-built export blob in the inbox so it shows up in Recent Exports. */
@@ -822,46 +828,93 @@ async function main() {
     return { sessionId: session.id };
   }
 
-  // Import a .partwright.json session, or a raw .js / .scad file, into a new session.
-  async function handleImportFile(file: File): Promise<void> {
-    const lowerName = file.name.toLowerCase();
+  // Run a JSON session import end-to-end: validate, show the preview modal, import.
+  async function importJSONFromText(filename: string, text: string): Promise<boolean> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      alert(`Could not parse "${filename}" as JSON.`);
+      return false;
+    }
+    const data = validateSessionPayload(parsed);
+    if (!data) {
+      alert(`"${filename}" doesn't look like a Partwright session file.`);
+      return false;
+    }
+    const summary = summarizeSessionImport(data);
+    const ok = await showImportPreview(filename, summary);
+    if (!ok) return false;
+    await importSessionPayload(data);
+    return true;
+  }
 
-    // Confirm before clobbering an active session
-    const cur = getState();
-    if (cur.session && cur.versionCount > 0) {
-      const ok = await showInlineConfirm(
-        editorUI,
-        `Open "${file.name}" as a new session? Your current session will be kept.`,
-      );
-      if (!ok) return;
+  // Import a .partwright.json session, or a raw .js / .scad file, into a new session.
+  // Returns whether the import committed (so callers know if the inbox should be updated).
+  async function handleImportFile(file: File, options: { skipPreActiveConfirm?: boolean } = {}): Promise<boolean> {
+    const source = classifyImportSource(file.name);
+    if (!source) {
+      alert(`Unsupported file type: ${file.name}\n\nSupported: .partwright.json, .js, .scad`);
+      return false;
+    }
+
+    // Raw code imports don't get a preview modal of their own — confirm before clobber.
+    // JSON imports skip this confirm because the preview modal already serves as confirmation.
+    if (!options.skipPreActiveConfirm && source !== 'JSON') {
+      const cur = getState();
+      if (cur.session && cur.versionCount > 0) {
+        const ok = await showInlineConfirm(
+          editorUI,
+          `Open "${file.name}" as a new session? Your current session will be kept.`,
+        );
+        if (!ok) return false;
+      }
     }
 
     try {
-      if (lowerName.endsWith('.json')) {
+      let committed = false;
+      if (source === 'JSON') {
         const text = await file.text();
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(text);
-        } catch {
-          alert(`Could not parse "${file.name}" as JSON.`);
-          return;
-        }
-        const data = validateSessionPayload(parsed);
-        if (!data) {
-          alert(`"${file.name}" doesn't look like a Partwright session file.`);
-          return;
-        }
-        await importSessionPayload(data);
-      } else if (lowerName.endsWith('.js') || lowerName.endsWith('.scad')) {
+        committed = await importJSONFromText(file.name, text);
+      } else if (source === 'JS' || source === 'SCAD') {
         const code = await file.text();
-        const lang: Language = lowerName.endsWith('.scad') ? 'scad' : 'manifold-js';
+        const lang: Language = source === 'SCAD' ? 'scad' : 'manifold-js';
         const sessionName = file.name.replace(/\.(js|scad)$/i, '');
         await importCodePayload(code, lang, sessionName);
-      } else {
-        alert(`Unsupported file type: ${file.name}\n\nSupported: .partwright.json, .js, .scad`);
+        committed = true;
       }
+      if (committed) registerImport(file, file.name, source);
+      return committed;
     } catch (e) {
       alert(`Failed to import "${file.name}": ${(e as Error).message}`);
+      return false;
+    }
+  }
+
+  // Re-import an entry from the Recent Imports inbox. Reuses the same flow as
+  // a fresh file import, including the JSON preview modal — it is still a
+  // session-creating action and the user may want to verify before clobbering.
+  async function handleReimportInboxEntry(entry: ImportInboxEntry): Promise<void> {
+    try {
+      if (entry.source === 'JSON') {
+        const text = await entry.blob.text();
+        await importJSONFromText(entry.filename, text);
+      } else {
+        const cur = getState();
+        if (cur.session && cur.versionCount > 0) {
+          const ok = await showInlineConfirm(
+            editorUI,
+            `Re-import "${entry.filename}" as a new session? Your current session will be kept.`,
+          );
+          if (!ok) return;
+        }
+        const code = await entry.blob.text();
+        const lang: Language = entry.source === 'SCAD' ? 'scad' : 'manifold-js';
+        const sessionName = entry.filename.replace(/\.(js|scad)$/i, '');
+        await importCodePayload(code, lang, sessionName);
+      }
+    } catch (e) {
+      alert(`Failed to re-import "${entry.filename}": ${(e as Error).message}`);
     }
   }
 
@@ -912,7 +965,8 @@ async function main() {
     onExportRawCode: () => {
       exportRawCode(getValue(), getActiveLanguage());
     },
-    onImportFile: handleImportFile,
+    onImportFile: async (file) => { await handleImportFile(file); },
+    onImportInboxEntry: handleReimportInboxEntry,
     onExampleSelect: async (entry: ExampleEntry) => {
       // Auto-switch engine + editor mode if the example uses a different language.
       if (entry.language !== getActiveLanguage()) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,11 +16,24 @@ import { createGalleryView, refreshGallery } from './ui/gallery';
 import { createDiffView, refreshDiff } from './ui/diffView';
 import { createNotesView, refreshNotes } from './ui/notes';
 import { initSessionList, showSessionList } from './ui/sessionList';
-import { exportGLB } from './export/gltf';
-import { exportSTL } from './export/stl';
-import { exportOBJ } from './export/obj';
-import { export3MF } from './export/threemf';
-import { exportSessionJSON, exportRawCode } from './export/session';
+import { exportGLB, buildGLB } from './export/gltf';
+import { exportSTL, buildSTL } from './export/stl';
+import { exportOBJ, buildOBJ } from './export/obj';
+import { export3MF, build3MF } from './export/threemf';
+import { exportSessionJSON, exportRawCode, buildSessionJSON, buildRawCode } from './export/session';
+import { blobToBase64, downloadBlob } from './export/download';
+import {
+  listExports as listInboxExports,
+  getExport as getInboxExport,
+  clearExports as clearInboxExports,
+  registerExport as registerInboxExport,
+} from './export/exportInbox';
+import type { BuiltExport } from './export/gltf';
+
+/** Register a freshly-built export blob in the inbox so it shows up in Recent Exports. */
+function registerExportFromBuilt(built: BuiltExport, source: string): void {
+  registerInboxExport(built.blob, built.filename, source, built.mimeType);
+}
 import type { MeshData, SourceDiagnostic } from './geometry/types';
 import { analyzeZProfile, type ZProfile } from './geometry/profileAnalysis';
 import { probeAtXY, probeRay, measureDistance, type ProbeResult, type GeneralRayResult } from './geometry/rayCast';
@@ -780,6 +793,35 @@ async function main() {
   const defaultExampleKey = Object.keys(examples).find(k => k.includes('basic_shapes')) ?? Object.keys(examples)[0];
   const defaultCode = examples[defaultExampleKey]?.code ?? '// Write your manifold code here\nconst { Manifold } = api;\nreturn Manifold.cube([5,5,5], true);';
 
+  // Shared validator for parsed session JSON. Returns null if shape is wrong.
+  function validateSessionPayload(data: unknown): ExportedSession | null {
+    if (!data || typeof data !== 'object') return null;
+    const d = data as ExportedSession;
+    if ((!d.partwright && !d.mainifold) || !d.session || !Array.isArray(d.versions)) return null;
+    return d;
+  }
+
+  // Import an already-parsed session payload. Used by both file import and the
+  // window.partwright.importSessionData() API so AI agents can bypass the file picker.
+  async function importSessionPayload(data: ExportedSession): Promise<{ sessionId: string }> {
+    const session = await importSession(data, async (code) => {
+      await runCodeSync(code);
+      return captureThumbnail();
+    });
+    const version = await openSession(session.id);
+    if (version) await loadVersionIntoEditor(version);
+    return { sessionId: session.id };
+  }
+
+  // Import a raw code payload as a new session. Shared between file drop and the AI API.
+  async function importCodePayload(code: string, language: Language, sessionName?: string): Promise<{ sessionId: string }> {
+    if (language !== getActiveLanguage()) await switchLanguage(language);
+    const session = await createSession(sessionName, language);
+    setValue(code);
+    await runCodeSync(code);
+    return { sessionId: session.id };
+  }
+
   // Import a .partwright.json session, or a raw .js / .scad file, into a new session.
   async function handleImportFile(file: File): Promise<void> {
     const lowerName = file.name.toLowerCase();
@@ -797,31 +839,24 @@ async function main() {
     try {
       if (lowerName.endsWith('.json')) {
         const text = await file.text();
-        let data: ExportedSession;
+        let parsed: unknown;
         try {
-          data = JSON.parse(text) as ExportedSession;
+          parsed = JSON.parse(text);
         } catch {
           alert(`Could not parse "${file.name}" as JSON.`);
           return;
         }
-        if ((!data.partwright && !data.mainifold) || !data.session || !Array.isArray(data.versions)) {
+        const data = validateSessionPayload(parsed);
+        if (!data) {
           alert(`"${file.name}" doesn't look like a Partwright session file.`);
           return;
         }
-        const session = await importSession(data, async (code) => {
-          await runCodeSync(code);
-          return captureThumbnail();
-        });
-        const version = await openSession(session.id);
-        if (version) await loadVersionIntoEditor(version);
+        await importSessionPayload(data);
       } else if (lowerName.endsWith('.js') || lowerName.endsWith('.scad')) {
         const code = await file.text();
         const lang: Language = lowerName.endsWith('.scad') ? 'scad' : 'manifold-js';
-        if (lang !== getActiveLanguage()) await switchLanguage(lang);
         const sessionName = file.name.replace(/\.(js|scad)$/i, '');
-        await createSession(sessionName, lang);
-        setValue(code);
-        await runCodeSync(code);
+        await importCodePayload(code, lang, sessionName);
       } else {
         alert(`Unsupported file type: ${file.name}\n\nSupported: .partwright.json, .js, .scad`);
       }
@@ -1523,6 +1558,189 @@ async function main() {
     export3MF(filename?: string) {
       assertString(filename, 'export3MF(filename)', { optional: true });
       if (currentMeshData) export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData, filename);
+    },
+
+    // === AI-friendly export API ===
+    // These return file contents over the API instead of triggering a browser
+    // download — so AI agents (which can't observe Downloads-folder files) can
+    // inspect, save elsewhere, or pipe the bytes onward. Each export is also
+    // added to the Recent Exports inbox so the user can re-download from the UI.
+
+    /** Build a GLB and return its bytes as base64. Same blob as exportGLB(). */
+    async exportGLBData(filename?: string) {
+      assertString(filename, 'exportGLBData(filename)', { optional: true });
+      const built = await buildGLB(filename);
+      registerExportFromBuilt(built, 'GLB');
+      return {
+        filename: built.filename,
+        mimeType: built.mimeType,
+        sizeBytes: built.blob.size,
+        base64: await blobToBase64(built.blob),
+      };
+    },
+
+    /** Build an STL and return its bytes as base64. */
+    async exportSTLData(filename?: string) {
+      assertString(filename, 'exportSTLData(filename)', { optional: true });
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      const built = buildSTL(currentMeshData, filename);
+      registerExportFromBuilt(built, 'STL');
+      return {
+        filename: built.filename,
+        mimeType: built.mimeType,
+        sizeBytes: built.blob.size,
+        base64: await blobToBase64(built.blob),
+      };
+    },
+
+    /**
+     * Build an OBJ. If the mesh has painted color regions the result is a ZIP
+     * (returned as base64); otherwise it's plain text (returned as `text`).
+     * Inspect `mimeType` to tell which.
+     */
+    async exportOBJData(filename?: string) {
+      assertString(filename, 'exportOBJData(filename)', { optional: true });
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      const mesh = hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData;
+      const built = buildOBJ(mesh, filename);
+      registerExportFromBuilt(built, 'OBJ');
+      const isText = built.mimeType === 'text/plain';
+      return {
+        filename: built.filename,
+        mimeType: built.mimeType,
+        sizeBytes: built.blob.size,
+        ...(isText
+          ? { text: await built.blob.text() }
+          : { base64: await blobToBase64(built.blob) }),
+      };
+    },
+
+    /** Build a 3MF (always a ZIP) and return its bytes as base64. */
+    async export3MFData(filename?: string) {
+      assertString(filename, 'export3MFData(filename)', { optional: true });
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      const mesh = hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData;
+      const built = build3MF(mesh, filename);
+      registerExportFromBuilt(built, '3MF');
+      return {
+        filename: built.filename,
+        mimeType: built.mimeType,
+        sizeBytes: built.blob.size,
+        base64: await blobToBase64(built.blob),
+      };
+    },
+
+    /** Build a session export (.partwright.json). Returns the parsed JSON object directly. */
+    async exportSessionData(sessionId?: string) {
+      assertString(sessionId, 'exportSessionData(sessionId)', { optional: true, allowEmpty: false });
+      const built = await buildSessionJSON(sessionId);
+      if (!built) return { error: 'No active session to export' };
+      registerExportFromBuilt(built, 'Session JSON');
+      return {
+        filename: built.filename,
+        mimeType: built.mimeType,
+        sizeBytes: built.blob.size,
+        data: built.data,
+      };
+    },
+
+    /** Return the current editor source as text + metadata. */
+    exportCodeData() {
+      const code = getValue();
+      const built = buildRawCode(code, getActiveLanguage());
+      registerExportFromBuilt(built, 'Code');
+      return {
+        filename: built.filename,
+        mimeType: built.mimeType,
+        sizeBytes: built.blob.size,
+        language: built.language,
+        text: built.text,
+      };
+    },
+
+    // === AI-friendly import API ===
+    // Bypass the file picker by accepting parsed payloads inline.
+
+    /**
+     * Import a parsed `.partwright.json` payload (object or string) as a new session.
+     * Activates the new session on success.
+     */
+    async importSessionData(data: unknown) {
+      let payload: unknown = data;
+      if (typeof payload === 'string') {
+        try { payload = JSON.parse(payload); } catch { return { error: 'importSessionData(data): could not parse string as JSON' }; }
+      }
+      const validated = validateSessionPayload(payload);
+      if (!validated) return { error: 'importSessionData(data): payload missing partwright/mainifold brand, session, or versions[]' };
+      const result = await importSessionPayload(validated);
+      return { sessionId: result.sessionId };
+    },
+
+    /**
+     * Import raw source code as a new session. `language` selects 'manifold-js' or 'scad'.
+     */
+    async importCodeData(code: string, language: Language, sessionName?: string) {
+      const check = guard(() => {
+        assertString(code, 'importCodeData(code)', { allowEmpty: false });
+        assertEnum(language, ['manifold-js', 'scad'], 'importCodeData(language)');
+        assertString(sessionName, 'importCodeData(sessionName)', { optional: true, allowEmpty: false });
+      });
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      const result = await importCodePayload(code, language, sessionName);
+      return { sessionId: result.sessionId };
+    },
+
+    // === Recent Exports inbox ===
+    // The same list shown in the toolbar's Export → Recent Exports section.
+
+    /** List recent exports (newest first). Bytes are not included — call getRecentExport() for those. */
+    listRecentExports() {
+      return listInboxExports().map(e => ({
+        id: e.id,
+        filename: e.filename,
+        mimeType: e.mimeType,
+        source: e.source,
+        sizeBytes: e.sizeBytes,
+        timestamp: e.timestamp,
+      }));
+    },
+
+    /**
+     * Look up a recent export by id and return its bytes.
+     * Text-typed exports return `text`; everything else returns `base64`.
+     */
+    async getRecentExport(id: string) {
+      const check = guard(() => assertString(id, 'getRecentExport(id)', { allowEmpty: false }));
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      const entry = getInboxExport(id);
+      if (!entry) return { error: `No export with id "${id}"` };
+      const isText = entry.mimeType === 'text/plain' || entry.mimeType === 'application/json';
+      return {
+        id: entry.id,
+        filename: entry.filename,
+        mimeType: entry.mimeType,
+        source: entry.source,
+        sizeBytes: entry.sizeBytes,
+        timestamp: entry.timestamp,
+        ...(isText
+          ? { text: await entry.blob.text() }
+          : { base64: await blobToBase64(entry.blob) }),
+      };
+    },
+
+    /** Trigger a re-download of a recent export by id (no new inbox entry). */
+    downloadRecentExport(id: string) {
+      const check = guard(() => assertString(id, 'downloadRecentExport(id)', { allowEmpty: false }));
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      const entry = getInboxExport(id);
+      if (!entry) return { error: `No export with id "${id}"` };
+      downloadBlob(entry.blob, entry.filename, entry.source, { register: false });
+      return { ok: true };
+    },
+
+    /** Empty the Recent Exports inbox. */
+    clearRecentExports() {
+      clearInboxExports();
     },
 
     /** Validate code without rendering. Returns { valid, error? } */
@@ -2786,6 +3004,21 @@ async function main() {
         'exportSTL':       { signature: 'exportSTL() -- Download STL file', docs: '/ai.md#console-api--windowpartwright' },
         'exportOBJ':       { signature: 'exportOBJ() -- Download OBJ file', docs: '/ai.md#console-api--windowpartwright' },
         'export3MF':       { signature: 'export3MF() -- Download 3MF file', docs: '/ai.md#console-api--windowpartwright' },
+        // AI-friendly export — return bytes over the API instead of triggering a download
+        'exportGLBData':   { signature: 'await exportGLBData() -- Return GLB as {filename, mimeType, base64, sizeBytes}', docs: '/ai.md#ai-friendly-file-io' },
+        'exportSTLData':   { signature: 'await exportSTLData() -- Return STL as {filename, mimeType, base64, sizeBytes}', docs: '/ai.md#ai-friendly-file-io' },
+        'exportOBJData':   { signature: 'await exportOBJData() -- Return OBJ as {filename, mimeType, text? | base64, sizeBytes}', docs: '/ai.md#ai-friendly-file-io' },
+        'export3MFData':   { signature: 'await export3MFData() -- Return 3MF as {filename, mimeType, base64, sizeBytes}', docs: '/ai.md#ai-friendly-file-io' },
+        'exportSessionData': { signature: 'await exportSessionData(sessionId?) -- Return parsed session JSON {filename, mimeType, data, sizeBytes}', docs: '/ai.md#ai-friendly-file-io' },
+        'exportCodeData':  { signature: 'exportCodeData() -- Return editor source as {filename, mimeType, language, text, sizeBytes}', docs: '/ai.md#ai-friendly-file-io' },
+        // AI-friendly import — bypass the file picker
+        'importSessionData': { signature: 'await importSessionData(jsonObjectOrString) -- Import .partwright.json payload -> {sessionId} or {error}', docs: '/ai.md#ai-friendly-file-io' },
+        'importCodeData':  { signature: 'await importCodeData(code, language, sessionName?) -- Import raw source as new session', docs: '/ai.md#ai-friendly-file-io' },
+        // Recent Exports inbox (also visible in toolbar Export dropdown)
+        'listRecentExports': { signature: 'listRecentExports() -- Recent export metadata, newest first', docs: '/ai.md#ai-friendly-file-io' },
+        'getRecentExport': { signature: 'await getRecentExport(id) -- Look up bytes by id -> {filename, mimeType, text? | base64, ...}', docs: '/ai.md#ai-friendly-file-io' },
+        'downloadRecentExport': { signature: 'downloadRecentExport(id) -- Re-trigger browser download for an inbox entry', docs: '/ai.md#ai-friendly-file-io' },
+        'clearRecentExports': { signature: 'clearRecentExports() -- Empty the Recent Exports list', docs: '/ai.md#ai-friendly-file-io' },
         // Color regions
         'paintRegion':     { signature: 'paintRegion({point, normal, color, name?, tolerance?}) -- Paint coplanar face region', docs: '/ai.md#color-regions' },
         'listRegions':     { signature: 'listRegions() -- List all color regions', docs: '/ai.md#color-regions' },

--- a/src/ui/importPreview.ts
+++ b/src/ui/importPreview.ts
@@ -1,0 +1,158 @@
+// Modal that shows a summary of a `.partwright.json` payload before committing
+// it to IndexedDB. Mirrors the styling of showInlineConfirm so importing feels
+// like the existing confirmation flow, just with more detail.
+
+import type { ExportedSession } from '../storage/sessionManager';
+
+export interface SessionImportSummary {
+  sessionName: string;
+  schemaVersion: string;
+  versionCount: number;
+  noteCount: number;
+  annotationCount: number;
+  referenceSides: string[];
+  language: string;
+  createdAt: number | null;
+  updatedAt: number | null;
+}
+
+/** Build a SessionImportSummary from a parsed .partwright.json payload. */
+export function summarizeSessionImport(data: ExportedSession): SessionImportSummary {
+  const refs = data.session.referenceImages ?? null;
+  const referenceSides: string[] = [];
+  if (refs && typeof refs === 'object') {
+    for (const k of ['front', 'right', 'back', 'left', 'top', 'perspective'] as const) {
+      if ((refs as Record<string, unknown>)[k]) referenceSides.push(k);
+    }
+  }
+  return {
+    sessionName: data.session.name || '(unnamed)',
+    schemaVersion: data.partwright ?? data.mainifold ?? 'unknown',
+    versionCount: data.versions.length,
+    noteCount: data.notes?.length ?? 0,
+    annotationCount: data.annotations?.length ?? 0,
+    referenceSides,
+    language: data.session.language ?? 'manifold-js',
+    createdAt: data.session.created ?? null,
+    updatedAt: data.session.updated ?? null,
+  };
+}
+
+function formatTimestamp(ts: number | null): string {
+  if (!ts) return '—';
+  const d = new Date(ts);
+  return d.toLocaleString();
+}
+
+/**
+ * Show a preview modal for a session import. Resolves true if the user
+ * confirms, false if they cancel or dismiss.
+ */
+export function showImportPreview(filename: string, summary: SessionImportSummary): Promise<boolean> {
+  return new Promise((resolve) => {
+    document.querySelector('.import-preview-overlay')?.remove();
+
+    const overlay = document.createElement('div');
+    overlay.className = 'import-preview-overlay fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center';
+
+    const modal = document.createElement('div');
+    modal.className = 'bg-zinc-800 border border-zinc-600 rounded-xl shadow-2xl p-5 max-w-md mx-4 animate-modal-in';
+
+    const heading = document.createElement('div');
+    heading.className = 'flex items-baseline justify-between gap-3 mb-1';
+    const title = document.createElement('h2');
+    title.className = 'text-zinc-100 text-base font-semibold';
+    title.textContent = 'Import session?';
+    const schema = document.createElement('span');
+    schema.className = 'text-[10px] uppercase tracking-wide text-zinc-400 border border-zinc-600 rounded px-1.5 py-0.5';
+    schema.textContent = `schema ${summary.schemaVersion}`;
+    heading.appendChild(title);
+    heading.appendChild(schema);
+
+    const file = document.createElement('p');
+    file.className = 'text-[11px] text-zinc-500 mb-3 truncate';
+    file.title = filename;
+    file.textContent = filename;
+
+    const sessionName = document.createElement('p');
+    sessionName.className = 'text-zinc-200 text-sm mb-3';
+    sessionName.innerHTML = `Session: <span class="font-medium">${escapeHtml(summary.sessionName)}</span>`;
+
+    const grid = document.createElement('div');
+    grid.className = 'grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-zinc-300 mb-4';
+
+    function addRow(label: string, value: string) {
+      const k = document.createElement('div');
+      k.className = 'text-zinc-500';
+      k.textContent = label;
+      const v = document.createElement('div');
+      v.className = 'text-zinc-200 truncate';
+      v.textContent = value;
+      v.title = value;
+      grid.appendChild(k);
+      grid.appendChild(v);
+    }
+
+    addRow('Versions', String(summary.versionCount));
+    addRow('Language', summary.language);
+    addRow('Notes', String(summary.noteCount));
+    addRow('Annotations', String(summary.annotationCount));
+    addRow('Reference images', summary.referenceSides.length ? summary.referenceSides.join(', ') : 'none');
+    addRow('Last updated', formatTimestamp(summary.updatedAt));
+
+    const note = document.createElement('p');
+    note.className = 'text-[11px] text-zinc-500 leading-relaxed mb-4';
+    note.textContent = 'Imports as a new session — your current session is kept.';
+
+    const btnGroup = document.createElement('div');
+    btnGroup.className = 'flex items-center justify-end gap-2';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'px-4 py-1.5 rounded-lg text-sm text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 transition-colors';
+    cancelBtn.textContent = 'Cancel';
+
+    const importBtn = document.createElement('button');
+    importBtn.className = 'px-4 py-1.5 rounded-lg text-sm font-medium bg-blue-600 text-white hover:bg-blue-500 transition-colors';
+    importBtn.textContent = 'Import';
+
+    btnGroup.appendChild(cancelBtn);
+    btnGroup.appendChild(importBtn);
+
+    modal.appendChild(heading);
+    modal.appendChild(file);
+    modal.appendChild(sessionName);
+    modal.appendChild(grid);
+    modal.appendChild(note);
+    modal.appendChild(btnGroup);
+    overlay.appendChild(modal);
+
+    let resolved = false;
+    function finish(result: boolean) {
+      if (resolved) return;
+      resolved = true;
+      overlay.remove();
+      document.removeEventListener('keydown', onKey);
+      resolve(result);
+    }
+
+    importBtn.addEventListener('click', () => finish(true));
+    cancelBtn.addEventListener('click', () => finish(false));
+
+    overlay.addEventListener('mousedown', (e) => {
+      if (e.target === overlay) finish(false);
+    });
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') finish(false);
+      if (e.key === 'Enter') finish(true);
+    }
+    document.addEventListener('keydown', onKey);
+
+    document.body.appendChild(overlay);
+    importBtn.focus();
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -1,6 +1,13 @@
 import { resetTour, startTour } from './tour';
 import { partwrightMarkSvg } from './brand';
 import { getTheme, onThemeChange, toggleTheme } from './theme';
+import { downloadBlob } from '../export/download';
+import {
+  listExports,
+  clearExports,
+  onExportInboxChange,
+  type ExportInboxEntry,
+} from '../export/exportInbox';
 
 export interface ExampleEntry {
   code: string;
@@ -274,9 +281,81 @@ export function createToolbar(
   dropdown.appendChild(sessionOpt);
   dropdown.appendChild(codeOpt);
 
+  // Section: Recent Exports — reuse-anything-you-just-downloaded list. Hidden when empty.
+  const recentDivider = createDivider();
+  const recentHeaderRow = document.createElement('div');
+  recentHeaderRow.className = 'flex items-center justify-between px-3 pt-1 pb-0.5';
+  const recentHeader = document.createElement('div');
+  recentHeader.className = 'text-[10px] uppercase tracking-wider text-zinc-500 font-semibold';
+  recentHeader.textContent = 'Recent Exports';
+  const clearBtn = document.createElement('button');
+  clearBtn.className = 'text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors';
+  clearBtn.textContent = 'Clear';
+  clearBtn.title = 'Clear recent exports list';
+  clearBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    clearExports();
+  });
+  recentHeaderRow.appendChild(recentHeader);
+  recentHeaderRow.appendChild(clearBtn);
+
+  const recentList = document.createElement('div');
+  recentList.id = 'export-recent-list';
+
+  function renderRecent() {
+    const entries = listExports();
+    const hasEntries = entries.length > 0;
+    recentDivider.classList.toggle('hidden', !hasEntries);
+    recentHeaderRow.classList.toggle('hidden', !hasEntries);
+    recentList.classList.toggle('hidden', !hasEntries);
+    recentList.replaceChildren(...entries.map(renderRecentItem));
+  }
+
+  function renderRecentItem(entry: ExportInboxEntry): HTMLElement {
+    const btn = document.createElement('button');
+    btn.className = 'block w-full text-left px-3 py-1 hover:bg-zinc-700 transition-colors';
+    btn.title = `Download ${entry.filename} again`;
+
+    const top = document.createElement('div');
+    top.className = 'flex items-center gap-1.5';
+
+    const sourceBadge = document.createElement('span');
+    sourceBadge.className = 'text-[9px] uppercase tracking-wide text-zinc-400 border border-zinc-600 rounded px-1 py-px shrink-0';
+    sourceBadge.textContent = entry.source;
+    top.appendChild(sourceBadge);
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'text-xs text-zinc-200 truncate';
+    nameEl.textContent = entry.filename;
+    top.appendChild(nameEl);
+
+    btn.appendChild(top);
+
+    const meta = document.createElement('div');
+    meta.className = 'text-[10px] text-zinc-500 leading-tight mt-0.5';
+    meta.textContent = `${formatSize(entry.sizeBytes)} • ${formatRelativeTime(entry.timestamp)}`;
+    btn.appendChild(meta);
+
+    btn.addEventListener('click', () => {
+      dropdown.classList.add('hidden');
+      // Re-download the existing blob; don't re-register (avoid duplicate entries).
+      downloadBlob(entry.blob, entry.filename, entry.source, { register: false });
+    });
+
+    return btn;
+  }
+
+  dropdown.appendChild(recentDivider);
+  dropdown.appendChild(recentHeaderRow);
+  dropdown.appendChild(recentList);
+  renderRecent();
+  onExportInboxChange(renderRecent);
+
   exportWrapper.appendChild(dropdown);
 
   btnExport.addEventListener('click', () => {
+    // Refresh relative timestamps each time the dropdown opens.
+    renderRecent();
     dropdown.classList.toggle('hidden');
   });
 
@@ -385,4 +464,21 @@ function createDivider(): HTMLElement {
   const el = document.createElement('div');
   el.className = 'my-1 border-t border-zinc-700';
   return el;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
 }

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -8,6 +8,12 @@ import {
   onExportInboxChange,
   type ExportInboxEntry,
 } from '../export/exportInbox';
+import {
+  listImports,
+  clearImports,
+  onImportInboxChange,
+  type ImportInboxEntry,
+} from '../import/importInbox';
 
 export interface ExampleEntry {
   code: string;
@@ -23,6 +29,8 @@ export interface ToolbarCallbacks {
   onExportSessionJSON: () => void;
   onExportRawCode: () => void;
   onImportFile: (file: File) => void | Promise<void>;
+  /** Re-import a blob already held in the inbox (e.g. recent-imports re-click). */
+  onImportInboxEntry: (entry: ImportInboxEntry) => void | Promise<void>;
   onExampleSelect: (entry: ExampleEntry) => void;
   onLanguageSwitch: (lang: 'manifold-js' | 'scad') => void;
   onGoHome: () => void;
@@ -180,11 +188,17 @@ export function createToolbar(
   });
   toolbar.appendChild(select);
 
-  // Import button — file picker accepting .partwright.json / .js / .scad
+  // Import dropdown — mirrors the Export dropdown. Holds a "Choose file…" entry
+  // (the existing OS file picker) and a "Recent Imports" section for re-import.
+  const importWrapper = document.createElement('div');
+  importWrapper.className = 'relative ml-2';
+  importWrapper.id = 'import-wrapper';
+
   const btnImport = createButton('btn-import', '\u2191 Import');
   btnImport.title = 'Import a .partwright.json session, or a .js / .scad file';
-  btnImport.classList.add('ml-2');
+  importWrapper.appendChild(btnImport);
 
+  // Hidden file input — kept inside the wrapper so click-outside-to-close still works.
   const importInput = document.createElement('input');
   importInput.type = 'file';
   importInput.accept = IMPORT_ACCEPT;
@@ -194,10 +208,106 @@ export function createToolbar(
     if (file) await callbacks.onImportFile(file);
     importInput.value = '';
   });
+  importWrapper.appendChild(importInput);
 
-  btnImport.addEventListener('click', () => importInput.click());
-  toolbar.appendChild(btnImport);
-  toolbar.appendChild(importInput);
+  const importDropdown = document.createElement('div');
+  importDropdown.id = 'import-dropdown';
+  importDropdown.className = 'absolute right-0 top-full mt-1 bg-zinc-800 border border-zinc-600 rounded shadow-lg py-1 hidden z-20 w-72 max-h-[80vh] overflow-y-auto';
+
+  importDropdown.appendChild(createSectionHeader('From file'));
+  const chooseFileOpt = createDescribedItem(
+    'Choose file\u2026',
+    'Open a .partwright.json session, or a .js / .scad file.',
+  );
+  chooseFileOpt.addEventListener('click', () => {
+    importDropdown.classList.add('hidden');
+    importInput.click();
+  });
+  importDropdown.appendChild(chooseFileOpt);
+
+  // Recent Imports section — populated from the import inbox.
+  const importRecentDivider = createDivider();
+  const importRecentHeaderRow = document.createElement('div');
+  importRecentHeaderRow.className = 'flex items-center justify-between px-3 pt-1 pb-0.5';
+  const importRecentHeader = document.createElement('div');
+  importRecentHeader.className = 'text-[10px] uppercase tracking-wider text-zinc-500 font-semibold';
+  importRecentHeader.textContent = 'Recent Imports';
+  const importClearBtn = document.createElement('button');
+  importClearBtn.className = 'text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors';
+  importClearBtn.textContent = 'Clear';
+  importClearBtn.title = 'Clear recent imports list';
+  importClearBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    clearImports();
+  });
+  importRecentHeaderRow.appendChild(importRecentHeader);
+  importRecentHeaderRow.appendChild(importClearBtn);
+
+  const importRecentList = document.createElement('div');
+  importRecentList.id = 'import-recent-list';
+
+  function renderImportRecent() {
+    const entries = listImports();
+    const hasEntries = entries.length > 0;
+    importRecentDivider.classList.toggle('hidden', !hasEntries);
+    importRecentHeaderRow.classList.toggle('hidden', !hasEntries);
+    importRecentList.classList.toggle('hidden', !hasEntries);
+    importRecentList.replaceChildren(...entries.map(renderImportRecentItem));
+  }
+
+  function renderImportRecentItem(entry: ImportInboxEntry): HTMLElement {
+    const btn = document.createElement('button');
+    btn.className = 'block w-full text-left px-3 py-1 hover:bg-zinc-700 transition-colors';
+    btn.title = `Re-import ${entry.filename}`;
+
+    const top = document.createElement('div');
+    top.className = 'flex items-center gap-1.5';
+
+    const sourceBadge = document.createElement('span');
+    sourceBadge.className = 'text-[9px] uppercase tracking-wide text-zinc-400 border border-zinc-600 rounded px-1 py-px shrink-0';
+    sourceBadge.textContent = entry.source;
+    top.appendChild(sourceBadge);
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'text-xs text-zinc-200 truncate';
+    nameEl.textContent = entry.filename;
+    top.appendChild(nameEl);
+
+    btn.appendChild(top);
+
+    const meta = document.createElement('div');
+    meta.className = 'text-[10px] text-zinc-500 leading-tight mt-0.5';
+    meta.textContent = `${formatSize(entry.sizeBytes)} • ${formatRelativeTime(entry.timestamp)}`;
+    btn.appendChild(meta);
+
+    btn.addEventListener('click', () => {
+      importDropdown.classList.add('hidden');
+      void callbacks.onImportInboxEntry(entry);
+    });
+
+    return btn;
+  }
+
+  importDropdown.appendChild(importRecentDivider);
+  importDropdown.appendChild(importRecentHeaderRow);
+  importDropdown.appendChild(importRecentList);
+  renderImportRecent();
+  onImportInboxChange(renderImportRecent);
+
+  importWrapper.appendChild(importDropdown);
+
+  btnImport.addEventListener('click', () => {
+    renderImportRecent();
+    importDropdown.classList.toggle('hidden');
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!importWrapper.contains(e.target as Node)) {
+      importDropdown.classList.add('hidden');
+    }
+  });
+
+  toolbar.appendChild(importWrapper);
 
   // Export dropdown
   const exportWrapper = document.createElement('div');

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -307,6 +307,12 @@ export function createToolbar(
     }
   });
 
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !importDropdown.classList.contains('hidden')) {
+      importDropdown.classList.add('hidden');
+    }
+  });
+
   toolbar.appendChild(importWrapper);
 
   // Export dropdown
@@ -472,6 +478,12 @@ export function createToolbar(
   // Close dropdown when clicking outside
   document.addEventListener('click', (e) => {
     if (!exportWrapper.contains(e.target as Node)) {
+      dropdown.classList.add('hidden');
+    }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !dropdown.classList.contains('hidden')) {
       dropdown.classList.add('hidden');
     }
   });


### PR DESCRIPTION
## Summary

AI agents driving Partwright can't see files dropped into the user's Downloads folder, and they can't click through OS file pickers — so today they're effectively locked out of the export and import flows. This PR adds inline equivalents on `window.partwright`, plus a Recent Exports inbox and a new Import menu (with preview) visible to both humans and agents.

### Export side

- **`*Data()` exporters** return file contents over the API: `exportGLBData()`, `exportSTLData()`, `exportOBJData()`, `export3MFData()`, `exportSessionData()`, `exportCodeData()`. Binary blobs come back as base64; text formats come back as `text`. Each call also lands in the Recent Exports inbox.
- **Recent Exports inbox** — in-memory ring buffer (last 10) shared by the toolbar and the API. Every export, whether the human clicked Export or an agent called `*Data()`, shows up in a new "Recent Exports" section in the toolbar's Export dropdown. Click any entry to re-download the same blob without re-running the geometry. Agents read the list via `listRecentExports()` / `getRecentExport(id)` / `downloadRecentExport(id)` / `clearRecentExports()`.
- Each exporter is split into a pure `build*()` returning `{ blob, filename, mimeType }` and a thin `export*()` that calls it plus `downloadBlob()`. The existing toolbar download behavior is unchanged.

### Import side

- **`importSessionData(jsonObjectOrString)`** and **`importCodeData(code, language, sessionName?)`** bypass the file picker.
- **Import button is now a dropdown** matching the Export pattern. It contains a "Choose file…" entry (existing OS picker) and a "Recent Imports" section (in-memory ring buffer, last 10) so the user can re-import a file without finding it on disk again.
- **Session JSON preview modal** — every `.partwright.json` import (file picker, drag-drop, or Recent Imports re-click) now shows a preview with session name, schema version, version count, language, notes count, annotations count, reference image sides, and last-updated timestamp before committing. Replaces the bare "Open as a new session?" confirm for JSON imports; JS/SCAD imports keep the existing confirm. `importSessionData()` (programmatic) skips the preview.

### Docs

`public/ai.md` gets a new "AI-friendly file I/O" section, a TOC entry, and updated method tables; `help()` lists the new methods with the correct anchor.

## Test plan

- [x] `npm run build` clean
- [x] Existing toolbar Export → GLB/STL/OBJ/3MF/Session/Code still works (downloads fire and entries appear in Recent Exports)
- [x] `partwright.exportGLBData()` returns `{filename, mimeType, base64, sizeBytes}` with valid GLB magic bytes
- [x] `partwright.exportOBJData()` returns `text` when no colors painted, `base64` (zip) when colors are painted
- [x] `partwright.exportSessionData()` returns `{data: {partwright: "1.2", ...}}`
- [x] Round-trip: `importSessionData(exportedData)` → new session activated
- [x] Bad payloads return `{error: "..."}` with helpful messages
- [x] Toolbar "Recent Exports" section: source badge + filename + size + relative time; click re-downloads; "Clear" empties and hides
- [x] `downloadRecentExport(id)` from the API does not double-register
- [x] Import button opens dropdown (not immediate file picker)
- [x] JSON file → preview modal with all stats; Cancel rejects with no inbox entry; Import commits and inboxes
- [x] JS/SCAD file → existing confirm modal; commit adds inbox entry with correct source badge
- [x] Recent Imports re-click for JSON re-shows the preview; for JS/SCAD re-runs the confirm path
- [x] Import "Clear" empties the list and hides the section
- [ ] Manual test on staging that the toolbar dropdowns still scroll correctly when both inboxes are full