### PR TITLE
fix: render painted colors in renderView, Elevations, and thumbnails

### DIFF
--- a/prompts/20260429-012442-color-render-views.md
+++ b/prompts/20260429-012442-color-render-views.md
@@ -1,0 +1,51 @@
+---
+session: "color-render-views"
+timestamp: "2026-04-29T01:24:42Z"
+model: claude-opus-4-7
+---
+
+## Human
+
+Make sure your git worktree is based off the latest staging branch. Then,
+research as needed to see if we can make the "AI Views" and "Elevations"
+panes render with color so they're usable to AI agents that are making
+color models. Is it possible and can it be done efficiently?
+
+## Assistant
+
+Rebased the worktree onto `origin/staging` (5c53124). Researched the
+rendering pipeline:
+
+- `meshDataToGeometry()` in `src/renderer/multiview.ts` already builds
+  per-vertex colors from `meshData.triColors` (unindexed triangles).
+- `createWhiteMaterial(true)` already sets `vertexColors: true`.
+- The viewport, AI Views, and Elevations panes already re-render with
+  `applyTriColorsIfVisible(currentMeshData)` on UI-driven paint events.
+
+So the in-DOM panes were correct. The remaining gaps were on the
+agent-facing paths: `renderView()`, `captureThumbnail()`, and the
+programmatic `paintRegion`/`paintFaces`/`paintSlab`/`clearColors` API
+(which updated the viewport and AI Views but never re-rendered the
+Elevations container).
+
+## Human
+
+Yes, proceed and create a PR when it's working.
+
+## Assistant
+
+Wrapped the renderView / thumbnail callsites in `applyTriColorsIfVisible`
+and added `renderElevationsToContainer` to the four programmatic paint
+endpoints. Verified in Chrome:
+
+- AI Views tab pixel-samples show painted faces (`[121,1,1]` red,
+  `[0,111,152]` blue) after `paintRegion` API calls.
+- Elevations tab shows Front=green, Right=blue, Top=red, Isometric blends
+  all three. Center pixels measured (e.g. Top `[121,1,1]`).
+- `renderView({elevation: 90, ortho: true})` returns red-painted PNG.
+- `clearColors()` returns elevations to gray (R==G==B regression check).
+- `npm run build` passes.
+
+No new GPU work — the offscreen `WebGLRenderer` is already a singleton
+and the colored geometry path was already used wherever paint was
+visible. Extending it to the agent-facing paths adds nothing new.

--- a/src/main.ts
+++ b/src/main.ts
@@ -446,7 +446,7 @@ function updateGeometryData(executionTimeMs?: number, sourceCode?: string) {
 function captureThumbnail(): Promise<Blob | null> {
   if (!currentMeshData) return Promise.resolve(null);
   try {
-    const canvas = renderCompositeCanvas(currentMeshData);
+    const canvas = renderCompositeCanvas(applyTriColorsIfVisible(currentMeshData));
     return new Promise(resolve => {
       canvas.toBlob(b => resolve(b), 'image/png');
     });
@@ -1998,7 +1998,7 @@ async function main() {
         assertNumber(o.size, 'renderView(options).size', { optional: true, min: 1, integer: true });
       }
       if (!currentMeshData) return null;
-      return renderSingleView(currentMeshData, options ?? {});
+      return renderSingleView(applyTriColorsIfVisible(currentMeshData), options ?? {});
     },
 
     /** Render a cross-section at Z height as an SVG string for visual verification */
@@ -2955,6 +2955,7 @@ async function main() {
       const colored = applyTriColorsIfVisible(currentMeshData);
       updateMesh(colored, { skipAutoFrame: true });
       updateMultiView(colored);
+      renderElevationsToContainer(elevationsContainer, colored);
       syncLockState();
 
       return { id: region.id, name: region.name, triangles: triangles.size };
@@ -2991,6 +2992,7 @@ async function main() {
       const colored = applyTriColorsIfVisible(currentMeshData);
       updateMesh(colored, { skipAutoFrame: true });
       updateMultiView(colored);
+      renderElevationsToContainer(elevationsContainer, colored);
       syncLockState();
 
       return { id: region.id, name: region.name, triangles: triangles.size };
@@ -3036,6 +3038,7 @@ async function main() {
       const colored = applyTriColorsIfVisible(currentMeshData);
       updateMesh(colored, { skipAutoFrame: true });
       updateMultiView(colored);
+      renderElevationsToContainer(elevationsContainer, colored);
       syncLockState();
 
       return { id: region.id, name: region.name, triangles: triangles.size };
@@ -3059,6 +3062,7 @@ async function main() {
       if (currentMeshData) {
         updateMesh(currentMeshData, { skipAutoFrame: true });
         updateMultiView(currentMeshData);
+        renderElevationsToContainer(elevationsContainer, currentMeshData);
       }
       syncLockState();
       return { cleared: true };


### PR DESCRIPTION
## Summary

- Agent-facing render paths now flow paint-region colors through to the
  output. The viewport and AI Views tab already showed colors; this
  closes the gaps for `renderView()`, gallery thumbnails, and the
  Elevations pane after programmatic paint API calls.
- Two-line wrap (`applyTriColorsIfVisible`) on `renderView()` and
  `captureThumbnail()`; one-line `renderElevationsToContainer` call
  added to `paintRegion` / `paintFaces` / `paintSlab` / `clearColors`.
- No perf cost: the offscreen `WebGLRenderer` is already a singleton and
  the colored geometry path was already used wherever paint visibility
  was on; this just extends it to the four bypassed callsites.

## Why this matters

AI agents building color models drive paint regions through the
`window.partwright` console API. Before this change, `renderView()` —
the primary agent verification tool — returned colorless PNGs even
when regions existed, and the Elevations tab stayed gray after every
programmatic paint until the user toggled tabs or hit annotation
events. Both make agent feedback loops misleading for color work.

## Test plan

- [x] `npm run build` passes
- [x] AI Views tab: pixel-sampled colors after `paintRegion` API calls
      (`[121,1,1]` red, `[0,111,152]` blue)
- [x] Elevations tab: Front=green, Right=blue, Top=red, Isometric
      blends all three (sampled programmatically)
- [x] `renderView({elevation: 90, ortho: true})` returns red top
- [x] `renderView({elevation: 0, azimuth: 90, ortho: true})` returns
      blue right
- [x] `renderView()` on unpainted face returns gray (R==G==B)
- [x] `clearColors()` returns elevations to all-gray (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)