### PR TITLE
fix: release previous Manifold WASM object before overwriting

### DIFF
--- a/prompts/20260428-fix-wasm-memory-leak.md
+++ b/prompts/20260428-fix-wasm-memory-leak.md
@@ -1,0 +1,55 @@
+---
+session: "fix-wasm-memory-leak"
+timestamp: "2026-04-28T22:18:00Z"
+model: claude-opus-4-7
+sequence: 1
+---
+
+## Human
+
+> After I've modeled several things, my laptop has tons of memory used by
+> chrome. I've closed many tabs but most of my memory is still used. Is
+> there a memory leak? Do we need to fix something in how this app works?
+
+## Assistant
+
+Audited the codebase against the three leak vectors documented in
+CLAUDE.md (Three.js disposal, Blob URLs, document/window listeners), plus
+WASM-specific concerns (manifold-3d objects, WebGL contexts, IndexedDB
+blobs). Three.js disposal, Blob URL revocation, and event-listener
+teardown are all handled correctly throughout the codebase.
+
+The real culprit for "memory grows after each model and doesn't free
+when tabs close" is in `src/main.ts`, in the run path at the bottom of
+`runCurrentCode`:
+
+```ts
+currentMeshData = result.mesh;
+currentManifold = result.manifold;  // overwrites without delete()
+```
+
+`Manifold` is a wasm-managed object. Its memory lives outside the JS
+heap, so re-binding the JS reference doesn't reclaim it — `Module.delete`
+is the only path. Every successful run leaked the previous Manifold.
+Across a long session this matches the user's symptom exactly: Chrome's
+GPU/WASM process holds memory that closing the tab doesn't release until
+the renderer process tears down completely.
+
+## Human
+
+> Create a new PR based off the staging branch for the easy fixes and
+> create a github issue for the one that needs more thought
+
+## Assistant
+
+Fixed the Manifold leak by deleting the previous `currentManifold`
+before overwriting. Guarded against re-deleting the same instance and
+swallowed a possible `BindingError` if the engine had already released
+it. The previous-mesh adjacency graph the audit also flagged isn't
+actually a leak — it's plain JS data that GC reclaims when the variable
+is reassigned, so no fix needed there.
+
+The offscreen renderer leak in `src/renderer/multiview.ts` is more
+subtle (singleton vs. dispose-between-uses, gallery render loops over
+every version) and goes to a separate GitHub issue for design
+discussion.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3743,6 +3743,11 @@ async function main() {
       clearEditorDiagnostics();
       clearEditorErrorPanel(editorErrorPanel);
       currentMeshData = result.mesh;
+      // Release the previous Manifold's WASM-heap memory before overwriting.
+      // Manifold objects live outside the JS heap and require manual .delete().
+      if (currentManifold && currentManifold !== result.manifold && typeof currentManifold.delete === 'function') {
+        try { currentManifold.delete(); } catch { /* already deleted */ }
+      }
       currentManifold = result.manifold;
 
       // Apply any existing color regions to the mesh


### PR DESCRIPTION
## Summary
- Audited the app for memory leaks after a user reported Chrome holding tons of memory across modeling sessions, even after closing tabs.
- Found one real leak: every successful code run reassigned \`currentManifold\` ([src/main.ts:3746](src/main.ts:3746)) without calling \`.delete()\` on the previous one. Manifold objects live in WASM heap memory and aren't reclaimed by JS GC, so old models accumulated for the lifetime of the page — which matches the "memory keeps growing and tabs closing doesn't free it" symptom (the WASM/GPU process memory only releases when the renderer process tears down).
- Fix: delete the previous \`currentManifold\` before overwriting, guarded against re-deleting the same instance and against a stray \`BindingError\` if the engine already released it.

The other items from the audit:
- **Three.js disposal, Blob URL revocation, document/window listeners** — already handled correctly throughout the codebase.
- **Paint adjacency graph rebuild** — flagged by the audit but isn't actually a leak. Plain JS data, GC handles reassignment fine.
- **Offscreen renderer in `multiview.ts` never disposed** — real and probably significant, but needs more design thought (singleton-with-context-loss vs. dispose-per-use, plus the gallery render-every-version loop). Tracked separately as a GitHub issue.

## Test plan
- [x] `npm run build` succeeds with no TypeScript errors.
- [ ] Smoke test on staging: open editor, run several different models in sequence, verify renders still work and no `BindingError: deleted object` appears in the console.
- [ ] In DevTools Memory tab, take a heap snapshot before and after running ~20 models — WASM heap retention should no longer grow unboundedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)