### PR TITLE
feat: predictable paint primitives + diagnostics for AI agents

### DIFF
--- a/prompts/20260428-230000-paint-api-improvements.md
+++ b/prompts/20260428-230000-paint-api-improvements.md
@@ -1,0 +1,59 @@
+---
+session: "paint-api-improvements"
+timestamp: "2026-04-28T23:00:00Z"
+model: claude-opus-4-7
+---
+
+## Human
+
+After spending too long fighting `paintRegion`'s flood-fill behavior on smooth
+geometry, I want generic, lasting improvements for AI agents that model and
+paint with this app.
+
+## Assistant
+
+Audited the paint surface and shipped a coherent set of additions in
+`src/main.ts` plus matching docs in `public/ai.md`:
+
+**New APIs**
+- `paintNear({ point, radius, normalCone?, color, name? })` — sphere selector,
+  no flood-fill tolerance to tune.
+- `paintInBox({ box, normalCone?, color, name? })` — AABB selector with
+  optional normal-cone restriction.
+- `paintPreview({ box?|point+radius?|triangleIds?, normalCone?, view? })` —
+  dry-run that returns a thumbnail with the candidate region tinted bright
+  yellow. Does not commit.
+- `assertPaint({ region, expectedTriangleCount?, expectedBoundingBox?,
+  expectedCentroid? })` — verify a previously-painted region; pairs with
+  `runAndAssert`.
+- `getMesh()` — direct triangle/vertex/normal/centroid access (typed arrays)
+  for procedural paint workflows.
+
+**Improvements**
+- `paintRegion`'s "no matching face found" error now includes the nearest
+  triangle's position, normal, distance, angle off the requested normal, and
+  a suggested tolerance value that would accept it. Same data is also
+  exposed structured under `r.nearest`.
+- `listRegions()` now includes `bbox` and `centroid` per region, so callers
+  can verify *where* a region landed without re-rendering.
+
+**Docs**
+- New "Common gotchas" section in `ai.md` documenting:
+  - `paintRegion` flood-fill bimodality on smooth surfaces (use `paintNear` /
+    `paintInBox` instead).
+  - "Trust `probeRay`'s hit normal — don't derive your own."
+  - Manifold's `rotate` direction with a 3-line verification snippet.
+  - "Painting locks the editor; `clearColors()` to iterate."
+  - "Verify before you commit" — `paintPreview` + `assertPaint`.
+  - `runIsolated` vs `runAndSave` for sanity checks.
+- Console API summary updated with all new method signatures.
+- `partwright.help()` entries updated.
+
+**Verification**
+- 10-step Playwright smoke test driving the new APIs against a localhost
+  dev build: `runAndSave`, `getMesh`, `paintRegion` success + diagnostic
+  failure, `paintInBox` (with and without normal cone), `paintNear`,
+  `listRegions` (bbox + centroid present), `paintPreview` (returns
+  thumbnail, does not mutate), `assertPaint` (passing + failing). All 10
+  pass.
+- `npm run build` clean.

