### PR TITLE
fix: dispose offscreen renderer after idle to reclaim GPU memory

### DIFF
--- a/src/renderer/multiview.ts
+++ b/src/renderer/multiview.ts
@@ -74,6 +74,31 @@ function meshDataToGeometry(meshData: MeshData): THREE.BufferGeometry {
 }
 
 let offRenderer: THREE.WebGLRenderer | null = null;
+let offRendererDisposeTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Three.js retains compiled shader programs, framebuffers, and texture handles
+// inside WebGLRenderer that setSize() does not free. Browsers also cap a tab
+// at ~16 live WebGL contexts. We dispose the offscreen renderer after a short
+// idle window so GPU memory is reclaimed between user actions; the lazy branch
+// in getOffscreenRenderer re-creates it on the next render.
+const OFFSCREEN_IDLE_DISPOSE_MS = 10_000;
+
+function disposeOffscreenRenderer(): void {
+  if (!offRenderer) return;
+  // forceContextLoss releases the underlying WebGL context; dispose() alone
+  // leaves it counted against the per-tab context cap.
+  offRenderer.forceContextLoss();
+  offRenderer.dispose();
+  offRenderer = null;
+}
+
+function scheduleOffscreenDispose(): void {
+  if (offRendererDisposeTimer) clearTimeout(offRendererDisposeTimer);
+  offRendererDisposeTimer = setTimeout(() => {
+    offRendererDisposeTimer = null;
+    disposeOffscreenRenderer();
+  }, OFFSCREEN_IDLE_DISPOSE_MS);
+}
 
 function getOffscreenRenderer(size: number): THREE.WebGLRenderer {
   if (!offRenderer) {
@@ -81,6 +106,7 @@ function getOffscreenRenderer(size: number): THREE.WebGLRenderer {
     offRenderer.setPixelRatio(1);
   }
   offRenderer.setSize(size, size);
+  scheduleOffscreenDispose();
   return offRenderer;
 }
 


### PR DESCRIPTION
## Summary
Closes #106.

The offscreen `WebGLRenderer` in `src/renderer/multiview.ts` is shared across the AI Views grid, Elevations tab, composite-canvas thumbnails, and single-view rendering. It was never disposed, so Three.js's internal caches (compiled shader programs, framebuffers, texture handles) grew across session iterations and were never reclaimed — `setSize()` does not free any of it. Browsers also cap a tab at ~16 live WebGL contexts.

**Fix:** Add a 10s idle-dispose timer inside `getOffscreenRenderer`. Every render resets the timer; when it fires, `forceContextLoss()` + `dispose()` fully release the renderer and the underlying GL context, and the existing lazy branch re-creates it on the next render. Cost is a one-time shader recompile after idle periods (sub-100ms, invisible in practice).

Scope is intentionally tight — 26 lines added, no API changes, every render call site (multiview / elevations / composite / single-view) benefits automatically because they all go through `getOffscreenRenderer`.

## Notes vs. the original issue
- Scene-level disposal (`geometry.dispose`, `material.dispose`) was already correct at every render site (lines 173, 249, 502, 571). The leak was purely the persistent renderer.
- The **gallery render-storm** scenario described in #106 no longer applies: thumbnails are cached as Blobs on the version record in IndexedDB (`src/storage/db.ts:51`) and the gallery reads them directly via `URL.createObjectURL` (`src/ui/gallery.ts:159-163`) — no offscreen render on gallery open. So the bounded render rate (a few per save / tab switch) made dispose-on-idle viable without the gallery performance concerns from the issue.
- I considered Three.js's `renderer.info.reset()` flush-only approach, but it doesn't actually reclaim GPU memory or the WebGL context slot — only `dispose()` does that.

## Test plan
- [x] `npm run build` succeeds.
- [x] `npm run dev` starts and `/editor` returns 200.
- [ ] **Manual:** open `/editor?view=ai`, iterate 30+ versions, leave the tab idle 15s, confirm in Chrome DevTools > Performance Monitor that "GPU memory" plateaus or drops rather than growing unbounded. (I can't drive a real browser from here — needs human verification before merging.)
- [ ] **Manual:** verify no visible regression — after the dispose fires, the next render in AI Views / Elevations / save-thumbnail should look identical (one-time shader recompile is the only difference).
- [ ] **Manual:** run 50 model iterations across multiple sessions — AI Views and elevations should keep working without WebGL context loss.

https://claude.ai/code/session_01CMSZahLQsGReVzezYCSnKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSZahLQsGReVzezYCSnKQ)_