### PR TITLE
fix: render imported annotations in offscreen panes

### DIFF
--- a/prompts/20260428-232039-fix-import-annotations-not-rendering.md
+++ b/prompts/20260428-232039-fix-import-annotations-not-rendering.md
@@ -1,0 +1,62 @@
+---
+session: "fix-import-annotations"
+timestamp: "2026-04-28T23:20:39Z"
+model: claude-opus-4-7
+---
+
+## Human
+
+> I merged your PR but noticed that now import now longer shows any
+> annotations. Can we fix that in a new PR?
+
+## Assistant
+
+## Key decisions
+
+**Diagnosis**: after the per-version annotations PR landed, two distinct
+`loadAnnotations` calls were happening on import:
+
+1. `importSession` ended with `loadAnnotations(latest.annotations)` so the
+   in-memory store was populated before the function returned.
+2. The caller (`importSessionPayload` in main.ts and the analogous path in
+   sessionList.ts) then ran `openSession` → `loadVersionIntoEditor` (or
+   `onLoadVersion`), which calls `applyVersionAnnotations(version)` —
+   another `loadAnnotations` of the same data.
+
+Each `loadAnnotations` fires `onChange`, which triggers the
+`refreshAnnotationDependentPanes` listener → `updateMultiView` →
+`renderViewsToContainer`, which builds a fresh `Sprite` + `CanvasTexture`,
+adds it to the offscreen scene, renders, removes it, and disposes it.
+
+In quick succession during import, this double-rebuild lands the multiview
+offscreen WebGLRenderer in a state where the FINAL render frame doesn't
+include the annotation pixels — even though the live overlay (interactive
+viewport) shows them correctly. Symptom: AI Views and Elevations tabs
+appear to have no annotations after import.
+
+**Fix**: remove the redundant `loadAnnotations` call from `importSession`.
+Both existing callers route through `applyVersionAnnotations` after
+`importSession` returns, so the annotations still get loaded — just once
+instead of twice. The single load fires `onChange` once and the multiview
+rebuild lands cleanly.
+
+**Why fix here, not at the multiview render**: the multiview-render path
+is shared with many other code-update flows (manual edit, runAndSave,
+gallery click, etc.) and works correctly there. The bug only manifests
+when two `loadAnnotations` happen with the offscreen renderer mid-flight.
+Eliminating the redundant load is precise and doesn't change behavior of
+any other code path. (If we wanted defense-in-depth, we could also debounce
+`refreshAnnotationDependentPanes`, but that adds complexity to fix what is
+really just a duplicate write.)
+
+**Tested**: round-trip export/import shows annotations on the latest
+version's AI Views; per-version swap (load v1, load v2) still works;
+schema-1.2 back-compat still attaches top-level annotations to the latest
+version on import.
+
+**Risk note discovered while debugging**: Vite was serving a different
+worktree's source than mine (CWD mismatch on a stale `npm run dev`
+process), which caused several false-negative test runs where my source
+edits weren't even live. Lesson: when adding console-log diagnostics that
+don't appear in the browser, verify `lsof -p <vite-pid> | grep cwd` before
+spelunking deeper. Lost ~30 min before catching this.

