### PR TITLE
feat(paint): coverageMode + maxTriangleArea defang fan-topology bleed

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -195,12 +195,12 @@ await partwright.clearAllSessions()      // Delete all sessions & versions
 // Color regions -- tag face regions with a color (see #color-regions)
 partwright.paintRegion({point, normal, color, name?, tolerance?})         // bucket: coplanar flood-fill -> {id, name, triangles} or {error, nearest?}
 partwright.paintNearestRegion({point, color, searchRadius?, name?, tolerance?}) // snap seed to nearest face, then flood-fill -> {id, name, triangles, snappedTo} or {error}
-partwright.paintNear({point, radius, normalCone?, topOnly?, color, name?})          // sphere: paint triangles whose centroid is within radius -> {id, name, triangles, bbox, centroid} or {error}
-partwright.paintInBox({box, normalCone?, topOnly?, color, name?})                   // box: paint triangles inside an AABB -> {id, name, triangles, bbox, centroid} or {error}
+partwright.paintNear({point, radius, normalCone?, topOnly?, coverageMode?, maxTriangleArea?, color, name?})    // sphere: paint triangles within radius -> {id, name, triangles, bbox, centroid} or {error}
+partwright.paintInBox({box, normalCone?, topOnly?, coverageMode?, maxTriangleArea?, color, name?})             // box: paint triangles inside an AABB -> {id, name, triangles, bbox, centroid} or {error}
 partwright.paintFaces({triangleIds, color, name?})                        // brush: paint specific triangle indices -> {id, name, triangles} or {error}
-partwright.paintSlab({axis|normal, offset, thickness, color, name?})      // slab: paint a planar range -> {id, name, triangles} or {error}
-partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) // dry-run -> {triangleCount, bbox, centroid, [thumbnail]} (default: count-only; withImage: true adds thumbnail)
-partwright.paintExplain({region, withImage?, view?}) // diagnose committed region -> {triangleCount, area, bbox, centroid, normalHistogram, [thumbnail]}
+partwright.paintSlab({axis|normal, offset, thickness, coverageMode?, maxTriangleArea?, color, name?})      // slab: paint a planar range -> {id, name, triangles} or {error}
+partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, coverageMode?, maxTriangleArea?, withImage?, view?}) // dry-run -> {triangleCount, bbox, centroid, totalArea, largestTriangleArea, [thumbnail]}
+partwright.paintExplain({region, withImage?, view?}) // diagnose committed region -> {triangleCount, area, largestTriangleArea, bbox, centroid, normalHistogram, [thumbnail]}
 partwright.assertPaint({region, expectedTriangleCount?, expectedBoundingBox?, expectedCentroid?}) // verify a region -> {passed, failures?}
 partwright.findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?}) // query triangle ids by geometry/color -> {triangleIds, count, matched, truncated}
 partwright.getMesh()                     // -> {numVert, numTri, vertices, triangles, normals, centroids, boundingBox} (typed arrays)
@@ -209,7 +209,7 @@ partwright.listRegions()                 // -> [{id, name, color, source, triang
 partwright.listComponents()              // -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- per-piece bbox for unioned models
 partwright.paintComponent({index, color, name?, topOnly?}) // One-call: paint the Nth boolean-distinct piece
 partwright.getFeatureCentroids({maxGroups?, withinBox?}?)  // Lightweight planning: centroids + normals + bbox per face group, NO triangleIds
-partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, [thumbnail]}
+partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, coverageMode?, maxTriangleArea?, withImage?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, totalArea, largestTriangleArea, [thumbnail]}
 partwright.undoLastPaint()               // Reverse the SINGLE most recent paint op -> {undone, id, ...}
 partwright.redoLastPaint()               // Reapply the most recently undone paint -> {redone, id, ...}
 partwright.removeRegion(id)              // Delete ONE region by id from listRegions()
@@ -458,18 +458,55 @@ partwright.clearColors()    // remove ALL regions — destructive, prefer the tw
 
 **Preview before commit (default workflow).** `paintPreview()` accepts
 the same selector args as `paintInBox` / `paintNear` / `paintFaces` but
