### PR TITLE
Paint mode: brush, slab, and tolerance tools (issue #56)

### DIFF
--- a/prompts/20260428-bucket-edge-bend.md
+++ b/prompts/20260428-bucket-edge-bend.md
@@ -1,0 +1,34 @@
+---
+session: "bucket-edge-bend"
+timestamp: "2026-04-28T20:50:00Z"
+model: claude-opus-4-7
+tools: [Edit, Bash]
+---
+
+## Human
+
+Bucket tolerance currently caps at 90° and uses seed-deviation: every face's
+normal is compared against the original seed face. That means a cylinder side
+can never flood-fill completely. Switch to edge-bend semantics (compare
+neighbor vs. parent face) and extend the slider to 180°.
+
+## Assistant
+
+### Key decisions
+
+- `findCoplanarRegion` now reads the *current* (parent) triangle's normal
+  inside the BFS loop and compares each neighbor against that, instead of
+  using a fixed seed normal captured before the loop. Same dot-product check;
+  one less captured variable; the difference is purely about *which* normal
+  the neighbor is compared against.
+- Tolerance range widens from `[0, 1]` to `[-1, 1]` because 180° → cos = -1.
+  `setBucketTolerance` clamps to the new range.
+- Slider 0..100 maps linearly to 0°..180°. The slider value-display already
+  showed `≤ N°` so no UI restructure was needed; only the conversion math
+  changed.
+- Help-line copy changed from "Strict ↔ Loose (more curved bleed)" to
+  "Coplanar only ↔ Whole connected mesh" — this conveys the new semantics
+  more accurately.
+- `public/ai.md` now documents the parent-vs-neighbor check explicitly with a
+  worked cylinder example so AI agents tuning `tolerance` understand the
+  geometry.

--- a/prompts/20260428-paint-phase-2-followup.md
+++ b/prompts/20260428-paint-phase-2-followup.md
@@ -1,0 +1,29 @@
+---
+session: "paint-phase-2-followup"
+timestamp: "2026-04-28T20:30:00Z"
+model: claude-opus-4-7
+tools: [Read, Edit, Write, Bash, Grep, mcp__playwright]
+---
+
+## Human
+
+Feedback on first pass of paint Phase 2:
+- Bucket tolerance should go up to 90°
+- Brush should be raycasting pixels, not triangle painting
+- Slab should be a draggable cuboid in the viewport, with drag-to-paint
+- Slab boundaries should be exact (not just nearest triangles)
+- Paint mode should lock model rotation
+
+Do quick wins (#1, #2 from a four-item plan); open issues for the harder ones.
+
+## Assistant
+
+### Key decisions
+
+- **Tolerance up to 90°**: replaced the sqrt-curve slider that capped at ~18° with a linear 0..90° → cos(angle) mapping. The `setBucketTolerance` API still accepts a cosine; only the slider semantics changed.
+- **Orbit lock**: matched the existing pattern from `selectMode.ts` / `textMode.ts` / `annotateMode.ts`. Paint mode `activate()` records `priorOrbitLock = isUserOrbitLocked()` and calls `setUserOrbitLock(true)`. `deactivate()` restores the prior state (so if the user manually unlocked, we don't re-lock when the next mode activates).
+- **Draggable slab cuboid**: new `src/color/slabDrag.ts` module owns its own canvas listeners (separate from paintMode's). When the slab tool is selected, paintMode's `setTool('slab')` activates the drag handler. The cuboid is a translucent `THREE.Mesh` (BoxGeometry) plus a `LineSegments` outline added to `meshGroup`.
+  - **Hover state** (no drag): cuboid appears as a thin slab (~1% of model span) at the cursor's hit-point axis coord.
+  - **Drag state**: mousedown captures start coord; subsequent mousemove updates end coord; mouseup commits a slab region from `min(start,end)` to `max(start,end)`.
+  - **Re-attach on viewport refresh**: viewport's `updateMesh` clears `meshGroup`, so `refreshVisual` checks `cuboid.parent` and re-adds if detached. Same pattern as the existing highlight mesh.
+- **Exact slab boundaries** and **pixel-level brush** are too big for this PR. Filed as separate issues for a later session.

--- a/prompts/20260428-paint-phase-2-tools.md
+++ b/prompts/20260428-paint-phase-2-tools.md
@@ -1,0 +1,44 @@
+---
+session: "paint-phase-2-tools"
+timestamp: "2026-04-28T20:00:00Z"
+model: claude-opus-4-7
+tools: [Read, Edit, Write, Bash, Grep, Glob, mcp__playwright]
+---
+
+## Human
+
+Find the GitHub issue covering paintbrush and slab painting. Add multi-direction
+slab painting (drag a slab along X/Y/Z, plus tilted/oblique slabs combining
+axes) to the issue, then implement it on a branch based on staging and open a
+PR.
+
+## Assistant
+
+### Key decisions
+
+- Found issue [#56](https://github.com/kemper/mainifold/issues/56) (Paint mode
+  Phase 2), now scoped (after #87 split) to paintbrush, slab, tolerance, and
+  OpenSCAD `color()` integration. Commented to add multi-direction slab
+  painting (axis-aligned X/Y/Z plus arbitrary tilted normals).
+- Extended `RegionDescriptor.kind === 'slab'` from `{axis, min, max}` to
+  `{normal, offset, thickness}` — collapses axis-aligned and oblique cases into
+  a single descriptor (axis-aligned is just `normal = (1,0,0)` etc). The old
+  shape was never actually wired up, so the change is internal.
+- Added `findSlabTriangles(mesh, normal, offset, thickness)` in
+  `src/color/slabPaint.ts`. Uses centroid-in-slab test:
+  `offset <= centroid · normal <= offset + thickness`.
+- Paint mode now has three tools: bucket (existing coplanar flood-fill with
+  configurable tolerance), brush (mousedown → drag → mouseup paints individual
+  triangles), slab (panel-driven; live preview via `previewTriangles`).
+- Bucket tolerance slider uses a sqrt curve over `1 - cos(θ)` and labels the
+  value as `≤ N°` so users think in angles rather than cosines.
+- Slab UI: axis selector (X/Y/Z) + offset + thickness sliders, "Paint slab"
+  button to commit. Defaults: offset = bottom of bounds, thickness = 20% of
+  span. Offset/thickness re-seed when the user picks a new axis or re-opens
+  the paint panel.
+- Added `partwright.paintFaces({triangleIds, color})` and
+  `partwright.paintSlab({axis|normal, offset, thickness, color})` API methods,
+  documented in `public/ai.md`.
+- Verified rehydration: painted a Z-slab, saved a version, navigated away,
+  reloaded `?session=...&v=1` — slab descriptor came back with the correct
+  triangle set.

--- a/public/ai.md
+++ b/public/ai.md
@@ -176,8 +176,10 @@ await partwright.listSessions()          // -> [{id, name, updated}]
 await partwright.openSession(id)         // Open existing session
 await partwright.clearAllSessions()      // Delete all sessions & versions
 
-// Color regions -- tag coplanar face regions with a color (see #color-regions)
-partwright.paintRegion({point, normal, color, name?, tolerance?}) // -> {id, name, triangles} or {error}
+// Color regions -- tag face regions with a color (see #color-regions)
+partwright.paintRegion({point, normal, color, name?, tolerance?}) // bucket: coplanar flood-fill -> {id, name, triangles} or {error}
+partwright.paintFaces({triangleIds, color, name?})                // brush: paint specific triangle indices -> {id, name, triangles} or {error}
+partwright.paintSlab({axis|normal, offset, thickness, color, name?}) // slab: paint a planar range -> {id, name, triangles} or {error}
 partwright.listRegions()                 // -> [{id, name, color, source, triangles, order}, ...]
 partwright.clearColors()                 // Remove all regions
 
@@ -421,6 +423,41 @@ partwright.clearColors()    // remove all regions
 ```
 
 **How face matching works.** `paintRegion` flood-fills outward from the seed triangle, including any neighbor whose normal is within `tolerance` of the seed's. Pick `point` slightly inside the model surface and pass the outward-pointing `normal` -- the seed resolver looks for the triangle whose plane the point lies on and whose normal aligns with yours.
+
+**Other paint tools.**
+
+```js
+// Brush: paint specific triangle indices (no flood-fill).
+// Use partwright.getGeometry() to find triangle indices, or capture them from
+// hover during a UI-driven paint session.
+partwright.paintFaces({
+  triangleIds: [12, 13, 14, 27],
+  color: [0, 0.6, 1],
+  name: "Inset detail",
+});
+
+// Slab: paint every face whose centroid falls inside a planar slab.
+// Axis-aligned slab (most common — pick X/Y/Z and slide along that axis):
+partwright.paintSlab({
+  axis: "z",
+  offset: 0,           // slab spans Z in [offset, offset + thickness]
+  thickness: 5,
+  color: [1, 0.4, 0],
+  name: "Bottom 5mm",
+});
+
+// Tilted/oblique slab — pass an arbitrary normal vector. Doesn't need to be
+// unit-length; it gets normalized. The slab is the set of points P satisfying
+// offset <= P · normal <= offset + thickness.
+partwright.paintSlab({
+  normal: [1, 0, 1],   // 45° between +X and +Z
+  offset: 0,
+  thickness: 8,
+  color: [0.8, 0, 0.5],
+});
+```
+
+**Bucket tolerance.** `paintRegion`'s `tolerance` is a cosine threshold (default `0.9995`, ≈ 1.8°). Loosen it to make flood-fill spill across slightly curved surfaces (e.g. a chamfered edge), tighten it to keep flood-fill confined to a single perfectly flat face. The Paint UI exposes the same control as a slider labeled in degrees.
 
 **Editor lock.** When color regions exist, the editor is locked (the model can't be re-run, because new geometry would invalidate the saved triangle indices). To edit code, the user clicks "Unlock to edit" in the UI. Agents that need to iterate on the geometry should call `clearColors()` first, or fork a new uncolored version with `forkVersion`.
 

--- a/public/ai.md
+++ b/public/ai.md
@@ -457,7 +457,7 @@ partwright.paintSlab({
 });
 ```
 
-**Bucket tolerance.** `paintRegion`'s `tolerance` is a cosine threshold (default `0.9995`, ≈ 1.8°). Loosen it to make flood-fill spill across slightly curved surfaces (e.g. a chamfered edge), tighten it to keep flood-fill confined to a single perfectly flat face. The Paint UI exposes the same control as a slider labeled in degrees.
+**Bucket tolerance.** `paintRegion`'s `tolerance` is a cosine threshold for the bend angle between adjacent faces (default `0.9995`, ≈ 1.8°). The flood-fill crosses an edge only when the bend at that edge is below the angle threshold — checked between the *parent* face and each *neighbor*, not against the seed. This means flood-fill follows curved surfaces: a 32-sided cylinder bends ~11° per face, so any tolerance ≥ cos(11°) ≈ `0.98` covers the whole cylinder. Set tolerance to `-1` (180°) to paint the entire connected mesh. The Paint UI exposes the same control as a slider labeled in degrees (0°–180°).
 
 **Editor lock.** When color regions exist, the editor is locked (the model can't be re-run, because new geometry would invalidate the saved triangle indices). To edit code, the user clicks "Unlock to edit" in the UI. Agents that need to iterate on the geometry should call `clearColors()` first, or fork a new uncolored version with `forkVersion`.
 

--- a/src/color/adjacency.ts
+++ b/src/color/adjacency.ts
@@ -89,9 +89,16 @@ export function buildAdjacency(mesh: MeshData): AdjacencyGraph {
   };
 }
 
-/** BFS from a seed triangle, collecting all adjacent triangles whose normal is
- *  within `normalTolerance` (dot product threshold, e.g. 0.9995) of the seed's normal.
- *  Returns the set of triangle indices forming the coplanar region. */
+/** BFS from a seed triangle, crossing each edge only when the bend angle
+ *  between the two faces sharing that edge is small enough — i.e. when
+ *  `cos(angle) >= normalTolerance`. The tolerance is checked against the
+ *  *parent* (already-visited) triangle's normal, not the seed's, so flood-fill
+ *  follows curved surfaces (e.g. a cylinder side) where each adjacent face
+ *  bends only a small amount even though the cumulative bend is large.
+ *
+ *  `normalTolerance` is in [-1, 1] — the cosine of the maximum allowed bend
+ *  angle. 1 = strict (only exactly-coplanar faces); -1 = no limit (whole
+ *  connected component). Default 0.9995 ≈ 1.8°. */
 export function findCoplanarRegion(
   seedTri: number,
   adjacency: AdjacencyGraph,
@@ -100,15 +107,15 @@ export function findCoplanarRegion(
   const { neighbors, normals } = adjacency;
   const result = new Set<number>();
 
-  const seedNx = normals[seedTri * 3];
-  const seedNy = normals[seedTri * 3 + 1];
-  const seedNz = normals[seedTri * 3 + 2];
-
   const queue = [seedTri];
   result.add(seedTri);
 
   while (queue.length > 0) {
     const current = queue.pop()!;
+    const cnx = normals[current * 3];
+    const cny = normals[current * 3 + 1];
+    const cnz = normals[current * 3 + 2];
+
     const adj = neighbors[current];
     for (let i = 0; i < adj.length; i++) {
       const neighbor = adj[i];
@@ -118,7 +125,7 @@ export function findCoplanarRegion(
       const ny = normals[neighbor * 3 + 1];
       const nz = normals[neighbor * 3 + 2];
 
-      const dot = seedNx * nx + seedNy * ny + seedNz * nz;
+      const dot = cnx * nx + cny * ny + cnz * nz;
       if (dot >= normalTolerance) {
         result.add(neighbor);
         queue.push(neighbor);

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -64,7 +64,7 @@ export function getTool(): PaintTool {
 }
 
 export function setBucketTolerance(tol: number): void {
-  bucketTolerance = Math.max(0, Math.min(1, tol));
+  bucketTolerance = Math.max(-1, Math.min(1, tol));
 }
 
 export function getBucketTolerance(): number {

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -6,7 +6,9 @@ import type { MeshData } from '../geometry/types';
 import { pickFace } from './facePicker';
 import { buildAdjacency, findCoplanarRegion, getTriangleNormal, type AdjacencyGraph } from './adjacency';
 import { addRegion, getRegions } from './regions';
-import { getMeshGroup, getRenderer } from '../renderer/viewport';
+import { getMeshGroup, getRenderer, setUserOrbitLock, isUserOrbitLocked } from '../renderer/viewport';
+import { activate as activateSlabDrag, deactivate as deactivateSlabDrag, onMeshChanged as onSlabDragMeshChanged } from './slabDrag';
+export { setSlabAxis, getSlabAxis } from './slabDrag';
 
 export type PaintTool = 'bucket' | 'brush' | 'slab';
 
@@ -25,6 +27,10 @@ let hoveredTriangles: Set<number> | null = null;
 let brushPainting = false;
 let brushSession: Set<number> | null = null;
 
+// Orbit lock — paint mode locks model rotation by default. The lock-toggle
+// button in the toolbar reflects this; users can unlock manually to reposition.
+let priorOrbitLock = false;
+
 // Callbacks
 let onRegionPainted: (() => void) | null = null;
 let onToolChange: ((tool: PaintTool) => void) | null = null;
@@ -41,8 +47,15 @@ export function getColor(): [number, number, number] {
 
 export function setTool(tool: PaintTool): void {
   if (currentTool === tool) return;
+  const prev = currentTool;
   currentTool = tool;
   clearHighlight();
+
+  if (active) {
+    if (tool === 'slab') activateSlabDrag();
+    else if (prev === 'slab') deactivateSlabDrag();
+  }
+
   if (onToolChange) onToolChange(tool);
 }
 
@@ -79,6 +92,7 @@ export function updatePaintMesh(mesh: MeshData): void {
   currentMesh = mesh;
   if (active) {
     adjacency = buildAdjacency(mesh);
+    onSlabDragMeshChanged();
   }
   clearHighlight();
 }
@@ -91,18 +105,27 @@ export function activate(): void {
     adjacency = buildAdjacency(currentMesh);
   }
 
+  priorOrbitLock = isUserOrbitLocked();
+  setUserOrbitLock(true);
+
   const canvas = getRenderer().domElement;
   canvas.addEventListener('mousemove', onMouseMove);
   canvas.addEventListener('mousedown', onMouseDown);
   canvas.addEventListener('mouseup', onMouseUp);
   canvas.addEventListener('mouseleave', onMouseLeave);
   canvas.style.cursor = 'crosshair';
+
+  if (currentTool === 'slab') activateSlabDrag();
 }
 
 export function deactivate(): void {
   if (!active) return;
   active = false;
   adjacency = null;
+
+  if (!priorOrbitLock) setUserOrbitLock(false);
+
+  deactivateSlabDrag();
 
   const canvas = getRenderer().domElement;
   canvas.removeEventListener('mousemove', onMouseMove);

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -1,4 +1,5 @@
-// Paint mode — coordinates face picking, hover preview, and color application
+// Paint mode — coordinates face picking, hover preview, and color application.
+// Supports three tools: bucket (coplanar flood fill), brush (single face), slab (axis/normal range).
 
 import * as THREE from 'three';
 import type { MeshData } from '../geometry/types';
@@ -7,8 +8,12 @@ import { buildAdjacency, findCoplanarRegion, getTriangleNormal, type AdjacencyGr
 import { addRegion, getRegions } from './regions';
 import { getMeshGroup, getRenderer } from '../renderer/viewport';
 
+export type PaintTool = 'bucket' | 'brush' | 'slab';
+
 let active = false;
 let currentColor: [number, number, number] = [1, 0.2, 0.2]; // default red
+let currentTool: PaintTool = 'bucket';
+let bucketTolerance = 0.9995;
 let adjacency: AdjacencyGraph | null = null;
 let currentMesh: MeshData | null = null;
 
@@ -16,8 +21,13 @@ let currentMesh: MeshData | null = null;
 let highlightMesh: THREE.Mesh | null = null;
 let hoveredTriangles: Set<number> | null = null;
 
+// Brush drag state
+let brushPainting = false;
+let brushSession: Set<number> | null = null;
+
 // Callbacks
 let onRegionPainted: (() => void) | null = null;
+let onToolChange: ((tool: PaintTool) => void) | null = null;
 
 export function isActive(): boolean { return active; }
 
@@ -29,8 +39,39 @@ export function getColor(): [number, number, number] {
   return currentColor;
 }
 
+export function setTool(tool: PaintTool): void {
+  if (currentTool === tool) return;
+  currentTool = tool;
+  clearHighlight();
+  if (onToolChange) onToolChange(tool);
+}
+
+export function getTool(): PaintTool {
+  return currentTool;
+}
+
+export function setBucketTolerance(tol: number): void {
+  bucketTolerance = Math.max(0, Math.min(1, tol));
+}
+
+export function getBucketTolerance(): number {
+  return bucketTolerance;
+}
+
 export function setOnRegionPainted(fn: () => void): void {
   onRegionPainted = fn;
+}
+
+export function setOnToolChange(fn: (tool: PaintTool) => void): void {
+  onToolChange = fn;
+}
+
+export function getCurrentMesh(): MeshData | null {
+  return currentMesh;
+}
+
+export function getAdjacency(): AdjacencyGraph | null {
+  return adjacency;
 }
 
 /** Rebuild adjacency graph for a new mesh. Call this whenever updateMesh fires. */
@@ -52,7 +93,9 @@ export function activate(): void {
 
   const canvas = getRenderer().domElement;
   canvas.addEventListener('mousemove', onMouseMove);
-  canvas.addEventListener('click', onClick);
+  canvas.addEventListener('mousedown', onMouseDown);
+  canvas.addEventListener('mouseup', onMouseUp);
+  canvas.addEventListener('mouseleave', onMouseLeave);
   canvas.style.cursor = 'crosshair';
 }
 
@@ -63,13 +106,33 @@ export function deactivate(): void {
 
   const canvas = getRenderer().domElement;
   canvas.removeEventListener('mousemove', onMouseMove);
-  canvas.removeEventListener('click', onClick);
+  canvas.removeEventListener('mousedown', onMouseDown);
+  canvas.removeEventListener('mouseup', onMouseUp);
+  canvas.removeEventListener('mouseleave', onMouseLeave);
   canvas.style.cursor = '';
   clearHighlight();
+  brushPainting = false;
+  brushSession = null;
 }
 
 function onMouseMove(event: MouseEvent): void {
   if (!adjacency || !currentMesh) return;
+
+  // Slab tool doesn't use viewport hover; controls are panel-based.
+  if (currentTool === 'slab') {
+    clearHighlight();
+    return;
+  }
+
+  // Brush drag: collect triangles into the active brush session.
+  if (currentTool === 'brush' && brushPainting && brushSession) {
+    const result = pickFace(event);
+    if (result) {
+      brushSession.add(result.triangleIndex);
+      showHighlight(brushSession);
+    }
+    return;
+  }
 
   const result = pickFace(event);
   if (!result) {
@@ -77,51 +140,119 @@ function onMouseMove(event: MouseEvent): void {
     return;
   }
 
-  const region = findCoplanarRegion(result.triangleIndex, adjacency);
+  let region: Set<number>;
+  if (currentTool === 'brush') {
+    region = new Set([result.triangleIndex]);
+  } else {
+    region = findCoplanarRegion(result.triangleIndex, adjacency, bucketTolerance);
+  }
+
   if (hoveredTriangles && setsEqual(hoveredTriangles, region)) return;
 
   hoveredTriangles = region;
   showHighlight(region);
 }
 
-function onClick(event: MouseEvent): void {
+function onMouseDown(event: MouseEvent): void {
   if (!adjacency || !currentMesh) return;
+  if (event.button !== 0) return;
+  if (currentTool === 'slab') return;
 
+  if (currentTool === 'brush') {
+    const result = pickFace(event);
+    if (!result) return;
+    brushPainting = true;
+    brushSession = new Set([result.triangleIndex]);
+    showHighlight(brushSession);
+    event.preventDefault();
+  }
+}
+
+function onMouseUp(event: MouseEvent): void {
+  if (!adjacency || !currentMesh) return;
+  if (event.button !== 0) return;
+  if (currentTool === 'slab') return;
+
+  if (currentTool === 'brush') {
+    if (!brushPainting || !brushSession || brushSession.size === 0) {
+      brushPainting = false;
+      brushSession = null;
+      return;
+    }
+    const triangles = brushSession;
+    const existingCount = getRegions().length;
+    addRegion(
+      `Region ${existingCount + 1}`,
+      [...currentColor] as [number, number, number],
+      'paintbrush',
+      { kind: 'triangles', ids: [...triangles] },
+      triangles,
+    );
+    brushPainting = false;
+    brushSession = null;
+    clearHighlight();
+    if (onRegionPainted) onRegionPainted();
+    return;
+  }
+
+  // Bucket: paint on click release (matches the previous click behavior)
   const result = pickFace(event);
   if (!result) return;
 
-  const region = findCoplanarRegion(result.triangleIndex, adjacency);
+  const region = findCoplanarRegion(result.triangleIndex, adjacency, bucketTolerance);
   const normal = getTriangleNormal(result.triangleIndex, adjacency);
 
-  // Create a named region
   const existingCount = getRegions().length;
-  const name = `Region ${existingCount + 1}`;
-
   addRegion(
-    name,
+    `Region ${existingCount + 1}`,
     [...currentColor] as [number, number, number],
     'face-pick',
     {
       kind: 'coplanar',
       seedPoint: result.point,
       seedNormal: normal,
-      normalTolerance: 0.9995,
+      normalTolerance: bucketTolerance,
     },
     region,
   );
 
   clearHighlight();
-
   if (onRegionPainted) onRegionPainted();
+}
+
+function onMouseLeave(): void {
+  if (currentTool === 'brush' && brushPainting && brushSession && brushSession.size > 0) {
+    // Commit whatever the user has painted so far.
+    const triangles = brushSession;
+    const existingCount = getRegions().length;
+    addRegion(
+      `Region ${existingCount + 1}`,
+      [...currentColor] as [number, number, number],
+      'paintbrush',
+      { kind: 'triangles', ids: [...triangles] },
+      triangles,
+    );
+    if (onRegionPainted) onRegionPainted();
+  }
+  brushPainting = false;
+  brushSession = null;
+  clearHighlight();
+}
+
+/** Public helper: render a hover-style highlight over a triangle set.
+ *  Used by the slab UI for live preview. Returns a teardown function. */
+export function previewTriangles(triangles: Set<number>): () => void {
+  showHighlight(triangles);
+  return () => clearHighlight();
 }
 
 function showHighlight(triangles: Set<number>): void {
   clearHighlight();
   if (!currentMesh) return;
+  if (triangles.size === 0) return;
 
   const { triVerts, vertProperties, numProp } = currentMesh;
 
-  // Build a geometry from just the highlighted triangles
   const positions = new Float32Array(triangles.size * 9);
   let idx = 0;
 

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -301,7 +301,7 @@ function createBucketControls(): HTMLElement {
   slider.step = '1';
   slider.value = String(toleranceToSliderPct(getBucketTolerance()));
   slider.className = 'w-full accent-blue-500';
-  slider.title = 'Maximum angle (0\u00B0\u201390\u00B0) the flood-fill is allowed to bleed across';
+  slider.title = 'Maximum bend angle (0\u00B0\u2013180\u00B0) between adjacent faces the flood-fill is allowed to cross';
   slider.addEventListener('input', () => {
     const tol = sliderPctToTolerance(parseInt(slider.value, 10));
     setBucketTolerance(tol);
@@ -311,21 +311,22 @@ function createBucketControls(): HTMLElement {
 
   const help = document.createElement('div');
   help.className = 'text-[10px] text-zinc-500 mt-1';
-  help.textContent = 'Strict \u2190\u2014\u2014\u2192 Loose (more curved bleed)';
+  help.textContent = 'Coplanar only \u2190\u2014\u2014\u2192 Whole connected mesh';
   wrap.appendChild(help);
 
   return wrap;
 }
 
 function toleranceToSliderPct(tol: number): number {
-  // Slider 0..100 maps directly to angle 0°..90° (i.e. tol = cos(angle)).
-  // 0 = strict (only the exact face), 100 = paints everything within 90°.
+  // Slider 0..100 maps to angle 0°..180° (i.e. tol = cos(angle)).
+  // 0 = strict (only exactly-coplanar adjacent faces);
+  // 100 = no limit (paints the whole connected component).
   const angleDeg = Math.acos(Math.max(-1, Math.min(1, tol))) * 180 / Math.PI;
-  return Math.round(Math.max(0, Math.min(90, angleDeg)) / 90 * 100);
+  return Math.round(Math.max(0, Math.min(180, angleDeg)) / 180 * 100);
 }
 
 function sliderPctToTolerance(pct: number): number {
-  const angleDeg = Math.max(0, Math.min(100, pct)) / 100 * 90;
+  const angleDeg = Math.max(0, Math.min(100, pct)) / 100 * 180;
   return Math.cos(angleDeg * Math.PI / 180);
 }
 

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -1,8 +1,22 @@
-// Paint mode UI — button toggle, color picker, region count badge,
-// undo/redo/hide/clear actions.
+// Paint mode UI — button toggle, color picker, region count badge, tool
+// selection (bucket / brush / slab), and undo/redo/hide/clear actions.
 
-import { activate, deactivate, isActive, setColor } from './paintMode';
 import {
+  activate,
+  deactivate,
+  isActive,
+  setColor,
+  getColor,
+  setTool,
+  getTool,
+  setBucketTolerance,
+  getBucketTolerance,
+  getCurrentMesh,
+  previewTriangles,
+  type PaintTool,
+} from './paintMode';
+import {
+  addRegion,
   getRegions,
   onChange as onRegionsChange,
   onRedoChange,
@@ -14,6 +28,7 @@ import {
   canRedoRegion,
   clearRegions,
 } from './regions';
+import { projectionRange, findSlabTriangles, AXIS_NORMALS } from './slabPaint';
 import { forceDeactivate as forceDeactivateAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as forceDeactivateAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as forceDeactivateAnnotateSelect } from '../annotations/selectMode';
@@ -35,24 +50,34 @@ let regionCountBadge: HTMLElement | null = null;
 let visibilityBtn: HTMLButtonElement | null = null;
 let undoBtn: HTMLButtonElement | null = null;
 let redoBtn: HTMLButtonElement | null = null;
+let toolButtons: Partial<Record<PaintTool, HTMLButtonElement>> = {};
+let bucketControls: HTMLElement | null = null;
+let slabControls: HTMLElement | null = null;
+
+// Slab UI state
+type SlabAxis = 'x' | 'y' | 'z';
+let slabAxis: SlabAxis = 'z';
+let slabOffsetInput: HTMLInputElement | null = null;
+let slabThicknessInput: HTMLInputElement | null = null;
+let slabOffsetValue: HTMLElement | null = null;
+let slabThicknessValue: HTMLElement | null = null;
+let slabPreviewTeardown: (() => void) | null = null;
+let slabInputsInitialized = false;
 
 /** Initialize the paint UI inside the clip-controls overlay area. */
 export function initPaintUI(controlsContainer: HTMLElement): void {
-  // Paint toggle button
   paintBtn = document.createElement('button');
   paintBtn.id = 'paint-toggle';
   paintBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
   paintBtn.textContent = '\uD83C\uDFA8 Paint';
   paintBtn.title = 'Paint color regions on model faces';
 
-  // Region count badge
   regionCountBadge = document.createElement('span');
   regionCountBadge.className = 'hidden ml-1 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-blue-500 text-white leading-none';
   paintBtn.appendChild(regionCountBadge);
 
   paintBtn.addEventListener('click', togglePaintMode);
 
-  // Insert before the measure toggle
   const measureBtn = controlsContainer.querySelector('#measure-toggle');
   if (measureBtn) {
     controlsContainer.insertBefore(paintBtn, measureBtn);
@@ -60,11 +85,9 @@ export function initPaintUI(controlsContainer: HTMLElement): void {
     controlsContainer.appendChild(paintBtn);
   }
 
-  // Color picker panel (hidden by default)
   pickerPanel = createPickerPanel();
   controlsContainer.appendChild(pickerPanel);
 
-  // Update badge + button states when regions / redo / visibility change
   onRegionsChange(() => {
     updateBadge();
     updateUndoButton();
@@ -82,14 +105,16 @@ function togglePaintMode(): void {
     deactivate();
     updateButtonState(false);
     pickerPanel?.classList.add('hidden');
+    teardownSlabPreview();
+    slabInputsInitialized = false;
   } else {
-    // Mutual exclusion with annotate (pen + text + select) modes.
     forceDeactivateAnnotate();
     forceDeactivateAnnotateText();
     forceDeactivateAnnotateSelect();
     activate();
     updateButtonState(true);
     pickerPanel?.classList.remove('hidden');
+    syncToolPanels();
   }
 }
 
@@ -117,15 +142,28 @@ function createPickerPanel(): HTMLElement {
   const panel = document.createElement('div');
   panel.id = 'paint-picker-panel';
   panel.className = 'hidden absolute top-10 right-2 z-20 bg-zinc-800/95 backdrop-blur border border-zinc-600/60 rounded-lg p-2.5 shadow-xl';
-  panel.style.minWidth = '160px';
+  panel.style.minWidth = '200px';
+  panel.style.maxWidth = '240px';
 
-  // Title
+  // === Tool selector ===
+  const toolTitle = document.createElement('div');
+  toolTitle.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1.5 font-medium';
+  toolTitle.textContent = 'Tool';
+  panel.appendChild(toolTitle);
+
+  const toolRow = document.createElement('div');
+  toolRow.className = 'grid grid-cols-3 gap-1 mb-2.5';
+  toolRow.appendChild(createToolButton('bucket', '\u{1FAA3} Bucket', 'Flood-fill across coplanar faces'));
+  toolRow.appendChild(createToolButton('brush', '\u{1F58C}\uFE0F Brush', 'Paint individual triangles (drag to paint)'));
+  toolRow.appendChild(createToolButton('slab', '\u{1F9F1} Slab', 'Paint all faces inside a slab range'));
+  panel.appendChild(toolRow);
+
+  // === Color picker ===
   const title = document.createElement('div');
   title.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1.5 font-medium';
   title.textContent = 'Color';
   panel.appendChild(title);
 
-  // Preset swatches grid
   const grid = document.createElement('div');
   grid.className = 'grid grid-cols-4 gap-1.5 mb-2';
 
@@ -134,22 +172,16 @@ function createPickerPanel(): HTMLElement {
     swatch.className = 'w-6 h-6 rounded border-2 border-transparent hover:border-white/50 transition-colors';
     swatch.style.backgroundColor = rgbToCSS(color);
     swatch.title = rgbToHex(color);
-
     swatch.addEventListener('click', () => {
       setColor(color);
       updateActiveSwatch(grid, swatch);
     });
-
     grid.appendChild(swatch);
   }
-
-  // Mark first swatch as active
   const first = grid.children[0] as HTMLElement;
   if (first) first.classList.add('border-white/80', 'ring-1', 'ring-white/30');
-
   panel.appendChild(grid);
 
-  // Custom color input
   const customRow = document.createElement('div');
   customRow.className = 'flex items-center gap-1.5';
 
@@ -158,14 +190,12 @@ function createPickerPanel(): HTMLElement {
   colorInput.value = rgbToHex(PRESET_COLORS[0]);
   colorInput.className = 'w-6 h-6 rounded cursor-pointer border-0 p-0 bg-transparent';
   colorInput.title = 'Custom color';
-
   colorInput.addEventListener('input', () => {
     const hex = colorInput.value;
     const r = parseInt(hex.slice(1, 3), 16) / 255;
     const g = parseInt(hex.slice(3, 5), 16) / 255;
     const b = parseInt(hex.slice(5, 7), 16) / 255;
     setColor([r, g, b]);
-    // Clear active swatch borders
     for (const child of Array.from(grid.children)) {
       (child as HTMLElement).classList.remove('border-white/80', 'ring-1', 'ring-white/30');
     }
@@ -179,7 +209,15 @@ function createPickerPanel(): HTMLElement {
   customRow.appendChild(customLabel);
   panel.appendChild(customRow);
 
-  // Region list (compact)
+  // === Bucket tool controls (tolerance slider) ===
+  bucketControls = createBucketControls();
+  panel.appendChild(bucketControls);
+
+  // === Slab tool controls ===
+  slabControls = createSlabControls();
+  panel.appendChild(slabControls);
+
+  // === Region list ===
   const regionList = document.createElement('div');
   regionList.id = 'paint-region-list';
   regionList.className = 'mt-2 border-t border-zinc-700 pt-2 max-h-32 overflow-y-auto';
@@ -187,7 +225,7 @@ function createPickerPanel(): HTMLElement {
 
   onRegionsChange(() => updateRegionList(regionList));
 
-  // Action row: visibility, undo, redo, clear
+  // === Action row ===
   const actions = document.createElement('div');
   actions.className = 'flex items-center gap-1.5 mt-2 pt-2 border-t border-zinc-700 flex-wrap';
 
@@ -223,6 +261,306 @@ function createPickerPanel(): HTMLElement {
   panel.appendChild(actions);
 
   return panel;
+}
+
+function createToolButton(tool: PaintTool, label: string, tooltip: string): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.className = toolButtonClass(tool === getTool());
+  btn.textContent = label;
+  btn.title = tooltip;
+  btn.addEventListener('click', () => {
+    setTool(tool);
+    syncToolPanels();
+  });
+  toolButtons[tool] = btn;
+  return btn;
+}
+
+function toolButtonClass(active: boolean): string {
+  if (active) {
+    return 'px-1.5 py-1 rounded text-[10px] bg-blue-500/30 text-blue-200 border border-blue-500/50 transition-colors text-center';
+  }
+  return 'px-1.5 py-1 rounded text-[10px] bg-zinc-700/40 text-zinc-300 hover:bg-zinc-600/60 border border-transparent transition-colors text-center';
+}
+
+function syncToolPanels(): void {
+  const tool = getTool();
+  for (const [t, btn] of Object.entries(toolButtons)) {
+    if (btn) btn.className = toolButtonClass(t === tool);
+  }
+  if (bucketControls) bucketControls.classList.toggle('hidden', tool !== 'bucket');
+  if (slabControls) {
+    slabControls.classList.toggle('hidden', tool !== 'slab');
+    if (tool === 'slab') {
+      refreshSlabRange();
+      updateSlabPreview();
+    } else {
+      teardownSlabPreview();
+    }
+  }
+}
+
+function createBucketControls(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'mt-2 pt-2 border-t border-zinc-700';
+
+  const label = document.createElement('div');
+  label.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium flex items-center justify-between';
+  const labelText = document.createElement('span');
+  labelText.textContent = 'Bucket tolerance';
+  const valueSpan = document.createElement('span');
+  valueSpan.className = 'text-zinc-400 normal-case tracking-normal';
+  valueSpan.textContent = formatTolerance(getBucketTolerance());
+  label.appendChild(labelText);
+  label.appendChild(valueSpan);
+  wrap.appendChild(label);
+
+  // Slider exposes 1 - tolerance on a quasi-log scale so small changes near
+  // 1.0 (the strict end) are easy to dial in.
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.min = '0';
+  slider.max = '100';
+  slider.step = '1';
+  slider.value = String(toleranceToSliderPct(getBucketTolerance()));
+  slider.className = 'w-full accent-blue-500';
+  slider.title = 'How aggressively flood-fill spreads across near-coplanar faces';
+  slider.addEventListener('input', () => {
+    const tol = sliderPctToTolerance(parseInt(slider.value, 10));
+    setBucketTolerance(tol);
+    valueSpan.textContent = formatTolerance(tol);
+  });
+  wrap.appendChild(slider);
+
+  const help = document.createElement('div');
+  help.className = 'text-[10px] text-zinc-500 mt-1';
+  help.textContent = 'Strict \u2190\u2014\u2014\u2192 Loose (more curved bleed)';
+  wrap.appendChild(help);
+
+  return wrap;
+}
+
+function toleranceToSliderPct(tol: number): number {
+  // tol in [0,1]. Map (1 - tol) in [0, 0.05] to slider 0..100 with sqrt curve.
+  // tol = 1 -> 0 (strictest); tol = 0.95 -> 100 (loosest practical)
+  const inv = Math.max(0, Math.min(0.05, 1 - tol));
+  return Math.round(Math.sqrt(inv / 0.05) * 100);
+}
+
+function sliderPctToTolerance(pct: number): number {
+  const t = Math.max(0, Math.min(100, pct)) / 100;
+  const inv = (t * t) * 0.05;
+  return Math.max(0.95, Math.min(1, 1 - inv));
+}
+
+function formatTolerance(tol: number): string {
+  // Show as "θ ≤ N°" — the angle whose cosine is `tol`. Friendlier than 0.9995.
+  const angleDeg = Math.acos(Math.max(-1, Math.min(1, tol))) * 180 / Math.PI;
+  return `\u2264 ${angleDeg.toFixed(1)}\u00B0`;
+}
+
+function createSlabControls(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'mt-2 pt-2 border-t border-zinc-700 hidden';
+
+  // Axis selector
+  const axisRow = document.createElement('div');
+  axisRow.className = 'mb-2';
+  const axisLabel = document.createElement('div');
+  axisLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium';
+  axisLabel.textContent = 'Slab axis';
+  axisRow.appendChild(axisLabel);
+
+  const axisBtns = document.createElement('div');
+  axisBtns.className = 'grid grid-cols-3 gap-1';
+  for (const axis of ['x', 'y', 'z'] as const) {
+    const btn = document.createElement('button');
+    btn.dataset.axis = axis;
+    btn.textContent = axis.toUpperCase();
+    btn.className = axisButtonClass(axis === slabAxis);
+    btn.addEventListener('click', () => {
+      slabAxis = axis;
+      for (const child of Array.from(axisBtns.children)) {
+        const el = child as HTMLButtonElement;
+        el.className = axisButtonClass(el.dataset.axis === slabAxis);
+      }
+      // Axis change: re-seed slider to the new axis's defaults.
+      slabInputsInitialized = false;
+      refreshSlabRange();
+      updateSlabPreview();
+    });
+    axisBtns.appendChild(btn);
+  }
+  axisRow.appendChild(axisBtns);
+  wrap.appendChild(axisRow);
+
+  // Offset slider
+  const offsetWrap = document.createElement('div');
+  offsetWrap.className = 'mb-2';
+  const offsetLabel = document.createElement('div');
+  offsetLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium flex items-center justify-between';
+  const offsetText = document.createElement('span');
+  offsetText.textContent = 'Offset';
+  slabOffsetValue = document.createElement('span');
+  slabOffsetValue.className = 'text-zinc-400 normal-case tracking-normal';
+  slabOffsetValue.textContent = '0';
+  offsetLabel.appendChild(offsetText);
+  offsetLabel.appendChild(slabOffsetValue);
+  offsetWrap.appendChild(offsetLabel);
+
+  slabOffsetInput = document.createElement('input');
+  slabOffsetInput.type = 'range';
+  slabOffsetInput.className = 'w-full accent-blue-500';
+  slabOffsetInput.title = 'Slide the slab along the chosen axis';
+  slabOffsetInput.addEventListener('input', updateSlabPreview);
+  offsetWrap.appendChild(slabOffsetInput);
+  wrap.appendChild(offsetWrap);
+
+  // Thickness slider
+  const thickWrap = document.createElement('div');
+  thickWrap.className = 'mb-2';
+  const thickLabel = document.createElement('div');
+  thickLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium flex items-center justify-between';
+  const thickText = document.createElement('span');
+  thickText.textContent = 'Thickness';
+  slabThicknessValue = document.createElement('span');
+  slabThicknessValue.className = 'text-zinc-400 normal-case tracking-normal';
+  slabThicknessValue.textContent = '0';
+  thickLabel.appendChild(thickText);
+  thickLabel.appendChild(slabThicknessValue);
+  thickWrap.appendChild(thickLabel);
+
+  slabThicknessInput = document.createElement('input');
+  slabThicknessInput.type = 'range';
+  slabThicknessInput.className = 'w-full accent-blue-500';
+  slabThicknessInput.title = 'Width of the slab along the chosen axis';
+  slabThicknessInput.addEventListener('input', updateSlabPreview);
+  thickWrap.appendChild(slabThicknessInput);
+  wrap.appendChild(thickWrap);
+
+  // Apply button
+  const apply = document.createElement('button');
+  apply.className = 'w-full px-2 py-1.5 rounded text-[11px] bg-blue-600 hover:bg-blue-500 text-white transition-colors font-medium';
+  apply.textContent = 'Paint slab';
+  apply.title = 'Apply the slab selection as a paint region';
+  apply.addEventListener('click', applySlab);
+  wrap.appendChild(apply);
+
+  return wrap;
+}
+
+function axisButtonClass(active: boolean): string {
+  if (active) {
+    return 'px-2 py-1 rounded text-[11px] bg-blue-500/30 text-blue-200 border border-blue-500/50 transition-colors';
+  }
+  return 'px-2 py-1 rounded text-[11px] bg-zinc-700/40 text-zinc-300 hover:bg-zinc-600/60 border border-transparent transition-colors';
+}
+
+function refreshSlabRange(): void {
+  const mesh = getCurrentMesh();
+  if (!mesh || !slabOffsetInput || !slabThicknessInput) return;
+
+  const range = projectionRange(mesh, AXIS_NORMALS[slabAxis]);
+  const span = Math.max(1e-6, range.max - range.min);
+  const step = roundStep(span / 200);
+
+  // Pad each side by ~1% so the slab can slide just past the model.
+  const pad = span * 0.01;
+
+  slabOffsetInput.min = String(range.min - pad);
+  slabOffsetInput.max = String(range.max + pad);
+  slabOffsetInput.step = String(step);
+
+  // Default offset = bottom of bounds; thickness = 20% of span (or smaller if tiny)
+  const defaultOffset = range.min;
+  const defaultThickness = Math.max(step, span * 0.2);
+
+  if (!slabInputsInitialized) {
+    slabOffsetInput.value = String(defaultOffset);
+  } else {
+    const cur = parseFloat(slabOffsetInput.value);
+    if (!Number.isFinite(cur) || cur < range.min - pad || cur > range.max + pad) {
+      slabOffsetInput.value = String(defaultOffset);
+    }
+  }
+
+  slabThicknessInput.min = String(step);
+  slabThicknessInput.max = String(span);
+  slabThicknessInput.step = String(step);
+  if (!slabInputsInitialized) {
+    slabThicknessInput.value = String(defaultThickness);
+  } else {
+    const cur = parseFloat(slabThicknessInput.value);
+    if (!Number.isFinite(cur) || cur > span) slabThicknessInput.value = String(Math.min(span, defaultThickness));
+    else if (cur < step) slabThicknessInput.value = String(step);
+  }
+
+  slabInputsInitialized = true;
+}
+
+function roundStep(s: number): number {
+  if (s <= 0) return 0.01;
+  // Round to one significant digit (e.g. 0.0345 -> 0.03)
+  const exp = Math.floor(Math.log10(s));
+  const mantissa = s / Math.pow(10, exp);
+  const rounded = Math.round(mantissa);
+  return Math.max(1e-6, rounded * Math.pow(10, exp));
+}
+
+function updateSlabPreview(): void {
+  const mesh = getCurrentMesh();
+  if (!mesh || !slabOffsetInput || !slabThicknessInput) return;
+
+  const offset = parseFloat(slabOffsetInput.value);
+  const thickness = parseFloat(slabThicknessInput.value);
+  const normal = AXIS_NORMALS[slabAxis];
+
+  if (slabOffsetValue) slabOffsetValue.textContent = formatNumber(offset);
+  if (slabThicknessValue) slabThicknessValue.textContent = formatNumber(thickness);
+
+  const triangles = findSlabTriangles(mesh, normal, offset, thickness);
+  teardownSlabPreview();
+  if (triangles.size > 0) {
+    slabPreviewTeardown = previewTriangles(triangles);
+  }
+}
+
+function teardownSlabPreview(): void {
+  if (slabPreviewTeardown) {
+    slabPreviewTeardown();
+    slabPreviewTeardown = null;
+  }
+}
+
+function applySlab(): void {
+  const mesh = getCurrentMesh();
+  if (!mesh || !slabOffsetInput || !slabThicknessInput) return;
+
+  const offset = parseFloat(slabOffsetInput.value);
+  const thickness = parseFloat(slabThicknessInput.value);
+  const normal = AXIS_NORMALS[slabAxis];
+
+  const triangles = findSlabTriangles(mesh, normal, offset, thickness);
+  if (triangles.size === 0) return;
+
+  teardownSlabPreview();
+
+  const existingCount = getRegions().length;
+  const name = `Slab ${slabAxis.toUpperCase()} ${existingCount + 1}`;
+  addRegion(
+    name,
+    [...getColor()] as [number, number, number],
+    'slab',
+    { kind: 'slab', normal, offset, thickness },
+    triangles,
+  );
+}
+
+function formatNumber(n: number): string {
+  if (!isFinite(n)) return '0';
+  const abs = Math.abs(n);
+  const digits = abs >= 100 ? 0 : abs >= 10 ? 1 : 2;
+  return n.toFixed(digits);
 }
 
 function updateVisibilityButton(): void {
@@ -299,6 +637,8 @@ export function forceDeactivate(): void {
     deactivate();
     updateButtonState(false);
     pickerPanel?.classList.add('hidden');
+    teardownSlabPreview();
+    slabInputsInitialized = false;
   }
 }
 

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -6,17 +6,15 @@ import {
   deactivate,
   isActive,
   setColor,
-  getColor,
   setTool,
   getTool,
   setBucketTolerance,
   getBucketTolerance,
-  getCurrentMesh,
-  previewTriangles,
+  setSlabAxis,
+  getSlabAxis,
   type PaintTool,
 } from './paintMode';
 import {
-  addRegion,
   getRegions,
   onChange as onRegionsChange,
   onRedoChange,
@@ -28,7 +26,6 @@ import {
   canRedoRegion,
   clearRegions,
 } from './regions';
-import { projectionRange, findSlabTriangles, AXIS_NORMALS } from './slabPaint';
 import { forceDeactivate as forceDeactivateAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as forceDeactivateAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as forceDeactivateAnnotateSelect } from '../annotations/selectMode';
@@ -53,16 +50,6 @@ let redoBtn: HTMLButtonElement | null = null;
 let toolButtons: Partial<Record<PaintTool, HTMLButtonElement>> = {};
 let bucketControls: HTMLElement | null = null;
 let slabControls: HTMLElement | null = null;
-
-// Slab UI state
-type SlabAxis = 'x' | 'y' | 'z';
-let slabAxis: SlabAxis = 'z';
-let slabOffsetInput: HTMLInputElement | null = null;
-let slabThicknessInput: HTMLInputElement | null = null;
-let slabOffsetValue: HTMLElement | null = null;
-let slabThicknessValue: HTMLElement | null = null;
-let slabPreviewTeardown: (() => void) | null = null;
-let slabInputsInitialized = false;
 
 /** Initialize the paint UI inside the clip-controls overlay area. */
 export function initPaintUI(controlsContainer: HTMLElement): void {
@@ -105,8 +92,6 @@ function togglePaintMode(): void {
     deactivate();
     updateButtonState(false);
     pickerPanel?.classList.add('hidden');
-    teardownSlabPreview();
-    slabInputsInitialized = false;
   } else {
     forceDeactivateAnnotate();
     forceDeactivateAnnotateText();
@@ -289,15 +274,7 @@ function syncToolPanels(): void {
     if (btn) btn.className = toolButtonClass(t === tool);
   }
   if (bucketControls) bucketControls.classList.toggle('hidden', tool !== 'bucket');
-  if (slabControls) {
-    slabControls.classList.toggle('hidden', tool !== 'slab');
-    if (tool === 'slab') {
-      refreshSlabRange();
-      updateSlabPreview();
-    } else {
-      teardownSlabPreview();
-    }
-  }
+  if (slabControls) slabControls.classList.toggle('hidden', tool !== 'slab');
 }
 
 function createBucketControls(): HTMLElement {
@@ -324,7 +301,7 @@ function createBucketControls(): HTMLElement {
   slider.step = '1';
   slider.value = String(toleranceToSliderPct(getBucketTolerance()));
   slider.className = 'w-full accent-blue-500';
-  slider.title = 'How aggressively flood-fill spreads across near-coplanar faces';
+  slider.title = 'Maximum angle (0\u00B0\u201390\u00B0) the flood-fill is allowed to bleed across';
   slider.addEventListener('input', () => {
     const tol = sliderPctToTolerance(parseInt(slider.value, 10));
     setBucketTolerance(tol);
@@ -341,16 +318,15 @@ function createBucketControls(): HTMLElement {
 }
 
 function toleranceToSliderPct(tol: number): number {
-  // tol in [0,1]. Map (1 - tol) in [0, 0.05] to slider 0..100 with sqrt curve.
-  // tol = 1 -> 0 (strictest); tol = 0.95 -> 100 (loosest practical)
-  const inv = Math.max(0, Math.min(0.05, 1 - tol));
-  return Math.round(Math.sqrt(inv / 0.05) * 100);
+  // Slider 0..100 maps directly to angle 0°..90° (i.e. tol = cos(angle)).
+  // 0 = strict (only the exact face), 100 = paints everything within 90°.
+  const angleDeg = Math.acos(Math.max(-1, Math.min(1, tol))) * 180 / Math.PI;
+  return Math.round(Math.max(0, Math.min(90, angleDeg)) / 90 * 100);
 }
 
 function sliderPctToTolerance(pct: number): number {
-  const t = Math.max(0, Math.min(100, pct)) / 100;
-  const inv = (t * t) * 0.05;
-  return Math.max(0.95, Math.min(1, 1 - inv));
+  const angleDeg = Math.max(0, Math.min(100, pct)) / 100 * 90;
+  return Math.cos(angleDeg * Math.PI / 180);
 }
 
 function formatTolerance(tol: number): string {
@@ -373,78 +349,28 @@ function createSlabControls(): HTMLElement {
 
   const axisBtns = document.createElement('div');
   axisBtns.className = 'grid grid-cols-3 gap-1';
-  for (const axis of ['x', 'y', 'z'] as const) {
+  for (const a of ['x', 'y', 'z'] as const) {
     const btn = document.createElement('button');
-    btn.dataset.axis = axis;
-    btn.textContent = axis.toUpperCase();
-    btn.className = axisButtonClass(axis === slabAxis);
+    btn.dataset.axis = a;
+    btn.textContent = a.toUpperCase();
+    btn.className = axisButtonClass(a === getSlabAxis());
     btn.addEventListener('click', () => {
-      slabAxis = axis;
+      setSlabAxis(a);
       for (const child of Array.from(axisBtns.children)) {
         const el = child as HTMLButtonElement;
-        el.className = axisButtonClass(el.dataset.axis === slabAxis);
+        el.className = axisButtonClass(el.dataset.axis === getSlabAxis());
       }
-      // Axis change: re-seed slider to the new axis's defaults.
-      slabInputsInitialized = false;
-      refreshSlabRange();
-      updateSlabPreview();
     });
     axisBtns.appendChild(btn);
   }
   axisRow.appendChild(axisBtns);
   wrap.appendChild(axisRow);
 
-  // Offset slider
-  const offsetWrap = document.createElement('div');
-  offsetWrap.className = 'mb-2';
-  const offsetLabel = document.createElement('div');
-  offsetLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium flex items-center justify-between';
-  const offsetText = document.createElement('span');
-  offsetText.textContent = 'Offset';
-  slabOffsetValue = document.createElement('span');
-  slabOffsetValue.className = 'text-zinc-400 normal-case tracking-normal';
-  slabOffsetValue.textContent = '0';
-  offsetLabel.appendChild(offsetText);
-  offsetLabel.appendChild(slabOffsetValue);
-  offsetWrap.appendChild(offsetLabel);
-
-  slabOffsetInput = document.createElement('input');
-  slabOffsetInput.type = 'range';
-  slabOffsetInput.className = 'w-full accent-blue-500';
-  slabOffsetInput.title = 'Slide the slab along the chosen axis';
-  slabOffsetInput.addEventListener('input', updateSlabPreview);
-  offsetWrap.appendChild(slabOffsetInput);
-  wrap.appendChild(offsetWrap);
-
-  // Thickness slider
-  const thickWrap = document.createElement('div');
-  thickWrap.className = 'mb-2';
-  const thickLabel = document.createElement('div');
-  thickLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium flex items-center justify-between';
-  const thickText = document.createElement('span');
-  thickText.textContent = 'Thickness';
-  slabThicknessValue = document.createElement('span');
-  slabThicknessValue.className = 'text-zinc-400 normal-case tracking-normal';
-  slabThicknessValue.textContent = '0';
-  thickLabel.appendChild(thickText);
-  thickLabel.appendChild(slabThicknessValue);
-  thickWrap.appendChild(thickLabel);
-
-  slabThicknessInput = document.createElement('input');
-  slabThicknessInput.type = 'range';
-  slabThicknessInput.className = 'w-full accent-blue-500';
-  slabThicknessInput.title = 'Width of the slab along the chosen axis';
-  slabThicknessInput.addEventListener('input', updateSlabPreview);
-  thickWrap.appendChild(slabThicknessInput);
-  wrap.appendChild(thickWrap);
-
-  // Apply button
-  const apply = document.createElement('button');
-  apply.className = 'w-full px-2 py-1.5 rounded text-[11px] bg-blue-600 hover:bg-blue-500 text-white transition-colors font-medium';
-  apply.textContent = 'Paint slab';
-  apply.title = 'Apply the slab selection as a paint region';
-  apply.addEventListener('click', applySlab);
-  wrap.appendChild(apply);
+  // Hint text
+  const hint = document.createElement('div');
+  hint.className = 'text-[10px] text-zinc-400 leading-relaxed';
+  hint.innerHTML = 'Hover the model to preview the slab plane.<br>Click and drag to extend the slab along the chosen axis. Release to paint.';
+  wrap.appendChild(hint);
 
   return wrap;
 }
@@ -454,113 +380,6 @@ function axisButtonClass(active: boolean): string {
     return 'px-2 py-1 rounded text-[11px] bg-blue-500/30 text-blue-200 border border-blue-500/50 transition-colors';
   }
   return 'px-2 py-1 rounded text-[11px] bg-zinc-700/40 text-zinc-300 hover:bg-zinc-600/60 border border-transparent transition-colors';
-}
-
-function refreshSlabRange(): void {
-  const mesh = getCurrentMesh();
-  if (!mesh || !slabOffsetInput || !slabThicknessInput) return;
-
-  const range = projectionRange(mesh, AXIS_NORMALS[slabAxis]);
-  const span = Math.max(1e-6, range.max - range.min);
-  const step = roundStep(span / 200);
-
-  // Pad each side by ~1% so the slab can slide just past the model.
-  const pad = span * 0.01;
-
-  slabOffsetInput.min = String(range.min - pad);
-  slabOffsetInput.max = String(range.max + pad);
-  slabOffsetInput.step = String(step);
-
-  // Default offset = bottom of bounds; thickness = 20% of span (or smaller if tiny)
-  const defaultOffset = range.min;
-  const defaultThickness = Math.max(step, span * 0.2);
-
-  if (!slabInputsInitialized) {
-    slabOffsetInput.value = String(defaultOffset);
-  } else {
-    const cur = parseFloat(slabOffsetInput.value);
-    if (!Number.isFinite(cur) || cur < range.min - pad || cur > range.max + pad) {
-      slabOffsetInput.value = String(defaultOffset);
-    }
-  }
-
-  slabThicknessInput.min = String(step);
-  slabThicknessInput.max = String(span);
-  slabThicknessInput.step = String(step);
-  if (!slabInputsInitialized) {
-    slabThicknessInput.value = String(defaultThickness);
-  } else {
-    const cur = parseFloat(slabThicknessInput.value);
-    if (!Number.isFinite(cur) || cur > span) slabThicknessInput.value = String(Math.min(span, defaultThickness));
-    else if (cur < step) slabThicknessInput.value = String(step);
-  }
-
-  slabInputsInitialized = true;
-}
-
-function roundStep(s: number): number {
-  if (s <= 0) return 0.01;
-  // Round to one significant digit (e.g. 0.0345 -> 0.03)
-  const exp = Math.floor(Math.log10(s));
-  const mantissa = s / Math.pow(10, exp);
-  const rounded = Math.round(mantissa);
-  return Math.max(1e-6, rounded * Math.pow(10, exp));
-}
-
-function updateSlabPreview(): void {
-  const mesh = getCurrentMesh();
-  if (!mesh || !slabOffsetInput || !slabThicknessInput) return;
-
-  const offset = parseFloat(slabOffsetInput.value);
-  const thickness = parseFloat(slabThicknessInput.value);
-  const normal = AXIS_NORMALS[slabAxis];
-
-  if (slabOffsetValue) slabOffsetValue.textContent = formatNumber(offset);
-  if (slabThicknessValue) slabThicknessValue.textContent = formatNumber(thickness);
-
-  const triangles = findSlabTriangles(mesh, normal, offset, thickness);
-  teardownSlabPreview();
-  if (triangles.size > 0) {
-    slabPreviewTeardown = previewTriangles(triangles);
-  }
-}
-
-function teardownSlabPreview(): void {
-  if (slabPreviewTeardown) {
-    slabPreviewTeardown();
-    slabPreviewTeardown = null;
-  }
-}
-
-function applySlab(): void {
-  const mesh = getCurrentMesh();
-  if (!mesh || !slabOffsetInput || !slabThicknessInput) return;
-
-  const offset = parseFloat(slabOffsetInput.value);
-  const thickness = parseFloat(slabThicknessInput.value);
-  const normal = AXIS_NORMALS[slabAxis];
-
-  const triangles = findSlabTriangles(mesh, normal, offset, thickness);
-  if (triangles.size === 0) return;
-
-  teardownSlabPreview();
-
-  const existingCount = getRegions().length;
-  const name = `Slab ${slabAxis.toUpperCase()} ${existingCount + 1}`;
-  addRegion(
-    name,
-    [...getColor()] as [number, number, number],
-    'slab',
-    { kind: 'slab', normal, offset, thickness },
-    triangles,
-  );
-}
-
-function formatNumber(n: number): string {
-  if (!isFinite(n)) return '0';
-  const abs = Math.abs(n);
-  const digits = abs >= 100 ? 0 : abs >= 10 ? 1 : 2;
-  return n.toFixed(digits);
 }
 
 function updateVisibilityButton(): void {
@@ -637,8 +456,6 @@ export function forceDeactivate(): void {
     deactivate();
     updateButtonState(false);
     pickerPanel?.classList.add('hidden');
-    teardownSlabPreview();
-    slabInputsInitialized = false;
   }
 }
 

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -14,7 +14,7 @@ export interface ColorRegion {
 
 export type RegionDescriptor =
   | { kind: 'coplanar'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; normalTolerance: number }
-  | { kind: 'slab'; axis: 'x' | 'y' | 'z'; min: number; max: number }
+  | { kind: 'slab'; normal: [number, number, number]; offset: number; thickness: number }
   | { kind: 'triangles'; ids: number[] };
 
 export interface SerializedColorRegion {

--- a/src/color/slabDrag.ts
+++ b/src/color/slabDrag.ts
@@ -1,0 +1,323 @@
+// Slab drag — interactive slab painting. The user picks an axis (X/Y/Z),
+// hovers the model to see a translucent cuboid showing where the slab will be,
+// then click-drags along the model surface to extend the slab from a start
+// coordinate to an end coordinate. Releasing the mouse commits the slab as a
+// paint region.
+
+import * as THREE from 'three';
+import type { MeshData } from '../geometry/types';
+import { getMeshGroup, getRenderer, getCamera } from '../renderer/viewport';
+import { addRegion, getRegions } from './regions';
+import { findSlabTriangles, projectionRange, AXIS_NORMALS } from './slabPaint';
+import { getColor, getCurrentMesh } from './paintMode';
+
+export type SlabAxis = 'x' | 'y' | 'z';
+
+let active = false;
+let axis: SlabAxis = 'z';
+let cuboid: THREE.Mesh | null = null;
+let edges: THREE.LineSegments | null = null;
+
+// Drag state
+let dragging = false;
+let dragStart: number | null = null;
+let dragEnd: number | null = null;
+let hoverCoord: number | null = null;
+
+// Cached mesh range for the active axis (recomputed when mesh or axis changes)
+let cachedRange: { min: number; max: number } | null = null;
+
+const raycaster = new THREE.Raycaster();
+const mouseVec = new THREE.Vector2();
+
+export function setSlabAxis(a: SlabAxis): void {
+  axis = a;
+  cachedRange = null;
+  rebuildCuboid();
+  refreshVisual();
+}
+
+export function getSlabAxis(): SlabAxis {
+  return axis;
+}
+
+export function activate(): void {
+  if (active) return;
+  active = true;
+
+  cachedRange = null;
+  rebuildCuboid();
+
+  const canvas = getRenderer().domElement;
+  canvas.addEventListener('mousemove', onMouseMove);
+  canvas.addEventListener('mousedown', onMouseDown);
+  canvas.addEventListener('mouseup', onMouseUp);
+  canvas.addEventListener('mouseleave', onMouseLeave);
+}
+
+export function deactivate(): void {
+  if (!active) return;
+  active = false;
+  dragging = false;
+  dragStart = null;
+  dragEnd = null;
+  hoverCoord = null;
+
+  const canvas = getRenderer().domElement;
+  canvas.removeEventListener('mousemove', onMouseMove);
+  canvas.removeEventListener('mousedown', onMouseDown);
+  canvas.removeEventListener('mouseup', onMouseUp);
+  canvas.removeEventListener('mouseleave', onMouseLeave);
+
+  disposeCuboid();
+}
+
+function ensureRange(mesh: MeshData): { min: number; max: number } {
+  if (cachedRange) return cachedRange;
+  cachedRange = projectionRange(mesh, AXIS_NORMALS[axis]);
+  return cachedRange;
+}
+
+function rebuildCuboid(): void {
+  disposeCuboid();
+  const mesh = getCurrentMesh();
+  if (!mesh) return;
+
+  const range = ensureRange(mesh);
+  const lateral = lateralAxes(axis);
+  const a = projectionRange(mesh, AXIS_NORMALS[lateral[0]]);
+  const b = projectionRange(mesh, AXIS_NORMALS[lateral[1]]);
+
+  // Pad lateral dimensions so the cuboid extends slightly past the model.
+  const padA = Math.max((a.max - a.min) * 0.02, 0.01);
+  const padB = Math.max((b.max - b.min) * 0.02, 0.01);
+
+  // Box geometry sized in world units. Default thickness = 1; we'll scale
+  // along the slab normal each frame.
+  const sizes = { x: 1, y: 1, z: 1 };
+  sizes[lateral[0]] = (a.max - a.min) + padA * 2;
+  sizes[lateral[1]] = (b.max - b.min) + padB * 2;
+
+  const color = colorToHex(getColor());
+
+  const geo = new THREE.BoxGeometry(sizes.x, sizes.y, sizes.z);
+  const mat = new THREE.MeshBasicMaterial({
+    color,
+    transparent: true,
+    opacity: 0.18,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+  });
+  cuboid = new THREE.Mesh(geo, mat);
+  cuboid.name = 'slab-cuboid';
+  cuboid.renderOrder = 998;
+  cuboid.visible = false;
+  getMeshGroup().add(cuboid);
+
+  // Wireframe edges for clearer slab boundary
+  const edgeGeo = new THREE.EdgesGeometry(geo);
+  const edgeMat = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.7, depthTest: false });
+  edges = new THREE.LineSegments(edgeGeo, edgeMat);
+  edges.name = 'slab-cuboid-edges';
+  edges.renderOrder = 999;
+  edges.visible = false;
+  getMeshGroup().add(edges);
+
+  // Center the box in the lateral axes; slab axis position is updated each frame
+  const centerLateral = (k: 'x' | 'y' | 'z'): number => {
+    const r = projectionRange(mesh, AXIS_NORMALS[k]);
+    return (r.min + r.max) / 2;
+  };
+  const cx = axis === 'x' ? 0 : centerLateral('x');
+  const cy = axis === 'y' ? 0 : centerLateral('y');
+  const cz = axis === 'z' ? 0 : centerLateral('z');
+  cuboid.position.set(cx, cy, cz);
+  edges.position.set(cx, cy, cz);
+  // Initial scale on slab axis is 0 (invisible until hover/drag sets it)
+  setSlabAxisScale(0, range.min);
+}
+
+function disposeCuboid(): void {
+  if (cuboid) {
+    getMeshGroup().remove(cuboid);
+    cuboid.geometry.dispose();
+    (cuboid.material as THREE.Material).dispose();
+    cuboid = null;
+  }
+  if (edges) {
+    getMeshGroup().remove(edges);
+    edges.geometry.dispose();
+    (edges.material as THREE.Material).dispose();
+    edges = null;
+  }
+}
+
+function lateralAxes(a: SlabAxis): [SlabAxis, SlabAxis] {
+  if (a === 'x') return ['y', 'z'];
+  if (a === 'y') return ['x', 'z'];
+  return ['x', 'y'];
+}
+
+function setSlabAxisScale(thickness: number, center: number): void {
+  if (!cuboid || !edges) return;
+  const scaleProp = axis;
+  cuboid.scale[scaleProp] = Math.max(thickness, 0.0001);
+  edges.scale[scaleProp] = Math.max(thickness, 0.0001);
+  cuboid.position[scaleProp] = center;
+  edges.position[scaleProp] = center;
+  const visible = thickness > 0;
+  cuboid.visible = visible;
+  edges.visible = visible;
+}
+
+function refreshVisual(): void {
+  // Re-add the cuboid if a viewport refresh detached it.
+  if (cuboid && !cuboid.parent) getMeshGroup().add(cuboid);
+  if (edges && !edges.parent) getMeshGroup().add(edges);
+  if (!cuboid) return;
+  let lo: number;
+  let hi: number;
+
+  if (dragging && dragStart !== null && dragEnd !== null) {
+    lo = Math.min(dragStart, dragEnd);
+    hi = Math.max(dragStart, dragEnd);
+  } else if (hoverCoord !== null) {
+    // No drag in progress — show a thin preview slab at the cursor coord.
+    const mesh = getCurrentMesh();
+    const span = mesh ? Math.max(0.01, ensureRange(mesh).max - ensureRange(mesh).min) : 1;
+    const halfThickness = span * 0.005;
+    lo = hoverCoord - halfThickness;
+    hi = hoverCoord + halfThickness;
+  } else {
+    setSlabAxisScale(0, 0);
+    return;
+  }
+
+  setSlabAxisScale(hi - lo, (lo + hi) / 2);
+
+  // Update colors in case the active paint color changed
+  const color = colorToHex(getColor());
+  if (cuboid) (cuboid.material as THREE.MeshBasicMaterial).color.setHex(color);
+  if (edges) (edges.material as THREE.LineBasicMaterial).color.setHex(color);
+}
+
+function pickAxisCoord(event: MouseEvent): number | null {
+  const canvas = getRenderer().domElement;
+  const rect = canvas.getBoundingClientRect();
+  mouseVec.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  mouseVec.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+
+  const camera = getCamera();
+  raycaster.setFromCamera(mouseVec, camera);
+
+  const meshGroup = getMeshGroup();
+  const solidMesh = meshGroup.children[0];
+  if (!(solidMesh instanceof THREE.Mesh)) return null;
+
+  const intersections = raycaster.intersectObject(solidMesh);
+  if (intersections.length === 0) return null;
+
+  const hit = intersections[0].point;
+  return axis === 'x' ? hit.x : axis === 'y' ? hit.y : hit.z;
+}
+
+function onMouseMove(event: MouseEvent): void {
+  if (!active) return;
+
+  const coord = pickAxisCoord(event);
+
+  if (dragging) {
+    if (coord !== null) {
+      dragEnd = coord;
+      refreshVisual();
+    }
+    // If no hit during drag, hold the previous dragEnd value.
+    return;
+  }
+
+  hoverCoord = coord;
+  refreshVisual();
+}
+
+function onMouseDown(event: MouseEvent): void {
+  if (!active) return;
+  if (event.button !== 0) return;
+
+  const coord = pickAxisCoord(event);
+  if (coord === null) return;
+
+  dragging = true;
+  dragStart = coord;
+  dragEnd = coord;
+  refreshVisual();
+  event.preventDefault();
+}
+
+function onMouseUp(event: MouseEvent): void {
+  if (!active) return;
+  if (event.button !== 0) return;
+  if (!dragging) return;
+
+  dragging = false;
+
+  if (dragStart !== null && dragEnd !== null) {
+    const offset = Math.min(dragStart, dragEnd);
+    const thickness = Math.max(dragStart, dragEnd) - offset;
+    if (thickness > 0) {
+      commitSlab(offset, thickness);
+    }
+  }
+
+  dragStart = null;
+  dragEnd = null;
+  refreshVisual();
+}
+
+function onMouseLeave(): void {
+  if (!active) return;
+  // If the user releases their mouse outside the canvas, commit what we have.
+  if (dragging && dragStart !== null && dragEnd !== null) {
+    const offset = Math.min(dragStart, dragEnd);
+    const thickness = Math.max(dragStart, dragEnd) - offset;
+    if (thickness > 0) commitSlab(offset, thickness);
+  }
+  dragging = false;
+  dragStart = null;
+  dragEnd = null;
+  hoverCoord = null;
+  refreshVisual();
+}
+
+function commitSlab(offset: number, thickness: number): void {
+  const mesh = getCurrentMesh();
+  if (!mesh) return;
+
+  const normal = AXIS_NORMALS[axis];
+  const triangles = findSlabTriangles(mesh, normal, offset, thickness);
+  if (triangles.size === 0) return;
+
+  const existingCount = getRegions().length;
+  const name = `Slab ${axis.toUpperCase()} ${existingCount + 1}`;
+  addRegion(
+    name,
+    [...getColor()] as [number, number, number],
+    'slab',
+    { kind: 'slab', normal: [...normal] as [number, number, number], offset, thickness },
+    triangles,
+  );
+}
+
+function colorToHex(color: [number, number, number]): number {
+  const r = Math.round(Math.max(0, Math.min(1, color[0])) * 255);
+  const g = Math.round(Math.max(0, Math.min(1, color[1])) * 255);
+  const b = Math.round(Math.max(0, Math.min(1, color[2])) * 255);
+  return (r << 16) | (g << 8) | b;
+}
+
+/** Notify the drag controller that the underlying mesh changed so it can
+ *  rebuild its cuboid against the new bounds. */
+export function onMeshChanged(): void {
+  if (!active) return;
+  cachedRange = null;
+  rebuildCuboid();
+}

--- a/src/color/slabPaint.ts
+++ b/src/color/slabPaint.ts
@@ -1,0 +1,91 @@
+// Slab painting — select all triangles whose centroid falls inside a planar slab
+// defined by a normal vector, an offset along that normal, and a thickness.
+//
+// A slab is the set of points P satisfying:   offset <= P · n <= offset + thickness
+// where n is a unit-length normal. With n = (0,0,1) this is a Z-range slab; with
+// arbitrary n it's an oblique/tilted slab.
+
+import type { MeshData } from '../geometry/types';
+import { getTriangleCentroid } from './adjacency';
+
+export interface AxisAlignedNormal {
+  axis: 'x' | 'y' | 'z';
+  normal: [number, number, number];
+}
+
+export const AXIS_NORMALS: Record<'x' | 'y' | 'z', [number, number, number]> = {
+  x: [1, 0, 0],
+  y: [0, 1, 0],
+  z: [0, 0, 1],
+};
+
+/** Bounding box of a mesh (axis-aligned, world coords). */
+export function meshBounds(mesh: MeshData): { min: [number, number, number]; max: [number, number, number] } {
+  const { vertProperties, numVert, numProp } = mesh;
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+
+  for (let i = 0; i < numVert; i++) {
+    const x = vertProperties[i * numProp];
+    const y = vertProperties[i * numProp + 1];
+    const z = vertProperties[i * numProp + 2];
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (z < minZ) minZ = z;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+    if (z > maxZ) maxZ = z;
+  }
+
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+/** Project all vertices onto a normal direction and return [min, max] dot products.
+ *  Used to size the offset slider for an arbitrary normal. */
+export function projectionRange(mesh: MeshData, normal: [number, number, number]): { min: number; max: number } {
+  const { vertProperties, numVert, numProp } = mesh;
+  const [nx, ny, nz] = normalize(normal);
+
+  let min = Infinity;
+  let max = -Infinity;
+
+  for (let i = 0; i < numVert; i++) {
+    const x = vertProperties[i * numProp];
+    const y = vertProperties[i * numProp + 1];
+    const z = vertProperties[i * numProp + 2];
+    const d = x * nx + y * ny + z * nz;
+    if (d < min) min = d;
+    if (d > max) max = d;
+  }
+
+  return { min, max };
+}
+
+/** Find all triangles whose centroid lies inside the slab. */
+export function findSlabTriangles(
+  mesh: MeshData,
+  normal: [number, number, number],
+  offset: number,
+  thickness: number,
+): Set<number> {
+  const result = new Set<number>();
+  if (thickness <= 0) return result;
+
+  const [nx, ny, nz] = normalize(normal);
+  const lo = offset;
+  const hi = offset + thickness;
+
+  for (let t = 0; t < mesh.numTri; t++) {
+    const c = getTriangleCentroid(t, mesh);
+    const d = c[0] * nx + c[1] * ny + c[2] * nz;
+    if (d >= lo && d <= hi) result.add(t);
+  }
+
+  return result;
+}
+
+function normalize(v: [number, number, number]): [number, number, number] {
+  const len = Math.hypot(v[0], v[1], v[2]);
+  if (len === 0) return [0, 0, 1];
+  return [v[0] / len, v[1] / len, v[2] / len];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,7 @@ import { restoreView as restoreAnnotationViewById } from './annotations/selectMo
 import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, type SerializedColorRegion } from './color/regions';
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
 import { buildAdjacency, findCoplanarRegion, resolveSeed } from './color/adjacency';
+import { findSlabTriangles } from './color/slabPaint';
 import {
   getSessionIdFromURL,
   getVersionFromURL,
@@ -477,6 +478,9 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): vo
       }
     } else if (region.descriptor.kind === 'triangles') {
       triangles = new Set(region.descriptor.ids);
+    } else if (region.descriptor.kind === 'slab') {
+      const { normal, offset, thickness } = region.descriptor;
+      triangles = findSlabTriangles(mesh, normal, offset, thickness);
     }
 
     if (triangles.size > 0) {
@@ -2809,6 +2813,87 @@ async function main() {
       );
 
       // Re-render with colors
+      const colored = applyTriColorsIfVisible(currentMeshData);
+      updateMesh(colored, { skipAutoFrame: true });
+      updateMultiView(colored);
+      syncLockState();
+
+      return { id: region.id, name: region.name, triangles: triangles.size };
+    },
+
+    /** Paint a specific set of triangle indices as a single region.
+     *  Useful for paintbrush-style selections produced programmatically. */
+    paintFaces(opts: { triangleIds: number[]; color: [number, number, number]; name?: string }) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintFaces requires {triangleIds, color}' };
+      const { triangleIds, color, name } = opts;
+      if (!Array.isArray(triangleIds) || triangleIds.length === 0) return { error: 'triangleIds must be a non-empty array of integers' };
+      if (!Array.isArray(color) || color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+
+      const numTri = currentMeshData.numTri;
+      const ids: number[] = [];
+      for (const id of triangleIds) {
+        if (typeof id !== 'number' || !Number.isInteger(id) || id < 0 || id >= numTri) {
+          return { error: `triangleIds contains invalid index ${id} (expected 0..${numTri - 1})` };
+        }
+        ids.push(id);
+      }
+
+      const triangles = new Set<number>(ids);
+      const regionName = name ?? `Region ${getRegions().length + 1}`;
+      const region = addRegion(
+        regionName,
+        color as [number, number, number],
+        'paintbrush',
+        { kind: 'triangles', ids: [...triangles] },
+        triangles,
+      );
+
+      const colored = applyTriColorsIfVisible(currentMeshData);
+      updateMesh(colored, { skipAutoFrame: true });
+      updateMultiView(colored);
+      syncLockState();
+
+      return { id: region.id, name: region.name, triangles: triangles.size };
+    },
+
+    /** Paint a slab — all faces whose centroid falls inside a planar slab.
+     *  `axis` is shorthand for axis-aligned slabs ('x'/'y'/'z'). For oblique
+     *  slabs, pass `normal` directly (does not need to be normalized). */
+    paintSlab(opts: { axis?: 'x' | 'y' | 'z'; normal?: [number, number, number]; offset: number; thickness: number; color: [number, number, number]; name?: string }) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintSlab requires {axis|normal, offset, thickness, color}' };
+      const { axis, normal: rawNormal, offset, thickness, color, name } = opts;
+
+      let normal: [number, number, number];
+      if (axis !== undefined) {
+        if (axis !== 'x' && axis !== 'y' && axis !== 'z') return { error: "axis must be 'x', 'y', or 'z'" };
+        normal = axis === 'x' ? [1, 0, 0] : axis === 'y' ? [0, 1, 0] : [0, 0, 1];
+      } else if (Array.isArray(rawNormal) && rawNormal.length === 3) {
+        const [nx, ny, nz] = rawNormal;
+        const len = Math.hypot(nx, ny, nz);
+        if (!Number.isFinite(len) || len === 0) return { error: 'normal must be a non-zero 3-vector' };
+        normal = [nx / len, ny / len, nz / len];
+      } else {
+        return { error: 'paintSlab requires either axis (x|y|z) or normal [nx,ny,nz]' };
+      }
+
+      if (typeof offset !== 'number' || !Number.isFinite(offset)) return { error: 'offset must be a finite number' };
+      if (typeof thickness !== 'number' || !Number.isFinite(thickness) || thickness <= 0) return { error: 'thickness must be a positive finite number' };
+      if (!Array.isArray(color) || color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+
+      const triangles = findSlabTriangles(currentMeshData, normal, offset, thickness);
+      if (triangles.size === 0) return { error: 'No triangles found inside the slab' };
+
+      const regionName = name ?? `Region ${getRegions().length + 1}`;
+      const region = addRegion(
+        regionName,
+        color as [number, number, number],
+        'slab',
+        { kind: 'slab', normal, offset, thickness },
+        triangles,
+      );
+
       const colored = applyTriColorsIfVisible(currentMeshData);
       updateMesh(colored, { skipAutoFrame: true });
       updateMultiView(colored);


### PR DESCRIPTION
## Summary

- Adds three tools to Paint mode: **Bucket** (existing coplanar flood-fill, now with a tolerance slider), **Brush** (drag-to-paint individual triangles), and **Slab** (paint every face whose centroid sits inside a planar slab)
- Slab supports both axis-aligned (X/Y/Z) and arbitrary tilted normals — pick any axis, drag offset/thickness sliders, hit *Paint slab*
- New `partwright.paintFaces({triangleIds, color})` and `partwright.paintSlab({axis|normal, offset, thickness, color})` API methods, documented in `public/ai.md`
- Slab regions persist on saved versions and rehydrate on reload alongside coplanar regions

Closes most of [#56](https://github.com/kemper/mainifold/issues/56) (paintbrush, slab, tolerance). The OpenSCAD `color()` integration remains open for follow-up.

## Implementation notes

- `RegionDescriptor.kind === 'slab'` was reshaped from `{axis, min, max}` to `{normal, offset, thickness}` so axis-aligned and oblique slabs share one descriptor. The previous shape was never wired up so the change is internal.
- `findSlabTriangles` uses the centroid-in-slab test: `offset <= centroid · normal <= offset + thickness`. Z-only slab is just a special case of `normal = (0, 0, 1)`.
- Bucket tolerance slider is labeled in degrees (`≤ N°`) and uses a sqrt curve over `1 - cos(θ)` so small movements near the strict end (1.0) are easy to dial in.

## Test plan

- [x] `npm run build` clean
- [x] Bucket tool still flood-fills coplanar faces
- [x] Brush tool paints a single face on click; drag paints multiple
- [x] Slab tool: switching X/Y/Z resets offset/thickness; live preview overlay updates as sliders move; *Paint slab* commits the region
- [x] `partwright.paintSlab({axis: 'z', offset: -5, thickness: 2, color: [1, 0.4, 0]})` paints bottom face
- [x] `partwright.paintSlab({normal: [1, 0, 1], offset: 0, thickness: 5, color: [...]})` paints an oblique slab
- [x] `partwright.paintFaces({triangleIds: [...], color: [...]})` paints specific triangle indices
- [x] Save a version with a slab region, reload `?session=...&v=N` — region rehydrates with correct triangles
- [ ] Visual review: orbit around model, verify all three tools paint accurately on the actual viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)