### PR TITLE
fix: keep Save button clickable after no-op save and paint/annotation/note edits

### DIFF
--- a/prompts/20260428-202443-fix-save-button-stuck-disabled.md
+++ b/prompts/20260428-202443-fix-save-button-stuck-disabled.md
@@ -1,0 +1,57 @@
+---
+session: "fix-save-button-stuck-disabled"
+timestamp: "2026-04-28T20:24:43Z"
+model: claude-opus-4-7
+tools: [chrome-devtools-mcp]
+---
+
+## Human
+
+I noticed that once a model is locked, painting doesn't reenable the save button
+so that I can click on it to save a new version. Please change your git
+worktree to be based on staging, then investigate and fix. Once you have a fix,
+create a PR.
+
+I also want annotations to reenable the save button. New notes as well.
+
+## Assistant
+
+### Root cause
+
+The Save button in the session bar got *stuck* in the disabled state. Two
+problems compounded:
+
+1. The click handler in `src/ui/sessionBar.ts` set `saveBtn.disabled = true`
+   and added `opacity-50` on click, but the `finally` block only reset the
+   `saving` guard — it never re-enabled the button. As long as `saveVersion`
+   notified state change (success path), the bar re-rendered and replaced the
+   button. But when `saveVersion` returned `null`…
+2. `sessionManager.saveVersion` skips with no notify when
+   `currentVersion.code === code`. After painting (code unchanged but
+   `geometryData.colorRegions` mutated), clicking Save hit this skip — the bar
+   never re-rendered, so the disabled button persisted forever.
+
+Annotations and notes have the same shape (no code mutation) but they're
+session-level, so saving a new version doesn't capture them differently. The
+user still wanted the button clickable after those edits.
+
+### Fix
+
+- **`src/ui/sessionBar.ts`** — re-enable the button in `finally`. Force-save
+  when `colorRegions` differ from the current version (the existing dedup
+  ignored them). Subscribe to `onColorRegionsChange`, `onAnnotationStrokesChange`,
+  and the new `onNotesChange` so the bar re-renders on those edits — defensive
+  and keeps the bar coherent if any other state-bound bit gets added later.
+- **`src/storage/sessionManager.ts`** — added `onNotesChange` listener and
+  `notifyNotes()` call inside `addSessionNote` / `updateSessionNote` /
+  `deleteSessionNote`.
+- **`src/ui/notes.ts`** — routed delete/update through the sessionManager
+  wrappers so the notify fires (was calling the db layer directly).
+
+### Verification
+
+Reproduced the bug in Chrome DevTools MCP: clicked Save once on an unchanged
+session, observed `disabled=true` and `opacity-50` persisting indefinitely.
+After the fix, the button briefly disables during the click, then comes back
+enabled — both for the silently-skipped save and for the successful save where
+the bar re-renders.

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -133,14 +133,28 @@ let currentState: SessionState = {
 };
 
 const listeners: StateChangeListener[] = [];
+const notesListeners: (() => void)[] = [];
 
 function notify() {
   for (const fn of listeners) fn(currentState);
   window.dispatchEvent(new CustomEvent('session-changed', { detail: currentState }));
 }
 
