### PR TITLE
Add missing window.partwright API wrappers for viewport and toolbar toggles

### DIFF
--- a/prompts/20260428-missing-api-wrappers.md
+++ b/prompts/20260428-missing-api-wrappers.md
@@ -1,0 +1,35 @@
+# Add missing window.partwright API wrappers
+
+Date: 2026-04-28
+
+## Goal
+
+Five interactive UI features (grid toggle, bounding box dimensions, camera orbit lock, theme toggle, auto-run) had working internal functions but no corresponding `window.partwright` API methods for AI agents. This prevents programmatic control of these features.
+
+## Changes
+
+### src/ui/toolbar.ts
+- Added `setAutoRun(enabled)` export that programmatically sets auto-run state and syncs the toolbar button UI
+- Added module-level `_syncAutoRunUI` reference so `setAutoRun` can update the button created inside `createToolbar`
+
+### src/main.ts
+- Added 10 new methods to the `partwrightAPI` object:
+  - `setGridVisible(on?)` / `isGridVisible()` — grid plane visibility
+  - `setDimensionsVisible(on?)` / `areDimensionsVisible()` — bounding box dimension overlay
+  - `setOrbitLock(on?)` / `isOrbitLocked()` — camera orbit lock
+  - `setTheme('dark'|'light')` / `getTheme()` — color theme
+  - `setAutoRun(enabled)` / `isAutoRunEnabled()` — auto-render on edit
+- Added all 10 methods to the `help()` output under "Viewport controls"
+- All setter methods include input validation via existing `assertBoolean`/`assertEnum` helpers
+- Toggle-style methods (`setGridVisible`, `setDimensionsVisible`, `setOrbitLock`) accept optional boolean — omit to toggle
+
+### public/ai.md
+- Added "Viewport controls" section to the console API reference listing all 10 new methods
+
+## Verification
+
+Tested all 5 features via Playwright browser automation:
+- Each get/set pair correctly reads and writes state
+- Toggle behavior works when argument is omitted
+- Validation throws on bad input (`setTheme('invalid')`, `setAutoRun('yes')`)
+- Build passes with no TypeScript errors

--- a/public/ai.md
+++ b/public/ai.md
@@ -129,6 +129,18 @@ await partwright.setActiveLanguage(lang) // Switch engine + editor mode ('manifo
 partwright.toggleClip(on?)     // Toggle 3D clipping plane -> {enabled, z, min, max}
 partwright.setClipZ(z)         // Set clip height -> {enabled, z, min, max}
 partwright.getClipState()      // -> {enabled, z, min, max}
+
+// Viewport controls
+partwright.setGridVisible(on?)       // Show/hide grid plane (omit to toggle) -> boolean
+partwright.isGridVisible()           // Whether grid plane is visible
+partwright.setDimensionsVisible(on?) // Show/hide bounding box dimensions (omit to toggle) -> boolean
+partwright.areDimensionsVisible()    // Whether dimensions overlay is visible
+partwright.setOrbitLock(on?)         // Lock/unlock camera rotation (omit to toggle) -> boolean
+partwright.isOrbitLocked()           // Whether camera orbit is locked
+partwright.setTheme('dark'|'light')  // Set color theme
+partwright.getTheme()                // -> 'dark' or 'light'
+partwright.setAutoRun(enabled)       // Enable/disable auto-render on code edit
+partwright.isAutoRunEnabled()        // Whether auto-run is active
 await partwright.exportGLB()   // Download GLB (browser file dialog -- prefer exportGLBData() in agent flows)
 partwright.exportSTL()         // Download STL ("                                       exportSTLData() ")
 partwright.exportOBJ()         // Download OBJ ("                                       exportOBJData() ")

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, r
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic } from './editor/codeEditor';
 import { createLayout, type TabName } from './ui/layout';
-import { createToolbar, isAutoRun, setToolbarLanguage } from './ui/toolbar';
+import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage } from './ui/toolbar';
 import { createLandingPage } from './ui/landing';
 import { createHelpPage } from './ui/help';
 import { createNotFoundPage } from './ui/notFound';