-doesn't commit. By default it returns just `{triangleCount, bbox,
-centroid}` — count alone is essentially free and catches most bad
-selectors. Pass `withImage: true` when the count surprises you and a
-yellow-highlighted thumbnail is worth the tokens. Cheap; no side effects.
+doesn't commit. By default it returns `{triangleCount, bbox, centroid,
+totalArea, largestTriangleArea}` — count and area summary are essentially
+free and catch most bad selectors. Inspect the ratio
+`largestTriangleArea / (totalArea / triangleCount)`: ratios above ~10
+are a fan-topology red flag (see "fan-bleed" below). Pass
+`withImage: true` when the count or ratio surprises you — the
+yellow-highlighted thumbnail shows the real triangle extents, including
+the bleed.
 
-**Diagnose a bad paint.** `paintExplain({region: id})` returns area,
-bbox, centroid, a normal-distribution histogram (`{xPos, xNeg, yPos,
-yNeg, zPos, zNeg, oblique}` summing to ~1), and a thumbnail of the
-region tinted yellow. Use after a paint that looks wrong — the
-histogram tells you in one number whether the region wrapped onto a
-face you didn't intend (e.g. `zPos: 0.4, xPos: 0.3` = caught the top
-AND a side).
+**Diagnose a bad paint.** `paintExplain({region: id})` returns
+triangleCount, area, largestTriangleArea, bbox, centroid, a
+normal-distribution histogram (`{xPos, xNeg, yPos, yNeg, zPos, zNeg,
+oblique}` summing to ~1), and a thumbnail of the region tinted yellow.
+Use after a paint that looks wrong — the histogram tells you in one
+number whether the region wrapped onto a face you didn't intend
+(e.g. `zPos: 0.4, xPos: 0.3` = caught the top AND a side), and
+`largestTriangleArea` confirms whether fan-bleed is to blame.
+
+**Avoiding fan-topology bleed.** `cylinder` / `revolve` / `linear_extrude`
+generate triangulations where every face triangle has one vertex at
+the central axis — long radial "fan wedges" that stretch from the
+center out to the rim. After a boolean union, those long triangles
+get inherited into the merged mesh. `paintNear` and `paintInBox`
+default to a *centroid* containment test, so a fan wedge with its
+centroid inside your selector gets painted even though most of its
+area extends visibly outside. The result looks like a "paint smear"
+beyond the intended region. Two fixes, in order of preference:
+
+```js
+// 1. Tighten the containment test — fully_inside requires all 3
+//    vertices in the selection, which excludes fan wedges that
+//    straddle the boundary:
+partwright.paintNear({ point: [0, 5, 2], radius: 3, coverageMode: 'fully_inside', color: ... });
+
+// 2. Or backstop with a max triangle area — set to ~3-5× the
+//    typical triangle of the feature you intend to paint:
+partwright.paintInBox({ box: { ... }, maxTriangleArea: 4, color: ... });
+
+// 3. If you're authoring the code: refine the mesh before painting
+//    so cylinder/revolve geometry has small local triangles instead
+//    of radial fans. .refine(2) doubles the resolution; the shape
+//    doesn't change.
+const head = api.Manifold.cylinder(10, 20).refine(2);
+```
+
+Inspect `paintPreview`'s `largestTriangleArea` to choose a sensible
+`maxTriangleArea`. Sphere / cube / hull primitives don't have fan
+topology and don't need either workaround — the centroid default is
+fine there.
 
 **Verify from multiple angles.** Use `renderViews()` for verification
 rather than a single `renderView` call. The default `views: 'auto'`

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -39,10 +39,19 @@ clearColors for "start completely over from scratch" requests.
 Paint workflow for any non-trivial selector:
 1. paintPreview({box / point+radius / etc.}) — ALWAYS call before
    committing. Count alone is essentially free and catches most bad
-   selectors. If the count is surprising (way more or fewer than you
-   expected), call again with withImage: true for a yellow-highlighted
-   thumbnail. Either way, much cheaper than paint → renderViews → undo.
-2. paintInBox / paintNear / paintSlab to commit.
+   selectors. ALSO inspect largestTriangleArea / (totalArea /
+   triangleCount): ratios above ~10 mean a long radial fan triangle is
+   in the selection and paint will bleed visibly outside it. If the
+   count or ratio looks off, call again with withImage: true for a
+   yellow-highlighted thumbnail — the yellow streaks show real bleed,
+   not a rendering artifact.
+2. paintInBox / paintNear / paintSlab to commit. On meshes built from
+   cylinder / revolve / linear_extrude (radial-fan topology), pass
+   coverageMode: 'fully_inside' so only triangles whose vertices ALL
+   lie in the selection are painted; or pass maxTriangleArea: <N> as
+   a backstop. Either one prevents fan-bleed at the cost of one extra
+   parameter. For meshes built from sphere / cube / hull (small local
+   triangles), the default 'centroid' mode is fine.
 3. renderViews() to visually verify. The default views: 'auto' picks
    angles by the model's bounding box (flat disks get [Top, Iso],
    tall columns get [Front, Right, Iso], otherwise [Front, Top, Iso])
@@ -50,8 +59,15 @@ Paint workflow for any non-trivial selector:
    angle can hide an asymmetric error.
 4. If wrong: paintExplain({region: id}) FIRST — its normal histogram
    tells you whether the region wrapped onto a face you didn't want
-   (e.g. zPos: 0.4 + xPos: 0.3 means it caught the top AND a side).
+   (e.g. zPos: 0.4 + xPos: 0.3 means it caught the top AND a side),
+   and largestTriangleArea confirms whether fan-bleed is to blame.
    Then undoLastPaint() (NOT clearColors), tweak, retry.
+
+Authoring tip: if you're writing model code that will be painted
+afterwards, prefer sphere / cube / hull over cylinder / revolve /
+linear_extrude for surfaces that need precise paint, or call
+.refine(2) on a cylinder/revolve part in your code before runAndSave
+to break the fan topology into small local triangles.
 
 Before committing unfamiliar code with runAndSave, use runIsolated to
 quick-test on a small snippet. Examples worth verifying first: revolve

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -181,7 +181,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintPreview',
-    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. The cheapest way to catch a bad selector — count alone is essentially free; ALWAYS call before any non-trivial paint. Pass `withImage: true` ONLY when the count is suspicious (wildly more or fewer than expected) or the selector geometry is fuzzy — that adds a yellow-highlighted thumbnail.',
+    description: 'DRY-RUN: returns {triangleCount, bbox, centroid, totalArea, largestTriangleArea} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. The cheapest way to catch a bad selector — count alone is essentially free; ALWAYS call before any non-trivial paint. The `largestTriangleArea / (totalArea / triangleCount)` ratio is the fan-topology diagnostic: ratios > ~10 mean a long radial triangle is dragging the selection beyond its intended footprint (common with cylinder / revolve meshes) — fix with `coverageMode: "fully_inside"` or a `maxTriangleArea` cap, or refine the mesh before painting. Pass `withImage: true` when the count or area ratio is suspicious — the thumbnail shows the real triangle extents tinted yellow.',
     input_schema: {
       type: 'object',
       properties: {
@@ -191,6 +191,8 @@ const ALL_TOOLS: ToolDefinition[] = [
         normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
         triangleIds: { type: 'array', items: { type: 'integer' }, description: 'Explicit triangle list — mostly for verifying findFaces results.' },
         withImage: { type: 'boolean', description: 'Default false (stats-only, free). Pass true to also return the highlighted thumbnail when the count is surprising or you want a visual sanity check.' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'How a triangle is tested for containment. Default "centroid" (cheap, historical). "fully_inside" excludes long radial fan triangles whose centroid is in the selection but whose vertices extend outside — the right choice for painting on cylinder/revolve geometry.' },
+        maxTriangleArea: { type: 'number', description: 'Backstop against fan-topology bleed: skip any triangle whose world area exceeds this. Set it ~3-5× the typical triangle area of the feature you intend to paint.' },
       },
     },
   },
@@ -261,7 +263,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintNear',
-    description: 'Paint every triangle within `radius` of `point` (optionally constrained by a normal cone). One call, no triangleId shuttling. Use for "paint the faces around this corner / nub / boss". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause.',
+    description: 'Paint every triangle within `radius` of `point` (optionally constrained by a normal cone). One call, no triangleId shuttling. Use for "paint the faces around this corner / nub / boss". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause. On fan-topology meshes (cylinder/revolve/linear_extrude surfaces), pass `coverageMode: "fully_inside"` and/or `maxTriangleArea` to avoid long radial triangles bleeding paint outside the radius.',
     input_schema: {
       type: 'object',
       properties: {
@@ -269,6 +271,8 @@ const ALL_TOOLS: ToolDefinition[] = [
         radius: { type: 'number' },
         normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
         topOnly: { type: 'boolean', description: 'Shortcut for normalCone: {axis: [0,0,1], angleDeg: 30}. Common case: paint only upward-facing faces in the region.' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'Triangle containment test. Default "centroid". "fully_inside" requires all 3 vertices within radius — defangs fan-bleed.' },
+        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this. Use to filter out the long radial triangles that cylinder/revolve produce.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
       },
@@ -277,13 +281,15 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintInBox',
-    description: 'Paint every triangle whose centroid is inside the axis-aligned box (optionally constrained by a normal cone). One call. Use for "paint the top half / the right rim / everything below z=0". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause.',
+    description: 'Paint every triangle whose centroid is inside the axis-aligned box (optionally constrained by a normal cone). One call. Use for "paint the top half / the right rim / everything below z=0". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause. On fan-topology meshes (cylinder/revolve/linear_extrude surfaces), pass `coverageMode: "fully_inside"` and/or `maxTriangleArea` to avoid long radial triangles bleeding paint outside the box.',
     input_schema: {
       type: 'object',
       properties: {
         box: { type: 'object', description: '{min: [x,y,z], max: [x,y,z]}' },
         normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n}.' },
         topOnly: { type: 'boolean', description: 'Shortcut for normalCone: {axis: [0,0,1], angleDeg: 30}. Common case: paint the top face of a feature without catching its sides.' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'Triangle containment test. Default "centroid". "fully_inside" requires all 3 vertices inside the box — defangs fan-bleed.' },
+        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this. Use to filter out the long radial triangles that cylinder/revolve produce.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
       },
@@ -292,7 +298,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintSlab',
-    description: 'Paint everything in a Z-slab (or arbitrary-axis slab). One call. Use for "paint the rim of this disk", "paint the side walls", "paint the top 5mm".',
+    description: 'Paint everything in a Z-slab (or arbitrary-axis slab). One call. Use for "paint the rim of this disk", "paint the side walls", "paint the top 5mm". Same coverageMode / maxTriangleArea options as the other selectors.',
     input_schema: {
       type: 'object',
       properties: {
@@ -300,6 +306,8 @@ const ALL_TOOLS: ToolDefinition[] = [
         normal: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Use instead of axis for an oblique slab.' },
         offset: { type: 'number', description: 'Slab center along the axis/normal.' },
         thickness: { type: 'number', description: 'Slab thickness (paint catches anything within ±thickness/2 of offset).' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'Triangle containment test. Default "centroid". "fully_inside" requires all 3 vertex projections within the slab range.' },
+        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
       },
@@ -332,6 +340,8 @@ const ALL_TOOLS: ToolDefinition[] = [
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         region: { type: 'string' },
         maxResults: { type: 'integer' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'Triangle containment test for the `box` predicate. Default "centroid". Use "fully_inside" on cylinder/revolve meshes to exclude long radial triangles.' },
+        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this.' },
       },
     },
   },

--- a/src/color/slabPaint.ts
+++ b/src/color/slabPaint.ts
@@ -61,12 +61,24 @@ export function projectionRange(mesh: MeshData, normal: [number, number, number]
   return { min, max };
 }
 
-/** Find all triangles whose centroid lies inside the slab. */
+export type SlabCoverageMode = 'centroid' | 'fully_inside' | 'any_vertex_inside';
+
+/** Find all triangles inside the slab. Coverage mode controls which
+ *  point on the triangle has to satisfy the slab containment test:
+ *
+ *  - `centroid` (default): the triangle's centroid lies in the slab.
+ *    Cheapest, matches historical behavior, but lets long radial fan
+ *    triangles "bleed" outside the slab when their centroid happens
+ *    to fall in range while their vertices extend further.
+ *  - `fully_inside`: all 3 vertices lie in the slab.
+ *  - `any_vertex_inside`: at least one vertex lies in the slab.
+ */
 export function findSlabTriangles(
   mesh: MeshData,
   normal: [number, number, number],
   offset: number,
   thickness: number,
+  coverage: SlabCoverageMode = 'centroid',
 ): Set<number> {
   const result = new Set<number>();
   if (thickness <= 0) return result;
@@ -74,11 +86,23 @@ export function findSlabTriangles(
   const [nx, ny, nz] = normalize(normal);
   const lo = offset;
   const hi = offset + thickness;
+  const { triVerts, vertProperties, numProp, numTri } = mesh;
 
-  for (let t = 0; t < mesh.numTri; t++) {
-    const c = getTriangleCentroid(t, mesh);
-    const d = c[0] * nx + c[1] * ny + c[2] * nz;
-    if (d >= lo && d <= hi) result.add(t);
+  for (let t = 0; t < numTri; t++) {
+    if (coverage === 'centroid') {
+      const c = getTriangleCentroid(t, mesh);
+      const d = c[0] * nx + c[1] * ny + c[2] * nz;
+      if (d >= lo && d <= hi) result.add(t);
+      continue;
+    }
+    const v0 = triVerts[t * 3], v1 = triVerts[t * 3 + 1], v2 = triVerts[t * 3 + 2];
+    const dA = vertProperties[v0 * numProp] * nx + vertProperties[v0 * numProp + 1] * ny + vertProperties[v0 * numProp + 2] * nz;
+    const dB = vertProperties[v1 * numProp] * nx + vertProperties[v1 * numProp + 1] * ny + vertProperties[v1 * numProp + 2] * nz;
+    const dC = vertProperties[v2 * numProp] * nx + vertProperties[v2 * numProp + 1] * ny + vertProperties[v2 * numProp + 2] * nz;
+    const inA = dA >= lo && dA <= hi;
+    const inB = dB >= lo && dB <= hi;
+    const inC = dC >= lo && dC <= hi;
+    if (coverage === 'fully_inside' ? (inA && inB && inC) : (inA || inB || inC)) result.add(t);
   }
 
   return result;

--- a/src/main.ts
+++ b/src/main.ts
@@ -138,6 +138,15 @@ let currentManifold: any = null;
 // #geometry-data element — always-updated machine-readable state
 let geometryDataEl: HTMLElement;
 
+/** Paint selector containment test. `centroid` is the historical default
+ *  (a triangle is in the selection when its centroid lies inside the
+ *  box / sphere / slab). `fully_inside` and `any_vertex_inside` are
+ *  per-vertex tests that defang the long radial triangles produced by
+ *  cylinder / revolve / linear_extrude — those can have a centroid in
+ *  the selection while extending visibly far outside it ("bleed"). */
+export const COVERAGE_MODES = ['centroid', 'fully_inside', 'any_vertex_inside'] as const;
+export type CoverageMode = typeof COVERAGE_MODES[number];
+
 // === Document title management ===
 // Actively manage document.title to reflect current state.
 // Some browser automation tools (MCP servers, extensions) can inadvertently
@@ -3240,10 +3249,10 @@ async function main() {
     /** Paint a slab — all faces whose centroid falls inside a planar slab.
      *  `axis` is shorthand for axis-aligned slabs ('x'/'y'/'z'). For oblique
      *  slabs, pass `normal` directly (does not need to be normalized). */
-    paintSlab(opts: { axis?: 'x' | 'y' | 'z'; normal?: [number, number, number]; offset: number; thickness: number; color: [number, number, number]; name?: string }) {
+    paintSlab(opts: { axis?: 'x' | 'y' | 'z'; normal?: [number, number, number]; offset: number; thickness: number; color: [number, number, number]; name?: string; coverageMode?: CoverageMode; maxTriangleArea?: number }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintSlab requires {axis|normal, offset, thickness, color}' };
-      const { axis, normal: rawNormal, offset, thickness, color, name } = opts;
+      const { axis, normal: rawNormal, offset, thickness, color, name, coverageMode, maxTriangleArea } = opts;
 
       let normal: [number, number, number];
       if (axis !== undefined) {
@@ -3261,8 +3270,15 @@ async function main() {
       if (typeof offset !== 'number' || !Number.isFinite(offset)) return { error: 'offset must be a finite number' };
       if (typeof thickness !== 'number' || !Number.isFinite(thickness) || thickness <= 0) return { error: 'thickness must be a positive finite number' };
       if (!Array.isArray(color) || color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+      const coverageErr = validateCoverageMode(coverageMode);
+      if (coverageErr) return { error: coverageErr };
+      const areaErr = validateMaxTriangleArea(maxTriangleArea);
+      if (areaErr) return { error: areaErr };
 
-      const triangles = findSlabTriangles(currentMeshData, normal, offset, thickness);
+      let triangles = findSlabTriangles(currentMeshData, normal, offset, thickness, coverageMode);
+      if (maxTriangleArea !== undefined && triangles.size > 0) {
+        triangles = new Set([...triangles].filter(t => triangleArea(t, currentMeshData!) <= maxTriangleArea));
+      }
       if (triangles.size === 0) return { error: 'No triangles found inside the slab' };
 
       const regionName = name ?? `Region ${getRegions().length + 1}`;
@@ -3273,11 +3289,7 @@ async function main() {
         { kind: 'slab', normal, offset, thickness },
         triangles,
       );
-
-      const colored = applyTriColorsIfVisible(currentMeshData);
-      updateMesh(colored, { skipAutoFrame: true });
-      updateMultiView(colored);
-      renderElevationsToContainer(elevationsContainer, colored);
+      scheduleColorRefresh();
       syncLockState();
 
       return { id: region.id, name: region.name, triangles: triangles.size };
@@ -3405,16 +3417,30 @@ async function main() {
        *  the common over-paint where the box also catches side walls and
        *  the bottom face. Ignored when `normalCone` is explicitly set. */
       topOnly?: boolean;
+      /** How triangles are tested for box containment. Default `'centroid'`
+       *  (the historical behavior). Use `'fully_inside'` to defang long
+       *  radial fan triangles from cylinder/revolve meshes — they often
+       *  have a centroid in the box but extend visibly outside it. */
+      coverageMode?: CoverageMode;
+      /** Skip any triangle whose world-space area exceeds this threshold.
+       *  Backstop against fan-topology bleed when `coverageMode` alone
+       *  isn't enough. Inspect `largestTriangleArea` from `paintPreview`
+       *  to pick a sensible value. */
+      maxTriangleArea?: number;
     }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintInBox requires { box, color }' };
       const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
       const filterErr = validateBoxAndCone(opts.box, cone);
       if (filterErr) return { error: filterErr };
+      const coverageErr = validateCoverageMode(opts.coverageMode);
+      if (coverageErr) return { error: coverageErr };
+      const areaErr = validateMaxTriangleArea(opts.maxTriangleArea);
+      if (areaErr) return { error: areaErr };
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
 
-      const triangles = collectTrianglesByFilter(currentMeshData, opts.box, cone, null);
-      if (triangles.size === 0) return { error: `paintInBox: no triangles matched the box${cone ? ' (with the normalCone' + (opts.topOnly ? '/topOnly' : '') + ' filter)' : ''}. Try widening the box, dropping topOnly/normalCone, or call findFaces() to see what passes each filter individually.` };
+      const triangles = collectTrianglesByFilter(currentMeshData, opts.box, cone, null, opts.coverageMode, opts.maxTriangleArea);
+      if (triangles.size === 0) return { error: `paintInBox: no triangles matched the box${cone ? ' (with the normalCone' + (opts.topOnly ? '/topOnly' : '') + ' filter)' : ''}${opts.coverageMode === 'fully_inside' ? ' (with coverageMode: fully_inside — try widening the box or dropping the mode)' : ''}${opts.maxTriangleArea !== undefined ? ` (with maxTriangleArea: ${opts.maxTriangleArea} — try raising it)` : ''}. Try widening the box, dropping topOnly/normalCone, or call findFaces() to see what passes each filter individually.` };
 
       return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
     },
@@ -3440,6 +3466,10 @@ async function main() {
       name?: string;
       /** Shortcut: only upward-facing triangles. See paintInBox.topOnly. */
       topOnly?: boolean;
+      /** See paintInBox.coverageMode. */
+      coverageMode?: CoverageMode;
+      /** See paintInBox.maxTriangleArea. */
+      maxTriangleArea?: number;
     }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintNear requires { point, radius, color }' };
@@ -3451,10 +3481,14 @@ async function main() {
       const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
       const coneErr = validateNormalCone(cone);
       if (coneErr) return { error: coneErr };
+      const coverageErr = validateCoverageMode(opts.coverageMode);
+      if (coverageErr) return { error: coverageErr };
+      const areaErr = validateMaxTriangleArea(opts.maxTriangleArea);
+      if (areaErr) return { error: areaErr };
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
 
-      const triangles = collectTrianglesBySphere(currentMeshData, opts.point as [number, number, number], opts.radius, cone);
-      if (triangles.size === 0) return { error: `paintNear: no triangles within ${opts.radius} of [${opts.point.join(', ')}]. Try a larger radius — call findFaces() with a bigger box first to see what's around.` };
+      const triangles = collectTrianglesBySphere(currentMeshData, opts.point as [number, number, number], opts.radius, cone, opts.coverageMode, opts.maxTriangleArea);
+      if (triangles.size === 0) return { error: `paintNear: no triangles within ${opts.radius} of [${opts.point.join(', ')}]${opts.coverageMode === 'fully_inside' ? ' (with coverageMode: fully_inside)' : ''}${opts.maxTriangleArea !== undefined ? ` (with maxTriangleArea: ${opts.maxTriangleArea})` : ''}. Try a larger radius — call findFaces() with a bigger box first to see what's around.` };
 
       return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
     },