--- a/public/ai.md
+++ b/public/ai.md
@@ -17,6 +17,7 @@ Partwright is a browser-based parametric CAD tool with two modeling engines: **m
 - [Common pitfalls for boolean operations](#common-pitfalls-for-boolean-operations)
 - [Print-safe geometry](#print-safe-geometry)
 - [Color regions](#color-regions)
+- [Common gotchas](#common-gotchas)
 - [AI-friendly file I/O](#ai-friendly-file-io)
 - [Images](#images)
 - [Photo-to-model workflow](#photo-to-model-workflow) (optional tooling)
@@ -191,13 +192,18 @@ await partwright.openSession(id)         // Open existing session
 await partwright.clearAllSessions()      // Delete all sessions & versions
 
 // Color regions -- tag face regions with a color (see #color-regions)
-partwright.paintRegion({point, normal, color, name?, tolerance?})         // bucket: coplanar flood-fill -> {id, name, triangles} or {error}
+partwright.paintRegion({point, normal, color, name?, tolerance?})         // bucket: coplanar flood-fill -> {id, name, triangles} or {error, nearest?}
 partwright.paintNearestRegion({point, color, searchRadius?, name?, tolerance?}) // snap seed to nearest face, then flood-fill -> {id, name, triangles, snappedTo} or {error}
+partwright.paintNear({point, radius, normalCone?, color, name?})          // sphere: paint triangles whose centroid is within radius -> {id, name, triangles, bbox, centroid} or {error}
+partwright.paintInBox({box, normalCone?, color, name?})                   // box: paint triangles inside an AABB -> {id, name, triangles, bbox, centroid} or {error}
 partwright.paintFaces({triangleIds, color, name?})                        // brush: paint specific triangle indices -> {id, name, triangles} or {error}
 partwright.paintSlab({axis|normal, offset, thickness, color, name?})      // slab: paint a planar range -> {id, name, triangles} or {error}
+partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, view?}) // dry-run: highlight a candidate region -> {thumbnail, triangleCount, bbox, centroid} (does not commit)
+partwright.assertPaint({region, expectedTriangleCount?, expectedBoundingBox?, expectedCentroid?}) // verify a region -> {passed, failures?}
 partwright.findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?}) // query triangle ids by geometry/color -> {triangleIds, count, matched, truncated}
+partwright.getMesh()                     // -> {numVert, numTri, vertices, triangles, normals, centroids, boundingBox} (typed arrays)
 partwright.getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?}?) // -> {groups[{id, normal, centroid, area, triangleCount, bbox, triangleIds}], totalTriangles, groupCount, tolerance}
-partwright.listRegions()                 // -> [{id, name, color, source, triangles, order}, ...]
+partwright.listRegions()                 // -> [{id, name, color, source, triangles, order, bbox, centroid}, ...]
 partwright.clearColors()                 // Remove all regions
 
 // Notes -- track design context, decisions, and measurements
@@ -441,6 +447,14 @@ partwright.clearColors()    // remove all regions
 
 **How face matching works.** `paintRegion` flood-fills outward from the seed triangle, including any neighbor whose normal is within `tolerance` of the seed's. Pick `point` slightly inside the model surface and pass the outward-pointing `normal` -- the seed resolver looks for the triangle whose plane the point lies on and whose normal aligns with yours.
 
+**Diagnostic on failure.** When `paintRegion` can't resolve a seed, the returned `error` string includes the position and normal of the *nearest* triangle, the angle off your requested normal, and a suggested tolerance value that would accept it. The same data is available structured under `{ error, nearest: { point, normal, distance, angleDeg, suggestedTolerance } }`. So a failed call tells you exactly what to change rather than leaving you guessing.
+
+```js
+const r = partwright.paintRegion({ point: [50, 50, 50], normal: [0, 0, 1], color: [1, 0, 0] });
+// r.error = "paintRegion: no face matched at point=[50.00, 50.00, 50.00], normal=[0.000, 0.000, 1.000], tolerance=0.9995. Nearest face is at [...] with normal [...] (3.2° off requested, distance 12.345). try tolerance 0.9981 (currently 0.9995)"
+// r.nearest = { point, normal, distance, angleDeg, suggestedTolerance }
+```
+
 **`paintRegion` is strict about seed placement** -- the point must lie on the surface within ~0.01 units. If you'd rather snap to the nearest face within a tolerance and skip the trial-and-error of placing a point exactly, use `paintNearestRegion`:
 
 ```js
@@ -478,17 +492,55 @@ partwright.paintFaces({ triangleIds: largestSideFace.triangleIds, color: [0.2, 0
 
 `findFaces` filters all AND together. Pass `region: <id>` from `listRegions()` to subset by an existing painted region. The default `normalTolerance` is `0.95` (≈18° cone) — looser than `paintRegion`'s `0.9995` because it's intended for catching whole faces of a primitive, not exact-coplanar fills.
 
-**Other paint tools.**
+**Predictable paint primitives (no flood-fill tolerance to tune).** `paintRegion` is the right tool when you have a flat face with sharp edges around it — pick a point on the face, paint that face. It's the *wrong* tool on smooth surfaces (capsules, hulled spheres, organic shapes) because the flood-fill threshold is bimodal: too tight and you paint 2 triangles, too loose and you paint the whole connected component, with almost no useful middle. Reach for `paintNear` or `paintInBox` instead — both filter triangles by world-space geometry, so the region you paint is described in coordinates rather than tolerances.
+```js
+// Sphere: every triangle whose centroid is within `radius` of `point`.
+// `normalCone` (optional) further restricts to triangles whose face normal is
+// within `angleDeg` of `axis`. Both narrow the result without flood-fill magic.
+partwright.paintNear({
+  point:  [10, 5, 67],                    // world-space center
+  radius: 4,
+  normalCone: { axis: [0, -1, 0.45], angleDeg: 25 }, // dorsal-facing only
+  color:  [0.88, 0.30, 0.45],
+  name:   "Index nail",
+});
+// -> { id, name, triangles, bbox, centroid } or { error }
+
+// Box: every triangle whose centroid lies inside an axis-aligned box.
+partwright.paintInBox({
+  box: { min: [-3, -2, 60], max: [3, 0, 75] },
+  normalCone: { axis: [0, -1, 0], angleDeg: 30 },    // optional
+  color: [0.88, 0.30, 0.45],
+  name:  "Front of fingertip",
+});
+```
+
+`paintNear` and `paintInBox` ignore mesh edges entirely — they collect triangles by *position* and (optionally) by face-normal direction, so the result is independent of how the boolean union tessellated the surface. Use them for organic geometry; use `paintRegion` for flat plates with crisp 90° edges.
+
+**Brush + slab + procedural targeting.**
 
 ```js
-// Brush: paint specific triangle indices (no flood-fill). Use findFaces() or
-// getMeshSummary() to source the indices procedurally; the Paint UI also
+// Brush: paint specific triangle indices (no flood-fill). Use findFaces(),
+// getMeshSummary(), or getMesh() to source ids procedurally; the Paint UI also
 // emits indices when picking faces interactively.
 partwright.paintFaces({
   triangleIds: [12, 13, 14, 27],
   color: [0, 0.6, 1],
   name: "Inset detail",
 });
+
+// Direct mesh access. getMesh() exposes typed arrays (vertices, triangles,
+// per-triangle normals, per-triangle centroids, bbox) so you can implement any
+// selection strategy yourself. Triangle indices are stable for a saved version.
+const mesh = partwright.getMesh();
+// mesh.numTri, mesh.normals (Float32Array, 3 per tri), mesh.centroids, ...
+const ids = [];
+for (let t = 0; t < mesh.numTri; t++) {
+  const cz = mesh.centroids[t * 3 + 2];
+  const nz = mesh.normals[t * 3 + 2];
+  if (cz > 60 && nz < -0.5) ids.push(t);   // backward-facing tris up high
+}
+partwright.paintFaces({ triangleIds: ids, color: [0.9, 0.3, 0.4] });
 
 // Slab: paint every face whose centroid falls inside a planar slab.
 // Axis-aligned slab (most common — pick X/Y/Z and slide along that axis):
@@ -511,6 +563,35 @@ partwright.paintSlab({
 });
 ```
 
+**Verifying paint before you commit it.** `paintPreview` accepts the same selectors as `paintInBox` / `paintNear` / `paintFaces` and returns a thumbnail with the candidate triangles tinted bright yellow on top of any existing paint, *without* adding a region. Use it to confirm the shape of a region before committing.
+
+```js
+const preview = partwright.paintPreview({
+  point: [10.4, 5.2, 67],
+  radius: 3,
+  normalCone: { axis: [0, -0.89, 0.45], angleDeg: 25 },
+  view: { elevation: 0, azimuth: 180, ortho: true, size: 320 }, // optional
+});
+// preview = { thumbnail, triangleCount, bbox, centroid }
+// Display preview.thumbnail (data URL) -- no region created, no editor lock.
+```
+
+**Asserting paint after you commit it.** `assertPaint` checks a region against expected triangle count and bbox/centroid ranges — same shape as `runAndAssert`, but for color regions. Use this in iterative agent loops to catch regressions when the underlying mesh changes (e.g. after a forkVersion).
+
+```js
+partwright.assertPaint({
+  region: 'Index nail',                              // or numeric region id
+  expectedTriangleCount: { min: 15, max: 60 },       // or exact number
+  expectedBoundingBox: {
+    z: [60, 75],                                     // any subset of axes
+    y: [3, 7],
+  },
+  expectedCentroid: { z: [62, 72] },
+});
+// -> { passed: true, region: { ... } }
+//    or { passed: false, failures: ["..."], region: { ... } }
+```
+
 **Bucket tolerance.** `paintRegion`'s `tolerance` is a cosine threshold for the bend angle between adjacent faces (default `0.9995`, ≈ 1.8°). The flood-fill crosses an edge only when the bend at that edge is below the angle threshold — checked between the *parent* face and each *neighbor*, not against the seed. This means flood-fill follows curved surfaces: a 32-sided cylinder bends ~11° per face, so any tolerance ≥ cos(11°) ≈ `0.98` covers the whole cylinder. Set tolerance to `-1` (180°) to paint the entire connected mesh. The Paint UI exposes the same control as a slider labeled in degrees (0°–180°).
 
 **Editor lock.** When color regions exist, the editor is locked (the model can't be re-run, because new geometry would invalidate the saved triangle indices). To edit code, the user clicks "Unlock to edit" in the UI. Agents that need to iterate on the geometry should call `clearColors()` first, or fork a new uncolored version with `forkVersion`.
@@ -521,6 +602,86 @@ partwright.paintSlab({
 - `exportGLB()` -- vertex colors flow through automatically.
 - `export3MF()` -- regions become `<basematerials>` entries with per-triangle `pid` attributes (compatible with PrusaSlicer / Bambu Studio multi-material slicing).
 - `exportSTL()` and `exportOBJ()` -- formats don't carry color, so colors are dropped.
+
+## Common gotchas
+
+These are the traps that previously cost an agent multiple turns of trial and error. Read once, save the next agent the same loop.
+
+### `paintRegion` flood-fill is bimodal on smooth surfaces
+
+On capsules, hulled spheres, and other smooth (no-edge) geometry, the bend angle between adjacent triangles is roughly the angular subdivision (e.g. 7.5° for a 48-segment cylinder, ≈ cos 7.5° = 0.991). Any tolerance > 0.991 paints almost nothing; any tolerance ≤ 0.99 paints almost everything. There is no useful middle.
+
+**Fix:** use `paintNear` (sphere selector) or `paintInBox` (AABB selector) for organic geometry. Both filter by world coordinates — predictable and bounded:
+
+```js
+// Don't:
+partwright.paintRegion({ point: [...], normal: [...], color, tolerance: 0.95 }); // floods entire finger
+
+// Do:
+partwright.paintNear({ point: [...], radius: 4, color });               // bounded by radius
+partwright.paintInBox({ box: { min, max }, normalCone: { axis, angleDeg: 25 }, color });
+```
+
+`paintRegion` is still the right tool for flat plates with crisp 90° edges (e.g. a cube face). For curved surfaces, prefer the position-based primitives.
+
+### Trust `probeRay`'s hit normal — don't derive your own
+
+`paintRegion`'s seed-resolution requires the seed normal to align with an actual triangle's normal within `tolerance`. Computed normals (e.g. derived from your construction math) are slightly off from the post-boolean-union mesh normals — they look right but won't match. The fix is one line:
+
+```js
+// Don't:
+const dorsal = [0, -Math.cos(P), Math.sin(P)];                          // looks correct...
+partwright.paintRegion({ point: derivedPoint, normal: dorsal, ... });   // ...silently misses
+
+// Do:
+const hit = partwright.probeRay(start, dir).hits[0];
+partwright.paintRegion({ point: hit.point, normal: hit.normal, tolerance: 0.999, ... });
+```
+
+`probeRay` returns the same data the resolver looks at internally; using it eliminates an entire class of "no matching face found" failures.
+
+### Manifold's `rotate` direction
+
+Manifold uses `rotate([degX, degY, degZ])` applied X→Y→Z. The convention follows the standard right-hand rule about each axis. Quick verification snippet:
+
+```js
+const cube = api.Manifold.cube([2, 4, 4], false);          // x∈[0,2], y∈[0,4], z∈[0,4]
+const rotated = cube.rotate([90, 0, 0]);                   // rotate +90° about X
+// After rotation: y∈[-4,0], z∈[0,4]. (0,1,0) → (0,0,1) → (0,-1,0).
+```
+
+If your rotated geometry looks mirrored, negate the angle. This burned 10+ minutes of debugging in earlier sessions — the test snippet above runs in `runIsolated` and resolves it in seconds.
+
+### Painting locks the editor — `clearColors()` to iterate
+
+Once any region exists, the editor goes read-only and `runAndSave` is rejected. To change the geometry mid-session, call `partwright.clearColors()` first, *then* run new code. To preserve a colored version while iterating, call `forkVersion(...)` instead — it loads, transforms, validates, and saves a fresh uncolored child without touching the colored one.
+
+### Verify before you commit
+
+Use `paintPreview` to see the candidate region tinted bright yellow on a thumbnail before adding a region. Saves the paint → render → undo loop:
+
+```js
+const dry = partwright.paintPreview({ point: [...], radius: 4, view: { ortho: true, size: 240 } });
+// Inspect dry.thumbnail; if happy, call paintNear with the same args to commit.
+```
+
+Use `assertPaint` to verify regions stayed where you expected after a re-render or version load:
+
+```js
+partwright.assertPaint({ region: 'Index nail', expectedTriangleCount: { min: 15, max: 60 } });
+```
+
+### `runAndSave` is for committed iterations; `runIsolated` is for sanity checks
+
+`runAndSave` writes a version to the gallery (and the lock state, and the diff, etc.). For "does this code produce 1 component or 7" questions, prefer `runIsolated(code)` — it returns `{ geometryData, thumbnail }` without mutating anything.
+
+```js
+const r = await partwright.runIsolated(`
+  const { Manifold } = api;
+  return Manifold.cube([1, 1, 1], true).hull();
+`);
+// r.geometryData.componentCount, r.thumbnail (data URL)
+```
 
 ## AI-friendly file I/O
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3004,7 +3004,10 @@ async function main() {
     // === Color Regions API ===
 
     /** Paint a coplanar region by specifying a point and normal on the model surface.
-     *  Returns the created region or {error}. */
+     *  Returns the created region or `{error}`. On failure, the error message
+     *  includes a diagnostic — the nearest hit point, its normal, the angle
+     *  off the requested normal, and a suggested tolerance value that would
+     *  include it. Pair with `probeRay` to get a known-on-surface seed. */
     paintRegion(opts: { point: [number, number, number]; normal: [number, number, number]; color: [number, number, number]; name?: string; tolerance?: number }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintRegion requires {point, normal, color}' };
@@ -3016,7 +3019,9 @@ async function main() {
       const normalTolerance = tolerance ?? 0.9995;
       const adjacency = buildAdjacency(currentMeshData);
       const seedTri = resolveSeed(point as [number, number, number], normal as [number, number, number], currentMeshData, adjacency, normalTolerance);
-      if (seedTri < 0) return { error: 'No matching face found at the given point/normal' };
+      if (seedTri < 0) {
+        return diagnoseSeedFailure(point as [number, number, number], normal as [number, number, number], currentMeshData, adjacency, normalTolerance);
+      }
 
       const triangles = findCoplanarRegion(seedTri, adjacency, normalTolerance);
       const regionName = name ?? `Region ${getRegions().length + 1}`;
@@ -3184,16 +3189,326 @@ async function main() {
       return { id: region.id, name: region.name, triangles: triangles.size };
     },
 
-    /** List all color regions on the current geometry */
+    /** List all color regions on the current geometry. Each entry includes
+     *  `bbox` (axis-aligned bounding box of the painted triangles' vertices)
+     *  and `centroid` (mean of those vertex positions) so callers can verify
+     *  *where* a region landed without re-rendering. Returns `{ ..., bbox: null,
+     *  centroid: null }` for regions whose triangles haven't been resolved
+     *  yet (e.g. just deserialized from a saved version). */
     listRegions() {
-      return getRegions().map(r => ({
-        id: r.id,
-        name: r.name,
-        color: r.color,
-        source: r.source,
-        triangles: r.triangles.size,
-        order: r.order,
-      }));
+      const mesh = currentMeshData;
+      return getRegions().map(r => {
+        const stats = mesh ? regionTriangleStats(r.triangles, mesh) : null;
+        return {
+          id: r.id,
+          name: r.name,
+          color: r.color,
+          source: r.source,
+          triangles: r.triangles.size,
+          order: r.order,
+          bbox: stats?.bbox ?? null,
+          centroid: stats?.centroid ?? null,
+        };
+      });
+    },
+
+    /** Direct mesh access for procedural paint workflows. Returns flat typed
+     *  arrays plus per-triangle face normals and centroids (the same arrays
+     *  the paint resolver uses internally), so a caller can implement any
+     *  selection strategy without trial-and-error tolerance tuning.
+     *
+     *  Shape:
+     *  ```
+     *  {
+     *    numVert, numTri,
+     *    vertices: Float32Array,   // numVert * 3 (x,y,z packed)
+     *    triangles: Uint32Array,   // numTri * 3 (vertex indices)
+     *    normals: Float32Array,    // numTri * 3 (face normals)
+     *    centroids: Float32Array,  // numTri * 3 (face centroids)
+     *    boundingBox: { min:[x,y,z], max:[x,y,z] }
+     *  }
+     *  ```
+     *  Triangle indices are stable for a given saved version — pass them to
+     *  `paintFaces({triangleIds})` directly. */
+    getMesh() {
+      const mesh = currentMeshData;
+      if (!mesh) return { error: 'No geometry loaded' };
+      const adjacency = buildAdjacency(mesh);
+      const numTri = mesh.numTri;
+      const numVert = mesh.numVert;
+
+      // Pack vertex positions into a tight Float32Array (mesh.vertProperties may
+      // include per-vertex extras like colors that callers don't need).
+      const vertices = new Float32Array(numVert * 3);
+      for (let v = 0; v < numVert; v++) {
+        vertices[v * 3] = mesh.vertProperties[v * mesh.numProp];
+        vertices[v * 3 + 1] = mesh.vertProperties[v * mesh.numProp + 1];
+        vertices[v * 3 + 2] = mesh.vertProperties[v * mesh.numProp + 2];
+      }
+
+      // Triangle indices may be backed by Uint32 already; copy to a stable, owned buffer.
+      const triangles = new Uint32Array(numTri * 3);
+      for (let t = 0; t < numTri * 3; t++) triangles[t] = mesh.triVerts[t];
+
+      // Centroids — average of the three vertex positions per triangle.
+      const centroids = new Float32Array(numTri * 3);
+      for (let t = 0; t < numTri; t++) {
+        const v0 = triangles[t * 3];
+        const v1 = triangles[t * 3 + 1];
+        const v2 = triangles[t * 3 + 2];
+        centroids[t * 3] = (vertices[v0 * 3] + vertices[v1 * 3] + vertices[v2 * 3]) / 3;
+        centroids[t * 3 + 1] = (vertices[v0 * 3 + 1] + vertices[v1 * 3 + 1] + vertices[v2 * 3 + 1]) / 3;
+        centroids[t * 3 + 2] = (vertices[v0 * 3 + 2] + vertices[v1 * 3 + 2] + vertices[v2 * 3 + 2]) / 3;
+      }
+
+      // Bounding box from the packed vertices (avoids walking the full vertProperties).
+      let xMin = Infinity, yMin = Infinity, zMin = Infinity;
+      let xMax = -Infinity, yMax = -Infinity, zMax = -Infinity;
+      for (let v = 0; v < numVert; v++) {
+        const x = vertices[v * 3], y = vertices[v * 3 + 1], z = vertices[v * 3 + 2];
+        if (x < xMin) xMin = x; if (x > xMax) xMax = x;
+        if (y < yMin) yMin = y; if (y > yMax) yMax = y;
+        if (z < zMin) zMin = z; if (z > zMax) zMax = z;
+      }
+
+      return {
+        numVert,
+        numTri,
+        vertices,
+        triangles,
+        normals: adjacency.normals,
+        centroids,
+        boundingBox: {
+          min: [xMin, yMin, zMin] as [number, number, number],
+          max: [xMax, yMax, zMax] as [number, number, number],
+        },
+      };
+    },
+
+    /** Paint every triangle whose centroid lies inside an axis-aligned bounding
+     *  box. Optional `normalCone` further restricts to triangles whose face
+     *  normal is within `angleDeg` of `axis` (a unit vector). One-shot wrapper
+     *  around `findFaces` + `paintFaces` for the common "paint that region of
+     *  the model" intent.
+     *
+     *  ```
+     *  partwright.paintInBox({
+     *    box: { min: [-5, -5, 60], max: [5, 5, 75] },
+     *    normalCone: { axis: [0, -1, 0.4], angleDeg: 20 },  // back-facing only
+     *    color: [0.88, 0.30, 0.45],
+     *    name: 'Index nail',
+     *  })
+     *  ```
+     *  Returns `{ id, name, triangles, bbox, centroid }` on success or
+     *  `{ error }`. Empty match returns `{ error: 'no triangles matched' }`. */
+    paintInBox(opts: {
+      box: { min: [number, number, number]; max: [number, number, number] };
+      normalCone?: { axis: [number, number, number]; angleDeg: number };
+      color: [number, number, number];
+      name?: string;
+    }) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintInBox requires { box, color }' };
+      const filterErr = validateBoxAndCone(opts.box, opts.normalCone);
+      if (filterErr) return { error: filterErr };
+      if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+
+      const triangles = collectTrianglesByFilter(currentMeshData, opts.box, opts.normalCone, null);
+      if (triangles.size === 0) return { error: 'paintInBox: no triangles matched the box (and normalCone, if any). Try widening the box, raising angleDeg, or call findFaces() to see what passes each filter individually.' };
+
+      return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
+    },
+
+    /** Paint every triangle whose centroid lies within `radius` of `point`.
+     *  Optional `normalCone` restricts by face normal direction. Use this for
+     *  "paint a fingernail-sized patch around X" without picking edge tolerances.
+     *
+     *  ```
+     *  partwright.paintNear({
+     *    point: [10, 5, 67],
+     *    radius: 4,
+     *    normalCone: { axis: [0, -0.89, 0.45], angleDeg: 25 },
+     *    color: [0.88, 0.30, 0.45],
+     *  })
+     *  ```
+     *  Returns `{ id, name, triangles, bbox, centroid }` or `{ error }`. */
+    paintNear(opts: {
+      point: [number, number, number];
+      radius: number;
+      normalCone?: { axis: [number, number, number]; angleDeg: number };
+      color: [number, number, number];
+      name?: string;
+    }) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintNear requires { point, radius, color }' };
+      if (!Array.isArray(opts.point) || opts.point.length !== 3) return { error: 'point must be [x,y,z]' };
+      for (let i = 0; i < 3; i++) {
+        if (typeof opts.point[i] !== 'number' || !Number.isFinite(opts.point[i])) return { error: 'point components must be finite numbers' };
+      }
+      if (typeof opts.radius !== 'number' || !Number.isFinite(opts.radius) || opts.radius <= 0) return { error: 'radius must be a positive finite number' };
+      const coneErr = validateNormalCone(opts.normalCone);
+      if (coneErr) return { error: coneErr };
+      if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+
+      const triangles = collectTrianglesBySphere(currentMeshData, opts.point as [number, number, number], opts.radius, opts.normalCone);
+      if (triangles.size === 0) return { error: `paintNear: no triangles within ${opts.radius} of [${opts.point.join(', ')}]. Try a larger radius — call findFaces() with a bigger box first to see what's around.` };
+
+      return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
+    },
+
+    /** Render a preview of the current model with a candidate region tinted
+     *  bright yellow, *without* committing the paint to the regions list.
+     *  Accepts the same selectors as `paintInBox` / `paintNear` plus an
+     *  optional explicit `triangleIds` set. Returns
+     *  `{ thumbnail, triangleCount, bbox, centroid }` so an agent can verify
+     *  the shape of the would-be region in one call instead of paint → render → undo.
+     *
+     *  ```
+     *  const preview = partwright.paintPreview({
+     *    box: { min: [...], max: [...] },
+     *    normalCone: { axis: [...], angleDeg: 25 },
+     *  })
+     *  // Display preview.thumbnail (data URL) to confirm before committing.
+     *  ```
+     *  `view` is forwarded to `renderView` (elevation/azimuth/ortho/size). */
+    paintPreview(opts: {
+      box?: { min: [number, number, number]; max: [number, number, number] };
+      normalCone?: { axis: [number, number, number]; angleDeg: number };
+      point?: [number, number, number];
+      radius?: number;
+      triangleIds?: number[];
+      view?: { elevation?: number; azimuth?: number; ortho?: boolean; size?: number };
+    } = {}) {
+      const mesh = currentMeshData;
+      if (!mesh) return { error: 'No geometry loaded' };
+
+      let triangles: Set<number>;
+      if (opts.triangleIds !== undefined) {
+        if (!Array.isArray(opts.triangleIds)) return { error: 'triangleIds must be an array of integers' };
+        triangles = new Set();
+        for (const id of opts.triangleIds) {
+          if (!Number.isInteger(id) || id < 0 || id >= mesh.numTri) return { error: `triangleIds contains invalid index ${id} (expected 0..${mesh.numTri - 1})` };
+          triangles.add(id);
+        }
+      } else if (opts.point !== undefined && opts.radius !== undefined) {
+        if (!Array.isArray(opts.point) || opts.point.length !== 3) return { error: 'point must be [x,y,z]' };
+        if (typeof opts.radius !== 'number' || !Number.isFinite(opts.radius) || opts.radius <= 0) return { error: 'radius must be a positive finite number' };
+        const coneErr = validateNormalCone(opts.normalCone);
+        if (coneErr) return { error: coneErr };
+        triangles = collectTrianglesBySphere(mesh, opts.point, opts.radius, opts.normalCone);
+      } else if (opts.box !== undefined) {
+        const err = validateBoxAndCone(opts.box, opts.normalCone);
+        if (err) return { error: err };
+        triangles = collectTrianglesByFilter(mesh, opts.box, opts.normalCone, null);
+      } else {
+        return { error: 'paintPreview requires one of: { triangleIds }, { point, radius }, or { box }' };
+      }
+
+      const stats = regionTriangleStats(triangles, mesh);
+      // Build a temporary mesh with the candidate triangles tinted bright yellow,
+      // overlayed on top of any existing regions.
+      const baseColored = applyTriColors(mesh) ?? mesh;
+      const numTri = mesh.numTri;
+      const triColors = new Uint8Array(numTri * 3);
+      const baseBuf = baseColored.triColors as Uint8Array | undefined;
+      const basePainted = baseBuf ? (baseBuf as Uint8Array & { _painted?: Uint8Array })._painted : undefined;
+      const painted = new Uint8Array(numTri);
+      for (let t = 0; t < numTri; t++) {
+        if (baseBuf && basePainted && basePainted[t]) {
+          triColors[t * 3] = baseBuf[t * 3];
+          triColors[t * 3 + 1] = baseBuf[t * 3 + 1];
+          triColors[t * 3 + 2] = baseBuf[t * 3 + 2];
+          painted[t] = 1;
+        }
+      }
+      // Highlight color: bright yellow-orange, strongly distinct from skin/nail palettes.
+      for (const t of triangles) {
+        triColors[t * 3] = 255;
+        triColors[t * 3 + 1] = 230;
+        triColors[t * 3 + 2] = 0;
+        painted[t] = 1;
+      }
+      (triColors as Uint8Array & { _painted?: Uint8Array })._painted = painted;
+      const previewMesh: MeshData = { ...mesh, triColors };
+      const thumbnail = renderSingleView(previewMesh, opts.view ?? {});
+      return {
+        thumbnail,
+        triangleCount: triangles.size,
+        bbox: stats.bbox,
+        centroid: stats.centroid,
+      };
+    },
+
+    /** Assert facts about a previously-painted region. Returns
+     *  `{ passed: true }` on success, otherwise `{ passed: false, failures: [...] }`.
+     *
+     *  ```
+     *  partwright.assertPaint({
+     *    region: 'Index nail',                            // or numeric region id
+     *    expectedTriangleCount: { min: 15, max: 60 },     // or exact number
+     *    expectedBoundingBox: {
+     *      x: [8, 11], y: [3, 7], z: [60, 75],            // any subset of axes
+     *    },
+     *    expectedCentroid: { z: [62, 72] },               // approximate centroid axes
+     *  })
+     *  ``` */
+    assertPaint(opts: {
+      region: number | string;
+      expectedTriangleCount?: number | { min?: number; max?: number };
+      expectedBoundingBox?: { x?: [number, number]; y?: [number, number]; z?: [number, number] };
+      expectedCentroid?: { x?: [number, number]; y?: [number, number]; z?: [number, number] };
+    }) {
+      const mesh = currentMeshData;
+      if (!mesh) return { passed: false, failures: ['No geometry loaded'] };
+      if (!opts || typeof opts !== 'object') return { passed: false, failures: ['assertPaint requires an options object'] };
+      if (opts.region === undefined) return { passed: false, failures: ['assertPaint.region (id or name) is required'] };
+
+      const regions = getRegions();
+      const region = typeof opts.region === 'number'
+        ? regions.find(r => r.id === opts.region)
+        : regions.find(r => r.name === opts.region);
+      if (!region) return { passed: false, failures: [`No region matching ${JSON.stringify(opts.region)}. Existing: ${regions.map(r => `"${r.name}" (id=${r.id})`).join(', ') || '(none)'}`] };
+
+      const stats = regionTriangleStats(region.triangles, mesh);
+      const failures: string[] = [];
+
+      if (opts.expectedTriangleCount !== undefined) {
+        const c = region.triangles.size;
+        if (typeof opts.expectedTriangleCount === 'number') {
+          if (c !== opts.expectedTriangleCount) failures.push(`triangle count: expected ${opts.expectedTriangleCount}, got ${c}`);
+        } else {
+          const { min, max } = opts.expectedTriangleCount;
+          if (typeof min === 'number' && c < min) failures.push(`triangle count: expected >= ${min}, got ${c}`);
+          if (typeof max === 'number' && c > max) failures.push(`triangle count: expected <= ${max}, got ${c}`);
+        }
+      }
+
+      if (opts.expectedBoundingBox && stats.bbox) {
+        const axes = ['x', 'y', 'z'] as const;
+        for (let i = 0; i < 3; i++) {
+          const axis = axes[i];
+          const range = opts.expectedBoundingBox[axis];
+          if (!range) continue;
+          const lo = stats.bbox.min[i], hi = stats.bbox.max[i];
+          if (lo < range[0]) failures.push(`bbox.${axis}.min: expected >= ${range[0]}, got ${lo.toFixed(3)}`);
+          if (hi > range[1]) failures.push(`bbox.${axis}.max: expected <= ${range[1]}, got ${hi.toFixed(3)}`);
+        }
+      }
+
+      if (opts.expectedCentroid && stats.centroid) {
+        const axes = ['x', 'y', 'z'] as const;
+        for (let i = 0; i < 3; i++) {
+          const axis = axes[i];
+          const range = opts.expectedCentroid[axis];
+          if (!range) continue;
+          const c = stats.centroid[i];
+          if (c < range[0] || c > range[1]) failures.push(`centroid.${axis}: expected within [${range[0]}, ${range[1]}], got ${c.toFixed(3)}`);
+        }
+      }
+
+      return failures.length === 0
+        ? { passed: true, region: { id: region.id, name: region.name, triangles: region.triangles.size, bbox: stats.bbox, centroid: stats.centroid } }
+        : { passed: false, failures, region: { id: region.id, name: region.name, triangles: region.triangles.size, bbox: stats.bbox, centroid: stats.centroid } };
     },
 
     /** Clear all color regions */