@@ -47,7 +47,8 @@ import { checkContainment, type ContainmentWarning } from './geometry/containmen
 import { setUnits as _setUnits, getUnits as _getUnits, type UnitSystem } from './geometry/units';
 import { initMeasureTool, activate as activateMeasure, deactivate as deactivateMeasure, getState as getMeasureState } from './ui/measureTool';
 import { maybeStartTour, resetTour, startTour } from './ui/tour';
-import { initTheme } from './ui/theme';
+import { initTheme, getTheme, setTheme } from './ui/theme';
+import type { Theme } from './ui/theme';
 import { initPaintUI, isPaintOpen, forceDeactivate as closePaintMenu } from './color/paintUI';
 import { updatePaintMesh, setOnRegionPainted, isActive as isPaintActive } from './color/paintMode';
 import { initAnnotateUI, isAnnotateOpen, closeMenu as closeAnnotateMenu } from './annotations/annotateUI';
@@ -1848,6 +1849,73 @@ async function main() {
       return getClipState();
     },
 
+    // === Viewport controls API ===
+
+    /** Show or hide the grid plane. Pass a boolean to set, omit to toggle. */
+    setGridVisible(visible?: boolean): boolean {
+      assertBoolean(visible, 'setGridVisible(visible)', { optional: true });
+      const on = visible ?? !isGridVisible();
+      setGridVisible(on);
+      return isGridVisible();
+    },
+
+    /** Whether the grid plane is currently visible */
+    isGridVisible(): boolean {
+      return isGridVisible();
+    },
+
+    /** Show or hide the bounding box dimension overlays. Pass a boolean to set, omit to toggle. */
+    setDimensionsVisible(visible?: boolean): boolean {
+      assertBoolean(visible, 'setDimensionsVisible(visible)', { optional: true });
+      const on = visible ?? !isDimensionsVisible();
+      setDimensionsVisible(on);
+      return isDimensionsVisible();
+    },
+
+    /** Whether bounding box dimensions are currently visible */
+    areDimensionsVisible(): boolean {
+      return isDimensionsVisible();
+    },
+
+    /** Lock or unlock camera orbit rotation. Pass a boolean to set, omit to toggle. */
+    setOrbitLock(locked?: boolean): boolean {
+      assertBoolean(locked, 'setOrbitLock(locked)', { optional: true });
+      const on = locked ?? !isUserOrbitLocked();
+      setUserOrbitLock(on);
+      return isUserOrbitLocked();
+    },
+
+    /** Whether camera orbit is currently locked */
+    isOrbitLocked(): boolean {
+      return isUserOrbitLocked();
+    },
+
+    // === Theme API ===
+
+    /** Set the color theme. */
+    setTheme(theme: Theme): void {
+      assertEnum(theme, ['dark', 'light'], 'setTheme(theme)');
+      setTheme(theme);
+    },
+
+    /** Get the current color theme */
+    getTheme(): Theme {
+      return getTheme();
+    },
+
+    // === Auto-run API ===
+
+    /** Enable or disable auto-run (re-render on edit). */
+    setAutoRun(enabled: boolean): void {
+      assertBoolean(enabled, 'setAutoRun(enabled)');
+      setAutoRun(enabled);
+    },
+
+    /** Whether auto-run is currently enabled */
+    isAutoRunEnabled(): boolean {
+      return isAutoRun();
+    },
+
     // === View rendering API ===
 
     /** Render a single view from any camera angle. Returns a data URL (PNG).
@@ -3050,6 +3118,17 @@ async function main() {
         'renderView':      { signature: 'renderView({elevation?, azimuth?, ortho?, size?}) -- Render from any angle -> data URL', docs: '/ai.md#visual-verification' },
         'analyzeProfile':  { signature: 'analyzeProfile(sampleCount?) -- Z-profile feature summary', docs: '/ai.md#console-api--windowpartwright' },
         'measureAt':       { signature: 'measureAt([x,y]) -- Ray-cast probe at XY -> {hits, thickness, topZ, bottomZ}', docs: '/ai.md#console-api--windowpartwright' },
+        // Viewport controls
+        'setGridVisible':       { signature: 'setGridVisible(on?) -- Show/hide grid plane (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
+        'isGridVisible':        { signature: 'isGridVisible() -- Whether grid plane is visible', docs: '/ai.md#viewport-controls' },
+        'setDimensionsVisible': { signature: 'setDimensionsVisible(on?) -- Show/hide bounding box dimensions (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
+        'areDimensionsVisible': { signature: 'areDimensionsVisible() -- Whether dimensions overlay is visible', docs: '/ai.md#viewport-controls' },
+        'setOrbitLock':         { signature: 'setOrbitLock(on?) -- Lock/unlock camera rotation (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
+        'isOrbitLocked':        { signature: 'isOrbitLocked() -- Whether camera orbit is locked', docs: '/ai.md#viewport-controls' },
+        'setTheme':             { signature: 'setTheme("dark"|"light") -- Set color theme', docs: '/ai.md#viewport-controls' },
+        'getTheme':             { signature: 'getTheme() -- Current color theme', docs: '/ai.md#viewport-controls' },
+        'setAutoRun':           { signature: 'setAutoRun(enabled) -- Enable/disable auto-render on edit', docs: '/ai.md#viewport-controls' },
+        'isAutoRunEnabled':     { signature: 'isAutoRunEnabled() -- Whether auto-run is active', docs: '/ai.md#viewport-controls' },
         // View
         'setView':         { signature: 'setView(tab) -- Switch tab: "interactive", "ai", "elevations", "gallery", "diff"', docs: '/ai.md#view-tabs' },
         'getViewState':    { signature: 'getViewState() -- Current tab and camera state', docs: '/ai.md#view-tabs' },

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -41,9 +41,18 @@ export const IMPORT_ACCEPT = '.partwright.json,.json,.js,.scad';
 
 let _autoRun = true;
 let _onAutoRunChange: ((on: boolean) => void) | null = null;
+let _syncAutoRunUI: (() => void) | null = null;
 
 /** Whether auto-run on edit is enabled */
 export function isAutoRun(): boolean { return _autoRun; }
