### PR TITLE
fix: scope annotations to a specific version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ After any changes that touch routing, Vite config, index.html, or initialization
 10. **Unlock modal**: Click "Unlock to edit" — a modal should appear with two options (preserve/destructive). Clicking "Unlock editor" with the default "preserve" option should save the colored version and create a new uncolored version. The editor should unlock.
 11. **Gallery badges**: Colored versions in the gallery should show small color-swatch dots next to the version label.
 12. **Color export**: With color regions painted, export GLB — the file should carry vertex colors. Export 3MF — the file should include `<basematerials>` and per-triangle `pid` attributes.
+13. **Annotations are per-version**: Annotate v1, save v2 (annotations persist into v2). Clear annotations, draw a different one, save v3. Navigating v1↔v2↔v3 should swap annotations to match each version (v1 empty, v2 first set, v3 second set). Importing a schema-1.2 file (top-level `annotations`) should attach those annotations to the latest version on import.
 
 ## AI Agent Workflow & API Reference
 

--- a/prompts/20260428-213453-annotations-per-version.md
+++ b/prompts/20260428-213453-annotations-per-version.md
@@ -1,0 +1,71 @@
+---
+session: "jovial-banzai-2848b1"
+timestamp: "2026-04-28T21:34:53Z"
+model: claude-opus-4-7
+---
+
+## Human
+
+> ensure your git worktree is based on staging. I noticed that annotations are
+> specific to a version and when I change versions the annotation stays across
+> all versions. That's not what I was expecting. What do you think makes sense
+> and what would be the implementation plan?
+
+> proceed
+
+> When you're done please make a PR
+
+## Assistant
+
+## Key decisions
+
+**Diagnosis**: `src/annotations/annotations.ts` keeps a single module-level
+array. Versions persist code, geometry, color regions, and thumbnails — but
+neither `loadVersionIntoEditor` nor `saveVersion` touches annotations. So they
+leak across version switches by design (well, by oversight).
+
+**Mental model chosen**: per-version snapshots, write-on-save, swap-on-load.
+This mirrors how `code` and `colorRegions` already behave — annotations are
+feedback *about a particular version of the model*, and once geometry changes
+the anchor may not even land on a face anymore. Tying them to a version is
+the only model that doesn't drift into nonsense.
+
+**Tradeoff accepted**: annotations made while viewing a version but not saved
+are dropped on nav-away (same lifecycle as edited-but-unsaved code). Picked
+this over write-through-on-edit because (a) it's symmetric with how the
+editor already behaves, (b) write-through would silently mutate historical
+versions, which is worse than losing scratch work. If users find the loss
+annoying, a "dirty" indicator on nav-away is a small follow-up.
+
+**Schema bump 1.2 → 1.3**: top-level `annotations` was the wrong place. Moved
+to `versions[].annotations`. 1.2 imports migrate the top-level field onto the
+*latest* exported version (best guess at where they belonged when exported,
+since 1.2 only stored annotations for the active session). Forward-compat is
+silent — older readers ignore new fields per the existing schema policy.
+
+**Wiring decision**: there are five distinct version-load code paths in
+main.ts (loadVersionIntoEditor, sessionBar nav, gallery click,
+partwright.loadVersion, partwright.navigateVersion), each duplicating
+setValue + runCodeSync + rehydrateColorRegions in slightly different ways.
+Rather than refactoring those into a single helper (out of scope for a
+bug fix), I added one `applyVersionAnnotations` helper and called it at
+each site — same shape as the existing `rehydrateColorRegions` pattern. The
+duplication was already there; I'm not making it worse, and consolidating
+all five paths is its own task.
+
+**Where saveVersion grabs the snapshot**: in `sessionManager.saveVersion`,
+not at the call site. The five call sites that save versions (manual save,
+runAndSave, paint-preserve fork x2, paint-clean sibling) all funnel through
+sessionManager — putting `serializeAnnotations()` there means every save
+picks up annotations consistently with no per-call-site bookkeeping.
+
+**Session boundaries**: `createSession`, `closeSession`, `clearAllSessions`
+all `loadAnnotations([])` so a brand-new context starts blank. Without this,
+creating a fresh session while a stale annotation lingered would carry it
+across the boundary.
+
+**Verification**: drove the dev server with chrome-devtools-mcp, ran a
+five-step scenario (v1 unannotated, annotate→save v2, clear-annotate→save
+v3, navigate v1↔v2↔v3) and confirmed annotations swap correctly. Also
+synthesized a 1.2-shape import payload to verify back-compat — top-level
+annotations correctly land on the highest-index version.

--- a/prompts/20260428-213453-annotations-per-version.md
+++ b/prompts/20260428-213453-annotations-per-version.md
@@ -107,3 +107,32 @@ this is fine.
 unchanged); same-code save with new annotation → new version created;
 two saves in a row with no further changes → first creates a version,
 second no-ops.
+
+## Human (third pass)
+
+> Is there anything we need to do to make sure the agent API works
+> correctly? Does ai.md need updating?
+
+## Assistant (third pass)
+
+## Key decisions
+
+**ai.md was factually wrong** in two places after this change. Fixed:
+  - "ephemeral, in-memory visual layer" → annotations now persist per-version.
+  - "ephemeral, not exported" → they ARE exported (in schema 1.3 under
+    `versions[].annotations`).
+
+**Added a Lifecycle paragraph** so AI agents working through the public
+docs know to treat annotations like code: snapshot on `runAndSave` /
+`saveVersion`, swapped on `loadVersion` / `navigateVersion`, lost on
+nav-away if unsaved. This is the kind of behavior an agent would
+otherwise discover only by surprise.
+
+**Did NOT add to `getSessionContext()`** — it currently exposes versions
+with geometry summary + notes but not annotations. Decided this is a
+feature-add, not a fix. The user asked about correctness, not
+completeness, and `listTextAnnotations()` / `listAnnotations()` already
+let an agent inspect the active version's annotations after they call
+`loadVersion`. Leaving session-context enrichment as a follow-up if
+agents start needing per-version annotation summaries before deciding
+which version to load.

--- a/prompts/20260428-213453-annotations-per-version.md
+++ b/prompts/20260428-213453-annotations-per-version.md
@@ -69,3 +69,41 @@ five-step scenario (v1 unannotated, annotate→save v2, clear-annotate→save
 v3, navigate v1↔v2↔v3) and confirmed annotations swap correctly. Also
 synthesized a 1.2-shape import payload to verify back-compat — top-level
 annotations correctly land on the highest-index version.
+
+## Human (follow-up)
+
+> I'm not seeing it work the way I want. I annotated. saved. Then annotated,
+> then clicked save. I didn't see a new version get created. I think that
+> might be a bug specific to this work but I also suspect you may need to
+> refresh your work off the latest staging
+
+## Assistant (follow-up)
+
+## Key decisions
+
+**Diagnosis**: `saveVersion`'s dedup compared only `code`. With annotations
+now per-version, an "annotate then save" sequence with unchanged code hit
+the dedup path and silently no-op'd — exactly the bug the user reported.
+
+**Staging context**: rebased onto staging and found commit `bb8dd8e` had
+already extended the same dedup for color regions, but at the *call site*
+(sessionBar passes `force: true` when colorRegions differ). I considered
+the same approach for annotations but chose to put the check inside
+`saveVersion` instead, because:
+  - sessionManager already calls `serializeAnnotations()` to capture the
+    snapshot, so it has both halves of the comparison locally.
+  - There are multiple save paths (manual button, runAndSave, paint
+    flows) and putting the check in saveVersion means none of them can
+    forget. The colorRegions-at-call-site approach was forced because
+    geometryData is opaque to sessionManager; annotations aren't.
+
+**Equality check**: JSON-stringify on both arrays. Order is meaningful
+(annotations are appended), so no sort. Empty-array fast path before
+serializing. Future optimization opportunity if annotation lists ever
+grow large enough to matter, but for the typical 1-20 annotation case
+this is fine.
+
+**Tested**: same-code save with no annotation change → no-op (count
+unchanged); same-code save with new annotation → new version created;
+two saves in a row with no further changes → first creates a version,
+second no-ops.

