### PR TITLE
Fix GLB export: colors hidden by wireframe overlay

### DIFF
--- a/prompts/20260428-fix-glb-export-colors.md
+++ b/prompts/20260428-fix-glb-export-colors.md
@@ -1,0 +1,33 @@
+---
+session: "fix-glb-export-colors"
+timestamp: "2026-04-28T18:08:38Z"
+model: claude-opus-4-7
+---
+
+## Human
+
+Asked to investigate why GLB export doesn't render the colors applied to a
+model when opening the GLB in external viewers.
+
+## Assistant
+
+**Root cause:** The viewport scene (`src/renderer/viewport.ts`) adds two
+meshes per model that share the same geometry: a colored solid mesh
+(`MeshPhongMaterial`, `vertexColors: true`) and a wireframe overlay
+(`MeshBasicMaterial`, `wireframe: true, color: 0x000000, transparent: true,
+opacity: 0.15`). When `exportGLB` exported the entire scene, three.js's
+`GLTFExporter` silently dropped the `wireframe` flag (glTF has no wireframe
+rendering primitive), so the overlay was written as a translucent black
+triangle mesh on top of the colored mesh. External viewers either dimmed the
+colors via blend, hid them entirely (viewers that ignore alphaMode=BLEND), or
+z-fought the coplanar tris.
+
+**Fix:** In `src/export/gltf.ts`, traverse the scene before export and hide
+all viewport-only objects, restoring visibility in a `finally` block:
+
+- Wireframe meshes (any mesh whose material has `wireframe: true`)
+- Named helpers: `phantom-reference`, `dimension-lines`, `measure-overlay`,
+  `clip-cap`, `clip-plane-helper`
+- `THREE.GridHelper`, `THREE.Line`, `THREE.LineSegments`, `THREE.Sprite`
+
+The pre-existing phantom-hiding logic was folded into the same pass.

--- a/src/export/gltf.ts
+++ b/src/export/gltf.ts
@@ -1,5 +1,5 @@
+import * as THREE from 'three';
 import { getScene } from '../renderer/viewport';
-import { getPhantomGroup } from '../renderer/phantomGeometry';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
 import { downloadBlob, getExportFilename } from './download';
 
@@ -9,24 +9,50 @@ export interface BuiltExport {
   mimeType: string;
 }
 
+const EXCLUDED_NAMES = new Set([
+  'phantom-reference',
+  'dimension-lines',
+  'measure-overlay',
+  'clip-cap',
+  'clip-plane-helper',
+]);
+
+function isWireframeMesh(obj: THREE.Object3D): boolean {
+  if (!(obj instanceof THREE.Mesh)) return false;
+  const mat = obj.material;
+  const mats = Array.isArray(mat) ? mat : [mat];
+  return mats.some(m => (m as THREE.Material & { wireframe?: boolean }).wireframe === true);
+}
+
+function shouldExcludeFromExport(obj: THREE.Object3D): boolean {
+  if (EXCLUDED_NAMES.has(obj.name)) return true;
+  if (isWireframeMesh(obj)) return true;
+  if (obj instanceof THREE.GridHelper) return true;
+  if (obj instanceof THREE.Line || obj instanceof THREE.LineSegments || obj instanceof THREE.Sprite) return true;
+  return false;
+}
+
 /** Build the GLB blob for the current scene without triggering a download. */
 export async function buildGLB(customName?: string): Promise<BuiltExport> {
   const scene = getScene();
   const exporter = new GLTFExporter();
 
-  // Hide phantom geometry during export so it's excluded
-  const phantom = getPhantomGroup();
-  const wasVisible = phantom?.visible ?? true;
-  if (phantom) phantom.visible = false;
+  const hidden: THREE.Object3D[] = [];
+  scene.traverse(obj => {
+    if (obj.visible && shouldExcludeFromExport(obj)) {
+      obj.visible = false;
+      hidden.push(obj);
+    }
+  });
 
-  const result = await exporter.parseAsync(scene, { binary: true });
-
-  // Restore phantom visibility
-  if (phantom) phantom.visible = wasVisible;
-
-  const mimeType = 'model/gltf-binary';
-  const blob = new Blob([result as ArrayBuffer], { type: mimeType });
-  return { blob, filename: getExportFilename('glb', customName), mimeType };
+  try {
+    const result = await exporter.parseAsync(scene, { binary: true });
+    const mimeType = 'model/gltf-binary';
+    const blob = new Blob([result as ArrayBuffer], { type: mimeType });
+    return { blob, filename: getExportFilename('glb', customName), mimeType };
+  } finally {
+    for (const obj of hidden) obj.visible = true;
+  }
 }
 
 export async function exportGLB(customName?: string): Promise<void> {


### PR DESCRIPTION
## Summary
- The viewport adds a wireframe overlay mesh that shares geometry with the colored solid mesh. `GLTFExporter` silently drops the `wireframe: true` flag (glTF has no wireframe rendering), so the overlay was exported as a translucent black triangle mesh on top of the model — hiding or darkening user-applied vertex colors in external GLB viewers.
- Fix: in `buildGLB`, traverse the scene and hide all viewport-only objects (wireframe meshes, clip cap, clip-plane helper, dimension lines, measure overlay, phantom reference, grid, lines, sprites) for the duration of the export, restoring visibility in a `finally` block. The pre-existing phantom-hiding logic is folded into the same pass.

## Test plan
- [x] Apply per-triangle colors to a model and export GLB; open the file in an external viewer and confirm colors render. Verified end-to-end: painted a cube via `addRegion`, exported GLB, loaded back through `GLTFLoader` and rendered — vertex colors render correctly. User confirmed the same in https://gltf-viewer.donmccurdy.com/, modelviewer.dev, and threejs.org/editor.
- [x] Export a model with no painted colors; default blue still renders (geometry has no `color` attribute, material `baseColorFactor` carries the blue).
- [x] GLB structure inspection: 1 mesh, 1 material, no wireframe overlay, no dimension/measure/clip helpers (verified via JSON chunk dump).
- [x] Sanity check: dev server loads, viewport still shows wireframe overlay after exporting (visibility restored in `finally`).
- [ ] (Not retested after rebase, but unchanged behavior) Export with the cross-section / clipping plane enabled — cap mesh and clip plane helper should not appear in the exported GLB.

Note: macOS Preview / Quick Look does not render glTF vertex colors correctly regardless of file content — that was the original confusion. Use a spec-compliant viewer (donmccurdy gltf-viewer, model-viewer, Babylon Sandbox, Three.js editor, Blender, or VS Code's glTF Tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)