+function notifyNotes() {
+  for (const fn of notesListeners) fn();
+}
+
 export function onStateChange(fn: StateChangeListener): void {
   listeners.push(fn);
+}
+
+/** Subscribe to session-note mutations (add / update / delete). */
+export function onNotesChange(fn: () => void): () => void {
+  notesListeners.push(fn);
+  return () => {
+    const i = notesListeners.indexOf(fn);
+    if (i >= 0) notesListeners.splice(i, 1);
+  };
 }
 
 export function getState(): SessionState {
@@ -382,7 +396,9 @@ export async function getReferenceImagesFromSession(): Promise<ReferenceImagesDa
 
 export async function addSessionNote(text: string): Promise<SessionNote | null> {
   if (!currentState.session) return null;
-  return dbAddNote(currentState.session.id, text);
+  const note = await dbAddNote(currentState.session.id, text);
+  notifyNotes();
+  return note;
 }
 
 export async function listSessionNotes(): Promise<SessionNote[]> {
@@ -392,10 +408,12 @@ export async function listSessionNotes(): Promise<SessionNote[]> {
 
 export async function deleteSessionNote(noteId: string): Promise<void> {
   await dbDeleteNote(noteId);
+  notifyNotes();
 }
 
 export async function updateSessionNote(noteId: string, text: string): Promise<void> {
   await dbUpdateNote(noteId, text);
+  notifyNotes();
 }
 
 // === Recent error tracking (for agentHints) ===

--- a/src/ui/notes.ts
+++ b/src/ui/notes.ts
@@ -1,7 +1,13 @@
 // Notes panel — list, create, edit, delete session notes
 
-import { listSessionNotes, addSessionNote, getState, type SessionNote } from '../storage/sessionManager';
-import { deleteNote as dbDeleteNote, updateNote as dbUpdateNote } from '../storage/db';
+import {
+  listSessionNotes,
+  addSessionNote,
+  deleteSessionNote,
+  updateSessionNote,
+  getState,
+  type SessionNote,
+} from '../storage/sessionManager';
 
 let notesEl: HTMLElement | null = null;
 
@@ -119,7 +125,7 @@ function createNoteRow(note: SessionNote): HTMLElement {
   deleteBtn.className = 'text-xs text-zinc-500 hover:text-red-400 transition-colors';
   deleteBtn.textContent = 'Delete';
   deleteBtn.addEventListener('click', async () => {
-    await dbDeleteNote(note.id);
+    await deleteSessionNote(note.id);
     await refreshNotes();
   });
   actions.appendChild(deleteBtn);
@@ -168,7 +174,7 @@ function enterEditMode(row: HTMLElement, note: SessionNote): void {
   saveBtn.addEventListener('click', async () => {
     const newText = textarea.value.trim();
     if (!newText) return;
-    await dbUpdateNote(note.id, newText);
+    await updateSessionNote(note.id, newText);
     await refreshNotes();
   });
 

--- a/src/ui/sessionBar.ts
+++ b/src/ui/sessionBar.ts
@@ -3,6 +3,7 @@
 import {
   getState,
   onStateChange,
+  onNotesChange,
   createSession,
   closeSession,
   saveVersion,
@@ -11,6 +12,8 @@ import {
   type SessionState,
 } from '../storage/sessionManager';
 import { getReferenceImages } from '../renderer/multiview';
+import { onChange as onColorRegionsChange } from '../color/regions';
+import { onChange as onAnnotationStrokesChange } from '../annotations/annotations';
 
 export interface SessionBarCallbacks {
   onSaveVersion: () => Promise<{ code: string; geometryData: Record<string, unknown> | null; thumbnail: Blob | null }>;
@@ -34,6 +37,13 @@ export function createSessionBar(container: HTMLElement, cb: SessionBarCallbacks
   barEl = bar;
   render(getState());
   onStateChange(render);
+
+  // Re-render when paint regions, annotations, or notes change so the Save
+  // button reflects current dirty state and is clickable after these edits.
+  const refresh = () => render(getState());
+  onColorRegionsChange(refresh);
+  onAnnotationStrokesChange(refresh);
+  onNotesChange(refresh);
 
   container.appendChild(bar);
   return bar;
@@ -137,19 +147,34 @@ function render(state: SessionState) {
 
   barEl.appendChild(el('span', 'text-zinc-600', '|'));
 
-  // Save version (with guard against double-click)
+  // Save version (with guard against double-click).
+  // The button must be re-enabled in finally so it doesn't get stuck disabled
+  // when saveVersion silently skips a code-identical save (e.g. clicking save
+  // after only painting, annotating, or adding notes — none of which mutate
+  // the code text). Force=true when colors differ so paint-only changes still
+  // create a new version.
   let saving = false;
   const saveBtn = btn('\uD83D\uDCBE Save', async () => {
     if (saving) return;
     saving = true;
     saveBtn.disabled = true;
-    saveBtn.className += ' opacity-50';
+    saveBtn.classList.add('opacity-50');
     try {
       const data = await callbacks.onSaveVersion();
       const label = `v${state.versionCount + 1}`;
-      await saveVersion(data.code, data.geometryData, data.thumbnail, label);
+      const force = colorRegionsDiffer(state.currentVersion?.geometryData, data.geometryData);
+      await saveVersion(
+        data.code,
+        data.geometryData,
+        data.thumbnail,
+        label,
+        undefined,
+        force ? { force: true } : undefined,
+      );
     } finally {
       saving = false;
+      saveBtn.disabled = false;
+      saveBtn.classList.remove('opacity-50');
     }
   });
   saveBtn.id = 'btn-save-version';
@@ -188,6 +213,15 @@ function el(tag: string, className: string, text: string): HTMLElement {
   e.className = className;
   e.textContent = text;
   return e;
+}
+
+function colorRegionsDiffer(
+  oldGeo: Record<string, unknown> | null | undefined,
+  newGeo: Record<string, unknown> | null | undefined,
+): boolean {
+  const oldColors = (oldGeo as Record<string, unknown> | null | undefined)?.colorRegions ?? null;
+  const newColors = (newGeo as Record<string, unknown> | null | undefined)?.colorRegions ?? null;
+  return JSON.stringify(oldColors) !== JSON.stringify(newColors);
 }
 
 function btn(text: string, onClick: () => void): HTMLButtonElement {


### PR DESCRIPTION
## Summary

- The Save button got stuck in the disabled state after a click that silently no-op'd. `sessionManager.saveVersion` only compares the code text, so painting, annotating, or adding notes (none of which mutate code) made the button unable to save the new state.
- Re-enable the button in `finally`, force-save when `colorRegions` differ from the current version, and route note mutations through `sessionManager` so a new `onNotesChange` listener fires.

## Test plan

- [x] `npm run build` — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] Repro: load existing session, click Save → button stays disabled forever (before fix).
- [x] After fix: same flow → button briefly dims during the save, then comes back enabled. Subsequent clicks work.
- [ ] Manual check on staging deploy: paint a face, click Save → new version created with colors.
- [ ] Manual check on staging deploy: add an annotation or note → Save button stays clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)