--- a/prompts/20260429-010003-fix-import-summary-annotation-count.md
+++ b/prompts/20260429-010003-fix-import-summary-annotation-count.md
@@ -1,0 +1,37 @@
+---
+session: "fix-import-annotations"
+timestamp: "2026-04-29T01:00:03Z"
+model: claude-opus-4-7
+sequence: 2
+---
+
+## Human
+
+> I created annotations across 3 versions, exported, then started new editor
+> session, then imported. The summary still shows 0 annotations to import.
+
+## Assistant
+
+## Key decisions
+
+**Diagnosis**: `summarizeSessionImport` in `src/ui/importPreview.ts` was
+written for schema 1.2, where annotations lived at the top level of the
+exported JSON (`data.annotations`). After PR #99 promoted them to
+per-version (`versions[].annotations`), the top-level field is no longer
+populated for 1.3 exports — so the summary always read 0.
+
+The fix is two lines: sum `versions[].annotations.length` across all
+versions for 1.3, AND keep the top-level fallback so 1.2 imports
+continue to summarize correctly. Both add together (mutually exclusive
+in practice — a writer never produces both — but the union is
+conservative and harmless).
+
+**Why not catch this in the merged PR**: I never updated
+`importPreview.ts` because I didn't grep for all readers of the legacy
+field when bumping the schema. Lesson: when relocating a field in an
+exported schema, grep the codebase for both the old and new locations
+and audit every reader. The summary modal was an obvious one I missed.
+
+**Tested**: created a session with 0 / 1 / 2 annotations across three
+versions (3 total). The summary now reports 3. Synthesized a 1.2-style
+payload with 2 top-level annotations. The summary reports 2.

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -692,12 +692,12 @@ export async function importSession(
   updateURL();
   notify();
 
-  // Restore the latest version's annotations into the in-memory store. The
-  // imported session is now the active context, so we replace whatever was
-  // there. (Per-version annotations live on each Version row; older 1.2 files
-  // got migrated onto the latest version above.)
-  const latestAnnotations = (latest?.annotations ?? []) as SerializedAnnotation[];
-  loadAnnotations(latestAnnotations);
+  // Note: annotations are NOT loaded here on purpose. The caller is expected to
+  // route the imported session through `loadVersionIntoEditor` (or equivalent)
+  // which will run the version's code, render the mesh, and call
+  // `applyVersionAnnotations`. Loading them twice (once here, once in the editor
+  // path) causes redundant rebuilds of the multiview offscreen renderer that
+  // can land mid-render and produce a frame that misses the annotations.
 
   return refreshedSession;
 }

--- a/src/ui/importPreview.ts
+++ b/src/ui/importPreview.ts
@@ -25,12 +25,20 @@ export function summarizeSessionImport(data: ExportedSession): SessionImportSumm
       if ((refs as Record<string, unknown>)[k]) referenceSides.push(k);
     }
   }
+  // Annotations live per-version since schema 1.3, but 1.2 files put them at
+  // the top level. Sum across both locations so the preview is accurate
+  // regardless of which schema the file was exported with.
+  const perVersionAnnotations = data.versions.reduce(
+    (sum, v) => sum + (v.annotations?.length ?? 0),
+    0,
+  );
+  const topLevelAnnotations = data.annotations?.length ?? 0;
   return {
     sessionName: data.session.name || '(unnamed)',
     schemaVersion: data.partwright ?? data.mainifold ?? 'unknown',
     versionCount: data.versions.length,
     noteCount: data.notes?.length ?? 0,
-    annotationCount: data.annotations?.length ?? 0,
+    annotationCount: perVersionAnnotations + topLevelAnnotations,
     referenceSides,
     language: data.session.language ?? 'manifold-js',
     createdAt: data.session.created ?? null,


### PR DESCRIPTION
## Summary

After [#99](https://github.com/kemper/mainifold/pull/99) merged, importing a session no longer showed annotations in the AI Views / Elevations tabs (the live interactive viewport still showed them). Per-version data was correct in storage and in the in-memory store — the multiview offscreen renderer was just dropping the final frame's annotations.

**Root cause**: two `loadAnnotations` calls fire on import:
1. `importSession` ended with `loadAnnotations(latest.annotations)`.
2. The caller routes through `loadVersionIntoEditor` → `applyVersionAnnotations`, which calls `loadAnnotations` again with the same data.

Each fires `onChange`, each triggers a multiview rebuild that creates fresh `Sprite` + `CanvasTexture`. In quick succession, the offscreen WebGLRenderer's final frame ends up without the annotation pixels.

**Fix**: drop the `loadAnnotations` from `importSession`. Both existing callers (`importSessionPayload` in main.ts and the file-picker import in `sessionList.ts`) already route through `applyVersionAnnotations` after the import returns, so annotations still get loaded — just once instead of twice.

## Test plan

- [x] Round-trip export/import: AI Views shows the latest version's annotation
- [x] Per-version navigation post-import: v1 empty, v2 has annotation, swap works
- [x] Schema-1.2 back-compat: synthesized 1.2 file with top-level `annotations` lands on latest version, visible after import
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)