--- a/public/ai.md
+++ b/public/ai.md
@@ -829,9 +829,14 @@ overlay). Two kinds of annotations:
 - **Text labels** placed with the text sub-mode -- pinned to a 3D anchor on the surface and
   rendered as a screen-facing label (so they stay readable from any angle).
 
-Both kinds are **not part of the model** -- they're an ephemeral, in-memory visual layer that
+Both kinds are **not part of the model** -- they're a visual feedback layer that
 survives orbiting and appears in **every** rendered output: the live viewport, `renderView()`
 output, the AI Views tab, and the Elevations tab.
+
+**Lifecycle**: annotations are scoped to the current version. `runAndSave` /
+`saveVersion` snapshots the current annotations into the new version, and
+`loadVersion` / `navigateVersion` swap them back in when you return. Unsaved
+annotations are dropped when you switch versions -- same as unsaved code.
 
 When the user has annotated, treat the marks as a directional cue tied to the geometry under
 them. Inspect them via `listAnnotations()` / `listTextAnnotations()`, infer which feature is
@@ -867,10 +872,10 @@ Each stroke and text label records its own color/width/font-size at creation, so
 active settings only affects new annotations.
 
 Annotations are intentionally separate from `paintRegion` colorization:
-- **Annotations** are floating visual marks on top of the surface -- ephemeral, not exported,
-  do not lock the editor.
+- **Annotations** are floating visual marks on top of the surface -- per-version, included in
+  session exports (`.partwright.json`), but do not modify the model geometry or lock the editor.
 - **Color regions** (`paintRegion`) modify the model's vertex colors -- persist with the