@@ -3636,13 +3951,18 @@ async function main() {
         'downloadRecentExport': { signature: 'downloadRecentExport(id) -- Re-trigger browser download for an inbox entry', docs: '/ai.md#ai-friendly-file-io' },
         'clearRecentExports': { signature: 'clearRecentExports() -- Empty the Recent Exports list', docs: '/ai.md#ai-friendly-file-io' },
         // Color regions
-        'paintRegion':     { signature: 'paintRegion({point, normal, color, name?, tolerance?}) -- Paint coplanar face region', docs: '/ai.md#color-regions' },
+        'paintRegion':     { signature: 'paintRegion({point, normal, color, name?, tolerance?}) -- Paint coplanar face region (flood-fill, edge-bounded). Diagnostic error on failure.', docs: '/ai.md#color-regions' },
         'paintNearestRegion': { signature: 'paintNearestRegion({point, color, searchRadius?, name?, tolerance?}) -- Snap seed to nearest face, then paint coplanar region', docs: '/ai.md#color-regions' },
+        'paintNear':       { signature: 'paintNear({point, radius, normalCone?, color, name?}) -- Paint triangles whose centroid is within `radius` of `point`. Predictable, no flood-fill tolerance to tune.', docs: '/ai.md#color-regions' },
+        'paintInBox':      { signature: 'paintInBox({box, normalCone?, color, name?}) -- Paint triangles whose centroid is inside an axis-aligned box (and optional normal cone).', docs: '/ai.md#color-regions' },
         'paintFaces':      { signature: 'paintFaces({triangleIds, color, name?}) -- Paint specific triangle indices', docs: '/ai.md#color-regions' },
         'paintSlab':       { signature: 'paintSlab({axis|normal, offset, thickness, color, name?}) -- Paint planar slab range', docs: '/ai.md#color-regions' },
+        'paintPreview':    { signature: 'paintPreview({box?|point+radius?|triangleIds?, normalCone?, view?}) -- Highlight a candidate region without committing -> {thumbnail, triangleCount, bbox, centroid}', docs: '/ai.md#color-regions' },
+        'assertPaint':     { signature: 'assertPaint({region, expectedTriangleCount?, expectedBoundingBox?, expectedCentroid?}) -- Verify a previously-painted region -> {passed, failures?}', docs: '/ai.md#color-regions' },
         'findFaces':       { signature: 'findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?}) -- Query triangle ids by geometry/color filters', docs: '/ai.md#color-regions' },
+        'getMesh':         { signature: 'getMesh() -- Direct triangle/vertex/normal/centroid access for procedural paint workflows', docs: '/ai.md#color-regions' },
         'getMeshSummary':  { signature: 'getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?}?) -- List coplanar face groups with centroid/normal/area/bbox', docs: '/ai.md#color-regions' },
-        'listRegions':     { signature: 'listRegions() -- List all color regions', docs: '/ai.md#color-regions' },
+        'listRegions':     { signature: 'listRegions() -- List all color regions with bbox + centroid for each', docs: '/ai.md#color-regions' },
         'clearColors':     { signature: 'clearColors() -- Remove all color regions', docs: '/ai.md#color-regions' },
         // Annotations
         'listAnnotations':    { signature: 'listAnnotations() -- List freehand strokes -> [{id, color, width, points}]', docs: '/ai.md#annotations' },
@@ -3716,6 +4036,214 @@ async function main() {
   console.info('Partwright: AI agents should use window.partwright -- start with partwright.help(). window.mainifold remains as a legacy alias. See /llms.txt');
 
   // === Internal functions ===
+
+  /** Report bounding box + centroid for a triangle set, walking only the
+   *  vertices used by those triangles. Returns `null` when the set is empty. */
+  function regionTriangleStats(triangles: Set<number>, mesh: MeshData): { bbox: { min: [number, number, number]; max: [number, number, number] }; centroid: [number, number, number] } | { bbox: null; centroid: null } {
+    if (triangles.size === 0) return { bbox: null, centroid: null };
+    const { triVerts, vertProperties, numProp } = mesh;
+    let xMin = Infinity, yMin = Infinity, zMin = Infinity;
+    let xMax = -Infinity, yMax = -Infinity, zMax = -Infinity;
+    let sx = 0, sy = 0, sz = 0, count = 0;
+    for (const t of triangles) {
+      for (let k = 0; k < 3; k++) {
+        const vi = triVerts[t * 3 + k];
+        const x = vertProperties[vi * numProp];
+        const y = vertProperties[vi * numProp + 1];
+        const z = vertProperties[vi * numProp + 2];
+        if (x < xMin) xMin = x; if (x > xMax) xMax = x;
+        if (y < yMin) yMin = y; if (y > yMax) yMax = y;
+        if (z < zMin) zMin = z; if (z > zMax) zMax = z;
+        sx += x; sy += y; sz += z; count++;
+      }
+    }
+    return {
+      bbox: { min: [xMin, yMin, zMin], max: [xMax, yMax, zMax] },
+      centroid: [sx / count, sy / count, sz / count],
+    };
+  }
+
+  /** Build a friendly diagnostic for `paintRegion` failures: locate the closest
+   *  surface point, report its position/normal, the angle off the requested
+   *  normal, and a tolerance value that would accept it. Avoids the
+   *  "no matching face found" black box that wastes agent debugging cycles. */
+  function diagnoseSeedFailure(
+    point: [number, number, number],
+    requestedNormal: [number, number, number],
+    mesh: MeshData,
+    adjacency: ReturnType<typeof buildAdjacency>,
+    tolerance: number,
+  ): { error: string; nearest?: { point: [number, number, number]; normal: [number, number, number]; distance: number; angleDeg: number; suggestedTolerance: number } } {
+    const nearest = findNearestTriangle(point, mesh, adjacency);
+    if (nearest.triIndex < 0) return { error: 'paintRegion: mesh has no triangles' };
+
+    // Normalize the requested normal so the angle calc is meaningful.
+    const len = Math.hypot(requestedNormal[0], requestedNormal[1], requestedNormal[2]);
+    const nx = len > 0 ? requestedNormal[0] / len : 0;
+    const ny = len > 0 ? requestedNormal[1] / len : 0;
+    const nz = len > 0 ? requestedNormal[2] / len : 0;
+    const dot = nx * nearest.normal[0] + ny * nearest.normal[1] + nz * nearest.normal[2];
+    const clamped = Math.max(-1, Math.min(1, dot));
+    const angleDeg = Math.acos(clamped) * 180 / Math.PI;
+
+    // Suggest a tolerance just permissive enough to include the nearest face.
+    // Round down to 4 decimal places so the suggestion clearly passes the threshold.
+    const suggested = Math.max(-1, Math.floor(clamped * 10000) / 10000 - 0.0001);
+    const suggestText = clamped >= tolerance
+      ? `tolerance ${tolerance} should already match — the seed point may be too far off the surface (${nearest.distance.toFixed(3)} units). Use the hit point/normal from probeRay() instead, or call paintNearestRegion({point, color}) which auto-snaps.`
+      : `try tolerance ${suggested.toFixed(4)} (currently ${tolerance})`;
+
+    return {
+      error: `paintRegion: no face matched at point=[${point.map(n => n.toFixed(2)).join(', ')}], normal=[${requestedNormal.map(n => n.toFixed(3)).join(', ')}], tolerance=${tolerance}. Nearest face is at [${nearest.closest.map(n => n.toFixed(2)).join(', ')}] with normal [${nearest.normal.map(n => n.toFixed(3)).join(', ')}] (${angleDeg.toFixed(1)}° off requested, distance ${nearest.distance.toFixed(3)}). ${suggestText}`,
+      nearest: {
+        point: nearest.closest,
+        normal: nearest.normal,
+        distance: nearest.distance,
+        angleDeg,
+        suggestedTolerance: suggested,
+      },
+    };
+  }
+
+  /** Validate `{ axis, angleDeg }` shape used by paint cone filters. Returns
+   *  an error string or `null`. */
+  function validateNormalCone(cone: { axis: [number, number, number]; angleDeg: number } | undefined): string | null {
+    if (cone === undefined) return null;
+    if (typeof cone !== 'object' || cone === null) return 'normalCone must be { axis: [x,y,z], angleDeg: number }';
+    if (!Array.isArray(cone.axis) || cone.axis.length !== 3) return 'normalCone.axis must be [nx, ny, nz]';
+    for (let i = 0; i < 3; i++) {
+      if (typeof cone.axis[i] !== 'number' || !Number.isFinite(cone.axis[i])) return 'normalCone.axis components must be finite numbers';
+    }
+    const len = Math.hypot(cone.axis[0], cone.axis[1], cone.axis[2]);
+    if (len === 0) return 'normalCone.axis must be a non-zero vector';
+    if (typeof cone.angleDeg !== 'number' || !Number.isFinite(cone.angleDeg)) return 'normalCone.angleDeg must be a finite number';
+    if (cone.angleDeg < 0 || cone.angleDeg > 180) return 'normalCone.angleDeg must be in [0, 180]';
+    return null;
+  }
+
+  function validateBoxAndCone(
+    box: { min: [number, number, number]; max: [number, number, number] } | undefined,
+    cone: { axis: [number, number, number]; angleDeg: number } | undefined,
+  ): string | null {
+    if (box === undefined || typeof box !== 'object' || box === null) return 'box must be { min: [x,y,z], max: [x,y,z] }';
+    if (!Array.isArray(box.min) || box.min.length !== 3 || !Array.isArray(box.max) || box.max.length !== 3) {
+      return 'box.min and box.max must be 3-tuples';
+    }
+    for (let i = 0; i < 3; i++) {
+      if (typeof box.min[i] !== 'number' || !Number.isFinite(box.min[i])) return `box.min[${i}] must be a finite number`;
+      if (typeof box.max[i] !== 'number' || !Number.isFinite(box.max[i])) return `box.max[${i}] must be a finite number`;
+      if (box.min[i] > box.max[i]) return `box.min[${i}] (${box.min[i]}) must be <= box.max[${i}] (${box.max[i]})`;
+    }
+    return validateNormalCone(cone);
+  }
+
+  /** Collect triangle ids whose centroid lies inside `box` and (optionally)
+   *  whose face normal aligns with `cone.axis` within `cone.angleDeg`.
+   *  `regionFilter`, when non-null, restricts to ids in that set. */
+  function collectTrianglesByFilter(
+    mesh: MeshData,
+    box: { min: [number, number, number]; max: [number, number, number] },
+    cone: { axis: [number, number, number]; angleDeg: number } | undefined,
+    regionFilter: Set<number> | null,
+  ): Set<number> {
+    const adjacency = cone ? buildAdjacency(mesh) : null;
+    let coneAxis: [number, number, number] | null = null;
+    let coneCos = -1;
+    if (cone) {
+      const len = Math.hypot(cone.axis[0], cone.axis[1], cone.axis[2]);
+      coneAxis = [cone.axis[0] / len, cone.axis[1] / len, cone.axis[2] / len];
+      coneCos = Math.cos(cone.angleDeg * Math.PI / 180);
+    }
+    const result = new Set<number>();
+    const { triVerts, vertProperties, numProp, numTri } = mesh;
+    for (let t = 0; t < numTri; t++) {
+      if (regionFilter && !regionFilter.has(t)) continue;
+      const v0 = triVerts[t * 3];
+      const v1 = triVerts[t * 3 + 1];
+      const v2 = triVerts[t * 3 + 2];
+      const cx = (vertProperties[v0 * numProp] + vertProperties[v1 * numProp] + vertProperties[v2 * numProp]) / 3;
+      const cy = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3;
+      const cz = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3;
+      if (cx < box.min[0] || cx > box.max[0]) continue;
+      if (cy < box.min[1] || cy > box.max[1]) continue;
+      if (cz < box.min[2] || cz > box.max[2]) continue;
+      if (coneAxis && adjacency) {
+        const nx = adjacency.normals[t * 3];
+        const ny = adjacency.normals[t * 3 + 1];
+        const nz = adjacency.normals[t * 3 + 2];
+        const dot = coneAxis[0] * nx + coneAxis[1] * ny + coneAxis[2] * nz;
+        if (dot < coneCos) continue;
+      }
+      result.add(t);
+    }
+    return result;
+  }
+
+  /** Collect triangle ids whose centroid lies within `radius` of `point`. */
+  function collectTrianglesBySphere(
+    mesh: MeshData,
+    point: [number, number, number],
+    radius: number,
+    cone: { axis: [number, number, number]; angleDeg: number } | undefined,
+  ): Set<number> {
+    const adjacency = cone ? buildAdjacency(mesh) : null;
+    let coneAxis: [number, number, number] | null = null;
+    let coneCos = -1;
+    if (cone) {
+      const len = Math.hypot(cone.axis[0], cone.axis[1], cone.axis[2]);
+      coneAxis = [cone.axis[0] / len, cone.axis[1] / len, cone.axis[2] / len];
+      coneCos = Math.cos(cone.angleDeg * Math.PI / 180);
+    }
+    const r2 = radius * radius;
+    const result = new Set<number>();
+    const { triVerts, vertProperties, numProp, numTri } = mesh;
+    for (let t = 0; t < numTri; t++) {
+      const v0 = triVerts[t * 3];
+      const v1 = triVerts[t * 3 + 1];
+      const v2 = triVerts[t * 3 + 2];
+      const cx = (vertProperties[v0 * numProp] + vertProperties[v1 * numProp] + vertProperties[v2 * numProp]) / 3;
+      const cy = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3;
+      const cz = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3;
+      const dx = cx - point[0], dy = cy - point[1], dz = cz - point[2];
+      if (dx * dx + dy * dy + dz * dz > r2) continue;
+      if (coneAxis && adjacency) {
+        const nx = adjacency.normals[t * 3];
+        const ny = adjacency.normals[t * 3 + 1];
+        const nz = adjacency.normals[t * 3 + 2];
+        const dot = coneAxis[0] * nx + coneAxis[1] * ny + coneAxis[2] * nz;
+        if (dot < coneCos) continue;
+      }
+      result.add(t);
+    }
+    return result;
+  }
+
+  /** Commit a triangle set as a region and refresh the viewport — shared by
+   *  `paintInBox` and `paintNear` so they stay byte-for-byte consistent with
+   *  the existing `paintFaces`/`paintRegion` rendering path. */
+  function commitPaintFromSet(
+    triangles: Set<number>,
+    color: [number, number, number],
+    name: string | undefined,
+    source: 'face-pick' | 'paintbrush',
+  ) {
+    if (!currentMeshData) return { error: 'No geometry loaded' };
+    const regionName = name ?? `Region ${getRegions().length + 1}`;
+    const region = addRegion(
+      regionName,
+      color,
+      source,
+      { kind: 'triangles', ids: [...triangles] },
+      triangles,
+    );
+    const colored = applyTriColorsIfVisible(currentMeshData);
+    updateMesh(colored, { skipAutoFrame: true });
+    updateMultiView(colored);
+    renderElevationsToContainer(elevationsContainer, colored);
+    syncLockState();
+    const stats = regionTriangleStats(triangles, currentMeshData);
+    return { id: region.id, name: region.name, triangles: triangles.size, bbox: stats.bbox, centroid: stats.centroid };
+  }
 
   function runCode(code?: string) {
     const src = code ?? getValue();


### PR DESCRIPTION
## Summary

Generic, lasting improvements to the paint API for AI agents modeling and painting in Partwright. Closes the gap that made smooth-surface painting essentially trial-and-error.

### New APIs

- **\`paintNear({ point, radius, normalCone?, color, name? })\`** — sphere selector. Filters triangles by world-space centroid distance, optionally restricted by face-normal cone. No flood-fill tolerance to tune.
- **\`paintInBox({ box, normalCone?, color, name? })\`** — AABB selector with optional normal-cone restriction. Same predictable, position-based filtering.
- **\`paintPreview({ box?|point+radius?|triangleIds?, normalCone?, view? })\`** — dry-run preview that returns a thumbnail with the candidate region tinted bright yellow on top of any existing paint. Does **not** commit.
- **\`assertPaint({ region, expectedTriangleCount?, expectedBoundingBox?, expectedCentroid? })\`** — verify a region; pairs with \`runAndAssert\`. Returns \`{ passed }\` or \`{ passed: false, failures: [...] }\`.
- **\`getMesh()\`** — direct triangle/vertex/normal/centroid access (typed arrays + bbox) for procedural paint workflows.

### Improvements

- **\`paintRegion\` diagnostic errors.** When seed resolution fails, the \`error\` string now includes the nearest triangle's position, normal, angle off the requested normal, distance, and a suggested tolerance value that would accept it. Same data is exposed structured under \`r.nearest\`.
- **\`listRegions()\` includes \`bbox\` and \`centroid\`** per region — callers can verify *where* a region landed without re-rendering.

### Docs

- New **\"Common gotchas\"** section in [\`public/ai.md\`](./public/ai.md) covering:
  - \`paintRegion\` flood-fill bimodality on smooth surfaces (use \`paintNear\` / \`paintInBox\` instead).
  - Trust \`probeRay\`'s hit normal — don't derive your own.
  - Manifold's \`rotate\` direction with a 3-line verification snippet.
  - Painting locks the editor — \`clearColors()\` to iterate.
  - Verify before you commit (\`paintPreview\`) and after (\`assertPaint\`).
  - \`runIsolated\` vs \`runAndSave\` for sanity checks.
- Console API summary and \`partwright.help()\` entries updated with all new methods.

### Why

The catalyst was a session where \`paintRegion\` ate 30+ minutes of trial-and-error tolerance tuning on capsule/hulled-sphere geometry. The flood-fill threshold is bimodal on smooth surfaces — too tight paints almost nothing, too loose paints almost everything, with no useful middle. The position-based primitives (\`paintNear\`, \`paintInBox\`) skip that entirely; the diagnostic error message would have collapsed the same debug loop in one turn instead of many.

## Test plan

- [x] \`npm run build\` clean.
- [x] 10-step Playwright smoke test driving every new API against a localhost dev build — all 10 pass:
  1. \`runAndSave\` — build a capsule + nail bump test rig
  2. \`getMesh\` returns vertices, triangles, normals, centroids, bbox
  3. \`paintRegion\` success path
  4. \`paintRegion\` failure returns diagnostic with nearest-face info
  5. \`paintInBox\` paints triangles inside an AABB
  6. \`paintInBox\` with \`normalCone\` further restricts results
  7. \`paintNear\` paints triangles within radius
  8. \`listRegions\` reports bbox + centroid per region
  9. \`paintPreview\` returns a PNG data URL and does not mutate regions
  10. \`assertPaint\` passes when expectations match, fails with \`failures[]\` when they don't
- [ ] Manual: drive a real organic model (capsule fingers, hulled body) and confirm \`paintNear\` produces clean nail-shaped patches without a single tolerance-fiddle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)