### PR TITLE
feat: mobile-friendly editor layout — stacked panes, touch splitter, pane toggle

### DIFF
--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,3 +1,5 @@
+import { getMobilePane, onMobilePaneChange, setMobilePane } from './mobilePane';
+
 export type TabName = 'interactive' | 'ai' | 'elevations' | 'gallery' | 'images' | 'diff' | 'notes';
 
 export interface LayoutElements {
@@ -22,12 +24,14 @@ export interface SwitchTabOptions {
 
 export function createLayout(appContainer: HTMLElement): LayoutElements {
   const main = document.createElement('div');
-  main.className = 'flex flex-1 min-h-0';
+  // Stack panes vertically on narrow viewports, side-by-side at md+.
+  main.className = 'flex flex-col md:flex-row flex-1 min-h-0';
 
-  // === Left: Editor pane ===
+  // === Left (or top on mobile): Editor pane ===
+  // Width is only applied via inline style at md+ (see syncEditorPaneWidth).
+  // On mobile the pane uses flex sizing so both panes share the vertical space.
   const editorPane = document.createElement('div');
-  editorPane.className = 'flex flex-col border-r border-zinc-700';
-  editorPane.style.width = '35%';
+  editorPane.className = 'flex flex-col flex-1 md:flex-none min-h-0 border-b md:border-b-0 md:border-r border-zinc-700';
 
   const editorHeader = document.createElement('div');
   editorHeader.className = 'flex items-center justify-between px-3 py-1.5 bg-zinc-800 border-b border-zinc-700';
@@ -57,17 +61,23 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   editorPane.appendChild(editorContainer);
 
   // === Splitter ===
+  // Outer is a wide transparent grab strip (touch-friendly); inner stripe is the
+  // 1px visible line. `touch-none` blocks the browser from claiming the gesture
+  // for scrolling so pointer drag works on touch devices.
   const splitter = document.createElement('div');
-  splitter.className = 'w-1 bg-zinc-700 hover:bg-blue-500 cursor-col-resize shrink-0 transition-colors';
+  splitter.className = 'hidden md:flex relative items-stretch w-2 bg-transparent cursor-col-resize shrink-0 touch-none group';
+  const splitterStripe = document.createElement('div');
+  splitterStripe.className = 'absolute inset-y-0 left-1/2 -translate-x-1/2 w-px bg-zinc-700 group-hover:bg-blue-500 group-[.is-dragging]:bg-blue-500 transition-colors';
+  splitter.appendChild(splitterStripe);
   initSplitter(splitter, editorPane);
 
-  // === Right: Tabbed viewport ===
+  // === Right (or bottom on mobile): Tabbed viewport ===
   const rightPane = document.createElement('div');
-  rightPane.className = 'flex-1 flex flex-col min-w-0';
+  rightPane.className = 'flex-1 flex flex-col min-w-0 min-h-0';
 
-  // Tab bar
+  // Tab bar — horizontally scrollable on narrow viewports so all tabs stay reachable.
   const tabBar = document.createElement('div');
-  tabBar.className = 'flex items-center bg-zinc-800 border-b border-zinc-700 shrink-0';
+  tabBar.className = 'flex items-stretch bg-zinc-800 border-b border-zinc-700 shrink-0 overflow-x-auto [scrollbar-width:thin]';
 
   const tabInteractive = createTab('Interactive', true);
   tabInteractive.title = 'Live 3D viewport \u2014 orbit, zoom, and inspect';
@@ -84,10 +94,11 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   const tabNotes = createTab('Notes', false);
   tabNotes.title = 'Session notes and design decisions log';
 
-  // Copy / Download buttons (shown only on AI Views tab)
+  // Copy / Download buttons (shown only on AI Views tab).
+  // `sticky right-0` keeps them reachable when the tab bar scrolls horizontally on narrow viewports.
   const viewActions = document.createElement('div');
   viewActions.id = 'view-actions';
-  viewActions.className = 'flex gap-2 ml-auto pr-3 hidden';
+  viewActions.className = 'flex items-center gap-2 ml-auto pl-3 pr-3 hidden shrink-0 sticky right-0 bg-zinc-800';
 
   const btnCopyViews = document.createElement('button');
   btnCopyViews.id = 'btn-copy-views';
@@ -146,22 +157,85 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   const allTabs = [tabInteractive, tabAI, tabElevations, tabGallery, tabImages, tabDiff, tabNotes];
   const allPanes = [viewportPane, viewsContainer, elevationsContainer, galleryContainer, imagesContainer, diffContainer, notesContainer];
 
+  // Mobile-only pane toggle: lets the user swap between editor and viewport
+  // when the layout is stacked. Hidden at md+ and on tabs that already hide
+  // the editor (AI/Elevations/Diff).
+  const mobilePaneToggle = document.createElement('div');
+  mobilePaneToggle.id = 'mobile-pane-toggle';
+  mobilePaneToggle.className = 'md:hidden flex items-stretch bg-zinc-800 border-b border-zinc-700 shrink-0';
+  const mobileEditorBtn = document.createElement('button');
+  mobileEditorBtn.textContent = 'Code';
+  mobileEditorBtn.title = 'Show code editor';
+  const mobileViewportBtn = document.createElement('button');
+  mobileViewportBtn.textContent = 'Viewport';
+  mobileViewportBtn.title = 'Show 3D viewport';
+  mobilePaneToggle.appendChild(mobileEditorBtn);
+  mobilePaneToggle.appendChild(mobileViewportBtn);
+
+  const MOBILE_TOGGLE_ACTIVE = 'flex-1 px-4 py-2 text-sm font-medium text-zinc-100 border-b-2 border-blue-500 bg-zinc-900';
+  const MOBILE_TOGGLE_INACTIVE = 'flex-1 px-4 py-2 text-sm font-medium text-zinc-500 border-b-2 border-transparent';
+  function syncMobileToggleUI(pane: 'editor' | 'viewport') {
+    mobileEditorBtn.className = pane === 'editor' ? MOBILE_TOGGLE_ACTIVE : MOBILE_TOGGLE_INACTIVE;
+    mobileViewportBtn.className = pane === 'viewport' ? MOBILE_TOGGLE_ACTIVE : MOBILE_TOGGLE_INACTIVE;
+  }
+  mobileEditorBtn.addEventListener('click', () => setMobilePane('editor'));
+  mobileViewportBtn.addEventListener('click', () => setMobilePane('viewport'));
+
+  // Tracks the most recently activated tab so breakpoint or mobile-pane
+  // changes can recompose visibility without re-running tab DOM toggling.
+  let _currentTab: TabName = 'interactive';
+  const mqDesktop = window.matchMedia('(min-width: 768px)');
+
+  // Composes desktop/mobile pane visibility from the active tab and (on mobile)
+  // the persisted mobile pane choice. Also keeps the editor pane's inline
+  // width in sync with the breakpoint: only set at md+, cleared on mobile so
+  // flex sizing drives height.
+  function syncPaneVisibility() {
+    const tab = _currentTab;
+    const tabHidesEditor = tab === 'ai' || tab === 'elevations' || tab === 'diff';
+    const isDesktop = mqDesktop.matches;
+
+    if (isDesktop) {
+      // Restore inline width if it was cleared on mobile.
+      if (!editorPane.style.width) editorPane.style.width = '35%';
+      editorPane.classList.toggle('hidden', tabHidesEditor);
+      splitter.classList.toggle('hidden', tabHidesEditor);
+      rightPane.classList.remove('hidden');
+      mobilePaneToggle.classList.add('hidden');
+    } else {
+      // Mobile: clear inline width so flex sizing controls the editor's height.
+      editorPane.style.width = '';
+      splitter.classList.add('hidden');
+      if (tabHidesEditor) {
+        editorPane.classList.add('hidden');
+        rightPane.classList.remove('hidden');
+        // No choice to make — hide the toggle on AI/Elevations/Diff.
+        mobilePaneToggle.classList.add('hidden');
+      } else {
+        const pane = getMobilePane();
+        editorPane.classList.toggle('hidden', pane !== 'editor');
+        rightPane.classList.toggle('hidden', pane !== 'viewport');
+        mobilePaneToggle.classList.remove('hidden');
+        syncMobileToggleUI(pane);
+      }
+    }
+  }
+
   // Shared tab activation logic (DOM toggling, editor visibility, events)
   function applyTab(tab: TabName) {
+    _currentTab = tab;
     const idx = tab === 'interactive' ? 0 : tab === 'ai' ? 1 : tab === 'elevations' ? 2 : tab === 'gallery' ? 3 : tab === 'images' ? 4 : tab === 'diff' ? 5 : 6;
     for (let i = 0; i < allPanes.length; i++) {
       if (i === idx) {
         allPanes[i].classList.remove('hidden');
-        allTabs[i].className = 'px-4 py-1.5 text-xs font-medium text-zinc-100 border-b-2 border-blue-500 bg-zinc-900';
+        allTabs[i].className = TAB_ACTIVE_CLASS;
       } else {
         allPanes[i].classList.add('hidden');
-        allTabs[i].className = 'px-4 py-1.5 text-xs font-medium text-zinc-500 hover:text-zinc-300 border-b-2 border-transparent';
+        allTabs[i].className = TAB_INACTIVE_CLASS;
       }
     }
     viewActions.classList.toggle('hidden', tab !== 'ai' && tab !== 'elevations');
-    const hideEditor = tab === 'ai' || tab === 'elevations' || tab === 'diff';
-    editorPane.classList.toggle('hidden', hideEditor);
-    splitter.classList.toggle('hidden', hideEditor);
+    syncPaneVisibility();
     window.dispatchEvent(new CustomEvent('tab-switched', { detail: { tab } }));
     window.dispatchEvent(new Event('resize'));
   }
@@ -266,16 +340,43 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   main.appendChild(splitter);
   main.appendChild(rightPane);
 
-  appContainer.appendChild(main);
+  // Outer wrapper holds the mobile pane toggle above the panes so it's
+  // visible regardless of which pane is currently shown.
+  const outer = document.createElement('div');
+  outer.className = 'flex flex-col flex-1 min-h-0';
+  outer.appendChild(mobilePaneToggle);
+  outer.appendChild(main);
+  appContainer.appendChild(outer);
+
+  // Apply initial pane visibility now that all elements are in the DOM.
+  syncPaneVisibility();
+
+  // Re-compose visibility on breakpoint crossing and on mobile-pane changes.
+  // Both must dispatch a resize so the Three.js canvas re-fits.
+  const onBreakpointChange = () => {
+    syncPaneVisibility();
+    window.dispatchEvent(new Event('resize'));
+  };
+  if (typeof mqDesktop.addEventListener === 'function') {
+    mqDesktop.addEventListener('change', onBreakpointChange);
+  } else {
+    // Safari < 14 fallback
+    (mqDesktop as unknown as { addListener: (cb: () => void) => void }).addListener(onBreakpointChange);
+  }
+  onMobilePaneChange(() => {
+    syncPaneVisibility();
+    window.dispatchEvent(new Event('resize'));
+  });
 
   return { editorPane, editorContainer, editorErrorPanel, viewportPane, viewsContainer, elevationsContainer, galleryContainer, imagesContainer, diffContainer, notesContainer, statusBar, clipControls, switchTab };
 }
 
+const TAB_ACTIVE_CLASS = 'shrink-0 whitespace-nowrap px-4 py-2 md:py-1.5 text-sm md:text-xs font-medium text-zinc-100 border-b-2 border-blue-500 bg-zinc-900';
+const TAB_INACTIVE_CLASS = 'shrink-0 whitespace-nowrap px-4 py-2 md:py-1.5 text-sm md:text-xs font-medium text-zinc-500 [@media(hover:hover)]:hover:text-zinc-300 border-b-2 border-transparent';
+
 function createTab(label: string, active: boolean): HTMLButtonElement {
   const btn = document.createElement('button');
-  btn.className = active
-    ? 'px-4 py-1.5 text-xs font-medium text-zinc-100 border-b-2 border-blue-500 bg-zinc-900'
-    : 'px-4 py-1.5 text-xs font-medium text-zinc-500 hover:text-zinc-300 border-b-2 border-transparent';
+  btn.className = active ? TAB_ACTIVE_CLASS : TAB_INACTIVE_CLASS;
   btn.textContent = label;
   btn.dataset.tab = label;
   return btn;
@@ -284,12 +385,12 @@ function createTab(label: string, active: boolean): HTMLButtonElement {
 function createClipControls(): HTMLElement {
   const container = document.createElement('div');
   container.id = 'clip-controls';
-  container.className = 'absolute top-2 right-2 z-10 flex items-center gap-2';
+  container.className = 'absolute top-2 right-2 z-10 flex flex-wrap justify-end items-center gap-2 max-w-[calc(100%-1rem)]';
 
   // Grid toggle (off by default)
   const gridBtn = document.createElement('button');
   gridBtn.id = 'grid-toggle';
-  gridBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  gridBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
   gridBtn.textContent = '\u25A6';
   gridBtn.title = 'Show grid plane';
   container.appendChild(gridBtn);
@@ -297,7 +398,7 @@ function createClipControls(): HTMLElement {
   // Dimensions toggle (on by default)
   const dimBtn = document.createElement('button');
   dimBtn.id = 'dimensions-toggle';
-  dimBtn.className = 'px-2 py-1 rounded text-xs bg-blue-500/20 backdrop-blur text-blue-400 hover:bg-blue-500/30 transition-colors border border-blue-500/30';
+  dimBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-blue-500/20 backdrop-blur text-blue-400 [@media(hover:hover)]:hover:bg-blue-500/30 transition-colors border border-blue-500/30';
   dimBtn.textContent = '\uD83D\uDCCF';
   dimBtn.title = 'Toggle bounding box dimensions';
   container.appendChild(dimBtn);
@@ -305,7 +406,7 @@ function createClipControls(): HTMLElement {
   // Orbit lock toggle
   const lockBtn = document.createElement('button');
   lockBtn.id = 'orbit-lock-toggle';
-  lockBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  lockBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
   lockBtn.textContent = '\uD83D\uDD13';
   lockBtn.title = 'Lock camera rotation';
   container.appendChild(lockBtn);
@@ -313,7 +414,7 @@ function createClipControls(): HTMLElement {
   // Measure toggle button
   const measureBtn = document.createElement('button');
   measureBtn.id = 'measure-toggle';
-  measureBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  measureBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
   measureBtn.textContent = '\uD83D\uDCCF Measure';
   measureBtn.title = 'Measure distance between two points on your model';
   container.appendChild(measureBtn);
@@ -321,7 +422,7 @@ function createClipControls(): HTMLElement {
   // Clip toggle button
   const toggleBtn = document.createElement('button');
   toggleBtn.id = 'clip-toggle';
-  toggleBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  toggleBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
   toggleBtn.textContent = '\u2702 Cross Section';
   toggleBtn.title = 'Toggle cross-section clipping plane';
   container.appendChild(toggleBtn);
@@ -355,8 +456,10 @@ function createClipControls(): HTMLElement {
 function initSplitter(splitter: HTMLElement, editorPane: HTMLElement) {
   let startX = 0;
   let startWidth = 0;
+  let activePointerId: number | null = null;
 
-  const onMouseMove = (e: MouseEvent) => {
+  const onPointerMove = (e: PointerEvent) => {
+    if (e.pointerId !== activePointerId) return;
     const newWidth = startWidth + (e.clientX - startX);
     const minW = 200;
     const maxW = window.innerWidth - 200;
@@ -364,20 +467,29 @@ function initSplitter(splitter: HTMLElement, editorPane: HTMLElement) {
     window.dispatchEvent(new Event('resize'));
   };
 
-  const onMouseUp = () => {
-    document.removeEventListener('mousemove', onMouseMove);
-    document.removeEventListener('mouseup', onMouseUp);
+  const onPointerEnd = (e: PointerEvent) => {
+    if (e.pointerId !== activePointerId) return;
+    activePointerId = null;
+    splitter.classList.remove('is-dragging');
+    try { splitter.releasePointerCapture(e.pointerId); } catch { /* no capture */ }
     document.body.style.cursor = '';
     document.body.style.userSelect = '';
   };
 
-  splitter.addEventListener('mousedown', (e) => {
+  splitter.addEventListener('pointerdown', (e) => {
+    // Ignore secondary buttons; allow primary mouse, touch, and pen.
+    if (e.button !== 0 && e.pointerType === 'mouse') return;
     e.preventDefault();
+    activePointerId = e.pointerId;
     startX = e.clientX;
     startWidth = editorPane.getBoundingClientRect().width;
+    splitter.setPointerCapture(e.pointerId);
+    splitter.classList.add('is-dragging');
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
   });
+
+  splitter.addEventListener('pointermove', onPointerMove);
+  splitter.addEventListener('pointerup', onPointerEnd);
+  splitter.addEventListener('pointercancel', onPointerEnd);
 }

--- a/src/ui/mobilePane.ts
+++ b/src/ui/mobilePane.ts
@@ -1,0 +1,39 @@
+// Mobile-only state: which pane (editor or viewport/tabs) is currently
+// visible when the layout is stacked vertically. Persisted to localStorage
+// so refreshes preserve the user's choice.
+//
+// Intentionally NOT in the URL: query params are the public contract for
+// shared `/editor?session=…` links (see CLAUDE.md "URL State"). A phone user's
+// "viewport-only" choice should not propagate to a desktop user opening the
+// same link.
+
+export type MobilePane = 'editor' | 'viewport';
+
+const STORAGE_KEY = 'partwright.mobilePane';
+const listeners = new Set<(pane: MobilePane) => void>();
+
+let _current: MobilePane = readStored();
+
+function readStored(): MobilePane {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'editor' || stored === 'viewport') return stored;
+  } catch {
+    // localStorage may be unavailable (private mode, etc.)
+  }
+  return 'viewport';
+}
+
+export function getMobilePane(): MobilePane { return _current; }
+
+export function setMobilePane(pane: MobilePane): void {
+  if (_current === pane) return;
+  _current = pane;
+  try { localStorage.setItem(STORAGE_KEY, pane); } catch { /* ignore */ }
+  for (const cb of listeners) cb(pane);
+}
+
+export function onMobilePaneChange(cb: (pane: MobilePane) => void): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -77,7 +77,7 @@ export function createToolbar(
   callbacks: ToolbarCallbacks,
 ): HTMLElement {
   const toolbar = document.createElement('div');
-  toolbar.className = 'flex items-center gap-1 px-3 py-1.5 bg-zinc-900 border-b border-zinc-700 text-sm shrink-0';
+  toolbar.className = 'flex flex-wrap md:flex-nowrap items-center gap-1 px-3 py-1.5 bg-zinc-900 border-b border-zinc-700 text-sm shrink-0';
 
   // Logo — clicking returns to the landing page
   const logo = document.createElement('button');
@@ -489,7 +489,7 @@ export function createToolbar(
   // Help button
   const helpBtn = document.createElement('button');
   helpBtn.id = 'btn-help';
-  helpBtn.className = 'flex items-center justify-center w-6 h-6 rounded-full text-zinc-500 hover:text-zinc-200 hover:bg-zinc-700 transition-colors text-xs font-bold ml-2';
+  helpBtn.className = 'flex items-center justify-center w-10 h-10 md:w-6 md:h-6 rounded-full text-zinc-500 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700 transition-colors text-sm md:text-xs font-bold ml-2';
   helpBtn.textContent = '?';
   helpBtn.title = 'Help';
   helpBtn.addEventListener('click', () => {
@@ -502,7 +502,7 @@ export function createToolbar(
   // Tour re-entry button
   const tourBtn = document.createElement('button');
   tourBtn.id = 'btn-retake-tour';
-  tourBtn.className = 'flex items-center justify-center w-6 h-6 rounded-full text-zinc-500 hover:text-zinc-200 hover:bg-zinc-700 transition-colors text-xs ml-1';
+  tourBtn.className = 'flex items-center justify-center w-10 h-10 md:w-6 md:h-6 rounded-full text-zinc-500 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700 transition-colors text-sm md:text-xs ml-1';
   tourBtn.textContent = '\uD83C\uDFAF';
   tourBtn.title = 'Take the guided tour';
   tourBtn.addEventListener('click', () => {
@@ -519,7 +519,7 @@ export function createToolbar(
 function createButton(id: string, text: string): HTMLButtonElement {
   const btn = document.createElement('button');
   btn.id = id;
-  btn.className = 'flex items-center gap-1.5 px-2.5 py-1 rounded text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 transition-colors text-xs';
+  btn.className = 'flex items-center gap-1.5 px-3 py-2 md:px-2.5 md:py-1 rounded text-zinc-300 [@media(hover:hover)]:hover:bg-zinc-700 [@media(hover:hover)]:hover:text-zinc-100 transition-colors text-sm md:text-xs';
   btn.textContent = text;
   return btn;
 }


### PR DESCRIPTION
Closes #118.

## Summary

Makes the editor usable on phones. Below 768px the panes stack vertically and a "Code | Viewport" toggle lets the user swap between them; the splitter is now a Pointer Events drag with a tappable hit area; the tab bar scrolls horizontally; and tap targets / hover affordances are touch-aware. Desktop layout is unchanged at md+ (≥768px).

## What changed

**Splitter** (`src/ui/layout.ts`)
- Converted `mousedown`/`mousemove`/`mouseup` (mouse-only) to **Pointer Events** with `setPointerCapture` — works with mouse, touch, and pen.
- 1px visible stripe is now wrapped in an 8px transparent grab strip so it's tappable; `touch-none` blocks the browser from claiming the gesture for scrolling.
- Hidden entirely on mobile (no splitter when stacked).

**Responsive stack at < 768px** (`src/ui/layout.ts`)
- `main` flips from `flex-row` to `flex-col`.
- The hardcoded `editorPane.style.width = '35%'` only applies at md+; on mobile the inline width is cleared so flex sizing drives height.
- `matchMedia('(min-width: 768px)')` listener re-composes pane visibility and dispatches `resize` on breakpoint crossings (rotating a phone, resizing the browser) so the Three.js canvas reflows.

**Mobile pane toggle** (`src/ui/mobilePane.ts`, new)
- Segmented "Code | Viewport" control above the panes (visible only at < md). Lets the user swap which pane is shown.
- Choice is persisted to `localStorage` under `partwright.mobilePane`. Intentionally **not in the URL** per `CLAUDE.md` "URL State" — shared `?session=…` links shouldn't inherit a phone user's pane choice.
- Auto-hidden on tabs that already force the editor hidden (AI Views, Elevations, Diff).
- Factored `applyTab`'s editor-visibility logic into a `syncPaneVisibility()` helper so the breakpoint, tab, and mobile-pane choice all compose through one path.

**Tab bar overflow** (`src/ui/layout.ts`)
- `overflow-x-auto` so all six tabs stay reachable on narrow viewports.
- Tabs get `shrink-0 whitespace-nowrap` and bump to `py-2 text-sm` on mobile.
- The Copy/Download actions (shown on AI Views) stay pinned via `sticky right-0 bg-zinc-800` so they're reachable while scrolling.

**Tap targets + hover cleanup** (`src/ui/toolbar.ts`, `src/ui/layout.ts`)
- Toolbar buttons: `px-3 py-2 text-sm` on mobile, `px-2.5 py-1 text-xs` at md+.
- Help and tour buttons grow from 24px to 40px on mobile (WCAG-ish 44px target).
- Toolbar gets `flex-wrap md:flex-nowrap` so it can wrap to two rows on narrow widths instead of horizontally overflowing.
- All `hover:` affordances gated behind `[@media(hover:hover)]:hover:…` so styles don't stick after tap on touch devices.

**Overlay audit** (`src/ui/layout.ts`)
- Clip controls (top-right of viewport): `flex-wrap justify-end max-w-[calc(100%-1rem)]` so the 5 buttons + slider don't push off-screen on narrow viewports.
- Clip-control buttons get the same mobile-padding bump.

## Files

- `src/ui/layout.ts` — splitter rewrite, responsive stack, mobile toggle, tab bar overflow, clip controls wrap.
- `src/ui/toolbar.ts` — toolbar `flex-wrap`, tap-target/hover-gating on buttons.
- `src/ui/mobilePane.ts` (new) — localStorage-backed `MobilePane` state with listeners. Mirrors the pattern in `src/ui/theme.ts`.

## Test plan

**Desktop (≥ 768px) — should be unchanged:**
- [ ] Smoke 1: landing page renders.
- [ ] Smoke 2: open editor → status "Ready", code on the left, 3D viewport on the right.
- [ ] Smoke 4: `?` button → `/help` works.
- [ ] Smoke 5: `/editor?view=ai` bypasses landing.
- [ ] Smoke 7: `npm run build` succeeds (verified locally).
- [ ] Splitter still drags with the mouse, viewport reflows in real time.
- [ ] AI Views / Elevations / Diff still hide the editor; Interactive / Gallery / Images / Notes still show it.

**Mobile (< 768px) — new behavior:**
- [ ] At 375px width, panes are stacked vertically with a "Code | Viewport" toggle bar at the top.
- [ ] Tapping "Code" shows the editor full-screen; tapping "Viewport" shows the 3D viewport full-screen.
- [ ] Pane choice persists across reload.
- [ ] Switching to AI Views / Elevations / Diff hides the toggle (no choice to make) and shows the right pane.
- [ ] Tab bar scrolls horizontally; all six tabs reachable; Copy/Download stay pinned to the right edge on AI Views.
- [ ] No horizontal page scroll on the toolbar — it wraps to two rows.
- [ ] Clip-control buttons wrap instead of overflowing.

**Breakpoint crossing:**
- [ ] Resize the browser across 768px — editor reflows from stacked → side-by-side without white bars in the canvas.

**Touch devices (use DevTools touch emulation):**
- [ ] Splitter drag works with a finger (in landscape tablet width).
- [ ] Buttons don't show stuck hover styles after tap.

https://claude.ai/code/session_01JpXxKAPNDQHE8wg8zmCRp2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpXxKAPNDQHE8wg8zmCRp2)_