### PR TITLE
fix: mark 3MF as Recommended export and correct help copy

### DIFF
--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -53,7 +53,7 @@ export function createHelpPage(
     },
     {
       heading: 'Exporting',
-      body: 'Export your geometry as GLB, STL, OBJ, or 3MF using the Export dropdown in the toolbar. GLB is recommended for most uses.',
+      body: 'Export your geometry as 3MF, OBJ, STL, or GLB using the Export dropdown in the toolbar. 3MF is recommended for 3D printing — it carries color regions natively and imports cleanly into Bambu Studio and other slicers. Use GLB for web preview only (slicers do not read it).',
     },
     {
       heading: 'AI agent workflow',

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -312,6 +312,7 @@ export function createToolbar(
   const threemfOpt = createDescribedItem(
     '3MF',
     'Geometry + color. Native format for Bambu Studio multi-color prints.',
+    'Recommended',
   );
   threemfOpt.addEventListener('click', () => {
     dropdown.classList.add('hidden');


### PR DESCRIPTION
## Summary
Closes #41.

- Adds a `Recommended` badge to the **3MF** entry in the Export dropdown (`createDescribedItem` already supports a `badge` arg — just wiring it up).
- Rewrites the help page's "Exporting" section. The old copy said "GLB is recommended for most uses," which contradicted the dropdown's own "GLB — Not supported by slicers." New copy points users at 3MF for prints and clarifies GLB is web-preview only.

3MF color import has been verified end-to-end against Bambu Studio, so promoting it to the Recommended slot is safe.

OBJ + MTL color import was the original concern in #41 (PR #34 had badged OBJ as Recommended). Since the dropdown was already reorganized to put 3MF first and downgrade OBJ's wording, the only remaining gap was the missing Recommended badge and the stale help text — both fixed here.

## Test plan
- [ ] `npm run dev`, open `/editor`, click Export. 3MF row shows a green "RECOMMENDED" pill next to the label.
- [ ] Visit `/help`, find the "Exporting" section. Copy mentions 3MF for printing and GLB for web preview only.
- [ ] `npm run build` succeeds (verified locally).

https://claude.ai/code/session_01CMSZahLQsGReVzezYCSnKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSZahLQsGReVzezYCSnKQ)_