### PR TITLE
feat: paintNearestRegion, findFaces, getMeshSummary, saveVersion no-op feedback

### DIFF
--- a/prompts/20260429-013000-agent-feedback-paint-and-savversion.md
+++ b/prompts/20260429-013000-agent-feedback-paint-and-savversion.md
@@ -1,0 +1,62 @@
+---
+session: "agent-feedback-paint-apis"
+timestamp: "2026-04-29T01:30:00Z"
+model: claude-opus-4-7
+sequence: 1
+---
+
+## Human
+
+> I had a Chrome-extension AI driving the staging deploy. It reported three
+> friction points: (1) `paintRegion` is unforgiving about seed-point
+> placement — `[8, 0.39, 5]` failed but `[8, 0.4, 5]` worked, with no
+> "snap to nearest within tolerance" mode and no error indicating how
+> close the point was; (2) `saveVersion()` silently returned `null` after
+> color regions were applied — the agent had to discover this by listing
+> versions; (3) targeting faces by point is fiddly. Suggested adding
+> `paintNearestRegion({point, color, searchRadius})`, a `findFaces` query
+> by box/normal/color, a `getMeshSummary` returning per-face-group
+> centroids/normals, and either making `saveVersion` work when colors
+> are applied or returning a clear error.
+
+## Assistant
+
+## Key decisions
+
+**`paintNearestRegion`** lives next to `paintRegion` in `src/main.ts`. It
+calls a new `findNearestTriangle` helper in `src/color/adjacency.ts`
+which uses Ericson's closest-point-on-triangle algorithm
+(Real-Time Collision Detection §5.1.5) inlined for hot-loop speed. The
+seed normal comes from the snapped triangle, so callers don't need to
+provide one. On failure, returns `{error, nearestDistance}` with the
+distance so an agent can iterate the radius.
+
+**`findFaces`** is a generic triangle query: filter by `box` (centroid
+inside), `normal` (alignment within `normalTolerance`, default `0.95`),
+`color` (matches a painted region's color), or `region` (subset of an
+existing region's triangles). Returns `{triangleIds, count, matched,
+truncated}` so the caller knows when results were capped at
+`maxResults`. Default normal tolerance is looser than `paintRegion`'s
+`0.9995` because this is for coarse face targeting, not exact-coplanar
+fills.
+
+**`getMeshSummary`** lives in a new `src/color/faceGroups.ts`. It
+flood-fills the mesh into coplanar groups (same BFS as `paintRegion`'s
+`findCoplanarRegion`) and reports each group's area-weighted centroid,
+area-weighted normal, area, bbox, triangleCount, and a sample of
+triangle ids. Sorted largest-first so an agent that only inspects the
+top N gets the most structurally significant faces.
+
+**`saveVersion` no-op fix**: the dedupe check in `sessionManager.ts`
+compared code + annotations only, so saving after `paintRegion` returned
+`null` because the code was unchanged. Added `colorRegionsEqual` to the
+check — if regions differ, the save proceeds. Updated the public API
+wrapper to return `{skipped: true, reason}` for true no-ops and `{error}`
+for missing-session, instead of bare `null`.
+
+**Tested via Playwright**: ran a `cube([10,10,10], true)` and verified all
+6 face-center seeds for `paintNearestRegion` (distance 0); `findFaces`
+by normal/box/region returns 2 triangles per face; `getMeshSummary`
+reports 6 groups with correct centroids and 100-unit areas;
+`saveVersion()` returns `{skipped}` on no-op and saves successfully
+after a paint.

--- a/public/ai.md
+++ b/public/ai.md
@@ -189,9 +189,12 @@ await partwright.openSession(id)         // Open existing session
 await partwright.clearAllSessions()      // Delete all sessions & versions
 
 // Color regions -- tag face regions with a color (see #color-regions)
-partwright.paintRegion({point, normal, color, name?, tolerance?}) // bucket: coplanar flood-fill -> {id, name, triangles} or {error}
-partwright.paintFaces({triangleIds, color, name?})                // brush: paint specific triangle indices -> {id, name, triangles} or {error}
-partwright.paintSlab({axis|normal, offset, thickness, color, name?}) // slab: paint a planar range -> {id, name, triangles} or {error}
+partwright.paintRegion({point, normal, color, name?, tolerance?})         // bucket: coplanar flood-fill -> {id, name, triangles} or {error}
+partwright.paintNearestRegion({point, color, searchRadius?, name?, tolerance?}) // snap seed to nearest face, then flood-fill -> {id, name, triangles, snappedTo} or {error}
+partwright.paintFaces({triangleIds, color, name?})                        // brush: paint specific triangle indices -> {id, name, triangles} or {error}
+partwright.paintSlab({axis|normal, offset, thickness, color, name?})      // slab: paint a planar range -> {id, name, triangles} or {error}
+partwright.findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?}) // query triangle ids by geometry/color -> {triangleIds, count, matched, truncated}
+partwright.getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?}?) // -> {groups[{id, normal, centroid, area, triangleCount, bbox, triangleIds}], totalTriangles, groupCount, tolerance}
 partwright.listRegions()                 // -> [{id, name, color, source, triangles, order}, ...]
 partwright.clearColors()                 // Remove all regions
 
@@ -436,12 +439,49 @@ partwright.clearColors()    // remove all regions
 
 **How face matching works.** `paintRegion` flood-fills outward from the seed triangle, including any neighbor whose normal is within `tolerance` of the seed's. Pick `point` slightly inside the model surface and pass the outward-pointing `normal` -- the seed resolver looks for the triangle whose plane the point lies on and whose normal aligns with yours.
 
+**`paintRegion` is strict about seed placement** -- the point must lie on the surface within ~0.01 units. If you'd rather snap to the nearest face within a tolerance and skip the trial-and-error of placing a point exactly, use `paintNearestRegion`:
+
+```js
+// Snap [8, 0.39, 5] to whatever face is closest within 1.0 units, then paint.
+const r = partwright.paintNearestRegion({
+  point: [8, 0.39, 5],
+  color: [0, 0.6, 1],
+  searchRadius: 1.0,        // optional cap; omit to always pick the closest face
+  name: "Fin",              // optional
+  tolerance: 0.9995,        // optional flood-fill tolerance, same semantics as paintRegion
+});
+// On success: { id, name, triangles, snappedTo: { point, normal, distance } }
+// On failure: { error: "...nearest face is X.XX units away, outside searchRadius=...", nearestDistance }
+// The seed normal is taken from the snapped triangle, so callers don't have to know it in advance.
+```
+
+**Targeting faces by geometry instead of by point.** `findFaces` queries triangle indices by box, normal, color, or region — pass the result straight to `paintFaces` to color procedurally. `getMeshSummary` partitions the mesh into coplanar face groups (sorted largest-first) and reports each group's centroid, normal, area, and bounding box; pick a group, then call `paintFaces({ triangleIds: group.triangleIds, color })`.
+
+```js
+// Find every roughly-upward face inside a bounding box (e.g. the top of a part).
+const top = partwright.findFaces({
+  box: { min: [-50, -50, 9], max: [50, 50, 11] },
+  normal: [0, 0, 1],
+  normalTolerance: 0.95,    // ~18° cone around +Z
+});
+// -> { triangleIds: [...], count, matched, truncated }
+partwright.paintFaces({ triangleIds: top.triangleIds, color: [1, 0.6, 0], name: "Top" });
+
+// Or get a structural overview and pick by area.
+const summary = partwright.getMeshSummary({ minTriangles: 4 });
+// summary.groups is sorted largest first.
+const largestSideFace = summary.groups.find(g => Math.abs(g.normal[2]) < 0.1);
+partwright.paintFaces({ triangleIds: largestSideFace.triangleIds, color: [0.2, 0.4, 0.9] });
+```
+
+`findFaces` filters all AND together. Pass `region: <id>` from `listRegions()` to subset by an existing painted region. The default `normalTolerance` is `0.95` (≈18° cone) — looser than `paintRegion`'s `0.9995` because it's intended for catching whole faces of a primitive, not exact-coplanar fills.
+
 **Other paint tools.**
 
 ```js
-// Brush: paint specific triangle indices (no flood-fill).
-// Use partwright.getGeometry() to find triangle indices, or capture them from
-// hover during a UI-driven paint session.
+// Brush: paint specific triangle indices (no flood-fill). Use findFaces() or
+// getMeshSummary() to source the indices procedurally; the Paint UI also
+// emits indices when picking faces interactively.
 partwright.paintFaces({
   triangleIds: [12, 13, 14, 27],
   color: [0, 0.6, 1],
@@ -472,6 +512,8 @@ partwright.paintSlab({
 **Bucket tolerance.** `paintRegion`'s `tolerance` is a cosine threshold for the bend angle between adjacent faces (default `0.9995`, ≈ 1.8°). The flood-fill crosses an edge only when the bend at that edge is below the angle threshold — checked between the *parent* face and each *neighbor*, not against the seed. This means flood-fill follows curved surfaces: a 32-sided cylinder bends ~11° per face, so any tolerance ≥ cos(11°) ≈ `0.98` covers the whole cylinder. Set tolerance to `-1` (180°) to paint the entire connected mesh. The Paint UI exposes the same control as a slider labeled in degrees (0°–180°).
 
 **Editor lock.** When color regions exist, the editor is locked (the model can't be re-run, because new geometry would invalidate the saved triangle indices). To edit code, the user clicks "Unlock to edit" in the UI. Agents that need to iterate on the geometry should call `clearColors()` first, or fork a new uncolored version with `forkVersion`.
+
+**Saving a colored version.** Calling `saveVersion(label)` after painting *will* persist the regions onto a new version — the dedupe check considers code, annotations, and color regions together. If nothing has changed, `saveVersion()` returns `{ skipped: true, reason: "..." }` instead of `null`, so a no-op is visible. If you want to be sure a save happened, check the return shape: `{ id, index, label }` on success, `{ skipped }` on no-op, `{ error }` if no session is open.
 
 **Export behavior.**
 - `exportGLB()` -- vertex colors flow through automatically.

--- a/src/color/adjacency.ts
+++ b/src/color/adjacency.ts
@@ -159,6 +159,109 @@ export function getTriangleCentroid(triIndex: number, mesh: MeshData): [number, 
   ];
 }
 
+/** Find the triangle whose surface point is closest to a given world point.
+ *  Returns the triangle index, the closest point on that triangle, the
+ *  triangle's normal, and the distance from the input point. Returns -1 for
+ *  the index when the mesh has no triangles. */
+export function findNearestTriangle(
+  point: [number, number, number],
+  mesh: MeshData,
+  adjacency: AdjacencyGraph,
+): { triIndex: number; closest: [number, number, number]; normal: [number, number, number]; distance: number } {
+  const { triVerts, vertProperties, numProp, numTri } = mesh;
+
+  let bestDist = Infinity;
+  let bestTri = -1;
+  let bestPoint: [number, number, number] = [0, 0, 0];
+
+  const px = point[0], py = point[1], pz = point[2];
+
+  for (let t = 0; t < numTri; t++) {
+    const v0i = triVerts[t * 3];
+    const v1i = triVerts[t * 3 + 1];
+    const v2i = triVerts[t * 3 + 2];
+
+    const ax = vertProperties[v0i * numProp];
+    const ay = vertProperties[v0i * numProp + 1];
+    const az = vertProperties[v0i * numProp + 2];
+    const bx = vertProperties[v1i * numProp];
+    const by = vertProperties[v1i * numProp + 1];
+    const bz = vertProperties[v1i * numProp + 2];
+    const cx = vertProperties[v2i * numProp];
+    const cy = vertProperties[v2i * numProp + 1];
+    const cz = vertProperties[v2i * numProp + 2];
+
+    const cp = closestPointOnTriangle(px, py, pz, ax, ay, az, bx, by, bz, cx, cy, cz);
+    const dx = cp[0] - px, dy = cp[1] - py, dz = cp[2] - pz;
+    const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestTri = t;
+      bestPoint = cp;
+    }
+  }
+
+  const normal: [number, number, number] = bestTri >= 0
+    ? [adjacency.normals[bestTri * 3], adjacency.normals[bestTri * 3 + 1], adjacency.normals[bestTri * 3 + 2]]
+    : [0, 0, 0];
+
+  return { triIndex: bestTri, closest: bestPoint, normal, distance: bestDist };
+}
+
+/** Closest point on triangle ABC to point P (Ericson, Real-Time Collision
+ *  Detection, ch. 5.1.5). Inlined for hot-loop use. */
+function closestPointOnTriangle(
+  px: number, py: number, pz: number,
+  ax: number, ay: number, az: number,
+  bx: number, by: number, bz: number,
+  cx: number, cy: number, cz: number,
+): [number, number, number] {
+  const abx = bx - ax, aby = by - ay, abz = bz - az;
+  const acx = cx - ax, acy = cy - ay, acz = cz - az;
+  const apx = px - ax, apy = py - ay, apz = pz - az;
+
+  const d1 = abx * apx + aby * apy + abz * apz;
+  const d2 = acx * apx + acy * apy + acz * apz;
+  if (d1 <= 0 && d2 <= 0) return [ax, ay, az];
+
+  const bpx = px - bx, bpy = py - by, bpz = pz - bz;
+  const d3 = abx * bpx + aby * bpy + abz * bpz;
+  const d4 = acx * bpx + acy * bpy + acz * bpz;
+  if (d3 >= 0 && d4 <= d3) return [bx, by, bz];
+
+  const vc = d1 * d4 - d3 * d2;
+  if (vc <= 0 && d1 >= 0 && d3 <= 0) {
+    const v = d1 / (d1 - d3);
+    return [ax + v * abx, ay + v * aby, az + v * abz];
+  }
+
+  const cpx = px - cx, cpy = py - cy, cpz = pz - cz;
+  const d5 = abx * cpx + aby * cpy + abz * cpz;
+  const d6 = acx * cpx + acy * cpy + acz * cpz;
+  if (d6 >= 0 && d5 <= d6) return [cx, cy, cz];
+
+  const vb = d5 * d2 - d1 * d6;
+  if (vb <= 0 && d2 >= 0 && d6 <= 0) {
+    const w = d2 / (d2 - d6);
+    return [ax + w * acx, ay + w * acy, az + w * acz];
+  }
+
+  const va = d3 * d6 - d5 * d4;
+  if (va <= 0 && d4 - d3 >= 0 && d5 - d6 >= 0) {
+    const w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+    return [bx + w * (cx - bx), by + w * (cy - by), bz + w * (cz - bz)];
+  }
+
+  const denom = 1 / (va + vb + vc);
+  const v = vb * denom;
+  const w = vc * denom;
+  return [
+    ax + abx * v + acx * w,
+    ay + aby * v + acy * w,
+    az + abz * v + acz * w,
+  ];
+}
+
 /** Resolve a spatial seed descriptor back to a triangle index by raycasting
  *  from seedPoint along -seedNormal into the mesh. Returns the first triangle
  *  whose normal matches within tolerance, or -1 if none found. */

--- a/src/color/faceGroups.ts
+++ b/src/color/faceGroups.ts
@@ -1,0 +1,159 @@
+// Face groups — partition the mesh into coplanar (or near-coplanar) regions
+// and report each group's centroid, area, normal, and bounding box. This gives
+// agents a structural overview of large face groups so they can target paint
+// operations procedurally instead of guessing exact seed points.
+
+import type { MeshData } from '../geometry/types';
+import { buildAdjacency, findCoplanarRegion, type AdjacencyGraph } from './adjacency';
+
+export interface FaceGroup {
+  /** Stable index assigned by traversal order. */
+  id: number;
+  /** Average outward-pointing unit normal (area-weighted). */
+  normal: [number, number, number];
+  /** Area-weighted centroid in world coordinates. */
+  centroid: [number, number, number];
+  /** Sum of triangle areas in this group. */
+  area: number;
+  /** Number of triangles in this group. */
+  triangleCount: number;
+  /** Axis-aligned bounding box of the group's triangles. */
+  bbox: { min: [number, number, number]; max: [number, number, number] };
+  /** Triangle indices belonging to this group. Capped by `maxTrianglesPerGroup`. */
+  triangleIds: number[];
+}
+
+export interface FaceGroupSummary {
+  groups: FaceGroup[];
+  /** Total triangles in the mesh (sum of triangleCount across all groups). */
+  totalTriangles: number;
+  /** Tolerance used to compute the grouping. */
+  tolerance: number;
+}
+
+interface FaceGroupOptions {
+  /** Cosine bend tolerance for the BFS that gathers each group. Default 0.9995 (≈1.8°). */
+  tolerance?: number;
+  /** Skip groups smaller than this many triangles. Default 1 (return everything). */
+  minTriangles?: number;
+  /** Maximum number of triangle indices to include per group. Default 64.
+   *  Set to 0 to omit triangle ids and keep only summary stats. */
+  maxTrianglesPerGroup?: number;
+  /** Maximum number of groups to return (largest by triangle count first).
+   *  Default 256 — large enough for typical models. Set 0 for unlimited. */
+  maxGroups?: number;
+}
+
+export function computeFaceGroups(mesh: MeshData, options?: FaceGroupOptions): FaceGroupSummary {
+  const tolerance = options?.tolerance ?? 0.9995;
+  const minTriangles = Math.max(1, options?.minTriangles ?? 1);
+  const maxTrianglesPerGroup = options?.maxTrianglesPerGroup ?? 64;
+  const maxGroups = options?.maxGroups ?? 256;
+
+  const adjacency = buildAdjacency(mesh);
+  const visited = new Uint8Array(mesh.numTri);
+  const groups: FaceGroup[] = [];
+
+  for (let seed = 0; seed < mesh.numTri; seed++) {
+    if (visited[seed]) continue;
+    const triangles = findCoplanarRegion(seed, adjacency, tolerance);
+    for (const t of triangles) visited[t] = 1;
+    if (triangles.size < minTriangles) continue;
+    groups.push(buildGroup(groups.length, triangles, mesh, adjacency, maxTrianglesPerGroup));
+  }
+
+  // Largest groups first so an agent that only inspects the top N gets the
+  // most structurally significant faces.
+  groups.sort((a, b) => b.triangleCount - a.triangleCount);
+  for (let i = 0; i < groups.length; i++) groups[i].id = i;
+
+  const trimmed = maxGroups > 0 ? groups.slice(0, maxGroups) : groups;
+
+  return {
+    groups: trimmed,
+    totalTriangles: mesh.numTri,
+    tolerance,
+  };
+}
+
+function buildGroup(
+  id: number,
+  triangles: Set<number>,
+  mesh: MeshData,
+  adjacency: AdjacencyGraph,
+  maxIds: number,
+): FaceGroup {
+  const { triVerts, vertProperties, numProp } = mesh;
+
+  let cx = 0, cy = 0, cz = 0;
+  let nx = 0, ny = 0, nz = 0;
+  let totalArea = 0;
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+
+  const ids: number[] = [];
+
+  for (const t of triangles) {
+    if (maxIds === 0 ? false : ids.length < maxIds) ids.push(t);
+
+    const v0 = triVerts[t * 3];
+    const v1 = triVerts[t * 3 + 1];
+    const v2 = triVerts[t * 3 + 2];
+
+    const ax = vertProperties[v0 * numProp];
+    const ay = vertProperties[v0 * numProp + 1];
+    const az = vertProperties[v0 * numProp + 2];
+    const bx = vertProperties[v1 * numProp];
+    const by = vertProperties[v1 * numProp + 1];
+    const bz = vertProperties[v1 * numProp + 2];
+    const cx2 = vertProperties[v2 * numProp];
+    const cy2 = vertProperties[v2 * numProp + 1];
+    const cz2 = vertProperties[v2 * numProp + 2];
+
+    if (ax < minX) minX = ax; if (ay < minY) minY = ay; if (az < minZ) minZ = az;
+    if (bx < minX) minX = bx; if (by < minY) minY = by; if (bz < minZ) minZ = bz;
+    if (cx2 < minX) minX = cx2; if (cy2 < minY) minY = cy2; if (cz2 < minZ) minZ = cz2;
+    if (ax > maxX) maxX = ax; if (ay > maxY) maxY = ay; if (az > maxZ) maxZ = az;
+    if (bx > maxX) maxX = bx; if (by > maxY) maxY = by; if (bz > maxZ) maxZ = bz;
+    if (cx2 > maxX) maxX = cx2; if (cy2 > maxY) maxY = cy2; if (cz2 > maxZ) maxZ = cz2;
+
+    // Triangle area = 0.5 * |AB x AC|
+    const e1x = bx - ax, e1y = by - ay, e1z = bz - az;
+    const e2x = cx2 - ax, e2y = cy2 - ay, e2z = cz2 - az;
+    const crx = e1y * e2z - e1z * e2y;
+    const cry = e1z * e2x - e1x * e2z;
+    const crz = e1x * e2y - e1y * e2x;
+    const area = 0.5 * Math.sqrt(crx * crx + cry * cry + crz * crz);
+
+    const triCx = (ax + bx + cx2) / 3;
+    const triCy = (ay + by + cy2) / 3;
+    const triCz = (az + bz + cz2) / 3;
+    cx += triCx * area;
+    cy += triCy * area;
+    cz += triCz * area;
+
+    nx += adjacency.normals[t * 3] * area;
+    ny += adjacency.normals[t * 3 + 1] * area;
+    nz += adjacency.normals[t * 3 + 2] * area;
+
+    totalArea += area;
+  }
+
+  const safeArea = totalArea > 0 ? totalArea : 1;
+  const centroid: [number, number, number] = [cx / safeArea, cy / safeArea, cz / safeArea];
+
+  const nLen = Math.hypot(nx, ny, nz);
+  const normal: [number, number, number] = nLen > 0
+    ? [nx / nLen, ny / nLen, nz / nLen]
+    : [0, 0, 0];
+
+  return {
+    id,
+    normal,
+    centroid,
+    area: totalArea,
+    triangleCount: triangles.size,
+    bbox: { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] },
+    triangleIds: ids,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,8 +78,9 @@ import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontS
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
 import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, type SerializedColorRegion } from './color/regions';
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
-import { buildAdjacency, findCoplanarRegion, resolveSeed } from './color/adjacency';
+import { buildAdjacency, findCoplanarRegion, resolveSeed, findNearestTriangle } from './color/adjacency';
 import { findSlabTriangles } from './color/slabPaint';
+import { computeFaceGroups } from './color/faceGroups';
 import {
   getSessionIdFromURL,
   getVersionFromURL,
@@ -2115,12 +2116,22 @@ async function main() {
       await deleteSession(id);
     },
 
-    /** Save current state as a new version in the active session */
+    /** Save current state as a new version in the active session.
+     *  Returns `{ id, index, label }` on success, `{ error }` if no session is
+     *  active, or `{ skipped: true, reason }` when nothing has changed since
+     *  the current version (code, annotations, and color regions all match). */
     async saveVersion(label?: string) {
       assertString(label, 'saveVersion(label)', { optional: true });
+      if (!getState().session) {
+        return { error: 'No active session. Call createSession() or openSession(id) first.' };
+      }
       const thumbnail = await captureThumbnail();
       const version = await saveVersion(getValue(), enrichGeometryDataWithColors(getGeometryDataObj()), thumbnail, label);
-      return version ? { id: version.id, index: version.index, label: version.label } : null;
+      if (version) return { id: version.id, index: version.index, label: version.label };
+      return {
+        skipped: true,
+        reason: 'No changes since the current version (code, annotations, and color regions all match). Add a new region, edit code, or pass a different label to force a save.',
+      };
     },
 
     /** List all versions in the current session */
@@ -2960,6 +2971,69 @@ async function main() {
       return { id: region.id, name: region.name, triangles: triangles.size };
     },
 
+    /** Paint a coplanar region by snapping the seed point to the nearest face on
+     *  the model. Tolerant of off-surface points within `searchRadius` (default
+     *  `Infinity` — always picks the closest face). The seed normal is taken
+     *  from the snapped triangle, so callers don't need to know it. Returns
+     *  `{ id, name, triangles, snappedTo: { point, normal, distance } }` on
+     *  success, or `{ error, nearestDistance? }` on failure. */
+    paintNearestRegion(opts: {
+      point: [number, number, number];
+      color: [number, number, number];
+      searchRadius?: number;
+      name?: string;
+      tolerance?: number;
+    }) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      if (!opts || typeof opts !== 'object') {
+        return { error: 'paintNearestRegion requires {point, color, searchRadius?, tolerance?}' };
+      }
+      const { point, color, searchRadius, name, tolerance } = opts;
+      if (!Array.isArray(point) || point.length !== 3) return { error: 'point must be [x,y,z]' };
+      if (!Array.isArray(color) || color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+      if (searchRadius !== undefined && (typeof searchRadius !== 'number' || !Number.isFinite(searchRadius) || searchRadius < 0)) {
+        return { error: 'searchRadius must be a non-negative finite number' };
+      }
+
+      const normalTolerance = tolerance ?? 0.9995;
+      const adjacency = buildAdjacency(currentMeshData);
+      const nearest = findNearestTriangle(point as [number, number, number], currentMeshData, adjacency);
+      if (nearest.triIndex < 0) return { error: 'Mesh has no triangles' };
+
+      if (searchRadius !== undefined && nearest.distance > searchRadius) {
+        return {
+          error: `Nearest face is ${nearest.distance.toFixed(4)} units from the seed point, outside searchRadius=${searchRadius}. Increase searchRadius or move the point closer to the surface.`,
+          nearestDistance: nearest.distance,
+        };
+      }
+
+      const triangles = findCoplanarRegion(nearest.triIndex, adjacency, normalTolerance);
+      const regionName = name ?? `Region ${getRegions().length + 1}`;
+      const region = addRegion(
+        regionName,
+        color as [number, number, number],
+        'face-pick',
+        { kind: 'coplanar', seedPoint: nearest.closest, seedNormal: nearest.normal, normalTolerance },
+        triangles,
+      );
+
+      const colored = applyTriColorsIfVisible(currentMeshData);
+      updateMesh(colored, { skipAutoFrame: true });
+      updateMultiView(colored);
+      syncLockState();
+
+      return {
+        id: region.id,
+        name: region.name,
+        triangles: triangles.size,
+        snappedTo: {
+          point: nearest.closest,
+          normal: nearest.normal,
+          distance: nearest.distance,
+        },
+      };
+    },
+
     /** Paint a specific set of triangle indices as a single region.
      *  Useful for paintbrush-style selections produced programmatically. */
     paintFaces(opts: { triangleIds: number[]; color: [number, number, number]; name?: string }) {
@@ -3062,6 +3136,189 @@ async function main() {
       }
       syncLockState();
       return { cleared: true };
+    },
+
+    /** Query triangles on the current mesh by geometric or color filters.
+     *  Returns `{ triangleIds, count, sampled }` so the result can be passed
+     *  directly to `paintFaces({ triangleIds, color })`.
+     *
+     *  Filters (all optional, ANDed together):
+     *  - `box`: `{ min: [x,y,z], max: [x,y,z] }` — triangle centroid lies inside
+     *  - `normal`: `[nx,ny,nz]` — triangle normal aligns within `normalTolerance`
+     *  - `normalTolerance`: cosine threshold (default `0.95`, ≈18°)
+     *  - `color`: `[r,g,b]` — triangle is currently painted this color (RGB 0..1, matched to ±0.01)
+     *  - `region`: number — only triangles inside the listRegions() entry with this `id`
+     *  - `maxResults`: cap output (default `5000`)
+     */
+    findFaces(opts: {
+      box?: { min: [number, number, number]; max: [number, number, number] };
+      normal?: [number, number, number];
+      normalTolerance?: number;
+      color?: [number, number, number];
+      region?: number;
+      maxResults?: number;
+    } = {}) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      if (typeof opts !== 'object' || opts === null) {
+        return { error: 'findFaces requires an options object — see /ai.md#color-regions' };
+      }
+
+      const { box, normal, normalTolerance, color, region, maxResults } = opts;
+
+      let boxMin: [number, number, number] | null = null;
+      let boxMax: [number, number, number] | null = null;
+      if (box !== undefined) {
+        if (typeof box !== 'object' || box === null || !Array.isArray(box.min) || !Array.isArray(box.max)) {
+          return { error: 'findFaces.box must be { min: [x,y,z], max: [x,y,z] }' };
+        }
+        if (box.min.length !== 3 || box.max.length !== 3) {
+          return { error: 'findFaces.box.min/max must be 3-tuples' };
+        }
+        boxMin = box.min as [number, number, number];
+        boxMax = box.max as [number, number, number];
+        for (let i = 0; i < 3; i++) {
+          if (!Number.isFinite(boxMin[i]) || !Number.isFinite(boxMax[i])) {
+            return { error: 'findFaces.box values must be finite numbers' };
+          }
+          if (boxMin[i] > boxMax[i]) return { error: `findFaces.box.min[${i}] (${boxMin[i]}) must be <= box.max[${i}] (${boxMax[i]})` };
+        }
+      }
+
+      let nrm: [number, number, number] | null = null;
+      if (normal !== undefined) {
+        if (!Array.isArray(normal) || normal.length !== 3) return { error: 'findFaces.normal must be [nx,ny,nz]' };
+        const [nx, ny, nz] = normal;
+        const len = Math.hypot(nx, ny, nz);
+        if (!Number.isFinite(len) || len === 0) return { error: 'findFaces.normal must be a non-zero 3-vector' };
+        nrm = [nx / len, ny / len, nz / len];
+      }
+
+      const cosTol = normalTolerance ?? 0.95;
+      if (typeof cosTol !== 'number' || !Number.isFinite(cosTol)) {
+        return { error: 'findFaces.normalTolerance must be a finite number in [-1, 1]' };
+      }
+
+      let colorTarget: [number, number, number] | null = null;
+      if (color !== undefined) {
+        if (!Array.isArray(color) || color.length !== 3) return { error: 'findFaces.color must be [r,g,b] with values 0..1' };
+        colorTarget = [color[0], color[1], color[2]];
+      }
+
+      let regionTriangles: Set<number> | null = null;
+      if (region !== undefined) {
+        if (typeof region !== 'number' || !Number.isInteger(region)) {
+          return { error: 'findFaces.region must be a region id (integer) from listRegions()' };
+        }
+        const found = getRegions().find(r => r.id === region);
+        if (!found) return { error: `findFaces.region: no region with id=${region}. Use listRegions() to see ids.` };
+        regionTriangles = found.triangles;
+      }
+
+      const limit = maxResults ?? 5000;
+      if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) {
+        return { error: 'findFaces.maxResults must be a positive integer' };
+      }
+
+      const mesh = currentMeshData;
+      const adjacency = nrm ? buildAdjacency(mesh) : null;
+      const triColors = colorTarget ? (() => {
+        const numTri = mesh.numTri;
+        return (function() {
+          const buf = new Uint8Array(numTri * 3);
+          for (const r of [...getRegions()].sort((a, b) => a.order - b.order)) {
+            const rr = Math.round(r.color[0] * 255);
+            const gg = Math.round(r.color[1] * 255);
+            const bb = Math.round(r.color[2] * 255);
+            for (const t of r.triangles) {
+              if (t >= 0 && t < numTri) {
+                buf[t * 3] = rr;
+                buf[t * 3 + 1] = gg;
+                buf[t * 3 + 2] = bb;
+              }
+            }
+          }
+          return buf;
+        })();
+      })() : null;
+
+      const result: number[] = [];
+      let visited = 0;
+
+      const cR = colorTarget ? Math.round(colorTarget[0] * 255) : 0;
+      const cG = colorTarget ? Math.round(colorTarget[1] * 255) : 0;
+      const cB = colorTarget ? Math.round(colorTarget[2] * 255) : 0;
+
+      for (let t = 0; t < mesh.numTri; t++) {
+        if (regionTriangles && !regionTriangles.has(t)) continue;
+
+        if (boxMin && boxMax) {
+          const v0 = mesh.triVerts[t * 3];
+          const v1 = mesh.triVerts[t * 3 + 1];
+          const v2 = mesh.triVerts[t * 3 + 2];
+          const cx = (mesh.vertProperties[v0 * mesh.numProp] + mesh.vertProperties[v1 * mesh.numProp] + mesh.vertProperties[v2 * mesh.numProp]) / 3;
+          const cy = (mesh.vertProperties[v0 * mesh.numProp + 1] + mesh.vertProperties[v1 * mesh.numProp + 1] + mesh.vertProperties[v2 * mesh.numProp + 1]) / 3;
+          const cz = (mesh.vertProperties[v0 * mesh.numProp + 2] + mesh.vertProperties[v1 * mesh.numProp + 2] + mesh.vertProperties[v2 * mesh.numProp + 2]) / 3;
+          if (cx < boxMin[0] || cx > boxMax[0] || cy < boxMin[1] || cy > boxMax[1] || cz < boxMin[2] || cz > boxMax[2]) continue;
+        }
+
+        if (nrm && adjacency) {
+          const nx = adjacency.normals[t * 3];
+          const ny = adjacency.normals[t * 3 + 1];
+          const nz = adjacency.normals[t * 3 + 2];
+          const dot = nrm[0] * nx + nrm[1] * ny + nrm[2] * nz;
+          if (dot < cosTol) continue;
+        }
+
+        if (triColors) {
+          if (triColors[t * 3] !== cR || triColors[t * 3 + 1] !== cG || triColors[t * 3 + 2] !== cB) continue;
+        }
+
+        visited++;
+        if (result.length < limit) result.push(t);
+      }
+
+      return {
+        triangleIds: result,
+        count: result.length,
+        matched: visited,
+        truncated: visited > result.length,
+      };
+    },
+
+    /** Summarize the mesh as a list of coplanar face groups, sorted by
+     *  triangle count descending. Each group reports a centroid, area-weighted
+     *  normal, area, bounding box, and a sample of triangle ids. Use this to
+     *  pick paint targets procedurally without trial-and-error point placement.
+     *
+     *  Options:
+     *  - `tolerance`: cosine bend threshold (default `0.9995`, ≈1.8°)
+     *  - `minTriangles`: skip groups smaller than this (default `1`)
+     *  - `maxTrianglesPerGroup`: cap reported triangleIds per group (default `64`, `0` to omit)
+     *  - `maxGroups`: cap number of returned groups (default `256`, `0` for unlimited)
+     */
+    getMeshSummary(opts?: { tolerance?: number; minTriangles?: number; maxTrianglesPerGroup?: number; maxGroups?: number }) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      const o = opts ?? {};
+      if (o.tolerance !== undefined && (typeof o.tolerance !== 'number' || !Number.isFinite(o.tolerance))) {
+        return { error: 'getMeshSummary.tolerance must be a finite number in [-1, 1]' };
+      }
+      if (o.minTriangles !== undefined && (typeof o.minTriangles !== 'number' || !Number.isInteger(o.minTriangles) || o.minTriangles < 1)) {
+        return { error: 'getMeshSummary.minTriangles must be a positive integer' };
+      }
+      if (o.maxTrianglesPerGroup !== undefined && (typeof o.maxTrianglesPerGroup !== 'number' || !Number.isInteger(o.maxTrianglesPerGroup) || o.maxTrianglesPerGroup < 0)) {
+        return { error: 'getMeshSummary.maxTrianglesPerGroup must be a non-negative integer' };
+      }
+      if (o.maxGroups !== undefined && (typeof o.maxGroups !== 'number' || !Number.isInteger(o.maxGroups) || o.maxGroups < 0)) {
+        return { error: 'getMeshSummary.maxGroups must be a non-negative integer' };
+      }
+
+      const summary = computeFaceGroups(currentMeshData, o);
+      return {
+        groups: summary.groups,
+        totalTriangles: summary.totalTriangles,
+        groupCount: summary.groups.length,
+        tolerance: summary.tolerance,
+      };
     },
 
     // === Annotations API ===
@@ -3310,6 +3567,11 @@ async function main() {
         'clearRecentExports': { signature: 'clearRecentExports() -- Empty the Recent Exports list', docs: '/ai.md#ai-friendly-file-io' },
         // Color regions
         'paintRegion':     { signature: 'paintRegion({point, normal, color, name?, tolerance?}) -- Paint coplanar face region', docs: '/ai.md#color-regions' },
+        'paintNearestRegion': { signature: 'paintNearestRegion({point, color, searchRadius?, name?, tolerance?}) -- Snap seed to nearest face, then paint coplanar region', docs: '/ai.md#color-regions' },
+        'paintFaces':      { signature: 'paintFaces({triangleIds, color, name?}) -- Paint specific triangle indices', docs: '/ai.md#color-regions' },
+        'paintSlab':       { signature: 'paintSlab({axis|normal, offset, thickness, color, name?}) -- Paint planar slab range', docs: '/ai.md#color-regions' },
+        'findFaces':       { signature: 'findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?}) -- Query triangle ids by geometry/color filters', docs: '/ai.md#color-regions' },
+        'getMeshSummary':  { signature: 'getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?}?) -- List coplanar face groups with centroid/normal/area/bbox', docs: '/ai.md#color-regions' },
         'listRegions':     { signature: 'listRegions() -- List all color regions', docs: '/ai.md#color-regions' },
         'clearColors':     { signature: 'clearColors() -- Remove all color regions', docs: '/ai.md#color-regions' },
         // Annotations

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -308,6 +308,19 @@ function annotationsEqual(a: unknown[] | undefined, b: unknown[] | undefined): b
   return JSON.stringify(aArr) === JSON.stringify(bArr);
 }
 
+/** Color regions are persisted as `geometryData.colorRegions` on each version.
+ *  Compare them so a save that only adds/edits color regions still creates a
+ *  new version — code may be identical, but the painted state is the change. */
+function colorRegionsEqual(prev: Record<string, unknown> | null | undefined, next: Record<string, unknown> | null | undefined): boolean {
+  const prevRegions = (prev?.colorRegions ?? []) as unknown[];
+  const nextRegions = (next?.colorRegions ?? []) as unknown[];
+  if (prevRegions.length !== nextRegions.length) return false;
+  if (prevRegions.length === 0) return true;
+  // Order is stable across saves — regions are stored in the order they were
+  // added, and we serialize via the same path.
+  return JSON.stringify(prevRegions) === JSON.stringify(nextRegions);
+}
+
 export async function saveVersion(
   code: string,
   geometryData: Record<string, unknown> | null,
@@ -320,14 +333,16 @@ export async function saveVersion(
 
   const annotationSnapshot = serializeAnnotations();
 
-  // Skip if both code AND annotations are identical to the current version
-  // (unless forced). Annotations live per-version, so a save that only changes
-  // them must still create a new version — comparing code alone would no-op.
+  // Skip if code AND annotations AND color regions are all identical to the
+  // current version (unless forced). Annotations and color regions live
+  // per-version, so a save that only changes either must still create a new
+  // version — comparing code alone would no-op.
   if (
     !options?.force &&
     currentState.currentVersion &&
     currentState.currentVersion.code === code &&
-    annotationsEqual(currentState.currentVersion.annotations, annotationSnapshot)
+    annotationsEqual(currentState.currentVersion.annotations, annotationSnapshot) &&
+    colorRegionsEqual(currentState.currentVersion.geometryData as Record<string, unknown> | null, geometryData)
   ) {
     return null;
   }


### PR DESCRIPTION
## Summary

Addresses three pain points an AI agent reported while driving Partwright via the staging deploy:

- **`paintRegion` is unforgiving about seed placement** — point must lie ~exactly on the surface (`[8, 0.39, 5]` failed but `[8, 0.4, 5]` worked) with no helpful error.
- **`saveVersion()` silently returned `null` after painting** because the dedupe check ignored color regions.
- **Targeting faces by point is fiddly** — agents had to guess exact coordinates instead of querying by geometry.

## Changes

- **`paintNearestRegion({point, color, searchRadius?, name?, tolerance?})`** — snaps the seed to the nearest face within `searchRadius`, then flood-fills. Seed normal is taken from the snapped triangle. Returns `{id, name, triangles, snappedTo: {point, normal, distance}}` on success, or `{error, nearestDistance}` when nothing is within radius (so the agent can adjust). Implemented via Ericson's closest-point-on-triangle (`src/color/adjacency.ts: findNearestTriangle`).

- **`findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?})`** — query triangle ids by geometry/color filters. Pass results straight to `paintFaces({triangleIds, color})`. Default `normalTolerance` is 0.95 (~18° cone), looser than `paintRegion`'s 0.9995 because this is for coarse face targeting.

- **`getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?}?)`** — partitions the mesh into coplanar face groups (sorted largest-first), reporting each group's area-weighted centroid + normal, area, bbox, triangleCount, and a sample of triangle ids. Lives in new `src/color/faceGroups.ts`.

- **`saveVersion()` no-op feedback** — extended dedupe check in `sessionManager.ts` to compare color regions too, so a paint-only save creates a new version. The public API wrapper now returns `{skipped: true, reason}` for true no-ops and `{error}` for missing-session, instead of bare `null`.

- Registered all of the above in `help()` and documented in `public/ai.md` under `#color-regions`.

## Test plan

- [x] `npm run build` passes (no TypeScript errors)
- [x] Playwright smoke test on a `cube([10,10,10], true)`:
  - `paintNearestRegion` at all 6 face-center points → distance 0 ✓
  - `findFaces` by normal/box/region → 2 triangles per face ✓
  - `getMeshSummary` → 6 groups, correct centroids, 100-unit areas ✓
  - `saveVersion()` after paint → creates v2 ✓
  - `saveVersion()` no-op → `{skipped: true, reason: "..."}` ✓
- [ ] Verify on staging deploy after merge: paint a face by point, confirm `saveVersion` creates a new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)