+
+/** Programmatically set auto-run state (also syncs the toolbar button UI) */
+export function setAutoRun(enabled: boolean): void {
+  if (_autoRun === enabled) return;
+  _autoRun = enabled;
+  _syncAutoRunUI?.();
+  if (_onAutoRunChange) _onAutoRunChange(_autoRun);
+}
 
 /** Register a callback for when auto-run state changes */
 export function onAutoRunChange(cb: (on: boolean) => void): void { _onAutoRunChange = cb; }
@@ -111,6 +120,7 @@ export function createToolbar(
       btnRun.classList.remove('hidden');
     }
   }
+  _syncAutoRunUI = syncAutoRunUI;
 
   autoRunBtn.addEventListener('click', () => {
     _autoRun = !_autoRun;


### PR DESCRIPTION
## Summary

- Adds 10 new `window.partwright` API methods for 5 UI features that had no programmatic interface
- Grid visibility, bounding box dimensions, orbit lock, theme toggle, and auto-run are now all controllable by AI agents
- All methods documented in `public/ai.md` and registered in `partwright.help()`

Closes #92.

## New API methods

| Method | Description |
|---|---|
| `setGridVisible(on?)` | Show/hide grid plane (omit to toggle) |
| `isGridVisible()` | Query grid visibility |
| `setDimensionsVisible(on?)` | Show/hide bounding box dimensions |
| `areDimensionsVisible()` | Query dimensions visibility |
| `setOrbitLock(on?)` | Lock/unlock camera rotation |
| `isOrbitLocked()` | Query orbit lock state |
| `setTheme('dark'\|'light')` | Set color theme |
| `getTheme()` | Query current theme |
| `setAutoRun(enabled)` | Enable/disable auto-render on edit |
| `isAutoRunEnabled()` | Query auto-run state |

## Test plan

- [x] All 5 get/set pairs correctly read and write state (verified via Playwright)
- [x] Toggle behavior works when boolean argument is omitted
- [x] Input validation throws on invalid args (`setTheme('invalid')`, `setAutoRun('yes')`)
- [x] `npm run build` passes with no TypeScript errors
- [x] Methods appear in `partwright.help()` output
- [x] Methods documented in `public/ai.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)