-  version, export with the model, and lock the editor while present.
+  version, export with the model (GLB/3MF), and lock the editor while present.
 
 ## Stat-based verification
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,9 +60,11 @@ import {
   clearStrokes as clearStrokesStore,
   clearTexts as clearTextsStore,
   clearAll as clearAllAnnotations,
+  loadFromSerialized as loadAnnotations,
   removeLastAnnotation,
   removeAnnotationById,
   onChange as onAnnotationStrokesChange,
+  type SerializedAnnotation,
 } from './annotations/annotations';
 import {
   setAnnotationsVisible as setAnnotationsVisibleOverlay,
@@ -454,6 +456,14 @@ function getGeometryDataObj(): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+/** Swap the in-memory annotation store to the version's snapshot.
+ *  Treats absence as "empty", so navigating to a version without annotations
+ *  clears any that were on screen for the previously-active version. */
+function applyVersionAnnotations(version: Version | null | undefined): void {
+  const snapshot = (version?.annotations ?? []) as SerializedAnnotation[];
+  loadAnnotations(snapshot);
 }
 
 /** Rehydrate color regions from a version's geometryData.
@@ -1016,6 +1026,7 @@ async function main() {
       if (loadedVersion) {
         rehydrateColorRegions(loadedVersion.geometryData);
       }
+      applyVersionAnnotations(loadedVersion);
     },
     onOpenGallery: () => {
       switchTab('gallery');
@@ -1050,11 +1061,12 @@ async function main() {
   createGalleryView(galleryContainer, async (code: string) => {
     setValue(code);
     await runCodeSync(code);
-    // Rehydrate color regions from the loaded version
+    // Rehydrate color regions and annotations from the loaded version
     const loadedVersion = getState().currentVersion;
     if (loadedVersion) {
       rehydrateColorRegions(loadedVersion.geometryData);
     }
+    applyVersionAnnotations(loadedVersion);
     switchTab('interactive');
   });
 
@@ -1126,6 +1138,7 @@ async function main() {
     setValue(version.code);
     await runCodeSync(version.code);
     rehydrateColorRegions(version.geometryData);
+    applyVersionAnnotations(version);
     const refImages = await getReferenceImagesFromSession();
     if (refImages) {
       _setRefImages(refImages as ReferenceImages);
@@ -2089,6 +2102,7 @@ async function main() {
       setValue(version.code);
       await runCodeSync(version.code);
       rehydrateColorRegions(version.geometryData);
+      applyVersionAnnotations(version);
       return {
         id: version.id,
         index: version.index,
@@ -2107,6 +2121,7 @@ async function main() {
         setValue(version.code);
         await runCodeSync(version.code);
         rehydrateColorRegions(version.geometryData);
+        applyVersionAnnotations(version);
       }
       return version ? { id: version.id, index: version.index, label: version.label } : null;
     },

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -29,6 +29,10 @@ export interface Version {
   label: string;
   timestamp: number;
   notes?: string;
+  /** Snapshot of annotations (freehand strokes + pinned text labels) at the time
+   *  this version was saved. Shape matches `SerializedAnnotation[]` from the
+   *  annotations module — kept as `unknown[]` here to preserve db-layer isolation. */
+  annotations?: unknown[];
 }
 
 export interface SessionNote {
@@ -286,6 +290,8 @@ export async function saveVersion(
   notes?: string,
   /** Override the version timestamp (used by import to preserve the original). */
   timestamp?: number,
+  /** Snapshot of annotations at save time (opaque to the db layer). */
+  annotations?: unknown[],
 ): Promise<Version> {
   const versions = await listVersions(sessionId);
   const nextIndex = versions.length > 0 ? Math.max(...versions.map(v => v.index)) + 1 : 1;
@@ -300,6 +306,7 @@ export async function saveVersion(
     label: label || `v${nextIndex}`,
     timestamp: timestamp ?? Date.now(),
     ...(notes ? { notes } : {}),
+    ...(annotations && annotations.length > 0 ? { annotations } : {}),
   };
 
   const store = await tx('versions', 'readwrite');

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -285,6 +285,17 @@ export async function setSessionLanguage(id: string, language: 'manifold-js' | '
 
 // === Version operations ===
 
+/** Stable structural comparison for annotation snapshots. Both are arrays of
+ *  POJOs, so JSON-stringify is the simplest "equal value" check — order is
+ *  meaningful (annotations are appended) so we don't sort. */
+function annotationsEqual(a: unknown[] | undefined, b: unknown[] | undefined): boolean {
+  const aArr = a ?? [];
+  const bArr = b ?? [];
+  if (aArr.length !== bArr.length) return false;
+  if (aArr.length === 0) return true;
+  return JSON.stringify(aArr) === JSON.stringify(bArr);
+}
+
 export async function saveVersion(
   code: string,
   geometryData: Record<string, unknown> | null,
@@ -295,12 +306,20 @@ export async function saveVersion(
 ): Promise<Version | null> {
   if (!currentState.session) return null;
 
-  // Skip if code is identical to the current version (unless forced)
-  if (!options?.force && currentState.currentVersion && currentState.currentVersion.code === code) {
+  const annotationSnapshot = serializeAnnotations();
+
+  // Skip if both code AND annotations are identical to the current version
+  // (unless forced). Annotations live per-version, so a save that only changes
+  // them must still create a new version — comparing code alone would no-op.
+  if (
+    !options?.force &&
+    currentState.currentVersion &&
+    currentState.currentVersion.code === code &&
+    annotationsEqual(currentState.currentVersion.annotations, annotationSnapshot)
+  ) {
     return null;
   }
 
-  const annotationSnapshot = serializeAnnotations();
   const version = await dbSaveVersion(
     currentState.session.id,
     code,

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -45,8 +45,12 @@ import {
  *  - `1.2` — annotations (freehand strokes + pinned text labels) included at the top
  *           level. Snapshots the in-memory annotation store at export time and is
  *           restored on import. Older readers ignore the field.
+ *  - `1.3` — annotations promoted to a per-version field (`versions[].annotations`).
+ *           Each version snapshots its own annotations, so switching versions swaps
+ *           them in. On import, files at schema 1.2 (top-level annotations) are
+ *           assigned to the latest version for back-compat.
  */
-export const SCHEMA_VERSION = '1.2';
+export const SCHEMA_VERSION = '1.3';
 
 const CURRENT_MAJOR = 1;
 
@@ -69,14 +73,20 @@ export interface ExportedSession {
      * @since 1.1
      */
     colorRegions?: SerializedColorRegion[];
+    /**
+     * Per-version snapshot of freehand strokes and pinned text labels drawn on
+     * the model to communicate intent. Promoted to a per-version field in 1.3.
+     * @since 1.3
+     */
+    annotations?: SerializedAnnotation[];
   }[];
   notes?: { text: string; timestamp: number }[];
   /**
-   * Freehand strokes and pinned text labels drawn on the model to communicate
-   * intent to AI agents working on it. Only included when exporting the
-   * currently active session (annotations live in transient module state and
-   * are not associated with non-active sessions).
-   * @since 1.2
+   * **Deprecated in 1.3** — top-level annotations were the 1.2 location.
+   * Still read on import (assigned to the latest version) for back-compat,
+   * but no longer written. New writers attach annotations per-version under
+   * `versions[].annotations`.
+   * @deprecated since 1.3
    */
   annotations?: SerializedAnnotation[];
 }
@@ -202,6 +212,9 @@ export async function createSession(name?: string, language?: 'manifold-js' | 's
   }
   const session = await dbCreateSession(name, language);
   currentState = { session, currentVersion: null, versionCount: 0 };
+  // Annotations are per-version; a fresh session starts empty so nothing
+  // bleeds in from the previously-active session.
+  loadAnnotations([]);
   updateURL();
   notify();
   return session;
@@ -238,6 +251,7 @@ export async function closeSession(): Promise<void> {
     await deleteIfEmpty(currentState.session.id);
   }
   currentState = { session: null, currentVersion: null, versionCount: 0 };
+  loadAnnotations([]);
   updateURL();
   notify();
 }
@@ -286,6 +300,7 @@ export async function saveVersion(
     return null;
   }
 
+  const annotationSnapshot = serializeAnnotations();
   const version = await dbSaveVersion(
     currentState.session.id,
     code,
@@ -293,6 +308,8 @@ export async function saveVersion(
     thumbnail,
     label,
     notes,
+    undefined,
+    annotationSnapshot,
   );
 
   currentState = {
@@ -530,6 +547,7 @@ export async function deleteIfEmpty(sessionId: string): Promise<boolean> {
 export async function clearAllSessions(): Promise<void> {
   await clearAllData();
   currentState = { session: null, currentVersion: null, versionCount: 0 };
+  loadAnnotations([]);
   updateURL();
   notify();
 }
@@ -554,17 +572,12 @@ export async function exportSession(sessionId?: string): Promise<ExportedSession
   const versions = await dbListVersions(id);
   const notes = await dbListNotes(id);
 
-  // Annotations live in transient module state, not in the database. Only attach
-  // them when the export target is the currently active session — exporting an
-  // inactive session shouldn't pick up annotations belonging to a different model.
-  const isActive = currentState.session?.id === id;
-  const annotations = isActive ? serializeAnnotations() : [];
-
   return {
     partwright: SCHEMA_VERSION,
     session: { name: session.name, created: session.created, updated: session.updated, referenceImages: session.referenceImages ?? null, ...(session.language ? { language: session.language } : {}) },
     versions: versions.map(v => {
       const colorRegions = extractColorRegions(v.geometryData);
+      const versionAnnotations = (v.annotations ?? []) as SerializedAnnotation[];
       return {
         index: v.index,
         code: v.code,
@@ -573,10 +586,10 @@ export async function exportSession(sessionId?: string): Promise<ExportedSession
         timestamp: v.timestamp,
         ...(v.notes ? { notes: v.notes } : {}),
         ...(colorRegions ? { colorRegions } : {}),
+        ...(versionAnnotations.length > 0 ? { annotations: versionAnnotations } : {}),
       };
     }),
     ...(notes.length > 0 ? { notes: notes.map(n => ({ text: n.text, timestamp: n.timestamp })) } : {}),
-    ...(annotations.length > 0 ? { annotations } : {}),
   };
 }
 
@@ -594,6 +607,11 @@ export async function importSession(
   if (data.session.referenceImages) {
     await dbUpdateSession(session.id, { referenceImages: data.session.referenceImages });
   }
+
+  // Determine the index of the latest exported version. Schema 1.2 stored
+  // annotations at the top level; for back-compat we attach them to whichever
+  // version was most recent at export time (assumed to be the highest index).
+  const latestExportedIndex = data.versions.reduce((m, v) => Math.max(m, v.index), -Infinity);
 
   for (const v of data.versions) {
     // Normalize color regions: prefer the explicit (1.1+) field; fall back to the legacy
@@ -613,7 +631,24 @@ export async function importSession(
     if (regenerateThumbnail) {
       thumbnail = await regenerateThumbnail(v.code);
     }
-    await dbSaveVersion(session.id, v.code, geometryData, thumbnail, v.label, v.notes, v.timestamp);
+
+    // Annotations: prefer the per-version field (1.3+). Fall back to the
+    // top-level field (1.2) attached to the latest exported version only.
+    let versionAnnotations: SerializedAnnotation[] | undefined = v.annotations;
+    if (!versionAnnotations && data.annotations && data.annotations.length > 0 && v.index === latestExportedIndex) {
+      versionAnnotations = data.annotations;
+    }
+
+    await dbSaveVersion(
+      session.id,
+      v.code,
+      geometryData,
+      thumbnail,
+      v.label,
+      v.notes,
+      v.timestamp,
+      versionAnnotations,
+    );
   }
 
   // Restore session notes
@@ -638,11 +673,12 @@ export async function importSession(
   updateURL();
   notify();
 
-  // Restore annotations into the in-memory store. This replaces any existing
-  // annotations — the imported session is now the active context.
-  if (data.annotations && data.annotations.length > 0) {
-    loadAnnotations(data.annotations);
-  }
+  // Restore the latest version's annotations into the in-memory store. The
+  // imported session is now the active context, so we replace whatever was
+  // there. (Per-version annotations live on each Version row; older 1.2 files
+  // got migrated onto the latest version above.)
+  const latestAnnotations = (latest?.annotations ?? []) as SerializedAnnotation[];
+  loadAnnotations(latestAnnotations);
 
   return refreshedSession;
 }


### PR DESCRIPTION
## Summary

- Annotations (freehand strokes + pinned text labels) were module-level state and never tied to a version. Switching versions kept whatever was on screen, which doesn't match the rest of the per-version model (code, geometry, color regions).
- Now: each `saveVersion` snapshots the in-memory annotation store; each version-load path swaps annotations to match the loaded version. Unsaved annotations are dropped on nav-away — same lifecycle as edited-but-unsaved code.
- Schema bumped 1.2 → 1.3 (annotations move from top-level to `versions[].annotations`). 1.2 imports migrate top-level annotations onto the latest exported version for back-compat.

## Test plan

- [x] Annotate v1, save v2, clear+annotate, save v3 → v1 empty, v2 first set, v3 second set
- [x] `navigateVersion('prev'/'next')` swaps annotations to match each version
- [x] Add unsaved annotation on v2, nav to v3, nav back → v2 shows only its saved set
- [x] `partwright.loadVersion({ index })` swaps annotations
- [x] Importing a synthesized schema-1.2 payload (top-level `annotations`) attaches them to the highest-indexed version
- [x] `npm run build` succeeds with no TypeScript errors
- [x] Round-trip export: schema is `1.3`, annotations live under `versions[].annotations`, no top-level field

🤖 Generated with [Claude Code](https://claude.com/claude-code)