### PR TITLE
feat: in-app AI chat (BYO Anthropic key, tools, vision, compaction)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ dist-ssr
 # Playwright MCP artifacts
 .playwright-mcp/
 
+# Playwright test runner output
+test-results/
+playwright-report/
+playwright/.cache/
+
 # Interstitial planning files
 .plans/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 ```bash
 npm run dev          # Start dev server at http://localhost:5173
 npm run build        # Production build to dist/
+npm run test:e2e     # Run Playwright smoke tests (auto-starts dev server)
 ```
 
 Open `http://localhost:5173/editor?view=ai` to start with the 4 isometric views visible (instead of the interactive viewport). This is the recommended URL for AI agents — all views are visible on page load without clicking any tabs.
@@ -29,6 +30,68 @@ Hosted on **Cloudflare Pages** with production custom domain `www.partwrightstud
 - **SPA routing:** `public/_redirects` (`/* /index.html 200`)
 - **Headers:** `public/_headers` (COEP, COOP, CSP) — Cloudflare Pages serves these automatically
 - **Environment variable:** Set `SITE_URL` in Cloudflare Pages dashboard (Settings > Environment variables) to the production URL (`https://www.partwrightstudio.com`). This is used at build time by the `absoluteUrls` Vite plugin to make Open Graph image URLs and canonical links absolute. If `SITE_URL` is not set, the plugin falls back to `CF_PAGES_URL` (provided automatically by Cloudflare Pages for each deployment).
+
+## Browser Tests (Playwright)
+
+End-to-end smoke tests live in `tests/*.spec.ts` and run against a Vite dev
+server that Playwright starts automatically. Run them with:
+
+```bash
+npm run test:e2e               # full suite
+npx playwright test --grep "AI chat"   # one describe block
+npx playwright test --headed   # watch the browser run (local only)
+```
+
+**Run these whenever you touch UI, routing, or anything in `src/ai/` or
+`src/ui/ai*`** — the suite covers landing → editor → AI panel toggle →
+key modal → toggle pills → ai.md serving in ~15s.
+
+### Multi-environment browser detection
+
+`playwright.config.ts` auto-picks the right Chromium binary so the same
+test command works on a developer laptop and inside the Anthropic Claude
+Code on the web sandbox without per-environment setup:
+
+- **Sandbox** (`/opt/pw-browsers/` exists): config picks the highest
+  installed `chromium-N` directory and uses its `chrome` binary directly
+  via `launchOptions.executablePath`. The version pinned by the
+  `playwright` npm package may differ from what's cached, but the
+  installed browser still satisfies the test runner — no download
+  needed (which is good, because the sandbox often blocks Chrome for
+  Testing's CDN).
+- **Local laptop** (no `/opt/pw-browsers/`): config leaves
+  `executablePath` unset, and Playwright finds its own cache at
+  `~/.cache/ms-playwright/` (Linux) or `~/Library/Caches/ms-playwright/`
+  (macOS). Run `npx playwright install chromium` once on a new machine.
+
+If the auto-detection picks the wrong binary, override it at the shell:
+
+```bash
+PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/path/to/chrome npm run test:e2e
+```
+
+### When AI agents need to run a browser test
+
+1. Don't reinstall browsers blindly. Check `/opt/pw-browsers/` first; the
+   sandbox image already has Chromium. `playwright.config.ts` handles the
+   wiring.
+2. The default Desktop Chrome viewport (1280×720) clips the AI panel's
+   toggle strip. The config sets 1280×900 — keep it that way for
+   anything that interacts with elements in the bottom half of the
+   panel.
+3. Tiny flex children of recently-transformed parents sometimes fail
+   Playwright's viewport hit-test (`Element is outside of the viewport`).
+   When the bounding box is verifiably inside, prefer
+   `locator.dispatchEvent('click')` over `locator.click({ force: true })`
+   — the latter still enforces the viewport bound.
+4. Each Playwright test gets a fresh `BrowserContext`, so localStorage
+   and IndexedDB are isolated by default. **Don't add `localStorage.clear()`
+   in `beforeEach`** unless you mean it — it'll fire on `page.reload()`
+   inside a test too, breaking any "state persists across reload"
+   assertion.
+5. Tests must run with no external network. The `validateKey` flow hits
+   `api.anthropic.com`; assert on the surfaced error message, not on
+   whether the request succeeded.
 
 ## Smoke Test — Verifying the App Works
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "partwright-cad",
       "version": "0.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.92.0",
         "@codemirror/lang-javascript": "^6.2.5",
         "@codemirror/lint": "^6.9.5",
         "@codemirror/merge": "^6.12.1",
@@ -26,6 +27,35 @@
         "playwright": "^1.58.2",
         "typescript": "~5.8.3",
         "vite": "^6.3.5"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.92.0.tgz",
+      "integrity": "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -1943,6 +1973,19 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/ktx-parse": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-1.1.0.tgz",
@@ -2518,6 +2561,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-replace-all": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "deploy": "npm audit --audit-level=high && tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@types/three": "^0.183.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "vite": "^6.3.5"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.92.0",
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lint": "^6.9.5",
     "@codemirror/merge": "^6.12.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,69 @@
+import { defineConfig, devices } from 'playwright/test';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Multi-env browser path detection. The Anthropic Claude Code on the web
+// sandbox preinstalls Playwright browsers at /opt/pw-browsers/ — using a
+// version (e.g. chromium-1194) that may not match the SDK pinned in
+// package.json. On a developer laptop, browsers live under Playwright's
+// default cache (~/.cache/ms-playwright on Linux, ~/Library/Caches on
+// macOS) and the SDK + browser versions match.
+//
+// Strategy:
+//   1. If /opt/pw-browsers exists, pick the highest chromium-* there and
+//      use its `chrome` binary directly via launchOptions.executablePath.
+//   2. Otherwise, leave executablePath unset and Playwright finds its own
+//      cache. Run `npx playwright install chromium` once on a new machine.
+function detectChromiumExecutable(): string | undefined {
+  const sandboxRoot = '/opt/pw-browsers';
+  if (!existsSync(sandboxRoot)) return undefined;
+  const dirs = readdirSync(sandboxRoot)
+    .filter(d => /^chromium-\d+$/.test(d))
+    .sort((a, b) => Number(b.split('-')[1]) - Number(a.split('-')[1]));
+  for (const d of dirs) {
+    const candidate = join(sandboxRoot, d, 'chrome-linux', 'chrome');
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+const executablePath = detectChromiumExecutable();
+if (executablePath) {
+  // eslint-disable-next-line no-console
+  console.info(`[playwright.config] Using sandbox browser at ${executablePath}`);
+}
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['list']],
+  timeout: 30_000,
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    // Default Desktop Chrome (1280x720) clips the bottom of the AI panel
+    // (toggle strip + input row land below the fold), making low-pill
+    // clicks fail. 900px gives comfortable headroom on every test.
+    viewport: { width: 1280, height: 900 },
+    launchOptions: {
+      ...(executablePath ? { executablePath } : {}),
+      // The sandbox's chrome binary needs --no-sandbox; harmless on a laptop.
+      args: ['--no-sandbox'],
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/public/ai.md
+++ b/public/ai.md
@@ -166,7 +166,8 @@ await partwright.runAndAssert(code, assertions) // -> {passed, failures?, stats}
 await partwright.runAndExplain(code)     // -> {stats, components[], hints[]} (debug disconnects)
 await partwright.modifyAndTest(patchFn, assertions?) // Modify current code + test in isolation
 partwright.query({sliceAt?, decompose?, boundingBox?}) // Multi-query current geometry in one call
-partwright.renderView({elevation?, azimuth?, ortho?, size?}) // Render from any angle -> data URL
+partwright.renderView({elevation?, azimuth?, ortho?, size?})  // Render ONE angle -> data URL
+await partwright.renderViews({views?: 'tri'|'all', size?})    // 3- or 4-angle labeled composite -> data URL; prefer for verification
 partwright.sliceAtZVisual(z)            // Cross-section SVG at height z -> {svg, area, contours}
 partwright.isRunning()                   // -> boolean (is code executing?)
 
@@ -455,11 +456,32 @@ partwright.removeRegion(id) // delete one region by id (older mistake)
 partwright.clearColors()    // remove ALL regions — destructive, prefer the two above for single mistakes
 ```
 
-**Preview before commit.** `paintPreview()` accepts the same selector args
-as `paintInBox` / `paintNear` / `paintFaces` but doesn't commit. It
-returns `{triangleCount, bbox, centroid, thumbnail}` — use the count and
-bbox to validate your selector is in the right ballpark before paying
-the round-trip to paint, observe, and undo. Cheap; free of side effects.
+**Preview before commit (default workflow).** `paintPreview()` accepts
+the same selector args as `paintInBox` / `paintNear` / `paintFaces` but
+doesn't commit. It returns `{triangleCount, bbox, centroid, thumbnail}` —
+the thumbnail shows candidate triangles highlighted yellow over the
+current model, so you can confirm visually before paying the round-trip
+to paint, observe, and undo. Cheap; free of side effects.
+
+**Verify from multiple angles.** Use `renderViews({views: 'tri'})` (front
++ top + iso composite) for verification rather than a single
+`renderView` call. A single top-down view can hide an asymmetric error
+that's obvious from the front — e.g. a smile curve arching the wrong
+way. Same one-call cost, much better coverage.
+
+**Test before commit.** For unfamiliar primitives (revolve axis,
+hull edges, decompose order, any boolean chain), call `runIsolated(code)`
+on a tiny snippet first — it returns stats + a thumbnail without
+mutating the editor or the session. Saves a paint-undo-retry cycle
+when the geometry surprises you.
+
+**Engine choice for paint workflows.** SCAD's `revolve`,
+`linear_extrude`, and `cylinder` produce radial-fan triangle topology
+(every face triangle radiates from the central axis). That topology is
+awkward to paint cleanly — `paintInBox` tends to bleed across the
+adjacent fan wedges. If a task involves precise painting of curved
+features, prefer `manifold-js` from the start. SCAD remains the right
+choice for parametric extrusion-heavy parts where painting is secondary.
 
 ```js
 const preview = partwright.paintPreview({ box: { min: [-5, -5, 8], max: [5, 5, 12] } });

--- a/public/ai.md
+++ b/public/ai.md
@@ -204,7 +204,11 @@ partwright.findFaces({box?, normal?, normalTolerance?, color?, region?, maxResul
 partwright.getMesh()                     // -> {numVert, numTri, vertices, triangles, normals, centroids, boundingBox} (typed arrays)
 partwright.getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?}?) // -> {groups[{id, normal, centroid, area, triangleCount, bbox, triangleIds}], totalTriangles, groupCount, tolerance}
 partwright.listRegions()                 // -> [{id, name, color, source, triangles, order, bbox, centroid}, ...]
-partwright.clearColors()                 // Remove all regions
+partwright.undoLastPaint()               // Reverse the SINGLE most recent paint op -> {undone, id, ...}
+partwright.redoLastPaint()               // Reapply the most recently undone paint -> {redone, id, ...}
+partwright.canRedoPaint()                // -> {canRedo: bool}
+partwright.removeRegion(id)              // Delete ONE region by id from listRegions()
+partwright.clearColors()                 // Remove ALL regions (destructive — prefer undoLastPaint/removeRegion for fixing single mistakes)
 
 // Notes -- track design context, decisions, and measurements
 await partwright.addSessionNote(text)    // -> {id, text, timestamp}
@@ -442,8 +446,25 @@ const r = partwright.paintRegion({
 // r = { id, name, triangles } on success, or { error } if no matching face found
 
 partwright.listRegions()    // [{ id, name, color, source, triangles, order }, ...]
-partwright.clearColors()    // remove all regions
+partwright.undoLastPaint()  // reverse just the most recent paint op
+partwright.removeRegion(id) // delete one region by id (older mistake)
+partwright.clearColors()    // remove ALL regions — destructive, prefer the two above for single mistakes
 ```
+
+**Fixing mistakes.** If a paint operation went wrong, prefer the surgical
+tools over `clearColors()`:
+
+- `undoLastPaint()` reverses the single most recent paint. The removed
+  region goes onto a redo stack — `redoLastPaint()` puts it back. This
+  is the right call ~95% of the time when you painted something wrong.
+- `removeRegion(id)` deletes one specific region (id from
+  `listRegions()`). Use when the mistake wasn't the most recent paint.
+- `clearColors()` removes every region. Only call this when the user
+  explicitly asks to start over.
+
+Calling `clearColors()` to fix a single mistake forces you to repaint
+every other region from scratch — multiple round-trips, multiple chances
+to introduce new mistakes. Don't do it.
 
 **How face matching works.** `paintRegion` flood-fills outward from the seed triangle, including any neighbor whose normal is within `tolerance` of the seed's. Pick `point` slightly inside the model surface and pass the outward-pointing `normal` -- the seed resolver looks for the triangle whose plane the point lies on and whose normal aligns with yours.
 

--- a/public/ai.md
+++ b/public/ai.md
@@ -194,8 +194,8 @@ await partwright.clearAllSessions()      // Delete all sessions & versions
 // Color regions -- tag face regions with a color (see #color-regions)
 partwright.paintRegion({point, normal, color, name?, tolerance?})         // bucket: coplanar flood-fill -> {id, name, triangles} or {error, nearest?}
 partwright.paintNearestRegion({point, color, searchRadius?, name?, tolerance?}) // snap seed to nearest face, then flood-fill -> {id, name, triangles, snappedTo} or {error}
-partwright.paintNear({point, radius, normalCone?, color, name?})          // sphere: paint triangles whose centroid is within radius -> {id, name, triangles, bbox, centroid} or {error}
-partwright.paintInBox({box, normalCone?, color, name?})                   // box: paint triangles inside an AABB -> {id, name, triangles, bbox, centroid} or {error}
+partwright.paintNear({point, radius, normalCone?, topOnly?, color, name?})          // sphere: paint triangles whose centroid is within radius -> {id, name, triangles, bbox, centroid} or {error}
+partwright.paintInBox({box, normalCone?, topOnly?, color, name?})                   // box: paint triangles inside an AABB -> {id, name, triangles, bbox, centroid} or {error}
 partwright.paintFaces({triangleIds, color, name?})                        // brush: paint specific triangle indices -> {id, name, triangles} or {error}
 partwright.paintSlab({axis|normal, offset, thickness, color, name?})      // slab: paint a planar range -> {id, name, triangles} or {error}
 partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, view?}) // dry-run: highlight a candidate region -> {thumbnail, triangleCount, bbox, centroid} (does not commit)
@@ -205,6 +205,8 @@ partwright.getMesh()                     // -> {numVert, numTri, vertices, trian
 partwright.getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?, withinBox?}?) // -> {groups[{id, normal, centroid, area, triangleCount, bbox, triangleIds}], totalTriangles, groupCount, tolerance, unfiltered?}
 partwright.listRegions()                 // -> [{id, name, color, source, triangles, order, bbox, centroid}, ...]
 partwright.listComponents()              // -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- per-piece bbox for unioned models
+partwright.paintComponent({index, color, name?, topOnly?}) // One-call: paint the Nth boolean-distinct piece
+partwright.getFeatureCentroids({maxGroups?, withinBox?}?)  // Lightweight planning: centroids + normals + bbox per face group, NO triangleIds
 partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, thumbnail}
 partwright.undoLastPaint()               // Reverse the SINGLE most recent paint op -> {undone, id, ...}
 partwright.redoLastPaint()               // Reapply the most recently undone paint -> {redone, id, ...}
@@ -468,19 +470,31 @@ const preview = partwright.paintPreview({ box: { min: [-5, -5, 8], max: [5, 5, 1
 
 **Paint by feature on unioned models.** When the geometry is a boolean
 union of distinct pieces (head + eyes + mouth, body + arms + legs, etc.),
-call `listComponents()` first to get the per-piece bbox:
+the one-call form is `paintComponent(index, color)` — it decomposes and
+paints in a single round trip:
 
 ```js
 const { components } = partwright.listComponents();
 // components: [{index, centroid, boundingBox, volume, surfaceArea}, ...]
-// Sort by centroid.y or volume to identify which is which.
+// Sort by centroid.y / volume to identify which piece is which, then:
 for (const c of components) {
-  partwright.paintInBox({ box: c.boundingBox, color: chooseColor(c.index) });
+  partwright.paintComponent({ index: c.index, color: chooseColor(c.index) });
 }
 ```
 
-This avoids guessing world coordinates and survives small parametric
-tweaks to the model.
+This avoids guessing world coordinates, survives small parametric
+tweaks to the model, and skips the listComponents → paintInBox pair.
+
+**Avoiding over-paint.** When `paintInBox` / `paintNear` catches side
+walls or the bottom face by mistake, pass `topOnly: true` — restricts
+to upward-facing triangles (axis +Z within 30°). Equivalent to
+`normalCone: { axis: [0, 0, 1], angleDeg: 30 }` but easier to remember.
+
+**Cheap planning.** `getFeatureCentroids({maxGroups, withinBox?})`
+returns face-group centroids + normals + bbox + area, WITHOUT the
+triangleId arrays that make `getMeshSummary` expensive on complex
+models. Use this when planning paint targets; only escalate to the
+full `getMeshSummary` when you actually need the per-triangle ids.
 
 **Fixing mistakes.** If a paint operation went wrong, prefer the surgical
 tools over `clearColors()`:

--- a/public/ai.md
+++ b/public/ai.md
@@ -202,8 +202,10 @@ partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, view?}) /
 partwright.assertPaint({region, expectedTriangleCount?, expectedBoundingBox?, expectedCentroid?}) // verify a region -> {passed, failures?}
 partwright.findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?}) // query triangle ids by geometry/color -> {triangleIds, count, matched, truncated}
 partwright.getMesh()                     // -> {numVert, numTri, vertices, triangles, normals, centroids, boundingBox} (typed arrays)
-partwright.getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?}?) // -> {groups[{id, normal, centroid, area, triangleCount, bbox, triangleIds}], totalTriangles, groupCount, tolerance}
+partwright.getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?, withinBox?}?) // -> {groups[{id, normal, centroid, area, triangleCount, bbox, triangleIds}], totalTriangles, groupCount, tolerance, unfiltered?}
 partwright.listRegions()                 // -> [{id, name, color, source, triangles, order, bbox, centroid}, ...]
+partwright.listComponents()              // -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- per-piece bbox for unioned models
+partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, thumbnail}
 partwright.undoLastPaint()               // Reverse the SINGLE most recent paint op -> {undone, id, ...}
 partwright.redoLastPaint()               // Reapply the most recently undone paint -> {redone, id, ...}
 partwright.canRedoPaint()                // -> {canRedo: bool}
@@ -450,6 +452,35 @@ partwright.undoLastPaint()  // reverse just the most recent paint op
 partwright.removeRegion(id) // delete one region by id (older mistake)
 partwright.clearColors()    // remove ALL regions — destructive, prefer the two above for single mistakes
 ```
+
+**Preview before commit.** `paintPreview()` accepts the same selector args
+as `paintInBox` / `paintNear` / `paintFaces` but doesn't commit. It
+returns `{triangleCount, bbox, centroid, thumbnail}` — use the count and
+bbox to validate your selector is in the right ballpark before paying
+the round-trip to paint, observe, and undo. Cheap; free of side effects.
+
+```js
+const preview = partwright.paintPreview({ box: { min: [-5, -5, 8], max: [5, 5, 12] } });
+// preview.triangleCount === 0  →  selector matched nothing, widen it
+// preview.triangleCount > 5000 →  too greedy, tighten
+// otherwise: partwright.paintInBox({box: same, color: [1,0,0]})
+```
+
+**Paint by feature on unioned models.** When the geometry is a boolean
+union of distinct pieces (head + eyes + mouth, body + arms + legs, etc.),
+call `listComponents()` first to get the per-piece bbox:
+
+```js
+const { components } = partwright.listComponents();
+// components: [{index, centroid, boundingBox, volume, surfaceArea}, ...]
+// Sort by centroid.y or volume to identify which is which.
+for (const c of components) {
+  partwright.paintInBox({ box: c.boundingBox, color: chooseColor(c.index) });
+}
+```
+
+This avoids guessing world coordinates and survives small parametric
+tweaks to the model.
 
 **Fixing mistakes.** If a paint operation went wrong, prefer the surgical
 tools over `clearColors()`:

--- a/public/ai.md
+++ b/public/ai.md
@@ -212,7 +212,6 @@ partwright.getFeatureCentroids({maxGroups?, withinBox?}?)  // Lightweight planni
 partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, [thumbnail]}
 partwright.undoLastPaint()               // Reverse the SINGLE most recent paint op -> {undone, id, ...}
 partwright.redoLastPaint()               // Reapply the most recently undone paint -> {redone, id, ...}
-partwright.canRedoPaint()                // -> {canRedo: bool}
 partwright.removeRegion(id)              // Delete ONE region by id from listRegions()
 partwright.clearColors()                 // Remove ALL regions (destructive — prefer undoLastPaint/removeRegion for fixing single mistakes)
 

--- a/public/ai.md
+++ b/public/ai.md
@@ -167,7 +167,7 @@ await partwright.runAndExplain(code)     // -> {stats, components[], hints[]} (d
 await partwright.modifyAndTest(patchFn, assertions?) // Modify current code + test in isolation
 partwright.query({sliceAt?, decompose?, boundingBox?}) // Multi-query current geometry in one call
 partwright.renderView({elevation?, azimuth?, ortho?, size?})  // Render ONE angle -> data URL
-await partwright.renderViews({views?: 'tri'|'all', size?})    // 3- or 4-angle labeled composite -> data URL; prefer for verification
+await partwright.renderViews({views?: 'auto'|'tri'|'all', size?})  // multi-angle labeled composite -> data URL; 'auto' (default) picks angles by aspect ratio; prefer for verification
 partwright.sliceAtZVisual(z)            // Cross-section SVG at height z -> {svg, area, contours}
 partwright.isRunning()                   // -> boolean (is code executing?)
 
@@ -199,7 +199,8 @@ partwright.paintNear({point, radius, normalCone?, topOnly?, color, name?})      
 partwright.paintInBox({box, normalCone?, topOnly?, color, name?})                   // box: paint triangles inside an AABB -> {id, name, triangles, bbox, centroid} or {error}
 partwright.paintFaces({triangleIds, color, name?})                        // brush: paint specific triangle indices -> {id, name, triangles} or {error}
 partwright.paintSlab({axis|normal, offset, thickness, color, name?})      // slab: paint a planar range -> {id, name, triangles} or {error}
-partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, view?}) // dry-run: highlight a candidate region -> {thumbnail, triangleCount, bbox, centroid} (does not commit)
+partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) // dry-run -> {triangleCount, bbox, centroid, [thumbnail]} (default: count-only; withImage: true adds thumbnail)
+partwright.paintExplain({region, withImage?, view?}) // diagnose committed region -> {triangleCount, area, bbox, centroid, normalHistogram, [thumbnail]}
 partwright.assertPaint({region, expectedTriangleCount?, expectedBoundingBox?, expectedCentroid?}) // verify a region -> {passed, failures?}
 partwright.findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?}) // query triangle ids by geometry/color -> {triangleIds, count, matched, truncated}
 partwright.getMesh()                     // -> {numVert, numTri, vertices, triangles, normals, centroids, boundingBox} (typed arrays)
@@ -208,7 +209,7 @@ partwright.listRegions()                 // -> [{id, name, color, source, triang
 partwright.listComponents()              // -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- per-piece bbox for unioned models
 partwright.paintComponent({index, color, name?, topOnly?}) // One-call: paint the Nth boolean-distinct piece
 partwright.getFeatureCentroids({maxGroups?, withinBox?}?)  // Lightweight planning: centroids + normals + bbox per face group, NO triangleIds
-partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, thumbnail}
+partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, [thumbnail]}
 partwright.undoLastPaint()               // Reverse the SINGLE most recent paint op -> {undone, id, ...}
 partwright.redoLastPaint()               // Reapply the most recently undone paint -> {redone, id, ...}
 partwright.canRedoPaint()                // -> {canRedo: bool}
@@ -458,16 +459,27 @@ partwright.clearColors()    // remove ALL regions — destructive, prefer the tw
 
 **Preview before commit (default workflow).** `paintPreview()` accepts
 the same selector args as `paintInBox` / `paintNear` / `paintFaces` but
-doesn't commit. It returns `{triangleCount, bbox, centroid, thumbnail}` —
-the thumbnail shows candidate triangles highlighted yellow over the
-current model, so you can confirm visually before paying the round-trip
-to paint, observe, and undo. Cheap; free of side effects.
+doesn't commit. By default it returns just `{triangleCount, bbox,
+centroid}` — count alone is essentially free and catches most bad
+selectors. Pass `withImage: true` when the count surprises you and a
+yellow-highlighted thumbnail is worth the tokens. Cheap; no side effects.
 
-**Verify from multiple angles.** Use `renderViews({views: 'tri'})` (front
-+ top + iso composite) for verification rather than a single
-`renderView` call. A single top-down view can hide an asymmetric error
-that's obvious from the front — e.g. a smile curve arching the wrong
-way. Same one-call cost, much better coverage.
+**Diagnose a bad paint.** `paintExplain({region: id})` returns area,
+bbox, centroid, a normal-distribution histogram (`{xPos, xNeg, yPos,
+yNeg, zPos, zNeg, oblique}` summing to ~1), and a thumbnail of the
+region tinted yellow. Use after a paint that looks wrong — the
+histogram tells you in one number whether the region wrapped onto a
+face you didn't intend (e.g. `zPos: 0.4, xPos: 0.3` = caught the top
+AND a side).
+
+**Verify from multiple angles.** Use `renderViews()` for verification
+rather than a single `renderView` call. The default `views: 'auto'`
+picks angles by the model's bounding box: flat disks get [Top, Iso]
+(a front elevation of a disk is a thin sliver), tall columns get
+[Front, Right, Iso] (the top of a column is a dot), everything else
+gets [Front, Top, Iso]. Use `views: 'tri'` or `'all'` to force a
+specific composite. A single angle can hide an asymmetric error —
+e.g. a smile curve arching the wrong way.
 
 **Test before commit.** For unfamiliar primitives (revolve axis,
 hull edges, decompose order, any boolean chain), call `runIsolated(code)`
@@ -651,17 +663,36 @@ partwright.paintSlab({
 });
 ```
 
-**Verifying paint before you commit it.** `paintPreview` accepts the same selectors as `paintInBox` / `paintNear` / `paintFaces` and returns a thumbnail with the candidate triangles tinted bright yellow on top of any existing paint, *without* adding a region. Use it to confirm the shape of a region before committing.
+**Verifying paint before you commit it.** `paintPreview` accepts the same selectors as `paintInBox` / `paintNear` / `paintFaces`, *without* adding a region. Default: count-only (free sanity check). Pass `withImage: true` to also get a thumbnail with the candidate triangles tinted bright yellow on top of any existing paint.
 
 ```js
-const preview = partwright.paintPreview({
+const dry = partwright.paintPreview({
   point: [10.4, 5.2, 67],
   radius: 3,
   normalCone: { axis: [0, -0.89, 0.45], angleDeg: 25 },
+});
+// dry = { triangleCount, bbox, centroid }   // count-only, cheap
+// If dry.triangleCount looks off, opt into the visual:
+const visual = partwright.paintPreview({
+  point: [10.4, 5.2, 67], radius: 3, withImage: true,
   view: { elevation: 0, azimuth: 180, ortho: true, size: 320 }, // optional
 });
-// preview = { thumbnail, triangleCount, bbox, centroid }
-// Display preview.thumbnail (data URL) -- no region created, no editor lock.
+// visual = { triangleCount, bbox, centroid, thumbnail }
+```
+
+**Explaining a region after the fact.** `paintExplain({region: id})`
+returns counts, bbox, centroid, surface area, a normal-distribution
+histogram, and a yellow-highlighted thumbnail of just that region.
+Use when a painted region looks wrong and you need to diagnose *why*
+without re-running the selector:
+
+```js
+partwright.paintExplain({ region: 'mouth' });
+// -> { id, name, color, source, triangleCount, area, bbox, centroid,
+//      normalHistogram: { xPos, xNeg, yPos, yNeg, zPos, zNeg, oblique },
+//      thumbnail }
+// Pass `withImage: false` to skip the WebGL render when you only need
+// the histogram (e.g. "is this region all top-facing or did it wrap?").
 ```
 
 **Asserting paint after you commit it.** `assertPaint` checks a region against expected triangle count and bbox/centroid ranges — same shape as `runAndAssert`, but for color regions. Use this in iterative agent loops to catch regressions when the underlying mesh changes (e.g. after a forkVersion).
@@ -746,11 +777,13 @@ Once any region exists, the editor goes read-only and `runAndSave` is rejected. 
 
 ### Verify before you commit
 
-Use `paintPreview` to see the candidate region tinted bright yellow on a thumbnail before adding a region. Saves the paint → render → undo loop:
+`paintPreview` is count-only by default — call it before any non-trivial paint as a free sanity check on selector geometry. If the count is surprising, opt into the visual:
 
 ```js
-const dry = partwright.paintPreview({ point: [...], radius: 4, view: { ortho: true, size: 240 } });
-// Inspect dry.thumbnail; if happy, call paintNear with the same args to commit.
+const dry = partwright.paintPreview({ point: [...], radius: 4 });
+// dry.triangleCount > 0? if happy, call paintNear with the same args to commit.
+// If the count is wildly off, add withImage: true to see what got selected:
+partwright.paintPreview({ point: [...], radius: 4, withImage: true, view: { ortho: true, size: 240 } });
 ```
 
 Use `assertPaint` to verify regions stayed where you expected after a re-render or version load:

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -1,0 +1,277 @@
+// Anthropic SDK wrapper. Owns the browser-side client (with
+// dangerouslyAllowBrowser=true), the request shape, and streaming. The
+// agent loop in chatLoop.ts calls into this module — it does not import the
+// Anthropic SDK directly so the provider can be swapped out later.
+
+import Anthropic from '@anthropic-ai/sdk';
+import type {
+  ChatBlock,
+  ChatMessage,
+  ChatToggles,
+  ImageSource,
+  ModelId,
+  PersistedToolCall,
+  PersistedToolResult,
+  TurnUsage,
+} from './types';
+import type { ToolDefinition } from './tools';
+
+let cachedClient: Anthropic | null = null;
+let cachedKey: string | null = null;
+
+function getClient(apiKey: string): Anthropic {
+  if (cachedClient && cachedKey === apiKey) return cachedClient;
+  cachedClient = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
+  cachedKey = apiKey;
+  return cachedClient;
+}
+
+/** Drop the cached client. Called on disconnect so the next connect rebuilds
+ *  with the new key. */
+export function resetClient(): void {
+  cachedClient = null;
+  cachedKey = null;
+}
+
+/** Validate a key by issuing the cheapest possible request. Returns null on
+ *  success or an error message. We intentionally hit /v1/messages (not
+ *  /v1/models) so we exercise the same code path the chat will use — auth,
+ *  CORS, and beta-header handling. */
+export async function validateKey(apiKey: string): Promise<string | null> {
+  try {
+    const client = getClient(apiKey);
+    await client.messages.create({
+      model: 'claude-haiku-4-5',
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'ok' }],
+    });
+    return null;
+  } catch (err) {
+    if (err instanceof Anthropic.AuthenticationError) {
+      return 'Invalid API key.';
+    }
+    if (err instanceof Anthropic.APIError) {
+      return `${err.status ?? 'API'}: ${err.message}`;
+    }
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+export interface StreamCallbacks {
+  /** Called for each text delta as it arrives. Use to incrementally update
+   *  the in-progress assistant bubble. */
+  onText?: (delta: string) => void;
+  /** Called once the model has decided to call a tool — input may still be
+   *  streaming, so don't act on this yet. */
+  onToolStart?: (toolUseId: string, toolName: string) => void;
+}
+
+export interface StreamResult {
+  /** The model's text response for this turn (concatenation of text blocks). */
+  text: string;
+  /** Tool calls the model wants executed. */
+  toolCalls: PersistedToolCall[];
+  /** Why the model stopped: 'end_turn' | 'tool_use' | 'max_tokens' | 'refusal' | etc. */
+  stopReason: string;
+  /** Token usage attributed to this single API call. */
+  usage: TurnUsage;
+  /** Raw assistant content blocks — needed verbatim on the next request. */
+  rawAssistantBlocks: Anthropic.ContentBlock[];
+}
+
+export interface RequestSpec {
+  apiKey: string;
+  model: ModelId;
+  systemPrompt: string;
+  /** Per-toggle suffix appended after the cached system prompt. Kept on a
+   *  separate cache breakpoint so it doesn't poison the main cache. */
+  systemSuffix: string;
+  /** Full prior conversation, in API format (already includes any tool
+   *  results). */
+  apiMessages: Anthropic.MessageParam[];
+  tools: ToolDefinition[];
+  /** Hard ceiling on output tokens for this turn. We default to 8K — large
+   *  enough for verbose reasoning + a tool call, small enough to not hit
+   *  HTTP timeouts on browsers. */
+  maxTokens?: number;
+}
+
+export async function streamTurn(spec: RequestSpec, callbacks: StreamCallbacks = {}): Promise<StreamResult> {
+  const client = getClient(spec.apiKey);
+  const max_tokens = spec.maxTokens ?? 8192;
+
+  // System is sent as an array of blocks so we can attach cache_control to
+  // the large stable prefix (the full ai.md body) while leaving the small
+  // toggle-aware suffix uncached. See shared/prompt-caching.md for the
+  // prefix-match invariant.
+  const system: Anthropic.TextBlockParam[] = [
+    { type: 'text', text: spec.systemPrompt, cache_control: { type: 'ephemeral' } },
+  ];
+  if (spec.systemSuffix.trim().length > 0) {
+    system.push({ type: 'text', text: spec.systemSuffix });
+  }
+
+  const tools: Anthropic.Tool[] = spec.tools.map(t => ({
+    name: t.name,
+    description: t.description,
+    input_schema: t.input_schema,
+  }));
+
+  const stream = client.messages.stream({
+    model: spec.model,
+    max_tokens,
+    system,
+    tools,
+    messages: spec.apiMessages,
+  });
+
+  // Wire up text deltas so the UI can render progressively.
+  if (callbacks.onText) {
+    stream.on('text', delta => callbacks.onText!(delta));
+  }
+
+  // Track tool_use blocks as they start so the UI can render a "calling X..."
+  // bubble even before the input is fully streamed.
+  if (callbacks.onToolStart) {
+    stream.on('streamEvent', event => {
+      if (event.type === 'content_block_start' && event.content_block.type === 'tool_use') {
+        callbacks.onToolStart!(event.content_block.id, event.content_block.name);
+      }
+    });
+  }
+
+  const finalMessage = await stream.finalMessage();
+  return collectResult(finalMessage);
+}
+
+function collectResult(message: Anthropic.Message): StreamResult {
+  let text = '';
+  const toolCalls: PersistedToolCall[] = [];
+  for (const block of message.content) {
+    if (block.type === 'text') {
+      text += block.text;
+    } else if (block.type === 'tool_use') {
+      toolCalls.push({
+        id: block.id,
+        name: block.name,
+        // The SDK gives us the parsed object — never raw-string match.
+        input: (block.input as Record<string, unknown>) ?? {},
+      });
+    }
+  }
+  const usage: TurnUsage = {
+    inputTokens: message.usage.input_tokens,
+    outputTokens: message.usage.output_tokens,
+    cacheCreationInputTokens: message.usage.cache_creation_input_tokens ?? 0,
+    cacheReadInputTokens: message.usage.cache_read_input_tokens ?? 0,
+  };
+  return {
+    text,
+    toolCalls,
+    stopReason: message.stop_reason ?? 'unknown',
+    usage,
+    rawAssistantBlocks: message.content,
+  };
+}
+
+/** Convert our persisted ChatMessage history into the Anthropic message
+ *  array shape. Tool calls and tool results need to interleave properly:
+ *  an assistant turn that called tools becomes a single message containing
+ *  text + tool_use blocks; the user reply containing tool_result blocks
+ *  follows immediately. */
+export function buildApiMessages(history: ChatMessage[]): Anthropic.MessageParam[] {
+  const out: Anthropic.MessageParam[] = [];
+  for (const msg of history) {
+    if (msg.role === 'user') {
+      const content = userBlocksToApi(msg.blocks, msg.toolResults ?? []);
+      if (content.length > 0) out.push({ role: 'user', content });
+    } else {
+      const content = assistantBlocksToApi(msg.blocks, msg.toolCalls ?? []);
+      if (content.length > 0) out.push({ role: 'assistant', content });
+    }
+  }
+  return out;
+}
+
+function userBlocksToApi(blocks: ChatBlock[], toolResults: PersistedToolResult[]): Anthropic.ContentBlockParam[] {
+  // Tool results MUST come first per the API rules when a user turn carries
+  // them — and an assistant tool_use block must be answered before any new
+  // user text in that same turn.
+  const out: Anthropic.ContentBlockParam[] = [];
+  for (const r of toolResults) {
+    out.push({
+      type: 'tool_result',
+      tool_use_id: r.toolUseId,
+      content: r.content,
+      is_error: r.isError,
+    });
+  }
+  for (const b of blocks) {
+    if (b.type === 'text') {
+      if (b.text.trim().length > 0) out.push({ type: 'text', text: b.text });
+    } else if (b.type === 'image') {
+      out.push(imageBlockToApi(b.source));
+    }
+  }
+  return out;
+}
+
+function assistantBlocksToApi(blocks: ChatBlock[], toolCalls: PersistedToolCall[]): Anthropic.ContentBlockParam[] {
+  const out: Anthropic.ContentBlockParam[] = [];
+  for (const b of blocks) {
+    if (b.type === 'text' && b.text.length > 0) out.push({ type: 'text', text: b.text });
+  }
+  for (const tc of toolCalls) {
+    out.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input });
+  }
+  return out;
+}
+
+function imageBlockToApi(source: ImageSource): Anthropic.ImageBlockParam {
+  return {
+    type: 'image',
+    source: { type: 'base64', media_type: source.mediaType, data: source.data },
+  };
+}
+
+/** Sum token usage from the response into the per-key counters. The current
+ *  turn's costUsd should be computed via cost.ts and added separately to the
+ *  KeyRecord total. */
+export function applyToggleSpecificParams(_toggles: ChatToggles, _model: ModelId): void {
+  // Currently no model needs special params (we never set temperature/top_p,
+  // and adaptive thinking is off by default). Kept as a hook for when we
+  // want to opt into adaptive thinking on Opus 4.7, etc.
+}
+
+/** Run a single non-streamed message — used by manual compaction (fast,
+ *  cheap, on Haiku) where we just want the summary text. */
+export async function summarize(
+  apiKey: string,
+  model: ModelId,
+  system: string,
+  user: string,
+  maxTokens = 4096,
+): Promise<{ text: string; usage: TurnUsage }> {
+  const client = getClient(apiKey);
+  const response = await client.messages.create({
+    model,
+    max_tokens: maxTokens,
+    system,
+    messages: [{ role: 'user', content: user }],
+  });
+  const text = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map(b => b.text)
+    .join('');
+  return {
+    text,
+    usage: {
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+      cacheCreationInputTokens: response.usage.cache_creation_input_tokens ?? 0,
+      cacheReadInputTokens: response.usage.cache_read_input_tokens ?? 0,
+    },
+  };
+}
+
+export { Anthropic };

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -96,7 +96,11 @@ export interface RequestSpec {
   maxTokens?: number;
 }
 
-export async function streamTurn(spec: RequestSpec, callbacks: StreamCallbacks = {}): Promise<StreamResult> {
+export async function streamTurn(
+  spec: RequestSpec,
+  callbacks: StreamCallbacks = {},
+  signal?: AbortSignal,
+): Promise<StreamResult> {
   const client = getClient(spec.apiKey);
   const max_tokens = spec.maxTokens ?? 8192;
 
@@ -125,10 +129,13 @@ export async function streamTurn(spec: RequestSpec, callbacks: StreamCallbacks =
     messages: spec.apiMessages,
   });
 
-  // Wire up text deltas so the UI can render progressively.
-  if (callbacks.onText) {
-    stream.on('text', delta => callbacks.onText!(delta));
-  }
+  // Mirror text deltas into a local buffer so we still have the partial
+  // response if the stream is aborted before finalMessage() resolves.
+  let collectedText = '';
+  stream.on('text', delta => {
+    collectedText += delta;
+    callbacks.onText?.(delta);
+  });
 
   // Track tool_use blocks as they start so the UI can render a "calling X..."
   // bubble even before the input is fully streamed.
@@ -140,8 +147,40 @@ export async function streamTurn(spec: RequestSpec, callbacks: StreamCallbacks =
     });
   }
 
-  const finalMessage = await stream.finalMessage();
-  return collectResult(finalMessage);
+  // Tear down the stream when the caller aborts. The SDK exposes both
+  // stream.abort() and the underlying AbortController via stream.controller;
+  // abort() is the public API and works across SDK versions.
+  const abortListener = () => { try { stream.abort(); } catch { /* already done */ } };
+  if (signal) {
+    if (signal.aborted) abortListener();
+    else signal.addEventListener('abort', abortListener);
+  }
+
+  try {
+    const finalMessage = await stream.finalMessage();
+    return collectResult(finalMessage);
+  } catch (err) {
+    if (signal?.aborted) {
+      // Abort race: return what we collected. Tool calls are dropped
+      // because a tool_use block that streamed only partial input cannot
+      // be a valid request to the model on the next turn — the parser
+      // would reject it. The partial text stays so the user can see how
+      // far the model had gotten.
+      const partialBlocks: Anthropic.ContentBlock[] = collectedText.length > 0
+        ? [{ type: 'text', text: collectedText, citations: null }]
+        : [];
+      return {
+        text: collectedText,
+        toolCalls: [],
+        stopReason: 'aborted',
+        usage: { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        rawAssistantBlocks: partialBlocks,
+      };
+    }
+    throw err;
+  } finally {
+    if (signal) signal.removeEventListener('abort', abortListener);
+  }
 }
 
 function collectResult(message: Anthropic.Message): StreamResult {

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -238,12 +238,29 @@ function userBlocksToApi(blocks: ChatBlock[], toolResults: PersistedToolResult[]
   // user text in that same turn.
   const out: Anthropic.ContentBlockParam[] = [];
   for (const r of toolResults) {
-    out.push({
-      type: 'tool_result',
-      tool_use_id: r.toolUseId,
-      content: r.content,
-      is_error: r.isError,
-    });
+    // When the tool returned an image (renderView), we pass array content
+    // with a short text block + the image block. The model treats this
+    // exactly like a multimodal user message: vision can interpret the
+    // pixels, and the text gives the result context (e.g. the camera
+    // parameters used).
+    if (r.image) {
+      out.push({
+        type: 'tool_result',
+        tool_use_id: r.toolUseId,
+        content: [
+          { type: 'text', text: r.content },
+          imageBlockToApi(r.image),
+        ],
+        is_error: r.isError,
+      });
+    } else {
+      out.push({
+        type: 'tool_result',
+        tool_use_id: r.toolUseId,
+        content: r.content,
+        is_error: r.isError,
+      });
+    }
   }
   for (const b of blocks) {
     if (b.type === 'text') {

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -7,7 +7,6 @@ import Anthropic from '@anthropic-ai/sdk';
 import type {
   ChatBlock,
   ChatMessage,
-  ChatToggles,
   ImageSource,
   ModelId,
   PersistedToolCall,
@@ -288,15 +287,6 @@ function imageBlockToApi(source: ImageSource): Anthropic.ImageBlockParam {
     type: 'image',
     source: { type: 'base64', media_type: source.mediaType, data: source.data },
   };
-}
-
-/** Sum token usage from the response into the per-key counters. The current
- *  turn's costUsd should be computed via cost.ts and added separately to the
- *  KeyRecord total. */
-export function applyToggleSpecificParams(_toggles: ChatToggles, _model: ModelId): void {
-  // Currently no model needs special params (we never set temperature/top_p,
-  // and adaptive thinking is off by default). Kept as a hook for when we
-  // want to opt into adaptive thinking on Opus 4.7, etc.
 }
 
 /** Run a single non-streamed message — used by manual compaction (fast,

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -1,0 +1,220 @@
+// Main agent loop: assembles the request, streams the response, executes
+// tools, persists everything, and loops until the model hits end_turn.
+
+import { generateId } from '../storage/db';
+import { streamTurn, buildApiMessages, type StreamCallbacks } from './anthropic';
+import { recordUsage, putMessages } from './db';
+import { buildToolList, executeTool } from './tools';
+import { buildSystemPrompt, loadAiMd, toggleSuffix } from './systemPrompt';
+import { turnCostUsd } from './cost';
+import type { ChatBlock, ChatMessage, ChatToggles, PersistedToolCall, PersistedToolResult, TurnUsage } from './types';
+
+export interface RunTurnInput {
+  apiKey: string;
+  toggles: ChatToggles;
+  /** sessionId for the current chat bucket. */
+  sessionId: string;
+  /** Prior conversation, oldest first. */
+  history: ChatMessage[];
+  /** The user's new message blocks (text + any pending image attachments). */
+  userBlocks: ChatBlock[];
+}
+
+export interface RunTurnCallbacks {
+  /** Called once with the persisted user-message record so the panel can
+   *  show it immediately. */
+  onUserPersisted?: (msg: ChatMessage) => void;
+  /** Called once per assistant turn (a single API round). The panel uses
+   *  this to render an in-progress bubble that subsequent text deltas
+   *  populate. */
+  onAssistantStart?: (id: string) => void;
+  /** Streamed text deltas for the active assistant bubble. */
+  onAssistantText?: (delta: string) => void;
+  /** A tool call has begun streaming — render a "calling X..." chip. */
+  onToolStart?: (toolUseId: string, toolName: string) => void;
+  /** A tool has finished executing. Render the result bubble. */
+  onToolResult?: (toolUseId: string, toolName: string, result: PersistedToolResult) => void;
+  /** Persisted assistant message at the end of one round (post-tools). */
+  onAssistantPersisted?: (msg: ChatMessage) => void;
+  /** Loop ended (either end_turn or unrecoverable error). */
+  onTurnComplete?: (info: { totalCostUsd: number; toolCalls: number }) => void;
+  /** Unrecoverable error — the loop stops here. */
+  onError?: (err: Error) => void;
+}
+
+const MAX_AGENT_ITERATIONS = 8;
+
+/** Run one user turn through the agent loop. Returns the final history. */
+export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks = {}): Promise<ChatMessage[]> {
+  const { apiKey, toggles, sessionId, history, userBlocks } = input;
+  const tools = buildToolList(toggles);
+  const aiMd = await loadAiMd();
+  const systemPrompt = buildSystemPrompt(aiMd);
+
+  const seqStart = nextSeq(history);
+
+  const userMsg: ChatMessage = {
+    id: generateId(),
+    sessionId,
+    role: 'user',
+    blocks: userBlocks,
+    createdAt: Date.now(),
+    seq: seqStart,
+  };
+  await putMessages([userMsg]);
+  callbacks.onUserPersisted?.(userMsg);
+
+  let workingHistory: ChatMessage[] = [...history, userMsg];
+  let totalCostUsd = 0;
+  let totalToolCalls = 0;
+
+  for (let iter = 0; iter < MAX_AGENT_ITERATIONS; iter++) {
+    const apiMessages = buildApiMessages(workingHistory);
+    const assistantId = generateId();
+    callbacks.onAssistantStart?.(assistantId);
+
+    const streamCallbacks: StreamCallbacks = {
+      onText: callbacks.onAssistantText,
+      onToolStart: callbacks.onToolStart,
+    };
+
+    let result;
+    try {
+      result = await streamTurn({
+        apiKey,
+        model: toggles.model,
+        systemPrompt,
+        systemSuffix: toggleSuffix(toggles),
+        apiMessages,
+        tools,
+      }, streamCallbacks);
+    } catch (err) {
+      callbacks.onError?.(err instanceof Error ? err : new Error(String(err)));
+      return workingHistory;
+    }
+
+    const turnCost = turnCostUsd(toggles.model, result.usage);
+    totalCostUsd += turnCost;
+
+    const assistantMsg: ChatMessage = {
+      id: assistantId,
+      sessionId,
+      role: 'assistant',
+      blocks: result.text.length > 0 ? [{ type: 'text', text: result.text }] : [],
+      toolCalls: result.toolCalls.length > 0 ? result.toolCalls : undefined,
+      usage: result.usage,
+      costUsd: turnCost,
+      createdAt: Date.now(),
+      seq: seqStart + 1 + iter * 2,
+    };
+    await putMessages([assistantMsg]);
+    workingHistory = [...workingHistory, assistantMsg];
+    callbacks.onAssistantPersisted?.(assistantMsg);
+
+    void recordUsage('anthropic', result.usage.inputTokens + result.usage.cacheReadInputTokens + result.usage.cacheCreationInputTokens, result.usage.outputTokens, turnCost);
+
+    if (result.stopReason !== 'tool_use' || result.toolCalls.length === 0) {
+      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls });
+      return workingHistory;
+    }
+
+    // Execute tools, then loop with the results posted back.
+    const toolResults = await executeAllWithRetry(result.toolCalls, toggles, callbacks);
+    totalToolCalls += result.toolCalls.length;
+
+    const toolResultMsg: ChatMessage = {
+      id: generateId(),
+      sessionId,
+      role: 'user',
+      blocks: [],
+      toolResults,
+      createdAt: Date.now(),
+      seq: seqStart + 2 + iter * 2,
+    };
+    await putMessages([toolResultMsg]);
+    workingHistory = [...workingHistory, toolResultMsg];
+  }
+
+  // Hit iteration cap — surface to the user so they can intervene.
+  callbacks.onError?.(new Error(`Agent loop exceeded ${MAX_AGENT_ITERATIONS} iterations without completing. Try a more focused prompt or compact the conversation.`));
+  callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls });
+  return workingHistory;
+}
+
+async function executeAllWithRetry(
+  toolCalls: PersistedToolCall[],
+  toggles: ChatToggles,
+  callbacks: RunTurnCallbacks,
+): Promise<PersistedToolResult[]> {
+  const results: PersistedToolResult[] = [];
+  for (const tc of toolCalls) {
+    let attempt = 0;
+    let result = await executeTool(tc.name, tc.input);
+    while (result.isError && attempt < toggles.autoRetry) {
+      attempt++;
+      result = await executeTool(tc.name, tc.input);
+    }
+    const persisted: PersistedToolResult = {
+      toolUseId: tc.id,
+      content: result.content,
+      isError: result.isError,
+    };
+    results.push(persisted);
+    callbacks.onToolResult?.(tc.id, tc.name, persisted);
+  }
+  return results;
+}
+
+function nextSeq(history: ChatMessage[]): number {
+  if (history.length === 0) return 0;
+  return Math.max(...history.map(m => m.seq)) + 1;
+}
+
+/** Compute estimated cached/fresh token counts for the cost estimator.
+ *  Rough heuristic: assume the system prompt + tool list fits in cache after
+ *  the first turn, and per-turn cost is dominated by the recent messages
+ *  plus output. */
+export function estimateCachedPrefixTokens(systemPromptChars: number): number {
+  // ~4 chars per token average
+  return Math.round(systemPromptChars / 4);
+}
+
+/** Sum the total chars in a chat message's blocks for rough token estimation. */
+export function messageChars(msg: ChatMessage): number {
+  let n = 0;
+  for (const b of msg.blocks) if (b.type === 'text') n += b.text.length;
+  if (msg.toolCalls) for (const tc of msg.toolCalls) n += JSON.stringify(tc.input).length + tc.name.length;
+  if (msg.toolResults) for (const tr of msg.toolResults) n += tr.content.length;
+  return n;
+}
+
+/** Rough total token estimate for the current history. Used by the
+ *  context meter to color-code the bar (green/amber/red) and decide when
+ *  to nudge the user toward Compact. */
+export function totalTokensEstimate(history: ChatMessage[], systemPromptChars: number): number {
+  let chars = systemPromptChars;
+  for (const m of history) chars += messageChars(m);
+  // Image blocks: ~1500 tokens each at standard res for a mid-size image.
+  const imageBlocks = history.flatMap(m => m.blocks.filter(b => b.type === 'image')).length;
+  return Math.round(chars / 4) + imageBlocks * 1500;
+}
+
+/** Sum of all assistant-turn costs in the given history. */
+export function totalCost(history: ChatMessage[]): number {
+  let total = 0;
+  for (const m of history) if (m.costUsd) total += m.costUsd;
+  return total;
+}
+
+/** Token usage summed across the assistant turns. */
+export function totalUsage(history: ChatMessage[]): TurnUsage {
+  const out: TurnUsage = { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
+  for (const m of history) {
+    if (!m.usage) continue;
+    out.inputTokens += m.usage.inputTokens;
+    out.outputTokens += m.usage.outputTokens;
+    out.cacheCreationInputTokens += m.usage.cacheCreationInputTokens;
+    out.cacheReadInputTokens += m.usage.cacheReadInputTokens;
+  }
+  return out;
+}

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -18,6 +18,10 @@ export interface RunTurnInput {
   history: ChatMessage[];
   /** The user's new message blocks (text + any pending image attachments). */
   userBlocks: ChatBlock[];
+  /** Optional abort signal — when fired, the in-flight stream and the
+   *  agent loop both stop at the next safe seam. Any partial assistant
+   *  text that was streamed is preserved as `aborted: true`. */
+  signal?: AbortSignal;
 }
 
 export interface RunTurnCallbacks {
@@ -36,8 +40,15 @@ export interface RunTurnCallbacks {
   onToolResult?: (toolUseId: string, toolName: string, result: PersistedToolResult) => void;
   /** Persisted assistant message at the end of one round (post-tools). */
   onAssistantPersisted?: (msg: ChatMessage) => void;
+  /** A "thinking" beat — fires when a turn begins, when each tool starts,
+   *  and on a wall-clock interval while waiting for the first text delta.
+   *  Use to keep an indicator alive so the user knows we haven't frozen. */
+  onProgress?: (info: { phase: 'thinking' | 'streaming' | 'tool' | 'idle'; detail?: string }) => void;
   /** Loop ended (either end_turn or unrecoverable error). */
   onTurnComplete?: (info: { totalCostUsd: number; toolCalls: number }) => void;
+  /** User aborted the turn. Fires after the partial assistant message has
+   *  been persisted. Distinct from onError — abort is intentional. */
+  onAborted?: () => void;
   /** Unrecoverable error — the loop stops here. */
   onError?: (err: Error) => void;
 }
@@ -46,7 +57,7 @@ const MAX_AGENT_ITERATIONS = 8;
 
 /** Run one user turn through the agent loop. Returns the final history. */
 export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks = {}): Promise<ChatMessage[]> {
-  const { apiKey, toggles, sessionId, history, userBlocks } = input;
+  const { apiKey, toggles, sessionId, history, userBlocks, signal } = input;
   const tools = buildToolList(toggles);
   const aiMd = await loadAiMd();
   const systemPrompt = buildSystemPrompt(aiMd);
@@ -73,9 +84,20 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
     const assistantId = generateId();
     callbacks.onAssistantStart?.(assistantId);
 
+    callbacks.onProgress?.({ phase: 'thinking', detail: 'Waiting for first token...' });
+    let sawFirstDelta = false;
     const streamCallbacks: StreamCallbacks = {
-      onText: callbacks.onAssistantText,
-      onToolStart: callbacks.onToolStart,
+      onText: delta => {
+        if (!sawFirstDelta) {
+          sawFirstDelta = true;
+          callbacks.onProgress?.({ phase: 'streaming' });
+        }
+        callbacks.onAssistantText?.(delta);
+      },
+      onToolStart: (id, name) => {
+        callbacks.onProgress?.({ phase: 'tool', detail: name });
+        callbacks.onToolStart?.(id, name);
+      },
     };
 
     let result;
@@ -87,7 +109,7 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
         systemSuffix: toggleSuffix(toggles),
         apiMessages,
         tools,
-      }, streamCallbacks);
+      }, streamCallbacks, signal);
     } catch (err) {
       callbacks.onError?.(err instanceof Error ? err : new Error(String(err)));
       return workingHistory;
@@ -95,6 +117,8 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
 
     const turnCost = turnCostUsd(toggles.model, result.usage);
     totalCostUsd += turnCost;
+
+    const aborted = result.stopReason === 'aborted' || signal?.aborted === true;
 
     const assistantMsg: ChatMessage = {
       id: assistantId,
@@ -106,6 +130,7 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
       costUsd: turnCost,
       createdAt: Date.now(),
       seq: seqStart + 1 + iter * 2,
+      ...(aborted ? { aborted: true } : {}),
     };
     await putMessages([assistantMsg]);
     workingHistory = [...workingHistory, assistantMsg];
@@ -113,13 +138,23 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
 
     void recordUsage('anthropic', result.usage.inputTokens + result.usage.cacheReadInputTokens + result.usage.cacheCreationInputTokens, result.usage.outputTokens, turnCost);
 
+    if (aborted) {
+      callbacks.onAborted?.();
+      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls });
+      return workingHistory;
+    }
+
     if (result.stopReason !== 'tool_use' || result.toolCalls.length === 0) {
       callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls });
       return workingHistory;
     }
 
-    // Execute tools, then loop with the results posted back.
-    const toolResults = await executeAllWithRetry(result.toolCalls, toggles, callbacks);
+    // Execute tools, then loop with the results posted back. Tools run
+    // synchronously against window.partwright and can't be cancelled mid-
+    // flight, but we check the signal between calls so a stop request
+    // takes effect within ~one tool's duration.
+    callbacks.onProgress?.({ phase: 'tool', detail: `running ${result.toolCalls.length} tool(s)...` });
+    const toolResults = await executeAllWithRetry(result.toolCalls, toggles, callbacks, signal);
     totalToolCalls += result.toolCalls.length;
 
     const toolResultMsg: ChatMessage = {
@@ -133,6 +168,12 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
     };
     await putMessages([toolResultMsg]);
     workingHistory = [...workingHistory, toolResultMsg];
+
+    if (signal?.aborted) {
+      callbacks.onAborted?.();
+      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls });
+      return workingHistory;
+    }
   }
 
   // Hit iteration cap — surface to the user so they can intervene.
@@ -145,12 +186,26 @@ async function executeAllWithRetry(
   toolCalls: PersistedToolCall[],
   toggles: ChatToggles,
   callbacks: RunTurnCallbacks,
+  signal?: AbortSignal,
 ): Promise<PersistedToolResult[]> {
   const results: PersistedToolResult[] = [];
   for (const tc of toolCalls) {
+    // If the user hit Stop, every remaining tool call gets a synthetic
+    // "aborted by user" result. The API requires every tool_use to have a
+    // matching tool_result on the next turn, so we can't just drop them.
+    if (signal?.aborted) {
+      const aborted: PersistedToolResult = {
+        toolUseId: tc.id,
+        content: '[aborted by user]',
+        isError: true,
+      };
+      results.push(aborted);
+      callbacks.onToolResult?.(tc.id, tc.name, aborted);
+      continue;
+    }
     let attempt = 0;
     let result = await executeTool(tc.name, tc.input);
-    while (result.isError && attempt < toggles.autoRetry) {
+    while (result.isError && attempt < toggles.autoRetry && !signal?.aborted) {
       attempt++;
       result = await executeTool(tc.name, tc.input);
     }

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -221,6 +221,7 @@ async function executeAllWithRetry(
       toolUseId: tc.id,
       content: result.content,
       isError: result.isError,
+      ...(result.image ? { image: result.image } : {}),
     };
     results.push(persisted);
     callbacks.onToolResult?.(tc.id, tc.name, persisted);

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -7,7 +7,23 @@ import { recordUsage, putMessages } from './db';
 import { buildToolList, executeTool } from './tools';
 import { buildSystemPrompt, loadAiMd, toggleSuffix } from './systemPrompt';
 import { turnCostUsd } from './cost';
-import type { ChatBlock, ChatMessage, ChatToggles, PersistedToolCall, PersistedToolResult, TurnUsage } from './types';
+import { ITERATION_CAP, type ChatBlock, type ChatMessage, type ChatToggles, type PersistedToolCall, type PersistedToolResult, type TurnUsage } from './types';
+
+/** Yield to the browser between heavy synchronous work blocks so the
+ *  page stays responsive. requestAnimationFrame lets the browser paint
+ *  pending frames and process input events; without it, a chain of
+ *  paint tools can lock the main thread long enough for Chrome to show
+ *  "page unresponsive". Used between tool executions and between agent
+ *  loop iterations. */
+function yieldToBrowser(): Promise<void> {
+  return new Promise(resolve => requestAnimationFrame(() => resolve()));
+}
+
+/** Log tool execution time. Anything over this threshold is flagged in
+ *  the console so we can pinpoint the slow op if the page freezes — the
+ *  most common culprits are commitPaintFromSet (re-renders all 4 iso
+ *  views per call) and Manifold boolean ops on complex meshes. */
+const SLOW_TOOL_MS = 250;
 
 export interface RunTurnInput {
   apiKey: string;
@@ -61,7 +77,7 @@ export interface RunTurnCallbacks {
   onError?: (err: Error) => void;
 }
 
-const MAX_AGENT_ITERATIONS = 16;
+// MAX_AGENT_ITERATIONS is now per-turn from toggles.maxIterations.
 
 /** Run one user turn through the agent loop. Returns the final history. */
 export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks = {}): Promise<ChatMessage[]> {
@@ -86,8 +102,12 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
   let workingHistory: ChatMessage[] = [...history, userMsg];
   let totalCostUsd = 0;
   let totalToolCalls = 0;
+  const maxIter = ITERATION_CAP[toggles.maxIterations];
 
-  for (let iter = 0; iter < MAX_AGENT_ITERATIONS; iter++) {
+  for (let iter = 0; Number.isFinite(maxIter) ? iter < maxIter : true; iter++) {
+    // Give the browser a frame between iterations so an agent running
+    // many tool round-trips doesn't lock up the page.
+    if (iter > 0) await yieldToBrowser();
     const apiMessages = buildApiMessages(workingHistory);
     const assistantId = generateId();
     callbacks.onAssistantStart?.(assistantId);
@@ -200,7 +220,10 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
   }
 
   // Hit iteration cap — surface to the user so they can intervene.
-  callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason: 'iteration_cap', iterations: MAX_AGENT_ITERATIONS });
+  // Sentinel — only reachable for finite caps. The infinite case loops
+  // forever above and exits via end_turn / error / abort.
+  const reached = Number.isFinite(maxIter) ? maxIter : totalToolCalls;
+  callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason: 'iteration_cap', iterations: reached });
   return workingHistory;
 }
 
@@ -226,10 +249,10 @@ async function executeAllWithRetry(
       continue;
     }
     let attempt = 0;
-    let result = await executeTool(tc.name, tc.input);
+    let result = await timedExecuteTool(tc.name, tc.input);
     while (result.isError && attempt < toggles.autoRetry && !signal?.aborted) {
       attempt++;
-      result = await executeTool(tc.name, tc.input);
+      result = await timedExecuteTool(tc.name, tc.input);
     }
     const persisted: PersistedToolResult = {
       toolUseId: tc.id,
@@ -239,8 +262,28 @@ async function executeAllWithRetry(
     };
     results.push(persisted);
     callbacks.onToolResult?.(tc.id, tc.name, persisted);
+    // Yield BETWEEN tool calls so the browser can flush a frame and the
+    // user can interact (click Stop, scroll the transcript). A run of 5
+    // paint tools without yields is enough to trigger Chrome's "page
+    // unresponsive" warning on a moderately complex mesh.
+    await yieldToBrowser();
   }
   return results;
+}
+
+async function timedExecuteTool(name: string, input: Record<string, unknown>) {
+  const t0 = performance.now();
+  const result = await executeTool(name, input);
+  const elapsed = performance.now() - t0;
+  if (elapsed > SLOW_TOOL_MS) {
+    // Visible only in dev tools — meant for diagnosing the
+    // "page unresponsive" case. We don't surface this in the UI to
+    // avoid alarming users when the warning is benign (a Manifold
+    // boolean op on a complex mesh is just genuinely slow).
+    // eslint-disable-next-line no-console
+    console.warn(`[AI tool] ${name} took ${Math.round(elapsed)}ms (threshold ${SLOW_TOOL_MS}ms).`);
+  }
+  return result;
 }
 
 function nextSeq(history: ChatMessage[]): number {

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -7,7 +7,7 @@ import { recordUsage, putMessages } from './db';
 import { buildToolList, executeTool } from './tools';
 import { buildSystemPrompt, loadAiMd, toggleSuffix } from './systemPrompt';
 import { turnCostUsd } from './cost';
-import { ITERATION_CAP, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type PersistedToolCall, type PersistedToolResult, type TurnUsage } from './types';
+import { ITERATION_CAP, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type PersistedToolCall, type PersistedToolResult } from './types';
 
 /** Yield to the browser between heavy synchronous work blocks so the
  *  page stays responsive. requestAnimationFrame lets the browser paint
@@ -76,8 +76,6 @@ export interface RunTurnCallbacks {
   /** Unrecoverable error — the loop stops here. */
   onError?: (err: Error) => void;
 }
-
-// MAX_AGENT_ITERATIONS is now per-turn from toggles.maxIterations.
 
 /** Run one user turn through the agent loop. Returns the final history. */
 export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks = {}): Promise<ChatMessage[]> {
@@ -341,17 +339,4 @@ export function totalCost(history: ChatMessage[]): number {
   let total = 0;
   for (const m of history) if (m.costUsd) total += m.costUsd;
   return total;
-}
-
-/** Token usage summed across the assistant turns. */
-export function totalUsage(history: ChatMessage[]): TurnUsage {
-  const out: TurnUsage = { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
-  for (const m of history) {
-    if (!m.usage) continue;
-    out.inputTokens += m.usage.inputTokens;
-    out.outputTokens += m.usage.outputTokens;
-    out.cacheCreationInputTokens += m.usage.cacheCreationInputTokens;
-    out.cacheReadInputTokens += m.usage.cacheReadInputTokens;
-  }
-  return out;
 }

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -44,8 +44,16 @@ export interface RunTurnCallbacks {
    *  and on a wall-clock interval while waiting for the first text delta.
    *  Use to keep an indicator alive so the user knows we haven't frozen. */
   onProgress?: (info: { phase: 'thinking' | 'streaming' | 'tool' | 'idle'; detail?: string }) => void;
-  /** Loop ended (either end_turn or unrecoverable error). */
-  onTurnComplete?: (info: { totalCostUsd: number; toolCalls: number }) => void;
+  /** Loop ended. `reason` distinguishes a clean end_turn from the
+   *  iteration cap, an empty final response, or other stop reasons so
+   *  the UI can surface what actually happened. */
+  onTurnComplete?: (info: {
+    totalCostUsd: number;
+    toolCalls: number;
+    reason: 'end_turn' | 'empty_final' | 'iteration_cap' | 'max_tokens' | 'refusal' | 'aborted' | 'error' | 'other';
+    detail?: string;
+    iterations: number;
+  }) => void;
   /** User aborted the turn. Fires after the partial assistant message has
    *  been persisted. Distinct from onError — abort is intentional. */
   onAborted?: () => void;
@@ -53,7 +61,7 @@ export interface RunTurnCallbacks {
   onError?: (err: Error) => void;
 }
 
-const MAX_AGENT_ITERATIONS = 8;
+const MAX_AGENT_ITERATIONS = 16;
 
 /** Run one user turn through the agent loop. Returns the final history. */
 export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks = {}): Promise<ChatMessage[]> {
@@ -148,12 +156,19 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
 
     if (aborted) {
       callbacks.onAborted?.();
-      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls });
+      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason: 'aborted', iterations: iter + 1 });
       return workingHistory;
     }
 
     if (result.stopReason !== 'tool_use' || result.toolCalls.length === 0) {
-      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls });
+      // Map stop reason to a UI-friendly outcome so the panel can show
+      // "✓ done" vs "⚠ model exited without final text" vs other.
+      const hasText = result.text.trim().length > 0;
+      let reason: 'end_turn' | 'empty_final' | 'max_tokens' | 'refusal' | 'other' = 'other';
+      if (result.stopReason === 'end_turn') reason = hasText ? 'end_turn' : 'empty_final';
+      else if (result.stopReason === 'max_tokens') reason = 'max_tokens';
+      else if (result.stopReason === 'refusal') reason = 'refusal';
+      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason, detail: result.stopReason, iterations: iter + 1 });
       return workingHistory;
     }
 
@@ -179,14 +194,13 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
 
     if (signal?.aborted) {
       callbacks.onAborted?.();
-      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls });
+      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason: 'aborted', iterations: iter + 1 });
       return workingHistory;
     }
   }
 
   // Hit iteration cap — surface to the user so they can intervene.
-  callbacks.onError?.(new Error(`Agent loop exceeded ${MAX_AGENT_ITERATIONS} iterations without completing. Try a more focused prompt or compact the conversation.`));
-  callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls });
+  callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason: 'iteration_cap', iterations: MAX_AGENT_ITERATIONS });
   return workingHistory;
 }
 

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -7,7 +7,7 @@ import { recordUsage, putMessages } from './db';
 import { buildToolList, executeTool } from './tools';
 import { buildSystemPrompt, loadAiMd, toggleSuffix } from './systemPrompt';
 import { turnCostUsd } from './cost';
-import { ITERATION_CAP, type ChatBlock, type ChatMessage, type ChatToggles, type PersistedToolCall, type PersistedToolResult, type TurnUsage } from './types';
+import { ITERATION_CAP, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type PersistedToolCall, type PersistedToolResult, type TurnUsage } from './types';
 
 /** Yield to the browser between heavy synchronous work blocks so the
  *  page stays responsive. requestAnimationFrame lets the browser paint
@@ -61,12 +61,12 @@ export interface RunTurnCallbacks {
    *  Use to keep an indicator alive so the user knows we haven't frozen. */
   onProgress?: (info: { phase: 'thinking' | 'streaming' | 'tool' | 'idle'; detail?: string }) => void;
   /** Loop ended. `reason` distinguishes a clean end_turn from the
-   *  iteration cap, an empty final response, or other stop reasons so
-   *  the UI can surface what actually happened. */
+   *  iteration cap, the spend cap, an empty final response, or other
+   *  stop reasons so the UI can surface what actually happened. */
   onTurnComplete?: (info: {
     totalCostUsd: number;
     toolCalls: number;
-    reason: 'end_turn' | 'empty_final' | 'iteration_cap' | 'max_tokens' | 'refusal' | 'aborted' | 'error' | 'other';
+    reason: 'end_turn' | 'empty_final' | 'iteration_cap' | 'spend_cap' | 'max_tokens' | 'refusal' | 'aborted' | 'error' | 'other';
     detail?: string;
     iterations: number;
   }) => void;
@@ -103,6 +103,7 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
   let totalCostUsd = 0;
   let totalToolCalls = 0;
   const maxIter = ITERATION_CAP[toggles.maxIterations];
+  const maxSpend = SPEND_CAP_USD[toggles.maxSpend];
 
   for (let iter = 0; Number.isFinite(maxIter) ? iter < maxIter : true; iter++) {
     // Give the browser a frame between iterations so an agent running
@@ -177,6 +178,21 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
     if (aborted) {
       callbacks.onAborted?.();
       callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason: 'aborted', iterations: iter + 1 });
+      return workingHistory;
+    }
+
+    // Spend cap — stop BEFORE the next iteration if we've already
+    // exceeded the user's per-turn budget. We check after persisting
+    // the current iteration so the assistant message they paid for
+    // still lands in the transcript.
+    if (Number.isFinite(maxSpend) && totalCostUsd > maxSpend) {
+      callbacks.onTurnComplete?.({
+        totalCostUsd,
+        toolCalls: totalToolCalls,
+        reason: 'spend_cap',
+        detail: `$${maxSpend.toFixed(2)}`,
+        iterations: iter + 1,
+      });
       return workingHistory;
     }
 

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -112,21 +112,14 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
     callbacks.onAssistantStart?.(assistantId);
 
     callbacks.onProgress?.({ phase: 'thinking', detail: 'Waiting for first token...' });
-    let sawFirstDelta = false;
     const streamCallbacks: StreamCallbacks = {
       onText: delta => {
-        if (!sawFirstDelta) {
-          sawFirstDelta = true;
-          callbacks.onProgress?.({ phase: 'streaming' });
-        } else {
-          // Beat on EVERY delta so the stall watchdog sees a healthy
-          // stream and so the elapsed-seconds counter in the UI doesn't
-          // keep ticking up while text is actually arriving. Without this
-          // the watchdog can spuriously retry mid-stream on Opus 4.7
-          // when adaptive thinking inserts a long pause between
-          // tokens — but real stalls during streaming still get caught.
-          callbacks.onProgress?.({ phase: 'streaming' });
-        }
+        // Beat on EVERY delta so the stall watchdog sees a healthy stream
+        // and the elapsed-seconds counter doesn't keep climbing while text
+        // is actually arriving. The progress handler short-circuits the
+        // DOM rebuild when the phase is unchanged, so this is essentially
+        // free past the first delta.
+        callbacks.onProgress?.({ phase: 'streaming' });
         callbacks.onAssistantText?.(delta);
       },
       onToolStart: (id, name) => {

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -7,7 +7,7 @@ import { recordUsage, putMessages } from './db';
 import { buildToolList, executeTool } from './tools';
 import { buildSystemPrompt, loadAiMd, toggleSuffix } from './systemPrompt';
 import { turnCostUsd } from './cost';
-import { ITERATION_CAP, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type PersistedToolCall, type PersistedToolResult } from './types';
+import { ITERATION_CAP, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type PersistedToolCall, type PersistedToolResult, type TurnOutcomeReason } from './types';
 
 /** Yield to the browser between heavy synchronous work blocks so the
  *  page stays responsive. requestAnimationFrame lets the browser paint
@@ -66,7 +66,7 @@ export interface RunTurnCallbacks {
   onTurnComplete?: (info: {
     totalCostUsd: number;
     toolCalls: number;
-    reason: 'end_turn' | 'empty_final' | 'iteration_cap' | 'spend_cap' | 'max_tokens' | 'refusal' | 'aborted' | 'error' | 'other';
+    reason: TurnOutcomeReason;
     detail?: string;
     iterations: number;
   }) => void;
@@ -198,7 +198,7 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
       // Map stop reason to a UI-friendly outcome so the panel can show
       // "✓ done" vs "⚠ model exited without final text" vs other.
       const hasText = result.text.trim().length > 0;
-      let reason: 'end_turn' | 'empty_final' | 'max_tokens' | 'refusal' | 'other' = 'other';
+      let reason: TurnOutcomeReason = 'other';
       if (result.stopReason === 'end_turn') reason = hasText ? 'end_turn' : 'empty_final';
       else if (result.stopReason === 'max_tokens') reason = 'max_tokens';
       else if (result.stopReason === 'refusal') reason = 'refusal';

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -91,6 +91,14 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
         if (!sawFirstDelta) {
           sawFirstDelta = true;
           callbacks.onProgress?.({ phase: 'streaming' });
+        } else {
+          // Beat on EVERY delta so the stall watchdog sees a healthy
+          // stream and so the elapsed-seconds counter in the UI doesn't
+          // keep ticking up while text is actually arriving. Without this
+          // the watchdog can spuriously retry mid-stream on Opus 4.7
+          // when adaptive thinking inserts a long pause between
+          // tokens — but real stalls during streaming still get caught.
+          callbacks.onProgress?.({ phase: 'streaming' });
         }
         callbacks.onAssistantText?.(delta);
       },

--- a/src/ai/compaction.ts
+++ b/src/ai/compaction.ts
@@ -1,0 +1,125 @@
+// Manual compaction. The user clicks "Compact" → we ask Haiku to (a)
+// summarize the transcript and (b) propose session notes worth promoting
+// into the durable session log. The user reviews the proposal in a confirm
+// modal; on accept, the chat history collapses to a single summary block +
+// the most recent N turns, and the proposed notes are written to
+// window.partwright.addSessionNote so they survive future compactions.
+
+import { summarize } from './anthropic';
+import type { ChatMessage } from './types';
+
+export interface CompactionProposal {
+  /** Plain-text summary of the conversation up to the kept tail. */
+  summary: string;
+  /** Notes the user can opt to promote into the persistent session log.
+   *  Each is already prefixed with one of the standard tags. */
+  proposedNotes: string[];
+  /** Messages the compaction will keep verbatim — the summary replaces the
+   *  rest. By default we keep the last 4. */
+  keep: ChatMessage[];
+  /** Messages that will be deleted on accept. */
+  drop: ChatMessage[];
+  /** Cost of the compaction call itself, USD. */
+  costUsd: number;
+  /** Token usage of the compaction call. */
+  usage: { inputTokens: number; outputTokens: number };
+}
+
+const KEEP_TAIL = 4;
+
+const COMPACTION_SYSTEM = `You are condensing a Partwright modeling-session transcript so the
+follow-up conversation pays less for context. Output ONLY a JSON object,
+no prose:
+
+{
+  "summary": "<2-3 paragraphs that capture: the user's goal, the design
+              direction taken, key parameters chosen, what's currently in
+              the editor, and any unresolved questions. Write for a future
+              instance of yourself joining this session.>",
+  "notes": [
+    "[REQUIREMENT] ...",
+    "[DECISION] ...",
+    "[FEEDBACK] ...",
+    "[MEASUREMENT] ..."
+  ]
+}
+
+Rules for notes:
+- Each note must start with one of [REQUIREMENT], [DECISION], [FEEDBACK],
+  [MEASUREMENT], [TODO].
+- Include only information that should outlive this conversation. Skip
+  anything already obvious from the current code or from earlier saved
+  versions.
+- Keep notes one-line each. No code blocks.
+
+Return strictly the JSON. No markdown fences, no commentary.`;
+
+export async function proposeCompaction(
+  apiKey: string,
+  history: ChatMessage[],
+): Promise<CompactionProposal> {
+  if (history.length <= KEEP_TAIL) {
+    throw new Error('Not enough history to compact yet — chat for a few more turns first.');
+  }
+  const keep = history.slice(-KEEP_TAIL);
+  const drop = history.slice(0, history.length - KEEP_TAIL);
+  const transcript = drop.map(formatForSummary).join('\n\n');
+
+  const { text, usage } = await summarize(
+    apiKey,
+    'claude-haiku-4-5',
+    COMPACTION_SYSTEM,
+    `Compact this transcript:\n\n${transcript}`,
+  );
+
+  const parsed = parseProposal(text);
+  const costUsd = (usage.inputTokens * 1.0 + usage.outputTokens * 5.0) / 1_000_000;
+  return {
+    summary: parsed.summary,
+    proposedNotes: parsed.notes,
+    keep,
+    drop,
+    costUsd,
+    usage: { inputTokens: usage.inputTokens, outputTokens: usage.outputTokens },
+  };
+}
+
+function formatForSummary(msg: ChatMessage): string {
+  const lines: string[] = [`[${msg.role}]`];
+  for (const b of msg.blocks) {
+    if (b.type === 'text') lines.push(b.text);
+    else if (b.type === 'image') lines.push(`<image: ${b.source.label ?? 'attachment'}>`);
+  }
+  if (msg.toolCalls && msg.toolCalls.length > 0) {
+    for (const tc of msg.toolCalls) {
+      lines.push(`tool: ${tc.name}(${JSON.stringify(tc.input).slice(0, 200)})`);
+    }
+  }
+  if (msg.toolResults && msg.toolResults.length > 0) {
+    for (const tr of msg.toolResults) {
+      const head = tr.content.slice(0, 200);
+      lines.push(`result: ${tr.isError ? '[ERROR] ' : ''}${head}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+interface ParsedProposal {
+  summary: string;
+  notes: string[];
+}
+
+function parseProposal(text: string): ParsedProposal {
+  // Be lenient: strip markdown fences if Haiku adds them despite the rules.
+  const stripped = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+  try {
+    const parsed = JSON.parse(stripped) as { summary?: string; notes?: unknown };
+    const notes = Array.isArray(parsed.notes)
+      ? parsed.notes.filter((n): n is string => typeof n === 'string')
+      : [];
+    return { summary: typeof parsed.summary === 'string' ? parsed.summary : stripped, notes };
+  } catch {
+    // Fall back to using the raw text as the summary with no notes.
+    return { summary: stripped, notes: [] };
+  }
+}

--- a/src/ai/cost.ts
+++ b/src/ai/cost.ts
@@ -1,0 +1,55 @@
+// USD cost calculation per Anthropic public list pricing (Apr 2026 cache).
+// Prices in $ per million tokens. Cache reads are billed at ~10% of input,
+// cache writes (5-min TTL) at ~125% of input. We don't expose 1h-TTL caching.
+
+import type { ModelId, TurnUsage } from './types';
+
+interface ModelPricing {
+  /** USD per 1M input tokens (uncached). */
+  input: number;
+  /** USD per 1M output tokens. */
+  output: number;
+}
+
+const PRICING: Record<ModelId, ModelPricing> = {
+  'claude-haiku-4-5': { input: 1.0, output: 5.0 },
+  'claude-sonnet-4-6': { input: 3.0, output: 15.0 },
+  'claude-opus-4-7': { input: 5.0, output: 25.0 },
+};
+
+const CACHE_READ_MULTIPLIER = 0.1;
+const CACHE_WRITE_MULTIPLIER = 1.25;
+
+export function turnCostUsd(model: ModelId, usage: TurnUsage): number {
+  const p = PRICING[model];
+  const inputCost = (usage.inputTokens * p.input) / 1_000_000;
+  const cacheReadCost = (usage.cacheReadInputTokens * p.input * CACHE_READ_MULTIPLIER) / 1_000_000;
+  const cacheWriteCost = (usage.cacheCreationInputTokens * p.input * CACHE_WRITE_MULTIPLIER) / 1_000_000;
+  const outputCost = (usage.outputTokens * p.output) / 1_000_000;
+  return inputCost + cacheReadCost + cacheWriteCost + outputCost;
+}
+
+/** Pre-turn estimate. Treats the cached prefix as cache-read (~0.1x), the
+ *  per-turn user content as fresh input, and assumes a moderate output size.
+ *  Used to render the "~$0.03/turn" hint next to the send button. */
+export function estimateTurnCostUsd(
+  model: ModelId,
+  cachedPrefixTokens: number,
+  freshInputTokens: number,
+  expectedOutputTokens: number = 800,
+): number {
+  return turnCostUsd(model, {
+    inputTokens: freshInputTokens,
+    outputTokens: expectedOutputTokens,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: cachedPrefixTokens,
+  });
+}
+
+export function formatUsd(amount: number): string {
+  if (amount === 0) return '$0';
+  if (amount < 0.0005) return '<$0.001';
+  if (amount < 0.01) return `$${amount.toFixed(4)}`;
+  if (amount < 1) return `$${amount.toFixed(3)}`;
+  return `$${amount.toFixed(2)}`;
+}

--- a/src/ai/db.ts
+++ b/src/ai/db.ts
@@ -1,0 +1,124 @@
+// IndexedDB layer for the AI subsystem. Reuses the existing partwright DB
+// connection (schema bumped to v3 in src/storage/db.ts) so we don't open a
+// second IndexedDB instance.
+
+import { openPartwrightDB } from '../storage/db';
+import type { ChatMessage, KeyRecord, Provider } from './types';
+
+const KEYS_STORE = 'aiKeys';
+const CHATS_STORE = 'aiChats';
+
+/** Sentinel sessionId used for chat that happens before a session is opened.
+ *  Restored when the user reopens the editor with no session selected. */
+export const GLOBAL_CHAT_BUCKET = '__global__';
+
+function reqToPromise<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function txComplete(txn: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    txn.oncomplete = () => resolve();
+    txn.onerror = () => reject(txn.error);
+    txn.onabort = () => reject(txn.error);
+  });
+}
+
+// === Keys ===
+
+export async function getKey(provider: Provider): Promise<KeyRecord | null> {
+  const db = await openPartwrightDB();
+  const txn = db.transaction(KEYS_STORE, 'readonly');
+  const record = await reqToPromise(txn.objectStore(KEYS_STORE).get(provider)) as KeyRecord | undefined;
+  await txComplete(txn);
+  return record ?? null;
+}
+
+export async function putKey(record: KeyRecord): Promise<void> {
+  const db = await openPartwrightDB();
+  const txn = db.transaction(KEYS_STORE, 'readwrite');
+  txn.objectStore(KEYS_STORE).put(record);
+  await txComplete(txn);
+}
+
+export async function deleteKey(provider: Provider): Promise<void> {
+  const db = await openPartwrightDB();
+  const txn = db.transaction(KEYS_STORE, 'readwrite');
+  txn.objectStore(KEYS_STORE).delete(provider);
+  await txComplete(txn);
+}
+
+/** Bumps usage counters on the existing record. No-op when no key exists
+ *  (the record is created by the key modal — we only update it). */
+export async function recordUsage(
+  provider: Provider,
+  inputTokens: number,
+  outputTokens: number,
+  costUsd: number,
+): Promise<void> {
+  const db = await openPartwrightDB();
+  const txn = db.transaction(KEYS_STORE, 'readwrite');
+  const store = txn.objectStore(KEYS_STORE);
+  const existing = await reqToPromise(store.get(provider)) as KeyRecord | undefined;
+  if (existing) {
+    existing.lastUsed = Date.now();
+    existing.totalInputTokens += inputTokens;
+    existing.totalOutputTokens += outputTokens;
+    existing.totalCostUsd += costUsd;
+    store.put(existing);
+  }
+  await txComplete(txn);
+}
+
+// === Chats ===
+
+export async function listMessages(sessionId: string): Promise<ChatMessage[]> {
+  const db = await openPartwrightDB();
+  const txn = db.transaction(CHATS_STORE, 'readonly');
+  const idx = txn.objectStore(CHATS_STORE).index('sessionId');
+  const messages = await reqToPromise(idx.getAll(IDBKeyRange.only(sessionId))) as ChatMessage[];
+  await txComplete(txn);
+  return messages.sort((a, b) => a.seq - b.seq);
+}
+
+export async function putMessages(messages: ChatMessage[]): Promise<void> {
+  if (messages.length === 0) return;
+  const db = await openPartwrightDB();
+  const txn = db.transaction(CHATS_STORE, 'readwrite');
+  const store = txn.objectStore(CHATS_STORE);
+  for (const m of messages) store.put(m);
+  await txComplete(txn);
+}
+
+export async function deleteMessages(messageIds: string[]): Promise<void> {
+  if (messageIds.length === 0) return;
+  const db = await openPartwrightDB();
+  const txn = db.transaction(CHATS_STORE, 'readwrite');
+  const store = txn.objectStore(CHATS_STORE);
+  for (const id of messageIds) store.delete(id);
+  await txComplete(txn);
+}
+
+export async function clearChat(sessionId: string): Promise<void> {
+  const db = await openPartwrightDB();
+  const txn = db.transaction(CHATS_STORE, 'readwrite');
+  const store = txn.objectStore(CHATS_STORE);
+  const idx = store.index('sessionId');
+  const req = idx.openCursor(IDBKeyRange.only(sessionId));
+  await new Promise<void>((resolve, reject) => {
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (cursor) {
+        cursor.delete();
+        cursor.continue();
+      } else {
+        resolve();
+      }
+    };
+    req.onerror = () => reject(req.error);
+  });
+  await txComplete(txn);
+}

--- a/src/ai/images.ts
+++ b/src/ai/images.ts
@@ -1,0 +1,117 @@
+// Image capture for the "Show AI" button. We use window.partwright.renderView
+// to produce data-URL PNGs from any angle without touching the live viewport
+// canvas (which has preserveDrawingBuffer=false and would race with normal
+// rendering). Each call returns one stitched PNG laying out front / right /
+// top / iso in a 2x2 grid — one image block instead of four, which costs the
+// model less context.
+
+import type { ImageSource } from './types';
+
+interface ViewSpec {
+  label: string;
+  elevation: number;
+  azimuth: number;
+  ortho: boolean;
+}
+
+const ISO_VIEWS: ViewSpec[] = [
+  { label: 'Front',   elevation: 0,  azimuth: 0,   ortho: true },
+  { label: 'Right',   elevation: 0,  azimuth: 90,  ortho: true },
+  { label: 'Top',     elevation: 90, azimuth: 0,   ortho: true },
+  { label: 'Iso',     elevation: 35, azimuth: 45,  ortho: false },
+];
+
+const TILE_SIZE = 384;
+const LABEL_HEIGHT = 24;
+
+type RenderViewFn = (opts: { elevation: number; azimuth: number; ortho: boolean; size: number }) => string | null;
+
+function getRenderView(): RenderViewFn | null {
+  const w = window as unknown as { partwright?: { renderView?: RenderViewFn } };
+  return w.partwright?.renderView ?? null;
+}
+
+/** Snapshot the 4 iso views as a single composited PNG. Returns null when
+ *  no geometry is loaded (renderView returns null) or partwright isn't
+ *  ready. */
+export async function captureIsoViews(): Promise<ImageSource | null> {
+  const renderView = getRenderView();
+  if (!renderView) return null;
+
+  const tiles: { label: string; image: HTMLImageElement }[] = [];
+  for (const spec of ISO_VIEWS) {
+    const dataUrl = renderView({ elevation: spec.elevation, azimuth: spec.azimuth, ortho: spec.ortho, size: TILE_SIZE });
+    if (!dataUrl) return null;
+    const image = await loadImage(dataUrl);
+    tiles.push({ label: spec.label, image });
+  }
+
+  const cellHeight = TILE_SIZE + LABEL_HEIGHT;
+  const composite = document.createElement('canvas');
+  composite.width = TILE_SIZE * 2;
+  composite.height = cellHeight * 2;
+  const ctx = composite.getContext('2d');
+  if (!ctx) return null;
+  ctx.fillStyle = '#f4f4f5';
+  ctx.fillRect(0, 0, composite.width, composite.height);
+
+  tiles.forEach((tile, i) => {
+    const col = i % 2;
+    const row = Math.floor(i / 2);
+    const x = col * TILE_SIZE;
+    const y = row * cellHeight;
+    ctx.drawImage(tile.image, x, y, TILE_SIZE, TILE_SIZE);
+    ctx.fillStyle = '#27272a';
+    ctx.fillRect(x, y + TILE_SIZE, TILE_SIZE, LABEL_HEIGHT);
+    ctx.fillStyle = '#f4f4f5';
+    ctx.font = '13px -apple-system, system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(tile.label, x + TILE_SIZE / 2, y + TILE_SIZE + 16);
+  });
+
+  const blob = await canvasToBlob(composite, 'image/png');
+  if (!blob) return null;
+  const data = await blobToBase64(blob);
+  return { data, mediaType: 'image/png', label: 'iso views (front, right, top, iso)' };
+}
+
+/** Convert a user-supplied File (drag-drop or paste) to an ImageSource.
+ *  Rejects anything that isn't an image. */
+export async function fileToImageSource(file: File): Promise<ImageSource | null> {
+  if (!file.type.startsWith('image/')) return null;
+  const data = await blobToBase64(file);
+  const media = file.type as ImageSource['mediaType'];
+  // Anthropic accepts png / jpeg / gif / webp. Fall back to png label if the
+  // browser reports something exotic — the bytes are what matter.
+  const safeMedia: ImageSource['mediaType'] = (
+    media === 'image/png' || media === 'image/jpeg' || media === 'image/gif' || media === 'image/webp'
+  ) ? media : 'image/png';
+  return { data, mediaType: safeMedia, label: file.name };
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('image decode failed'));
+    img.src = src;
+  });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, type: string): Promise<Blob | null> {
+  return new Promise(resolve => canvas.toBlob(b => resolve(b), type));
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      // strip the "data:<media>;base64," prefix — we store raw base64
+      const comma = result.indexOf(',');
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}

--- a/src/ai/images.ts
+++ b/src/ai/images.ts
@@ -6,20 +6,9 @@
 // model less context.
 
 import type { ImageSource } from './types';
+import { STANDARD_VIEWS } from '../renderer/multiview';
 
-interface ViewSpec {
-  label: string;
-  elevation: number;
-  azimuth: number;
-  ortho: boolean;
-}
-
-const ISO_VIEWS: ViewSpec[] = [
-  { label: 'Front',   elevation: 0,  azimuth: 0,   ortho: true },
-  { label: 'Right',   elevation: 0,  azimuth: 90,  ortho: true },
-  { label: 'Top',     elevation: 90, azimuth: 0,   ortho: true },
-  { label: 'Iso',     elevation: 35, azimuth: 45,  ortho: false },
-];
+const ISO_VIEWS = Object.values(STANDARD_VIEWS);
 
 const TILE_SIZE = 384;
 const LABEL_HEIGHT = 24;

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -1,0 +1,144 @@
+// Per-browser AI settings (preset, model, toggles). Persisted to
+// localStorage as one JSON blob — they're sticky across sessions and
+// separate from the per-session chat transcripts in IndexedDB.
+
+import type { ChatToggles, ModelId, Preset } from './types';
+
+const STORAGE_KEY = 'partwright-ai-settings-v1';
+
+export interface AiSettings {
+  preset: Preset;
+  toggles: ChatToggles;
+  /** When `false`, the chat drawer starts collapsed on page load. */
+  drawerOpen: boolean;
+  /** Default for new sessions before the user has touched the toggle bar. */
+  autoCompactMode: 'off' | 'conservative' | 'standard' | 'aggressive';
+}
+
+const PRESET_TOGGLES: Record<Exclude<Preset, 'custom'>, ChatToggles> = {
+  minimal: {
+    vision: { views: false },
+    scope: { runCode: true, saveVersions: true, paintFaces: false },
+    autoRetry: 0,
+    model: 'claude-haiku-4-5',
+  },
+  standard: {
+    vision: { views: true },
+    scope: { runCode: true, saveVersions: true, paintFaces: true },
+    autoRetry: 1,
+    model: 'claude-sonnet-4-6',
+  },
+  full: {
+    vision: { views: true },
+    scope: { runCode: true, saveVersions: true, paintFaces: true },
+    autoRetry: 3,
+    model: 'claude-opus-4-7',
+  },
+};
+
+const DEFAULT_SETTINGS: AiSettings = {
+  preset: 'standard',
+  toggles: PRESET_TOGGLES.standard,
+  drawerOpen: false,
+  autoCompactMode: 'off',
+};
+
+let cached: AiSettings | null = null;
+const listeners = new Set<(settings: AiSettings) => void>();
+
+export function loadSettings(): AiSettings {
+  if (cached) return cached;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<AiSettings>;
+      cached = mergeWithDefaults(parsed);
+      return cached;
+    }
+  } catch {
+    // Fall through to defaults on parse / storage error.
+  }
+  cached = { ...DEFAULT_SETTINGS, toggles: { ...DEFAULT_SETTINGS.toggles, vision: { ...DEFAULT_SETTINGS.toggles.vision }, scope: { ...DEFAULT_SETTINGS.toggles.scope } } };
+  return cached;
+}
+
+export function saveSettings(next: AiSettings): void {
+  cached = next;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // localStorage may be full or disabled (private browsing). Settings
+    // remain applied for this session; we don't surface the failure.
+  }
+  for (const fn of listeners) fn(next);
+}
+
+export function onSettingsChange(fn: (settings: AiSettings) => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+export function applyPreset(settings: AiSettings, preset: Preset): AiSettings {
+  if (preset === 'custom') return { ...settings, preset };
+  const p = PRESET_TOGGLES[preset];
+  return {
+    ...settings,
+    preset,
+    toggles: {
+      vision: { ...p.vision },
+      scope: { ...p.scope },
+      autoRetry: p.autoRetry,
+      model: p.model,
+    },
+  };
+}
+
+export function setModel(settings: AiSettings, model: ModelId): AiSettings {
+  return {
+    ...settings,
+    preset: 'custom',
+    toggles: { ...settings.toggles, model },
+  };
+}
+
+export function setToggles(settings: AiSettings, partial: DeepPartial<ChatToggles>): AiSettings {
+  const next: ChatToggles = {
+    vision: { ...settings.toggles.vision, ...(partial.vision ?? {}) },
+    scope: { ...settings.toggles.scope, ...(partial.scope ?? {}) },
+    autoRetry: partial.autoRetry ?? settings.toggles.autoRetry,
+    model: partial.model ?? settings.toggles.model,
+  };
+  return { ...settings, preset: 'custom', toggles: next };
+}
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+function mergeWithDefaults(partial: Partial<AiSettings>): AiSettings {
+  const tgls: Partial<ChatToggles> = partial.toggles ?? {};
+  return {
+    preset: partial.preset ?? DEFAULT_SETTINGS.preset,
+    autoCompactMode: partial.autoCompactMode ?? DEFAULT_SETTINGS.autoCompactMode,
+    drawerOpen: partial.drawerOpen ?? DEFAULT_SETTINGS.drawerOpen,
+    toggles: {
+      vision: { ...DEFAULT_SETTINGS.toggles.vision, ...(tgls.vision ?? {}) },
+      scope: { ...DEFAULT_SETTINGS.toggles.scope, ...(tgls.scope ?? {}) },
+      autoRetry: tgls.autoRetry ?? DEFAULT_SETTINGS.toggles.autoRetry,
+      model: tgls.model ?? DEFAULT_SETTINGS.toggles.model,
+    },
+  };
+}
+
+export const MODEL_OPTIONS: { id: ModelId; label: string }[] = [
+  { id: 'claude-haiku-4-5', label: 'Haiku 4.5' },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+  { id: 'claude-opus-4-7', label: 'Opus 4.7' },
+];
+
+export const PRESET_OPTIONS: { id: Preset; label: string; hint: string }[] = [
+  { id: 'minimal', label: 'Minimal', hint: 'code-only, Haiku, no retries' },
+  { id: 'standard', label: 'Standard', hint: 'code + iso views, Sonnet, 1 retry' },
+  { id: 'full', label: 'Full', hint: 'all tools + views, Opus, 3 retries' },
+  { id: 'custom', label: 'Custom', hint: 'your toggles' },
+];

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -24,7 +24,10 @@ const PRESET_TOGGLES: Record<Exclude<Preset, 'custom'>, ChatToggles> = {
   },
   standard: {
     vision: { views: true },
-    scope: { runCode: true, saveVersions: true, paintFaces: true },
+    // Paint off by default — color regions lock the editor and are easy
+    // for the model to mis-target. Users who want AI-driven painting
+    // can flip the Paint pill on, or pick the Full preset.
+    scope: { runCode: true, saveVersions: true, paintFaces: false },
     autoRetry: 1,
     model: 'claude-sonnet-4-6',
   },
@@ -137,8 +140,8 @@ export const MODEL_OPTIONS: { id: ModelId; label: string }[] = [
 ];
 
 export const PRESET_OPTIONS: { id: Preset; label: string; hint: string }[] = [
-  { id: 'minimal', label: 'Minimal', hint: 'code-only, Haiku, no retries' },
-  { id: 'standard', label: 'Standard', hint: 'code + iso views, Sonnet, 1 retry' },
-  { id: 'full', label: 'Full', hint: 'all tools + views, Opus, 3 retries' },
-  { id: 'custom', label: 'Custom', hint: 'your toggles' },
+  { id: 'minimal', label: 'Minimal', hint: 'Haiku · code only · no images · no retries' },
+  { id: 'standard', label: 'Standard', hint: 'Sonnet · run + save + views · paint off · 1 retry' },
+  { id: 'full', label: 'Full', hint: 'Opus · every tool incl. paint · views · 3 retries' },
+  { id: 'custom', label: 'Custom', hint: 'whatever you have set with the toggles below' },
 ];

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -20,6 +20,7 @@ const PRESET_TOGGLES: Record<Exclude<Preset, 'custom'>, ChatToggles> = {
     vision: { views: false },
     scope: { runCode: true, saveVersions: true, paintFaces: false },
     autoRetry: 0,
+    maxIterations: 'low',
     model: 'claude-haiku-4-5',
   },
   standard: {
@@ -29,12 +30,14 @@ const PRESET_TOGGLES: Record<Exclude<Preset, 'custom'>, ChatToggles> = {
     // can flip the Paint pill on, or pick the Full preset.
     scope: { runCode: true, saveVersions: true, paintFaces: false },
     autoRetry: 1,
+    maxIterations: 'medium',
     model: 'claude-sonnet-4-6',
   },
   full: {
     vision: { views: true },
     scope: { runCode: true, saveVersions: true, paintFaces: true },
     autoRetry: 3,
+    maxIterations: 'high',
     model: 'claude-opus-4-7',
   },
 };
@@ -91,6 +94,7 @@ export function applyPreset(settings: AiSettings, preset: Preset): AiSettings {
       vision: { ...p.vision },
       scope: { ...p.scope },
       autoRetry: p.autoRetry,
+      maxIterations: p.maxIterations,
       model: p.model,
     },
   };
@@ -109,6 +113,7 @@ export function setToggles(settings: AiSettings, partial: DeepPartial<ChatToggle
     vision: { ...settings.toggles.vision, ...(partial.vision ?? {}) },
     scope: { ...settings.toggles.scope, ...(partial.scope ?? {}) },
     autoRetry: partial.autoRetry ?? settings.toggles.autoRetry,
+    maxIterations: partial.maxIterations ?? settings.toggles.maxIterations,
     model: partial.model ?? settings.toggles.model,
   };
   return { ...settings, preset: 'custom', toggles: next };
@@ -128,10 +133,18 @@ function mergeWithDefaults(partial: Partial<AiSettings>): AiSettings {
       vision: { ...DEFAULT_SETTINGS.toggles.vision, ...(tgls.vision ?? {}) },
       scope: { ...DEFAULT_SETTINGS.toggles.scope, ...(tgls.scope ?? {}) },
       autoRetry: tgls.autoRetry ?? DEFAULT_SETTINGS.toggles.autoRetry,
+      maxIterations: tgls.maxIterations ?? DEFAULT_SETTINGS.toggles.maxIterations,
       model: tgls.model ?? DEFAULT_SETTINGS.toggles.model,
     },
   };
 }
+
+export const MAX_ITERATIONS_OPTIONS: { id: ChatToggles['maxIterations']; label: string; hint: string }[] = [
+  { id: 'low', label: 'Low (4)', hint: 'Short turns. Useful when the model wanders.' },
+  { id: 'medium', label: 'Med (16)', hint: 'Default. Comfortable for most paint workflows.' },
+  { id: 'high', label: 'High (64)', hint: 'Long autonomous runs. Watch the cost meter.' },
+  { id: 'infinity', label: '∞', hint: 'Unlimited. Only stops on completion / error / your Stop click.' },
+];
 
 export const MODEL_OPTIONS: { id: ModelId; label: string }[] = [
   { id: 'claude-haiku-4-5', label: 'Haiku 4.5' },

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -2,7 +2,7 @@
 // localStorage as one JSON blob — they're sticky across sessions and
 // separate from the per-session chat transcripts in IndexedDB.
 
-import type { ChatToggles, ModelId, Preset } from './types';
+import { MAX_ITERATIONS, MAX_SPEND, type ChatToggles, type ModelId, type Preset } from './types';
 
 const STORAGE_KEY = 'partwright-ai-settings-v1';
 
@@ -141,20 +141,13 @@ function mergeWithDefaults(partial: Partial<AiSettings>): AiSettings {
   };
 }
 
-export const MAX_ITERATIONS_OPTIONS: { id: ChatToggles['maxIterations']; label: string; hint: string }[] = [
-  { id: 'low', label: 'Low (4)', hint: 'Short turns. Useful when the model wanders.' },
-  { id: 'medium', label: 'Med (16)', hint: 'Default. Comfortable for most paint workflows.' },
-  { id: 'high', label: 'High (64)', hint: 'Long autonomous runs. Watch the cost meter.' },
-  { id: 'infinity', label: '∞', hint: 'Unlimited. Only stops on completion / error / your Stop click.' },
-];
+export const MAX_ITERATIONS_OPTIONS: { id: ChatToggles['maxIterations']; label: string; hint: string }[] =
+  (Object.entries(MAX_ITERATIONS) as [ChatToggles['maxIterations'], (typeof MAX_ITERATIONS)[keyof typeof MAX_ITERATIONS]][])
+    .map(([id, v]) => ({ id, label: v.label, hint: v.hint }));
 
-export const MAX_SPEND_OPTIONS: { id: ChatToggles['maxSpend']; label: string; hint: string }[] = [
-  { id: 'cheap', label: '$0.10', hint: 'Tight budget. Pairs well with Haiku and short turns.' },
-  { id: 'low', label: '$0.50', hint: 'Safety net for casual iteration.' },
-  { id: 'medium', label: '$2', hint: 'Default. Comfortable for most Sonnet turns including a few vision calls.' },
-  { id: 'high', label: '$10', hint: 'Long autonomous runs on Opus, lots of vision verification.' },
-  { id: 'infinity', label: '∞', hint: 'No budget cap. The model can spend whatever it wants.' },
-];
+export const MAX_SPEND_OPTIONS: { id: ChatToggles['maxSpend']; label: string; hint: string }[] =
+  (Object.entries(MAX_SPEND) as [ChatToggles['maxSpend'], (typeof MAX_SPEND)[keyof typeof MAX_SPEND]][])
+    .map(([id, v]) => ({ id, label: v.label, hint: v.hint }));
 
 export const MODEL_OPTIONS: { id: ModelId; label: string }[] = [
   { id: 'claude-haiku-4-5', label: 'Haiku 4.5' },

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -21,6 +21,7 @@ const PRESET_TOGGLES: Record<Exclude<Preset, 'custom'>, ChatToggles> = {
     scope: { runCode: true, saveVersions: true, paintFaces: false },
     autoRetry: 0,
     maxIterations: 'low',
+    maxSpend: 'cheap',
     model: 'claude-haiku-4-5',
   },
   standard: {
@@ -31,6 +32,7 @@ const PRESET_TOGGLES: Record<Exclude<Preset, 'custom'>, ChatToggles> = {
     scope: { runCode: true, saveVersions: true, paintFaces: false },
     autoRetry: 1,
     maxIterations: 'medium',
+    maxSpend: 'medium',
     model: 'claude-sonnet-4-6',
   },
   full: {
@@ -38,6 +40,7 @@ const PRESET_TOGGLES: Record<Exclude<Preset, 'custom'>, ChatToggles> = {
     scope: { runCode: true, saveVersions: true, paintFaces: true },
     autoRetry: 3,
     maxIterations: 'high',
+    maxSpend: 'high',
     model: 'claude-opus-4-7',
   },
 };
@@ -95,6 +98,7 @@ export function applyPreset(settings: AiSettings, preset: Preset): AiSettings {
       scope: { ...p.scope },
       autoRetry: p.autoRetry,
       maxIterations: p.maxIterations,
+      maxSpend: p.maxSpend,
       model: p.model,
     },
   };
@@ -114,6 +118,7 @@ export function setToggles(settings: AiSettings, partial: DeepPartial<ChatToggle
     scope: { ...settings.toggles.scope, ...(partial.scope ?? {}) },
     autoRetry: partial.autoRetry ?? settings.toggles.autoRetry,
     maxIterations: partial.maxIterations ?? settings.toggles.maxIterations,
+    maxSpend: partial.maxSpend ?? settings.toggles.maxSpend,
     model: partial.model ?? settings.toggles.model,
   };
   return { ...settings, preset: 'custom', toggles: next };
@@ -134,6 +139,7 @@ function mergeWithDefaults(partial: Partial<AiSettings>): AiSettings {
       scope: { ...DEFAULT_SETTINGS.toggles.scope, ...(tgls.scope ?? {}) },
       autoRetry: tgls.autoRetry ?? DEFAULT_SETTINGS.toggles.autoRetry,
       maxIterations: tgls.maxIterations ?? DEFAULT_SETTINGS.toggles.maxIterations,
+      maxSpend: tgls.maxSpend ?? DEFAULT_SETTINGS.toggles.maxSpend,
       model: tgls.model ?? DEFAULT_SETTINGS.toggles.model,
     },
   };
@@ -144,6 +150,14 @@ export const MAX_ITERATIONS_OPTIONS: { id: ChatToggles['maxIterations']; label: 
   { id: 'medium', label: 'Med (16)', hint: 'Default. Comfortable for most paint workflows.' },
   { id: 'high', label: 'High (64)', hint: 'Long autonomous runs. Watch the cost meter.' },
   { id: 'infinity', label: '∞', hint: 'Unlimited. Only stops on completion / error / your Stop click.' },
+];
+
+export const MAX_SPEND_OPTIONS: { id: ChatToggles['maxSpend']; label: string; hint: string }[] = [
+  { id: 'cheap', label: '$0.10', hint: 'Tight budget. Pairs well with Haiku and short turns.' },
+  { id: 'low', label: '$0.50', hint: 'Safety net for casual iteration.' },
+  { id: 'medium', label: '$2', hint: 'Default. Comfortable for most Sonnet turns including a few vision calls.' },
+  { id: 'high', label: '$10', hint: 'Long autonomous runs on Opus, lots of vision verification.' },
+  { id: 'infinity', label: '∞', hint: 'No budget cap. The model can spend whatever it wants.' },
 ];
 
 export const MODEL_OPTIONS: { id: ModelId; label: string }[] = [

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -11,8 +11,6 @@ export interface AiSettings {
   toggles: ChatToggles;
   /** When `false`, the chat drawer starts collapsed on page load. */
   drawerOpen: boolean;
-  /** Default for new sessions before the user has touched the toggle bar. */
-  autoCompactMode: 'off' | 'conservative' | 'standard' | 'aggressive';
 }
 
 const PRESET_TOGGLES: Record<Exclude<Preset, 'custom'>, ChatToggles> = {
@@ -49,7 +47,6 @@ const DEFAULT_SETTINGS: AiSettings = {
   preset: 'standard',
   toggles: PRESET_TOGGLES.standard,
   drawerOpen: false,
-  autoCompactMode: 'off',
 };
 
 let cached: AiSettings | null = null;
@@ -132,7 +129,6 @@ function mergeWithDefaults(partial: Partial<AiSettings>): AiSettings {
   const tgls: Partial<ChatToggles> = partial.toggles ?? {};
   return {
     preset: partial.preset ?? DEFAULT_SETTINGS.preset,
-    autoCompactMode: partial.autoCompactMode ?? DEFAULT_SETTINGS.autoCompactMode,
     drawerOpen: partial.drawerOpen ?? DEFAULT_SETTINGS.drawerOpen,
     toggles: {
       vision: { ...DEFAULT_SETTINGS.toggles.vision, ...(tgls.vision ?? {}) },

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -1,0 +1,90 @@
+// System prompt assembly. The base body is `public/ai.md` — the same doc
+// the external Claude Code agent reads — and the model sees it via prompt
+// caching so we don't pay for it on every turn. A short, generated suffix
+// communicates the current toggle state so the model doesn't ask for tools
+// it can't call.
+
+import type { ChatToggles } from './types';
+
+let aiMdCache: string | null = null;
+let aiMdPromise: Promise<string> | null = null;
+
+const PREAMBLE = `You are an AI modeling assistant embedded inside Partwright, a parametric
+CAD tool that runs in the user's browser. You drive the app through tools
+that wrap window.partwright. Always use a session for user-requested
+geometry (do not write to examples/). When you write code, return a
+Manifold object — see ai.md below for the full conventions.
+
+Be concise in chat. Long explanations cost tokens the user pays for. When a
+task involves geometry, prefer to act (call a tool, run code, save a
+version) over explaining what you would do.
+
+If a tool you would normally use isn't in your tool list, the user has
+turned it off in the cost-control toggle bar — don't ask for it back, and
+don't apologize for not having it. Acknowledge the constraint and continue
+with what you can do.
+
+Current Partwright API surface and conventions follow.
+
+`;
+
+/** Loads `/ai.md` once and returns the full body. The doc lives in
+ *  public/ai.md and is served at the root by Vite. */
+export function loadAiMd(): Promise<string> {
+  if (aiMdCache !== null) return Promise.resolve(aiMdCache);
+  if (aiMdPromise) return aiMdPromise;
+  aiMdPromise = fetch('/ai.md')
+    .then(r => {
+      if (!r.ok) throw new Error(`/ai.md HTTP ${r.status}`);
+      return r.text();
+    })
+    .then(text => {
+      aiMdCache = text;
+      return text;
+    })
+    .catch(err => {
+      // Fall back to a stub so the agent can still run if ai.md is missing
+      // (e.g. a misconfigured deploy). Logged so it surfaces in dev tools.
+      console.warn('Partwright: failed to load /ai.md, using stub:', err);
+      aiMdCache = '[ai.md could not be loaded — refer to window.partwright.help() at runtime]';
+      return aiMdCache;
+    });
+  return aiMdPromise;
+}
+
+/** Builds the suffix that describes the current toggle state. Generated
+ *  per-turn, appended after the cached `ai.md` body. Kept small so the
+ *  cache prefix invalidation only affects the very last block. */
+export function toggleSuffix(toggles: ChatToggles): string {
+  const restrictions: string[] = [];
+  if (!toggles.scope.runCode) {
+    restrictions.push('You CANNOT run code. Suggest code in chat for the user to run themselves.');
+  }
+  if (!toggles.scope.saveVersions) {
+    restrictions.push('You CANNOT save new versions. Run-and-test is allowed but not commit.');
+  }
+  if (!toggles.scope.paintFaces) {
+    restrictions.push('You CANNOT paint faces / set color regions.');
+  }
+  if (!toggles.vision.views) {
+    restrictions.push('You CANNOT see the rendered model. Reason from code and geometry stats only — do not ask for screenshots.');
+  }
+
+  const lines = [
+    '',
+    '## Session toggle state',
+    '',
+    `Model: ${toggles.model}`,
+    `Auto-retry on tool error: ${toggles.autoRetry}`,
+  ];
+  if (restrictions.length > 0) {
+    lines.push('');
+    lines.push('User has restricted you this session:');
+    for (const r of restrictions) lines.push(`- ${r}`);
+  }
+  return lines.join('\n');
+}
+
+export function buildSystemPrompt(aiMd: string): string {
+  return PREAMBLE + aiMd;
+}

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -36,7 +36,11 @@ Paint workflow for any non-trivial selector:
    selector args before committing. paintPreview is free of side effects
    — use it liberally.
 2. paintInBox / paintNear / paintSlab to commit.
-3. If wrong: undoLastPaint() (NOT clearColors), tweak, retry.
+3. renderView({elevation, azimuth}) to visually verify. The image is
+   sent back to you as a multimodal block — you can actually see the
+   result, not just the stats. Pick an angle that shows the painted
+   feature.
+4. If wrong: undoLastPaint() (NOT clearColors), tweak, retry.
 
 For models built as a boolean union of distinct features (e.g. a smiley =
 head ∪ left_eye ∪ right_eye ∪ mouth), call listComponents() FIRST to get

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -12,8 +12,13 @@ let aiMdPromise: Promise<string> | null = null;
 const PREAMBLE = `You are an AI modeling assistant embedded inside Partwright, a parametric
 CAD tool that runs in the user's browser. You drive the app through tools
 that wrap window.partwright. Always use a session for user-requested
-geometry (do not write to examples/). When you write code, return a
-Manifold object — see ai.md below for the full conventions.
+geometry (do not write to examples/). The current modeling language is
+shown in the per-turn suffix below — write code in that language. If the
+user explicitly asks for a different language, or if the request is much
+better expressed in the other one, switch via setActiveLanguage('scad'
+| 'manifold-js'); otherwise stay in whatever the user has open. When you
+write JavaScript, return a Manifold object — see ai.md below for the
+full conventions.
 
 Be concise in chat. Long explanations cost tokens the user pays for. When a
 task involves geometry, prefer to act (call a tool, run code, save a
@@ -105,10 +110,12 @@ export function toggleSuffix(toggles: ChatToggles): string {
     restrictions.push('You CANNOT call renderView. The user disabled auto-render to save cost — reason from code, geometry stats, and any images the user explicitly attaches (Show AI). Do not ask for screenshots.');
   }
 
+  const lang = currentLanguage();
   const lines = [
     '',
     '## Session toggle state',
     '',
+    `Active language: ${lang}  — write code in this language. Use setActiveLanguage to switch only when justified (e.g. user asked, or the request maps obviously better to the other engine: OpenSCAD for parametric extrusion-heavy parts, manifold-js for boolean composition and fine programmatic control).`,
     `Model: ${toggles.model}`,
     `Auto-retry on tool error: ${toggles.autoRetry}`,
   ];
@@ -118,6 +125,15 @@ export function toggleSuffix(toggles: ChatToggles): string {
     for (const r of restrictions) lines.push(`- ${r}`);
   }
   return lines.join('\n');
+}
+
+function currentLanguage(): string {
+  try {
+    const w = window as unknown as { partwright?: { getActiveLanguage?: () => string } };
+    return w.partwright?.getActiveLanguage?.() ?? 'manifold-js';
+  } catch {
+    return 'manifold-js';
+  }
 }
 
 export function buildSystemPrompt(aiMd: string): string {

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -111,6 +111,9 @@ export function toggleSuffix(toggles: ChatToggles): string {
   }
 
   const lang = currentLanguage();
+  const capLabel: Record<ChatToggles['maxIterations'], string> = {
+    low: '4', medium: '16', high: '64', infinity: 'unlimited',
+  };
   const lines = [
     '',
     '## Session toggle state',
@@ -118,6 +121,7 @@ export function toggleSuffix(toggles: ChatToggles): string {
     `Active language: ${lang}  — write code in this language. Use setActiveLanguage to switch only when justified (e.g. user asked, or the request maps obviously better to the other engine: OpenSCAD for parametric extrusion-heavy parts, manifold-js for boolean composition and fine programmatic control).`,
     `Model: ${toggles.model}`,
     `Auto-retry on tool error: ${toggles.autoRetry}`,
+    `Iteration cap (tool round-trips this turn): ${capLabel[toggles.maxIterations]}. Pace your tool calls accordingly — if the cap is low, batch related work and prefer one-shot tools like paintComponent or paintInBox over verify-then-paint loops.`,
   ];
   if (restrictions.length > 0) {
     lines.push('');

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -4,7 +4,8 @@
 // communicates the current toggle state so the model doesn't ask for tools
 // it can't call.
 
-import type { ChatToggles } from './types';
+import { MAX_ITERATIONS, MAX_SPEND, type ChatToggles } from './types';
+import type { Language } from '../geometry/engines/types';
 
 let aiMdCache: string | null = null;
 let aiMdPromise: Promise<string> | null = null;
@@ -128,12 +129,8 @@ export function toggleSuffix(toggles: ChatToggles): string {
   }
 
   const lang = currentLanguage();
-  const capLabel: Record<ChatToggles['maxIterations'], string> = {
-    low: '4', medium: '16', high: '64', infinity: 'unlimited',
-  };
-  const spendLabel: Record<ChatToggles['maxSpend'], string> = {
-    cheap: '$0.10', low: '$0.50', medium: '$2', high: '$10', infinity: 'unlimited',
-  };
+  const capLabel = MAX_ITERATIONS[toggles.maxIterations].promptLabel;
+  const spendLabel = MAX_SPEND[toggles.maxSpend].promptLabel;
   const lines = [
     '',
     '## Session toggle state',
@@ -145,8 +142,8 @@ export function toggleSuffix(toggles: ChatToggles): string {
     }`,
     `Model: ${toggles.model}`,
     `Auto-retry on tool error: ${toggles.autoRetry}`,
-    `Iteration cap (tool round-trips this turn): ${capLabel[toggles.maxIterations]}. Pace your tool calls accordingly — if the cap is low, batch related work and prefer one-shot tools like paintComponent or paintInBox over verify-then-paint loops.`,
-    `Spend cap (USD this turn): ${spendLabel[toggles.maxSpend]}. Vision tool calls (renderView, paintPreview withImage) are the most expensive — skip them when stats alone are enough.`,
+    `Iteration cap (tool round-trips this turn): ${capLabel}. Pace your tool calls accordingly — if the cap is low, batch related work and prefer one-shot tools like paintComponent or paintInBox over verify-then-paint loops.`,
+    `Spend cap (USD this turn): ${spendLabel}. Vision tool calls (renderView, paintPreview withImage) are the most expensive — skip them when stats alone are enough.`,
   ];
   if (restrictions.length > 0) {
     lines.push('');
@@ -156,9 +153,9 @@ export function toggleSuffix(toggles: ChatToggles): string {
   return lines.join('\n');
 }
 
-function currentLanguage(): string {
+function currentLanguage(): Language {
   try {
-    const w = window as unknown as { partwright?: { getActiveLanguage?: () => string } };
+    const w = window as unknown as { partwright?: { getActiveLanguage?: () => Language } };
     return w.partwright?.getActiveLanguage?.() ?? 'manifold-js';
   } catch {
     return 'manifold-js';

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -36,18 +36,21 @@ to delete a specific older mistake (get the id from listRegions). Save
 clearColors for "start completely over from scratch" requests.
 
 Paint workflow for any non-trivial selector:
-1. paintPreview({box / point+radius / etc., withImage: true}) →
-   ALWAYS pass withImage: true unless you only need the triangleCount.
-   The yellow-highlighted thumbnail is the cheapest way to catch a
-   bad selector before committing. Cheaper than paint → renderViews →
-   undoLastPaint.
+1. paintPreview({box / point+radius / etc.}) — ALWAYS call before
+   committing. Count alone is essentially free and catches most bad
+   selectors. If the count is surprising (way more or fewer than you
+   expected), call again with withImage: true for a yellow-highlighted
+   thumbnail. Either way, much cheaper than paint → renderViews → undo.
 2. paintInBox / paintNear / paintSlab to commit.
-3. renderViews() to visually verify from front + top + iso in one
-   composite. A single angle can hide an asymmetric error (e.g. a
-   smile that arches the wrong way is invisible from top but obvious
-   from front). Prefer renderViews over a single renderView for
-   verification — same one-call cost but far better coverage.
-4. If wrong: undoLastPaint() (NOT clearColors), tweak, retry.
+3. renderViews() to visually verify. The default views: 'auto' picks
+   angles by the model's bounding box (flat disks get [Top, Iso],
+   tall columns get [Front, Right, Iso], otherwise [Front, Top, Iso])
+   so you get the most informative angles automatically. A single
+   angle can hide an asymmetric error.
+4. If wrong: paintExplain({region: id}) FIRST — its normal histogram
+   tells you whether the region wrapped onto a face you didn't want
+   (e.g. zPos: 0.4 + xPos: 0.3 means it caught the top AND a side).
+   Then undoLastPaint() (NOT clearColors), tweak, retry.
 
 Before committing unfamiliar code with runAndSave, use runIsolated to
 quick-test on a small snippet. Examples worth verifying first: revolve

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -30,6 +30,23 @@ undoLastPaint() to reverse just the most recent paint, or removeRegion(id)
 to delete a specific older mistake (get the id from listRegions). Save
 clearColors for "start completely over from scratch" requests.
 
+Paint workflow for any non-trivial selector:
+1. paintPreview({box / point+radius / etc.}) → check triangleCount, bbox.
+   If the count looks wildly wrong (way too many or zero), adjust the
+   selector args before committing. paintPreview is free of side effects
+   — use it liberally.
+2. paintInBox / paintNear / paintSlab to commit.
+3. If wrong: undoLastPaint() (NOT clearColors), tweak, retry.
+
+For models built as a boolean union of distinct features (e.g. a smiley =
+head ∪ left_eye ∪ right_eye ∪ mouth), call listComponents() FIRST to get
+the bbox of each piece, then paintInBox({box: component.boundingBox,
+color}) per component. Don't guess world coordinates.
+
+For getMeshSummary on a complex model, scope queries with withinBox to
+the feature you care about — full-mesh summaries on hundreds of groups
+charge tokens for data you will discard.
+
 Current Partwright API surface and conventions follow.
 
 `;

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -114,6 +114,9 @@ export function toggleSuffix(toggles: ChatToggles): string {
   const capLabel: Record<ChatToggles['maxIterations'], string> = {
     low: '4', medium: '16', high: '64', infinity: 'unlimited',
   };
+  const spendLabel: Record<ChatToggles['maxSpend'], string> = {
+    cheap: '$0.10', low: '$0.50', medium: '$2', high: '$10', infinity: 'unlimited',
+  };
   const lines = [
     '',
     '## Session toggle state',
@@ -122,6 +125,7 @@ export function toggleSuffix(toggles: ChatToggles): string {
     `Model: ${toggles.model}`,
     `Auto-retry on tool error: ${toggles.autoRetry}`,
     `Iteration cap (tool round-trips this turn): ${capLabel[toggles.maxIterations]}. Pace your tool calls accordingly — if the cap is low, batch related work and prefer one-shot tools like paintComponent or paintInBox over verify-then-paint loops.`,
+    `Spend cap (USD this turn): ${spendLabel[toggles.maxSpend]}. Vision tool calls (renderView, paintPreview withImage) are the most expensive — skip them when stats alone are enough.`,
   ];
   if (restrictions.length > 0) {
     lines.push('');

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -43,13 +43,21 @@ Paint workflow for any non-trivial selector:
 4. If wrong: undoLastPaint() (NOT clearColors), tweak, retry.
 
 For models built as a boolean union of distinct features (e.g. a smiley =
-head ∪ left_eye ∪ right_eye ∪ mouth), call listComponents() FIRST to get
-the bbox of each piece, then paintInBox({box: component.boundingBox,
-color}) per component. Don't guess world coordinates.
+head ∪ left_eye ∪ right_eye ∪ mouth), use paintComponent(index, color)
+to paint each piece in ONE call — it decomposes and paints in one round
+trip. Use listComponents() FIRST only when you need to inspect bboxes
+before deciding what to paint.
 
-For getMeshSummary on a complex model, scope queries with withinBox to
-the feature you care about — full-mesh summaries on hundreds of groups
-charge tokens for data you will discard.
+When paintInBox / paintNear catches side walls or bottom faces by
+mistake, pass topOnly: true — that restricts the selector to upward-
+facing triangles only (axis +Z within 30°) and eliminates the most
+common over-paint cause.
+
+For planning paint targets without committing, prefer
+getFeatureCentroids() over getMeshSummary — it omits the triangleIds
+payload (which can be tens of thousands of integers) and ships only
+the centroid + normal + bbox per group. Pass withinBox to scope to one
+feature of the model.
 
 Current Partwright API surface and conventions follow.
 

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -24,6 +24,12 @@ turned it off in the cost-control toggle bar — don't ask for it back, and
 don't apologize for not having it. Acknowledge the constraint and continue
 with what you can do.
 
+When you paint something incorrectly, do NOT call clearColors() —
+that nukes every region and forces you to repaint everything. Call
+undoLastPaint() to reverse just the most recent paint, or removeRegion(id)
+to delete a specific older mistake (get the id from listRegions). Save
+clearColors for "start completely over from scratch" requests.
+
 Current Partwright API surface and conventions follow.
 
 `;

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -36,16 +36,30 @@ to delete a specific older mistake (get the id from listRegions). Save
 clearColors for "start completely over from scratch" requests.
 
 Paint workflow for any non-trivial selector:
-1. paintPreview({box / point+radius / etc.}) → check triangleCount, bbox.
-   If the count looks wildly wrong (way too many or zero), adjust the
-   selector args before committing. paintPreview is free of side effects
-   — use it liberally.
+1. paintPreview({box / point+radius / etc., withImage: true}) →
+   ALWAYS pass withImage: true unless you only need the triangleCount.
+   The yellow-highlighted thumbnail is the cheapest way to catch a
+   bad selector before committing. Cheaper than paint → renderViews →
+   undoLastPaint.
 2. paintInBox / paintNear / paintSlab to commit.
-3. renderView({elevation, azimuth}) to visually verify. The image is
-   sent back to you as a multimodal block — you can actually see the
-   result, not just the stats. Pick an angle that shows the painted
-   feature.
+3. renderViews() to visually verify from front + top + iso in one
+   composite. A single angle can hide an asymmetric error (e.g. a
+   smile that arches the wrong way is invisible from top but obvious
+   from front). Prefer renderViews over a single renderView for
+   verification — same one-call cost but far better coverage.
 4. If wrong: undoLastPaint() (NOT clearColors), tweak, retry.
+
+Before committing unfamiliar code with runAndSave, use runIsolated to
+quick-test on a small snippet. Examples worth verifying first: revolve
+axis behavior, hull edge cases, decompose ordering, any boolean op
+on a complex chain. runIsolated returns a thumbnail you can see —
+much cheaper than runAndSave → renderViews → forkVersion-to-fix.
+
+When the user's request is genuinely ambiguous (e.g. "add a smile" —
+is it a carved recess, raised feature, or flat color region?
+"thicker handle" — by how much, on what axis?), ASK ONE clarifying
+question instead of guessing. A clarification turn costs less than
+3 wasted versions.
 
 For models built as a boolean union of distinct features (e.g. a smiley =
 head ∪ left_eye ∪ right_eye ∪ mouth), use paintComponent(index, color)
@@ -121,7 +135,11 @@ export function toggleSuffix(toggles: ChatToggles): string {
     '',
     '## Session toggle state',
     '',
-    `Active language: ${lang}  — write code in this language. Use setActiveLanguage to switch only when justified (e.g. user asked, or the request maps obviously better to the other engine: OpenSCAD for parametric extrusion-heavy parts, manifold-js for boolean composition and fine programmatic control).`,
+    `Active language: ${lang}  — write code in this language. Use setActiveLanguage to switch only when justified (e.g. user asked, or the request maps obviously better to the other engine: OpenSCAD for parametric extrusion-heavy parts, manifold-js for boolean composition and fine programmatic control).${
+      lang === 'scad'
+        ? ' Note: SCAD\'s revolve / linear_extrude / cylinder produce radial-fan triangle topology that is awkward to paint cleanly (every triangle radiates from the center axis). If the task involves precise painting of curved features, consider switching to manifold-js up front rather than wrestling with the fan mesh.'
+        : ''
+    }`,
     `Model: ${toggles.model}`,
     `Auto-retry on tool error: ${toggles.autoRetry}`,
     `Iteration cap (tool round-trips this turn): ${capLabel[toggles.maxIterations]}. Pace your tool calls accordingly — if the cap is low, batch related work and prefer one-shot tools like paintComponent or paintInBox over verify-then-paint loops.`,

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -102,7 +102,7 @@ export function toggleSuffix(toggles: ChatToggles): string {
     restrictions.push('You CANNOT paint faces / set color regions.');
   }
   if (!toggles.vision.views) {
-    restrictions.push('You CANNOT see the rendered model. Reason from code and geometry stats only — do not ask for screenshots.');
+    restrictions.push('You CANNOT call renderView. The user disabled auto-render to save cost — reason from code, geometry stats, and any images the user explicitly attaches (Show AI). Do not ask for screenshots.');
   }
 
   const lines = [

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1,0 +1,251 @@
+// Tool bridge: defines the schemas the model sees and dispatches calls to
+// window.partwright. The set of tools the model receives is filtered by the
+// per-session scope toggles (see settings.ts). Disabled tools are removed
+// from the request payload entirely — the model can't call what isn't there.
+
+import type { ChatToggles } from './types';
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  input_schema: {
+    type: 'object';
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+export interface ToolExecResult {
+  content: string;
+  isError: boolean;
+}
+
+const ALL_TOOLS: ToolDefinition[] = [
+  {
+    name: 'getCode',
+    description: 'Read the current code in the editor. Always available. Returns the full source as a string.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'setCode',
+    description: 'Replace the editor contents. Does NOT auto-run — call runAndSave or runCode after to render.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        code: { type: 'string', description: 'New editor contents (must be a complete program ending in `return manifold;`).' },
+      },
+      required: ['code'],
+    },
+  },
+  {
+    name: 'runCode',
+    description: 'Run the given code (or the editor contents if `code` is omitted) and return the resulting geometry stats. Does NOT save a version. Use for quick iteration before committing.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        code: { type: 'string', description: 'Optional code to run instead of editor contents.' },
+      },
+    },
+  },
+  {
+    name: 'runAndSave',
+    description: 'Run code and commit the result as a new gallery version in the current session. The preferred way to make progress — leaves a versioned record. Returns geometry stats and the saved version number.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        code: { type: 'string', description: 'Code to run (overwrites the editor with the run-passing variant).' },
+        label: { type: 'string', description: 'Short label for the gallery (e.g. "tapered legs"). Defaults to v<index>.' },
+      },
+      required: ['code'],
+    },
+  },
+  {
+    name: 'getGeometryData',
+    description: 'Read the current geometry stats (volume, surfaceArea, vertexCount, triangleCount, isManifold, componentCount, boundingBox). Cheap — no re-execution.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'getMeshSummary',
+    description: 'Group triangles by coplanar regions and return per-group bounds + centroids. Useful before painting to know which face is where.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'getSessionContext',
+    description: 'Read the current session: notes, version history with labels, current version. Call FIRST when resuming work — gives you what was decided previously.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'listVersions',
+    description: 'List versions in the current session: { id, index, label, timestamp, status }.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'loadVersion',
+    description: 'Load a previously saved version by index. Updates the editor and viewport. Use to compare against an earlier state.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        index: { type: 'integer', description: '1-based version index.' },
+      },
+      required: ['index'],
+    },
+  },
+  {
+    name: 'addSessionNote',
+    description: 'Append a durable note to the session log. Notes survive compaction and are visible to future agents. Prefix with one of [REQUIREMENT], [DECISION], [FEEDBACK], [MEASUREMENT], [ATTEMPT], [TODO].',
+    input_schema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string', description: 'Note body, prefixed with a tag.' },
+      },
+      required: ['text'],
+    },
+  },
+  {
+    name: 'listSessionNotes',
+    description: 'Read all session notes ordered by time. Cheaper than getSessionContext when you only want notes.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'paintRegion',
+    description: 'Paint the coplanar region containing a point with the given color. Best paint primitive when you know exactly where to click.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        point: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[x, y, z] world point on the face.' },
+        normal: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Optional normal hint to disambiguate at edges.' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[r, g, b] in 0..1.' },
+        name: { type: 'string', description: 'Optional human-readable region name.' },
+        tolerance: { type: 'number', description: 'Coplanarity angle tolerance in degrees.' },
+      },
+      required: ['point', 'color'],
+    },
+  },
+  {
+    name: 'paintFaces',
+    description: 'Paint a specific set of triangle ids. Use after findFaces() to act on a query result.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        triangleIds: { type: 'array', items: { type: 'integer' } },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        name: { type: 'string' },
+      },
+      required: ['triangleIds', 'color'],
+    },
+  },
+  {
+    name: 'findFaces',
+    description: 'Search for triangles matching a box / normal / color predicate. Returns { triangleIds, count }. Use before paintFaces to target by geometry.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        box: { type: 'object', description: '{min: [x,y,z], max: [x,y,z]}' },
+        normal: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        normalTolerance: { type: 'number' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        region: { type: 'string' },
+        maxResults: { type: 'integer' },
+      },
+    },
+  },
+  {
+    name: 'clearColors',
+    description: 'Remove all color regions from the current version. Restores the unlocked, code-only state.',
+    input_schema: { type: 'object', properties: {} },
+  },
+];
+
+const ALWAYS_AVAILABLE = new Set([
+  'getCode',
+  'setCode',
+  'getGeometryData',
+  'getMeshSummary',
+  'getSessionContext',
+  'listVersions',
+  'loadVersion',
+  'addSessionNote',
+  'listSessionNotes',
+  'findFaces',
+]);
+
+const RUN_GATED = new Set(['runCode']);
+const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'clearColors']);
+
+export function buildToolList(toggles: ChatToggles): ToolDefinition[] {
+  return ALL_TOOLS.filter(t => {
+    if (ALWAYS_AVAILABLE.has(t.name)) return true;
+    if (RUN_GATED.has(t.name)) return toggles.scope.runCode;
+    if (SAVE_GATED.has(t.name)) {
+      // loadVersion is non-mutating but gating it under saveVersions keeps
+      // the model from rewinding state when the user has paused commits.
+      return t.name === 'loadVersion' ? toggles.scope.saveVersions : (toggles.scope.runCode && toggles.scope.saveVersions);
+    }
+    if (PAINT_GATED.has(t.name)) return toggles.scope.paintFaces;
+    return false;
+  });
+}
+
+type PartwrightAPI = Record<string, (...args: unknown[]) => unknown>;
+
+function getApi(): PartwrightAPI {
+  const w = window as unknown as { partwright?: PartwrightAPI };
+  if (!w.partwright) {
+    throw new Error('window.partwright is not ready — the Partwright engine has not finished initializing.');
+  }
+  return w.partwright;
+}
+
+/** Dispatches a tool call to window.partwright and stringifies the result.
+ *  Errors are caught and returned with isError: true so the loop can feed
+ *  them back to the model for self-correction. */
+export async function executeTool(name: string, input: Record<string, unknown>): Promise<ToolExecResult> {
+  try {
+    const api = getApi();
+    const result = await dispatch(api, name, input);
+    if (result === undefined) return { content: '(ok)', isError: false };
+    if (typeof result === 'string') return { content: result, isError: false };
+    return { content: JSON.stringify(result, null, 2), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: msg, isError: true };
+  }
+}
+
+async function dispatch(api: PartwrightAPI, name: string, input: Record<string, unknown>): Promise<unknown> {
+  switch (name) {
+    case 'getCode':
+      return api.getCode();
+    case 'setCode':
+      return api.setCode(input.code as string);
+    case 'runCode':
+      return api.run(input.code as string | undefined);
+    case 'runAndSave':
+      return api.runAndSave(input.code as string, input.label as string | undefined);
+    case 'getGeometryData':
+      return api.getGeometryData();
+    case 'getMeshSummary':
+      return api.getMeshSummary();
+    case 'getSessionContext':
+      return api.getSessionContext();
+    case 'listVersions':
+      return api.listVersions();
+    case 'loadVersion':
+      return api.loadVersion({ index: input.index as number });
+    case 'addSessionNote':
+      return api.addSessionNote(input.text as string);
+    case 'listSessionNotes':
+      return api.listSessionNotes();
+    case 'paintRegion':
+      return api.paintRegion(input);
+    case 'paintFaces':
+      return api.paintFaces(input);
+    case 'findFaces':
+      return api.findFaces(input);
+    case 'clearColors':
+      return api.clearColors();
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -15,9 +15,15 @@ export interface ToolDefinition {
   };
 }
 
+import type { ImageSource } from './types';
+
 export interface ToolExecResult {
   content: string;
   isError: boolean;
+  /** Optional image to forward back to the model as a multimodal content
+   *  block. Set by renderView (and any future tools that produce vision
+   *  output) so the agent can self-verify against a fresh snapshot. */
+  image?: ImageSource;
 }
 
 const ALL_TOOLS: ToolDefinition[] = [
@@ -84,8 +90,21 @@ const ALL_TOOLS: ToolDefinition[] = [
     input_schema: { type: 'object', properties: {} },
   },
   {
+    name: 'renderView',
+    description: 'Render the current model from a specified angle and return the PNG directly to you as a multimodal image. THIS IS HOW YOU SEE YOUR WORK — call after any paint or geometry change to visually verify the result, then undoLastPaint() if it landed wrong. Cheap (one render) but each image costs ~1500 input tokens on the next turn, so render with intent (one good angle that shows the feature) rather than spamming all 4 iso views.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        elevation: { type: 'number', description: 'Camera elevation in degrees. 0 = side view, 90 = top. Default 30.' },
+        azimuth: { type: 'number', description: 'Camera azimuth in degrees. 0 = front, 90 = right, 180 = back, 270 = left. Default 0.' },
+        ortho: { type: 'boolean', description: 'true = orthographic (technical drawing), false = perspective. Default false.' },
+        size: { type: 'integer', description: 'Pixel size of the rendered square. Default 320. Larger costs more tokens.' },
+      },
+    },
+  },
+  {
     name: 'paintPreview',
-    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. Use to gauge whether your selector is too tight or too loose before spending the round-trip to paint and undo. (The underlying API also returns a thumbnail image — stripped from the tool result because you cannot interpret it.)',
+    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. Use to gauge whether your selector is too tight or too loose before spending the round-trip to paint and undo. (The underlying API also returns a thumbnail image — stripped from the tool result because you cannot interpret it; call renderView separately if you need to see.)',
     input_schema: {
       type: 'object',
       properties: {
@@ -282,6 +301,11 @@ const ALWAYS_AVAILABLE = new Set([
 const RUN_GATED = new Set(['runCode']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
 const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
+/** renderView ships a PNG back to the model via a multimodal content
+ *  block. Gated by the Views vision toggle so the user can disable
+ *  vision spend in one place — when off, the agent has to reason from
+ *  code + stats alone. */
+const VIEWS_GATED = new Set(['renderView']);
 
 export function buildToolList(toggles: ChatToggles): ToolDefinition[] {
   return ALL_TOOLS.filter(t => {
@@ -293,6 +317,7 @@ export function buildToolList(toggles: ChatToggles): ToolDefinition[] {
       return t.name === 'loadVersion' ? toggles.scope.saveVersions : (toggles.scope.runCode && toggles.scope.saveVersions);
     }
     if (PAINT_GATED.has(t.name)) return toggles.scope.paintFaces;
+    if (VIEWS_GATED.has(t.name)) return toggles.vision.views;
     return false;
   });
 }
@@ -309,18 +334,61 @@ function getApi(): PartwrightAPI {
 
 /** Dispatches a tool call to window.partwright and stringifies the result.
  *  Errors are caught and returned with isError: true so the loop can feed
- *  them back to the model for self-correction. */
+ *  them back to the model for self-correction. Tools that return an
+ *  image (renderView today) bypass the JSON path and return a structured
+ *  ToolExecResult directly. */
 export async function executeTool(name: string, input: Record<string, unknown>): Promise<ToolExecResult> {
   try {
     const api = getApi();
+    // renderView is the only tool that hands back an image. Handled
+    // directly here so the data-URL parsing + multimodal wrapping stays
+    // out of the generic dispatch helper.
+    if (name === 'renderView') return executeRenderView(api, input);
+
     const result = await dispatch(api, name, input);
     if (result === undefined) return { content: '(ok)', isError: false };
     if (typeof result === 'string') return { content: result, isError: false };
+    // If a dispatch returned an object that already looks like our
+    // ToolExecResult shape (image-bearing), pass it through. Otherwise
+    // serialize normally.
+    if (result && typeof result === 'object' && 'content' in (result as Record<string, unknown>) && 'isError' in (result as Record<string, unknown>)) {
+      return result as ToolExecResult;
+    }
     return { content: JSON.stringify(result, null, 2), isError: false };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { content: msg, isError: true };
   }
+}
+
+function executeRenderView(api: PartwrightAPI, input: Record<string, unknown>): ToolExecResult {
+  const result = api.renderView(input) as string | { error: string } | null | undefined;
+  if (result == null) return { content: 'renderView returned no image — is there geometry loaded? Run code first.', isError: true };
+  if (typeof result === 'object' && 'error' in result) return { content: result.error, isError: true };
+  if (typeof result !== 'string') return { content: 'renderView returned an unexpected value', isError: true };
+
+  // data URL format: "data:image/png;base64,...."
+  const match = result.match(/^data:(image\/[a-z+]+);base64,(.+)$/i);
+  if (!match) return { content: 'renderView returned a non-data-URL string', isError: true };
+  const mediaTypeStr = match[1];
+  const data = match[2];
+  const safeMedia: ImageSource['mediaType'] =
+    mediaTypeStr === 'image/png' || mediaTypeStr === 'image/jpeg' ||
+    mediaTypeStr === 'image/gif' || mediaTypeStr === 'image/webp'
+      ? mediaTypeStr
+      : 'image/png';
+
+  const elevation = (input.elevation as number | undefined) ?? 30;
+  const azimuth = (input.azimuth as number | undefined) ?? 0;
+  const ortho = (input.ortho as boolean | undefined) ?? false;
+  const size = (input.size as number | undefined) ?? 320;
+  const label = `view: elev=${elevation}°, az=${azimuth}°${ortho ? ', ortho' : ''}, ${size}px`;
+
+  return {
+    content: `Rendered ${label}. The image is attached to this result — inspect it visually before deciding next steps.`,
+    isError: false,
+    image: { data, mediaType: safeMedia, label },
+  };
 }
 
 async function dispatch(api: PartwrightAPI, name: string, input: Record<string, unknown>): Promise<unknown> {

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -28,6 +28,22 @@ export interface ToolExecResult {
 
 const ALL_TOOLS: ToolDefinition[] = [
   {
+    name: 'getActiveLanguage',
+    description: 'Returns the editor\'s current modeling language: "manifold-js" or "scad". The per-turn system suffix already includes this, but call when in doubt or after a tool sequence that might have switched it.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'setActiveLanguage',
+    description: 'Switch the editor between "manifold-js" and "scad". Switching DISCARDS the current editor contents and resets to a stub — only do this when the user asked for the switch, or when the new request is much better expressed in the other language. Do NOT switch back and forth speculatively.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        lang: { type: 'string', enum: ['manifold-js', 'scad'] },
+      },
+      required: ['lang'],
+    },
+  },
+  {
     name: 'getCode',
     description: 'Read the current code in the editor. Always available. Returns the full source as a string.',
     input_schema: { type: 'object', properties: {} },
@@ -312,6 +328,8 @@ const ALL_TOOLS: ToolDefinition[] = [
 ];
 
 const ALWAYS_AVAILABLE = new Set([
+  'getActiveLanguage',
+  'setActiveLanguage',
   'getCode',
   'setCode',
   'getGeometryData',
@@ -422,6 +440,10 @@ function executeRenderView(api: PartwrightAPI, input: Record<string, unknown>): 
 
 async function dispatch(api: PartwrightAPI, name: string, input: Record<string, unknown>): Promise<unknown> {
   switch (name) {
+    case 'getActiveLanguage':
+      return api.getActiveLanguage();
+    case 'setActiveLanguage':
+      return api.setActiveLanguage(input.lang as 'manifold-js' | 'scad');
     case 'getCode':
       return api.getCode();
     case 'setCode':

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -66,8 +66,16 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'getMeshSummary',
-    description: 'Group triangles by coplanar regions and return per-group bounds + centroids. Useful before painting to know which face is where.',
-    input_schema: { type: 'object', properties: {} },
+    description: 'Group triangles by coplanar regions and return per-group {centroid, normal, area, bbox, triangleIds}. Use `maxGroups: 8` and `maxTrianglesPerGroup: 0` aggressively — the full mesh on complex models is hundreds of groups and tens of thousands of triangle ids, all charged as input tokens.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        tolerance: { type: 'number', description: 'Coplanarity cosine in [-1, 1]. Default 0.999.' },
+        minTriangles: { type: 'integer', description: 'Drop groups smaller than this. Default 1.' },
+        maxGroups: { type: 'integer', description: 'Return only the N largest groups. Default unlimited — pass 8-16 for a first pass.' },
+        maxTrianglesPerGroup: { type: 'integer', description: 'Cap triangleIds per group. Pass 0 to OMIT triangleIds entirely (saves the most tokens — use this when you just need centroids/normals to plan painting).' },
+      },
+    },
   },
   {
     name: 'getSessionContext',
@@ -123,7 +131,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintFaces',
-    description: 'Paint a specific set of triangle ids. Use after findFaces() to act on a query result.',
+    description: 'Paint a specific set of triangle ids. Last-resort primitive — prefer paintInBox / paintNear / paintSlab when the intent is "all faces matching a geometric predicate", because they collapse the find+paint pair into one tool call (saves a full round-trip plus the triangleId payload).',
     input_schema: {
       type: 'object',
       properties: {
@@ -135,8 +143,67 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'paintNear',
+    description: 'Paint every triangle within `radius` of `point` (optionally constrained by a normal cone). One call, no triangleId shuttling. Use for "paint the faces around this corner / nub / boss".',
+    input_schema: {
+      type: 'object',
+      properties: {
+        point: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        radius: { type: 'number' },
+        normalCone: { type: 'object', description: 'Optional {normal: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        name: { type: 'string' },
+      },
+      required: ['point', 'radius', 'color'],
+    },
+  },
+  {
+    name: 'paintInBox',
+    description: 'Paint every triangle whose centroid is inside the axis-aligned box (optionally constrained by a normal cone). One call. Use for "paint the top half / the right rim / everything below z=0".',
+    input_schema: {
+      type: 'object',
+      properties: {
+        box: { type: 'object', description: '{min: [x,y,z], max: [x,y,z]}' },
+        normalCone: { type: 'object', description: 'Optional {normal: [x,y,z], angleDeg: n}.' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        name: { type: 'string' },
+      },
+      required: ['box', 'color'],
+    },
+  },
+  {
+    name: 'paintSlab',
+    description: 'Paint everything in a Z-slab (or arbitrary-axis slab). One call. Use for "paint the rim of this disk", "paint the side walls", "paint the top 5mm".',
+    input_schema: {
+      type: 'object',
+      properties: {
+        axis: { type: 'string', enum: ['x', 'y', 'z'], description: 'Slab axis. Or pass `normal` for an arbitrary direction.' },
+        normal: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Use instead of axis for an oblique slab.' },
+        offset: { type: 'number', description: 'Slab center along the axis/normal.' },
+        thickness: { type: 'number', description: 'Slab thickness (paint catches anything within ±thickness/2 of offset).' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        name: { type: 'string' },
+      },
+      required: ['offset', 'thickness', 'color'],
+    },
+  },
+  {
+    name: 'paintNearestRegion',
+    description: 'Paint the nearest coplanar region to `point` within `searchRadius`. Use when paintRegion fails because the click point landed slightly off a face (common with iso-view coordinates).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        point: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        searchRadius: { type: 'number', description: 'How far to look for a face. Default ~1.0.' },
+        name: { type: 'string' },
+      },
+      required: ['point', 'color'],
+    },
+  },
+  {
     name: 'findFaces',
-    description: 'Search for triangles matching a box / normal / color predicate. Returns { triangleIds, count }. Use before paintFaces to target by geometry.',
+    description: 'Search for triangles matching a box / normal / color predicate. Returns { triangleIds, count }. Use ONLY when you need to *inspect* matches first — if you intend to paint them right after, call paintInBox / paintNear / paintSlab directly instead and skip the round-trip.',
     input_schema: {
       type: 'object',
       properties: {
@@ -171,7 +238,7 @@ const ALWAYS_AVAILABLE = new Set([
 
 const RUN_GATED = new Set(['runCode']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
-const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'clearColors']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'clearColors']);
 
 export function buildToolList(toggles: ChatToggles): ToolDefinition[] {
   return ALL_TOOLS.filter(t => {
@@ -241,6 +308,14 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.paintRegion(input);
     case 'paintFaces':
       return api.paintFaces(input);
+    case 'paintNear':
+      return api.paintNear(input);
+    case 'paintInBox':
+      return api.paintInBox(input);
+    case 'paintSlab':
+      return api.paintSlab(input);
+    case 'paintNearestRegion':
+      return api.paintNearestRegion(input);
     case 'findFaces':
       return api.findFaces(input);
     case 'clearColors':

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -132,7 +132,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'renderView',
-    description: 'Render the current model from a specified angle and return the PNG directly to you as a multimodal image. THIS IS HOW YOU SEE YOUR WORK — call after any paint or geometry change to visually verify the result, then undoLastPaint() if it landed wrong. Cheap (one render) but each image costs ~1500 input tokens on the next turn, so render with intent (one good angle that shows the feature) rather than spamming all 4 iso views.',
+    description: 'Render the current model from ONE angle and return the PNG as a multimodal image. Cheap (one render, ~1500 input tokens next turn). Use when you have a specific suspicion to confirm from a known angle. For general "did this paint land correctly" verification, prefer renderViews — a single angle can hide an error visible from another.',
     input_schema: {
       type: 'object',
       properties: {
@@ -144,8 +144,30 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'renderViews',
+    description: 'Render MULTIPLE labeled angles (front + top + iso by default) as ONE composite PNG. THIS IS HOW YOU SEE YOUR WORK reliably — a top-down view can hide a smile that arches the wrong way, but front+top+iso together catch it. Costs ~1500-2500 input tokens for the whole composite (one image, multiple cells), only slightly more than a single renderView but with far better verification coverage.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        views: { type: 'string', enum: ['tri', 'all'], description: '"tri" = front + top + iso (default, 3 cells, lower cost). "all" = front + right + top + iso (4 cells, more coverage).' },
+        size: { type: 'integer', description: 'Pixel size per cell. Default 320.' },
+      },
+    },
+  },
+  {
+    name: 'runIsolated',
+    description: 'Run code WITHOUT side effects — does not modify the editor, does not save a version, does not affect currentMeshData. Returns {geometryData, thumbnail}; the thumbnail is forwarded back to you as a multimodal image so you can see the result. Use to TEST unfamiliar primitives (revolve axis behavior, hull edge cases, decompose ordering) on a 3-line snippet before committing a full runAndSave. Much cheaper than running, undoing, and retrying.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        code: { type: 'string', description: 'Code to run in the active language. Must return a Manifold (manifold-js) or evaluate to one (SCAD).' },
+      },
+      required: ['code'],
+    },
+  },
+  {
     name: 'paintPreview',
-    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. Use to gauge whether your selector is too tight or too loose before spending the round-trip to paint and undo. Pass `withImage: true` to ALSO get back a vision-readable thumbnail of the candidate region (highlighted yellow over the current model) — costs ~1500 tokens, only ask when stats alone are inconclusive.',
+    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. The cheapest way to catch a bad selector before you commit — call this before any non-trivial paint. Returns a yellow-highlighted thumbnail by default (the model can see it); pass `withImage: false` for the stats-only cheap path when you only need triangleCount.',
     input_schema: {
       type: 'object',
       properties: {
@@ -154,7 +176,7 @@ const ALL_TOOLS: ToolDefinition[] = [
         radius: { type: 'number' },
         normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
         triangleIds: { type: 'array', items: { type: 'integer' }, description: 'Explicit triangle list — mostly for verifying findFaces results.' },
-        withImage: { type: 'boolean', description: 'When true, returns the preview thumbnail as a multimodal image. Default false (stats only).' },
+        withImage: { type: 'boolean', description: 'When true (default), returns the preview thumbnail as a multimodal image. Pass false for stats-only.' },
       },
     },
   },
@@ -348,11 +370,12 @@ const ALWAYS_AVAILABLE = new Set([
 const RUN_GATED = new Set(['runCode']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
 const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
-/** renderView ships a PNG back to the model via a multimodal content
+/** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
  *  vision spend in one place — when off, the agent has to reason from
- *  code + stats alone. */
-const VIEWS_GATED = new Set(['renderView']);
+ *  code + stats alone. runIsolated is here because its primary value is
+ *  the thumbnail; without vision it degrades to just the stats. */
+const VIEWS_GATED = new Set(['renderView', 'renderViews', 'runIsolated']);
 
 export function buildToolList(toggles: ChatToggles): ToolDefinition[] {
   return ALL_TOOLS.filter(t => {
@@ -387,10 +410,11 @@ function getApi(): PartwrightAPI {
 export async function executeTool(name: string, input: Record<string, unknown>): Promise<ToolExecResult> {
   try {
     const api = getApi();
-    // renderView is the only tool that hands back an image. Handled
-    // directly here so the data-URL parsing + multimodal wrapping stays
-    // out of the generic dispatch helper.
+    // Tools that ship images back to the model bypass the generic JSON
+    // dispatch — they need the data-URL → multimodal-image wrapping.
     if (name === 'renderView') return executeRenderView(api, input);
+    if (name === 'renderViews') return await executeRenderViews(api, input);
+    if (name === 'runIsolated') return await executeRunIsolated(api, input);
 
     const result = await dispatch(api, name, input);
     if (result === undefined) return { content: '(ok)', isError: false };
@@ -410,32 +434,64 @@ export async function executeTool(name: string, input: Record<string, unknown>):
 
 function executeRenderView(api: PartwrightAPI, input: Record<string, unknown>): ToolExecResult {
   const result = api.renderView(input) as string | { error: string } | null | undefined;
-  if (result == null) return { content: 'renderView returned no image — is there geometry loaded? Run code first.', isError: true };
-  if (typeof result === 'object' && 'error' in result) return { content: result.error, isError: true };
-  if (typeof result !== 'string') return { content: 'renderView returned an unexpected value', isError: true };
-
-  // data URL format: "data:image/png;base64,...."
-  const match = result.match(/^data:(image\/[a-z+]+);base64,(.+)$/i);
-  if (!match) return { content: 'renderView returned a non-data-URL string', isError: true };
-  const mediaTypeStr = match[1];
-  const data = match[2];
-  const safeMedia: ImageSource['mediaType'] =
-    mediaTypeStr === 'image/png' || mediaTypeStr === 'image/jpeg' ||
-    mediaTypeStr === 'image/gif' || mediaTypeStr === 'image/webp'
-      ? mediaTypeStr
-      : 'image/png';
-
   const elevation = (input.elevation as number | undefined) ?? 30;
   const azimuth = (input.azimuth as number | undefined) ?? 0;
   const ortho = (input.ortho as boolean | undefined) ?? false;
   const size = (input.size as number | undefined) ?? 320;
   const label = `view: elev=${elevation}°, az=${azimuth}°${ortho ? ', ortho' : ''}, ${size}px`;
+  return wrapImageResult(result, 'renderView', label);
+}
 
+async function executeRenderViews(api: PartwrightAPI, input: Record<string, unknown>): Promise<ToolExecResult> {
+  const result = await api.renderViews(input) as string | { error: string } | null | undefined;
+  const views = (input.views as string | undefined) ?? 'tri';
+  const size = (input.size as number | undefined) ?? 320;
+  const label = `views: ${views} composite (${size}px per cell)`;
+  return wrapImageResult(result, 'renderViews', label);
+}
+
+async function executeRunIsolated(api: PartwrightAPI, input: Record<string, unknown>): Promise<ToolExecResult> {
+  const code = input.code as string;
+  const result = await api.runIsolated(code) as { geometryData?: unknown; thumbnail?: string | null; error?: string } | undefined;
+  if (!result || typeof result !== 'object') return { content: 'runIsolated returned no result', isError: true };
+  if ('error' in result && typeof result.error === 'string') return { content: result.error, isError: true };
+  const stats = result.geometryData ?? {};
+  const summary = `runIsolated stats: ${JSON.stringify(stats, null, 2)}`;
+  if (typeof result.thumbnail !== 'string') {
+    return { content: summary, isError: false };
+  }
+  const img = parseImageDataUrl(result.thumbnail);
+  if (!img) return { content: summary, isError: false };
+  return {
+    content: `${summary}\n\nThumbnail attached — this is what the code would produce without side effects. Use to verify before runAndSave.`,
+    isError: false,
+    image: { ...img, label: 'runIsolated preview' },
+  };
+}
+
+function wrapImageResult(result: string | { error: string } | null | undefined, toolName: string, label: string): ToolExecResult {
+  if (result == null) return { content: `${toolName} returned no image — is there geometry loaded? Run code first.`, isError: true };
+  if (typeof result === 'object' && 'error' in result) return { content: result.error, isError: true };
+  if (typeof result !== 'string') return { content: `${toolName} returned an unexpected value`, isError: true };
+  const img = parseImageDataUrl(result);
+  if (!img) return { content: `${toolName} returned a non-data-URL string`, isError: true };
   return {
     content: `Rendered ${label}. The image is attached to this result — inspect it visually before deciding next steps.`,
     isError: false,
-    image: { data, mediaType: safeMedia, label },
+    image: { ...img, label },
   };
+}
+
+function parseImageDataUrl(dataUrl: string): { data: string; mediaType: ImageSource['mediaType'] } | null {
+  const match = dataUrl.match(/^data:(image\/[a-z+]+);base64,(.+)$/i);
+  if (!match) return null;
+  const mediaTypeStr = match[1];
+  const safeMedia: ImageSource['mediaType'] =
+    mediaTypeStr === 'image/png' || mediaTypeStr === 'image/jpeg' ||
+    mediaTypeStr === 'image/gif' || mediaTypeStr === 'image/webp'
+      ? mediaTypeStr
+      : 'image/png';
+  return { data: match[2], mediaType: safeMedia };
 }
 
 async function dispatch(api: PartwrightAPI, name: string, input: Record<string, unknown>): Promise<unknown> {
@@ -488,10 +544,10 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.getFeatureCentroids(input);
     case 'paintPreview': {
       // paintPreview returns {thumbnail, triangleCount, bbox, centroid}.
-      // When the caller didn't ask for the image, strip it before
-      // returning — saves tokens. When withImage: true, repackage the
-      // thumbnail as a multimodal ToolExecResult so the model can see it.
-      const wantImage = input.withImage === true;
+      // The thumbnail is on by default — it's the cheapest way for the
+      // model to catch a bad selector before committing. Opt out with
+      // withImage: false for the stats-only cheap path.
+      const wantImage = input.withImage !== false;
       // The underlying API doesn't know about withImage — drop it.
       const apiInput = { ...input };
       delete apiInput.withImage;

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -66,7 +66,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'getMeshSummary',
-    description: 'Group triangles by coplanar regions and return per-group {centroid, normal, area, bbox, triangleIds}. Use `maxGroups: 8` and `maxTrianglesPerGroup: 0` aggressively — the full mesh on complex models is hundreds of groups and tens of thousands of triangle ids, all charged as input tokens.',
+    description: 'Group triangles by coplanar regions and return per-group {centroid, normal, area, bbox, triangleIds}. Use `maxGroups: 8` and `maxTrianglesPerGroup: 0` aggressively — the full mesh on complex models is hundreds of groups and tens of thousands of triangle ids, all charged as input tokens. Pass `withinBox` to scope to one feature of the model.',
     input_schema: {
       type: 'object',
       properties: {
@@ -74,6 +74,26 @@ const ALL_TOOLS: ToolDefinition[] = [
         minTriangles: { type: 'integer', description: 'Drop groups smaller than this. Default 1.' },
         maxGroups: { type: 'integer', description: 'Return only the N largest groups. Default unlimited — pass 8-16 for a first pass.' },
         maxTrianglesPerGroup: { type: 'integer', description: 'Cap triangleIds per group. Pass 0 to OMIT triangleIds entirely (saves the most tokens — use this when you just need centroids/normals to plan painting).' },
+        withinBox: { type: 'object', description: 'Optional {min: [x,y,z], max: [x,y,z]} — return only groups whose bbox intersects this region. Use to focus on one feature (e.g. the eyes of a face) without pulling the whole mesh summary.' },
+      },
+    },
+  },
+  {
+    name: 'listComponents',
+    description: 'Decompose the current manifold into its boolean-distinct components and return {index, centroid, boundingBox, volume, surfaceArea} for each. Use this for "paint each feature" workflows on unioned models — for a smiley built from head + 2 eyes + mouth, this returns 4 components with bboxes, and you can call paintInBox({box: component.boundingBox, color}) for each instead of guessing world coordinates.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'paintPreview',
+    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. Use to gauge whether your selector is too tight or too loose before spending the round-trip to paint and undo. (The underlying API also returns a thumbnail image — stripped from the tool result because you cannot interpret it.)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        box: { type: 'object', description: '{min: [x,y,z], max: [x,y,z]}' },
+        point: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        radius: { type: 'number' },
+        normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
+        triangleIds: { type: 'array', items: { type: 'integer' }, description: 'Explicit triangle list — mostly for verifying findFaces results.' },
       },
     },
   },
@@ -255,6 +275,8 @@ const ALWAYS_AVAILABLE = new Set([
   'addSessionNote',
   'listSessionNotes',
   'findFaces',
+  'listComponents',
+  'paintPreview',
 ]);
 
 const RUN_GATED = new Set(['runCode']);
@@ -339,6 +361,18 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.paintNearestRegion(input);
     case 'findFaces':
       return api.findFaces(input);
+    case 'listComponents':
+      return api.listComponents();
+    case 'paintPreview': {
+      // paintPreview returns a {thumbnail, triangleCount, bbox, centroid}
+      // — the thumbnail is a large base64 PNG the model can't interpret
+      // and costs tokens to ship, so we strip it before returning.
+      const result = await api.paintPreview(input) as Record<string, unknown> | undefined;
+      if (result && typeof result === 'object') {
+        delete result.thumbnail;
+      }
+      return result;
+    }
     case 'undoLastPaint':
       return api.undoLastPaint();
     case 'redoLastPaint':

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -145,11 +145,11 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'renderViews',
-    description: 'Render MULTIPLE labeled angles (front + top + iso by default) as ONE composite PNG. THIS IS HOW YOU SEE YOUR WORK reliably — a top-down view can hide a smile that arches the wrong way, but front+top+iso together catch it. Costs ~1500-2500 input tokens for the whole composite (one image, multiple cells), only slightly more than a single renderView but with far better verification coverage.',
+    description: 'Render MULTIPLE labeled angles as ONE composite PNG. THIS IS HOW YOU SEE YOUR WORK reliably — a single angle can hide an asymmetric error that another angle catches. Costs ~1500-2500 input tokens. Default `views: "auto"` picks angles by the model\'s bounding box: flat disks get [Top, Iso] (a front elevation of a disk is a useless sliver), tall columns get [Front, Right, Iso] (the top of a column is a useless dot), everything else gets [Front, Top, Iso]. Use `tri` or `all` to force a specific set.',
     input_schema: {
       type: 'object',
       properties: {
-        views: { type: 'string', enum: ['tri', 'all'], description: '"tri" = front + top + iso (default, 3 cells, lower cost). "all" = front + right + top + iso (4 cells, more coverage).' },
+        views: { type: 'string', enum: ['auto', 'tri', 'all'], description: '"auto" (default) picks angles from the model aspect ratio. "tri" = front + top + iso (3 cells). "all" = front + right + top + iso (4 cells).' },
         size: { type: 'integer', description: 'Pixel size per cell. Default 320.' },
       },
     },
@@ -166,8 +166,20 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'paintExplain',
+    description: 'Diagnose an existing painted region. Returns {triangleCount, area, bbox, centroid, normalHistogram, thumbnail}. Use after a paint that looks wrong — the histogram tells you which axis the region faces (e.g. zPos: 0.7 means 70% of the surface area faces up), the thumbnail shows the region tinted yellow on the current model. Cheaper and more diagnostic than paint → renderViews → undo. Pass `withImage: false` for stats-only when you only need the histogram.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        region: { description: 'Region id (integer, from listRegions) or name (string).' },
+        withImage: { type: 'boolean', description: 'Default true. Pass false for stats-only (skip the thumbnail render).' },
+      },
+      required: ['region'],
+    },
+  },
+  {
     name: 'paintPreview',
-    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. The cheapest way to catch a bad selector before you commit — call this before any non-trivial paint. Returns a yellow-highlighted thumbnail by default (the model can see it); pass `withImage: false` for the stats-only cheap path when you only need triangleCount.',
+    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. The cheapest way to catch a bad selector — count alone is essentially free; ALWAYS call before any non-trivial paint. Pass `withImage: true` ONLY when the count is suspicious (wildly more or fewer than expected) or the selector geometry is fuzzy — that adds a yellow-highlighted thumbnail.',
     input_schema: {
       type: 'object',
       properties: {
@@ -176,7 +188,7 @@ const ALL_TOOLS: ToolDefinition[] = [
         radius: { type: 'number' },
         normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
         triangleIds: { type: 'array', items: { type: 'integer' }, description: 'Explicit triangle list — mostly for verifying findFaces results.' },
-        withImage: { type: 'boolean', description: 'When true (default), returns the preview thumbnail as a multimodal image. Pass false for stats-only.' },
+        withImage: { type: 'boolean', description: 'Default false (stats-only, free). Pass true to also return the highlighted thumbnail when the count is surprising or you want a visual sanity check.' },
       },
     },
   },
@@ -365,6 +377,7 @@ const ALWAYS_AVAILABLE = new Set([
   'findFaces',
   'listComponents',
   'paintPreview',
+  'paintExplain',
 ]);
 
 const RUN_GATED = new Set(['runCode']);
@@ -542,16 +555,38 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.paintComponent(input);
     case 'getFeatureCentroids':
       return api.getFeatureCentroids(input);
-    case 'paintPreview': {
-      // paintPreview returns {thumbnail, triangleCount, bbox, centroid}.
-      // The thumbnail is on by default — it's the cheapest way for the
-      // model to catch a bad selector before committing. Opt out with
-      // withImage: false for the stats-only cheap path.
+    case 'paintExplain': {
+      // paintExplain returns {thumbnail, ...stats}. Image-on by default
+      // because the visual is the most useful diagnostic for the model;
+      // strip when withImage: false.
       const wantImage = input.withImage !== false;
-      // The underlying API doesn't know about withImage — drop it.
       const apiInput = { ...input };
       delete apiInput.withImage;
-      const result = await api.paintPreview(apiInput) as Record<string, unknown> | undefined;
+      const result = await api.paintExplain(apiInput) as Record<string, unknown> | undefined;
+      if (!result || typeof result !== 'object') return result;
+      if ('error' in result) return result;
+      const thumbnail = result.thumbnail as string | undefined;
+      delete result.thumbnail;
+      if (wantImage && typeof thumbnail === 'string') {
+        const img = parseImageDataUrl(thumbnail);
+        if (img) {
+          const summary = `paintExplain: ${JSON.stringify(result)}. Region triangles highlighted yellow over the current model.`;
+          return {
+            content: summary,
+            isError: false,
+            image: { ...img, label: `paintExplain "${result.name}"` },
+          } satisfies ToolExecResult;
+        }
+      }
+      return result;
+    }
+    case 'paintPreview': {
+      // paintPreview returns {triangleCount, bbox, centroid, [thumbnail]}.
+      // The underlying API takes `withImage` directly and skips the WebGL
+      // render when false (count-only is the cheap sanity check). Pass
+      // through unchanged.
+      const wantImage = input.withImage === true;
+      const result = await api.paintPreview(input) as Record<string, unknown> | undefined;
       if (!result || typeof result !== 'object') return result;
       const thumbnail = result.thumbnail as string | undefined;
       delete result.thumbnail;

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -4,6 +4,8 @@
 // from the request payload entirely — the model can't call what isn't there.
 
 import type { ChatToggles } from './types';
+import type { Language } from '../geometry/engines/types';
+import { RENDER_VIEW_MODES } from '../renderer/multiview';
 
 export interface ToolDefinition {
   name: string;
@@ -149,7 +151,7 @@ const ALL_TOOLS: ToolDefinition[] = [
     input_schema: {
       type: 'object',
       properties: {
-        views: { type: 'string', enum: ['auto', 'tri', 'all'], description: '"auto" (default) picks angles from the model aspect ratio. "tri" = front + top + iso (3 cells). "all" = front + right + top + iso (4 cells).' },
+        views: { type: 'string', enum: [...RENDER_VIEW_MODES], description: '"auto" (default) picks angles from the model aspect ratio. "tri" = front + top + iso (3 cells). "all" = front + right + top + iso (4 cells).' },
         size: { type: 'integer', description: 'Pixel size per cell. Default 320.' },
       },
     },
@@ -512,7 +514,7 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
     case 'getActiveLanguage':
       return api.getActiveLanguage();
     case 'setActiveLanguage':
-      return api.setActiveLanguage(input.lang as 'manifold-js' | 'scad');
+      return api.setActiveLanguage(input.lang as Language);
     case 'getCode':
       return api.getCode();
     case 'setCode':

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -86,8 +86,33 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'listComponents',
-    description: 'Decompose the current manifold into its boolean-distinct components and return {index, centroid, boundingBox, volume, surfaceArea} for each. Use this for "paint each feature" workflows on unioned models — for a smiley built from head + 2 eyes + mouth, this returns 4 components with bboxes, and you can call paintInBox({box: component.boundingBox, color}) for each instead of guessing world coordinates.',
+    description: 'Decompose the current manifold into its boolean-distinct components and return {index, centroid, boundingBox, volume, surfaceArea} for each. Use this for "paint each feature" workflows on unioned models — for a smiley built from head + 2 eyes + mouth, this returns 4 components with bboxes. Prefer paintComponent(index, color) if you intend to paint right after — it skips this query entirely.',
     input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'paintComponent',
+    description: 'Paint a boolean-distinct component (from listComponents) in one call. Equivalent to listComponents → paintInBox(component.boundingBox) but a single round-trip. Use whenever the user wants "paint the Nth piece a color" — eyes, nose, mouth on a unioned smiley, arms of a robot, etc.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        index: { type: 'integer', description: 'Component index from listComponents() (0-based).' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[r, g, b] in 0..1.' },
+        name: { type: 'string', description: 'Optional human-readable region name. Defaults to "Component <index>".' },
+        topOnly: { type: 'boolean', description: 'If true, only paint upward-facing triangles (skip side walls + bottom). Same shortcut as paintInBox.topOnly.' },
+      },
+      required: ['index', 'color'],
+    },
+  },
+  {
+    name: 'getFeatureCentroids',
+    description: 'Token-cheap planning aid: returns coplanar face groups with just centroid + normal + bbox + area (NO triangle IDs). Use this when planning where to paint without committing yet — cheaper than getMeshSummary because the triangleIds payload is omitted. Optional `withinBox` scopes to one feature.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        maxGroups: { type: 'integer', description: 'Return the N largest groups. Default 32.' },
+        withinBox: { type: 'object', description: 'Optional {min: [x,y,z], max: [x,y,z]} — only groups whose bbox intersects.' },
+      },
+    },
   },
   {
     name: 'renderView',
@@ -104,7 +129,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintPreview',
-    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. Use to gauge whether your selector is too tight or too loose before spending the round-trip to paint and undo. (The underlying API also returns a thumbnail image — stripped from the tool result because you cannot interpret it; call renderView separately if you need to see.)',
+    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. Use to gauge whether your selector is too tight or too loose before spending the round-trip to paint and undo. Pass `withImage: true` to ALSO get back a vision-readable thumbnail of the candidate region (highlighted yellow over the current model) — costs ~1500 tokens, only ask when stats alone are inconclusive.',
     input_schema: {
       type: 'object',
       properties: {
@@ -113,6 +138,7 @@ const ALL_TOOLS: ToolDefinition[] = [
         radius: { type: 'number' },
         normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
         triangleIds: { type: 'array', items: { type: 'integer' }, description: 'Explicit triangle list — mostly for verifying findFaces results.' },
+        withImage: { type: 'boolean', description: 'When true, returns the preview thumbnail as a multimodal image. Default false (stats only).' },
       },
     },
   },
@@ -183,13 +209,14 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintNear',
-    description: 'Paint every triangle within `radius` of `point` (optionally constrained by a normal cone). One call, no triangleId shuttling. Use for "paint the faces around this corner / nub / boss".',
+    description: 'Paint every triangle within `radius` of `point` (optionally constrained by a normal cone). One call, no triangleId shuttling. Use for "paint the faces around this corner / nub / boss". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause.',
     input_schema: {
       type: 'object',
       properties: {
         point: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         radius: { type: 'number' },
-        normalCone: { type: 'object', description: 'Optional {normal: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
+        normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
+        topOnly: { type: 'boolean', description: 'Shortcut for normalCone: {axis: [0,0,1], angleDeg: 30}. Common case: paint only upward-facing faces in the region.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
       },
@@ -198,12 +225,13 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintInBox',
-    description: 'Paint every triangle whose centroid is inside the axis-aligned box (optionally constrained by a normal cone). One call. Use for "paint the top half / the right rim / everything below z=0".',
+    description: 'Paint every triangle whose centroid is inside the axis-aligned box (optionally constrained by a normal cone). One call. Use for "paint the top half / the right rim / everything below z=0". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause.',
     input_schema: {
       type: 'object',
       properties: {
         box: { type: 'object', description: '{min: [x,y,z], max: [x,y,z]}' },
-        normalCone: { type: 'object', description: 'Optional {normal: [x,y,z], angleDeg: n}.' },
+        normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n}.' },
+        topOnly: { type: 'boolean', description: 'Shortcut for normalCone: {axis: [0,0,1], angleDeg: 30}. Common case: paint the top face of a feature without catching its sides.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
       },
@@ -288,6 +316,7 @@ const ALWAYS_AVAILABLE = new Set([
   'setCode',
   'getGeometryData',
   'getMeshSummary',
+  'getFeatureCentroids',
   'getSessionContext',
   'listVersions',
   'loadVersion',
@@ -300,7 +329,7 @@ const ALWAYS_AVAILABLE = new Set([
 
 const RUN_GATED = new Set(['runCode']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
-const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
 /** renderView ships a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
  *  vision spend in one place — when off, the agent has to reason from
@@ -431,13 +460,38 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.findFaces(input);
     case 'listComponents':
       return api.listComponents();
+    case 'paintComponent':
+      return api.paintComponent(input);
+    case 'getFeatureCentroids':
+      return api.getFeatureCentroids(input);
     case 'paintPreview': {
-      // paintPreview returns a {thumbnail, triangleCount, bbox, centroid}
-      // — the thumbnail is a large base64 PNG the model can't interpret
-      // and costs tokens to ship, so we strip it before returning.
-      const result = await api.paintPreview(input) as Record<string, unknown> | undefined;
-      if (result && typeof result === 'object') {
-        delete result.thumbnail;
+      // paintPreview returns {thumbnail, triangleCount, bbox, centroid}.
+      // When the caller didn't ask for the image, strip it before
+      // returning — saves tokens. When withImage: true, repackage the
+      // thumbnail as a multimodal ToolExecResult so the model can see it.
+      const wantImage = input.withImage === true;
+      // The underlying API doesn't know about withImage — drop it.
+      const apiInput = { ...input };
+      delete apiInput.withImage;
+      const result = await api.paintPreview(apiInput) as Record<string, unknown> | undefined;
+      if (!result || typeof result !== 'object') return result;
+      const thumbnail = result.thumbnail as string | undefined;
+      delete result.thumbnail;
+      if (wantImage && typeof thumbnail === 'string') {
+        const match = thumbnail.match(/^data:(image\/[a-z+]+);base64,(.+)$/i);
+        if (match) {
+          const mediaTypeStr = match[1];
+          const safeMedia: ImageSource['mediaType'] =
+            mediaTypeStr === 'image/png' || mediaTypeStr === 'image/jpeg' ||
+            mediaTypeStr === 'image/gif' || mediaTypeStr === 'image/webp'
+              ? mediaTypeStr : 'image/png';
+          const summary = `Preview: ${JSON.stringify(result)}. Candidate triangles are highlighted yellow over the current model.`;
+          return {
+            content: summary,
+            isError: false,
+            image: { data: match[2], mediaType: safeMedia, label: 'paintPreview' },
+          } satisfies ToolExecResult;
+        }
       }
       return result;
     }

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -457,7 +457,7 @@ function executeRenderView(api: PartwrightAPI, input: Record<string, unknown>): 
 
 async function executeRenderViews(api: PartwrightAPI, input: Record<string, unknown>): Promise<ToolExecResult> {
   const result = await api.renderViews(input) as string | { error: string } | null | undefined;
-  const views = (input.views as string | undefined) ?? 'tri';
+  const views = (input.views as string | undefined) ?? 'auto';
   const size = (input.size as number | undefined) ?? 320;
   const label = `views: ${views} composite (${size}px per cell)`;
   return wrapImageResult(result, 'renderViews', label);

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -217,8 +217,29 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'undoLastPaint',
+    description: 'Undo the SINGLE most recent paint operation. Always prefer this over clearColors when you only need to fix one mistake — clearColors wipes every region and forces you to repaint everything from scratch. The undone region goes onto a redo stack you can recover with redoLastPaint.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'redoLastPaint',
+    description: 'Reapply the most recently undone paint operation. Use after an over-eager undoLastPaint.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'removeRegion',
+    description: 'Remove ONE color region by id (from listRegions). Use to delete a specific mistake when it is not the most recent paint operation — undoLastPaint is faster for the most recent.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'integer', description: 'Region id from listRegions().' },
+      },
+      required: ['id'],
+    },
+  },
+  {
     name: 'clearColors',
-    description: 'Remove all color regions from the current version. Restores the unlocked, code-only state.',
+    description: 'Remove ALL color regions from the current version. Destructive — only use when you want a completely clean slate. To fix a single mistake, call undoLastPaint or removeRegion(id) instead.',
     input_schema: { type: 'object', properties: {} },
   },
 ];
@@ -238,7 +259,7 @@ const ALWAYS_AVAILABLE = new Set([
 
 const RUN_GATED = new Set(['runCode']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
-const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'clearColors']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
 
 export function buildToolList(toggles: ChatToggles): ToolDefinition[] {
   return ALL_TOOLS.filter(t => {
@@ -318,6 +339,12 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.paintNearestRegion(input);
     case 'findFaces':
       return api.findFaces(input);
+    case 'undoLastPaint':
+      return api.undoLastPaint();
+    case 'redoLastPaint':
+      return api.redoLastPaint();
+    case 'removeRegion':
+      return api.removeRegion(input.id as number);
     case 'clearColors':
       return api.clearColors();
     default:

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -593,18 +593,12 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       const thumbnail = result.thumbnail as string | undefined;
       delete result.thumbnail;
       if (wantImage && typeof thumbnail === 'string') {
-        const match = thumbnail.match(/^data:(image\/[a-z+]+);base64,(.+)$/i);
-        if (match) {
-          const mediaTypeStr = match[1];
-          const safeMedia: ImageSource['mediaType'] =
-            mediaTypeStr === 'image/png' || mediaTypeStr === 'image/jpeg' ||
-            mediaTypeStr === 'image/gif' || mediaTypeStr === 'image/webp'
-              ? mediaTypeStr : 'image/png';
-          const summary = `Preview: ${JSON.stringify(result)}. Candidate triangles are highlighted yellow over the current model.`;
+        const img = parseImageDataUrl(thumbnail);
+        if (img) {
           return {
-            content: summary,
+            content: `Preview: ${JSON.stringify(result)}. Candidate triangles are highlighted yellow over the current model.`,
             isError: false,
-            image: { data: match[2], mediaType: safeMedia, label: 'paintPreview' },
+            image: { ...img, label: 'paintPreview' },
           } satisfies ToolExecResult;
         }
       }

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,0 +1,102 @@
+// Shared types for the in-app AI chat. The wire format mirrors what the
+// Anthropic SDK accepts for `messages.create` so transcripts can round-trip
+// through the API with minimal massaging — but we own this interface so a
+// future provider (OpenAI, Gemini, Ollama) can adapt to it without changing
+// the storage layer.
+
+export type Provider = 'anthropic';
+
+export type ModelId = 'claude-haiku-4-5' | 'claude-sonnet-4-6' | 'claude-opus-4-7';
+
+export type Preset = 'minimal' | 'standard' | 'full' | 'custom';
+
+/** Per-session knobs the user can flip in the toggle strip above the chat
+ *  input. These directly shape the request payload (image blocks, tool list,
+ *  system-prompt suffix). */
+export interface ChatToggles {
+  vision: {
+    /** Send a snapshot of the 4 iso views with each turn. */
+    views: boolean;
+  };
+  scope: {
+    /** Allow the model to call run/runAndSave (+ runIsolated). */
+    runCode: boolean;
+    /** Allow the model to call saveVersion / forkVersion. */
+    saveVersions: boolean;
+    /** Allow the model to call paint helpers. */
+    paintFaces: boolean;
+  };
+  /** Number of times the loop will silently feed an error back to the model
+   *  before surfacing it. 0/1/3. */
+  autoRetry: 0 | 1 | 3;
+  model: ModelId;
+}
+
+/** Persisted per-message record. One row per chat message in IndexedDB. */
+export interface ChatMessage {
+  id: string;
+  /** Session this chat belongs to. `'__global__'` when no session is open. */
+  sessionId: string;
+  role: 'user' | 'assistant';
+  /** Free-form blocks. We store a normalized array so multimodal user turns
+   *  (text + images) and tool-using assistant turns survive a refresh. */
+  blocks: ChatBlock[];
+  /** Tool calls emitted by the model on this turn (assistant only). */
+  toolCalls?: PersistedToolCall[];
+  /** Tool results posted back to the model on this turn (user only —
+   *  the next turn's user message carries the previous turn's results). */
+  toolResults?: PersistedToolResult[];
+  /** Token usage attributed to this turn (assistant only). */
+  usage?: TurnUsage;
+  /** Estimated USD cost for this turn (assistant only). */
+  costUsd?: number;
+  createdAt: number;
+  /** Sequence ordinal — monotonically increases per session. Restored
+   *  ordering uses this rather than createdAt to avoid clock-skew jitter. */
+  seq: number;
+  /** When the message was synthesized by a compaction summary. */
+  compacted?: boolean;
+}
+
+export type ChatBlock =
+  | { type: 'text'; text: string }
+  | { type: 'image'; source: ImageSource };
+
+export interface ImageSource {
+  /** base64-encoded PNG/JPEG bytes (no data: prefix). */
+  data: string;
+  mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+  /** Caller-supplied label shown to the user above the chip (e.g. "iso views"). */
+  label?: string;
+}
+
+export interface PersistedToolCall {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface PersistedToolResult {
+  toolUseId: string;
+  /** Either a JSON-stringified value the executor returned, or the raw error
+   *  message when `isError`. We don't store binary blobs in chat results. */
+  content: string;
+  isError?: boolean;
+}
+
+export interface TurnUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+}
+
+export interface KeyRecord {
+  provider: Provider;
+  apiKey: string;
+  createdAt: number;
+  lastUsed: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+}

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -84,6 +84,10 @@ export interface PersistedToolResult {
    *  message when `isError`. We don't store binary blobs in chat results. */
   content: string;
   isError?: boolean;
+  /** Optional image returned by the tool (e.g. renderView snapshots). Sent
+   *  to the model as a multimodal content block AND rendered inline in the
+   *  panel so the user sees what the agent saw. */
+  image?: ImageSource;
 }
 
 export interface TurnUsage {

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -56,6 +56,8 @@ export interface ChatMessage {
   seq: number;
   /** When the message was synthesized by a compaction summary. */
   compacted?: boolean;
+  /** When the user hit Stop mid-stream and we preserved the partial. */
+  aborted?: boolean;
 }
 
 export type ChatBlock =

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -42,20 +42,46 @@ export interface ChatToggles {
   model: ModelId;
 }
 
-export const ITERATION_CAP: Record<ChatToggles['maxIterations'], number> = {
-  low: 4,
-  medium: 16,
-  high: 64,
-  infinity: Number.POSITIVE_INFINITY,
+/** Source of truth for the iteration-cap dropdown. The toggle pill,
+ *  the agent loop, and the per-turn system suffix all derive from this
+ *  single record — add/rename a tier here and the three call sites
+ *  pick it up automatically. */
+export const MAX_ITERATIONS: Record<ChatToggles['maxIterations'], { value: number; label: string; promptLabel: string; hint: string }> = {
+  low:      { value: 4,  label: 'Low (4)',  promptLabel: '4',         hint: 'Short turns. Useful when the model wanders.' },
+  medium:   { value: 16, label: 'Med (16)', promptLabel: '16',        hint: 'Default. Comfortable for most paint workflows.' },
+  high:     { value: 64, label: 'High (64)', promptLabel: '64',       hint: 'Long autonomous runs. Watch the cost meter.' },
+  infinity: { value: Number.POSITIVE_INFINITY, label: '∞', promptLabel: 'unlimited', hint: 'Unlimited. Only stops on completion / error / your Stop click.' },
 };
 
-export const SPEND_CAP_USD: Record<ChatToggles['maxSpend'], number> = {
-  cheap: 0.10,
-  low: 0.50,
-  medium: 2.00,
-  high: 10.00,
-  infinity: Number.POSITIVE_INFINITY,
+/** Source of truth for the spend-cap dropdown. Same pattern as
+ *  MAX_ITERATIONS. */
+export const MAX_SPEND: Record<ChatToggles['maxSpend'], { value: number; label: string; promptLabel: string; hint: string }> = {
+  cheap:    { value: 0.10,  label: '$0.10', promptLabel: '$0.10',     hint: 'Tight budget. Pairs well with Haiku and short turns.' },
+  low:      { value: 0.50,  label: '$0.50', promptLabel: '$0.50',     hint: 'Safety net for casual iteration.' },
+  medium:   { value: 2.00,  label: '$2',    promptLabel: '$2',        hint: 'Default. Comfortable for most Sonnet turns including a few vision calls.' },
+  high:     { value: 10.00, label: '$10',   promptLabel: '$10',       hint: 'Long autonomous runs on Opus, lots of vision verification.' },
+  infinity: { value: Number.POSITIVE_INFINITY, label: '∞', promptLabel: 'unlimited', hint: 'No budget cap. The model can spend whatever it wants.' },
 };
+
+/** Cap value lookups — derived from MAX_ITERATIONS / MAX_SPEND so the
+ *  numbers can never drift from the dropdown labels. */
+export const ITERATION_CAP: Record<ChatToggles['maxIterations'], number> =
+  Object.fromEntries(Object.entries(MAX_ITERATIONS).map(([k, v]) => [k, v.value])) as Record<ChatToggles['maxIterations'], number>;
+export const SPEND_CAP_USD: Record<ChatToggles['maxSpend'], number> =
+  Object.fromEntries(Object.entries(MAX_SPEND).map(([k, v]) => [k, v.value])) as Record<ChatToggles['maxSpend'], number>;
+
+/** Outcome category the agent loop reports back to the UI. Single
+ *  source of truth — chatLoop produces these, aiPanel renders them. */
+export type TurnOutcomeReason =
+  | 'end_turn'
+  | 'empty_final'
+  | 'iteration_cap'
+  | 'spend_cap'
+  | 'max_tokens'
+  | 'refusal'
+  | 'aborted'
+  | 'error'
+  | 'other';
 
 /** Persisted per-message record. One row per chat message in IndexedDB. */
 export interface ChatMessage {

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -33,6 +33,12 @@ export interface ChatToggles {
    *  turn. The agent stops with a "stopped at cap" banner if it would
    *  exceed this. 'low'=4, 'medium'=16, 'high'=64, 'infinity'=unlimited. */
   maxIterations: 'low' | 'medium' | 'high' | 'infinity';
+  /** Hard cap on USD spend per user turn. Sums input + output + cache
+   *  read/write across every iteration. When exceeded the loop stops
+   *  with a "stopped at spend cap" banner. Both this and maxIterations
+   *  apply — whichever trips first stops the turn. 'infinity' disables
+   *  the cap. */
+  maxSpend: 'cheap' | 'low' | 'medium' | 'high' | 'infinity';
   model: ModelId;
 }
 
@@ -40,6 +46,14 @@ export const ITERATION_CAP: Record<ChatToggles['maxIterations'], number> = {
   low: 4,
   medium: 16,
   high: 64,
+  infinity: Number.POSITIVE_INFINITY,
+};
+
+export const SPEND_CAP_USD: Record<ChatToggles['maxSpend'], number> = {
+  cheap: 0.10,
+  low: 0.50,
+  medium: 2.00,
+  high: 10.00,
   infinity: Number.POSITIVE_INFINITY,
 };
 

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -29,8 +29,19 @@ export interface ChatToggles {
   /** Number of times the loop will silently feed an error back to the model
    *  before surfacing it. 0/1/3. */
   autoRetry: 0 | 1 | 3;
+  /** Maximum number of agent-loop iterations (tool round-trips) per user
+   *  turn. The agent stops with a "stopped at cap" banner if it would
+   *  exceed this. 'low'=4, 'medium'=16, 'high'=64, 'infinity'=unlimited. */
+  maxIterations: 'low' | 'medium' | 'high' | 'infinity';
   model: ModelId;
 }
+
+export const ITERATION_CAP: Record<ChatToggles['maxIterations'], number> = {
+  low: 4,
+  medium: 16,
+  high: 64,
+  infinity: Number.POSITIVE_INFINITY,
+};
 
 /** Persisted per-message record. One row per chat message in IndexedDB. */
 export interface ChatMessage {

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -219,6 +219,37 @@ export function isPainted(triColors: Uint8Array, triIndex: number): boolean {
   return painted ? painted[triIndex] === 1 : (triColors[triIndex * 3] !== 0 || triColors[triIndex * 3 + 1] !== 0 || triColors[triIndex * 3 + 2] !== 0);
 }
 
+/** Allocate an empty (all-zero) triColors buffer with the `_painted`
+ *  sidecar attached. Use this when you need a paintable buffer but the
+ *  current regions list is empty (so `buildTriColors` returned null). */
+export function createEmptyTriColors(numTri: number): Uint8Array {
+  const buf = new Uint8Array(numTri * 3);
+  (buf as Uint8Array & { _painted?: Uint8Array })._painted = new Uint8Array(numTri);
+  return buf;
+}
+
+/** Overlay a color onto specific triangles in a triColors buffer
+ *  (typically one returned by buildTriColors). Keeps the `_painted`
+ *  sidecar in sync. Used by paintPreview / paintExplain to highlight
+ *  a candidate or committed region in bright yellow over the existing
+ *  paint layer. */
+export function overlayPainted(
+  triColors: Uint8Array,
+  indices: Iterable<number>,
+  color: [number, number, number],
+): void {
+  const painted = (triColors as Uint8Array & { _painted?: Uint8Array })._painted;
+  const r = Math.round(color[0] * 255);
+  const g = Math.round(color[1] * 255);
+  const b = Math.round(color[2] * 255);
+  for (const t of indices) {
+    triColors[t * 3] = r;
+    triColors[t * 3 + 1] = g;
+    triColors[t * 3 + 2] = b;
+    if (painted) painted[t] = 1;
+  }
+}
+
 export function serialize(): SerializedColorRegion[] {
   return regions.map(r => ({
     id: r.id,

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,9 @@ import { generateId } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic } from './editor/codeEditor';
 import { createLayout, type TabName } from './ui/layout';
-import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage } from './ui/toolbar';
+import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState } from './ui/toolbar';
+import { initAiPanel, setActiveSession as setAiActiveSession, toggleAiPanel } from './ui/aiPanel';
+import { getKey as getAiKey } from './ai/db';
 import { createLandingPage } from './ui/landing';
 import { createHelpPage } from './ui/help';
 import { showExportOptionsDialog } from './ui/exportOptionsDialog';
@@ -1001,6 +1003,7 @@ async function main() {
     },
     onImportFile: async (file) => { await handleImportFile(file); },
     onImportInboxEntry: handleReimportInboxEntry,
+    onToggleAi: () => { toggleAiPanel(); },
     onLanguageSwitch: async (lang: 'manifold-js' | 'scad') => {
       if (lang === getActiveLanguage()) return;
       // If current session has work, ask before switching
@@ -1537,7 +1540,30 @@ async function main() {
   // Update document title when session state changes (create, open, close, rename)
   onStateChange((state) => {
     updateDocumentTitle({ page: 'editor', sessionName: state.session?.name ?? null });
+    // Re-bind the AI panel to the current session so chat history follows.
+    void setAiActiveSession(state.session?.id ?? null);
   });
+
+  // Initialize the AI chat side drawer once the editor UI is mounted.
+  // Wraps initAiPanel + setAiToolbarState; tolerated if it fails (e.g.
+  // network blocks /ai.md) — toolbar still shows the Connect button.
+  void (async () => {
+    try {
+      await initAiPanel();
+      const cur = getState();
+      await setAiActiveSession(cur.session?.id ?? null);
+      const key = await getAiKey('anthropic');
+      setAiToolbarState(!!key);
+      // Watch for key changes via a poll-on-focus trigger — cheap, and
+      // matches the chip's update cadence in the AI settings modal.
+      window.addEventListener('focus', async () => {
+        const k = await getAiKey('anthropic');
+        setAiToolbarState(!!k);
+      });
+    } catch (err) {
+      console.warn('AI panel init failed:', err);
+    }
+  })();
 
   // Set initial editor title if we're on the editor page
   if (!showLanding && !showHelpPage && !show404) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3786,12 +3786,63 @@ async function main() {
       }
 
       const summary = computeFaceGroups(currentMeshData, o);
+
+      // Optional bbox filter — agents painting one feature of a complex
+      // model can pass `withinBox` to get only the groups in that region.
+      // Cheap to compute (we already have group bboxes); keeps the per-
+      // group `triangleIds` payload from drowning the response in groups
+      // the agent doesn't care about.
+      let groups = summary.groups;
+      const within = (opts as { withinBox?: { min?: unknown; max?: unknown } } | undefined)?.withinBox;
+      if (within && typeof within === 'object') {
+        const min = within.min as [number, number, number] | undefined;
+        const max = within.max as [number, number, number] | undefined;
+        if (Array.isArray(min) && min.length === 3 && Array.isArray(max) && max.length === 3) {
+          groups = groups.filter(g => bboxesIntersect(g.bbox, { min, max }));
+        }
+      }
+
       return {
-        groups: summary.groups,
+        groups,
         totalTriangles: summary.totalTriangles,
-        groupCount: summary.groups.length,
+        groupCount: groups.length,
         tolerance: summary.tolerance,
+        ...(groups.length < summary.groups.length ? { unfiltered: summary.groups.length } : {}),
       };
+    },
+
+    /** Decompose the current manifold into its boolean-distinct components
+     *  and return per-component metadata: `{index, centroid, boundingBox,
+     *  volume, surfaceArea}`. The killer use case is "paint each feature
+     *  of a unioned model" — for a smiley face built from a head + two
+     *  eyes + a mouth, this returns 4 components with their bboxes, and
+     *  the agent can then call `paintInBox({box: component.boundingBox,
+     *  color})` for each, with no coordinate guessing. */
+    listComponents() {
+      if (!currentManifold) return { error: 'No geometry loaded — run code first.' };
+      try {
+        const parts = currentManifold.decompose();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const components = parts.map((p: any, i: number) => {
+          const bb = getBoundingBox(p);
+          const vol = (() => { try { return p.volume(); } catch { return 0; } })();
+          const sa = (() => { try { return p.surfaceArea(); } catch { return 0; } })();
+          const centroid: [number, number, number] = bb
+            ? [(bb.min[0] + bb.max[0]) / 2, (bb.min[1] + bb.max[1]) / 2, (bb.min[2] + bb.max[2]) / 2]
+            : [0, 0, 0];
+          p.delete();
+          return {
+            index: i,
+            volume: Math.round(vol * 100) / 100,
+            surfaceArea: Math.round(sa * 100) / 100,
+            centroid,
+            boundingBox: bb ?? { min: [0, 0, 0], max: [0, 0, 0] },
+          };
+        });
+        return { count: components.length, components };
+      } catch (err) {
+        return { error: `decompose failed: ${err instanceof Error ? err.message : String(err)}` };
+      }
     },
 
     // === Annotations API ===
@@ -4052,6 +4103,7 @@ async function main() {
         'getMeshSummary':  { signature: 'getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?}?) -- List coplanar face groups with centroid/normal/area/bbox', docs: '/ai.md#color-regions' },
         'listRegions':     { signature: 'listRegions() -- List all color regions with bbox + centroid for each', docs: '/ai.md#color-regions' },
         'clearColors':     { signature: 'clearColors() -- Remove ALL color regions (use undoLastPaint to reverse just one)', docs: '/ai.md#color-regions' },
+        'listComponents':  { signature: 'listComponents() -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- Decompose the manifold into boolean-distinct parts. For "paint each feature" workflows (e.g. unioned head + eyes + mouth).', docs: '/ai.md#color-regions' },
         'removeRegion':    { signature: 'removeRegion(id) -- Remove ONE color region by id from listRegions(). Use this to fix a single mistake without nuking the rest.', docs: '/ai.md#color-regions' },
         'undoLastPaint':   { signature: 'undoLastPaint() -- Undo the most recent paint op. Removed region goes on a redo stack.', docs: '/ai.md#color-regions' },
         'redoLastPaint':   { signature: 'redoLastPaint() -- Reapply the most recently undone paint op.', docs: '/ai.md#color-regions' },
@@ -4128,6 +4180,21 @@ async function main() {
   console.info('Partwright: AI agents should use window.partwright -- start with partwright.help(). window.mainifold remains as a legacy alias. See /llms.txt');
 
   // === Internal functions ===
+
+  /** Axis-aligned bounding-box intersection test. Used by getMeshSummary's
+   *  `withinBox` filter and any other callers that need to scope a query
+   *  region. Inclusive on both ends so a face touching the box boundary
+   *  counts as inside. */
+  function bboxesIntersect(
+    a: { min: [number, number, number]; max: [number, number, number] },
+    b: { min: [number, number, number]; max: [number, number, number] },
+  ): boolean {
+    return (
+      a.max[0] >= b.min[0] && a.min[0] <= b.max[0] &&
+      a.max[1] >= b.min[1] && a.min[1] <= b.max[1] &&
+      a.max[2] >= b.min[2] && a.min[2] <= b.max[2]
+    );
+  }
 
   /** Report bounding box + centroid for a triangle set, walking only the
    *  vertices used by those triangles. Returns `null` when the set is empty. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -1356,6 +1356,16 @@ async function main() {
   }
 
   async function syncRouteFromURL() {
+    // Routing to a non-editor page (landing, catalog, help, 404) drops
+    // the AI chat back to the global bucket. The drawer is a body-level
+    // overlay that follows the user across pages, so without this the
+    // last session's transcript would still be visible after clicking
+    // Home — confusing because no editor / session is loaded to act on
+    // it. /editor's own loader updates the AI session via onStateChange
+    // when a session opens, so we don't need to set it explicitly here.
+    if (shouldShowLanding() || shouldShowHelp() || shouldShowCatalog() || shouldShow404()) {
+      void setAiActiveSession(null);
+    }
     if (shouldShowLanding()) {
       await showLandingPage();
     } else if (shouldShowHelp()) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import './style.css';
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, type Language } from './geometry/engine';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
 import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible } from './renderer/viewport';
-import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, type AttachedImage } from './renderer/multiview';
+import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, RENDER_VIEW_MODES, type AttachedImage, type RenderViewMode } from './renderer/multiview';
 import { generateId } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic } from './editor/codeEditor';
@@ -2069,11 +2069,11 @@ async function main() {
      *  everything else gets [Front, Top, Iso]. `views: 'tri'` forces the
      *  front/top/iso composite regardless of shape; `views: 'all'` is the
      *  classic 4-view iso grid (front/right/top/iso). */
-    async renderViews(options?: { views?: 'auto' | 'tri' | 'all'; size?: number }): Promise<string | null> {
+    async renderViews(options?: { views?: RenderViewMode; size?: number }): Promise<string | null> {
       if (options !== undefined) {
         const o = assertObject(options, 'renderViews(options)')!;
         assertNoUnknownKeys(o, ['views', 'size'], 'renderViews(options)');
-        if (o.views !== undefined) assertEnum(o.views, ['auto', 'tri', 'all'], 'renderViews(options).views');
+        if (o.views !== undefined) assertEnum(o.views, RENDER_VIEW_MODES, 'renderViews(options).views');
         assertNumber(o.size, 'renderViews(options).size', { optional: true, min: 1, integer: true });
       }
       if (!currentMeshData) return null;
@@ -4366,7 +4366,7 @@ async function main() {
    *  - very tall (max(dx, dy) / dz < 0.3) → [Front, Right, Iso]:
    *    top view would be a tiny disk, the side elevations matter.
    *  - otherwise the classic [Front, Top, Iso] trio. */
-  function chooseRenderAngles(which: 'auto' | 'tri' | 'all'): { label: string; opts: { elevation: number; azimuth: number; ortho: boolean } }[] {
+  function chooseRenderAngles(which: RenderViewMode): { label: string; opts: { elevation: number; azimuth: number; ortho: boolean } }[] {
     const FRONT = { label: 'Front', opts: { elevation: 0,  azimuth: 0,  ortho: true } };
     const RIGHT = { label: 'Right', opts: { elevation: 0,  azimuth: 90, ortho: true } };
     const TOP   = { label: 'Top',   opts: { elevation: 90, azimuth: 0,  ortho: true } };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3337,15 +3337,21 @@ async function main() {
       normalCone?: { axis: [number, number, number]; angleDeg: number };
       color: [number, number, number];
       name?: string;
+      /** Shortcut: paint only upward-facing triangles inside the box. Same
+       *  as `normalCone: { axis: [0, 0, 1], angleDeg: 30 }` — eliminates
+       *  the common over-paint where the box also catches side walls and
+       *  the bottom face. Ignored when `normalCone` is explicitly set. */
+      topOnly?: boolean;
     }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintInBox requires { box, color }' };
-      const filterErr = validateBoxAndCone(opts.box, opts.normalCone);
+      const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
+      const filterErr = validateBoxAndCone(opts.box, cone);
       if (filterErr) return { error: filterErr };
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
 
-      const triangles = collectTrianglesByFilter(currentMeshData, opts.box, opts.normalCone, null);
-      if (triangles.size === 0) return { error: 'paintInBox: no triangles matched the box (and normalCone, if any). Try widening the box, raising angleDeg, or call findFaces() to see what passes each filter individually.' };
+      const triangles = collectTrianglesByFilter(currentMeshData, opts.box, cone, null);
+      if (triangles.size === 0) return { error: `paintInBox: no triangles matched the box${cone ? ' (with the normalCone' + (opts.topOnly ? '/topOnly' : '') + ' filter)' : ''}. Try widening the box, dropping topOnly/normalCone, or call findFaces() to see what passes each filter individually.` };
 
       return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
     },
@@ -3369,6 +3375,8 @@ async function main() {
       normalCone?: { axis: [number, number, number]; angleDeg: number };
       color: [number, number, number];
       name?: string;
+      /** Shortcut: only upward-facing triangles. See paintInBox.topOnly. */
+      topOnly?: boolean;
     }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintNear requires { point, radius, color }' };
@@ -3377,11 +3385,12 @@ async function main() {
         if (typeof opts.point[i] !== 'number' || !Number.isFinite(opts.point[i])) return { error: 'point components must be finite numbers' };
       }
       if (typeof opts.radius !== 'number' || !Number.isFinite(opts.radius) || opts.radius <= 0) return { error: 'radius must be a positive finite number' };
-      const coneErr = validateNormalCone(opts.normalCone);
+      const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
+      const coneErr = validateNormalCone(cone);
       if (coneErr) return { error: coneErr };
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
 
-      const triangles = collectTrianglesBySphere(currentMeshData, opts.point as [number, number, number], opts.radius, opts.normalCone);
+      const triangles = collectTrianglesBySphere(currentMeshData, opts.point as [number, number, number], opts.radius, cone);
       if (triangles.size === 0) return { error: `paintNear: no triangles within ${opts.radius} of [${opts.point.join(', ')}]. Try a larger radius — call findFaces() with a bigger box first to see what's around.` };
 
       return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
@@ -3816,6 +3825,57 @@ async function main() {
       };
     },
 
+    /** Paint a single boolean-distinct component by index from
+     *  `listComponents()`. Convenience wrapper that runs decompose, pulls
+     *  the component's bounding box, and calls paintInBox in one round
+     *  trip. Use this when you already know "the 3rd unioned part is the
+     *  mouth, paint it red" — saves the listComponents → paintInBox
+     *  two-call dance. */
+    paintComponent(opts: {
+      index: number;
+      color: [number, number, number];
+      name?: string;
+      /** Inherits the same topOnly shortcut as paintInBox. */
+      topOnly?: boolean;
+    }) {
+      if (!opts || typeof opts !== 'object') return { error: 'paintComponent requires { index, color }' };
+      if (!Number.isInteger(opts.index) || opts.index < 0) return { error: 'paintComponent.index must be a non-negative integer (from listComponents)' };
+      if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+      if (!currentManifold) return { error: 'No geometry loaded — run code first.' };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let parts: any[] | null = null;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        parts = currentManifold.decompose() as any[];
+        if (opts.index >= parts.length) {
+          return { error: `paintComponent.index ${opts.index} out of range — listComponents has ${parts.length} component(s).` };
+        }
+        const bb = getBoundingBox(parts[opts.index]);
+        if (!bb) return { error: `Component ${opts.index} has no bounding box (degenerate geometry?).` };
+        // Pad the box slightly so a flat coplanar boundary doesn't miss
+        // triangles whose centroid lies exactly on the edge.
+        const pad = 1e-4;
+        const box = {
+          min: [bb.min[0] - pad, bb.min[1] - pad, bb.min[2] - pad] as [number, number, number],
+          max: [bb.max[0] + pad, bb.max[1] + pad, bb.max[2] + pad] as [number, number, number],
+        };
+        return partwrightAPI.paintInBox({ box, color: opts.color, name: opts.name ?? `Component ${opts.index}`, topOnly: opts.topOnly });
+      } catch (err) {
+        return { error: `paintComponent failed: ${err instanceof Error ? err.message : String(err)}` };
+      } finally {
+        if (parts) for (const p of parts) { try { p.delete(); } catch { /* noop */ } }
+      }
+    },
+
+    /** Token-cheap planning aid for paint workflows: returns just the
+     *  centroid + normal + bbox of each coplanar face group, no triangle
+     *  IDs. Same as `getMeshSummary({maxTrianglesPerGroup: 0, maxGroups})`
+     *  but a one-liner that signals "I'm planning, not painting yet". */
+    getFeatureCentroids(opts?: { maxGroups?: number; withinBox?: { min: [number, number, number]; max: [number, number, number] } }) {
+      const maxGroups = Math.max(1, opts?.maxGroups ?? 32);
+      return partwrightAPI.getMeshSummary({ maxTrianglesPerGroup: 0, maxGroups, ...(opts?.withinBox ? { withinBox: opts.withinBox } : {}) });
+    },
+
     /** Decompose the current manifold into its boolean-distinct components
      *  and return per-component metadata: `{index, centroid, boundingBox,
      *  volume, surfaceArea}`. The killer use case is "paint each feature
@@ -4109,6 +4169,8 @@ async function main() {
         'listRegions':     { signature: 'listRegions() -- List all color regions with bbox + centroid for each', docs: '/ai.md#color-regions' },
         'clearColors':     { signature: 'clearColors() -- Remove ALL color regions (use undoLastPaint to reverse just one)', docs: '/ai.md#color-regions' },
         'listComponents':  { signature: 'listComponents() -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- Decompose the manifold into boolean-distinct parts. For "paint each feature" workflows (e.g. unioned head + eyes + mouth).', docs: '/ai.md#color-regions' },
+        'paintComponent':  { signature: 'paintComponent({index, color, name?, topOnly?}) -- One-call shortcut: listComponents + paintInBox for the Nth piece.', docs: '/ai.md#color-regions' },
+        'getFeatureCentroids': { signature: 'getFeatureCentroids({maxGroups?, withinBox?}?) -- Token-cheap: face-group centroids + normals + bbox, no triangleIds. Use to plan paint targets.', docs: '/ai.md#color-regions' },
         'removeRegion':    { signature: 'removeRegion(id) -- Remove ONE color region by id from listRegions(). Use this to fix a single mistake without nuking the rest.', docs: '/ai.md#color-regions' },
         'undoLastPaint':   { signature: 'undoLastPaint() -- Undo the most recent paint op. Removed region goes on a redo stack.', docs: '/ai.md#color-regions' },
         'redoLastPaint':   { signature: 'redoLastPaint() -- Reapply the most recently undone paint op.', docs: '/ai.md#color-regions' },
@@ -4271,6 +4333,18 @@ async function main() {
 
   /** Validate `{ axis, angleDeg }` shape used by paint cone filters. Returns
    *  an error string or `null`. */
+  /** Resolve the normalCone to use for a paint op. Explicit cone wins;
+   *  `topOnly: true` is sugar for "upward-facing within ~30° of +Z" and
+   *  is the most common case the agent over-paints without. */
+  function resolvePaintCone(
+    explicit: { axis: [number, number, number]; angleDeg: number } | undefined,
+    topOnly: boolean | undefined,
+  ): { axis: [number, number, number]; angleDeg: number } | undefined {
+    if (explicit) return explicit;
+    if (topOnly) return { axis: [0, 0, 1], angleDeg: 30 };
+    return undefined;
+  }
+
   function validateNormalCone(cone: { axis: [number, number, number]; angleDeg: number } | undefined): string | null {
     if (cone === undefined) return null;
     if (typeof cone !== 'object' || cone === null) return 'normalCone must be { axis: [x,y,z], angleDeg: number }';

--- a/src/main.ts
+++ b/src/main.ts
@@ -2059,6 +2059,62 @@ async function main() {
       return renderSingleView(applyTriColorsIfVisible(currentMeshData), options ?? {});
     },
 
+    /** Render multiple angles of the current model laid out in a single
+     *  labeled grid, returned as one PNG data URL. The killer use case
+     *  is "did this paint operation land where I thought" — a single
+     *  top-down view can hide errors that show clearly from the front.
+     *  Default `views: 'tri'` returns front / top / iso (3 cells, 2x2
+     *  grid with one blank); pass `views: 'all'` for the standard 4-view
+     *  iso grid (front / right / top / iso). */
+    async renderViews(options?: { views?: 'tri' | 'all'; size?: number }): Promise<string | null> {
+      if (options !== undefined) {
+        const o = assertObject(options, 'renderViews(options)')!;
+        assertNoUnknownKeys(o, ['views', 'size'], 'renderViews(options)');
+        if (o.views !== undefined) assertEnum(o.views, ['tri', 'all'], 'renderViews(options).views');
+        assertNumber(o.size, 'renderViews(options).size', { optional: true, min: 1, integer: true });
+      }
+      if (!currentMeshData) return null;
+      const which = options?.views ?? 'tri';
+      const tileSize = options?.size ?? 320;
+      const colored = applyTriColorsIfVisible(currentMeshData);
+      const angles: { label: string; opts: { elevation: number; azimuth: number; ortho: boolean } }[] =
+        which === 'tri'
+          ? [
+              { label: 'Front', opts: { elevation: 0,  azimuth: 0,  ortho: true } },
+              { label: 'Top',   opts: { elevation: 90, azimuth: 0,  ortho: true } },
+              { label: 'Iso',   opts: { elevation: 35, azimuth: 45, ortho: false } },
+            ]
+          : [
+              { label: 'Front', opts: { elevation: 0,  azimuth: 0,   ortho: true } },
+              { label: 'Right', opts: { elevation: 0,  azimuth: 90,  ortho: true } },
+              { label: 'Top',   opts: { elevation: 90, azimuth: 0,   ortho: true } },
+              { label: 'Iso',   opts: { elevation: 35, azimuth: 45,  ortho: false } },
+            ];
+
+      const labelHeight = 24;
+      const cellHeight = tileSize + labelHeight;
+      const composite = document.createElement('canvas');
+      composite.width = tileSize * 2;
+      composite.height = cellHeight * 2;
+      const ctx = composite.getContext('2d');
+      if (!ctx) return null;
+      ctx.fillStyle = '#f4f4f5';
+      ctx.fillRect(0, 0, composite.width, composite.height);
+
+      // Render each angle to a data URL via renderSingleView (each call
+      // reuses the same offscreen WebGLRenderer), decode each to an
+      // HTMLImageElement, then stamp into the composite grid.
+      for (let i = 0; i < angles.length; i++) {
+        const { label, opts } = angles[i];
+        const dataUrl = renderSingleView(colored, { ...opts, size: tileSize });
+        if (!dataUrl) continue;
+        const img = await loadImageFromDataUrl(dataUrl);
+        if (!img) continue;
+        drawCell(ctx, img, i, tileSize, cellHeight, label);
+      }
+      return composite.toDataURL('image/png');
+    },
+
     /** Render a cross-section at Z height as an SVG string for visual verification */
     sliceAtZVisual(z: number): { svg: string; area: number; contours: number } | null {
       assertNumber(z, 'sliceAtZVisual(z)');
@@ -4128,6 +4184,7 @@ async function main() {
         'sliceAtZ':        { signature: 'sliceAtZ(z) -- Cross-section at height -> {polygons, svg, area}', docs: '/ai.md#console-api--windowpartwright' },
         'getBoundingBox':  { signature: 'getBoundingBox() -- -> {min, max}', docs: '/ai.md#console-api--windowpartwright' },
         'renderView':      { signature: 'renderView({elevation?, azimuth?, ortho?, size?}) -- Render from any angle -> data URL', docs: '/ai.md#visual-verification' },
+        'renderViews':     { signature: 'await renderViews({views?: "tri"|"all", size?}) -- 3- or 4-angle labeled composite -> data URL. Use for verification when one angle could hide errors.', docs: '/ai.md#visual-verification' },
         'analyzeProfile':  { signature: 'analyzeProfile(sampleCount?) -- Z-profile feature summary', docs: '/ai.md#console-api--windowpartwright' },
         'measureAt':       { signature: 'measureAt([x,y]) -- Ray-cast probe at XY -> {hits, thickness, topZ, bottomZ}', docs: '/ai.md#console-api--windowpartwright' },
         // Viewport controls
@@ -4262,6 +4319,43 @@ async function main() {
    *  `withinBox` filter and any other callers that need to scope a query
    *  region. Inclusive on both ends so a face touching the box boundary
    *  counts as inside. */
+  /** Draw one rendered angle into the renderViews composite grid:
+   *  the rendered tile occupies the top of the cell, with a labelled
+   *  footer band beneath it identifying the angle. */
+  function drawCell(
+    ctx: CanvasRenderingContext2D,
+    src: CanvasImageSource,
+    cellIndex: number,
+    tileSize: number,
+    cellHeight: number,
+    label: string,
+  ): void {
+    const col = cellIndex % 2;
+    const row = Math.floor(cellIndex / 2);
+    const x = col * tileSize;
+    const y = row * cellHeight;
+    ctx.drawImage(src, x, y, tileSize, tileSize);
+    ctx.fillStyle = '#27272a';
+    ctx.fillRect(x, y + tileSize, tileSize, cellHeight - tileSize);
+    ctx.fillStyle = '#f4f4f5';
+    ctx.font = '13px -apple-system, system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(label, x + tileSize / 2, y + tileSize + 16);
+    ctx.textAlign = 'start';
+  }
+
+  /** Decode a data: URL into an HTMLImageElement. Image decoding from a
+   *  data URL is async even when the bytes are local — returning a
+   *  promise here keeps the renderViews caller cleanly awaitable. */
+  function loadImageFromDataUrl(dataUrl: string): Promise<HTMLImageElement | null> {
+    return new Promise(resolve => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => resolve(null);
+      img.src = dataUrl;
+    });
+  }
+
   function bboxesIntersect(
     a: { min: [number, number, number]; max: [number, number, number] },
     b: { min: [number, number, number]; max: [number, number, number] },

--- a/src/main.ts
+++ b/src/main.ts
@@ -3642,11 +3642,7 @@ async function main() {
     /** Clear all color regions */
     clearColors() {
       clearRegions();
-      if (currentMeshData) {
-        updateMesh(currentMeshData, { skipAutoFrame: true });
-        updateMultiView(currentMeshData);
-        renderElevationsToContainer(elevationsContainer, currentMeshData);
-      }
+      scheduleColorRefresh();
       syncLockState();
       return { cleared: true };
     },
@@ -3658,11 +3654,7 @@ async function main() {
       if (!Number.isFinite(id)) return { error: 'removeRegion(id) requires a finite integer id from listRegions()' };
       const ok = removeRegion(id);
       if (!ok) return { error: `No region with id=${id}. Call listRegions() to see current ids.` };
-      if (currentMeshData) {
-        updateMesh(currentMeshData, { skipAutoFrame: true });
-        updateMultiView(currentMeshData);
-        renderElevationsToContainer(elevationsContainer, currentMeshData);
-      }
+      scheduleColorRefresh();
       syncLockState();
       return { removed: true, id };
     },
@@ -3673,11 +3665,7 @@ async function main() {
     undoLastPaint() {
       const region = removeLastRegion();
       if (!region) return { error: 'Nothing to undo — no paint operations on the current version.' };
-      if (currentMeshData) {
-        updateMesh(currentMeshData, { skipAutoFrame: true });
-        updateMultiView(currentMeshData);
-        renderElevationsToContainer(elevationsContainer, currentMeshData);
-      }
+      scheduleColorRefresh();
       syncLockState();
       return {
         undone: true,
@@ -3693,11 +3681,7 @@ async function main() {
     redoLastPaint() {
       const region = redoLastRegion();
       if (!region) return { error: 'Nothing to redo — call undoLastPaint() first.' };
-      if (currentMeshData) {
-        updateMesh(currentMeshData, { skipAutoFrame: true });
-        updateMultiView(currentMeshData);
-        renderElevationsToContainer(elevationsContainer, currentMeshData);
-      }
+      scheduleColorRefresh();
       syncLockState();
       return {
         redone: true,
@@ -4684,13 +4668,30 @@ async function main() {
       { kind: 'triangles', ids: [...triangles] },
       triangles,
     );
-    const colored = applyTriColorsIfVisible(currentMeshData);
-    updateMesh(colored, { skipAutoFrame: true });
-    updateMultiView(colored);
-    renderElevationsToContainer(elevationsContainer, colored);
+    scheduleColorRefresh();
     syncLockState();
     const stats = regionTriangleStats(triangles, currentMeshData);
     return { id: region.id, name: region.name, triangles: triangles.size, bbox: stats.bbox, centroid: stats.centroid };
+  }
+
+  /** Coalesce viewport + multi-view + elevations-strip refreshes triggered
+   *  by paint mutations (commit / undo / redo / removeRegion / clearColors).
+   *  An agent turn that paints N regions in a row otherwise pays the full
+   *  three-renderer cost N times; with rAF batching it pays once at the
+   *  next frame boundary. Each sub-renderer is 50-150ms on complex meshes,
+   *  so this was a primary source of the "page unresponsive" warning. */
+  let paintRefreshPending = false;
+  function scheduleColorRefresh(): void {
+    if (paintRefreshPending) return;
+    paintRefreshPending = true;
+    requestAnimationFrame(() => {
+      paintRefreshPending = false;
+      if (!currentMeshData) return;
+      const colored = applyTriColorsIfVisible(currentMeshData);
+      updateMesh(colored, { skipAutoFrame: true });
+      updateMultiView(colored);
+      renderElevationsToContainer(elevationsContainer, colored);
+    });
   }
 
   function runCode(code?: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ import {
 import { setColor as setAnnotateColor, setWidth as setAnnotateWidth, getWidth as getAnnotateWidth } from './annotations/annotateMode';
 import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontSize as getAnnotateFontSize } from './annotations/textMode';
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
-import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, canRedoRegion, type SerializedColorRegion } from './color/regions';
+import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, type SerializedColorRegion } from './color/regions';
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
 import { buildAdjacency, findCoplanarRegion, resolveSeed, findNearestTriangle } from './color/adjacency';
 import { findSlabTriangles } from './color/slabPaint';
@@ -3477,9 +3477,10 @@ async function main() {
       radius?: number;
       triangleIds?: number[];
       view?: { elevation?: number; azimuth?: number; ortho?: boolean; size?: number };
-      /** Skip the WebGL render and omit `thumbnail` from the result.
-       *  Default `true` (count-only is the cheap sanity check); pass
-       *  `withImage: true` when you want a visual on top of the stats. */
+      /** When `true`, render a yellow-highlighted thumbnail of the
+       *  would-be region and return it in `thumbnail`. Default `false` —
+       *  count-only is the cheap sanity check that should always be
+       *  affordable. */
       withImage?: boolean;
     } = {}) {
       const mesh = currentMeshData;
@@ -3705,11 +3706,6 @@ async function main() {
         color: region.color,
         triangles: region.triangles.size,
       };
-    },
-
-    /** Check whether `redoLastPaint()` would succeed. */
-    canRedoPaint() {
-      return { canRedo: canRedoRegion() };
     },
 
     /** Query triangles on the current mesh by geometric or color filters.
@@ -4263,7 +4259,6 @@ async function main() {
         'removeRegion':    { signature: 'removeRegion(id) -- Remove ONE color region by id from listRegions(). Use this to fix a single mistake without nuking the rest.', docs: '/ai.md#color-regions' },
         'undoLastPaint':   { signature: 'undoLastPaint() -- Undo the most recent paint op. Removed region goes on a redo stack.', docs: '/ai.md#color-regions' },
         'redoLastPaint':   { signature: 'redoLastPaint() -- Reapply the most recently undone paint op.', docs: '/ai.md#color-regions' },
-        'canRedoPaint':    { signature: 'canRedoPaint() -> {canRedo: bool} -- Check if redoLastPaint() would do anything.', docs: '/ai.md#color-regions' },
         // Annotations
         'listAnnotations':    { signature: 'listAnnotations() -- List freehand strokes -> [{id, color, width, points}]', docs: '/ai.md#annotations' },
         'listTextAnnotations':{ signature: 'listTextAnnotations() -- List pinned text labels -> [{id, text, color, fontSizePx, anchor}]', docs: '/ai.md#annotations' },
@@ -4337,10 +4332,6 @@ async function main() {
 
   // === Internal functions ===
 
-  /** Axis-aligned bounding-box intersection test. Used by getMeshSummary's
-   *  `withinBox` filter and any other callers that need to scope a query
-   *  region. Inclusive on both ends so a face touching the box boundary
-   *  counts as inside. */
   /** Draw one rendered angle into the renderViews composite grid:
    *  the rendered tile occupies the top of the cell, with a labelled
    *  footer band beneath it identifying the angle. `cols` controls
@@ -4504,6 +4495,8 @@ async function main() {
     });
   }
 
+  /** Axis-aligned bounding-box intersection test. Inclusive on both ends
+   *  so a face touching the box boundary counts as inside. */
   function bboxesIntersect(
     a: { min: [number, number, number]; max: [number, number, number] },
     b: { min: [number, number, number]; max: [number, number, number] },
@@ -4583,8 +4576,6 @@ async function main() {
     };
   }
 
-  /** Validate `{ axis, angleDeg }` shape used by paint cone filters. Returns
-   *  an error string or `null`. */
   /** Resolve the normalCone to use for a paint op. Explicit cone wins;
    *  `topOnly: true` is sugar for "upward-facing within ~30° of +Z" and
    *  is the most common case the agent over-paints without. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -2063,39 +2063,32 @@ async function main() {
      *  labeled grid, returned as one PNG data URL. The killer use case
      *  is "did this paint operation land where I thought" — a single
      *  top-down view can hide errors that show clearly from the front.
-     *  Default `views: 'tri'` returns front / top / iso (3 cells, 2x2
-     *  grid with one blank); pass `views: 'all'` for the standard 4-view
-     *  iso grid (front / right / top / iso). */
-    async renderViews(options?: { views?: 'tri' | 'all'; size?: number }): Promise<string | null> {
+     *
+     *  `views: 'auto'` (default) picks the angles by bounding-box aspect:
+     *  flat models get [Top, Iso]; tall models get [Front, Right, Iso];
+     *  everything else gets [Front, Top, Iso]. `views: 'tri'` forces the
+     *  front/top/iso composite regardless of shape; `views: 'all'` is the
+     *  classic 4-view iso grid (front/right/top/iso). */
+    async renderViews(options?: { views?: 'auto' | 'tri' | 'all'; size?: number }): Promise<string | null> {
       if (options !== undefined) {
         const o = assertObject(options, 'renderViews(options)')!;
         assertNoUnknownKeys(o, ['views', 'size'], 'renderViews(options)');
-        if (o.views !== undefined) assertEnum(o.views, ['tri', 'all'], 'renderViews(options).views');
+        if (o.views !== undefined) assertEnum(o.views, ['auto', 'tri', 'all'], 'renderViews(options).views');
         assertNumber(o.size, 'renderViews(options).size', { optional: true, min: 1, integer: true });
       }
       if (!currentMeshData) return null;
-      const which = options?.views ?? 'tri';
+      const which = options?.views ?? 'auto';
       const tileSize = options?.size ?? 320;
       const colored = applyTriColorsIfVisible(currentMeshData);
-      const angles: { label: string; opts: { elevation: number; azimuth: number; ortho: boolean } }[] =
-        which === 'tri'
-          ? [
-              { label: 'Front', opts: { elevation: 0,  azimuth: 0,  ortho: true } },
-              { label: 'Top',   opts: { elevation: 90, azimuth: 0,  ortho: true } },
-              { label: 'Iso',   opts: { elevation: 35, azimuth: 45, ortho: false } },
-            ]
-          : [
-              { label: 'Front', opts: { elevation: 0,  azimuth: 0,   ortho: true } },
-              { label: 'Right', opts: { elevation: 0,  azimuth: 90,  ortho: true } },
-              { label: 'Top',   opts: { elevation: 90, azimuth: 0,   ortho: true } },
-              { label: 'Iso',   opts: { elevation: 35, azimuth: 45,  ortho: false } },
-            ];
+      const angles = chooseRenderAngles(which);
 
       const labelHeight = 24;
       const cellHeight = tileSize + labelHeight;
+      const cols = angles.length === 1 ? 1 : 2;
+      const rows = Math.ceil(angles.length / cols);
       const composite = document.createElement('canvas');
-      composite.width = tileSize * 2;
-      composite.height = cellHeight * 2;
+      composite.width = tileSize * cols;
+      composite.height = cellHeight * rows;
       const ctx = composite.getContext('2d');
       if (!ctx) return null;
       ctx.fillStyle = '#f4f4f5';
@@ -2110,7 +2103,7 @@ async function main() {
         if (!dataUrl) continue;
         const img = await loadImageFromDataUrl(dataUrl);
         if (!img) continue;
-        drawCell(ctx, img, i, tileSize, cellHeight, label);
+        drawCell(ctx, img, i, tileSize, cellHeight, label, cols);
       }
       return composite.toDataURL('image/png');
     },
@@ -3484,6 +3477,10 @@ async function main() {
       radius?: number;
       triangleIds?: number[];
       view?: { elevation?: number; azimuth?: number; ortho?: boolean; size?: number };
+      /** Skip the WebGL render and omit `thumbnail` from the result.
+       *  Default `true` (count-only is the cheap sanity check); pass
+       *  `withImage: true` when you want a visual on top of the stats. */
+      withImage?: boolean;
     } = {}) {
       const mesh = currentMeshData;
       if (!mesh) return { error: 'No geometry loaded' };
@@ -3511,37 +3508,61 @@ async function main() {
       }
 
       const stats = regionTriangleStats(triangles, mesh);
-      // Build a temporary mesh with the candidate triangles tinted bright yellow,
-      // overlayed on top of any existing regions.
-      const baseColored = applyTriColors(mesh) ?? mesh;
-      const numTri = mesh.numTri;
-      const triColors = new Uint8Array(numTri * 3);
-      const baseBuf = baseColored.triColors as Uint8Array | undefined;
-      const basePainted = baseBuf ? (baseBuf as Uint8Array & { _painted?: Uint8Array })._painted : undefined;
-      const painted = new Uint8Array(numTri);
-      for (let t = 0; t < numTri; t++) {
-        if (baseBuf && basePainted && basePainted[t]) {
-          triColors[t * 3] = baseBuf[t * 3];
-          triColors[t * 3 + 1] = baseBuf[t * 3 + 1];
-          triColors[t * 3 + 2] = baseBuf[t * 3 + 2];
-          painted[t] = 1;
-        }
-      }
-      // Highlight color: bright yellow-orange, strongly distinct from skin/nail palettes.
-      for (const t of triangles) {
-        triColors[t * 3] = 255;
-        triColors[t * 3 + 1] = 230;
-        triColors[t * 3 + 2] = 0;
-        painted[t] = 1;
-      }
-      (triColors as Uint8Array & { _painted?: Uint8Array })._painted = painted;
-      const previewMesh: MeshData = { ...mesh, triColors };
-      const thumbnail = renderSingleView(previewMesh, opts.view ?? {});
+      const wantImage = opts.withImage === true;
+      const thumbnail = wantImage ? renderRegionHighlight(mesh, triangles, opts.view ?? {}) : undefined;
       return {
-        thumbnail,
+        ...(thumbnail !== undefined ? { thumbnail } : {}),
         triangleCount: triangles.size,
         bbox: stats.bbox,
         centroid: stats.centroid,
+      };
+    },
+
+    /** Diagnose an existing painted region: returns counts, bbox, area,
+     *  a normal-distribution histogram (axis-aligned bins), and a yellow-
+     *  highlighted thumbnail of just the region's triangles overlaid on
+     *  the current model. Use to self-correct after a bad paint without
+     *  the paint → render → undo → repaint cycle.
+     *
+     *  ```
+     *  partwright.paintExplain({ region: 'mouth' })       // by name
+     *  partwright.paintExplain({ region: 17042, withImage: false })  // stats-only
+     *  ``` */
+    paintExplain(opts: {
+      region: number | string;
+      withImage?: boolean;
+      view?: { elevation?: number; azimuth?: number; ortho?: boolean; size?: number };
+    }) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintExplain requires { region }' };
+      if (opts.region === undefined) return { error: 'paintExplain.region (id or name) is required' };
+
+      const regions = getRegions();
+      const region = typeof opts.region === 'number'
+        ? regions.find(r => r.id === opts.region)
+        : regions.find(r => r.name === opts.region);
+      if (!region) {
+        const existing = regions.map(r => `"${r.name}" (id=${r.id})`).join(', ') || '(none)';
+        return { error: `No region matching ${JSON.stringify(opts.region)}. Existing: ${existing}` };
+      }
+
+      const mesh = currentMeshData;
+      const stats = regionTriangleStats(region.triangles, mesh);
+      const { area, normalHistogram } = computeRegionAreaAndNormalHistogram(region.triangles, mesh);
+      const wantImage = opts.withImage !== false; // default true — explain wants visual
+      const thumbnail = wantImage ? renderRegionHighlight(mesh, region.triangles, opts.view ?? {}) : undefined;
+
+      return {
+        id: region.id,
+        name: region.name,
+        color: region.color,
+        source: region.source,
+        triangleCount: region.triangles.size,
+        area: Math.round(area * 1000) / 1000,
+        bbox: stats.bbox,
+        centroid: stats.centroid,
+        normalHistogram,
+        ...(thumbnail !== undefined ? { thumbnail } : {}),
       };
     },
 
@@ -4228,7 +4249,8 @@ async function main() {
         'paintInBox':      { signature: 'paintInBox({box, normalCone?, color, name?}) -- Paint triangles whose centroid is inside an axis-aligned box (and optional normal cone).', docs: '/ai.md#color-regions' },
         'paintFaces':      { signature: 'paintFaces({triangleIds, color, name?}) -- Paint specific triangle indices', docs: '/ai.md#color-regions' },
         'paintSlab':       { signature: 'paintSlab({axis|normal, offset, thickness, color, name?}) -- Paint planar slab range', docs: '/ai.md#color-regions' },
-        'paintPreview':    { signature: 'paintPreview({box?|point+radius?|triangleIds?, normalCone?, view?}) -- Highlight a candidate region without committing -> {thumbnail, triangleCount, bbox, centroid}', docs: '/ai.md#color-regions' },
+        'paintPreview':    { signature: 'paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) -- DRY-RUN -> {triangleCount, bbox, centroid, [thumbnail]}. Default count-only; pass withImage:true for the yellow-highlighted thumbnail.', docs: '/ai.md#color-regions' },
+        'paintExplain':    { signature: 'paintExplain({region, withImage?, view?}) -- Diagnose a committed region -> {triangleCount, area, bbox, centroid, normalHistogram, [thumbnail]}.', docs: '/ai.md#color-regions' },
         'assertPaint':     { signature: 'assertPaint({region, expectedTriangleCount?, expectedBoundingBox?, expectedCentroid?}) -- Verify a previously-painted region -> {passed, failures?}', docs: '/ai.md#color-regions' },
         'findFaces':       { signature: 'findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?}) -- Query triangle ids by geometry/color filters', docs: '/ai.md#color-regions' },
         'getMesh':         { signature: 'getMesh() -- Direct triangle/vertex/normal/centroid access for procedural paint workflows', docs: '/ai.md#color-regions' },
@@ -4321,7 +4343,8 @@ async function main() {
    *  counts as inside. */
   /** Draw one rendered angle into the renderViews composite grid:
    *  the rendered tile occupies the top of the cell, with a labelled
-   *  footer band beneath it identifying the angle. */
+   *  footer band beneath it identifying the angle. `cols` controls
+   *  whether cellIndex wraps after 1 or 2 columns. */
   function drawCell(
     ctx: CanvasRenderingContext2D,
     src: CanvasImageSource,
@@ -4329,9 +4352,10 @@ async function main() {
     tileSize: number,
     cellHeight: number,
     label: string,
+    cols: number,
   ): void {
-    const col = cellIndex % 2;
-    const row = Math.floor(cellIndex / 2);
+    const col = cellIndex % cols;
+    const row = Math.floor(cellIndex / cols);
     const x = col * tileSize;
     const y = row * cellHeight;
     ctx.drawImage(src, x, y, tileSize, tileSize);
@@ -4342,6 +4366,130 @@ async function main() {
     ctx.textAlign = 'center';
     ctx.fillText(label, x + tileSize / 2, y + tileSize + 16);
     ctx.textAlign = 'start';
+  }
+
+  /** Pick the angle set for `renderViews`. `auto` reads the current
+   *  manifold's bounding box and chooses based on aspect ratio:
+   *  - very flat (dz / max(dx, dy) < 0.15) → [Top, Iso]: front view
+   *    would be a thin sliver, top carries the information.
+   *  - very tall (max(dx, dy) / dz < 0.3) → [Front, Right, Iso]:
+   *    top view would be a tiny disk, the side elevations matter.
+   *  - otherwise the classic [Front, Top, Iso] trio. */
+  function chooseRenderAngles(which: 'auto' | 'tri' | 'all'): { label: string; opts: { elevation: number; azimuth: number; ortho: boolean } }[] {
+    const FRONT = { label: 'Front', opts: { elevation: 0,  azimuth: 0,  ortho: true } };
+    const RIGHT = { label: 'Right', opts: { elevation: 0,  azimuth: 90, ortho: true } };
+    const TOP   = { label: 'Top',   opts: { elevation: 90, azimuth: 0,  ortho: true } };
+    const ISO   = { label: 'Iso',   opts: { elevation: 35, azimuth: 45, ortho: false } };
+    if (which === 'tri') return [FRONT, TOP, ISO];
+    if (which === 'all') return [FRONT, RIGHT, TOP, ISO];
+    // 'auto': inspect the current manifold's bounding box.
+    let bb: { min: [number, number, number]; max: [number, number, number] } | null = null;
+    if (currentManifold) {
+      try { bb = getBoundingBox(currentManifold); } catch { bb = null; }
+    }
+    if (!bb) return [FRONT, TOP, ISO];
+    const dx = bb.max[0] - bb.min[0];
+    const dy = bb.max[1] - bb.min[1];
+    const dz = bb.max[2] - bb.min[2];
+    const widest = Math.max(dx, dy);
+    if (widest <= 0 || dz <= 0) return [FRONT, TOP, ISO];
+    const flatness = dz / widest;
+    if (flatness < 0.15) return [TOP, ISO];
+    if (widest / dz < 0.3) return [FRONT, RIGHT, ISO];
+    return [FRONT, TOP, ISO];
+  }
+
+  /** Render the current mesh with `highlightTriangles` tinted bright
+   *  yellow on top of any existing color regions. Shared between
+   *  `paintPreview` (highlight a candidate selector) and `paintExplain`
+   *  (highlight an already-committed region). */
+  function renderRegionHighlight(
+    mesh: MeshData,
+    highlightTriangles: Set<number>,
+    viewOpts: { elevation?: number; azimuth?: number; ortho?: boolean; size?: number },
+  ): string | null {
+    const baseColored = applyTriColors(mesh) ?? mesh;
+    const numTri = mesh.numTri;
+    const triColors = new Uint8Array(numTri * 3);
+    const baseBuf = baseColored.triColors as Uint8Array | undefined;
+    const basePainted = baseBuf ? (baseBuf as Uint8Array & { _painted?: Uint8Array })._painted : undefined;
+    const painted = new Uint8Array(numTri);
+    for (let t = 0; t < numTri; t++) {
+      if (baseBuf && basePainted && basePainted[t]) {
+        triColors[t * 3] = baseBuf[t * 3];
+        triColors[t * 3 + 1] = baseBuf[t * 3 + 1];
+        triColors[t * 3 + 2] = baseBuf[t * 3 + 2];
+        painted[t] = 1;
+      }
+    }
+    // Highlight color: bright yellow-orange, strongly distinct from skin/nail palettes.
+    for (const t of highlightTriangles) {
+      triColors[t * 3] = 255;
+      triColors[t * 3 + 1] = 230;
+      triColors[t * 3 + 2] = 0;
+      painted[t] = 1;
+    }
+    (triColors as Uint8Array & { _painted?: Uint8Array })._painted = painted;
+    const previewMesh: MeshData = { ...mesh, triColors };
+    return renderSingleView(previewMesh, viewOpts);
+  }
+
+  /** For a triangle set, compute total surface area and an area-weighted
+   *  histogram of face normals binned by cardinal axis (within 30°).
+   *  Triangles whose normal is more than 30° off every axis fall into
+   *  `oblique`. All bins normalize to sum ≈ 1. Useful for telling the
+   *  agent "this region is 70% top-facing, 25% wrap-around side" without
+   *  shipping the raw triangle list. */
+  function computeRegionAreaAndNormalHistogram(
+    triangles: Set<number>,
+    mesh: MeshData,
+  ): {
+    area: number;
+    normalHistogram: { xPos: number; xNeg: number; yPos: number; yNeg: number; zPos: number; zNeg: number; oblique: number };
+  } {
+    const adjacency = buildAdjacency(mesh);
+    const cosThresh = Math.cos(30 * Math.PI / 180); // ≈ 0.866
+    const bins = { xPos: 0, xNeg: 0, yPos: 0, yNeg: 0, zPos: 0, zNeg: 0, oblique: 0 };
+    let totalArea = 0;
+    const { triVerts, vertProperties, numProp } = mesh;
+    for (const t of triangles) {
+      const v0 = triVerts[t * 3];
+      const v1 = triVerts[t * 3 + 1];
+      const v2 = triVerts[t * 3 + 2];
+      const ax = vertProperties[v0 * numProp], ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
+      const bx = vertProperties[v1 * numProp], by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
+      const cx = vertProperties[v2 * numProp], cy = vertProperties[v2 * numProp + 1], cz = vertProperties[v2 * numProp + 2];
+      const e1x = bx - ax, e1y = by - ay, e1z = bz - az;
+      const e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
+      const crx = e1y * e2z - e1z * e2y;
+      const cry = e1z * e2x - e1x * e2z;
+      const crz = e1x * e2y - e1y * e2x;
+      const area = 0.5 * Math.sqrt(crx * crx + cry * cry + crz * crz);
+      totalArea += area;
+      const nx = adjacency.normals[t * 3];
+      const ny = adjacency.normals[t * 3 + 1];
+      const nz = adjacency.normals[t * 3 + 2];
+      if (nx > cosThresh) bins.xPos += area;
+      else if (nx < -cosThresh) bins.xNeg += area;
+      else if (ny > cosThresh) bins.yPos += area;
+      else if (ny < -cosThresh) bins.yNeg += area;
+      else if (nz > cosThresh) bins.zPos += area;
+      else if (nz < -cosThresh) bins.zNeg += area;
+      else bins.oblique += area;
+    }
+    if (totalArea > 0) {
+      const norm = (v: number) => Math.round((v / totalArea) * 1000) / 1000;
+      return {
+        area: totalArea,
+        normalHistogram: {
+          xPos: norm(bins.xPos), xNeg: norm(bins.xNeg),
+          yPos: norm(bins.yPos), yNeg: norm(bins.yNeg),
+          zPos: norm(bins.zPos), zNeg: norm(bins.zNeg),
+          oblique: norm(bins.oblique),
+        },
+      };
+    }
+    return { area: 0, normalHistogram: { xPos: 0, xNeg: 0, yPos: 0, yNeg: 0, zPos: 0, zNeg: 0, oblique: 0 } };
   }
 
   /** Decode a data: URL into an HTMLImageElement. Image decoding from a

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import './style.css';
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, type Language } from './geometry/engine';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
 import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible } from './renderer/viewport';
-import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, RENDER_VIEW_MODES, type AttachedImage, type RenderViewMode } from './renderer/multiview';
+import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, RENDER_VIEW_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode } from './renderer/multiview';
 import { generateId } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic } from './editor/codeEditor';
@@ -80,7 +80,7 @@ import {
 import { setColor as setAnnotateColor, setWidth as setAnnotateWidth, getWidth as getAnnotateWidth } from './annotations/annotateMode';
 import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontSize as getAnnotateFontSize } from './annotations/textMode';
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
-import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, type SerializedColorRegion } from './color/regions';
+import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, buildTriColors, createEmptyTriColors, overlayPainted, type SerializedColorRegion } from './color/regions';
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
 import { buildAdjacency, findCoplanarRegion, resolveSeed, findNearestTriangle } from './color/adjacency';
 import { findSlabTriangles } from './color/slabPaint';
@@ -3791,25 +3791,7 @@ async function main() {
 
       const mesh = currentMeshData;
       const adjacency = nrm ? buildAdjacency(mesh) : null;
-      const triColors = colorTarget ? (() => {
-        const numTri = mesh.numTri;
-        return (function() {
-          const buf = new Uint8Array(numTri * 3);
-          for (const r of [...getRegions()].sort((a, b) => a.order - b.order)) {
-            const rr = Math.round(r.color[0] * 255);
-            const gg = Math.round(r.color[1] * 255);
-            const bb = Math.round(r.color[2] * 255);
-            for (const t of r.triangles) {
-              if (t >= 0 && t < numTri) {
-                buf[t * 3] = rr;
-                buf[t * 3 + 1] = gg;
-                buf[t * 3 + 2] = bb;
-              }
-            }
-          }
-          return buf;
-        })();
-      })() : null;
+      const triColors = colorTarget ? (buildTriColors(mesh.numTri) ?? new Uint8Array(mesh.numTri * 3)) : null;
 
       const result: number[] = [];
       let visited = 0;
@@ -4367,10 +4349,14 @@ async function main() {
    *    top view would be a tiny disk, the side elevations matter.
    *  - otherwise the classic [Front, Top, Iso] trio. */
   function chooseRenderAngles(which: RenderViewMode): { label: string; opts: { elevation: number; azimuth: number; ortho: boolean } }[] {
-    const FRONT = { label: 'Front', opts: { elevation: 0,  azimuth: 0,  ortho: true } };
-    const RIGHT = { label: 'Right', opts: { elevation: 0,  azimuth: 90, ortho: true } };
-    const TOP   = { label: 'Top',   opts: { elevation: 90, azimuth: 0,  ortho: true } };
-    const ISO   = { label: 'Iso',   opts: { elevation: 35, azimuth: 45, ortho: false } };
+    const view = (v: typeof STANDARD_VIEWS[keyof typeof STANDARD_VIEWS]) => ({
+      label: v.label,
+      opts: { elevation: v.elevation, azimuth: v.azimuth, ortho: v.ortho },
+    });
+    const FRONT = view(STANDARD_VIEWS.front);
+    const RIGHT = view(STANDARD_VIEWS.right);
+    const TOP   = view(STANDARD_VIEWS.top);
+    const ISO   = view(STANDARD_VIEWS.iso);
     if (which === 'tri') return [FRONT, TOP, ISO];
     if (which === 'all') return [FRONT, RIGHT, TOP, ISO];
     // 'auto': inspect the current manifold's bounding box.
@@ -4393,36 +4379,17 @@ async function main() {
   /** Render the current mesh with `highlightTriangles` tinted bright
    *  yellow on top of any existing color regions. Shared between
    *  `paintPreview` (highlight a candidate selector) and `paintExplain`
-   *  (highlight an already-committed region). */
+   *  (highlight an already-committed region). The yellow is intentionally
+   *  off-palette from anything a user would commit, so it reads as
+   *  "in-progress / unsaved" against real paint. */
   function renderRegionHighlight(
     mesh: MeshData,
     highlightTriangles: Set<number>,
     viewOpts: { elevation?: number; azimuth?: number; ortho?: boolean; size?: number },
   ): string | null {
-    const baseColored = applyTriColors(mesh) ?? mesh;
-    const numTri = mesh.numTri;
-    const triColors = new Uint8Array(numTri * 3);
-    const baseBuf = baseColored.triColors as Uint8Array | undefined;
-    const basePainted = baseBuf ? (baseBuf as Uint8Array & { _painted?: Uint8Array })._painted : undefined;
-    const painted = new Uint8Array(numTri);
-    for (let t = 0; t < numTri; t++) {
-      if (baseBuf && basePainted && basePainted[t]) {
-        triColors[t * 3] = baseBuf[t * 3];
-        triColors[t * 3 + 1] = baseBuf[t * 3 + 1];
-        triColors[t * 3 + 2] = baseBuf[t * 3 + 2];
-        painted[t] = 1;
-      }
-    }
-    // Highlight color: bright yellow-orange, strongly distinct from skin/nail palettes.
-    for (const t of highlightTriangles) {
-      triColors[t * 3] = 255;
-      triColors[t * 3 + 1] = 230;
-      triColors[t * 3 + 2] = 0;
-      painted[t] = 1;
-    }
-    (triColors as Uint8Array & { _painted?: Uint8Array })._painted = painted;
-    const previewMesh: MeshData = { ...mesh, triColors };
-    return renderSingleView(previewMesh, viewOpts);
+    const triColors = buildTriColors(mesh.numTri) ?? createEmptyTriColors(mesh.numTri);
+    overlayPainted(triColors, highlightTriangles, [1, 230 / 255, 0]);
+    return renderSingleView({ ...mesh, triColors }, viewOpts);
   }
 
   /** For a triangle set, compute total surface area and an area-weighted

--- a/src/main.ts
+++ b/src/main.ts
@@ -1549,7 +1549,12 @@ async function main() {
   // network blocks /ai.md) — toolbar still shows the Connect button.
   void (async () => {
     try {
-      await initAiPanel();
+      await initAiPanel({
+        onNavigateToEditor: async () => {
+          updateAppHistory('/editor', 'push');
+          await syncRouteFromURL();
+        },
+      });
       const cur = getState();
       await setAiActiveSession(cur.session?.id ?? null);
       const key = await getAiKey('anthropic');

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ import {
 import { setColor as setAnnotateColor, setWidth as setAnnotateWidth, getWidth as getAnnotateWidth } from './annotations/annotateMode';
 import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontSize as getAnnotateFontSize } from './annotations/textMode';
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
-import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, type SerializedColorRegion } from './color/regions';
+import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, canRedoRegion, type SerializedColorRegion } from './color/regions';
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
 import { buildAdjacency, findCoplanarRegion, resolveSeed, findNearestTriangle } from './color/adjacency';
 import { findSlabTriangles } from './color/slabPaint';
@@ -3549,6 +3549,68 @@ async function main() {
       return { cleared: true };
     },
 
+    /** Remove a single color region by id. Reverses one paint operation
+     *  without nuking the rest. Returns `{ removed: true, id }` on success
+     *  or `{ error }` if no region matches. */
+    removeRegion(id: number) {
+      if (!Number.isFinite(id)) return { error: 'removeRegion(id) requires a finite integer id from listRegions()' };
+      const ok = removeRegion(id);
+      if (!ok) return { error: `No region with id=${id}. Call listRegions() to see current ids.` };
+      if (currentMeshData) {
+        updateMesh(currentMeshData, { skipAutoFrame: true });
+        updateMultiView(currentMeshData);
+        renderElevationsToContainer(elevationsContainer, currentMeshData);
+      }
+      syncLockState();
+      return { removed: true, id };
+    },
+
+    /** Undo the most recent paint operation. The removed region goes onto
+     *  a redo stack — `redoLastPaint()` puts it back. Returns the removed
+     *  region's metadata, or `{ error }` if nothing to undo. */
+    undoLastPaint() {
+      const region = removeLastRegion();
+      if (!region) return { error: 'Nothing to undo — no paint operations on the current version.' };
+      if (currentMeshData) {
+        updateMesh(currentMeshData, { skipAutoFrame: true });
+        updateMultiView(currentMeshData);
+        renderElevationsToContainer(elevationsContainer, currentMeshData);
+      }
+      syncLockState();
+      return {
+        undone: true,
+        id: region.id,
+        name: region.name,
+        color: region.color,
+        triangles: region.triangles.size,
+      };
+    },
+
+    /** Redo the most recently undone paint operation. Pairs with
+     *  `undoLastPaint()`. */
+    redoLastPaint() {
+      const region = redoLastRegion();
+      if (!region) return { error: 'Nothing to redo — call undoLastPaint() first.' };
+      if (currentMeshData) {
+        updateMesh(currentMeshData, { skipAutoFrame: true });
+        updateMultiView(currentMeshData);
+        renderElevationsToContainer(elevationsContainer, currentMeshData);
+      }
+      syncLockState();
+      return {
+        redone: true,
+        id: region.id,
+        name: region.name,
+        color: region.color,
+        triangles: region.triangles.size,
+      };
+    },
+
+    /** Check whether `redoLastPaint()` would succeed. */
+    canRedoPaint() {
+      return { canRedo: canRedoRegion() };
+    },
+
     /** Query triangles on the current mesh by geometric or color filters.
      *  Returns `{ triangleIds, count, sampled }` so the result can be passed
      *  directly to `paintFaces({ triangleIds, color })`.
@@ -3989,7 +4051,11 @@ async function main() {
         'getMesh':         { signature: 'getMesh() -- Direct triangle/vertex/normal/centroid access for procedural paint workflows', docs: '/ai.md#color-regions' },
         'getMeshSummary':  { signature: 'getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?}?) -- List coplanar face groups with centroid/normal/area/bbox', docs: '/ai.md#color-regions' },
         'listRegions':     { signature: 'listRegions() -- List all color regions with bbox + centroid for each', docs: '/ai.md#color-regions' },
-        'clearColors':     { signature: 'clearColors() -- Remove all color regions', docs: '/ai.md#color-regions' },
+        'clearColors':     { signature: 'clearColors() -- Remove ALL color regions (use undoLastPaint to reverse just one)', docs: '/ai.md#color-regions' },
+        'removeRegion':    { signature: 'removeRegion(id) -- Remove ONE color region by id from listRegions(). Use this to fix a single mistake without nuking the rest.', docs: '/ai.md#color-regions' },
+        'undoLastPaint':   { signature: 'undoLastPaint() -- Undo the most recent paint op. Removed region goes on a redo stack.', docs: '/ai.md#color-regions' },
+        'redoLastPaint':   { signature: 'redoLastPaint() -- Reapply the most recently undone paint op.', docs: '/ai.md#color-regions' },
+        'canRedoPaint':    { signature: 'canRedoPaint() -> {canRedo: bool} -- Check if redoLastPaint() would do anything.', docs: '/ai.md#color-regions' },
         // Annotations
         'listAnnotations':    { signature: 'listAnnotations() -- List freehand strokes -> [{id, color, width, points}]', docs: '/ai.md#annotations' },
         'listTextAnnotations':{ signature: 'listTextAnnotations() -- List pinned text labels -> [{id, text, color, fontSizePx, anchor}]', docs: '/ai.md#annotations' },

--- a/src/renderer/multiview.ts
+++ b/src/renderer/multiview.ts
@@ -4,6 +4,12 @@ import type { MeshData } from '../geometry/types';
 import { buildStrokesGroup, disposeStrokesGroup } from '../annotations/annotationOverlay';
 import { presetIndex } from '../storage/db';
 
+/** Composite-render angle sets accepted by `partwright.renderViews`.
+ *  Single source of truth shared by the API surface (main.ts), the AI
+ *  tool schema (src/ai/tools.ts), and the per-turn system prompt. */
+export const RENDER_VIEW_MODES = ['auto', 'tri', 'all'] as const;
+export type RenderViewMode = typeof RENDER_VIEW_MODES[number];
+
 interface ViewConfig {
   name: string;
   position: (d: number) => [number, number, number];

--- a/src/renderer/multiview.ts
+++ b/src/renderer/multiview.ts
@@ -10,6 +10,19 @@ import { presetIndex } from '../storage/db';
 export const RENDER_VIEW_MODES = ['auto', 'tri', 'all'] as const;
 export type RenderViewMode = typeof RENDER_VIEW_MODES[number];
 
+/** Standard camera angles used by `renderSingleView` consumers across
+ *  the app: the renderViews composite, the Show-AI iso-views capture,
+ *  and any future thumbnail caller. Each value is exactly the shape
+ *  `renderSingleView` accepts. Single source so the Front-elevation
+ *  semantics can't drift between callers. */
+export const STANDARD_VIEWS = {
+  front: { label: 'Front', elevation: 0,  azimuth: 0,   ortho: true  },
+  right: { label: 'Right', elevation: 0,  azimuth: 90,  ortho: true  },
+  top:   { label: 'Top',   elevation: 90, azimuth: 0,   ortho: true  },
+  iso:   { label: 'Iso',   elevation: 35, azimuth: 45,  ortho: false },
+} as const;
+export type StandardViewAngle = typeof STANDARD_VIEWS[keyof typeof STANDARD_VIEWS];
+
 interface ViewConfig {
   name: string;
   position: (d: number) => [number, number, number];

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -68,7 +68,13 @@ export interface SessionNote {
 const DB_NAME = 'partwright';
 const LEGACY_DB_NAME = 'mainifold';
 const LEGACY_MIGRATION_KEY = 'partwright-migrated-mainifold-db';
-const DB_VERSION = 2;
+const DB_VERSION = 3;
+
+/** Opens the partwright IndexedDB. Exposed so the AI subsystem can attach
+ *  its own stores (`aiKeys`, `aiChats`) without duplicating the connection. */
+export function openPartwrightDB(): Promise<IDBDatabase> {
+  return openDB();
+}
 
 let dbPromise: Promise<IDBDatabase> | null = null;
 
@@ -88,6 +94,16 @@ function openDB(): Promise<IDBDatabase> {
       }
       if (!db.objectStoreNames.contains('notes')) {
         const store = db.createObjectStore('notes', { keyPath: 'id' });
+        store.createIndex('sessionId', 'sessionId', { unique: false });
+      }
+      // Bumped to v3 with stores backing the in-app AI chat — one row per
+      // provider in `aiKeys`, one row per chat message in `aiChats` indexed
+      // by sessionId so opening a session restores its transcript.
+      if (!db.objectStoreNames.contains('aiKeys')) {
+        db.createObjectStore('aiKeys', { keyPath: 'provider' });
+      }
+      if (!db.objectStoreNames.contains('aiChats')) {
+        const store = db.createObjectStore('aiChats', { keyPath: 'id' });
         store.createIndex('sessionId', 'sessionId', { unique: false });
       }
     };

--- a/src/ui/aiCompactModal.ts
+++ b/src/ui/aiCompactModal.ts
@@ -1,0 +1,145 @@
+// Confirm-before-compact modal. Shows the proposed summary, the proposed
+// session notes (each editable / dismissable), the count of turns to drop
+// vs keep, and the cost of the compaction call itself.
+
+import { formatUsd } from '../ai/cost';
+import type { CompactionProposal } from '../ai/compaction';
+
+let modalEl: HTMLElement | null = null;
+
+export interface CompactConfirm {
+  /** The summary text the user accepted (may be edited from the proposal). */
+  summary: string;
+  /** Notes the user kept and wants written to the session log. */
+  notes: string[];
+}
+
+export function showCompactConfirmModal(
+  proposal: CompactionProposal,
+  onConfirm: (result: CompactConfirm) => void,
+): void {
+  closeModal();
+
+  const overlay = document.createElement('div');
+  overlay.className = 'fixed inset-0 bg-black/60 flex items-center justify-center z-50';
+  overlay.addEventListener('click', e => { if (e.target === overlay) closeModal(); });
+
+  const modal = document.createElement('div');
+  modal.className = 'bg-zinc-800 rounded-xl shadow-2xl border border-zinc-700 w-full max-w-2xl max-h-[80vh] flex flex-col';
+
+  const header = document.createElement('div');
+  header.className = 'px-5 py-3 border-b border-zinc-700 flex items-center justify-between';
+  const title = document.createElement('h2');
+  title.className = 'text-sm font-semibold text-zinc-100';
+  title.textContent = 'Compact conversation';
+  header.appendChild(title);
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
+  closeBtn.textContent = '✕';
+  closeBtn.addEventListener('click', closeModal);
+  header.appendChild(closeBtn);
+  modal.appendChild(header);
+
+  const body = document.createElement('div');
+  body.className = 'px-5 py-4 flex flex-col gap-4 overflow-auto text-sm text-zinc-200';
+
+  const stats = document.createElement('div');
+  stats.className = 'flex gap-4 text-xs text-zinc-400';
+  const dropEl = document.createElement('span');
+  dropEl.innerHTML = `<span class="text-zinc-200 font-medium">${proposal.drop.length}</span> turns dropped`;
+  const keepEl = document.createElement('span');
+  keepEl.innerHTML = `<span class="text-zinc-200 font-medium">${proposal.keep.length}</span> turns kept verbatim`;
+  const costEl = document.createElement('span');
+  costEl.innerHTML = `compaction cost: <span class="text-zinc-200 font-medium">${formatUsd(proposal.costUsd)}</span>`;
+  stats.appendChild(dropEl);
+  stats.appendChild(keepEl);
+  stats.appendChild(costEl);
+  body.appendChild(stats);
+
+  const summaryHeader = document.createElement('h3');
+  summaryHeader.className = 'text-xs uppercase tracking-wider text-zinc-500 font-semibold';
+  summaryHeader.textContent = 'Summary';
+  body.appendChild(summaryHeader);
+
+  const summaryArea = document.createElement('textarea');
+  summaryArea.className = 'w-full min-h-[120px] px-3 py-2 rounded bg-zinc-900 border border-zinc-600 text-zinc-100 text-xs leading-relaxed font-mono resize-y';
+  summaryArea.value = proposal.summary;
+  body.appendChild(summaryArea);
+
+  const notesHeader = document.createElement('h3');
+  notesHeader.className = 'text-xs uppercase tracking-wider text-zinc-500 font-semibold mt-2';
+  notesHeader.textContent = `Session notes to add (${proposal.proposedNotes.length})`;
+  body.appendChild(notesHeader);
+
+  const notesIntro = document.createElement('p');
+  notesIntro.className = 'text-xs text-zinc-500 leading-snug';
+  notesIntro.textContent = 'These get appended to the session log so they survive future compactions and are visible to future agents. Uncheck any you do not want to keep, or edit the text in place.';
+  body.appendChild(notesIntro);
+
+  const notesContainer = document.createElement('div');
+  notesContainer.className = 'flex flex-col gap-1';
+  const noteRows: { include: HTMLInputElement; text: HTMLInputElement }[] = [];
+  for (const note of proposal.proposedNotes) {
+    const row = document.createElement('div');
+    row.className = 'flex items-center gap-2';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = true;
+    cb.className = 'shrink-0 accent-blue-500';
+    const txt = document.createElement('input');
+    txt.type = 'text';
+    txt.value = note;
+    txt.className = 'flex-1 px-2 py-1 rounded bg-zinc-900 border border-zinc-600 text-zinc-100 text-xs font-mono';
+    row.appendChild(cb);
+    row.appendChild(txt);
+    notesContainer.appendChild(row);
+    noteRows.push({ include: cb, text: txt });
+  }
+  if (proposal.proposedNotes.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'text-xs text-zinc-500';
+    empty.textContent = 'No notes proposed — the summary is enough.';
+    notesContainer.appendChild(empty);
+  }
+  body.appendChild(notesContainer);
+
+  modal.appendChild(body);
+
+  const footer = document.createElement('div');
+  footer.className = 'px-5 py-3 border-t border-zinc-700 flex items-center justify-end gap-2';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'px-3 py-1.5 rounded text-xs text-zinc-300 hover:bg-zinc-700';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', closeModal);
+  footer.appendChild(cancelBtn);
+  const confirmBtn = document.createElement('button');
+  confirmBtn.className = 'px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white';
+  confirmBtn.textContent = 'Compact';
+  confirmBtn.addEventListener('click', () => {
+    const notes = noteRows
+      .filter(r => r.include.checked)
+      .map(r => r.text.value.trim())
+      .filter(n => n.length > 0);
+    closeModal();
+    onConfirm({ summary: summaryArea.value.trim(), notes });
+  });
+  footer.appendChild(confirmBtn);
+  modal.appendChild(footer);
+
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+  modalEl = overlay;
+
+  const escHandler = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      closeModal();
+      document.removeEventListener('keydown', escHandler);
+    }
+  };
+  document.addEventListener('keydown', escHandler);
+}
+
+function closeModal(): void {
+  modalEl?.remove();
+  modalEl = null;
+}

--- a/src/ui/aiCompactModal.ts
+++ b/src/ui/aiCompactModal.ts
@@ -4,8 +4,7 @@
 
 import { formatUsd } from '../ai/cost';
 import type { CompactionProposal } from '../ai/compaction';
-
-let modalEl: HTMLElement | null = null;
+import { createModalShell } from './modalShell';
 
 export interface CompactConfirm {
   /** The summary text the user accepted (may be edited from the proposal). */
@@ -18,30 +17,10 @@ export function showCompactConfirmModal(
   proposal: CompactionProposal,
   onConfirm: (result: CompactConfirm) => void,
 ): void {
-  closeModal();
-
-  const overlay = document.createElement('div');
-  overlay.className = 'fixed inset-0 bg-black/60 flex items-center justify-center z-50';
-  overlay.addEventListener('click', e => { if (e.target === overlay) closeModal(); });
-
-  const modal = document.createElement('div');
-  modal.className = 'bg-zinc-800 rounded-xl shadow-2xl border border-zinc-700 w-full max-w-2xl max-h-[80vh] flex flex-col';
-
-  const header = document.createElement('div');
-  header.className = 'px-5 py-3 border-b border-zinc-700 flex items-center justify-between';
-  const title = document.createElement('h2');
-  title.className = 'text-sm font-semibold text-zinc-100';
-  title.textContent = 'Compact conversation';
-  header.appendChild(title);
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
-  closeBtn.textContent = '✕';
-  closeBtn.addEventListener('click', closeModal);
-  header.appendChild(closeBtn);
-  modal.appendChild(header);
-
-  const body = document.createElement('div');
-  body.className = 'px-5 py-4 flex flex-col gap-4 overflow-auto text-sm text-zinc-200';
+  const shell = createModalShell({ title: 'Compact conversation', maxWidth: '2xl', scrollable: true });
+  // The compaction modal uses a slightly larger gap than the default.
+  shell.body.classList.remove('gap-3');
+  shell.body.classList.add('gap-4');
 
   const stats = document.createElement('div');
   stats.className = 'flex gap-4 text-xs text-zinc-400';
@@ -54,27 +33,27 @@ export function showCompactConfirmModal(
   stats.appendChild(dropEl);
   stats.appendChild(keepEl);
   stats.appendChild(costEl);
-  body.appendChild(stats);
+  shell.body.appendChild(stats);
 
   const summaryHeader = document.createElement('h3');
   summaryHeader.className = 'text-xs uppercase tracking-wider text-zinc-500 font-semibold';
   summaryHeader.textContent = 'Summary';
-  body.appendChild(summaryHeader);
+  shell.body.appendChild(summaryHeader);
 
   const summaryArea = document.createElement('textarea');
   summaryArea.className = 'w-full min-h-[120px] px-3 py-2 rounded bg-zinc-900 border border-zinc-600 text-zinc-100 text-xs leading-relaxed font-mono resize-y';
   summaryArea.value = proposal.summary;
-  body.appendChild(summaryArea);
+  shell.body.appendChild(summaryArea);
 
   const notesHeader = document.createElement('h3');
   notesHeader.className = 'text-xs uppercase tracking-wider text-zinc-500 font-semibold mt-2';
   notesHeader.textContent = `Session notes to add (${proposal.proposedNotes.length})`;
-  body.appendChild(notesHeader);
+  shell.body.appendChild(notesHeader);
 
   const notesIntro = document.createElement('p');
   notesIntro.className = 'text-xs text-zinc-500 leading-snug';
   notesIntro.textContent = 'These get appended to the session log so they survive future compactions and are visible to future agents. Uncheck any you do not want to keep, or edit the text in place.';
-  body.appendChild(notesIntro);
+  shell.body.appendChild(notesIntro);
 
   const notesContainer = document.createElement('div');
   notesContainer.className = 'flex flex-col gap-1';
@@ -101,17 +80,14 @@ export function showCompactConfirmModal(
     empty.textContent = 'No notes proposed — the summary is enough.';
     notesContainer.appendChild(empty);
   }
-  body.appendChild(notesContainer);
+  shell.body.appendChild(notesContainer);
 
-  modal.appendChild(body);
-
-  const footer = document.createElement('div');
-  footer.className = 'px-5 py-3 border-t border-zinc-700 flex items-center justify-end gap-2';
   const cancelBtn = document.createElement('button');
   cancelBtn.className = 'px-3 py-1.5 rounded text-xs text-zinc-300 hover:bg-zinc-700';
   cancelBtn.textContent = 'Cancel';
-  cancelBtn.addEventListener('click', closeModal);
-  footer.appendChild(cancelBtn);
+  cancelBtn.addEventListener('click', shell.close);
+  shell.footer.appendChild(cancelBtn);
+
   const confirmBtn = document.createElement('button');
   confirmBtn.className = 'px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white';
   confirmBtn.textContent = 'Compact';
@@ -120,26 +96,8 @@ export function showCompactConfirmModal(
       .filter(r => r.include.checked)
       .map(r => r.text.value.trim())
       .filter(n => n.length > 0);
-    closeModal();
+    shell.close();
     onConfirm({ summary: summaryArea.value.trim(), notes });
   });
-  footer.appendChild(confirmBtn);
-  modal.appendChild(footer);
-
-  overlay.appendChild(modal);
-  document.body.appendChild(overlay);
-  modalEl = overlay;
-
-  const escHandler = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      closeModal();
-      document.removeEventListener('keydown', escHandler);
-    }
-  };
-  document.addEventListener('keydown', escHandler);
-}
-
-function closeModal(): void {
-  modalEl?.remove();
-  modalEl = null;
+  shell.footer.appendChild(confirmBtn);
 }

--- a/src/ui/aiKeyModal.ts
+++ b/src/ui/aiKeyModal.ts
@@ -1,0 +1,164 @@
+// First-run modal: collect the user's Anthropic API key, validate it,
+// persist it to IndexedDB. Closes on success; reopens on error with the
+// reason inline.
+
+import { putKey, getKey } from '../ai/db';
+import { resetClient, validateKey } from '../ai/anthropic';
+
+let modalEl: HTMLElement | null = null;
+
+export interface AiKeyModalCallbacks {
+  onConnected: () => void;
+}
+
+export async function showAiKeyModal(cb: AiKeyModalCallbacks): Promise<void> {
+  closeModal();
+
+  const overlay = document.createElement('div');
+  overlay.className = 'fixed inset-0 bg-black/60 flex items-center justify-center z-50';
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay) closeModal();
+  });
+
+  const modal = document.createElement('div');
+  modal.className = 'bg-zinc-800 rounded-xl shadow-2xl border border-zinc-700 w-full max-w-md flex flex-col';
+
+  const header = document.createElement('div');
+  header.className = 'px-5 py-3 border-b border-zinc-700 flex items-center justify-between';
+  const title = document.createElement('h2');
+  title.className = 'text-sm font-semibold text-zinc-100';
+  title.textContent = 'Connect Anthropic API';
+  header.appendChild(title);
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
+  closeBtn.textContent = '✕';
+  closeBtn.addEventListener('click', closeModal);
+  header.appendChild(closeBtn);
+  modal.appendChild(header);
+
+  const body = document.createElement('div');
+  body.className = 'px-5 py-4 flex flex-col gap-3 text-sm text-zinc-200';
+
+  const intro = document.createElement('p');
+  intro.className = 'text-zinc-300 leading-snug';
+  intro.textContent = 'Partwright AI uses your Anthropic API key. The key is stored only in this browser — not on any Partwright server.';
+  body.appendChild(intro);
+
+  const link = document.createElement('a');
+  link.href = 'https://console.anthropic.com/settings/keys';
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  link.className = 'text-blue-400 hover:text-blue-300 underline text-xs';
+  link.textContent = 'Get a key at console.anthropic.com →';
+  body.appendChild(link);
+
+  const tipBox = document.createElement('div');
+  tipBox.className = 'rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 leading-snug';
+  tipBox.innerHTML = '<strong>Recommended:</strong> use a workspace-scoped key with a monthly spend cap. Anyone who can run code in this page (extensions, devtools) can read the key.';
+  body.appendChild(tipBox);
+
+  const label = document.createElement('label');
+  label.className = 'flex flex-col gap-1';
+  const labelText = document.createElement('span');
+  labelText.className = 'text-xs text-zinc-400';
+  labelText.textContent = 'API key';
+  label.appendChild(labelText);
+
+  const input = document.createElement('input');
+  input.type = 'password';
+  input.placeholder = 'sk-ant-...';
+  input.className = 'w-full px-3 py-2 rounded bg-zinc-900 border border-zinc-600 text-zinc-100 text-sm font-mono placeholder:text-zinc-600 focus:outline-none focus:border-blue-500';
+  input.spellcheck = false;
+  input.autocomplete = 'off';
+  label.appendChild(input);
+  body.appendChild(label);
+
+  const errorBox = document.createElement('div');
+  errorBox.className = 'text-xs text-red-400 hidden';
+  body.appendChild(errorBox);
+
+  const status = document.createElement('div');
+  status.className = 'text-xs text-zinc-500 hidden';
+  body.appendChild(status);
+
+  modal.appendChild(body);
+
+  const footer = document.createElement('div');
+  footer.className = 'px-5 py-3 border-t border-zinc-700 flex items-center justify-end gap-2';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'px-3 py-1.5 rounded text-xs text-zinc-300 hover:bg-zinc-700';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', closeModal);
+  footer.appendChild(cancelBtn);
+
+  const connectBtn = document.createElement('button');
+  connectBtn.className = 'px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed';
+  connectBtn.textContent = 'Connect';
+  footer.appendChild(connectBtn);
+  modal.appendChild(footer);
+
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+  modalEl = overlay;
+
+  setTimeout(() => input.focus(), 0);
+
+  async function attemptConnect() {
+    const key = input.value.trim();
+    if (key.length < 10) {
+      showError('That key looks too short.');
+      return;
+    }
+    connectBtn.disabled = true;
+    connectBtn.textContent = 'Validating...';
+    status.classList.remove('hidden');
+    status.textContent = 'Sending a 1-token test request to verify the key...';
+    errorBox.classList.add('hidden');
+
+    const error = await validateKey(key);
+    if (error) {
+      showError(error);
+      connectBtn.disabled = false;
+      connectBtn.textContent = 'Connect';
+      status.classList.add('hidden');
+      return;
+    }
+
+    const existing = await getKey('anthropic');
+    await putKey({
+      provider: 'anthropic',
+      apiKey: key,
+      createdAt: existing?.createdAt ?? Date.now(),
+      lastUsed: Date.now(),
+      totalInputTokens: existing?.totalInputTokens ?? 0,
+      totalOutputTokens: existing?.totalOutputTokens ?? 0,
+      totalCostUsd: existing?.totalCostUsd ?? 0,
+    });
+    resetClient();
+    closeModal();
+    cb.onConnected();
+  }
+
+  function showError(msg: string) {
+    errorBox.textContent = msg;
+    errorBox.classList.remove('hidden');
+  }
+
+  connectBtn.addEventListener('click', () => { void attemptConnect(); });
+  input.addEventListener('keydown', e => {
+    if (e.key === 'Enter') { e.preventDefault(); void attemptConnect(); }
+  });
+
+  const escHandler = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      closeModal();
+      document.removeEventListener('keydown', escHandler);
+    }
+  };
+  document.addEventListener('keydown', escHandler);
+}
+
+function closeModal(): void {
+  modalEl?.remove();
+  modalEl = null;
+}

--- a/src/ui/aiKeyModal.ts
+++ b/src/ui/aiKeyModal.ts
@@ -4,45 +4,19 @@
 
 import { putKey, getKey } from '../ai/db';
 import { resetClient, validateKey } from '../ai/anthropic';
-
-let modalEl: HTMLElement | null = null;
+import { createModalShell } from './modalShell';
 
 export interface AiKeyModalCallbacks {
   onConnected: () => void;
 }
 
 export async function showAiKeyModal(cb: AiKeyModalCallbacks): Promise<void> {
-  closeModal();
-
-  const overlay = document.createElement('div');
-  overlay.className = 'fixed inset-0 bg-black/60 flex items-center justify-center z-50';
-  overlay.addEventListener('click', e => {
-    if (e.target === overlay) closeModal();
-  });
-
-  const modal = document.createElement('div');
-  modal.className = 'bg-zinc-800 rounded-xl shadow-2xl border border-zinc-700 w-full max-w-md flex flex-col';
-
-  const header = document.createElement('div');
-  header.className = 'px-5 py-3 border-b border-zinc-700 flex items-center justify-between';
-  const title = document.createElement('h2');
-  title.className = 'text-sm font-semibold text-zinc-100';
-  title.textContent = 'Connect Anthropic API';
-  header.appendChild(title);
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
-  closeBtn.textContent = '✕';
-  closeBtn.addEventListener('click', closeModal);
-  header.appendChild(closeBtn);
-  modal.appendChild(header);
-
-  const body = document.createElement('div');
-  body.className = 'px-5 py-4 flex flex-col gap-3 text-sm text-zinc-200';
+  const shell = createModalShell({ title: 'Connect Anthropic API' });
 
   const intro = document.createElement('p');
   intro.className = 'text-zinc-300 leading-snug';
   intro.textContent = 'Partwright AI uses your Anthropic API key. The key is stored only in this browser — not on any Partwright server.';
-  body.appendChild(intro);
+  shell.body.appendChild(intro);
 
   const link = document.createElement('a');
   link.href = 'https://console.anthropic.com/settings/keys';
@@ -50,12 +24,12 @@ export async function showAiKeyModal(cb: AiKeyModalCallbacks): Promise<void> {
   link.rel = 'noopener noreferrer';
   link.className = 'text-blue-400 hover:text-blue-300 underline text-xs';
   link.textContent = 'Get a key at console.anthropic.com →';
-  body.appendChild(link);
+  shell.body.appendChild(link);
 
   const tipBox = document.createElement('div');
   tipBox.className = 'rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 leading-snug';
   tipBox.innerHTML = '<strong>Recommended:</strong> use a workspace-scoped key with a monthly spend cap. Anyone who can run code in this page (extensions, devtools) can read the key.';
-  body.appendChild(tipBox);
+  shell.body.appendChild(tipBox);
 
   const label = document.createElement('label');
   label.className = 'flex flex-col gap-1';
@@ -71,35 +45,26 @@ export async function showAiKeyModal(cb: AiKeyModalCallbacks): Promise<void> {
   input.spellcheck = false;
   input.autocomplete = 'off';
   label.appendChild(input);
-  body.appendChild(label);
+  shell.body.appendChild(label);
 
   const errorBox = document.createElement('div');
   errorBox.className = 'text-xs text-red-400 hidden';
-  body.appendChild(errorBox);
+  shell.body.appendChild(errorBox);
 
   const status = document.createElement('div');
   status.className = 'text-xs text-zinc-500 hidden';
-  body.appendChild(status);
+  shell.body.appendChild(status);
 
-  modal.appendChild(body);
-
-  const footer = document.createElement('div');
-  footer.className = 'px-5 py-3 border-t border-zinc-700 flex items-center justify-end gap-2';
   const cancelBtn = document.createElement('button');
   cancelBtn.className = 'px-3 py-1.5 rounded text-xs text-zinc-300 hover:bg-zinc-700';
   cancelBtn.textContent = 'Cancel';
-  cancelBtn.addEventListener('click', closeModal);
-  footer.appendChild(cancelBtn);
+  cancelBtn.addEventListener('click', shell.close);
+  shell.footer.appendChild(cancelBtn);
 
   const connectBtn = document.createElement('button');
   connectBtn.className = 'px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed';
   connectBtn.textContent = 'Connect';
-  footer.appendChild(connectBtn);
-  modal.appendChild(footer);
-
-  overlay.appendChild(modal);
-  document.body.appendChild(overlay);
-  modalEl = overlay;
+  shell.footer.appendChild(connectBtn);
 
   setTimeout(() => input.focus(), 0);
 
@@ -135,7 +100,7 @@ export async function showAiKeyModal(cb: AiKeyModalCallbacks): Promise<void> {
       totalCostUsd: existing?.totalCostUsd ?? 0,
     });
     resetClient();
-    closeModal();
+    shell.close();
     cb.onConnected();
   }
 
@@ -148,17 +113,4 @@ export async function showAiKeyModal(cb: AiKeyModalCallbacks): Promise<void> {
   input.addEventListener('keydown', e => {
     if (e.key === 'Enter') { e.preventDefault(); void attemptConnect(); }
   });
-
-  const escHandler = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      closeModal();
-      document.removeEventListener('keydown', escHandler);
-    }
-  };
-  document.addEventListener('keydown', escHandler);
-}
-
-function closeModal(): void {
-  modalEl?.remove();
-  modalEl = null;
 }

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1,0 +1,763 @@
+// Right-side floating chat drawer. The single largest UI surface of the AI
+// feature — owns the transcript view, the cost-control toggle strip, the
+// input row, the cost meter, and the compact button. State lives in the
+// ai/* modules; this file is mostly DOM wiring.
+
+import { runTurn, totalCost, totalTokensEstimate, estimateCachedPrefixTokens } from '../ai/chatLoop';
+import { listMessages, GLOBAL_CHAT_BUCKET, putMessages, deleteMessages, getKey } from '../ai/db';
+import { proposeCompaction } from '../ai/compaction';
+import { captureIsoViews, fileToImageSource } from '../ai/images';
+import { loadSettings, saveSettings, applyPreset, setModel, setToggles, MODEL_OPTIONS, PRESET_OPTIONS, type AiSettings } from '../ai/settings';
+import { buildSystemPrompt, loadAiMd } from '../ai/systemPrompt';
+import { estimateTurnCostUsd, formatUsd } from '../ai/cost';
+import { generateId } from '../storage/db';
+import { showAiKeyModal } from './aiKeyModal';
+import { showAiSettingsModal } from './aiSettingsModal';
+import { showCompactConfirmModal } from './aiCompactModal';
+import type { ChatBlock, ChatMessage, ImageSource, ModelId, PersistedToolResult } from '../ai/types';
+
+interface PanelState {
+  open: boolean;
+  sessionId: string;
+  history: ChatMessage[];
+  pendingImages: ImageSource[];
+  systemPromptChars: number;
+  inFlight: boolean;
+}
+
+const state: PanelState = {
+  open: false,
+  sessionId: GLOBAL_CHAT_BUCKET,
+  history: [],
+  pendingImages: [],
+  systemPromptChars: 0,
+  inFlight: false,
+};
+
+let drawerEl: HTMLElement | null = null;
+let transcriptEl: HTMLElement | null = null;
+let inputEl: HTMLTextAreaElement | null = null;
+let pendingImagesEl: HTMLElement | null = null;
+let toggleStripEl: HTMLElement | null = null;
+let costMeterEl: HTMLElement | null = null;
+let panelStatusEl: HTMLElement | null = null;
+
+let onPanelStateChange: ((open: boolean) => void) | null = null;
+
+/** Mount the drawer once on app start. Idempotent. */
+export async function initAiPanel(): Promise<void> {
+  if (drawerEl) return;
+  // Pre-load ai.md so the first turn doesn't pay the fetch latency on top
+  // of the API round trip. Also seeds the systemPromptChars estimate.
+  const aiMd = await loadAiMd();
+  state.systemPromptChars = buildSystemPrompt(aiMd).length;
+
+  const settings = loadSettings();
+  state.open = settings.drawerOpen;
+
+  buildDrawer();
+  // Don't try to load history until a session is opened or we know we're
+  // in the global bucket. main.ts will call setActiveSession when ready.
+  await loadHistoryForCurrentSession();
+  if (state.open) showDrawer();
+  else hideDrawer();
+}
+
+/** Called by main.ts whenever the active session changes (open / close). */
+export async function setActiveSession(sessionId: string | null): Promise<void> {
+  state.sessionId = sessionId ?? GLOBAL_CHAT_BUCKET;
+  await loadHistoryForCurrentSession();
+  renderTranscript();
+  renderCostMeter();
+}
+
+export function toggleAiPanel(): void {
+  if (state.open) hideDrawer();
+  else showDrawer();
+}
+
+export function isAiPanelOpen(): boolean {
+  return state.open;
+}
+
+export function onAiPanelStateChange(fn: (open: boolean) => void): void {
+  onPanelStateChange = fn;
+}
+
+function showDrawer(): void {
+  if (!drawerEl) return;
+  state.open = true;
+  drawerEl.classList.remove('translate-x-full');
+  drawerEl.classList.add('translate-x-0');
+  saveSettings({ ...loadSettings(), drawerOpen: true });
+  onPanelStateChange?.(true);
+  inputEl?.focus();
+}
+
+function hideDrawer(): void {
+  if (!drawerEl) return;
+  state.open = false;
+  drawerEl.classList.remove('translate-x-0');
+  drawerEl.classList.add('translate-x-full');
+  saveSettings({ ...loadSettings(), drawerOpen: false });
+  onPanelStateChange?.(false);
+}
+
+async function loadHistoryForCurrentSession(): Promise<void> {
+  state.history = await listMessages(state.sessionId);
+}
+
+// === DOM construction ===
+
+function buildDrawer(): void {
+  const root = document.createElement('div');
+  root.id = 'ai-panel';
+  root.className = 'fixed top-0 right-0 h-screen w-[420px] bg-zinc-900 border-l border-zinc-700 shadow-2xl z-40 flex flex-col transition-transform duration-200 translate-x-full';
+  drawerEl = root;
+
+  // Header — title, model picker, preset picker, close
+  const header = document.createElement('div');
+  header.className = 'flex items-center gap-2 px-3 py-2 border-b border-zinc-700 shrink-0';
+
+  const titleEl = document.createElement('div');
+  titleEl.className = 'text-sm font-semibold text-zinc-100 mr-1';
+  titleEl.textContent = 'AI';
+  header.appendChild(titleEl);
+
+  const modelSelect = createModelSelect();
+  header.appendChild(modelSelect);
+
+  const presetSelect = createPresetSelect();
+  header.appendChild(presetSelect);
+
+  const compactBtn = createIconButton('Compact', '⤓ Compact');
+  compactBtn.title = 'Compact the conversation: summarize older turns and promote insights to session notes.';
+  compactBtn.addEventListener('click', () => { void runCompact(); });
+  header.appendChild(compactBtn);
+
+  const settingsBtn = createIconButton('Settings', '⚙');
+  settingsBtn.title = 'AI settings: provider, key, lifetime usage.';
+  settingsBtn.addEventListener('click', () => {
+    void showAiSettingsModal({ onChange: () => { renderTranscript(); renderToggleStrip(); renderCostMeter(); panelStatusUpdate(); } });
+  });
+  header.appendChild(settingsBtn);
+
+  const spacer = document.createElement('div');
+  spacer.className = 'flex-1';
+  header.appendChild(spacer);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 text-sm';
+  closeBtn.textContent = '✕';
+  closeBtn.addEventListener('click', hideDrawer);
+  header.appendChild(closeBtn);
+
+  root.appendChild(header);
+
+  // Status bar — surfaces "no key" / "ready" / errors
+  panelStatusEl = document.createElement('div');
+  panelStatusEl.className = 'px-3 py-1.5 text-[11px] border-b border-zinc-800 hidden';
+  root.appendChild(panelStatusEl);
+
+  // Transcript
+  transcriptEl = document.createElement('div');
+  transcriptEl.className = 'flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-3';
+  root.appendChild(transcriptEl);
+
+  // Toggle strip
+  toggleStripEl = document.createElement('div');
+  toggleStripEl.className = 'px-3 py-1.5 border-t border-zinc-800 flex flex-wrap items-center gap-1.5 shrink-0';
+  root.appendChild(toggleStripEl);
+
+  // Cost meter
+  costMeterEl = document.createElement('div');
+  costMeterEl.className = 'px-3 pb-1.5 text-[10px] text-zinc-500 flex items-center gap-2 shrink-0';
+  root.appendChild(costMeterEl);
+
+  // Pending image attachments row (hidden until something is pending)
+  pendingImagesEl = document.createElement('div');
+  pendingImagesEl.className = 'px-3 pb-1.5 flex flex-wrap gap-1.5 shrink-0 hidden';
+  root.appendChild(pendingImagesEl);
+
+  // Input row
+  const inputRow = document.createElement('div');
+  inputRow.className = 'px-3 py-2 border-t border-zinc-700 flex items-end gap-2 shrink-0';
+
+  const showAiBtn = document.createElement('button');
+  showAiBtn.className = 'shrink-0 px-2 py-1 rounded text-[11px] text-zinc-300 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700';
+  showAiBtn.textContent = '📷 Show AI';
+  showAiBtn.title = 'Snapshot the 4 iso views and attach to your next message.';
+  showAiBtn.addEventListener('click', () => { void attachIsoViews(); });
+  inputRow.appendChild(showAiBtn);
+
+  const fileBtn = document.createElement('button');
+  fileBtn.className = 'shrink-0 px-2 py-1 rounded text-[11px] text-zinc-300 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700';
+  fileBtn.textContent = '📎';
+  fileBtn.title = 'Attach an image from disk.';
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  fileInput.accept = 'image/*';
+  fileInput.multiple = true;
+  fileInput.className = 'hidden';
+  fileInput.addEventListener('change', async () => {
+    if (!fileInput.files) return;
+    for (const file of Array.from(fileInput.files)) await attachFile(file);
+    fileInput.value = '';
+  });
+  fileBtn.addEventListener('click', () => fileInput.click());
+  inputRow.appendChild(fileBtn);
+  inputRow.appendChild(fileInput);
+
+  const ta = document.createElement('textarea');
+  ta.placeholder = 'Ask the AI to model something...';
+  ta.rows = 2;
+  ta.className = 'flex-1 px-2 py-1 rounded bg-zinc-800 border border-zinc-600 text-zinc-100 text-sm placeholder:text-zinc-500 focus:outline-none focus:border-blue-500 resize-none';
+  ta.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void sendMessage();
+    }
+  });
+  ta.addEventListener('paste', e => {
+    if (!e.clipboardData) return;
+    for (const item of Array.from(e.clipboardData.items)) {
+      if (item.kind === 'file') {
+        const file = item.getAsFile();
+        if (file) {
+          e.preventDefault();
+          void attachFile(file);
+        }
+      }
+    }
+  });
+  inputEl = ta;
+  inputRow.appendChild(ta);
+
+  const sendBtn = document.createElement('button');
+  sendBtn.className = 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed';
+  sendBtn.textContent = 'Send';
+  sendBtn.addEventListener('click', () => { void sendMessage(); });
+  inputRow.appendChild(sendBtn);
+
+  root.appendChild(inputRow);
+
+  // Drag-drop image handling
+  root.addEventListener('dragover', e => { e.preventDefault(); root.classList.add('ring-2', 'ring-blue-500'); });
+  root.addEventListener('dragleave', e => { if (e.target === root) root.classList.remove('ring-2', 'ring-blue-500'); });
+  root.addEventListener('drop', async e => {
+    e.preventDefault();
+    root.classList.remove('ring-2', 'ring-blue-500');
+    if (!e.dataTransfer) return;
+    for (const file of Array.from(e.dataTransfer.files)) await attachFile(file);
+  });
+
+  document.body.appendChild(root);
+
+  renderToggleStrip();
+  renderCostMeter();
+  renderTranscript();
+  panelStatusUpdate();
+}
+
+function createIconButton(_label: string, glyph: string): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.className = 'px-2 py-1 rounded text-[11px] text-zinc-300 hover:bg-zinc-800 border border-transparent hover:border-zinc-700';
+  btn.textContent = glyph;
+  return btn;
+}
+
+function createModelSelect(): HTMLSelectElement {
+  const sel = document.createElement('select');
+  sel.className = 'px-2 py-1 rounded text-[11px] bg-zinc-800 border border-zinc-700 text-zinc-200 focus:outline-none';
+  for (const opt of MODEL_OPTIONS) {
+    const o = document.createElement('option');
+    o.value = opt.id;
+    o.textContent = opt.label;
+    sel.appendChild(o);
+  }
+  sel.value = loadSettings().toggles.model;
+  sel.addEventListener('change', () => {
+    saveSettings(setModel(loadSettings(), sel.value as ModelId));
+    renderToggleStrip();
+    renderCostMeter();
+  });
+  return sel;
+}
+
+function createPresetSelect(): HTMLSelectElement {
+  const sel = document.createElement('select');
+  sel.className = 'px-2 py-1 rounded text-[11px] bg-zinc-800 border border-zinc-700 text-zinc-200 focus:outline-none';
+  for (const opt of PRESET_OPTIONS) {
+    const o = document.createElement('option');
+    o.value = opt.id;
+    o.textContent = opt.label;
+    o.title = opt.hint;
+    sel.appendChild(o);
+  }
+  sel.value = loadSettings().preset;
+  sel.addEventListener('change', () => {
+    const next = applyPreset(loadSettings(), sel.value as AiSettings['preset']);
+    saveSettings(next);
+    // Sync the model picker too
+    const modelSelect = drawerEl?.querySelector('select') as HTMLSelectElement | null;
+    if (modelSelect) modelSelect.value = next.toggles.model;
+    renderToggleStrip();
+    renderCostMeter();
+  });
+  return sel;
+}
+
+// === Toggle strip rendering ===
+
+function renderToggleStrip(): void {
+  if (!toggleStripEl) return;
+  toggleStripEl.replaceChildren();
+  const settings = loadSettings();
+  const { toggles } = settings;
+
+  toggleStripEl.appendChild(togglePill('👁 Views', toggles.vision.views, () => {
+    saveSettings(setToggles(loadSettings(), { vision: { views: !toggles.vision.views } }));
+    renderToggleStrip();
+    renderCostMeter();
+  }));
+  toggleStripEl.appendChild(togglePill('▶ Run', toggles.scope.runCode, () => {
+    saveSettings(setToggles(loadSettings(), { scope: { runCode: !toggles.scope.runCode } }));
+    renderToggleStrip();
+  }));
+  toggleStripEl.appendChild(togglePill('💾 Save', toggles.scope.saveVersions, () => {
+    saveSettings(setToggles(loadSettings(), { scope: { saveVersions: !toggles.scope.saveVersions } }));
+    renderToggleStrip();
+  }));
+  toggleStripEl.appendChild(togglePill('🎨 Paint', toggles.scope.paintFaces, () => {
+    saveSettings(setToggles(loadSettings(), { scope: { paintFaces: !toggles.scope.paintFaces } }));
+    renderToggleStrip();
+  }));
+
+  const retry = document.createElement('select');
+  retry.className = 'px-1.5 py-0.5 rounded text-[10px] bg-zinc-800 border border-zinc-700 text-zinc-300 focus:outline-none';
+  retry.title = 'Auto-retry on tool error: how many times to feed the error back before surfacing it.';
+  for (const n of [0, 1, 3]) {
+    const opt = document.createElement('option');
+    opt.value = String(n);
+    opt.textContent = `↻ ${n}`;
+    retry.appendChild(opt);
+  }
+  retry.value = String(toggles.autoRetry);
+  retry.addEventListener('change', () => {
+    saveSettings(setToggles(loadSettings(), { autoRetry: Number(retry.value) as 0 | 1 | 3 }));
+  });
+  toggleStripEl.appendChild(retry);
+}
+
+function togglePill(label: string, on: boolean, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.className = on
+    ? 'px-2 py-0.5 rounded text-[10px] bg-emerald-700/40 border border-emerald-700/60 text-emerald-200'
+    : 'px-2 py-0.5 rounded text-[10px] bg-zinc-800 border border-zinc-700 text-zinc-500';
+  btn.textContent = label;
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+// === Cost meter ===
+
+function renderCostMeter(): void {
+  if (!costMeterEl) return;
+  const settings = loadSettings();
+  const tokens = totalTokensEstimate(state.history, state.systemPromptChars);
+  const cost = totalCost(state.history);
+  const cachedPrefix = estimateCachedPrefixTokens(state.systemPromptChars);
+  const turnEst = estimateTurnCostUsd(settings.toggles.model, cachedPrefix, 500 + (settings.toggles.vision.views ? 6000 : 0));
+
+  // Color the context bar by % of model context window
+  const ctxLimit = settings.toggles.model === 'claude-haiku-4-5' ? 200_000 : 1_000_000;
+  const pct = Math.min(100, Math.round((tokens / ctxLimit) * 100));
+  const barColor = pct < 60 ? 'bg-emerald-500' : pct < 85 ? 'bg-amber-500' : 'bg-red-500';
+
+  costMeterEl.replaceChildren();
+  const meter = document.createElement('div');
+  meter.className = 'flex items-center gap-1.5';
+  meter.innerHTML = `
+    <span>ctx</span>
+    <span class="w-16 h-1.5 bg-zinc-800 rounded-full overflow-hidden inline-block">
+      <span class="block h-full ${barColor}" style="width: ${pct}%"></span>
+    </span>
+    <span class="text-zinc-400">${pct}%</span>
+  `;
+  costMeterEl.appendChild(meter);
+
+  const sep = document.createElement('span');
+  sep.className = 'text-zinc-700';
+  sep.textContent = '·';
+  costMeterEl.appendChild(sep);
+
+  const session = document.createElement('span');
+  session.textContent = `session: ${formatUsd(cost)}`;
+  costMeterEl.appendChild(session);
+
+  const sep2 = document.createElement('span');
+  sep2.className = 'text-zinc-700';
+  sep2.textContent = '·';
+  costMeterEl.appendChild(sep2);
+
+  const next = document.createElement('span');
+  next.textContent = `next turn ~${formatUsd(turnEst)}`;
+  costMeterEl.appendChild(next);
+}
+
+// === Status bar ===
+
+function panelStatusUpdate(): void {
+  if (!panelStatusEl) return;
+  void getKey('anthropic').then(key => {
+    if (!panelStatusEl) return;
+    if (!key) {
+      panelStatusEl.classList.remove('hidden', 'text-emerald-400');
+      panelStatusEl.classList.add('text-amber-400');
+      panelStatusEl.replaceChildren();
+      const text = document.createTextNode('Not connected. ');
+      panelStatusEl.appendChild(text);
+      const link = document.createElement('button');
+      link.className = 'underline text-amber-200 hover:text-amber-100';
+      link.textContent = 'Connect Anthropic API';
+      link.addEventListener('click', () => {
+        void showAiKeyModal({ onConnected: () => { panelStatusUpdate(); } });
+      });
+      panelStatusEl.appendChild(link);
+    } else {
+      panelStatusEl.classList.add('hidden');
+    }
+  });
+}
+
+// === Transcript rendering ===
+
+function renderTranscript(): void {
+  if (!transcriptEl) return;
+  transcriptEl.replaceChildren();
+  if (state.history.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'flex-1 flex items-center justify-center text-zinc-600 text-xs text-center px-6';
+    empty.textContent = state.sessionId === GLOBAL_CHAT_BUCKET
+      ? 'Open a session and ask the AI to model something. Try: "Build a coffee mug, 80mm tall."'
+      : 'Ask the AI to model, modify, or describe this session.';
+    transcriptEl.appendChild(empty);
+    return;
+  }
+  for (const msg of state.history) {
+    transcriptEl.appendChild(renderMessage(msg));
+  }
+  transcriptEl.scrollTop = transcriptEl.scrollHeight;
+}
+
+function renderMessage(msg: ChatMessage): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = msg.role === 'user' ? 'flex flex-col items-end gap-1' : 'flex flex-col items-start gap-1';
+  wrap.dataset.messageId = msg.id;
+
+  // Tool results (user role) get rendered as collapsed bubbles
+  if (msg.role === 'user' && msg.toolResults && msg.toolResults.length > 0) {
+    for (const tr of msg.toolResults) {
+      wrap.appendChild(renderToolResultBubble(tr));
+    }
+  }
+
+  for (const b of msg.blocks) {
+    if (b.type === 'text' && b.text.trim().length > 0) {
+      wrap.appendChild(renderTextBubble(msg.role, b.text, msg.compacted));
+    } else if (b.type === 'image') {
+      wrap.appendChild(renderImageBubble(b.source));
+    }
+  }
+
+  if (msg.role === 'assistant' && msg.toolCalls && msg.toolCalls.length > 0) {
+    for (const tc of msg.toolCalls) {
+      wrap.appendChild(renderToolCallChip(tc.name, tc.input));
+    }
+  }
+
+  if (msg.role === 'assistant' && msg.costUsd !== undefined) {
+    const meta = document.createElement('div');
+    meta.className = 'text-[10px] text-zinc-600';
+    meta.textContent = `${formatUsd(msg.costUsd)}${msg.usage ? ` · ${msg.usage.outputTokens}t out` : ''}`;
+    wrap.appendChild(meta);
+  }
+
+  return wrap;
+}
+
+function renderTextBubble(role: 'user' | 'assistant', text: string, compacted?: boolean): HTMLElement {
+  const bubble = document.createElement('div');
+  const baseClass = 'max-w-[90%] px-3 py-2 rounded-lg text-sm whitespace-pre-wrap leading-snug';
+  if (compacted) {
+    bubble.className = `${baseClass} bg-zinc-800/60 border border-zinc-700 text-zinc-300 italic`;
+  } else if (role === 'user') {
+    bubble.className = `${baseClass} bg-blue-600 text-white`;
+  } else {
+    bubble.className = `${baseClass} bg-zinc-800 text-zinc-100`;
+  }
+  bubble.textContent = text;
+  return bubble;
+}
+
+function renderImageBubble(source: ImageSource): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'max-w-[90%] rounded-lg overflow-hidden border border-zinc-700';
+  const img = document.createElement('img');
+  img.src = `data:${source.mediaType};base64,${source.data}`;
+  img.alt = source.label ?? 'image';
+  img.className = 'block max-w-full max-h-64';
+  wrap.appendChild(img);
+  if (source.label) {
+    const label = document.createElement('div');
+    label.className = 'px-2 py-1 text-[10px] text-zinc-400 bg-zinc-800';
+    label.textContent = source.label;
+    wrap.appendChild(label);
+  }
+  return wrap;
+}
+
+function renderToolCallChip(name: string, input: Record<string, unknown>): HTMLElement {
+  const chip = document.createElement('details');
+  chip.className = 'max-w-[90%] text-[11px] rounded border border-zinc-700 bg-zinc-800/40 px-2 py-1';
+  const summary = document.createElement('summary');
+  summary.className = 'cursor-pointer text-zinc-300 select-none';
+  summary.textContent = `◆ ${name}(…)`;
+  chip.appendChild(summary);
+  const pre = document.createElement('pre');
+  pre.className = 'mt-1 text-[10px] text-zinc-400 overflow-x-auto whitespace-pre-wrap';
+  pre.textContent = JSON.stringify(input, null, 2);
+  chip.appendChild(pre);
+  return chip;
+}
+
+function renderToolResultBubble(result: PersistedToolResult): HTMLElement {
+  const chip = document.createElement('details');
+  const tone = result.isError ? 'border-red-700/60 bg-red-900/20 text-red-200' : 'border-emerald-700/40 bg-emerald-900/10 text-emerald-200';
+  chip.className = `max-w-[90%] text-[11px] rounded border ${tone} px-2 py-1`;
+  const summary = document.createElement('summary');
+  summary.className = 'cursor-pointer select-none';
+  const head = result.content.split('\n')[0].slice(0, 80);
+  summary.textContent = `${result.isError ? '✗' : '✓'} ${head}${result.content.length > head.length ? '…' : ''}`;
+  chip.appendChild(summary);
+  const pre = document.createElement('pre');
+  pre.className = 'mt-1 text-[10px] opacity-80 overflow-x-auto whitespace-pre-wrap';
+  pre.textContent = result.content;
+  chip.appendChild(pre);
+  return chip;
+}
+
+// === Pending images ===
+
+async function attachIsoViews(): Promise<void> {
+  const img = await captureIsoViews();
+  if (!img) {
+    setTransientStatus('No geometry to snapshot — run some code first.');
+    return;
+  }
+  state.pendingImages.push(img);
+  renderPendingImages();
+}
+
+async function attachFile(file: File): Promise<void> {
+  const img = await fileToImageSource(file);
+  if (!img) {
+    setTransientStatus(`Skipped non-image: ${file.name}`);
+    return;
+  }
+  state.pendingImages.push(img);
+  renderPendingImages();
+}
+
+function renderPendingImages(): void {
+  if (!pendingImagesEl) return;
+  pendingImagesEl.replaceChildren();
+  if (state.pendingImages.length === 0) {
+    pendingImagesEl.classList.add('hidden');
+    return;
+  }
+  pendingImagesEl.classList.remove('hidden');
+  state.pendingImages.forEach((img, i) => {
+    const chip = document.createElement('div');
+    chip.className = 'relative w-12 h-12 rounded border border-zinc-600 overflow-hidden';
+    const el = document.createElement('img');
+    el.src = `data:${img.mediaType};base64,${img.data}`;
+    el.className = 'w-full h-full object-cover';
+    chip.appendChild(el);
+    const rm = document.createElement('button');
+    rm.className = 'absolute top-0 right-0 w-4 h-4 bg-black/70 text-white text-[10px] rounded-bl';
+    rm.textContent = '✕';
+    rm.title = `Remove ${img.label ?? 'image'}`;
+    rm.addEventListener('click', () => {
+      state.pendingImages.splice(i, 1);
+      renderPendingImages();
+    });
+    chip.appendChild(rm);
+    pendingImagesEl!.appendChild(chip);
+  });
+}
+
+// === Send message ===
+
+async function sendMessage(): Promise<void> {
+  if (state.inFlight) return;
+  if (!inputEl) return;
+  const text = inputEl.value.trim();
+  if (text.length === 0 && state.pendingImages.length === 0) return;
+
+  const key = await getKey('anthropic');
+  if (!key) {
+    void showAiKeyModal({ onConnected: () => { panelStatusUpdate(); void sendMessage(); } });
+    return;
+  }
+
+  const settings = loadSettings();
+  const blocks: ChatBlock[] = [];
+  if (text.length > 0) blocks.push({ type: 'text', text });
+  // Only attach images the user added if vision is on. Iso views are
+  // user-initiated via Show AI; pending images get sent regardless because
+  // the user's intent is explicit when they attached them.
+  for (const img of state.pendingImages) blocks.push({ type: 'image', source: img });
+
+  inputEl.value = '';
+  state.pendingImages = [];
+  renderPendingImages();
+  state.inFlight = true;
+
+  let activeAssistantId: string | null = null;
+  let liveTextEl: HTMLElement | null = null;
+
+  await runTurn({
+    apiKey: key.apiKey,
+    toggles: settings.toggles,
+    sessionId: state.sessionId,
+    history: state.history,
+    userBlocks: blocks,
+  }, {
+    onUserPersisted: msg => {
+      state.history.push(msg);
+      renderTranscript();
+    },
+    onAssistantStart: id => {
+      activeAssistantId = id;
+      const placeholder: ChatMessage = {
+        id, sessionId: state.sessionId, role: 'assistant',
+        blocks: [{ type: 'text', text: '' }], createdAt: Date.now(),
+        seq: (state.history[state.history.length - 1]?.seq ?? 0) + 1,
+      };
+      state.history.push(placeholder);
+      renderTranscript();
+      // Grab the just-rendered bubble's text element so we can append deltas
+      if (transcriptEl) {
+        const wrap = transcriptEl.querySelector(`[data-message-id="${id}"]`) as HTMLElement | null;
+        liveTextEl = wrap?.querySelector('.bg-zinc-800') as HTMLElement | null;
+        if (liveTextEl) liveTextEl.textContent = '';
+      }
+    },
+    onAssistantText: delta => {
+      if (liveTextEl) {
+        liveTextEl.textContent = (liveTextEl.textContent ?? '') + delta;
+        if (transcriptEl) transcriptEl.scrollTop = transcriptEl.scrollHeight;
+      }
+    },
+    onAssistantPersisted: msg => {
+      // Replace the placeholder with the persisted message
+      const idx = state.history.findIndex(m => m.id === activeAssistantId);
+      if (idx >= 0) state.history[idx] = msg;
+      activeAssistantId = null;
+      liveTextEl = null;
+      renderTranscript();
+      renderCostMeter();
+    },
+    onToolResult: (_id, _name, result) => {
+      // The user-message that carries the tool result will be rendered when
+      // the loop persists it; nothing to do here in v0 beyond a flash
+      // notification for errors.
+      if (result.isError) setTransientStatus('A tool errored. The agent will retry or surface the issue.');
+    },
+    onError: err => {
+      setTransientStatus(`Error: ${err.message}`);
+    },
+    onTurnComplete: () => {
+      // Refresh from DB to catch any tool-result messages
+      void loadHistoryForCurrentSession().then(() => {
+        renderTranscript();
+        renderCostMeter();
+      });
+    },
+  });
+
+  state.inFlight = false;
+}
+
+// === Compaction ===
+
+async function runCompact(): Promise<void> {
+  if (state.inFlight) {
+    setTransientStatus('Wait for the current turn to finish before compacting.');
+    return;
+  }
+  const key = await getKey('anthropic');
+  if (!key) {
+    void showAiKeyModal({ onConnected: () => panelStatusUpdate() });
+    return;
+  }
+  setTransientStatus('Asking Haiku to summarize...');
+  let proposal;
+  try {
+    proposal = await proposeCompaction(key.apiKey, state.history);
+  } catch (err) {
+    setTransientStatus(`Compaction failed: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  setTransientStatus('');
+
+  showCompactConfirmModal(proposal, async ({ summary, notes }) => {
+    // Promote selected notes to durable session log via the existing API
+    const w = window as unknown as { partwright?: { addSessionNote?: (t: string) => Promise<unknown> } };
+    if (w.partwright?.addSessionNote && state.sessionId !== GLOBAL_CHAT_BUCKET) {
+      for (const note of notes) {
+        try { await w.partwright.addSessionNote(note); } catch { /* noop */ }
+      }
+    }
+    // Replace the dropped tail with one synthetic summary message
+    const summaryMsg: ChatMessage = {
+      id: generateId(),
+      sessionId: state.sessionId,
+      role: 'assistant',
+      blocks: [{ type: 'text', text: `[compacted summary]\n${summary}` }],
+      createdAt: Date.now(),
+      seq: -1, // sorts before everything kept
+      compacted: true,
+    };
+    await deleteMessages(proposal.drop.map(m => m.id));
+    await putMessages([summaryMsg]);
+    await loadHistoryForCurrentSession();
+    renderTranscript();
+    renderCostMeter();
+    setTransientStatus(`Compacted ${proposal.drop.length} turn(s); promoted ${notes.length} note(s).`);
+  });
+}
+
+// === Status flash ===
+
+let statusTimer: number | null = null;
+
+function setTransientStatus(text: string): void {
+  if (!panelStatusEl) return;
+  if (statusTimer !== null) {
+    clearTimeout(statusTimer);
+    statusTimer = null;
+  }
+  if (!text) {
+    panelStatusUpdate();
+    return;
+  }
+  panelStatusEl.classList.remove('hidden', 'text-amber-400');
+  panelStatusEl.classList.add('text-blue-300');
+  panelStatusEl.textContent = text;
+  statusTimer = window.setTimeout(() => {
+    statusTimer = null;
+    panelStatusUpdate();
+  }, 4000);
+}

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -14,7 +14,7 @@ import { generateId } from '../storage/db';
 import { showAiKeyModal } from './aiKeyModal';
 import { showAiSettingsModal } from './aiSettingsModal';
 import { showCompactConfirmModal } from './aiCompactModal';
-import type { ChatBlock, ChatMessage, ImageSource, ModelId, PersistedToolResult } from '../ai/types';
+import type { ChatBlock, ChatMessage, ChatToggles, ImageSource, ModelId, PersistedToolResult } from '../ai/types';
 
 interface PanelState {
   open: boolean;
@@ -23,6 +23,9 @@ interface PanelState {
   pendingImages: ImageSource[];
   systemPromptChars: number;
   inFlight: boolean;
+  /** Live for the duration of a turn. Stop button aborts via this. Null
+   *  when no turn is in flight. */
+  inFlightController: AbortController | null;
 }
 
 const state: PanelState = {
@@ -32,7 +35,10 @@ const state: PanelState = {
   pendingImages: [],
   systemPromptChars: 0,
   inFlight: false,
+  inFlightController: null,
 };
+
+let sendBtnRef: HTMLButtonElement | null = null;
 
 let drawerEl: HTMLElement | null = null;
 let transcriptEl: HTMLElement | null = null;
@@ -41,6 +47,8 @@ let pendingImagesEl: HTMLElement | null = null;
 let toggleStripEl: HTMLElement | null = null;
 let costMeterEl: HTMLElement | null = null;
 let panelStatusEl: HTMLElement | null = null;
+let progressEl: HTMLElement | null = null;
+let progressTickerId: number | null = null;
 
 let onPanelStateChange: ((open: boolean) => void) | null = null;
 
@@ -179,6 +187,14 @@ function buildDrawer(): void {
   pendingImagesEl.className = 'px-3 pb-1.5 flex flex-wrap gap-1.5 shrink-0 hidden';
   root.appendChild(pendingImagesEl);
 
+  // In-progress indicator — shown while a turn is in flight so the user
+  // knows we haven't frozen. Hidden by default; populated by
+  // showProgress() / hideProgress() driven by runTurn's onProgress callback
+  // and the stall watchdog.
+  progressEl = document.createElement('div');
+  progressEl.className = 'px-3 pb-1.5 text-[11px] text-zinc-400 flex items-center gap-2 shrink-0 hidden';
+  root.appendChild(progressEl);
+
   // Input row
   const inputRow = document.createElement('div');
   inputRow.className = 'px-3 py-2 border-t border-zinc-700 flex items-end gap-2 shrink-0';
@@ -236,7 +252,16 @@ function buildDrawer(): void {
   const sendBtn = document.createElement('button');
   sendBtn.className = 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed';
   sendBtn.textContent = 'Send';
-  sendBtn.addEventListener('click', () => { void sendMessage(); });
+  sendBtn.addEventListener('click', () => {
+    // While a turn is in flight the button is "Stop" — click aborts the
+    // controller, which propagates through runTurn → streamTurn → SDK.
+    if (state.inFlight) {
+      state.inFlightController?.abort();
+      return;
+    }
+    void sendMessage();
+  });
+  sendBtnRef = sendBtn;
   inputRow.appendChild(sendBtn);
 
   root.appendChild(inputRow);
@@ -483,7 +508,40 @@ function renderMessage(msg: ChatMessage): HTMLElement {
     wrap.appendChild(meta);
   }
 
+  if (msg.role === 'assistant' && msg.aborted) {
+    const banner = document.createElement('div');
+    banner.className = 'flex items-center gap-2 text-[10px] text-amber-400';
+    const label = document.createElement('span');
+    label.textContent = '⊘ Stopped by user.';
+    banner.appendChild(label);
+    const discard = document.createElement('button');
+    discard.className = 'underline hover:text-amber-200';
+    discard.textContent = 'Discard partial';
+    discard.title = 'Delete this aborted message so the next turn starts clean.';
+    discard.addEventListener('click', () => { void discardPartial(msg.id); });
+    banner.appendChild(discard);
+    wrap.appendChild(banner);
+  }
+
   return wrap;
+}
+
+async function discardPartial(messageId: string): Promise<void> {
+  // Drop the aborted assistant message from both the DB and the in-memory
+  // history so the next turn doesn't see (or have to refer to) it. We also
+  // drop any tool_result message that immediately followed — that pair
+  // only makes sense together.
+  const idx = state.history.findIndex(m => m.id === messageId);
+  if (idx < 0) return;
+  const toDelete = [state.history[idx].id];
+  const next = state.history[idx + 1];
+  if (next && next.role === 'user' && next.toolResults && next.toolResults.length > 0) {
+    toDelete.push(next.id);
+  }
+  await deleteMessages(toDelete);
+  await loadHistoryForCurrentSession();
+  renderTranscript();
+  renderCostMeter();
 }
 
 function renderTextBubble(role: 'user' | 'assistant', text: string, compacted?: boolean): HTMLElement {
@@ -622,73 +680,218 @@ async function sendMessage(): Promise<void> {
   inputEl.value = '';
   state.pendingImages = [];
   renderPendingImages();
-  state.inFlight = true;
+  progressState.retryCount = 0;
+  stalledByWatchdog = false;
+  await runTurnWithStallRetry(key.apiKey, settings.toggles, blocks);
+}
 
-  let activeAssistantId: string | null = null;
-  let liveTextEl: HTMLElement | null = null;
+/** Wraps runTurn with: in-progress indicator, stall watchdog, and bounded
+ *  auto-retry. When the watchdog fires we abort and re-issue the same
+ *  conversation; on retry attempts userBlocks is empty because the user
+ *  message is already in history from the first attempt. */
+async function runTurnWithStallRetry(apiKey: string, toggles: ChatToggles, userBlocks: ChatBlock[]): Promise<void> {
+  let attempt = 0;
+  while (true) {
+    attempt++;
+    const controller = new AbortController();
+    state.inFlight = true;
+    state.inFlightController = controller;
+    setSendButtonMode('stop');
+    showProgress('thinking', 'starting…');
 
-  await runTurn({
-    apiKey: key.apiKey,
-    toggles: settings.toggles,
-    sessionId: state.sessionId,
-    history: state.history,
-    userBlocks: blocks,
-  }, {
-    onUserPersisted: msg => {
-      state.history.push(msg);
-      renderTranscript();
-    },
-    onAssistantStart: id => {
-      activeAssistantId = id;
-      const placeholder: ChatMessage = {
-        id, sessionId: state.sessionId, role: 'assistant',
-        blocks: [{ type: 'text', text: '' }], createdAt: Date.now(),
-        seq: (state.history[state.history.length - 1]?.seq ?? 0) + 1,
-      };
-      state.history.push(placeholder);
-      renderTranscript();
-      // Grab the just-rendered bubble's text element so we can append deltas
-      if (transcriptEl) {
-        const wrap = transcriptEl.querySelector(`[data-message-id="${id}"]`) as HTMLElement | null;
-        liveTextEl = wrap?.querySelector('.bg-zinc-800') as HTMLElement | null;
-        if (liveTextEl) liveTextEl.textContent = '';
-      }
-    },
-    onAssistantText: delta => {
-      if (liveTextEl) {
-        liveTextEl.textContent = (liveTextEl.textContent ?? '') + delta;
-        if (transcriptEl) transcriptEl.scrollTop = transcriptEl.scrollHeight;
-      }
-    },
-    onAssistantPersisted: msg => {
-      // Replace the placeholder with the persisted message
-      const idx = state.history.findIndex(m => m.id === activeAssistantId);
-      if (idx >= 0) state.history[idx] = msg;
-      activeAssistantId = null;
-      liveTextEl = null;
-      renderTranscript();
-      renderCostMeter();
-    },
-    onToolResult: (_id, _name, result) => {
-      // The user-message that carries the tool result will be rendered when
-      // the loop persists it; nothing to do here in v0 beyond a flash
-      // notification for errors.
-      if (result.isError) setTransientStatus('A tool errored. The agent will retry or surface the issue.');
-    },
-    onError: err => {
-      setTransientStatus(`Error: ${err.message}`);
-    },
-    onTurnComplete: () => {
-      // Refresh from DB to catch any tool-result messages
-      void loadHistoryForCurrentSession().then(() => {
+    let activeAssistantId: string | null = null;
+    let liveTextEl: HTMLElement | null = null;
+    const blocksForThisAttempt = attempt === 1 ? userBlocks : [];
+
+    await runTurn({
+      apiKey,
+      toggles,
+      sessionId: state.sessionId,
+      history: state.history,
+      userBlocks: blocksForThisAttempt,
+      signal: controller.signal,
+    }, {
+      onUserPersisted: msg => {
+        state.history.push(msg);
+        renderTranscript();
+      },
+      onAssistantStart: id => {
+        activeAssistantId = id;
+        const placeholder: ChatMessage = {
+          id, sessionId: state.sessionId, role: 'assistant',
+          blocks: [{ type: 'text', text: '' }], createdAt: Date.now(),
+          seq: (state.history[state.history.length - 1]?.seq ?? 0) + 1,
+        };
+        state.history.push(placeholder);
+        renderTranscript();
+        if (transcriptEl) {
+          const wrap = transcriptEl.querySelector(`[data-message-id="${id}"]`) as HTMLElement | null;
+          liveTextEl = wrap?.querySelector('.bg-zinc-800') as HTMLElement | null;
+          if (liveTextEl) liveTextEl.textContent = '';
+        }
+      },
+      onAssistantText: delta => {
+        if (liveTextEl) {
+          liveTextEl.textContent = (liveTextEl.textContent ?? '') + delta;
+          if (transcriptEl) transcriptEl.scrollTop = transcriptEl.scrollHeight;
+        }
+      },
+      onProgress: info => showProgress(info.phase, info.detail),
+      onAssistantPersisted: msg => {
+        const idx = state.history.findIndex(m => m.id === activeAssistantId);
+        if (idx >= 0) state.history[idx] = msg;
+        activeAssistantId = null;
+        liveTextEl = null;
         renderTranscript();
         renderCostMeter();
-      });
-    },
-  });
+      },
+      onToolResult: (_id, _name, result) => {
+        if (result.isError) setTransientStatus('A tool errored. The agent will retry or surface the issue.');
+      },
+      onError: err => {
+        setTransientStatus(`Error: ${err.message}`);
+      },
+      onAborted: () => {
+        // Only show the user-stopped notice if the user actually clicked
+        // Stop — when the watchdog fires, the message is misleading.
+        if (!stalledByWatchdog) {
+          setTransientStatus('Stopped. Type a new message to continue or redirect.');
+          inputEl?.focus();
+        }
+      },
+      onTurnComplete: () => {
+        void loadHistoryForCurrentSession().then(() => {
+          renderTranscript();
+          renderCostMeter();
+        });
+      },
+    });
 
-  state.inFlight = false;
+    state.inFlight = false;
+    state.inFlightController = null;
+    setSendButtonMode('send');
+    hideProgress();
+
+    if (stalledByWatchdog && progressState.retryCount <= MAX_STALL_RETRIES) {
+      // Strip the empty/partial assistant message left by the stalled
+      // attempt so the retry doesn't see (or send back to the model) a
+      // ghost bubble.
+      await stripLastAbortedAssistant();
+      stalledByWatchdog = false;
+      continue;
+    }
+    return;
+  }
 }
+
+/** Find the last assistant message marked `aborted` at the tail of the
+ *  in-memory history, delete it from IndexedDB, and reload. Used to clean
+ *  up after the stall watchdog. */
+async function stripLastAbortedAssistant(): Promise<void> {
+  for (let i = state.history.length - 1; i >= 0; i--) {
+    const m = state.history[i];
+    if (m.role !== 'assistant') continue;
+    if (m.aborted) {
+      await deleteMessages([m.id]);
+      await loadHistoryForCurrentSession();
+      renderTranscript();
+      return;
+    }
+    break;
+  }
+}
+
+function setSendButtonMode(mode: 'send' | 'stop'): void {
+  if (!sendBtnRef) return;
+  if (mode === 'stop') {
+    sendBtnRef.textContent = 'Stop';
+    sendBtnRef.className = 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-red-600 hover:bg-red-500 text-white';
+    sendBtnRef.title = 'Stop the model; partial output is kept so you can redirect.';
+  } else {
+    sendBtnRef.textContent = 'Send';
+    sendBtnRef.className = 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed';
+    sendBtnRef.title = '';
+  }
+}
+
+// === Progress indicator + stall watchdog ===
+
+interface ProgressTracker {
+  phase: 'thinking' | 'streaming' | 'tool' | 'idle';
+  detail?: string;
+  lastBeat: number;
+  retryCount: number;
+}
+
+const progressState: ProgressTracker = { phase: 'idle', lastBeat: 0, retryCount: 0 };
+
+/** Wall-clock seconds without a stream beat before we treat the request as
+ *  stalled. Anthropic's adaptive thinking can pause output for tens of
+ *  seconds during deep reasoning, so this threshold needs to be generous —
+ *  smaller numbers cause spurious "auto-resume" loops on Opus 4.7. */
+const STALL_THRESHOLD_MS = 45_000;
+const MAX_STALL_RETRIES = 2;
+
+function showProgress(phase: ProgressTracker['phase'], detail?: string): void {
+  progressState.phase = phase;
+  progressState.detail = detail;
+  progressState.lastBeat = Date.now();
+  renderProgress();
+  if (!progressEl) return;
+  progressEl.classList.remove('hidden');
+  if (progressTickerId === null) {
+    // Re-render every second so the "(15s)" elapsed counter updates and
+    // the stall watchdog can fire from the same tick.
+    progressTickerId = window.setInterval(renderProgress, 1000);
+  }
+}
+
+function hideProgress(): void {
+  progressState.phase = 'idle';
+  if (progressEl) progressEl.classList.add('hidden');
+  if (progressTickerId !== null) {
+    clearInterval(progressTickerId);
+    progressTickerId = null;
+  }
+}
+
+function renderProgress(): void {
+  if (!progressEl) return;
+  if (progressState.phase === 'idle') return;
+  const elapsedSec = Math.max(1, Math.round((Date.now() - progressState.lastBeat) / 1000));
+  const label =
+    progressState.phase === 'thinking' ? `🧠 thinking… (${elapsedSec}s silent)` :
+    progressState.phase === 'streaming' ? '✎ streaming response…' :
+    progressState.phase === 'tool' ? `🔧 ${progressState.detail ?? 'running tool'}…` :
+    '';
+  progressEl.replaceChildren();
+  const dot = document.createElement('span');
+  dot.className = 'inline-block w-2 h-2 rounded-full bg-blue-400 animate-pulse';
+  progressEl.appendChild(dot);
+  const text = document.createElement('span');
+  text.textContent = label;
+  progressEl.appendChild(text);
+  if (state.inFlightController && progressState.phase === 'thinking' && elapsedSec * 1000 > STALL_THRESHOLD_MS) {
+    triggerStallRetry();
+  }
+}
+
+function triggerStallRetry(): void {
+  if (progressState.retryCount >= MAX_STALL_RETRIES) {
+    // Hand off to the user — surface that we've given up auto-retrying.
+    setTransientStatus(`Model stalled (no tokens for ${Math.round(STALL_THRESHOLD_MS / 1000)}s) after ${MAX_STALL_RETRIES} retries — stopping.`);
+    state.inFlightController?.abort();
+    return;
+  }
+  // Abort the current attempt with a stall marker so sendMessage knows to
+  // re-issue rather than treat it as a user-initiated stop.
+  progressState.retryCount++;
+  setTransientStatus(`No response for ${Math.round(STALL_THRESHOLD_MS / 1000)}s — auto-resuming (retry ${progressState.retryCount}/${MAX_STALL_RETRIES})...`);
+  stalledByWatchdog = true;
+  state.inFlightController?.abort();
+}
+
+let stalledByWatchdog = false;
 
 // === Compaction ===
 

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -304,6 +304,7 @@ function createIconButton(_label: string, glyph: string): HTMLButtonElement {
 function createModelSelect(): HTMLSelectElement {
   const sel = document.createElement('select');
   sel.className = 'px-2 py-1 rounded text-[11px] bg-zinc-800 border border-zinc-700 text-zinc-200 focus:outline-none';
+  sel.title = 'Claude model. Haiku is cheap and fast for simple iteration; Sonnet is the balanced default; Opus is the most capable but the most expensive.';
   for (const opt of MODEL_OPTIONS) {
     const o = document.createElement('option');
     o.value = opt.id;
@@ -322,6 +323,7 @@ function createModelSelect(): HTMLSelectElement {
 function createPresetSelect(): HTMLSelectElement {
   const sel = document.createElement('select');
   sel.className = 'px-2 py-1 rounded text-[11px] bg-zinc-800 border border-zinc-700 text-zinc-200 focus:outline-none';
+  sel.title = 'Preset bundles the model + toggle settings. Picking a preset resets the toggles below to its defaults; manually changing any toggle switches you to "Custom".';
   for (const opt of PRESET_OPTIONS) {
     const o = document.createElement('option');
     o.value = opt.id;
@@ -350,23 +352,43 @@ function renderToggleStrip(): void {
   const settings = loadSettings();
   const { toggles } = settings;
 
-  toggleStripEl.appendChild(togglePill('👁 Views', toggles.vision.views, () => {
-    saveSettings(setToggles(loadSettings(), { vision: { views: !toggles.vision.views } }));
-    renderToggleStrip();
-    renderCostMeter();
-  }));
-  toggleStripEl.appendChild(togglePill('▶ Run', toggles.scope.runCode, () => {
-    saveSettings(setToggles(loadSettings(), { scope: { runCode: !toggles.scope.runCode } }));
-    renderToggleStrip();
-  }));
-  toggleStripEl.appendChild(togglePill('💾 Save', toggles.scope.saveVersions, () => {
-    saveSettings(setToggles(loadSettings(), { scope: { saveVersions: !toggles.scope.saveVersions } }));
-    renderToggleStrip();
-  }));
-  toggleStripEl.appendChild(togglePill('🎨 Paint', toggles.scope.paintFaces, () => {
-    saveSettings(setToggles(loadSettings(), { scope: { paintFaces: !toggles.scope.paintFaces } }));
-    renderToggleStrip();
-  }));
+  toggleStripEl.appendChild(togglePill(
+    '👁 Views',
+    toggles.vision.views,
+    'Vision: send rendered images to the AI (Show AI snapshot + renderView tool). When ON, the model can see what it modeled — costs ~1500 tokens per image. When OFF, the model reasons from code + geometry stats only.',
+    () => {
+      saveSettings(setToggles(loadSettings(), { vision: { views: !toggles.vision.views } }));
+      renderToggleStrip();
+      renderCostMeter();
+    },
+  ));
+  toggleStripEl.appendChild(togglePill(
+    '▶ Run',
+    toggles.scope.runCode,
+    'Run code: allow the AI to execute geometry code (runCode, runAndSave). OFF makes it suggest code in chat without running.',
+    () => {
+      saveSettings(setToggles(loadSettings(), { scope: { runCode: !toggles.scope.runCode } }));
+      renderToggleStrip();
+    },
+  ));
+  toggleStripEl.appendChild(togglePill(
+    '💾 Save',
+    toggles.scope.saveVersions,
+    'Save versions: allow the AI to commit results to the gallery (runAndSave, loadVersion). OFF keeps the model in run-only / dry-run mode.',
+    () => {
+      saveSettings(setToggles(loadSettings(), { scope: { saveVersions: !toggles.scope.saveVersions } }));
+      renderToggleStrip();
+    },
+  ));
+  toggleStripEl.appendChild(togglePill(
+    '🎨 Paint',
+    toggles.scope.paintFaces,
+    'Paint: allow the AI to set color regions (paintInBox, paintSlab, paintNear, etc.). OFF by default — painting locks the editor and is the easiest place for the AI to over-select.',
+    () => {
+      saveSettings(setToggles(loadSettings(), { scope: { paintFaces: !toggles.scope.paintFaces } }));
+      renderToggleStrip();
+    },
+  ));
 
   const retry = document.createElement('select');
   retry.className = 'px-1.5 py-0.5 rounded text-[10px] bg-zinc-800 border border-zinc-700 text-zinc-300 focus:outline-none';
@@ -384,12 +406,14 @@ function renderToggleStrip(): void {
   toggleStripEl.appendChild(retry);
 }
 
-function togglePill(label: string, on: boolean, onClick: () => void): HTMLButtonElement {
+function togglePill(label: string, on: boolean, tooltip: string, onClick: () => void): HTMLButtonElement {
   const btn = document.createElement('button');
   btn.className = on
     ? 'px-2 py-0.5 rounded text-[10px] bg-emerald-700/40 border border-emerald-700/60 text-emerald-200'
     : 'px-2 py-0.5 rounded text-[10px] bg-zinc-800 border border-zinc-700 text-zinc-500';
   btn.textContent = label;
+  btn.title = `${tooltip}\n\nCurrently: ${on ? 'ON' : 'OFF'} — click to ${on ? 'disable' : 'enable'}.`;
+  btn.setAttribute('aria-pressed', String(on));
   btn.addEventListener('click', onClick);
   return btn;
 }
@@ -600,9 +624,14 @@ function renderToolCallChip(name: string, input: Record<string, unknown>): HTMLE
 }
 
 function renderToolResultBubble(result: PersistedToolResult): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'flex flex-col items-start gap-1 max-w-[90%]';
   const chip = document.createElement('details');
   const tone = result.isError ? 'border-red-700/60 bg-red-900/20 text-red-200' : 'border-emerald-700/40 bg-emerald-900/10 text-emerald-200';
-  chip.className = `max-w-[90%] text-[11px] rounded border ${tone} px-2 py-1`;
+  chip.className = `text-[11px] rounded border ${tone} px-2 py-1`;
+  // If the tool returned an image, default to open so the user can see
+  // it without expanding — that's the whole point of the affordance.
+  if (result.image) chip.open = true;
   const summary = document.createElement('summary');
   summary.className = 'cursor-pointer select-none';
   const head = result.content.split('\n')[0].slice(0, 80);
@@ -612,7 +641,13 @@ function renderToolResultBubble(result: PersistedToolResult): HTMLElement {
   pre.className = 'mt-1 text-[10px] opacity-80 overflow-x-auto whitespace-pre-wrap';
   pre.textContent = result.content;
   chip.appendChild(pre);
-  return chip;
+  wrap.appendChild(chip);
+  // Image bubble — the same render the AI sees, so the human and the
+  // model are looking at literally the same pixels.
+  if (result.image) {
+    wrap.appendChild(renderImageBubble(result.image));
+  }
+  return wrap;
 }
 
 // === Pending images ===
@@ -840,11 +875,11 @@ function setSendButtonMode(mode: 'send' | 'stop'): void {
   if (mode === 'stop') {
     sendBtnRef.textContent = 'Stop';
     sendBtnRef.className = 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-red-600 hover:bg-red-500 text-white';
-    sendBtnRef.title = 'Stop the model; partial output is kept so you can redirect.';
+    sendBtnRef.title = 'Stop the model. Partial output is kept so you can redirect.';
   } else {
     sendBtnRef.textContent = 'Send';
     sendBtnRef.className = 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed';
-    sendBtnRef.title = '';
+    sendBtnRef.title = 'Send your message (Enter). Shift+Enter for newline.';
   }
 }
 

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -49,12 +49,22 @@ let costMeterEl: HTMLElement | null = null;
 let panelStatusEl: HTMLElement | null = null;
 let progressEl: HTMLElement | null = null;
 let progressTickerId: number | null = null;
+let navigateToEditorFn: (() => Promise<void> | void) | null = null;
 
 let onPanelStateChange: ((open: boolean) => void) | null = null;
 
+export interface AiPanelOptions {
+  /** main.ts hands in a navigation helper so the panel can move the user
+   *  to the editor before firing a request from another page. Avoids a
+   *  silent-modeling-on-landing-page UX bug where the AI runs code but
+   *  the user can't see the result. */
+  onNavigateToEditor?: () => Promise<void> | void;
+}
+
 /** Mount the drawer once on app start. Idempotent. */
-export async function initAiPanel(): Promise<void> {
+export async function initAiPanel(opts: AiPanelOptions = {}): Promise<void> {
   if (drawerEl) return;
+  navigateToEditorFn = opts.onNavigateToEditor ?? null;
   // Pre-load ai.md so the first turn doesn't pay the fetch latency on top
   // of the API round trip. Also seeds the systemPromptChars estimate.
   const aiMd = await loadAiMd();
@@ -669,6 +679,30 @@ async function sendMessage(): Promise<void> {
     return;
   }
 
+  // The drawer is a fixed overlay on every page (landing, catalog, help),
+  // but the AI's tools (runAndSave, setCode, paint*) target the editor.
+  // If the user fires from anywhere else, navigate to /editor and give
+  // the route handler a beat to mount the editor + engine before runTurn
+  // starts calling window.partwright methods.
+  if (window.location.pathname !== '/editor' && navigateToEditorFn) {
+    setTransientStatus('Switching to editor…');
+    try {
+      await navigateToEditorFn();
+    } catch (err) {
+      setTransientStatus(`Navigation failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    // Wait for window.partwright to actually be live before proceeding.
+    // The editor mount + engine init is async; polling is simpler than
+    // wiring a dedicated ready event for one caller.
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      const w = window as unknown as { partwright?: { run?: unknown } };
+      if (w.partwright?.run) break;
+      await new Promise(r => setTimeout(r, 50));
+    }
+  }
+
   const settings = loadSettings();
   const blocks: ChatBlock[] = [];
   if (text.length > 0) blocks.push({ type: 'text', text });
@@ -828,9 +862,15 @@ const progressState: ProgressTracker = { phase: 'idle', lastBeat: 0, retryCount:
 /** Wall-clock seconds without a stream beat before we treat the request as
  *  stalled. Anthropic's adaptive thinking can pause output for tens of
  *  seconds during deep reasoning, so this threshold needs to be generous —
- *  smaller numbers cause spurious "auto-resume" loops on Opus 4.7. */
-const STALL_THRESHOLD_MS = 45_000;
+ *  smaller numbers cause spurious "auto-resume" loops on Opus 4.7. The
+ *  watchdog beats on every text delta, so this is the gap BETWEEN tokens,
+ *  not total turn time. */
+const STALL_THRESHOLD_MS = 35_000;
 const MAX_STALL_RETRIES = 2;
+/** Phases where a long silence indicates a real stall — not 'tool' (tool
+ *  execution is synchronous JS and may legitimately run for a few seconds
+ *  with no progress events) and not 'idle' (we shouldn't be running). */
+const STALL_PHASES = new Set<ProgressTracker['phase']>(['thinking', 'streaming']);
 
 function showProgress(phase: ProgressTracker['phase'], detail?: string): void {
   progressState.phase = phase;
@@ -858,10 +898,11 @@ function hideProgress(): void {
 function renderProgress(): void {
   if (!progressEl) return;
   if (progressState.phase === 'idle') return;
-  const elapsedSec = Math.max(1, Math.round((Date.now() - progressState.lastBeat) / 1000));
+  const elapsedSec = Math.max(0, Math.round((Date.now() - progressState.lastBeat) / 1000));
+  const silentSuffix = elapsedSec > 3 ? ` (${elapsedSec}s silent)` : '';
   const label =
-    progressState.phase === 'thinking' ? `🧠 thinking… (${elapsedSec}s silent)` :
-    progressState.phase === 'streaming' ? '✎ streaming response…' :
+    progressState.phase === 'thinking' ? `🧠 thinking…${silentSuffix}` :
+    progressState.phase === 'streaming' ? `✎ streaming response…${silentSuffix}` :
     progressState.phase === 'tool' ? `🔧 ${progressState.detail ?? 'running tool'}…` :
     '';
   progressEl.replaceChildren();
@@ -871,7 +912,11 @@ function renderProgress(): void {
   const text = document.createElement('span');
   text.textContent = label;
   progressEl.appendChild(text);
-  if (state.inFlightController && progressState.phase === 'thinking' && elapsedSec * 1000 > STALL_THRESHOLD_MS) {
+  if (
+    state.inFlightController &&
+    STALL_PHASES.has(progressState.phase) &&
+    elapsedSec * 1000 > STALL_THRESHOLD_MS
+  ) {
     triggerStallRetry();
   }
 }

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -51,7 +51,9 @@ let progressEl: HTMLElement | null = null;
 let progressTickerId: number | null = null;
 let navigateToEditorFn: (() => Promise<void> | void) | null = null;
 
-let onPanelStateChange: ((open: boolean) => void) | null = null;
+/** Set by the watchdog when it abort()s mid-stream so sendMessage knows
+ *  this was a stall recovery (auto-resume), not a user-initiated stop. */
+let stalledByWatchdog = false;
 
 export interface AiPanelOptions {
   /** main.ts hands in a navigation helper so the panel can move the user
@@ -105,21 +107,12 @@ export function toggleAiPanel(): void {
   else showDrawer();
 }
 
-export function isAiPanelOpen(): boolean {
-  return state.open;
-}
-
-export function onAiPanelStateChange(fn: (open: boolean) => void): void {
-  onPanelStateChange = fn;
-}
-
 function showDrawer(): void {
   if (!drawerEl) return;
   state.open = true;
   drawerEl.classList.remove('translate-x-full');
   drawerEl.classList.add('translate-x-0');
   saveSettings({ ...loadSettings(), drawerOpen: true });
-  onPanelStateChange?.(true);
   inputEl?.focus();
 }
 
@@ -129,7 +122,6 @@ function hideDrawer(): void {
   drawerEl.classList.remove('translate-x-0');
   drawerEl.classList.add('translate-x-full');
   saveSettings({ ...loadSettings(), drawerOpen: false });
-  onPanelStateChange?.(false);
 }
 
 async function loadHistoryForCurrentSession(): Promise<void> {
@@ -1100,8 +1092,6 @@ function triggerStallRetry(): void {
   stalledByWatchdog = true;
   state.inFlightController?.abort();
 }
-
-let stalledByWatchdog = false;
 
 // === Compaction ===
 

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1003,10 +1003,16 @@ const MAX_STALL_RETRIES = 2;
 const STALL_PHASES = new Set<ProgressTracker['phase']>(['thinking', 'streaming']);
 
 function showProgress(phase: ProgressTracker['phase'], detail?: string): void {
+  // Per-text-delta calls land here too (the watchdog needs lastBeat fresh
+  // to know the stream is healthy). Skip the DOM rebuild when nothing the
+  // user can see has changed — the 1s ticker keeps the "(15s silent)"
+  // counter accurate, and avoiding replaceChildren() on every token saves
+  // hundreds of DOM rewrites/sec during a streaming response.
+  const visualChanged = progressState.phase !== phase || progressState.detail !== detail;
   progressState.phase = phase;
   progressState.detail = detail;
   progressState.lastBeat = Date.now();
-  renderProgress();
+  if (visualChanged) renderProgress();
   if (!progressEl) return;
   progressEl.classList.remove('hidden');
   if (progressTickerId === null) {

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -14,7 +14,7 @@ import { generateId } from '../storage/db';
 import { showAiKeyModal } from './aiKeyModal';
 import { showAiSettingsModal } from './aiSettingsModal';
 import { showCompactConfirmModal } from './aiCompactModal';
-import type { ChatBlock, ChatMessage, ChatToggles, ImageSource, ModelId, PersistedToolResult } from '../ai/types';
+import type { ChatBlock, ChatMessage, ChatToggles, ImageSource, ModelId, PersistedToolResult, TurnOutcomeReason } from '../ai/types';
 
 interface PanelState {
   open: boolean;
@@ -807,7 +807,7 @@ async function sendMessage(): Promise<void> {
 interface TurnOutcome {
   totalCostUsd: number;
   toolCalls: number;
-  reason: 'end_turn' | 'empty_final' | 'iteration_cap' | 'spend_cap' | 'max_tokens' | 'refusal' | 'aborted' | 'error' | 'other';
+  reason: TurnOutcomeReason;
   detail?: string;
   iterations: number;
 }

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -7,7 +7,7 @@ import { runTurn, totalCost, totalTokensEstimate, estimateCachedPrefixTokens } f
 import { listMessages, GLOBAL_CHAT_BUCKET, putMessages, deleteMessages, getKey } from '../ai/db';
 import { proposeCompaction } from '../ai/compaction';
 import { captureIsoViews, fileToImageSource } from '../ai/images';
-import { loadSettings, saveSettings, applyPreset, setModel, setToggles, MODEL_OPTIONS, PRESET_OPTIONS, type AiSettings } from '../ai/settings';
+import { loadSettings, saveSettings, applyPreset, setModel, setToggles, MODEL_OPTIONS, PRESET_OPTIONS, MAX_ITERATIONS_OPTIONS, type AiSettings } from '../ai/settings';
 import { buildSystemPrompt, loadAiMd } from '../ai/systemPrompt';
 import { estimateTurnCostUsd, formatUsd } from '../ai/cost';
 import { generateId } from '../storage/db';
@@ -415,6 +415,25 @@ function renderToggleStrip(): void {
     saveSettings(setToggles(loadSettings(), { autoRetry: Number(retry.value) as 0 | 1 | 3 }));
   });
   toggleStripEl.appendChild(retry);
+
+  // Iteration cap — how many tool round-trips per user turn before the
+  // loop forces a stop. Lower = safer (model can't run away on cost or
+  // time), higher = more autonomous (long paint runs complete in one go).
+  const iterCap = document.createElement('select');
+  iterCap.className = 'px-1.5 py-0.5 rounded text-[10px] bg-zinc-800 border border-zinc-700 text-zinc-300 focus:outline-none';
+  iterCap.title = 'Iteration cap: how many agent loop rounds before the loop forces a stop. Lower = safer (the model can\'t run away on cost or time), higher = more autonomous (long paint runs complete in one go). ∞ relies entirely on the model declaring done or you clicking Stop.';
+  for (const opt of MAX_ITERATIONS_OPTIONS) {
+    const o = document.createElement('option');
+    o.value = opt.id;
+    o.textContent = `⟲ ${opt.label}`;
+    o.title = opt.hint;
+    iterCap.appendChild(o);
+  }
+  iterCap.value = toggles.maxIterations;
+  iterCap.addEventListener('change', () => {
+    saveSettings(setToggles(loadSettings(), { maxIterations: iterCap.value as ChatToggles['maxIterations'] }));
+  });
+  toggleStripEl.appendChild(iterCap);
 }
 
 function togglePill(label: string, on: boolean, tooltip: string, onClick: () => void): HTMLButtonElement {

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -7,7 +7,7 @@ import { runTurn, totalCost, totalTokensEstimate, estimateCachedPrefixTokens } f
 import { listMessages, GLOBAL_CHAT_BUCKET, putMessages, deleteMessages, getKey } from '../ai/db';
 import { proposeCompaction } from '../ai/compaction';
 import { captureIsoViews, fileToImageSource } from '../ai/images';
-import { loadSettings, saveSettings, applyPreset, setModel, setToggles, MODEL_OPTIONS, PRESET_OPTIONS, MAX_ITERATIONS_OPTIONS, type AiSettings } from '../ai/settings';
+import { loadSettings, saveSettings, applyPreset, setModel, setToggles, MODEL_OPTIONS, PRESET_OPTIONS, MAX_ITERATIONS_OPTIONS, MAX_SPEND_OPTIONS, type AiSettings } from '../ai/settings';
 import { buildSystemPrompt, loadAiMd } from '../ai/systemPrompt';
 import { estimateTurnCostUsd, formatUsd } from '../ai/cost';
 import { generateId } from '../storage/db';
@@ -434,6 +434,26 @@ function renderToggleStrip(): void {
     saveSettings(setToggles(loadSettings(), { maxIterations: iterCap.value as ChatToggles['maxIterations'] }));
   });
   toggleStripEl.appendChild(iterCap);
+
+  // Spend cap — alternative / parallel control to iteration cap. Both
+  // apply; whichever trips first stops the loop. Useful when iteration
+  // count is hard to predict (vision-heavy turns can run a few
+  // iterations but spend $0.50+ each).
+  const spendCap = document.createElement('select');
+  spendCap.className = 'px-1.5 py-0.5 rounded text-[10px] bg-zinc-800 border border-zinc-700 text-zinc-300 focus:outline-none';
+  spendCap.title = 'Spend cap: max USD this turn can cost before the loop forces a stop. Applies alongside the iteration cap — whichever trips first wins. Useful when iteration count is unpredictable (a vision-heavy iteration may spend $0.50). Set ∞ to disable.';
+  for (const opt of MAX_SPEND_OPTIONS) {
+    const o = document.createElement('option');
+    o.value = opt.id;
+    o.textContent = `$ ${opt.label}`;
+    o.title = opt.hint;
+    spendCap.appendChild(o);
+  }
+  spendCap.value = toggles.maxSpend;
+  spendCap.addEventListener('change', () => {
+    saveSettings(setToggles(loadSettings(), { maxSpend: spendCap.value as ChatToggles['maxSpend'] }));
+  });
+  toggleStripEl.appendChild(spendCap);
 }
 
 function togglePill(label: string, on: boolean, tooltip: string, onClick: () => void): HTMLButtonElement {
@@ -795,7 +815,7 @@ async function sendMessage(): Promise<void> {
 interface TurnOutcome {
   totalCostUsd: number;
   toolCalls: number;
-  reason: 'end_turn' | 'empty_final' | 'iteration_cap' | 'max_tokens' | 'refusal' | 'aborted' | 'error' | 'other';
+  reason: 'end_turn' | 'empty_final' | 'iteration_cap' | 'spend_cap' | 'max_tokens' | 'refusal' | 'aborted' | 'error' | 'other';
   detail?: string;
   iterations: number;
 }
@@ -810,7 +830,9 @@ function formatTurnOutcome(o: TurnOutcome): string {
     case 'empty_final':
       return `⚠ model exited without a final message · ${cost} · ${iters}${tools} — last visible content is above`;
     case 'iteration_cap':
-      return `⚠ stopped at agent iteration cap (${o.iterations}) — try a more focused prompt or click Compact · ${cost}${tools}`;
+      return `⚠ stopped at agent iteration cap (${o.iterations}) — try a more focused prompt, click Compact, or raise the ⟲ cap · ${cost}${tools}`;
+    case 'spend_cap':
+      return `⚠ stopped at spend cap${o.detail ? ` (${o.detail})` : ''} — raise the $ cap or click Send to continue · ${cost} · ${iters}${tools}`;
     case 'max_tokens':
       return `⚠ hit max_tokens before finishing · ${cost} · ${iters}${tools} — ask the model to continue`;
     case 'refusal':

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -81,9 +81,20 @@ export async function initAiPanel(opts: AiPanelOptions = {}): Promise<void> {
   else hideDrawer();
 }
 
-/** Called by main.ts whenever the active session changes (open / close). */
+/** Called by main.ts whenever the active session changes (open / close).
+ *  When the user isn't on /editor (landing, catalog, help, 404), we
+ *  ignore whatever session the session manager is holding and pin the
+ *  chat to the global bucket — prior session chat shouldn't leak across
+ *  navigation. */
 export async function setActiveSession(sessionId: string | null): Promise<void> {
-  state.sessionId = sessionId ?? GLOBAL_CHAT_BUCKET;
+  const onEditor = window.location.pathname === '/editor';
+  const effective = (onEditor && sessionId) ? sessionId : GLOBAL_CHAT_BUCKET;
+  if (state.sessionId === effective && state.history.length > 0) {
+    // Already showing this bucket — skip the IndexedDB round trip and
+    // avoid a transcript re-render that scrolls the user to the bottom.
+    return;
+  }
+  state.sessionId = effective;
   await loadHistoryForCurrentSession();
   renderTranscript();
   renderCostMeter();

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -773,8 +773,41 @@ async function sendMessage(): Promise<void> {
  *  auto-retry. When the watchdog fires we abort and re-issue the same
  *  conversation; on retry attempts userBlocks is empty because the user
  *  message is already in history from the first attempt. */
+interface TurnOutcome {
+  totalCostUsd: number;
+  toolCalls: number;
+  reason: 'end_turn' | 'empty_final' | 'iteration_cap' | 'max_tokens' | 'refusal' | 'aborted' | 'error' | 'other';
+  detail?: string;
+  iterations: number;
+}
+
+function formatTurnOutcome(o: TurnOutcome): string {
+  const cost = formatUsd(o.totalCostUsd);
+  const iters = `${o.iterations} iter`;
+  const tools = o.toolCalls > 0 ? `, ${o.toolCalls} tool call${o.toolCalls === 1 ? '' : 's'}` : '';
+  switch (o.reason) {
+    case 'end_turn':
+      return `✓ done · ${cost} · ${iters}${tools}`;
+    case 'empty_final':
+      return `⚠ model exited without a final message · ${cost} · ${iters}${tools} — last visible content is above`;
+    case 'iteration_cap':
+      return `⚠ stopped at agent iteration cap (${o.iterations}) — try a more focused prompt or click Compact · ${cost}${tools}`;
+    case 'max_tokens':
+      return `⚠ hit max_tokens before finishing · ${cost} · ${iters}${tools} — ask the model to continue`;
+    case 'refusal':
+      return `⊘ model refused · ${cost} · ${iters}${tools}`;
+    case 'aborted':
+      return `⊘ stopped · ${cost} · ${iters}${tools}`;
+    case 'error':
+      return `✗ ${o.detail ?? 'error'} · ${cost} · ${iters}${tools}`;
+    default:
+      return `· ended (${o.detail ?? 'other'}) · ${cost} · ${iters}${tools}`;
+  }
+}
+
 async function runTurnWithStallRetry(apiKey: string, toggles: ChatToggles, userBlocks: ChatBlock[]): Promise<void> {
   let attempt = 0;
+  let lastTurnOutcome: TurnOutcome | null = null;
   while (true) {
     attempt++;
     const controller = new AbortController();
@@ -833,7 +866,11 @@ async function runTurnWithStallRetry(apiKey: string, toggles: ChatToggles, userB
         if (result.isError) setTransientStatus('A tool errored. The agent will retry or surface the issue.');
       },
       onError: err => {
+        // Capture as the outcome too so the sticky final-state banner
+        // shows the error instead of disappearing silently. The transient
+        // status still flashes for users watching that strip.
         setTransientStatus(`Error: ${err.message}`);
+        lastTurnOutcome = { totalCostUsd: 0, toolCalls: 0, reason: 'error', detail: err.message, iterations: 0 };
       },
       onAborted: () => {
         // Only show the user-stopped notice if the user actually clicked
@@ -843,18 +880,28 @@ async function runTurnWithStallRetry(apiKey: string, toggles: ChatToggles, userB
           inputEl?.focus();
         }
       },
-      onTurnComplete: () => {
+      onTurnComplete: info => {
         void loadHistoryForCurrentSession().then(() => {
           renderTranscript();
           renderCostMeter();
         });
+        lastTurnOutcome = info;
       },
     });
 
     state.inFlight = false;
     state.inFlightController = null;
     setSendButtonMode('send');
-    hideProgress();
+
+    // Surface a sticky completion banner so the user knows the turn
+    // actually ended and why — better than a silent hideProgress that
+    // reads as "the model stalled and gave up".
+    if (lastTurnOutcome) {
+      showProgressFinal(formatTurnOutcome(lastTurnOutcome));
+      lastTurnOutcome = null;
+    } else {
+      hideProgress();
+    }
 
     if (stalledByWatchdog && progressState.retryCount <= MAX_STALL_RETRIES) {
       // Strip the empty/partial assistant message left by the stalled
@@ -901,7 +948,7 @@ function setSendButtonMode(mode: 'send' | 'stop'): void {
 // === Progress indicator + stall watchdog ===
 
 interface ProgressTracker {
-  phase: 'thinking' | 'streaming' | 'tool' | 'idle';
+  phase: 'thinking' | 'streaming' | 'tool' | 'final' | 'idle';
   detail?: string;
   lastBeat: number;
   retryCount: number;
@@ -954,10 +1001,16 @@ function renderProgress(): void {
     progressState.phase === 'thinking' ? `🧠 thinking…${silentSuffix}` :
     progressState.phase === 'streaming' ? `✎ streaming response…${silentSuffix}` :
     progressState.phase === 'tool' ? `🔧 ${progressState.detail ?? 'running tool'}…` :
+    progressState.phase === 'final' ? (progressState.detail ?? '✓ done') :
     '';
   progressEl.replaceChildren();
   const dot = document.createElement('span');
-  dot.className = 'inline-block w-2 h-2 rounded-full bg-blue-400 animate-pulse';
+  // Final-state dot is static and colored by outcome rather than pulsing.
+  const dotColor =
+    progressState.phase === 'final'
+      ? (label.startsWith('⚠') ? 'bg-amber-400' : label.startsWith('✗') || label.startsWith('⊘') ? 'bg-red-400' : 'bg-emerald-400')
+      : 'bg-blue-400 animate-pulse';
+  dot.className = `inline-block w-2 h-2 rounded-full ${dotColor}`;
   progressEl.appendChild(dot);
   const text = document.createElement('span');
   text.textContent = label;
@@ -969,6 +1022,27 @@ function renderProgress(): void {
   ) {
     triggerStallRetry();
   }
+}
+
+/** Display a sticky completion / failure status for ~6s after a turn
+ *  ends. Replaces the silent hideProgress() that left users wondering
+ *  whether the model finished, errored, or just stopped speaking. */
+function showProgressFinal(detail: string): void {
+  if (!progressEl) return;
+  progressState.phase = 'final';
+  progressState.detail = detail;
+  progressState.lastBeat = Date.now();
+  progressEl.classList.remove('hidden');
+  renderProgress();
+  if (progressTickerId !== null) {
+    clearInterval(progressTickerId);
+    progressTickerId = null;
+  }
+  window.setTimeout(() => {
+    if (progressState.phase === 'final' && progressState.detail === detail) {
+      hideProgress();
+    }
+  }, 6000);
 }
 
 function triggerStallRetry(): void {

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -353,9 +353,9 @@ function renderToggleStrip(): void {
   const { toggles } = settings;
 
   toggleStripEl.appendChild(togglePill(
-    '👁 Views',
+    '📸 Auto-render',
     toggles.vision.views,
-    'Vision: send rendered images to the AI (Show AI snapshot + renderView tool). When ON, the model can see what it modeled — costs ~1500 tokens per image. When OFF, the model reasons from code + geometry stats only.',
+    'Auto-render: lets the model call renderView() to take its own screenshots after paint / geometry changes. Each render ≈ 1500 tokens of input on the next turn — verification is valuable but it adds up. The 📷 Show AI button still works manually when this is OFF.',
     () => {
       saveSettings(setToggles(loadSettings(), { vision: { views: !toggles.vision.views } }));
       renderToggleStrip();
@@ -426,7 +426,11 @@ function renderCostMeter(): void {
   const tokens = totalTokensEstimate(state.history, state.systemPromptChars);
   const cost = totalCost(state.history);
   const cachedPrefix = estimateCachedPrefixTokens(state.systemPromptChars);
-  const turnEst = estimateTurnCostUsd(settings.toggles.model, cachedPrefix, 500 + (settings.toggles.vision.views ? 6000 : 0));
+  // Per-turn estimate covers the user's input + a typical response. Image
+  // tokens (Show AI snapshot + any renderView calls the model makes) are
+  // observed on the post-turn meter rather than predicted here — they're
+  // too variable to estimate up front without lying to the user.
+  const turnEst = estimateTurnCostUsd(settings.toggles.model, cachedPrefix, 500);
 
   // Color the context bar by % of model context window
   const ctxLimit = settings.toggles.model === 'claude-haiku-4-5' ? 200_000 : 1_000_000;

--- a/src/ui/aiSettingsModal.ts
+++ b/src/ui/aiSettingsModal.ts
@@ -1,0 +1,128 @@
+// AI Settings modal — accessible from the AI chip overflow. Shows key
+// status (last 4 chars + lifetime usage), and exposes Replace key /
+// Disconnect actions.
+
+import { deleteKey, getKey } from '../ai/db';
+import { resetClient } from '../ai/anthropic';
+import { formatUsd } from '../ai/cost';
+import { showAiKeyModal } from './aiKeyModal';
+
+let modalEl: HTMLElement | null = null;
+
+export interface AiSettingsCallbacks {
+  onChange: () => void;
+}
+
+export async function showAiSettingsModal(cb: AiSettingsCallbacks): Promise<void> {
+  closeModal();
+
+  const overlay = document.createElement('div');
+  overlay.className = 'fixed inset-0 bg-black/60 flex items-center justify-center z-50';
+  overlay.addEventListener('click', e => { if (e.target === overlay) closeModal(); });
+
+  const modal = document.createElement('div');
+  modal.className = 'bg-zinc-800 rounded-xl shadow-2xl border border-zinc-700 w-full max-w-md flex flex-col';
+
+  const header = document.createElement('div');
+  header.className = 'px-5 py-3 border-b border-zinc-700 flex items-center justify-between';
+  const title = document.createElement('h2');
+  title.className = 'text-sm font-semibold text-zinc-100';
+  title.textContent = 'AI Settings';
+  header.appendChild(title);
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
+  closeBtn.textContent = '✕';
+  closeBtn.addEventListener('click', closeModal);
+  header.appendChild(closeBtn);
+  modal.appendChild(header);
+
+  const body = document.createElement('div');
+  body.className = 'px-5 py-4 flex flex-col gap-4 text-sm text-zinc-200';
+
+  const key = await getKey('anthropic');
+  if (!key) {
+    const empty = document.createElement('p');
+    empty.className = 'text-zinc-400';
+    empty.textContent = 'No Anthropic key connected.';
+    body.appendChild(empty);
+    const connectBtn = document.createElement('button');
+    connectBtn.className = 'self-start px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white';
+    connectBtn.textContent = 'Connect Anthropic API';
+    connectBtn.addEventListener('click', () => {
+      closeModal();
+      void showAiKeyModal({ onConnected: cb.onChange });
+    });
+    body.appendChild(connectBtn);
+  } else {
+    const last4 = key.apiKey.slice(-4);
+    const row = (label: string, value: string) => {
+      const r = document.createElement('div');
+      r.className = 'flex justify-between gap-3';
+      const l = document.createElement('span');
+      l.className = 'text-zinc-400';
+      l.textContent = label;
+      const v = document.createElement('span');
+      v.className = 'text-zinc-100 font-mono text-xs';
+      v.textContent = value;
+      r.appendChild(l);
+      r.appendChild(v);
+      return r;
+    };
+    body.appendChild(row('Provider', 'Anthropic'));
+    body.appendChild(row('Key', `…${last4}`));
+    body.appendChild(row('Connected', new Date(key.createdAt).toLocaleString()));
+    body.appendChild(row('Last used', new Date(key.lastUsed).toLocaleString()));
+    body.appendChild(row('Input tokens', key.totalInputTokens.toLocaleString()));
+    body.appendChild(row('Output tokens', key.totalOutputTokens.toLocaleString()));
+    body.appendChild(row('Spent (estimated)', formatUsd(key.totalCostUsd)));
+
+    const note = document.createElement('p');
+    note.className = 'text-xs text-zinc-500 leading-snug';
+    note.textContent = 'Estimated spend uses public list prices and may differ slightly from your Anthropic invoice.';
+    body.appendChild(note);
+
+    const actions = document.createElement('div');
+    actions.className = 'flex justify-end gap-2 pt-2';
+
+    const replaceBtn = document.createElement('button');
+    replaceBtn.className = 'px-3 py-1.5 rounded text-xs text-zinc-200 bg-zinc-700 hover:bg-zinc-600';
+    replaceBtn.textContent = 'Replace key';
+    replaceBtn.addEventListener('click', () => {
+      closeModal();
+      void showAiKeyModal({ onConnected: cb.onChange });
+    });
+    actions.appendChild(replaceBtn);
+
+    const disconnectBtn = document.createElement('button');
+    disconnectBtn.className = 'px-3 py-1.5 rounded text-xs text-red-300 bg-red-900/40 hover:bg-red-800/60';
+    disconnectBtn.textContent = 'Disconnect';
+    disconnectBtn.addEventListener('click', async () => {
+      if (!confirm('Disconnect Anthropic? Your chat history is kept; only the key is removed.')) return;
+      await deleteKey('anthropic');
+      resetClient();
+      closeModal();
+      cb.onChange();
+    });
+    actions.appendChild(disconnectBtn);
+
+    body.appendChild(actions);
+  }
+
+  modal.appendChild(body);
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+  modalEl = overlay;
+
+  const escHandler = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      closeModal();
+      document.removeEventListener('keydown', escHandler);
+    }
+  };
+  document.addEventListener('keydown', escHandler);
+}
+
+function closeModal(): void {
+  modalEl?.remove();
+  modalEl = null;
+}

--- a/src/ui/aiSettingsModal.ts
+++ b/src/ui/aiSettingsModal.ts
@@ -6,123 +6,80 @@ import { deleteKey, getKey } from '../ai/db';
 import { resetClient } from '../ai/anthropic';
 import { formatUsd } from '../ai/cost';
 import { showAiKeyModal } from './aiKeyModal';
-
-let modalEl: HTMLElement | null = null;
+import { createModalShell } from './modalShell';
 
 export interface AiSettingsCallbacks {
   onChange: () => void;
 }
 
 export async function showAiSettingsModal(cb: AiSettingsCallbacks): Promise<void> {
-  closeModal();
-
-  const overlay = document.createElement('div');
-  overlay.className = 'fixed inset-0 bg-black/60 flex items-center justify-center z-50';
-  overlay.addEventListener('click', e => { if (e.target === overlay) closeModal(); });
-
-  const modal = document.createElement('div');
-  modal.className = 'bg-zinc-800 rounded-xl shadow-2xl border border-zinc-700 w-full max-w-md flex flex-col';
-
-  const header = document.createElement('div');
-  header.className = 'px-5 py-3 border-b border-zinc-700 flex items-center justify-between';
-  const title = document.createElement('h2');
-  title.className = 'text-sm font-semibold text-zinc-100';
-  title.textContent = 'AI Settings';
-  header.appendChild(title);
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
-  closeBtn.textContent = '✕';
-  closeBtn.addEventListener('click', closeModal);
-  header.appendChild(closeBtn);
-  modal.appendChild(header);
-
-  const body = document.createElement('div');
-  body.className = 'px-5 py-4 flex flex-col gap-4 text-sm text-zinc-200';
+  const shell = createModalShell({ title: 'AI Settings' });
+  // Settings rows want a slightly larger gap than the default.
+  shell.body.classList.remove('gap-3');
+  shell.body.classList.add('gap-4');
 
   const key = await getKey('anthropic');
   if (!key) {
     const empty = document.createElement('p');
     empty.className = 'text-zinc-400';
     empty.textContent = 'No Anthropic key connected.';
-    body.appendChild(empty);
+    shell.body.appendChild(empty);
     const connectBtn = document.createElement('button');
-    connectBtn.className = 'self-start px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white';
+    connectBtn.className = 'px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white';
     connectBtn.textContent = 'Connect Anthropic API';
     connectBtn.addEventListener('click', () => {
-      closeModal();
+      shell.close();
       void showAiKeyModal({ onConnected: cb.onChange });
     });
-    body.appendChild(connectBtn);
-  } else {
-    const last4 = key.apiKey.slice(-4);
-    const row = (label: string, value: string) => {
-      const r = document.createElement('div');
-      r.className = 'flex justify-between gap-3';
-      const l = document.createElement('span');
-      l.className = 'text-zinc-400';
-      l.textContent = label;
-      const v = document.createElement('span');
-      v.className = 'text-zinc-100 font-mono text-xs';
-      v.textContent = value;
-      r.appendChild(l);
-      r.appendChild(v);
-      return r;
-    };
-    body.appendChild(row('Provider', 'Anthropic'));
-    body.appendChild(row('Key', `…${last4}`));
-    body.appendChild(row('Connected', new Date(key.createdAt).toLocaleString()));
-    body.appendChild(row('Last used', new Date(key.lastUsed).toLocaleString()));
-    body.appendChild(row('Input tokens', key.totalInputTokens.toLocaleString()));
-    body.appendChild(row('Output tokens', key.totalOutputTokens.toLocaleString()));
-    body.appendChild(row('Spent (estimated)', formatUsd(key.totalCostUsd)));
-
-    const note = document.createElement('p');
-    note.className = 'text-xs text-zinc-500 leading-snug';
-    note.textContent = 'Estimated spend uses public list prices and may differ slightly from your Anthropic invoice.';
-    body.appendChild(note);
-
-    const actions = document.createElement('div');
-    actions.className = 'flex justify-end gap-2 pt-2';
-
-    const replaceBtn = document.createElement('button');
-    replaceBtn.className = 'px-3 py-1.5 rounded text-xs text-zinc-200 bg-zinc-700 hover:bg-zinc-600';
-    replaceBtn.textContent = 'Replace key';
-    replaceBtn.addEventListener('click', () => {
-      closeModal();
-      void showAiKeyModal({ onConnected: cb.onChange });
-    });
-    actions.appendChild(replaceBtn);
-
-    const disconnectBtn = document.createElement('button');
-    disconnectBtn.className = 'px-3 py-1.5 rounded text-xs text-red-300 bg-red-900/40 hover:bg-red-800/60';
-    disconnectBtn.textContent = 'Disconnect';
-    disconnectBtn.addEventListener('click', async () => {
-      if (!confirm('Disconnect Anthropic? Your chat history is kept; only the key is removed.')) return;
-      await deleteKey('anthropic');
-      resetClient();
-      closeModal();
-      cb.onChange();
-    });
-    actions.appendChild(disconnectBtn);
-
-    body.appendChild(actions);
+    shell.footer.appendChild(connectBtn);
+    return;
   }
 
-  modal.appendChild(body);
-  overlay.appendChild(modal);
-  document.body.appendChild(overlay);
-  modalEl = overlay;
-
-  const escHandler = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      closeModal();
-      document.removeEventListener('keydown', escHandler);
-    }
+  const last4 = key.apiKey.slice(-4);
+  const row = (label: string, value: string) => {
+    const r = document.createElement('div');
+    r.className = 'flex justify-between gap-3';
+    const l = document.createElement('span');
+    l.className = 'text-zinc-400';
+    l.textContent = label;
+    const v = document.createElement('span');
+    v.className = 'text-zinc-100 font-mono text-xs';
+    v.textContent = value;
+    r.appendChild(l);
+    r.appendChild(v);
+    return r;
   };
-  document.addEventListener('keydown', escHandler);
-}
+  shell.body.appendChild(row('Provider', 'Anthropic'));
+  shell.body.appendChild(row('Key', `…${last4}`));
+  shell.body.appendChild(row('Connected', new Date(key.createdAt).toLocaleString()));
+  shell.body.appendChild(row('Last used', new Date(key.lastUsed).toLocaleString()));
+  shell.body.appendChild(row('Input tokens', key.totalInputTokens.toLocaleString()));
+  shell.body.appendChild(row('Output tokens', key.totalOutputTokens.toLocaleString()));
+  shell.body.appendChild(row('Spent (estimated)', formatUsd(key.totalCostUsd)));
 
-function closeModal(): void {
-  modalEl?.remove();
-  modalEl = null;
+  const note = document.createElement('p');
+  note.className = 'text-xs text-zinc-500 leading-snug';
+  note.textContent = 'Estimated spend uses public list prices and may differ slightly from your Anthropic invoice.';
+  shell.body.appendChild(note);
+
+  const replaceBtn = document.createElement('button');
+  replaceBtn.className = 'px-3 py-1.5 rounded text-xs text-zinc-200 bg-zinc-700 hover:bg-zinc-600';
+  replaceBtn.textContent = 'Replace key';
+  replaceBtn.addEventListener('click', () => {
+    shell.close();
+    void showAiKeyModal({ onConnected: cb.onChange });
+  });
+  shell.footer.appendChild(replaceBtn);
+
+  const disconnectBtn = document.createElement('button');
+  disconnectBtn.className = 'px-3 py-1.5 rounded text-xs text-red-300 bg-red-900/40 hover:bg-red-800/60';
+  disconnectBtn.textContent = 'Disconnect';
+  disconnectBtn.addEventListener('click', async () => {
+    if (!confirm('Disconnect Anthropic? Your chat history is kept; only the key is removed.')) return;
+    await deleteKey('anthropic');
+    resetClient();
+    shell.close();
+    cb.onChange();
+  });
+  shell.footer.appendChild(disconnectBtn);
 }

--- a/src/ui/modalShell.ts
+++ b/src/ui/modalShell.ts
@@ -1,0 +1,91 @@
+// Shared scaffolding for the AI-related modals (key entry, settings,
+// compact-confirm). Each used to hand-roll the same overlay, header,
+// ✕ button, Escape handler, and click-outside-to-close logic, plus a
+// module-level `modalEl` for "close-existing-before-show" — and each
+// also leaked one document keydown listener per open/close cycle.
+//
+// Callers receive an empty body + footer to fill. Opening a new shell
+// auto-closes any previous shell, so two of these can never overlap.
+
+export interface ModalShellOptions {
+  title: string;
+  /** Tailwind max-width fragment without the `max-w-` prefix.
+   *  Defaults to `'md'`. Compact-confirm uses `'2xl'`. */
+  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+  /** When true, applies `max-h-[80vh]` + `overflow-auto` so long bodies
+   *  (e.g. compaction proposal with many notes) scroll. */
+  scrollable?: boolean;
+}
+
+export interface ModalShell {
+  /** Empty flex column. Append your form rows, paragraphs, etc. */
+  body: HTMLElement;
+  /** Empty right-aligned button row with a top divider. Append Cancel /
+   *  primary action buttons. */
+  footer: HTMLElement;
+  /** Tear down the modal. Safe to call multiple times. */
+  close: () => void;
+}
+
+let currentModal: HTMLElement | null = null;
+
+export function createModalShell(opts: ModalShellOptions): ModalShell {
+  // Only one shell modal at a time. Close any previous before showing
+  // the new one — the previous shell's Escape listener is removed by
+  // its own teardown path so we don't double-leak.
+  if (currentModal) {
+    currentModal.dispatchEvent(new CustomEvent('shell:force-close'));
+  }
+
+  const maxW = `max-w-${opts.maxWidth ?? 'md'}`;
+  const maxH = opts.scrollable ? 'max-h-[80vh]' : '';
+
+  const overlay = document.createElement('div');
+  overlay.className = 'fixed inset-0 bg-black/60 flex items-center justify-center z-50';
+
+  const modal = document.createElement('div');
+  modal.className = `bg-zinc-800 rounded-xl shadow-2xl border border-zinc-700 w-full ${maxW} ${maxH} flex flex-col`.replace(/\s+/g, ' ').trim();
+
+  const header = document.createElement('div');
+  header.className = 'px-5 py-3 border-b border-zinc-700 flex items-center justify-between';
+  const titleEl = document.createElement('h2');
+  titleEl.className = 'text-sm font-semibold text-zinc-100';
+  titleEl.textContent = opts.title;
+  header.appendChild(titleEl);
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
+  closeBtn.textContent = '✕';
+  header.appendChild(closeBtn);
+  modal.appendChild(header);
+
+  const body = document.createElement('div');
+  const overflowClass = opts.scrollable ? 'overflow-auto' : '';
+  body.className = `px-5 py-4 flex flex-col gap-3 text-sm text-zinc-200 ${overflowClass}`.trim();
+  modal.appendChild(body);
+
+  const footer = document.createElement('div');
+  footer.className = 'px-5 py-3 border-t border-zinc-700 flex items-center justify-end gap-2';
+  modal.appendChild(footer);
+
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+  currentModal = overlay;
+
+  let closed = false;
+  const escHandler = (e: KeyboardEvent) => { if (e.key === 'Escape') close(); };
+  document.addEventListener('keydown', escHandler);
+  overlay.addEventListener('shell:force-close', () => close());
+
+  function close(): void {
+    if (closed) return;
+    closed = true;
+    document.removeEventListener('keydown', escHandler);
+    overlay.remove();
+    if (currentModal === overlay) currentModal = null;
+  }
+
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  closeBtn.addEventListener('click', close);
+
+  return { body, footer, close };
+}

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -29,6 +29,24 @@ export interface ToolbarCallbacks {
   onOpenCatalog: () => void;
   onLanguageSwitch: (lang: 'manifold-js' | 'scad') => void;
   onGoHome: () => void;
+  /** Toggle the AI chat side panel. */
+  onToggleAi: () => void;
+}
+
+let _aiBtn: HTMLButtonElement | null = null;
+
+/** Update the AI chip label/state from outside (e.g. when key connects/disconnects). */
+export function setAiToolbarState(connected: boolean): void {
+  if (!_aiBtn) return;
+  if (connected) {
+    _aiBtn.className = 'flex items-center gap-1.5 px-2 py-1 rounded text-xs text-blue-300 bg-blue-900/30 border border-blue-700/50 hover:bg-blue-900/50 transition-colors';
+    _aiBtn.innerHTML = '<span>✦ AI</span>';
+    _aiBtn.title = 'Open AI chat panel';
+  } else {
+    _aiBtn.className = 'flex items-center gap-1.5 px-2 py-1 rounded text-xs text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 transition-colors';
+    _aiBtn.innerHTML = '<span>✦ Connect AI</span>';
+    _aiBtn.title = 'Connect an Anthropic API key to chat with the AI';
+  }
 }
 
 /** File extensions accepted by the Import button and drag-and-drop. */
@@ -467,6 +485,16 @@ export function createToolbar(
   });
 
   toolbar.appendChild(exportWrapper);
+
+  // AI chat toggle — opens the side drawer; switches between "Connect AI"
+  // (no key yet) and a connected chip via setAiToolbarState() from main.ts.
+  _aiBtn = document.createElement('button');
+  _aiBtn.id = 'btn-ai';
+  _aiBtn.className = 'flex items-center gap-1.5 px-2 py-1 rounded text-xs text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 transition-colors ml-1';
+  _aiBtn.innerHTML = '<span>✦ Connect AI</span>';
+  _aiBtn.title = 'Connect an Anthropic API key to chat with the AI';
+  _aiBtn.addEventListener('click', callbacks.onToggleAi);
+  toolbar.appendChild(_aiBtn);
 
   // Dark mode toggle — text button, on by default, off when clicked
   const themeBtn = document.createElement('button');

--- a/tests/manifold-id-verify.spec.ts
+++ b/tests/manifold-id-verify.spec.ts
@@ -1,0 +1,149 @@
+// Phase 0 verification for the proposed labelled-construction feature
+// (Tier 3 of the painting workflow improvements). Empirically tests:
+//
+//  1. Does a freshly-constructed `Manifold.cube(...)` have a valid
+//     originalID()? Or is it -1 until asOriginal() is called?
+//  2. After `a.add(b)`, does the result.getMesh() populate runOriginalID
+//     and runIndex? Are the array lengths consistent?
+//  3. Does `shape.asOriginal().translate([...])` preserve the originalID
+//     through a boolean op?
+//  4. With overlapping shapes, is each output triangle attributed to
+//     exactly one input (i.e. is the run partition a proper covering)?
+//
+// This test exists to inform the labelled-construction design — if any
+// of these answers is "no", the design changes. Once we ship and have
+// confidence, we can delete this file.
+
+import { test, expect } from 'playwright/test';
+
+test.describe('manifold-3d ID propagation', () => {
+  test('asOriginal / originalID / runIndex behavior', async ({ page }) => {
+    await page.goto('/editor');
+    // Wait for the WASM engine to load. The status badge flips to "Ready"
+    // once init completes; we trigger a small run to be sure.
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // Run a tiny program to ensure manifold-3d is loaded into the page.
+    const warmup = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      if (!pw?.runIsolated) return { ok: false, reason: 'partwright.runIsolated missing' };
+      const r = await pw.runIsolated('return api.Manifold.cube([1,1,1]);');
+      return { ok: !r?.error, reason: r?.error };
+    });
+    expect(warmup.ok, `warmup failed: ${warmup.reason}`).toBe(true);
+
+    // Now load the manifold-3d module via the same path the app uses and
+    // run the verification. Vite serves node_modules in dev with the
+    // existing COEP/COOP headers, so the WASM threading works.
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const Module: any = await import('/node_modules/manifold-3d/manifold.js');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const m: any = await Module.default();
+      m.setup();
+      const { Manifold } = m;
+
+      const out: Record<string, unknown> = {};
+
+      // Q1: Does a fresh primitive have an originalID >= 0?
+      const cube = Manifold.cube([10, 10, 10]);
+      out.q1_freshCubeOriginalID = cube.originalID();
+
+      // Q1b: Does asOriginal() yield a different/new id?
+      const cubeOrig = cube.asOriginal();
+      out.q1b_asOriginalID = cubeOrig.originalID();
+      out.q1c_idsDiffer = cube.originalID() !== cubeOrig.originalID();
+
+      // Q2: After boolean add, does the result mesh carry runOriginalID/runIndex?
+      const a = Manifold.cube([10, 10, 10]).asOriginal();
+      const b = Manifold.sphere(5).translate([5, 5, 15]).asOriginal();
+      out.q2_a_id = a.originalID();
+      out.q2_b_id = b.originalID();
+      const sum = a.add(b);
+      const sumMesh = sum.getMesh();
+      out.q2_sumNumTri = sumMesh.numTri;
+      out.q2_runOriginalID = sumMesh.runOriginalID
+        ? Array.from(sumMesh.runOriginalID as Uint32Array)
+        : null;
+      out.q2_runIndex = sumMesh.runIndex
+        ? Array.from(sumMesh.runIndex as Uint32Array)
+        : null;
+      out.q2_runIndexCoversAllTris =
+        sumMesh.runIndex &&
+        sumMesh.runIndex[sumMesh.runIndex.length - 1] === sumMesh.numTri * 3;
+
+      // Q3: Does a translated labelled shape preserve its originalID after union?
+      const c = Manifold.cube([5, 5, 5]).asOriginal();
+      const cId = c.originalID();
+      const cTranslated = c.translate([20, 0, 0]);
+      // The translated copy: its originalID should match the un-translated
+      // original (since transforms don't change identity).
+      const sumWithTransform = Manifold.cube([10, 10, 10]).asOriginal().add(cTranslated);
+      const stMesh = sumWithTransform.getMesh();
+      out.q3_c_id_before_translate = cId;
+      out.q3_runOriginalID = stMesh.runOriginalID
+        ? Array.from(stMesh.runOriginalID as Uint32Array)
+        : null;
+      out.q3_transformedCubeIdPresent =
+        stMesh.runOriginalID && Array.from(stMesh.runOriginalID as Uint32Array).includes(cId);
+
+      // Q4: Overlapping shapes — is the run partition a proper covering?
+      const head = Manifold.sphere(20, 64).asOriginal();
+      const eye = Manifold.sphere(5, 32).translate([0, 18, 0]).asOriginal();
+      const headEyeUnion = head.add(eye);
+      const heMesh = headEyeUnion.getMesh();
+      const heCovers =
+        heMesh.runIndex &&
+        heMesh.runIndex[heMesh.runIndex.length - 1] === heMesh.numTri * 3;
+      // Each triangle is in exactly one run (by construction — runs are
+      // contiguous and span the full triVerts array). Count how many
+      // triangles are attributed to each input.
+      const heCounts: Record<number, number> = {};
+      if (heMesh.runOriginalID && heMesh.runIndex) {
+        const oids = heMesh.runOriginalID as Uint32Array;
+        const idxs = heMesh.runIndex as Uint32Array;
+        for (let i = 0; i < oids.length; i++) {
+          const tris = (idxs[i + 1] - idxs[i]) / 3;
+          heCounts[oids[i]] = (heCounts[oids[i]] || 0) + tris;
+        }
+      }
+      out.q4_headId = head.originalID();
+      out.q4_eyeId = eye.originalID();
+      out.q4_perInputTriCounts = heCounts;
+      out.q4_runIndexCoversAllTris = heCovers;
+
+      // Q5 (bonus): What if you DON'T call asOriginal — does the result mesh
+      // still get runOriginalID, or is it empty? This tells us whether
+      // asOriginal is *required* for labelling or merely useful.
+      const noLabelA = Manifold.cube([1, 1, 1]);
+      const noLabelB = Manifold.sphere(1).translate([2, 0, 0]);
+      const noLabelSum = noLabelA.add(noLabelB);
+      const nlMesh = noLabelSum.getMesh();
+      out.q5_a_id = noLabelA.originalID();
+      out.q5_b_id = noLabelB.originalID();
+      out.q5_runOriginalID = nlMesh.runOriginalID
+        ? Array.from(nlMesh.runOriginalID as Uint32Array)
+        : null;
+      out.q5_runIndex = nlMesh.runIndex
+        ? Array.from(nlMesh.runIndex as Uint32Array)
+        : null;
+
+      return out;
+    });
+
+    // Print everything so the test output captures the empirical answers.
+    // eslint-disable-next-line no-console
+    console.log('manifold-3d ID verification results:', JSON.stringify(result, null, 2));
+
+    // Assertions encode the behavior we EXPECT (per the docs); a failing
+    // assertion is the interesting case — it means the design changes.
+    expect(result.q1_freshCubeOriginalID, 'fresh primitives should have a valid originalID').toBeGreaterThanOrEqual(0);
+    expect(result.q2_runOriginalID, 'union result mesh should carry runOriginalID').not.toBeNull();
+    expect((result.q2_runOriginalID as number[]).length, 'union result should have >= 2 runs').toBeGreaterThanOrEqual(2);
+    expect(result.q2_runIndexCoversAllTris, 'runIndex should cover the full triVerts array').toBe(true);
+    expect(result.q3_transformedCubeIdPresent, 'translated copy of labelled shape should carry its originalID through the union').toBe(true);
+    expect(result.q4_runIndexCoversAllTris, 'overlapping union runIndex should still cover all triangles').toBe(true);
+    expect(Object.keys(result.q4_perInputTriCounts as object).length, 'overlapping union should attribute triangles to >= 2 distinct originalIDs').toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, type Page } from 'playwright/test';
+
+// Smoke tests that run with no external network — every assertion either
+// hits localhost or a same-origin static asset. The bad-key test does try
+// api.anthropic.com (and may legitimately fail in a network-restricted
+// sandbox) but is gated behind a connectivity probe so it self-skips.
+
+// Playwright gives each test a fresh BrowserContext by default, so
+// localStorage and IndexedDB are isolated. We don't need explicit storage
+// clearing — but we do guard against IndexedDB races between tests by
+// landing on `/` first and giving the engine a beat to settle.
+
+test.describe('Landing + editor', () => {
+  test('landing page renders hero', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Partwright', level: 1 })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Open Editor/i })).toBeVisible();
+  });
+
+  test('editor loads with AI button', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#btn-ai', { timeout: 10_000 });
+    await expect(page.locator('#btn-ai')).toContainText(/Connect AI|AI/);
+    expect(errors.filter(isAppRelevant)).toEqual([]);
+  });
+});
+
+test.describe('AI chat panel', () => {
+  test('toolbar button toggles the drawer', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#btn-ai');
+
+    // Drawer exists from boot but is translated off-screen until first open.
+    await page.click('#btn-ai');
+    await expect(page.locator('#ai-panel')).toHaveClass(/translate-x-0/);
+    await page.click('#ai-panel button:has-text("✕")');
+    await expect(page.locator('#ai-panel')).toHaveClass(/translate-x-full/);
+  });
+
+  test('drawer state persists across reload', async ({ page }) => {
+    // Start clean (beforeEach cleared storage), open drawer, then reload —
+    // the stored drawerOpen=true should bring it back open.
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#btn-ai');
+    await page.click('#btn-ai');
+    await expect(page.locator('#ai-panel')).toHaveClass(/translate-x-0/);
+
+    await page.reload();
+    await page.waitForSelector('#ai-panel');
+    await expect(page.locator('#ai-panel')).toHaveClass(/translate-x-0/);
+  });
+
+  test('drawer survives switching tabs', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#btn-ai');
+    await page.click('#btn-ai');
+    await expect(page.locator('#ai-panel')).toHaveClass(/translate-x-0/);
+
+    const galleryTab = page.locator('button', { hasText: /^Gallery$/ });
+    if (await galleryTab.count()) {
+      await galleryTab.first().click();
+      await expect(page.locator('#ai-panel')).toHaveClass(/translate-x-0/);
+    }
+  });
+
+  test('panel widgets render', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.click('#btn-ai');
+    const panel = page.locator('#ai-panel');
+
+    // Toggle pills
+    await expect(panel.locator('button', { hasText: /👁 Views/ })).toBeVisible();
+    await expect(panel.locator('button', { hasText: /▶ Run/ })).toBeVisible();
+    await expect(panel.locator('button', { hasText: /💾 Save/ })).toBeVisible();
+    await expect(panel.locator('button', { hasText: /🎨 Paint/ })).toBeVisible();
+
+    // Cost meter — "ctx", "session", "next turn"
+    await expect(panel).toContainText(/ctx/);
+    await expect(panel).toContainText(/session:/);
+    await expect(panel).toContainText(/next turn/);
+
+    // Show AI + paperclip + send
+    await expect(panel.locator('button', { hasText: /Show AI/ })).toBeVisible();
+    await expect(panel.locator('button', { hasText: /^Send$/ })).toBeVisible();
+  });
+
+  test('key modal opens and closes', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.click('#btn-ai');
+    await page.locator('#ai-panel button:has-text("Connect Anthropic API")').click();
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Connect Anthropic API' })).toBeVisible();
+
+    // Cancel returns to the panel, no key persisted
+    await page.locator('.bg-zinc-800.rounded-xl button:text-is("Cancel")').click();
+    await expect(page.locator('input[type="password"]')).toHaveCount(0);
+    await expect(page.locator('#btn-ai')).toContainText(/Connect AI/);
+  });
+
+  test('toggle pills flip state on click', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.click('#btn-ai');
+    const viewsPill = page.locator('#ai-panel button', { hasText: /👁 Views/ });
+    const before = await viewsPill.getAttribute('class');
+    // The toggle strip lives inside the panel's bottom region. Playwright
+    // (1.58 + chromium 141) intermittently reports `Element is outside of
+    // the viewport` for these even when their bounding box is well inside
+    // — likely a hit-test edge case with very small flex children of a
+    // recently-transformed parent. Dispatching a synthetic click event
+    // exercises the same handler path the user would and is what the
+    // app's onClick wiring registered for. We still asserted visibility
+    // and that the locator resolved to exactly one element above.
+    await viewsPill.dispatchEvent('click');
+    const after = await viewsPill.getAttribute('class');
+    expect(before).not.toBe(after);
+  });
+
+  test('ai.md is served at the root', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    const ok = await page.evaluate(async () => {
+      const r = await fetch('/ai.md');
+      return r.ok && (await r.text()).length > 100;
+    });
+    expect(ok).toBe(true);
+  });
+});
+
+// === helpers ===
+
+interface CollectedError {
+  type: 'pageerror' | 'console';
+  text: string;
+}
+
+function collectPageErrors(page: Page): CollectedError[] {
+  const errors: CollectedError[] = [];
+  page.on('pageerror', e => errors.push({ type: 'pageerror', text: e.message }));
+  page.on('console', msg => {
+    if (msg.type() === 'error') errors.push({ type: 'console', text: msg.text() });
+  });
+  return errors;
+}
+
+// Filter out errors that aren't from the app code under test:
+//   - coi-serviceworker.js' import.meta warning (pre-existing, build-time)
+//   - sandbox-only certificate failures from external assets
+function isAppRelevant(err: CollectedError): boolean {
+  const ignored = [
+    /import\.meta/i,
+    /ERR_CERT_AUTHORITY_INVALID/i,
+    /Failed to load resource.*coi-serviceworker/i,
+  ];
+  return !ignored.some(re => re.test(err.text));
+}

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -126,6 +126,21 @@ test.describe('AI chat panel', () => {
     expect(ok).toBe(true);
   });
 
+  test('toggle pills carry tooltips explaining what they do', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel');
+    await page.locator('#btn-ai').dispatchEvent('click');
+    const pillNames = ['👁 Views', '▶ Run', '💾 Save', '🎨 Paint'];
+    for (const name of pillNames) {
+      const pill = page.locator('#ai-panel button', { hasText: name });
+      await expect(pill).toBeVisible();
+      const title = await pill.getAttribute('title');
+      expect(title, `${name} should have a tooltip`).toBeTruthy();
+      expect(title!.length).toBeGreaterThan(20);
+      expect(title!.toLowerCase()).toMatch(/on|off|click/);
+    }
+  });
+
   test('drawer + send from landing page navigates to editor', async ({ page }) => {
     // Open the drawer on /editor first so it persists open, then go back
     // to the landing page. The drawer is a body-level overlay so it

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -88,7 +88,8 @@ test.describe('AI chat panel', () => {
   test('key modal opens and closes', async ({ page }) => {
     await page.goto('/editor?view=ai');
     await page.click('#btn-ai');
-    await page.locator('#ai-panel button:has-text("Connect Anthropic API")').click();
+    // dispatchEvent — same flex-child viewport quirk as the toggle pills.
+    await page.locator('#ai-panel button:has-text("Connect Anthropic API")').dispatchEvent('click');
     await expect(page.locator('input[type="password"]')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Connect Anthropic API' })).toBeVisible();
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -125,6 +125,34 @@ test.describe('AI chat panel', () => {
     });
     expect(ok).toBe(true);
   });
+
+  test('drawer + send from landing page navigates to editor', async ({ page }) => {
+    // Open the drawer on /editor first so it persists open, then go back
+    // to the landing page. The drawer is a body-level overlay so it
+    // should still be visible there.
+    await page.goto('/editor');
+    // Wait for the panel itself, not just the toolbar button — the button
+    // mounts first, the panel's click-handler comes online a beat later.
+    await page.waitForSelector('#ai-panel');
+    // Click via dispatchEvent so we sidestep the same viewport-hit-test
+    // edge case that bites the toggle-pill click on a freshly-mounted
+    // panel; we just need the click handler to fire.
+    await page.locator('#btn-ai').dispatchEvent('click');
+    await expect(page.locator('#ai-panel')).toHaveClass(/translate-x-0/, { timeout: 5000 });
+    await page.goto('/');
+    await page.waitForSelector('#ai-panel');
+    await expect(page.locator('#ai-panel')).toBeVisible();
+
+    // Sending a message from the landing page should navigate to /editor.
+    // No key is set so the key modal appears first — that path is fine,
+    // we just want to confirm we don't silently model on /.
+    await page.locator('#ai-panel textarea').fill('build a cube');
+    await page.locator('#ai-panel button:has-text("Send")').dispatchEvent('click');
+    const onEditor = page.waitForURL(/\/editor/, { timeout: 5000 }).then(() => 'editor');
+    const onModal = page.waitForSelector('input[type="password"]', { timeout: 5000 }).then(() => 'modal');
+    const which = await Promise.race([onEditor, onModal]);
+    expect(['editor', 'modal']).toContain(which);
+  });
 });
 
 // === helpers ===

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -70,7 +70,7 @@ test.describe('AI chat panel', () => {
     const panel = page.locator('#ai-panel');
 
     // Toggle pills
-    await expect(panel.locator('button', { hasText: /👁 Views/ })).toBeVisible();
+    await expect(panel.locator('button', { hasText: /📸 Auto-render/ })).toBeVisible();
     await expect(panel.locator('button', { hasText: /▶ Run/ })).toBeVisible();
     await expect(panel.locator('button', { hasText: /💾 Save/ })).toBeVisible();
     await expect(panel.locator('button', { hasText: /🎨 Paint/ })).toBeVisible();
@@ -102,7 +102,7 @@ test.describe('AI chat panel', () => {
   test('toggle pills flip state on click', async ({ page }) => {
     await page.goto('/editor?view=ai');
     await page.click('#btn-ai');
-    const viewsPill = page.locator('#ai-panel button', { hasText: /👁 Views/ });
+    const viewsPill = page.locator('#ai-panel button', { hasText: /📸 Auto-render/ });
     const before = await viewsPill.getAttribute('class');
     // The toggle strip lives inside the panel's bottom region. Playwright
     // (1.58 + chromium 141) intermittently reports `Element is outside of
@@ -130,7 +130,7 @@ test.describe('AI chat panel', () => {
     await page.goto('/editor');
     await page.waitForSelector('#ai-panel');
     await page.locator('#btn-ai').dispatchEvent('click');
-    const pillNames = ['👁 Views', '▶ Run', '💾 Save', '🎨 Paint'];
+    const pillNames = ['📸 Auto-render', '▶ Run', '💾 Save', '🎨 Paint'];
     for (const name of pillNames) {
       const pill = page.locator('#ai-panel button', { hasText: name });
       await expect(pill).toBeVisible();


### PR DESCRIPTION
## Summary

Adds a right-side AI chat drawer that drives Partwright through a Claude agent loop. Users paste their own Anthropic API key — no backend, no hosted proxy. The system prompt is the existing `public/ai.md` (served with prompt caching), tools wrap `window.partwright`, and a per-session toggle strip exposes vision / scope / model / auto-retry controls.

- **Connect AI** chip in the toolbar opens a key entry modal; key is validated with a 1-token request and stored in IndexedDB
- **Right-side drawer** with streaming chat, model picker (Haiku 4.5 / Sonnet 4.6 / Opus 4.7), preset dropdown (Minimal / Standard / Full / Custom), and a toggle bar
- **Tools** mapped to `window.partwright`: `getCode`, `setCode`, `runCode`, `runAndSave`, `getGeometryData`, `getMeshSummary`, `getSessionContext`, `listVersions`, `loadVersion`, `addSessionNote`, `listSessionNotes`, `paintRegion`, `paintFaces`, `findFaces`, `clearColors`. Disabled tools are removed from the request payload — the model can't call what it can't see, and a system-prompt suffix tells it which capabilities are off.
- **Vision** via "📷 Show AI" (snapshots the 4 iso views into one composited PNG) plus drag-drop and clipboard paste for reference photos
- **Cost transparency**: context meter, session total, per-turn estimate, per-message actual
- **Manual compaction**: Haiku summarizes older turns + proposes session notes; user reviews in a confirm modal; accepted notes get promoted via `addSessionNote` so they survive future compactions and are visible to external Claude Code agents
- **AI Settings** modal shows lifetime usage, Replace key, Disconnect

### What's deferred (tracked in `.plans/in-app-ai-chat.md`)

⌘K command bar, auto-compaction logic (UI ships, defaults Off), branch-on-compact / undo, pinned messages, multi-provider, screen capture, voice I/O, inline diff for code edits, "iterate from here" per-version button.

### Storage

Bumps the partwright IndexedDB to v3 with two new stores (`aiKeys`, `aiChats`). Settings live in `localStorage`. Existing sessions, versions, and notes stores are unchanged.

### Security disclosure (in the modal text and settings page)

> "Your key is stored only in this browser. Anyone who can run code in this page (extensions, devtools) can read it. Use a workspace-scoped key with a monthly spend cap."

`@anthropic-ai/sdk` is used with `dangerouslyAllowBrowser: true`.

## Test plan

- [ ] Click **Connect AI** in the toolbar → key modal opens; bad key shows an inline error; valid key flips the chip to "✦ AI" and the drawer opens
- [ ] Send "make a 10mm sphere at origin and run it" → expect a `runAndSave` tool call and a new gallery version
- [ ] Click **📷 Show AI** with geometry on screen → next turn includes the iso-views composite image
- [ ] Drag a PNG onto the panel → it appears as a pending chip; sending includes it
- [ ] Toggle off **👁 Views** → `renderView` disappears from the tool list and the model stops asking for screenshots
- [ ] Switch model picker to **Haiku** → cost meter shows lower per-turn estimate
- [ ] Click **⤓ Compact** with a non-trivial transcript → confirm modal shows summary + proposed `[DECISION]` / `[REQUIREMENT]` notes; accept → notes appear in Notes tab, transcript collapses to summary + last 4 turns
- [ ] Refresh the page → drawer restores per-session history
- [ ] **AI Settings** → **Disconnect** → chip reverts to "✦ Connect AI", chat history preserved
- [ ] All existing smoke tests in `CLAUDE.md` still pass
- [ ] `npm run build` succeeds (✓ verified locally)

https://claude.ai/code/session_018RSDXQg6Px1JD2RHHHmWcK

---
_Generated by [Claude Code](https://claude.ai/code/session_018RSDXQg6Px1JD2RHHHmWcK)_