@@ -3486,9 +3520,20 @@ async function main() {
        *  count-only is the cheap sanity check that should always be
        *  affordable. */
       withImage?: boolean;
+      /** See paintInBox.coverageMode. Applied to box / point+radius
+       *  selectors; ignored when `triangleIds` is passed (those bypass
+       *  the geometric filter). */
+      coverageMode?: CoverageMode;
+      /** See paintInBox.maxTriangleArea. */
+      maxTriangleArea?: number;
     } = {}) {
       const mesh = currentMeshData;
       if (!mesh) return { error: 'No geometry loaded' };
+
+      const coverageErr = validateCoverageMode(opts.coverageMode);
+      if (coverageErr) return { error: coverageErr };
+      const areaErr = validateMaxTriangleArea(opts.maxTriangleArea);
+      if (areaErr) return { error: areaErr };
 
       let triangles: Set<number>;
       if (opts.triangleIds !== undefined) {
@@ -3503,16 +3548,17 @@ async function main() {
         if (typeof opts.radius !== 'number' || !Number.isFinite(opts.radius) || opts.radius <= 0) return { error: 'radius must be a positive finite number' };
         const coneErr = validateNormalCone(opts.normalCone);
         if (coneErr) return { error: coneErr };
-        triangles = collectTrianglesBySphere(mesh, opts.point, opts.radius, opts.normalCone);
+        triangles = collectTrianglesBySphere(mesh, opts.point, opts.radius, opts.normalCone, opts.coverageMode, opts.maxTriangleArea);
       } else if (opts.box !== undefined) {
         const err = validateBoxAndCone(opts.box, opts.normalCone);
         if (err) return { error: err };
-        triangles = collectTrianglesByFilter(mesh, opts.box, opts.normalCone, null);
+        triangles = collectTrianglesByFilter(mesh, opts.box, opts.normalCone, null, opts.coverageMode, opts.maxTriangleArea);
       } else {
         return { error: 'paintPreview requires one of: { triangleIds }, { point, radius }, or { box }' };
       }
 
       const stats = regionTriangleStats(triangles, mesh);
+      const areas = summarizeTriangleAreas(triangles, mesh);
       const wantImage = opts.withImage === true;
       const thumbnail = wantImage ? renderRegionHighlight(mesh, triangles, opts.view ?? {}) : undefined;
       return {
@@ -3520,6 +3566,8 @@ async function main() {
         triangleCount: triangles.size,
         bbox: stats.bbox,
         centroid: stats.centroid,
+        totalArea: Math.round(areas.totalArea * 1000) / 1000,
+        largestTriangleArea: Math.round(areas.largestTriangleArea * 1000) / 1000,
       };
     },
 
@@ -3553,7 +3601,7 @@ async function main() {
 
       const mesh = currentMeshData;
       const stats = regionTriangleStats(region.triangles, mesh);
-      const { area, normalHistogram } = computeRegionAreaAndNormalHistogram(region.triangles, mesh);
+      const { area, normalHistogram, largestTriangleArea } = computeRegionAreaAndNormalHistogram(region.triangles, mesh);
       const wantImage = opts.withImage !== false; // default true — explain wants visual
       const thumbnail = wantImage ? renderRegionHighlight(mesh, region.triangles, opts.view ?? {}) : undefined;
 
@@ -3564,6 +3612,7 @@ async function main() {
         source: region.source,
         triangleCount: region.triangles.size,
         area: Math.round(area * 1000) / 1000,
+        largestTriangleArea: Math.round(largestTriangleArea * 1000) / 1000,
         bbox: stats.bbox,
         centroid: stats.centroid,
         normalHistogram,
@@ -3715,13 +3764,23 @@ async function main() {
       color?: [number, number, number];
       region?: number;
       maxResults?: number;
+      /** See paintInBox.coverageMode. Applies to the `box` predicate
+       *  only; the normal / color / region predicates are per-triangle
+       *  already. */
+      coverageMode?: CoverageMode;
+      /** See paintInBox.maxTriangleArea. */
+      maxTriangleArea?: number;
     } = {}) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (typeof opts !== 'object' || opts === null) {
         return { error: 'findFaces requires an options object — see /ai.md#color-regions' };
       }
 
-      const { box, normal, normalTolerance, color, region, maxResults } = opts;
+      const { box, normal, normalTolerance, color, region, maxResults, coverageMode, maxTriangleArea } = opts;
+      const coverageErr = validateCoverageMode(coverageMode);
+      if (coverageErr) return { error: coverageErr };
+      const areaErr = validateMaxTriangleArea(maxTriangleArea);
+      if (areaErr) return { error: areaErr };
 
       let boxMin: [number, number, number] | null = null;
       let boxMax: [number, number, number] | null = null;
@@ -3788,6 +3847,7 @@ async function main() {
       const cG = colorTarget ? Math.round(colorTarget[1] * 255) : 0;
       const cB = colorTarget ? Math.round(colorTarget[2] * 255) : 0;
 
+      const coverage: CoverageMode = coverageMode ?? 'centroid';
       for (let t = 0; t < mesh.numTri; t++) {
         if (regionTriangles && !regionTriangles.has(t)) continue;
 
@@ -3795,10 +3855,20 @@ async function main() {
           const v0 = mesh.triVerts[t * 3];
           const v1 = mesh.triVerts[t * 3 + 1];
           const v2 = mesh.triVerts[t * 3 + 2];
-          const cx = (mesh.vertProperties[v0 * mesh.numProp] + mesh.vertProperties[v1 * mesh.numProp] + mesh.vertProperties[v2 * mesh.numProp]) / 3;
-          const cy = (mesh.vertProperties[v0 * mesh.numProp + 1] + mesh.vertProperties[v1 * mesh.numProp + 1] + mesh.vertProperties[v2 * mesh.numProp + 1]) / 3;
-          const cz = (mesh.vertProperties[v0 * mesh.numProp + 2] + mesh.vertProperties[v1 * mesh.numProp + 2] + mesh.vertProperties[v2 * mesh.numProp + 2]) / 3;
-          if (cx < boxMin[0] || cx > boxMax[0] || cy < boxMin[1] || cy > boxMax[1] || cz < boxMin[2] || cz > boxMax[2]) continue;
+          const ax = mesh.vertProperties[v0 * mesh.numProp],     ay = mesh.vertProperties[v0 * mesh.numProp + 1], az = mesh.vertProperties[v0 * mesh.numProp + 2];
+          const bx = mesh.vertProperties[v1 * mesh.numProp],     by = mesh.vertProperties[v1 * mesh.numProp + 1], bz = mesh.vertProperties[v1 * mesh.numProp + 2];
+          const cx = mesh.vertProperties[v2 * mesh.numProp],     cy = mesh.vertProperties[v2 * mesh.numProp + 1], cz = mesh.vertProperties[v2 * mesh.numProp + 2];
+          const inA = ax >= boxMin[0] && ax <= boxMax[0] && ay >= boxMin[1] && ay <= boxMax[1] && az >= boxMin[2] && az <= boxMax[2];
+          const inB = bx >= boxMin[0] && bx <= boxMax[0] && by >= boxMin[1] && by <= boxMax[1] && bz >= boxMin[2] && bz <= boxMax[2];
+          const inC = cx >= boxMin[0] && cx <= boxMax[0] && cy >= boxMin[1] && cy <= boxMax[1] && cz >= boxMin[2] && cz <= boxMax[2];
+          if (coverage === 'fully_inside') {
+            if (!inA || !inB || !inC) continue;
+          } else if (coverage === 'any_vertex_inside') {
+            if (!inA && !inB && !inC) continue;
+          } else {
+            const ccx = (ax + bx + cx) / 3, ccy = (ay + by + cy) / 3, ccz = (az + bz + cz) / 3;
+            if (ccx < boxMin[0] || ccx > boxMax[0] || ccy < boxMin[1] || ccy > boxMax[1] || ccz < boxMin[2] || ccz > boxMax[2]) continue;
+          }
         }
 
         if (nrm && adjacency) {
@@ -3812,6 +3882,8 @@ async function main() {
         if (triColors) {
           if (triColors[t * 3] !== cR || triColors[t * 3 + 1] !== cG || triColors[t * 3 + 2] !== cB) continue;
         }
+
+        if (maxTriangleArea !== undefined && triangleArea(t, mesh) > maxTriangleArea) continue;
 
         visited++;
         if (result.length < limit) result.push(t);
@@ -4380,38 +4452,28 @@ async function main() {
     return renderSingleView({ ...mesh, triColors }, viewOpts);
   }
 
-  /** For a triangle set, compute total surface area and an area-weighted
-   *  histogram of face normals binned by cardinal axis (within 30°).
-   *  Triangles whose normal is more than 30° off every axis fall into
-   *  `oblique`. All bins normalize to sum ≈ 1. Useful for telling the
-   *  agent "this region is 70% top-facing, 25% wrap-around side" without
-   *  shipping the raw triangle list. */
+  /** For a triangle set, compute total surface area, the largest single-
+   *  triangle area (the diagnostic for fan-topology contamination), and
+   *  an area-weighted histogram of face normals binned by cardinal axis
+   *  (within 30°). Triangles whose normal is more than 30° off every
+   *  axis fall into `oblique`. The histogram bins normalize to sum ≈ 1. */
   function computeRegionAreaAndNormalHistogram(
     triangles: Set<number>,
     mesh: MeshData,
   ): {
     area: number;
+    largestTriangleArea: number;
     normalHistogram: { xPos: number; xNeg: number; yPos: number; yNeg: number; zPos: number; zNeg: number; oblique: number };
   } {
     const adjacency = buildAdjacency(mesh);
     const cosThresh = Math.cos(30 * Math.PI / 180); // ≈ 0.866
     const bins = { xPos: 0, xNeg: 0, yPos: 0, yNeg: 0, zPos: 0, zNeg: 0, oblique: 0 };
     let totalArea = 0;
-    const { triVerts, vertProperties, numProp } = mesh;
+    let largest = 0;
     for (const t of triangles) {
-      const v0 = triVerts[t * 3];
-      const v1 = triVerts[t * 3 + 1];
-      const v2 = triVerts[t * 3 + 2];
-      const ax = vertProperties[v0 * numProp], ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
-      const bx = vertProperties[v1 * numProp], by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
-      const cx = vertProperties[v2 * numProp], cy = vertProperties[v2 * numProp + 1], cz = vertProperties[v2 * numProp + 2];
-      const e1x = bx - ax, e1y = by - ay, e1z = bz - az;
-      const e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
-      const crx = e1y * e2z - e1z * e2y;
-      const cry = e1z * e2x - e1x * e2z;
-      const crz = e1x * e2y - e1y * e2x;
-      const area = 0.5 * Math.sqrt(crx * crx + cry * cry + crz * crz);
+      const area = triangleArea(t, mesh);
       totalArea += area;
+      if (area > largest) largest = area;
       const nx = adjacency.normals[t * 3];
       const ny = adjacency.normals[t * 3 + 1];
       const nz = adjacency.normals[t * 3 + 2];
@@ -4427,6 +4489,7 @@ async function main() {
       const norm = (v: number) => Math.round((v / totalArea) * 1000) / 1000;
       return {
         area: totalArea,
+        largestTriangleArea: largest,
         normalHistogram: {
           xPos: norm(bins.xPos), xNeg: norm(bins.xNeg),
           yPos: norm(bins.yPos), yNeg: norm(bins.yNeg),
@@ -4435,7 +4498,7 @@ async function main() {
         },
       };
     }
-    return { area: 0, normalHistogram: { xPos: 0, xNeg: 0, yPos: 0, yNeg: 0, zPos: 0, zNeg: 0, oblique: 0 } };
+    return { area: 0, largestTriangleArea: 0, normalHistogram: { xPos: 0, xNeg: 0, yPos: 0, yNeg: 0, zPos: 0, zNeg: 0, oblique: 0 } };
   }
 
   /** Decode a data: URL into an HTMLImageElement. Image decoding from a
@@ -4543,6 +4606,22 @@ async function main() {
     return undefined;
   }
 
+  function validateCoverageMode(mode: unknown): string | null {
+    if (mode === undefined) return null;
+    if (!COVERAGE_MODES.includes(mode as CoverageMode)) {
+      return `coverageMode must be one of: ${COVERAGE_MODES.join(', ')}`;
+    }
+    return null;
+  }
+
+  function validateMaxTriangleArea(area: unknown): string | null {
+    if (area === undefined) return null;
+    if (typeof area !== 'number' || !Number.isFinite(area) || area <= 0) {
+      return 'maxTriangleArea must be a positive finite number';
+    }
+    return null;
+  }
+
   function validateNormalCone(cone: { axis: [number, number, number]; angleDeg: number } | undefined): string | null {
     if (cone === undefined) return null;
     if (typeof cone !== 'object' || cone === null) return 'normalCone must be { axis: [x,y,z], angleDeg: number }';
@@ -4573,6 +4652,39 @@ async function main() {
     return validateNormalCone(cone);
   }
 
+  /** Compute the world-space area of a single triangle. Shared by the
+   *  selector `maxTriangleArea` filter, the region-stats walker, and the
+   *  normal-histogram weighter so they stay byte-consistent. */
+  function triangleArea(t: number, mesh: MeshData): number {
+    const { triVerts, vertProperties, numProp } = mesh;
+    const v0 = triVerts[t * 3], v1 = triVerts[t * 3 + 1], v2 = triVerts[t * 3 + 2];
+    const ax = vertProperties[v0 * numProp],     ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
+    const bx = vertProperties[v1 * numProp],     by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
+    const cx = vertProperties[v2 * numProp],     cy = vertProperties[v2 * numProp + 1], cz = vertProperties[v2 * numProp + 2];
+    const e1x = bx - ax, e1y = by - ay, e1z = bz - az;
+    const e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
+    const crx = e1y * e2z - e1z * e2y;
+    const cry = e1z * e2x - e1x * e2z;
+    const crz = e1x * e2y - e1y * e2x;
+    return 0.5 * Math.sqrt(crx * crx + cry * cry + crz * crz);
+  }
+
+  /** Summarize the area distribution of a triangle set without walking
+   *  the mesh twice. The `largestTriangleArea / (totalArea / count)`
+   *  ratio is the diagnostic for fan-topology bleed — anything > ~10×
+   *  means one or more long radial triangles are dragging the selector
+   *  beyond its intended footprint. */
+  function summarizeTriangleAreas(triangles: Iterable<number>, mesh: MeshData): { totalArea: number; largestTriangleArea: number } {
+    let total = 0;
+    let largest = 0;
+    for (const t of triangles) {
+      const a = triangleArea(t, mesh);
+      total += a;
+      if (a > largest) largest = a;
+    }
+    return { totalArea: total, largestTriangleArea: largest };
+  }
+
   /** Collect triangle ids whose centroid lies inside `box` and (optionally)
    *  whose face normal aligns with `cone.axis` within `cone.angleDeg`.
    *  `regionFilter`, when non-null, restricts to ids in that set. */
@@ -4581,6 +4693,8 @@ async function main() {
     box: { min: [number, number, number]; max: [number, number, number] },
     cone: { axis: [number, number, number]; angleDeg: number } | undefined,
     regionFilter: Set<number> | null,
+    coverage: CoverageMode = 'centroid',
+    maxArea: number | undefined = undefined,
   ): Set<number> {
     const adjacency = cone ? buildAdjacency(mesh) : null;
     let coneAxis: [number, number, number] | null = null;
@@ -4592,17 +4706,31 @@ async function main() {
     }
     const result = new Set<number>();
     const { triVerts, vertProperties, numProp, numTri } = mesh;
+    const [bMinX, bMinY, bMinZ] = box.min;
+    const [bMaxX, bMaxY, bMaxZ] = box.max;
     for (let t = 0; t < numTri; t++) {
       if (regionFilter && !regionFilter.has(t)) continue;
       const v0 = triVerts[t * 3];
       const v1 = triVerts[t * 3 + 1];
       const v2 = triVerts[t * 3 + 2];
-      const cx = (vertProperties[v0 * numProp] + vertProperties[v1 * numProp] + vertProperties[v2 * numProp]) / 3;
-      const cy = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3;
-      const cz = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3;
-      if (cx < box.min[0] || cx > box.max[0]) continue;
-      if (cy < box.min[1] || cy > box.max[1]) continue;
-      if (cz < box.min[2] || cz > box.max[2]) continue;
+      const ax = vertProperties[v0 * numProp], ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
+      const bx = vertProperties[v1 * numProp], by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
+      const cx = vertProperties[v2 * numProp], cy = vertProperties[v2 * numProp + 1], cz = vertProperties[v2 * numProp + 2];
+
+      if (coverage === 'fully_inside') {
+        if (ax < bMinX || ax > bMaxX || ay < bMinY || ay > bMaxY || az < bMinZ || az > bMaxZ) continue;
+        if (bx < bMinX || bx > bMaxX || by < bMinY || by > bMaxY || bz < bMinZ || bz > bMaxZ) continue;
+        if (cx < bMinX || cx > bMaxX || cy < bMinY || cy > bMaxY || cz < bMinZ || cz > bMaxZ) continue;
+      } else if (coverage === 'any_vertex_inside') {
+        const a = ax >= bMinX && ax <= bMaxX && ay >= bMinY && ay <= bMaxY && az >= bMinZ && az <= bMaxZ;
+        const b = bx >= bMinX && bx <= bMaxX && by >= bMinY && by <= bMaxY && bz >= bMinZ && bz <= bMaxZ;
+        const c = cx >= bMinX && cx <= bMaxX && cy >= bMinY && cy <= bMaxY && cz >= bMinZ && cz <= bMaxZ;
+        if (!a && !b && !c) continue;
+      } else {
+        const ccx = (ax + bx + cx) / 3, ccy = (ay + by + cy) / 3, ccz = (az + bz + cz) / 3;
+        if (ccx < bMinX || ccx > bMaxX || ccy < bMinY || ccy > bMaxY || ccz < bMinZ || ccz > bMaxZ) continue;
+      }
+
       if (coneAxis && adjacency) {
         const nx = adjacency.normals[t * 3];
         const ny = adjacency.normals[t * 3 + 1];
@@ -4610,6 +4738,9 @@ async function main() {
         const dot = coneAxis[0] * nx + coneAxis[1] * ny + coneAxis[2] * nz;
         if (dot < coneCos) continue;
       }
+
+      if (maxArea !== undefined && triangleArea(t, mesh) > maxArea) continue;
+
       result.add(t);
     }
     return result;
@@ -4621,6 +4752,8 @@ async function main() {
     point: [number, number, number],
     radius: number,
     cone: { axis: [number, number, number]; angleDeg: number } | undefined,
+    coverage: CoverageMode = 'centroid',
+    maxArea: number | undefined = undefined,
   ): Set<number> {
     const adjacency = cone ? buildAdjacency(mesh) : null;
     let coneAxis: [number, number, number] | null = null;
@@ -4633,15 +4766,30 @@ async function main() {
     const r2 = radius * radius;
     const result = new Set<number>();
     const { triVerts, vertProperties, numProp, numTri } = mesh;
+    const [px, py, pz] = point;
     for (let t = 0; t < numTri; t++) {
       const v0 = triVerts[t * 3];
       const v1 = triVerts[t * 3 + 1];
       const v2 = triVerts[t * 3 + 2];
-      const cx = (vertProperties[v0 * numProp] + vertProperties[v1 * numProp] + vertProperties[v2 * numProp]) / 3;
-      const cy = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3;
-      const cz = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3;
-      const dx = cx - point[0], dy = cy - point[1], dz = cz - point[2];
-      if (dx * dx + dy * dy + dz * dz > r2) continue;
+      const ax = vertProperties[v0 * numProp], ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
+      const bx = vertProperties[v1 * numProp], by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
+      const cx = vertProperties[v2 * numProp], cy = vertProperties[v2 * numProp + 1], cz = vertProperties[v2 * numProp + 2];
+
+      if (coverage === 'fully_inside') {
+        if ((ax - px) ** 2 + (ay - py) ** 2 + (az - pz) ** 2 > r2) continue;
+        if ((bx - px) ** 2 + (by - py) ** 2 + (bz - pz) ** 2 > r2) continue;
+        if ((cx - px) ** 2 + (cy - py) ** 2 + (cz - pz) ** 2 > r2) continue;
+      } else if (coverage === 'any_vertex_inside') {
+        const dA = (ax - px) ** 2 + (ay - py) ** 2 + (az - pz) ** 2;
+        const dB = (bx - px) ** 2 + (by - py) ** 2 + (bz - pz) ** 2;
+        const dC = (cx - px) ** 2 + (cy - py) ** 2 + (cz - pz) ** 2;
+        if (dA > r2 && dB > r2 && dC > r2) continue;
+      } else {
+        const ccx = (ax + bx + cx) / 3, ccy = (ay + by + cy) / 3, ccz = (az + bz + cz) / 3;
+        const dx = ccx - px, dy = ccy - py, dz = ccz - pz;
+        if (dx * dx + dy * dy + dz * dz > r2) continue;
+      }
+
       if (coneAxis && adjacency) {
         const nx = adjacency.normals[t * 3];
         const ny = adjacency.normals[t * 3 + 1];
@@ -4649,6 +4797,9 @@ async function main() {
         const dot = coneAxis[0] * nx + coneAxis[1] * ny + coneAxis[2] * nz;
         if (dot < coneCos) continue;
       }
+
+      if (maxArea !== undefined && triangleArea(t, mesh) > maxArea) continue;
+
       result.add(t);
     }
     return result;

--- a/tests/paint-coverage.spec.ts
+++ b/tests/paint-coverage.spec.ts
@@ -1,0 +1,89 @@
+// Verifies the new selector options (coverageMode, maxTriangleArea) on
+// paintPreview actually change which triangles get selected. Uses a
+// cylinder so the mesh has known fan topology — the top face's triangles
+// each span from center to rim, so a small box around the center catches
+// many by *centroid* but few by *fully_inside*.
+
+import { test, expect } from 'playwright/test';
+
+test.describe('paint coverage filters', () => {
+  test('coverageMode and area stats defang fan-topology bleed', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // Build a 12-segment cylinder of radius 10 centered at origin. The top
+    // face at z=2 is a fan of 12 triangles, each one a thin wedge from
+    // (0,0,2) out to two adjacent rim vertices ~10 units away.
+    const ran = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const r = await pw.run('return api.Manifold.cylinder(2, 10, 10, 12);');
+      return r;
+    });
+    expect(ran.error).toBeUndefined();
+
+    // Box covering only the central column of the top face. With centroid
+    // mode, the fan wedges whose centroid is inside (centroid is ~1/3 of
+    // the way from center to rim — about 3.3 units out) get picked up,
+    // even though their rim vertices extend to ~10 units. With
+    // fully_inside the same box catches strictly fewer triangles.
+    const centroid = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintPreview({ box: { min: [-4, -4, 1.9], max: [4, 4, 2.1] } });
+    });
+    const fullyInside = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintPreview({
+        box: { min: [-4, -4, 1.9], max: [4, 4, 2.1] },
+        coverageMode: 'fully_inside',
+      });
+    });
+
+    expect(centroid.triangleCount, 'centroid mode catches fan wedges').toBeGreaterThan(0);
+    expect(fullyInside.triangleCount, 'fully_inside strictly narrower than centroid').toBeLessThan(centroid.triangleCount);
+
+    // The new area stats are present and the centroid-mode largest is
+    // visibly bigger than the fully_inside one (because the long wedges
+    // got filtered out).
+    expect(centroid).toHaveProperty('totalArea');
+    expect(centroid).toHaveProperty('largestTriangleArea');
+    expect(centroid.largestTriangleArea).toBeGreaterThan(0);
+    expect(centroid.totalArea).toBeGreaterThan(0);
+    if (fullyInside.triangleCount > 0) {
+      expect(centroid.largestTriangleArea).toBeGreaterThanOrEqual(fullyInside.largestTriangleArea);
+    }
+
+    // maxTriangleArea backstop: passing a value smaller than the fan
+    // wedges' area should drop them entirely. The wedges in this
+    // 12-segment cylinder have area ~13 sq units; capping at 1 drops them.
+    const capped = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintPreview({
+        box: { min: [-4, -4, 1.9], max: [4, 4, 2.1] },
+        maxTriangleArea: 1,
+      });
+    });
+    expect(capped.triangleCount, 'maxTriangleArea filters fan wedges').toBeLessThan(centroid.triangleCount);
+  });
+
+  test('paintExplain reports largestTriangleArea', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run('return api.Manifold.cube([10, 10, 10]);');
+      const painted = pw.paintInBox({ box: { min: [-1, -1, -1], max: [11, 11, 11] }, color: [1, 0, 0] });
+      return pw.paintExplain({ region: painted.id, withImage: false });
+    });
+    expect(result.error).toBeUndefined();
+    expect(result).toHaveProperty('largestTriangleArea');
+    expect(result.largestTriangleArea).toBeGreaterThan(0);
+    expect(result.area).toBeGreaterThan(0);
+    expect(result.normalHistogram).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- New `coverageMode` and `maxTriangleArea` options on every geometric paint selector (`paintNear`, `paintInBox`, `paintSlab`, `paintPreview`, `findFaces`) to defang the radial-fan triangle topology produced by `cylinder` / `revolve` / `linear_extrude`. The old centroid-only containment test silently let those long wedges paint visibly beyond the intended region.
- `paintPreview` and `paintExplain` now return `totalArea` + `largestTriangleArea`. The ratio `largestTriangleArea / (totalArea / triangleCount)` is the diagnostic — ratios above ~10 mean a fan wedge is contaminating the selection.
- Prompt + `ai.md` updated with the cause, the diagnostic, the two fixes, and an authoring tip (`.refine(2)` on cylinder/revolve parts).

## Why

User feedback from a recent agent session:

> The fundamental problem is **triangle topology from `cylinder()`**. Manifold's cylinder generates a "fan" mesh: every triangle on the top face has one vertex at the center and two on the rim. After a boolean union, those long radial triangles get inherited into the merged mesh. When `paintNear(point, radius)` checks "is this triangle's centroid within radius?", the centroid might be near the eye center, but the triangle physically covers a large area — so you paint a triangle that *looks* local but visually bleeds far away.

Both proposed fixes (`coverageMode: "fully_inside"` and `maxTriangleArea`) are implemented; either alone would have prevented every bleed in that session. The area stats on `paintPreview` make the problem catchable before it ships.

## Implementation notes

- `coverageMode` defaults to `'centroid'`, so every existing caller and saved version behaves identically.
- Per-vertex containment costs ~3× the centroid check, but the loops already iterate all 3 vertices for the bbox accumulator — so the marginal cost is negligible.
- `findSlabTriangles` lives in `src/color/slabPaint.ts` and now accepts an optional coverage mode; rehydration + UI drag paths keep the centroid default.
- Bonus fix: `paintSlab`'s commit path still used the old per-mutation 3-render sequence instead of `scheduleColorRefresh` from the perf cleanup. Now coalesces under rAF like the other paint paths.
- The `_painted` sidecar invariant stayed encapsulated in `src/color/regions.ts` via the helpers added in the prior cleanup; new code just uses `buildTriColors` + `overlayPainted` + `createEmptyTriColors`.

## Test plan

- [x] `npm run build` — green
- [x] `npm run test:e2e` — 14/14 (12 smoke + 2 new selector regression tests)
- [x] New `tests/paint-coverage.spec.ts` builds a 12-segment cylinder and asserts: (a) `fully_inside` strictly narrows the count vs. `centroid`, (b) `maxTriangleArea` filters the fan wedges, (c) `paintPreview` exposes `totalArea` + `largestTriangleArea`, (d) `paintExplain` exposes `largestTriangleArea`.
- [ ] Manual: open editor, build a cylinder via the AI chat, ask the model to paint a small spot on the top face — verify it now uses `coverageMode: 'fully_inside'` instead of bleeding.

https://claude.ai/code/session_018RSDXQg6Px1JD2RHHHmWcK

---
_Generated by [Claude Code](https://claude.ai/code/session_018RSDXQg6Px1JD2RHHHmWcK)_