### PR TITLE
test: integration of #124 + #125 + #126 + #127 for combined testing

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -193,6 +193,8 @@ await partwright.openSession(id)         // Open existing session
 await partwright.clearAllSessions()      // Delete all sessions & versions
 
 // Color regions -- tag face regions with a color (see #color-regions)
+partwright.probePixel({pixel, view})                                      // "click in your perception": pixel in a rendered view -> {point, normal, distance, triangleId} or null
+partwright.paintConnected({seed: {point, normal?}, maxDeviationDeg?, color, name?}) // BFS-flood from seed gated by seed-normal deviation (not adjacent). For organic / smooth meshes paintRegion can't handle.
 partwright.paintRegion({point, normal, color, name?, tolerance?})         // bucket: coplanar flood-fill -> {id, name, triangles} or {error, nearest?}
 partwright.paintNearestRegion({point, color, searchRadius?, name?, tolerance?}) // snap seed to nearest face, then flood-fill -> {id, name, triangles, snappedTo} or {error}
 partwright.paintNear({point, radius, normalCone?, topOnly?, color, name?})          // sphere: paint triangles whose centroid is within radius -> {id, name, triangles, bbox, centroid} or {error}
@@ -615,6 +617,37 @@ partwright.paintInBox({
 ```
 
 `paintNear` and `paintInBox` ignore mesh edges entirely — they collect triangles by *position* and (optionally) by face-normal direction, so the result is independent of how the boolean union tessellated the surface. Use them for organic geometry; use `paintRegion` for flat plates with crisp 90° edges.
+
+**Paint by visual reasoning (organic / character meshes).** When bounding boxes won't separate the features (a hand from a sleeve at the same Z; an ear from a head), use `probePixel` + `paintConnected`. `probePixel` translates a pixel position in a rendered view back to an exact surface point + normal + triangleId — essentially clicking in your own perception. `paintConnected` then flood-fills from that seed, gated by deviation from the SEED normal, so it stays on the feature without bleeding to side faces with different orientations.
+
+```js
+// 1. Render the angle that shows the feature clearly.
+const img = partwright.renderView({ elevation: 0, azimuth: 0, ortho: true, size: 320 });
+// (the image is forwarded to you as a multimodal block)
+
+// 2. Identify the feature's pixel in the rendered image. Then probe
+//    that exact pixel back into world space — the view spec MUST
+//    match the renderView call above.
+const hit = partwright.probePixel({
+  pixel: [180, 220],
+  view: { elevation: 0, azimuth: 0, ortho: true, size: 320 },
+});
+// hit = { point: [x, y, z], normal: [nx, ny, nz], distance, triangleId } or null
+
+// 3. Flood from the seed, gated by 30° deviation from the seed normal.
+//    paintConnected stays on the feature where paintRegion (bimodal
+//    on smooth meshes) cannot.
+if (hit) {
+  partwright.paintConnected({
+    seed: { point: hit.point, normal: hit.normal },
+    maxDeviationDeg: 30,
+    color: [0.4, 0.7, 0.4],
+    name: 'skin',
+  });
+}
+```
+
+The seed point returned by `probePixel` is *exactly* on the mesh surface (raycast result, not a snap), so paint primitives that need precise seed placement (`paintRegion` in particular) work without seed-tolerance issues. The model's pixel-position estimation has built-in error (~±10-20px on a 320 render); `paintConnected` absorbs that fine since the seed normal anchors the flood. For `paintNear`, pick a radius generous enough for the same.
 
 **Brush + slab + procedural targeting.**
 

--- a/public/ai.md
+++ b/public/ai.md
@@ -195,12 +195,12 @@ await partwright.clearAllSessions()      // Delete all sessions & versions
 // Color regions -- tag face regions with a color (see #color-regions)
 partwright.paintRegion({point, normal, color, name?, tolerance?})         // bucket: coplanar flood-fill -> {id, name, triangles} or {error, nearest?}
 partwright.paintNearestRegion({point, color, searchRadius?, name?, tolerance?}) // snap seed to nearest face, then flood-fill -> {id, name, triangles, snappedTo} or {error}
-partwright.paintNear({point, radius, normalCone?, topOnly?, color, name?})          // sphere: paint triangles whose centroid is within radius -> {id, name, triangles, bbox, centroid} or {error}
-partwright.paintInBox({box, normalCone?, topOnly?, color, name?})                   // box: paint triangles inside an AABB -> {id, name, triangles, bbox, centroid} or {error}
+partwright.paintNear({point, radius, normalCone?, topOnly?, coverageMode?, maxTriangleArea?, color, name?})    // sphere: paint triangles within radius -> {id, name, triangles, bbox, centroid} or {error}
+partwright.paintInBox({box, normalCone?, topOnly?, coverageMode?, maxTriangleArea?, color, name?})             // box: paint triangles inside an AABB -> {id, name, triangles, bbox, centroid} or {error}
 partwright.paintFaces({triangleIds, color, name?})                        // brush: paint specific triangle indices -> {id, name, triangles} or {error}
-partwright.paintSlab({axis|normal, offset, thickness, color, name?})      // slab: paint a planar range -> {id, name, triangles} or {error}
-partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) // dry-run -> {triangleCount, bbox, centroid, [thumbnail]} (default: count-only; withImage: true adds thumbnail)
-partwright.paintExplain({region, withImage?, view?}) // diagnose committed region -> {triangleCount, area, bbox, centroid, normalHistogram, [thumbnail]}
+partwright.paintSlab({axis|normal, offset, thickness, coverageMode?, maxTriangleArea?, color, name?})      // slab: paint a planar range -> {id, name, triangles} or {error}
+partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, coverageMode?, maxTriangleArea?, withImage?, view?}) // dry-run -> {triangleCount, bbox, centroid, totalArea, largestTriangleArea, [thumbnail]}
+partwright.paintExplain({region, withImage?, view?}) // diagnose committed region -> {triangleCount, area, largestTriangleArea, bbox, centroid, normalHistogram, [thumbnail]}
 partwright.assertPaint({region, expectedTriangleCount?, expectedBoundingBox?, expectedCentroid?}) // verify a region -> {passed, failures?}
 partwright.findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?}) // query triangle ids by geometry/color -> {triangleIds, count, matched, truncated}
 partwright.getMesh()                     // -> {numVert, numTri, vertices, triangles, normals, centroids, boundingBox} (typed arrays)
@@ -209,7 +209,7 @@ partwright.listRegions()                 // -> [{id, name, color, source, triang
 partwright.listComponents()              // -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- per-piece bbox for unioned models
 partwright.paintComponent({index, color, name?, topOnly?}) // One-call: paint the Nth boolean-distinct piece
 partwright.getFeatureCentroids({maxGroups?, withinBox?}?)  // Lightweight planning: centroids + normals + bbox per face group, NO triangleIds
-partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, [thumbnail]}
+partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, coverageMode?, maxTriangleArea?, withImage?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, totalArea, largestTriangleArea, [thumbnail]}
 partwright.undoLastPaint()               // Reverse the SINGLE most recent paint op -> {undone, id, ...}
 partwright.redoLastPaint()               // Reapply the most recently undone paint -> {redone, id, ...}
 partwright.removeRegion(id)              // Delete ONE region by id from listRegions()
@@ -458,18 +458,55 @@ partwright.clearColors()    // remove ALL regions — destructive, prefer the tw
 
 **Preview before commit (default workflow).** `paintPreview()` accepts
 the same selector args as `paintInBox` / `paintNear` / `paintFaces` but
-doesn't commit. By default it returns just `{triangleCount, bbox,
-centroid}` — count alone is essentially free and catches most bad
-selectors. Pass `withImage: true` when the count surprises you and a
-yellow-highlighted thumbnail is worth the tokens. Cheap; no side effects.
+doesn't commit. By default it returns `{triangleCount, bbox, centroid,
+totalArea, largestTriangleArea}` — count and area summary are essentially
+free and catch most bad selectors. Inspect the ratio
+`largestTriangleArea / (totalArea / triangleCount)`: ratios above ~10
+are a fan-topology red flag (see "fan-bleed" below). Pass
+`withImage: true` when the count or ratio surprises you — the
+yellow-highlighted thumbnail shows the real triangle extents, including
+the bleed.
 
-**Diagnose a bad paint.** `paintExplain({region: id})` returns area,
-bbox, centroid, a normal-distribution histogram (`{xPos, xNeg, yPos,
-yNeg, zPos, zNeg, oblique}` summing to ~1), and a thumbnail of the
-region tinted yellow. Use after a paint that looks wrong — the
-histogram tells you in one number whether the region wrapped onto a
-face you didn't intend (e.g. `zPos: 0.4, xPos: 0.3` = caught the top
-AND a side).
+**Diagnose a bad paint.** `paintExplain({region: id})` returns
+triangleCount, area, largestTriangleArea, bbox, centroid, a
+normal-distribution histogram (`{xPos, xNeg, yPos, yNeg, zPos, zNeg,
+oblique}` summing to ~1), and a thumbnail of the region tinted yellow.
+Use after a paint that looks wrong — the histogram tells you in one
+number whether the region wrapped onto a face you didn't intend
+(e.g. `zPos: 0.4, xPos: 0.3` = caught the top AND a side), and
+`largestTriangleArea` confirms whether fan-bleed is to blame.
+
+**Avoiding fan-topology bleed.** `cylinder` / `revolve` / `linear_extrude`
+generate triangulations where every face triangle has one vertex at
+the central axis — long radial "fan wedges" that stretch from the
+center out to the rim. After a boolean union, those long triangles
+get inherited into the merged mesh. `paintNear` and `paintInBox`
+default to a *centroid* containment test, so a fan wedge with its
+centroid inside your selector gets painted even though most of its
+area extends visibly outside. The result looks like a "paint smear"
+beyond the intended region. Two fixes, in order of preference:
+
+```js
+// 1. Tighten the containment test — fully_inside requires all 3
+//    vertices in the selection, which excludes fan wedges that
+//    straddle the boundary:
+partwright.paintNear({ point: [0, 5, 2], radius: 3, coverageMode: 'fully_inside', color: ... });
+
+// 2. Or backstop with a max triangle area — set to ~3-5× the
+//    typical triangle of the feature you intend to paint:
+partwright.paintInBox({ box: { ... }, maxTriangleArea: 4, color: ... });
+
+// 3. If you're authoring the code: refine the mesh before painting
+//    so cylinder/revolve geometry has small local triangles instead
+//    of radial fans. .refine(2) doubles the resolution; the shape
+//    doesn't change.
+const head = api.Manifold.cylinder(10, 20).refine(2);
+```
+
+Inspect `paintPreview`'s `largestTriangleArea` to choose a sensible
+`maxTriangleArea`. Sphere / cube / hull primitives don't have fan
+topology and don't need either workaround — the centroid default is
+fine there.
 
 **Verify from multiple angles.** Use `renderViews()` for verification
 rather than a single `renderView` call. The default `views: 'auto'`

--- a/public/ai.md
+++ b/public/ai.md
@@ -208,6 +208,8 @@ partwright.getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, max
 partwright.listRegions()                 // -> [{id, name, color, source, triangles, order, bbox, centroid}, ...]
 partwright.listComponents()              // -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- per-piece bbox for unioned models
 partwright.paintComponent({index, color, name?, topOnly?}) // One-call: paint the Nth boolean-distinct piece
+partwright.listLabels()                  // -> {count, labels: [{name, triangleCount, bbox, centroid}]} -- labels registered via api.label(shape, name) in the current run
+partwright.paintByLabel({label, color, name?}) // Paint a labelled feature by name. Exact, survives boolean ops. manifold-js only.
 partwright.getFeatureCentroids({maxGroups?, withinBox?}?)  // Lightweight planning: centroids + normals + bbox per face group, NO triangleIds
 partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, [thumbnail]}
 partwright.undoLastPaint()               // Reverse the SINGLE most recent paint op -> {undone, id, ...}
@@ -501,10 +503,43 @@ const preview = partwright.paintPreview({ box: { min: [-5, -5, 8], max: [5, 5, 1
 // otherwise: partwright.paintInBox({box: same, color: [1,0,0]})
 ```
 
-**Paint by feature on unioned models.** When the geometry is a boolean
-union of distinct pieces (head + eyes + mouth, body + arms + legs, etc.),
-the one-call form is `paintComponent(index, color)` — it decomposes and
-paints in a single round trip:
+**Labelled construction (the cleanest paint primitive on
+agent-authored manifold-js).** When you're writing the model code AND
+plan to paint features after, wrap each feature in `api.label(shape, name)`
+at construction time. Painting after is then a pure name lookup — no
+coordinates, no bounding boxes, no fan-bleed. The triangle set comes
+straight from manifold-3d's `runOriginalID` provenance and is exact
+even when shapes overlap.
+
+```js
+// In your model code:
+const head = api.label(api.Manifold.sphere(10), 'head');
+const eyeL = api.label(api.Manifold.sphere(2).translate([-3, 5, 7]), 'eyeL');
+const eyeR = api.label(api.Manifold.sphere(2).translate([ 3, 5, 7]), 'eyeR');
+return head.add(eyeL).add(eyeR);
+
+// After runAndSave, paint by name:
+partwright.paintByLabel({ label: 'eyeL', color: [0, 0, 1] });
+partwright.paintByLabel({ label: 'eyeR', color: [0, 0, 1] });
+// listLabels() returns what's available; check it if a paintByLabel
+// returns "no label X".
+```
+
+`api.labeledUnion([{name, shape}, ...])` is sugar that labels each
+entry and unions them in one call. Labels are runtime-only state
+(manifold-3d assigns fresh originalIDs every run); region descriptors
+persist the name, and rehydration re-resolves by name on the next
+load — so saved-version round-trips work as long as the code still
+defines the same label names.
+
+Limitations: manifold-js only (SCAD has no equivalent). For
+geometry you didn't author with labels (user-imported, legacy code),
+fall back to `paintComponent` below.
+
+**Paint by feature on unioned models (legacy fallback).** When the
+geometry is a boolean union of distinct pieces but the code didn't
+use `api.label`, the one-call form is `paintComponent(index, color)`
+— it decomposes and paints in a single round trip:
 
 ```js
 const { components } = partwright.listComponents();
@@ -517,6 +552,8 @@ for (const c of components) {
 
 This avoids guessing world coordinates, survives small parametric
 tweaks to the model, and skips the listComponents → paintInBox pair.
+Prefer `paintByLabel` when you control the code; reach for
+`paintComponent` when you don't.
 
 **Avoiding over-paint.** When `paintInBox` / `paintNear` catches side
 walls or the bottom face by mistake, pass `topOnly: true` — restricts

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -71,6 +71,29 @@ to paint each piece in ONE call — it decomposes and paints in one round
 trip. Use listComponents() FIRST only when you need to inspect bboxes
 before deciding what to paint.
 
+For organic / character meshes where bounding boxes won't separate the
+features (a hand from a sleeve at the same Z height; an ear from a
+head), use the paint-by-vision loop:
+1. renderView (or renderViews) — pick the angle that shows the feature
+   you want to paint clearly.
+2. Identify the feature's pixel position in the returned PNG visually.
+3. probePixel({pixel, view}) — translates the pixel back to an exact
+   world-space surface point + normal + triangleId. The view object
+   MUST match the renderView call's view (same elevation/azimuth/
+   ortho/size). Returns null if you picked a background pixel; try a
+   different pixel on the silhouette.
+4. paintConnected({seed: {point, normal}, maxDeviationDeg: 30, color})
+   — flood-fills from the seed, gated by deviation from the SEED
+   normal (not adjacent-face). Stays on the feature instead of bleeding
+   across to side faces with different orientations. paintRegion is
+   bimodal on smooth meshes and won't work here.
+
+This is also the workflow when the agent did NOT author the geometry
+(imported STL, code provided by the user) and api.label is not
+available. Pixel-estimation has ~±10-20px uncertainty at 320px — fine
+for paintConnected (the seed is exactly on the surface from the
+raycast); for paintNear, pick a radius generous enough to absorb that.
+
 When paintInBox / paintNear catches side walls or bottom faces by
 mistake, pass topOnly: true — that restricts the selector to upward-
 facing triangles only (axis +Z within 30°) and eliminates the most

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -39,10 +39,19 @@ clearColors for "start completely over from scratch" requests.
 Paint workflow for any non-trivial selector:
 1. paintPreview({box / point+radius / etc.}) — ALWAYS call before
    committing. Count alone is essentially free and catches most bad
-   selectors. If the count is surprising (way more or fewer than you
-   expected), call again with withImage: true for a yellow-highlighted
-   thumbnail. Either way, much cheaper than paint → renderViews → undo.
-2. paintInBox / paintNear / paintSlab to commit.
+   selectors. ALSO inspect largestTriangleArea / (totalArea /
+   triangleCount): ratios above ~10 mean a long radial fan triangle is
+   in the selection and paint will bleed visibly outside it. If the
+   count or ratio looks off, call again with withImage: true for a
+   yellow-highlighted thumbnail — the yellow streaks show real bleed,
+   not a rendering artifact.
+2. paintInBox / paintNear / paintSlab to commit. On meshes built from
+   cylinder / revolve / linear_extrude (radial-fan topology), pass
+   coverageMode: 'fully_inside' so only triangles whose vertices ALL
+   lie in the selection are painted; or pass maxTriangleArea: <N> as
+   a backstop. Either one prevents fan-bleed at the cost of one extra
+   parameter. For meshes built from sphere / cube / hull (small local
+   triangles), the default 'centroid' mode is fine.
 3. renderViews() to visually verify. The default views: 'auto' picks
    angles by the model's bounding box (flat disks get [Top, Iso],
    tall columns get [Front, Right, Iso], otherwise [Front, Top, Iso])
@@ -50,8 +59,15 @@ Paint workflow for any non-trivial selector:
    angle can hide an asymmetric error.
 4. If wrong: paintExplain({region: id}) FIRST — its normal histogram
    tells you whether the region wrapped onto a face you didn't want
-   (e.g. zPos: 0.4 + xPos: 0.3 means it caught the top AND a side).
+   (e.g. zPos: 0.4 + xPos: 0.3 means it caught the top AND a side),
+   and largestTriangleArea confirms whether fan-bleed is to blame.
    Then undoLastPaint() (NOT clearColors), tweak, retry.
+
+Authoring tip: if you're writing model code that will be painted
+afterwards, prefer sphere / cube / hull over cylinder / revolve /
+linear_extrude for surfaces that need precise paint, or call
+.refine(2) on a cylinder/revolve part in your code before runAndSave
+to break the fan topology into small local triangles.
 
 Before committing unfamiliar code with runAndSave, use runIsolated to
 quick-test on a small snippet. Examples worth verifying first: revolve

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -65,11 +65,25 @@ is it a carved recess, raised feature, or flat color region?
 question instead of guessing. A clarification turn costs less than
 3 wasted versions.
 
-For models built as a boolean union of distinct features (e.g. a smiley =
-head ∪ left_eye ∪ right_eye ∪ mouth), use paintComponent(index, color)
-to paint each piece in ONE call — it decomposes and paints in one round
-trip. Use listComponents() FIRST only when you need to inspect bboxes
-before deciding what to paint.
+For multi-feature models you author in manifold-js, prefer labelled
+construction over coordinate-based selectors. In your code, wrap each
+feature in api.label(shape, 'name'):
+
+  const head = api.label(api.Manifold.sphere(10), 'head');
+  const eyeL = api.label(api.Manifold.sphere(2).translate([3, 5, 7]), 'eyeL');
+  return head.add(eyeL);
+
+After runAndSave, call paintByLabel({label: 'eyeL', color: [0, 0, 1]}).
+The triangle set comes from manifold-3d's runOriginalID provenance, so
+it's exact even when shapes overlap — no bounding-box guessing, no
+fan-bleed, survives boolean ops. listLabels() returns what's available
+in the current run. api.labeledUnion([{name, shape}, ...]) is sugar
+when you have an array of features.
+
+For models you didn't author with labels (or for SCAD), fall back to
+paintComponent(index, color) — it decomposes the union and paints the
+Nth piece in one call. Use listComponents() FIRST only when you need
+to inspect bboxes before deciding what to paint.
 
 When paintInBox / paintNear catches side walls or bottom faces by
 mistake, pass topOnly: true — that restricts the selector to upward-

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -122,6 +122,49 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'probePixel',
+    description: 'Click in your own perception. Translates a pixel in a renderView image back to a world-space surface hit on the mesh: {point, normal, distance, triangleId} or null when the pixel is background. The view must match the renderView call (same elevation/azimuth/ortho/size). This is THE tool for organic geometry: render → identify the feature visually → probePixel to get exact coords → paintConnected or paintNear. The returned point is exactly on the mesh surface (raycast, not snap), so paintRegion-style seed-precision worries are gone. Front-most hit = occlusion correct.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        pixel: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2, description: '[x, y] pixel position. (0, 0) is top-left.' },
+        view: {
+          type: 'object',
+          description: 'Camera spec. MUST match the renderView call that produced the image — same elevation, azimuth, ortho, size.',
+          properties: {
+            elevation: { type: 'number' },
+            azimuth: { type: 'number' },
+            ortho: { type: 'boolean' },
+            size: { type: 'integer' },
+          },
+        },
+      },
+      required: ['pixel', 'view'],
+    },
+  },
+  {
+    name: 'paintConnected',
+    description: 'Flood-fill paint from a surface seed, gated by deviation from the SEED normal (not adjacent-face). This is what paintRegion should have been on smooth meshes — paintRegion compares adjacent pairs and is bimodal (all or nothing) on capsules / spheres / organic surfaces, paintConnected keeps the reference fixed at the seed so 30° gives you "this region of the surface facing roughly this way", regardless of how curved the connecting topology is. Best paired with probePixel — probe a pixel in a render, hand the {point, normal} straight to paintConnected.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        seed: {
+          type: 'object',
+          description: 'Surface seed. `point` is required; `normal` optional (defaults to the nearest triangle\'s normal).',
+          properties: {
+            point: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+            normal: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+          },
+          required: ['point'],
+        },
+        maxDeviationDeg: { type: 'number', description: 'Maximum angle (degrees) a neighbor\'s normal may deviate from the seed normal. Default 30. Use larger values to follow curved features; smaller values to stay on a single facet.' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+        name: { type: 'string' },
+      },
+      required: ['seed', 'color'],
+    },
+  },
+  {
     name: 'getFeatureCentroids',
     description: 'Token-cheap planning aid: returns coplanar face groups with just centroid + normal + bbox + area (NO triangle IDs). Use this when planning where to paint without committing yet — cheaper than getMeshSummary because the triangleIds payload is omitted. Optional `withinBox` scopes to one feature.',
     input_schema: {
@@ -378,13 +421,14 @@ const ALWAYS_AVAILABLE = new Set([
   'listSessionNotes',
   'findFaces',
   'listComponents',
+  'probePixel',
   'paintPreview',
   'paintExplain',
 ]);
 
 const RUN_GATED = new Set(['runCode']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
-const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
 /** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
  *  vision spend in one place — when off, the agent has to reason from
@@ -555,6 +599,10 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.listComponents();
     case 'paintComponent':
       return api.paintComponent(input);
+    case 'probePixel':
+      return api.probePixel(input);
+    case 'paintConnected':
+      return api.paintConnected(input);
     case 'getFeatureCentroids':
       return api.getFeatureCentroids(input);
     case 'paintExplain': {

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -122,6 +122,24 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'listLabels',
+    description: 'Return labels registered in the current run via api.label(shape, name) — the cleanest paint primitive on agent-authored manifold-js geometry. Each entry: {name, triangleCount, bbox, centroid}. Empty when the code did not call api.label. Use to confirm labels resolved correctly before paintByLabel; otherwise prefer calling paintByLabel directly to save a round-trip.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'paintByLabel',
+    description: 'Paint a labelled feature by name. The label must have been registered in the current run via api.label(shape, name) or api.labeledUnion. This is the bullseye for "describe how to make and paint a model" workflows: write the geometry with labels, then paint by name — no coordinate guessing, no bounding-box estimation, no fan-bleed. Survives boolean ops because manifold-3d propagates originalID through runOriginalID on the result mesh. Only works for manifold-js (SCAD has no equivalent); falls back to paintComponent / paintInBox there.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        label: { type: 'string', description: 'Name passed to api.label() in the model code.' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[r, g, b] in 0..1.' },
+        name: { type: 'string', description: 'Optional region name; defaults to the label.' },
+      },
+      required: ['label', 'color'],
+    },
+  },
+  {
     name: 'getFeatureCentroids',
     description: 'Token-cheap planning aid: returns coplanar face groups with just centroid + normal + bbox + area (NO triangle IDs). Use this when planning where to paint without committing yet — cheaper than getMeshSummary because the triangleIds payload is omitted. Optional `withinBox` scopes to one feature.',
     input_schema: {
@@ -378,13 +396,14 @@ const ALWAYS_AVAILABLE = new Set([
   'listSessionNotes',
   'findFaces',
   'listComponents',
+  'listLabels',
   'paintPreview',
   'paintExplain',
 ]);
 
 const RUN_GATED = new Set(['runCode']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
-const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
 /** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
  *  vision spend in one place — when off, the agent has to reason from
@@ -555,6 +574,10 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.listComponents();
     case 'paintComponent':
       return api.paintComponent(input);
+    case 'listLabels':
+      return api.listLabels();
+    case 'paintByLabel':
+      return api.paintByLabel(input);
     case 'getFeatureCentroids':
       return api.getFeatureCentroids(input);
     case 'paintExplain': {

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -181,7 +181,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintPreview',
-    description: 'DRY-RUN: returns {triangleCount, bbox, centroid} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. The cheapest way to catch a bad selector — count alone is essentially free; ALWAYS call before any non-trivial paint. Pass `withImage: true` ONLY when the count is suspicious (wildly more or fewer than expected) or the selector geometry is fuzzy — that adds a yellow-highlighted thumbnail.',
+    description: 'DRY-RUN: returns {triangleCount, bbox, centroid, totalArea, largestTriangleArea} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. The cheapest way to catch a bad selector — count alone is essentially free; ALWAYS call before any non-trivial paint. The `largestTriangleArea / (totalArea / triangleCount)` ratio is the fan-topology diagnostic: ratios > ~10 mean a long radial triangle is dragging the selection beyond its intended footprint (common with cylinder / revolve meshes) — fix with `coverageMode: "fully_inside"` or a `maxTriangleArea` cap, or refine the mesh before painting. Pass `withImage: true` when the count or area ratio is suspicious — the thumbnail shows the real triangle extents tinted yellow.',
     input_schema: {
       type: 'object',
       properties: {
@@ -191,6 +191,8 @@ const ALL_TOOLS: ToolDefinition[] = [
         normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
         triangleIds: { type: 'array', items: { type: 'integer' }, description: 'Explicit triangle list — mostly for verifying findFaces results.' },
         withImage: { type: 'boolean', description: 'Default false (stats-only, free). Pass true to also return the highlighted thumbnail when the count is surprising or you want a visual sanity check.' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'How a triangle is tested for containment. Default "centroid" (cheap, historical). "fully_inside" excludes long radial fan triangles whose centroid is in the selection but whose vertices extend outside — the right choice for painting on cylinder/revolve geometry.' },
+        maxTriangleArea: { type: 'number', description: 'Backstop against fan-topology bleed: skip any triangle whose world area exceeds this. Set it ~3-5× the typical triangle area of the feature you intend to paint.' },
       },
     },
   },
@@ -261,7 +263,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintNear',
-    description: 'Paint every triangle within `radius` of `point` (optionally constrained by a normal cone). One call, no triangleId shuttling. Use for "paint the faces around this corner / nub / boss". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause.',
+    description: 'Paint every triangle within `radius` of `point` (optionally constrained by a normal cone). One call, no triangleId shuttling. Use for "paint the faces around this corner / nub / boss". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause. On fan-topology meshes (cylinder/revolve/linear_extrude surfaces), pass `coverageMode: "fully_inside"` and/or `maxTriangleArea` to avoid long radial triangles bleeding paint outside the radius.',
     input_schema: {
       type: 'object',
       properties: {
@@ -269,6 +271,8 @@ const ALL_TOOLS: ToolDefinition[] = [
         radius: { type: 'number' },
         normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },
         topOnly: { type: 'boolean', description: 'Shortcut for normalCone: {axis: [0,0,1], angleDeg: 30}. Common case: paint only upward-facing faces in the region.' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'Triangle containment test. Default "centroid". "fully_inside" requires all 3 vertices within radius — defangs fan-bleed.' },
+        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this. Use to filter out the long radial triangles that cylinder/revolve produce.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
       },
@@ -277,13 +281,15 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintInBox',
-    description: 'Paint every triangle whose centroid is inside the axis-aligned box (optionally constrained by a normal cone). One call. Use for "paint the top half / the right rim / everything below z=0". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause.',
+    description: 'Paint every triangle whose centroid is inside the axis-aligned box (optionally constrained by a normal cone). One call. Use for "paint the top half / the right rim / everything below z=0". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause. On fan-topology meshes (cylinder/revolve/linear_extrude surfaces), pass `coverageMode: "fully_inside"` and/or `maxTriangleArea` to avoid long radial triangles bleeding paint outside the box.',
     input_schema: {
       type: 'object',
       properties: {
         box: { type: 'object', description: '{min: [x,y,z], max: [x,y,z]}' },
         normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n}.' },
         topOnly: { type: 'boolean', description: 'Shortcut for normalCone: {axis: [0,0,1], angleDeg: 30}. Common case: paint the top face of a feature without catching its sides.' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'Triangle containment test. Default "centroid". "fully_inside" requires all 3 vertices inside the box — defangs fan-bleed.' },
+        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this. Use to filter out the long radial triangles that cylinder/revolve produce.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
       },
@@ -292,7 +298,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintSlab',
-    description: 'Paint everything in a Z-slab (or arbitrary-axis slab). One call. Use for "paint the rim of this disk", "paint the side walls", "paint the top 5mm".',
+    description: 'Paint everything in a Z-slab (or arbitrary-axis slab). One call. Use for "paint the rim of this disk", "paint the side walls", "paint the top 5mm". Same coverageMode / maxTriangleArea options as the other selectors.',
     input_schema: {
       type: 'object',
       properties: {
@@ -300,6 +306,8 @@ const ALL_TOOLS: ToolDefinition[] = [
         normal: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Use instead of axis for an oblique slab.' },
         offset: { type: 'number', description: 'Slab center along the axis/normal.' },
         thickness: { type: 'number', description: 'Slab thickness (paint catches anything within ±thickness/2 of offset).' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'Triangle containment test. Default "centroid". "fully_inside" requires all 3 vertex projections within the slab range.' },
+        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
       },
@@ -332,6 +340,8 @@ const ALL_TOOLS: ToolDefinition[] = [
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         region: { type: 'string' },
         maxResults: { type: 'integer' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'Triangle containment test for the `box` predicate. Default "centroid". Use "fully_inside" on cylinder/revolve meshes to exclude long radial triangles.' },
+        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this.' },
       },
     },
   },

--- a/src/color/adjacency.ts
+++ b/src/color/adjacency.ts
@@ -136,6 +136,58 @@ export function findCoplanarRegion(
   return result;
 }
 
+/** BFS from a seed triangle, accepting each neighbor whose normal is
+ *  within `maxSeedDeviationDeg` of the SEED's normal — not the parent's.
+ *
+ *  This is the right primitive for "paint everything contiguous to my
+ *  seed that's facing the same general direction." Unlike
+ *  `findCoplanarRegion`, which compares each adjacent pair, the seed-
+ *  relative threshold doesn't accumulate around curvature: a smooth
+ *  cylinder side won't suck in the whole component when you pick a 30°
+ *  deviation, because the floor for inclusion stays anchored to the
+ *  seed orientation instead of drifting around the surface.
+ *
+ *  Both the seed triangle's own normal and every successive candidate
+ *  must dot the seed normal >= `cos(maxSeedDeviationDeg)`. The seed
+ *  triangle is always included; it's the starting point. */
+export function findConnectedFromSeed(
+  seedTri: number,
+  adjacency: AdjacencyGraph,
+  maxSeedDeviationCos: number,
+): Set<number> {
+  const { neighbors, normals } = adjacency;
+  const result = new Set<number>();
+  if (seedTri < 0 || seedTri >= neighbors.length) return result;
+
+  const snx = normals[seedTri * 3];
+  const sny = normals[seedTri * 3 + 1];
+  const snz = normals[seedTri * 3 + 2];
+
+  const queue = [seedTri];
+  result.add(seedTri);
+
+  while (queue.length > 0) {
+    const current = queue.pop()!;
+    const adj = neighbors[current];
+    for (let i = 0; i < adj.length; i++) {
+      const neighbor = adj[i];
+      if (result.has(neighbor)) continue;
+
+      const nx = normals[neighbor * 3];
+      const ny = normals[neighbor * 3 + 1];
+      const nz = normals[neighbor * 3 + 2];
+
+      const dot = snx * nx + sny * ny + snz * nz;
+      if (dot >= maxSeedDeviationCos) {
+        result.add(neighbor);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  return result;
+}
+
 /** Get the normal of a specific triangle. */
 export function getTriangleNormal(triIndex: number, adjacency: AdjacencyGraph): [number, number, number] {
   return [

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -15,7 +15,8 @@ export interface ColorRegion {
 export type RegionDescriptor =
   | { kind: 'coplanar'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; normalTolerance: number }
   | { kind: 'slab'; normal: [number, number, number]; offset: number; thickness: number }
-  | { kind: 'triangles'; ids: number[] };
+  | { kind: 'triangles'; ids: number[] }
+  | { kind: 'connectedFromSeed'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; maxDeviationDeg: number };
 
 export interface SerializedColorRegion {
   id: number;

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -15,7 +15,8 @@ export interface ColorRegion {
 export type RegionDescriptor =
   | { kind: 'coplanar'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; normalTolerance: number }
   | { kind: 'slab'; normal: [number, number, number]; offset: number; thickness: number }
-  | { kind: 'triangles'; ids: number[] };
+  | { kind: 'triangles'; ids: number[] }
+  | { kind: 'byLabel'; label: string };
 
 export interface SerializedColorRegion {
   id: number;

--- a/src/color/slabPaint.ts
+++ b/src/color/slabPaint.ts
@@ -61,12 +61,24 @@ export function projectionRange(mesh: MeshData, normal: [number, number, number]
   return { min, max };
 }
 
-/** Find all triangles whose centroid lies inside the slab. */
+export type SlabCoverageMode = 'centroid' | 'fully_inside' | 'any_vertex_inside';
+
+/** Find all triangles inside the slab. Coverage mode controls which
+ *  point on the triangle has to satisfy the slab containment test:
+ *
+ *  - `centroid` (default): the triangle's centroid lies in the slab.
+ *    Cheapest, matches historical behavior, but lets long radial fan
+ *    triangles "bleed" outside the slab when their centroid happens
+ *    to fall in range while their vertices extend further.
+ *  - `fully_inside`: all 3 vertices lie in the slab.
+ *  - `any_vertex_inside`: at least one vertex lies in the slab.
+ */
 export function findSlabTriangles(
   mesh: MeshData,
   normal: [number, number, number],
   offset: number,
   thickness: number,
+  coverage: SlabCoverageMode = 'centroid',
 ): Set<number> {
   const result = new Set<number>();
   if (thickness <= 0) return result;
@@ -74,11 +86,23 @@ export function findSlabTriangles(
   const [nx, ny, nz] = normalize(normal);
   const lo = offset;
   const hi = offset + thickness;
+  const { triVerts, vertProperties, numProp, numTri } = mesh;
 
-  for (let t = 0; t < mesh.numTri; t++) {
-    const c = getTriangleCentroid(t, mesh);
-    const d = c[0] * nx + c[1] * ny + c[2] * nz;
-    if (d >= lo && d <= hi) result.add(t);
+  for (let t = 0; t < numTri; t++) {
+    if (coverage === 'centroid') {
+      const c = getTriangleCentroid(t, mesh);
+      const d = c[0] * nx + c[1] * ny + c[2] * nz;
+      if (d >= lo && d <= hi) result.add(t);
+      continue;
+    }
+    const v0 = triVerts[t * 3], v1 = triVerts[t * 3 + 1], v2 = triVerts[t * 3 + 2];
+    const dA = vertProperties[v0 * numProp] * nx + vertProperties[v0 * numProp + 1] * ny + vertProperties[v0 * numProp + 2] * nz;
+    const dB = vertProperties[v1 * numProp] * nx + vertProperties[v1 * numProp + 1] * ny + vertProperties[v1 * numProp + 2] * nz;
+    const dC = vertProperties[v2 * numProp] * nx + vertProperties[v2 * numProp + 1] * ny + vertProperties[v2 * numProp + 2] * nz;
+    const inA = dA >= lo && dA <= hi;
+    const inB = dB >= lo && dB <= hi;
+    const inC = dC >= lo && dC <= hi;
+    if (coverage === 'fully_inside' ? (inA && inB && inC) : (inA || inB || inC)) result.add(t);
   }
 
   return result;

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -36,12 +36,63 @@ export const manifoldJsEngine: Engine = {
       setCircularSegments,
     } = manifoldModule;
 
+    // Per-run registry mapping a fresh `originalID()` (assigned by
+    // shape.asOriginal()) back to the human-readable name the user
+    // passed to `api.label`. After the user's code finishes, we walk
+    // the result mesh's `runOriginalID` array and build the inverse:
+    // `{name -> Set<triangleId>}`. Cleared on every run.
+    const labelRegistry = new Map<number, string>();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const label = (shape: any, name: unknown): any => {
+      if (!shape || typeof shape.asOriginal !== 'function' || typeof shape.add !== 'function') {
+        throw new Error('api.label(shape, name): shape must be a Manifold (returned by Manifold.cube/sphere/cylinder/extrude/etc.)');
+      }
+      if (typeof name !== 'string' || name.length === 0) {
+        throw new Error('api.label(shape, name): name must be a non-empty string');
+      }
+      // asOriginal() returns a copy with a fresh, unique originalID().
+      // We register that id against the user-supplied name. After
+      // boolean ops the result mesh's runOriginalID array will carry
+      // this id for every triangle that traces back to this input.
+      const original = shape.asOriginal();
+      const id = original.originalID();
+      if (id < 0) {
+        // Shouldn't happen — asOriginal() always produces a valid id —
+        // but defensive in case manifold-3d's behavior changes.
+        throw new Error('api.label(shape, name): asOriginal() did not produce a valid originalID; cannot register label.');
+      }
+      labelRegistry.set(id, name);
+      return original;
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const labeledUnion = (parts: unknown): any => {
+      if (!Array.isArray(parts) || parts.length === 0) {
+        throw new Error('api.labeledUnion(parts): non-empty array required, each element { name: string, shape: Manifold }');
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let acc: any = null;
+      for (const p of parts) {
+        if (!p || typeof p !== 'object') {
+          throw new Error('api.labeledUnion: each entry must be { name: string, shape: Manifold }');
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const entry = p as { name?: unknown; shape?: any };
+        const labelled = label(entry.shape, entry.name);
+        acc = acc === null ? labelled : acc.add(labelled);
+      }
+      return acc;
+    };
+
     const api = {
       Manifold,
       CrossSection,
       setMinCircularAngle,
       setMinCircularEdgeLength,
       setCircularSegments,
+      label,
+      labeledUnion,
     };
 
     let result: InstanceType<typeof Manifold> | null = null;
@@ -60,6 +111,7 @@ export const manifoldJsEngine: Engine = {
       }
 
       const mesh = result.getMesh();
+      const labelMap = resolveLabelMap(mesh, labelRegistry);
       return {
         mesh: {
           vertProperties: mesh.vertProperties,
@@ -69,9 +121,12 @@ export const manifoldJsEngine: Engine = {
           numProp: mesh.numProp,
           mergeFromVert: mesh.mergeFromVert,
           mergeToVert: mesh.mergeToVert,
+          runIndex: mesh.runIndex,
+          runOriginalID: mesh.runOriginalID,
         },
         manifold: result,
         error: null,
+        labelMap,
       };
     } catch (e: unknown) {
       let msg = e instanceof Error ? e.message : String(e);
@@ -116,3 +171,32 @@ export const manifoldJsEngine: Engine = {
     }
   },
 };
+
+/** Walk the result mesh's `runOriginalID` + `runIndex` arrays and bucket
+ *  triangles by the human-readable name registered for each id at
+ *  `api.label()` time. Multiple runs may carry the same id (a labelled
+ *  shape used in two places of the union) — the bucket merges them. */
+function resolveLabelMap(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mesh: any,
+  registry: Map<number, string>,
+): Map<string, Set<number>> | undefined {
+  if (registry.size === 0) return undefined;
+  const out = new Map<string, Set<number>>();
+  const runOriginalID: Uint32Array | undefined = mesh.runOriginalID;
+  const runIndex: Uint32Array | undefined = mesh.runIndex;
+  if (!runOriginalID || !runIndex || runOriginalID.length === 0) return out;
+  for (let i = 0; i < runOriginalID.length; i++) {
+    const name = registry.get(runOriginalID[i]);
+    if (name === undefined) continue;
+    const startTri = runIndex[i] / 3;
+    const endTri = runIndex[i + 1] / 3;
+    let set = out.get(name);
+    if (!set) {
+      set = new Set<number>();
+      out.set(name, set);
+    }
+    for (let t = startTri; t < endTri; t++) set.add(t);
+  }
+  return out;
+}

--- a/src/geometry/rayCast.ts
+++ b/src/geometry/rayCast.ts
@@ -17,7 +17,14 @@ export interface ProbeResult {
 }
 
 export interface GeneralRayResult {
-  hits: { point: [number, number, number]; normal: [number, number, number]; distance: number }[];
+  hits: { point: [number, number, number]; normal: [number, number, number]; distance: number; triangleId: number }[];
+}
+
+export interface PixelHit {
+  point: [number, number, number];
+  normal: [number, number, number];
+  distance: number;
+  triangleId: number;
 }
 
 function meshDataToBufferGeometry(mesh: MeshData): THREE.BufferGeometry {
@@ -119,6 +126,7 @@ export function probeRay(
       ? [hit.face.normal.x, hit.face.normal.y, hit.face.normal.z] as [number, number, number]
       : [0, 0, 0] as [number, number, number],
     distance: Math.round(hit.distance * 1000) / 1000,
+    triangleId: hit.faceIndex ?? -1,
   }));
 
   // Deduplicate hits at the same distance (triangulated faces produce duplicates)
@@ -142,4 +150,50 @@ export function measureDistance(
   const dy = p2[1] - p1[1];
   const dz = p2[2] - p1[2];
   return Math.round(Math.sqrt(dx * dx + dy * dy + dz * dz) * 1000) / 1000;
+}
+
+/** Cast a ray from a pixel in a rendered view back into the mesh and
+ *  return the first hit (front-most along the ray — so occlusion is
+ *  correct by construction). Pixel coordinates use the rendered image's
+ *  convention: (0, 0) is top-left, (size-1, size-1) is bottom-right.
+ *  `camera` must be the same camera the render was produced with; use
+ *  `buildViewCamera` from the renderer module to construct it from the
+ *  same view options passed to `renderView`. Returns null when the
+ *  pixel ray misses the mesh entirely (background pixel). */
+export function probePixel(
+  meshData: MeshData,
+  camera: THREE.Camera,
+  pixel: [number, number],
+  size: number,
+): PixelHit | null {
+  const geometry = meshDataToBufferGeometry(meshData);
+  const material = new THREE.MeshBasicMaterial({ side: THREE.DoubleSide });
+  const tempMesh = new THREE.Mesh(geometry, material);
+
+  // NDC: pixel (0,0) → (-1, +1); pixel (size, size) → (+1, -1). Y is
+  // flipped because canvas pixel-y grows downward while NDC y grows
+  // upward.
+  const ndcX = (pixel[0] / size) * 2 - 1;
+  const ndcY = -((pixel[1] / size) * 2 - 1);
+  const raycaster = new THREE.Raycaster();
+  raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
+  const intersections = raycaster.intersectObject(tempMesh);
+
+  geometry.dispose();
+  material.dispose();
+
+  if (intersections.length === 0) return null;
+  const hit = intersections[0];
+  return {
+    point: [
+      Math.round(hit.point.x * 1000) / 1000,
+      Math.round(hit.point.y * 1000) / 1000,
+      Math.round(hit.point.z * 1000) / 1000,
+    ],
+    normal: hit.face
+      ? [hit.face.normal.x, hit.face.normal.y, hit.face.normal.z]
+      : [0, 0, 0],
+    distance: Math.round(hit.distance * 1000) / 1000,
+    triangleId: hit.faceIndex ?? -1,
+  };
 }

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -7,6 +7,14 @@ export interface MeshData {
   triColors?: Uint8Array; // numTri * 3 (RGB per triangle), optional
   mergeFromVert?: Uint32Array; // vertex merge pairs from manifold-3d (for export dedup)
   mergeToVert?: Uint32Array;
+  /** Per-triangle-run provenance from manifold-3d, used to resolve
+   *  `api.label(shape, name)` calls back to triangle sets after boolean
+   *  ops. `runIndex` has length `numRun + 1`; run `i` covers triangles
+   *  in `[runIndex[i]/3, runIndex[i+1]/3)`. `runOriginalID` has length
+   *  `numRun` and gives the `originalID()` of the input that produced
+   *  each run. Optional because not every engine populates it. */
+  runIndex?: Uint32Array;
+  runOriginalID?: Uint32Array;
 }
 
 export type DiagnosticSeverity = 'error' | 'warning' | 'info' | 'hint';
@@ -29,6 +37,11 @@ export interface MeshResult {
   manifold: unknown | null;
   error: string | null;
   diagnostics?: SourceDiagnostic[];
+  /** Map from `api.label(shape, name)` calls in the user's code to the
+   *  triangle ids in the result mesh that came from that labelled input.
+   *  Resolved by walking `mesh.runOriginalID` + `runIndex`. Empty / absent
+   *  when no labels were registered. */
+  labelMap?: Map<string, Set<number>>;
 }
 
 export interface CrossSectionResult {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import './style.css';
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, type Language } from './geometry/engine';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
 import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible } from './renderer/viewport';
-import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, RENDER_VIEW_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode } from './renderer/multiview';
+import { renderCompositeCanvas, renderElevationsToContainer, renderSingleView, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode } from './renderer/multiview';
 import { generateId } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic } from './editor/codeEditor';
@@ -49,7 +49,7 @@ function registerExportFromBuilt(built: BuiltExport, source: string): void {
 }
 import type { MeshData, SourceDiagnostic } from './geometry/types';
 import { analyzeZProfile, type ZProfile } from './geometry/profileAnalysis';
-import { probeAtXY, probeRay, measureDistance, type ProbeResult, type GeneralRayResult } from './geometry/rayCast';
+import { probeAtXY, probeRay, probePixel, measureDistance, type ProbeResult, type GeneralRayResult, type PixelHit } from './geometry/rayCast';
 import { checkContainment, type ContainmentWarning } from './geometry/containmentCheck';
 import { setUnits as _setUnits, getUnits as _getUnits, type UnitSystem } from './geometry/units';
 import { initMeasureTool, activate as activateMeasure, deactivate as deactivateMeasure, getState as getMeasureState } from './ui/measureTool';
@@ -83,7 +83,7 @@ import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontS
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
 import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, buildTriColors, createEmptyTriColors, overlayPainted, type SerializedColorRegion } from './color/regions';
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
-import { buildAdjacency, findCoplanarRegion, resolveSeed, findNearestTriangle } from './color/adjacency';
+import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, resolveSeed, findNearestTriangle } from './color/adjacency';
 import { findSlabTriangles } from './color/slabPaint';
 import { computeFaceGroups } from './color/faceGroups';
 import {
@@ -505,6 +505,39 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): vo
     } else if (region.descriptor.kind === 'slab') {
       const { normal, offset, thickness } = region.descriptor;
       triangles = findSlabTriangles(mesh, normal, offset, thickness);
+    } else if (region.descriptor.kind === 'connectedFromSeed') {
+      const { seedPoint, seedNormal, maxDeviationDeg } = region.descriptor;
+      // Find the closest triangle to the seed point — robust across
+      // re-runs because triangle indices are unstable but world-space
+      // points are not. Then BFS-flood gated by deviation from the
+      // stored seed normal.
+      const nearest = findNearestTriangle(seedPoint, mesh, adjacency);
+      if (nearest.triIndex >= 0) {
+        const cos = Math.cos(maxDeviationDeg * Math.PI / 180);
+        triangles = findConnectedFromSeed(nearest.triIndex, adjacency, cos);
+        // The flood starts from the seed triangle's own normal. If the
+        // user supplied a seedNormal that differs (e.g. they probed a
+        // pixel that hit a different feature than expected), the seed
+        // triangle still anchors the flood — but we'd ideally filter by
+        // dot(stored seedNormal, neighbor) >= cos. Compromise: when the
+        // stored seed normal disagrees with the resolved seed triangle's
+        // normal beyond the deviation, fall back to filtering against
+        // the stored normal explicitly so the bucket stays stable.
+        const sNorm = adjacency.normals;
+        const dotSeed = sNorm[nearest.triIndex * 3] * seedNormal[0]
+                      + sNorm[nearest.triIndex * 3 + 1] * seedNormal[1]
+                      + sNorm[nearest.triIndex * 3 + 2] * seedNormal[2];
+        if (dotSeed < cos) {
+          // Surface re-orientation between runs — re-filter conservatively.
+          const filtered = new Set<number>();
+          for (const t of triangles) {
+            const nx = sNorm[t * 3], ny = sNorm[t * 3 + 1], nz = sNorm[t * 3 + 2];
+            const d = seedNormal[0] * nx + seedNormal[1] * ny + seedNormal[2] * nz;
+            if (d >= cos) filtered.add(t);
+          }
+          triangles = filtered;
+        }
+      }
     }
 
     if (triangles.size > 0) {
@@ -2973,6 +3006,135 @@ async function main() {
       return probeRay(currentMeshData, origin, direction);
     },
 
+    /** Click in your perception. Translates a pixel in a rendered image
+     *  back to a world-space hit on the mesh — exact surface point,
+     *  face normal, and triangle id of the front-most hit (occlusion-
+     *  correct by construction). The `view` argument must be the SAME
+     *  shape `renderView` accepted for the image you're probing; the
+     *  camera is rebuilt deterministically so screen coordinates round-
+     *  trip without drift. Returns `null` when the pixel is background.
+     *
+     *  Pixel convention matches the rendered PNG: `(0, 0)` is top-left,
+     *  `(size - 1, size - 1)` is bottom-right.
+     *
+     *  ```
+     *  // renderView returned a 320×320 image; you identified the fingertip
+     *  // around pixel (180, 220) by eye:
+     *  const hit = partwright.probePixel({
+     *    pixel: [180, 220],
+     *    view:  { elevation: 0, azimuth: 0, ortho: true, size: 320 },
+     *  });
+     *  if (hit) partwright.paintNear({ point: hit.point, radius: 4, color: [...] });
+     *  ``` */
+    probePixel(opts: {
+      pixel: [number, number];
+      view: { elevation?: number; azimuth?: number; ortho?: boolean; size?: number };
+    }): PixelHit | { error: string } | null {
+      if (!opts || typeof opts !== 'object') return { error: 'probePixel requires { pixel, view }' };
+      if (!Array.isArray(opts.pixel) || opts.pixel.length !== 2) return { error: 'probePixel.pixel must be [x, y]' };
+      for (const c of opts.pixel) {
+        if (typeof c !== 'number' || !Number.isFinite(c)) return { error: 'probePixel.pixel components must be finite numbers' };
+      }
+      if (!opts.view || typeof opts.view !== 'object') return { error: 'probePixel.view must match the renderView options used to produce the image' };
+      const v = opts.view as { elevation?: unknown; azimuth?: unknown; ortho?: unknown; size?: unknown };
+      assertNoUnknownKeys(v, ['elevation', 'azimuth', 'ortho', 'size'], 'probePixel(opts).view');
+      assertNumber(v.elevation, 'probePixel(opts).view.elevation', { optional: true, min: -90, max: 90 });
+      assertNumber(v.azimuth, 'probePixel(opts).view.azimuth', { optional: true });
+      assertBoolean(v.ortho, 'probePixel(opts).view.ortho', { optional: true });
+      assertNumber(v.size, 'probePixel(opts).view.size', { optional: true, min: 1, integer: true });
+      if (!currentMeshData) return null;
+      const size = (v.size as number | undefined) ?? 500;
+      const [px, py] = opts.pixel;
+      if (px < 0 || px >= size || py < 0 || py >= size) {
+        return { error: `probePixel.pixel [${px}, ${py}] is outside the ${size}×${size} viewport. Pixel (0,0) is top-left, (${size - 1},${size - 1}) is bottom-right.` };
+      }
+      const camera = buildViewCamera(currentMeshData, opts.view);
+      return probePixel(currentMeshData, camera, [px, py], size);
+    },
+
+    /** Paint a connected patch starting from a seed point on the
+     *  surface, expanding through adjacent triangles only as far as the
+     *  surface stays within `maxDeviationDeg` of the seed's normal.
+     *
+     *  Unlike `paintRegion` (which compares each adjacent pair, so on a
+     *  smooth surface the threshold is bimodal — all or nothing),
+     *  `paintConnected` compares every candidate triangle against the
+     *  SEED's normal directly. That means picking a seed on a hand and
+     *  flooding with 30° tolerance gives you the hand's surface that
+     *  faces roughly the same way, no matter how curved the connecting
+     *  geometry is.
+     *
+     *  Best when paired with `probePixel`: probe a pixel in a rendered
+     *  view, take the returned `point` + `normal`, hand them to
+     *  `paintConnected`. The patch follows real mesh topology rather
+     *  than a coordinate box, so it doesn't bleed across feature
+     *  boundaries (a robe collar stops where the skin starts).
+     *
+     *  ```
+     *  partwright.paintConnected({
+     *    seed: { point: hit.point, normal: hit.normal },
+     *    maxDeviationDeg: 30,
+     *    color: [0.4, 0.7, 0.4],
+     *    name: 'skin patch',
+     *  })
+     *  ``` */
+    paintConnected(opts: {
+      seed: { point: [number, number, number]; normal?: [number, number, number] };
+      maxDeviationDeg?: number;
+      color: [number, number, number];
+      name?: string;
+    }) {
+      if (!opts || typeof opts !== 'object') return { error: 'paintConnected requires { seed: {point, normal?}, color }' };
+      if (!opts.seed || typeof opts.seed !== 'object') return { error: 'paintConnected.seed must be { point: [x,y,z], normal?: [nx,ny,nz] }' };
+      if (!Array.isArray(opts.seed.point) || opts.seed.point.length !== 3) return { error: 'paintConnected.seed.point must be [x,y,z]' };
+      for (const c of opts.seed.point) {
+        if (typeof c !== 'number' || !Number.isFinite(c)) return { error: 'paintConnected.seed.point components must be finite numbers' };
+      }
+      if (opts.seed.normal !== undefined) {
+        if (!Array.isArray(opts.seed.normal) || opts.seed.normal.length !== 3) return { error: 'paintConnected.seed.normal must be [nx,ny,nz] when provided' };
+        for (const c of opts.seed.normal) {
+          if (typeof c !== 'number' || !Number.isFinite(c)) return { error: 'paintConnected.seed.normal components must be finite numbers' };
+        }
+      }
+      const maxDev = opts.maxDeviationDeg ?? 30;
+      if (typeof maxDev !== 'number' || !Number.isFinite(maxDev) || maxDev < 0 || maxDev > 180) {
+        return { error: 'paintConnected.maxDeviationDeg must be a finite number in [0, 180]' };
+      }
+      if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'paintConnected.color must be [r,g,b] in 0..1' };
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+
+      const mesh = currentMeshData;
+      const adjacency = buildAdjacency(mesh);
+      const nearest = findNearestTriangle(opts.seed.point, mesh, adjacency);
+      if (nearest.triIndex < 0) return { error: 'paintConnected: mesh has no triangles' };
+
+      // Use the supplied normal if provided, else derive from the nearest
+      // triangle — same convention paintRegion uses.
+      const seedNormal: [number, number, number] = opts.seed.normal ?? nearest.normal;
+      // Persist the seed point we used (snapped to the surface) so
+      // rehydration finds the same triangle on re-load.
+      const seedPoint: [number, number, number] = nearest.closest;
+      const cos = Math.cos(maxDev * Math.PI / 180);
+      const triangles = findConnectedFromSeed(nearest.triIndex, adjacency, cos);
+      if (triangles.size === 0) return { error: `paintConnected: seed triangle ${nearest.triIndex} has no neighbors meeting the deviation threshold` };
+
+      const regionName = opts.name ?? `Region ${getRegions().length + 1}`;
+      const region = addRegion(
+        regionName,
+        opts.color as [number, number, number],
+        'paintbrush',
+        { kind: 'connectedFromSeed', seedPoint, seedNormal, maxDeviationDeg: maxDev },
+        triangles,
+      );
+      const colored = applyTriColorsIfVisible(mesh);
+      updateMesh(colored, { skipAutoFrame: true });
+      updateMultiView(colored);
+      renderElevationsToContainer(elevationsContainer, colored);
+      syncLockState();
+      const stats = regionTriangleStats(triangles, mesh);
+      return { id: region.id, name: region.name, triangles: triangles.size, bbox: stats.bbox, centroid: stats.centroid, seedTriangle: nearest.triIndex };
+    },
+
     /** Check if any component is fully contained inside another (invisible geometry) */
     checkContainment(): ContainmentWarning[] | null {
       if (!currentManifold) return null;
@@ -4174,6 +4336,7 @@ async function main() {
         'renderViews':     { signature: 'await renderViews({views?: "tri"|"all", size?}) -- 3- or 4-angle labeled composite -> data URL. Use for verification when one angle could hide errors.', docs: '/ai.md#visual-verification' },
         'analyzeProfile':  { signature: 'analyzeProfile(sampleCount?) -- Z-profile feature summary', docs: '/ai.md#console-api--windowpartwright' },
         'measureAt':       { signature: 'measureAt([x,y]) -- Ray-cast probe at XY -> {hits, thickness, topZ, bottomZ}', docs: '/ai.md#console-api--windowpartwright' },
+        'probePixel':      { signature: 'probePixel({pixel: [x,y], view}) -- Translate a pixel in a rendered view back to a surface hit: {point, normal, distance, triangleId}. The view spec must match the renderView call. null when the pixel is background.', docs: '/ai.md#console-api--windowpartwright' },
         // Viewport controls
         'setGridVisible':       { signature: 'setGridVisible(on?) -- Show/hide grid plane (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
         'isGridVisible':        { signature: 'isGridVisible() -- Whether grid plane is visible', docs: '/ai.md#viewport-controls' },
@@ -4225,6 +4388,7 @@ async function main() {
         'clearColors':     { signature: 'clearColors() -- Remove ALL color regions (use undoLastPaint to reverse just one)', docs: '/ai.md#color-regions' },
         'listComponents':  { signature: 'listComponents() -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- Decompose the manifold into boolean-distinct parts. For "paint each feature" workflows (e.g. unioned head + eyes + mouth).', docs: '/ai.md#color-regions' },
         'paintComponent':  { signature: 'paintComponent({index, color, name?, topOnly?}) -- One-call shortcut: listComponents + paintInBox for the Nth piece.', docs: '/ai.md#color-regions' },
+        'paintConnected':  { signature: 'paintConnected({seed: {point, normal?}, maxDeviationDeg?, color, name?}) -- BFS-flood from a surface seed, gated by deviation from SEED normal (not adjacent). Pairs with probePixel for "paint everything contiguous and facing this way".', docs: '/ai.md#color-regions' },
         'getFeatureCentroids': { signature: 'getFeatureCentroids({maxGroups?, withinBox?}?) -- Token-cheap: face-group centroids + normals + bbox, no triangleIds. Use to plan paint targets.', docs: '/ai.md#color-regions' },
         'removeRegion':    { signature: 'removeRegion(id) -- Remove ONE color region by id from listRegions(). Use this to fix a single mistake without nuking the rest.', docs: '/ai.md#color-regions' },
         'undoLastPaint':   { signature: 'undoLastPaint() -- Undo the most recent paint op. Removed region goes on a redo stack.', docs: '/ai.md#color-regions' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -138,6 +138,15 @@ let currentManifold: any = null;
 // #geometry-data element — always-updated machine-readable state
 let geometryDataEl: HTMLElement;
 
+/** Paint selector containment test. `centroid` is the historical default
+ *  (a triangle is in the selection when its centroid lies inside the
+ *  box / sphere / slab). `fully_inside` and `any_vertex_inside` are
+ *  per-vertex tests that defang the long radial triangles produced by
+ *  cylinder / revolve / linear_extrude — those can have a centroid in
+ *  the selection while extending visibly far outside it ("bleed"). */
+export const COVERAGE_MODES = ['centroid', 'fully_inside', 'any_vertex_inside'] as const;
+export type CoverageMode = typeof COVERAGE_MODES[number];
+
 // === Document title management ===
 // Actively manage document.title to reflect current state.
 // Some browser automation tools (MCP servers, extensions) can inadvertently
@@ -3240,10 +3249,10 @@ async function main() {
     /** Paint a slab — all faces whose centroid falls inside a planar slab.
      *  `axis` is shorthand for axis-aligned slabs ('x'/'y'/'z'). For oblique
      *  slabs, pass `normal` directly (does not need to be normalized). */
-    paintSlab(opts: { axis?: 'x' | 'y' | 'z'; normal?: [number, number, number]; offset: number; thickness: number; color: [number, number, number]; name?: string }) {
+    paintSlab(opts: { axis?: 'x' | 'y' | 'z'; normal?: [number, number, number]; offset: number; thickness: number; color: [number, number, number]; name?: string; coverageMode?: CoverageMode; maxTriangleArea?: number }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintSlab requires {axis|normal, offset, thickness, color}' };
-      const { axis, normal: rawNormal, offset, thickness, color, name } = opts;
+      const { axis, normal: rawNormal, offset, thickness, color, name, coverageMode, maxTriangleArea } = opts;
 
       let normal: [number, number, number];
       if (axis !== undefined) {
@@ -3261,8 +3270,15 @@ async function main() {
       if (typeof offset !== 'number' || !Number.isFinite(offset)) return { error: 'offset must be a finite number' };
       if (typeof thickness !== 'number' || !Number.isFinite(thickness) || thickness <= 0) return { error: 'thickness must be a positive finite number' };
       if (!Array.isArray(color) || color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+      const coverageErr = validateCoverageMode(coverageMode);
+      if (coverageErr) return { error: coverageErr };
+      const areaErr = validateMaxTriangleArea(maxTriangleArea);
+      if (areaErr) return { error: areaErr };
 
-      const triangles = findSlabTriangles(currentMeshData, normal, offset, thickness);
+      let triangles = findSlabTriangles(currentMeshData, normal, offset, thickness, coverageMode);
+      if (maxTriangleArea !== undefined && triangles.size > 0) {
+        triangles = new Set([...triangles].filter(t => triangleArea(t, currentMeshData!) <= maxTriangleArea));
+      }
       if (triangles.size === 0) return { error: 'No triangles found inside the slab' };
 
       const regionName = name ?? `Region ${getRegions().length + 1}`;
@@ -3273,11 +3289,7 @@ async function main() {
         { kind: 'slab', normal, offset, thickness },
         triangles,
       );
-
-      const colored = applyTriColorsIfVisible(currentMeshData);
-      updateMesh(colored, { skipAutoFrame: true });
-      updateMultiView(colored);
-      renderElevationsToContainer(elevationsContainer, colored);
+      scheduleColorRefresh();
       syncLockState();
 
       return { id: region.id, name: region.name, triangles: triangles.size };
@@ -3405,16 +3417,30 @@ async function main() {
        *  the common over-paint where the box also catches side walls and
        *  the bottom face. Ignored when `normalCone` is explicitly set. */
       topOnly?: boolean;
+      /** How triangles are tested for box containment. Default `'centroid'`
+       *  (the historical behavior). Use `'fully_inside'` to defang long
+       *  radial fan triangles from cylinder/revolve meshes — they often
+       *  have a centroid in the box but extend visibly outside it. */
+      coverageMode?: CoverageMode;
+      /** Skip any triangle whose world-space area exceeds this threshold.
+       *  Backstop against fan-topology bleed when `coverageMode` alone
+       *  isn't enough. Inspect `largestTriangleArea` from `paintPreview`
+       *  to pick a sensible value. */
+      maxTriangleArea?: number;
     }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintInBox requires { box, color }' };
       const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
       const filterErr = validateBoxAndCone(opts.box, cone);
       if (filterErr) return { error: filterErr };
+      const coverageErr = validateCoverageMode(opts.coverageMode);
+      if (coverageErr) return { error: coverageErr };
+      const areaErr = validateMaxTriangleArea(opts.maxTriangleArea);
+      if (areaErr) return { error: areaErr };
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
 
-      const triangles = collectTrianglesByFilter(currentMeshData, opts.box, cone, null);
-      if (triangles.size === 0) return { error: `paintInBox: no triangles matched the box${cone ? ' (with the normalCone' + (opts.topOnly ? '/topOnly' : '') + ' filter)' : ''}. Try widening the box, dropping topOnly/normalCone, or call findFaces() to see what passes each filter individually.` };
+      const triangles = collectTrianglesByFilter(currentMeshData, opts.box, cone, null, opts.coverageMode, opts.maxTriangleArea);
+      if (triangles.size === 0) return { error: `paintInBox: no triangles matched the box${cone ? ' (with the normalCone' + (opts.topOnly ? '/topOnly' : '') + ' filter)' : ''}${opts.coverageMode === 'fully_inside' ? ' (with coverageMode: fully_inside — try widening the box or dropping the mode)' : ''}${opts.maxTriangleArea !== undefined ? ` (with maxTriangleArea: ${opts.maxTriangleArea} — try raising it)` : ''}. Try widening the box, dropping topOnly/normalCone, or call findFaces() to see what passes each filter individually.` };
 
       return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
     },
@@ -3440,6 +3466,10 @@ async function main() {
       name?: string;
       /** Shortcut: only upward-facing triangles. See paintInBox.topOnly. */
       topOnly?: boolean;
+      /** See paintInBox.coverageMode. */
+      coverageMode?: CoverageMode;
+      /** See paintInBox.maxTriangleArea. */
+      maxTriangleArea?: number;
     }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintNear requires { point, radius, color }' };
@@ -3451,10 +3481,14 @@ async function main() {
       const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
       const coneErr = validateNormalCone(cone);
       if (coneErr) return { error: coneErr };
+      const coverageErr = validateCoverageMode(opts.coverageMode);
+      if (coverageErr) return { error: coverageErr };
+      const areaErr = validateMaxTriangleArea(opts.maxTriangleArea);
+      if (areaErr) return { error: areaErr };
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
 
-      const triangles = collectTrianglesBySphere(currentMeshData, opts.point as [number, number, number], opts.radius, cone);
-      if (triangles.size === 0) return { error: `paintNear: no triangles within ${opts.radius} of [${opts.point.join(', ')}]. Try a larger radius — call findFaces() with a bigger box first to see what's around.` };
+      const triangles = collectTrianglesBySphere(currentMeshData, opts.point as [number, number, number], opts.radius, cone, opts.coverageMode, opts.maxTriangleArea);
+      if (triangles.size === 0) return { error: `paintNear: no triangles within ${opts.radius} of [${opts.point.join(', ')}]${opts.coverageMode === 'fully_inside' ? ' (with coverageMode: fully_inside)' : ''}${opts.maxTriangleArea !== undefined ? ` (with maxTriangleArea: ${opts.maxTriangleArea})` : ''}. Try a larger radius — call findFaces() with a bigger box first to see what's around.` };
 
       return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
     },
@@ -3486,9 +3520,20 @@ async function main() {
        *  count-only is the cheap sanity check that should always be
        *  affordable. */
       withImage?: boolean;
+      /** See paintInBox.coverageMode. Applied to box / point+radius
+       *  selectors; ignored when `triangleIds` is passed (those bypass
+       *  the geometric filter). */
+      coverageMode?: CoverageMode;
+      /** See paintInBox.maxTriangleArea. */
+      maxTriangleArea?: number;
     } = {}) {
       const mesh = currentMeshData;
       if (!mesh) return { error: 'No geometry loaded' };
+
+      const coverageErr = validateCoverageMode(opts.coverageMode);
+      if (coverageErr) return { error: coverageErr };
+      const areaErr = validateMaxTriangleArea(opts.maxTriangleArea);
+      if (areaErr) return { error: areaErr };
 
       let triangles: Set<number>;
       if (opts.triangleIds !== undefined) {
@@ -3503,16 +3548,17 @@ async function main() {
         if (typeof opts.radius !== 'number' || !Number.isFinite(opts.radius) || opts.radius <= 0) return { error: 'radius must be a positive finite number' };
         const coneErr = validateNormalCone(opts.normalCone);
         if (coneErr) return { error: coneErr };
-        triangles = collectTrianglesBySphere(mesh, opts.point, opts.radius, opts.normalCone);
+        triangles = collectTrianglesBySphere(mesh, opts.point, opts.radius, opts.normalCone, opts.coverageMode, opts.maxTriangleArea);
       } else if (opts.box !== undefined) {
         const err = validateBoxAndCone(opts.box, opts.normalCone);
         if (err) return { error: err };
-        triangles = collectTrianglesByFilter(mesh, opts.box, opts.normalCone, null);
+        triangles = collectTrianglesByFilter(mesh, opts.box, opts.normalCone, null, opts.coverageMode, opts.maxTriangleArea);
       } else {
         return { error: 'paintPreview requires one of: { triangleIds }, { point, radius }, or { box }' };
       }
 
       const stats = regionTriangleStats(triangles, mesh);
+      const areas = summarizeTriangleAreas(triangles, mesh);
       const wantImage = opts.withImage === true;
       const thumbnail = wantImage ? renderRegionHighlight(mesh, triangles, opts.view ?? {}) : undefined;
       return {
@@ -3520,6 +3566,8 @@ async function main() {
         triangleCount: triangles.size,
         bbox: stats.bbox,
         centroid: stats.centroid,
+        totalArea: Math.round(areas.totalArea * 1000) / 1000,
+        largestTriangleArea: Math.round(areas.largestTriangleArea * 1000) / 1000,
       };
     },
 
@@ -3553,7 +3601,7 @@ async function main() {
 
       const mesh = currentMeshData;
       const stats = regionTriangleStats(region.triangles, mesh);
-      const { area, normalHistogram } = computeRegionAreaAndNormalHistogram(region.triangles, mesh);
+      const { area, normalHistogram, largestTriangleArea } = computeRegionAreaAndNormalHistogram(region.triangles, mesh);
       const wantImage = opts.withImage !== false; // default true — explain wants visual
       const thumbnail = wantImage ? renderRegionHighlight(mesh, region.triangles, opts.view ?? {}) : undefined;
 
@@ -3564,6 +3612,7 @@ async function main() {
         source: region.source,
         triangleCount: region.triangles.size,
         area: Math.round(area * 1000) / 1000,
+        largestTriangleArea: Math.round(largestTriangleArea * 1000) / 1000,
         bbox: stats.bbox,
         centroid: stats.centroid,
         normalHistogram,
@@ -3715,13 +3764,23 @@ async function main() {
       color?: [number, number, number];
       region?: number;
       maxResults?: number;
+      /** See paintInBox.coverageMode. Applies to the `box` predicate
+       *  only; the normal / color / region predicates are per-triangle
+       *  already. */
+      coverageMode?: CoverageMode;
+      /** See paintInBox.maxTriangleArea. */
+      maxTriangleArea?: number;
     } = {}) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (typeof opts !== 'object' || opts === null) {
         return { error: 'findFaces requires an options object — see /ai.md#color-regions' };
       }
 
-      const { box, normal, normalTolerance, color, region, maxResults } = opts;
+      const { box, normal, normalTolerance, color, region, maxResults, coverageMode, maxTriangleArea } = opts;
+      const coverageErr = validateCoverageMode(coverageMode);
+      if (coverageErr) return { error: coverageErr };
+      const areaErr = validateMaxTriangleArea(maxTriangleArea);
+      if (areaErr) return { error: areaErr };
 
       let boxMin: [number, number, number] | null = null;
       let boxMax: [number, number, number] | null = null;
@@ -3788,6 +3847,7 @@ async function main() {
       const cG = colorTarget ? Math.round(colorTarget[1] * 255) : 0;
       const cB = colorTarget ? Math.round(colorTarget[2] * 255) : 0;
 
+      const coverage: CoverageMode = coverageMode ?? 'centroid';
       for (let t = 0; t < mesh.numTri; t++) {
         if (regionTriangles && !regionTriangles.has(t)) continue;
 
@@ -3795,10 +3855,20 @@ async function main() {
           const v0 = mesh.triVerts[t * 3];
           const v1 = mesh.triVerts[t * 3 + 1];
           const v2 = mesh.triVerts[t * 3 + 2];
-          const cx = (mesh.vertProperties[v0 * mesh.numProp] + mesh.vertProperties[v1 * mesh.numProp] + mesh.vertProperties[v2 * mesh.numProp]) / 3;
-          const cy = (mesh.vertProperties[v0 * mesh.numProp + 1] + mesh.vertProperties[v1 * mesh.numProp + 1] + mesh.vertProperties[v2 * mesh.numProp + 1]) / 3;
-          const cz = (mesh.vertProperties[v0 * mesh.numProp + 2] + mesh.vertProperties[v1 * mesh.numProp + 2] + mesh.vertProperties[v2 * mesh.numProp + 2]) / 3;
-          if (cx < boxMin[0] || cx > boxMax[0] || cy < boxMin[1] || cy > boxMax[1] || cz < boxMin[2] || cz > boxMax[2]) continue;
+          const ax = mesh.vertProperties[v0 * mesh.numProp],     ay = mesh.vertProperties[v0 * mesh.numProp + 1], az = mesh.vertProperties[v0 * mesh.numProp + 2];
+          const bx = mesh.vertProperties[v1 * mesh.numProp],     by = mesh.vertProperties[v1 * mesh.numProp + 1], bz = mesh.vertProperties[v1 * mesh.numProp + 2];
+          const cx = mesh.vertProperties[v2 * mesh.numProp],     cy = mesh.vertProperties[v2 * mesh.numProp + 1], cz = mesh.vertProperties[v2 * mesh.numProp + 2];
+          const inA = ax >= boxMin[0] && ax <= boxMax[0] && ay >= boxMin[1] && ay <= boxMax[1] && az >= boxMin[2] && az <= boxMax[2];
+          const inB = bx >= boxMin[0] && bx <= boxMax[0] && by >= boxMin[1] && by <= boxMax[1] && bz >= boxMin[2] && bz <= boxMax[2];
+          const inC = cx >= boxMin[0] && cx <= boxMax[0] && cy >= boxMin[1] && cy <= boxMax[1] && cz >= boxMin[2] && cz <= boxMax[2];
+          if (coverage === 'fully_inside') {
+            if (!inA || !inB || !inC) continue;
+          } else if (coverage === 'any_vertex_inside') {
+            if (!inA && !inB && !inC) continue;
+          } else {
+            const ccx = (ax + bx + cx) / 3, ccy = (ay + by + cy) / 3, ccz = (az + bz + cz) / 3;
+            if (ccx < boxMin[0] || ccx > boxMax[0] || ccy < boxMin[1] || ccy > boxMax[1] || ccz < boxMin[2] || ccz > boxMax[2]) continue;
+          }
         }
 
         if (nrm && adjacency) {
@@ -3812,6 +3882,8 @@ async function main() {
         if (triColors) {
           if (triColors[t * 3] !== cR || triColors[t * 3 + 1] !== cG || triColors[t * 3 + 2] !== cB) continue;
         }
+
+        if (maxTriangleArea !== undefined && triangleArea(t, mesh) > maxTriangleArea) continue;
 
         visited++;
         if (result.length < limit) result.push(t);
@@ -4380,38 +4452,28 @@ async function main() {
     return renderSingleView({ ...mesh, triColors }, viewOpts);
   }
 
-  /** For a triangle set, compute total surface area and an area-weighted
-   *  histogram of face normals binned by cardinal axis (within 30°).
-   *  Triangles whose normal is more than 30° off every axis fall into
-   *  `oblique`. All bins normalize to sum ≈ 1. Useful for telling the
-   *  agent "this region is 70% top-facing, 25% wrap-around side" without
-   *  shipping the raw triangle list. */
+  /** For a triangle set, compute total surface area, the largest single-
+   *  triangle area (the diagnostic for fan-topology contamination), and
+   *  an area-weighted histogram of face normals binned by cardinal axis
+   *  (within 30°). Triangles whose normal is more than 30° off every
+   *  axis fall into `oblique`. The histogram bins normalize to sum ≈ 1. */
   function computeRegionAreaAndNormalHistogram(
     triangles: Set<number>,
     mesh: MeshData,
   ): {
     area: number;
+    largestTriangleArea: number;
     normalHistogram: { xPos: number; xNeg: number; yPos: number; yNeg: number; zPos: number; zNeg: number; oblique: number };
   } {
     const adjacency = buildAdjacency(mesh);
     const cosThresh = Math.cos(30 * Math.PI / 180); // ≈ 0.866
     const bins = { xPos: 0, xNeg: 0, yPos: 0, yNeg: 0, zPos: 0, zNeg: 0, oblique: 0 };
     let totalArea = 0;
-    const { triVerts, vertProperties, numProp } = mesh;
+    let largest = 0;
     for (const t of triangles) {
-      const v0 = triVerts[t * 3];
-      const v1 = triVerts[t * 3 + 1];
-      const v2 = triVerts[t * 3 + 2];
-      const ax = vertProperties[v0 * numProp], ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
-      const bx = vertProperties[v1 * numProp], by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
-      const cx = vertProperties[v2 * numProp], cy = vertProperties[v2 * numProp + 1], cz = vertProperties[v2 * numProp + 2];
-      const e1x = bx - ax, e1y = by - ay, e1z = bz - az;
-      const e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
-      const crx = e1y * e2z - e1z * e2y;
-      const cry = e1z * e2x - e1x * e2z;
-      const crz = e1x * e2y - e1y * e2x;
-      const area = 0.5 * Math.sqrt(crx * crx + cry * cry + crz * crz);
+      const area = triangleArea(t, mesh);
       totalArea += area;
+      if (area > largest) largest = area;
       const nx = adjacency.normals[t * 3];
       const ny = adjacency.normals[t * 3 + 1];
       const nz = adjacency.normals[t * 3 + 2];
@@ -4427,6 +4489,7 @@ async function main() {
       const norm = (v: number) => Math.round((v / totalArea) * 1000) / 1000;
       return {
         area: totalArea,
+        largestTriangleArea: largest,
         normalHistogram: {
           xPos: norm(bins.xPos), xNeg: norm(bins.xNeg),
           yPos: norm(bins.yPos), yNeg: norm(bins.yNeg),
@@ -4435,7 +4498,7 @@ async function main() {
         },
       };
     }
-    return { area: 0, normalHistogram: { xPos: 0, xNeg: 0, yPos: 0, yNeg: 0, zPos: 0, zNeg: 0, oblique: 0 } };
+    return { area: 0, largestTriangleArea: 0, normalHistogram: { xPos: 0, xNeg: 0, yPos: 0, yNeg: 0, zPos: 0, zNeg: 0, oblique: 0 } };
   }
 
   /** Decode a data: URL into an HTMLImageElement. Image decoding from a
@@ -4543,6 +4606,22 @@ async function main() {
     return undefined;
   }
 
+  function validateCoverageMode(mode: unknown): string | null {
+    if (mode === undefined) return null;
+    if (!COVERAGE_MODES.includes(mode as CoverageMode)) {
+      return `coverageMode must be one of: ${COVERAGE_MODES.join(', ')}`;
+    }
+    return null;
+  }
+
+  function validateMaxTriangleArea(area: unknown): string | null {
+    if (area === undefined) return null;
+    if (typeof area !== 'number' || !Number.isFinite(area) || area <= 0) {
+      return 'maxTriangleArea must be a positive finite number';
+    }
+    return null;
+  }
+
   function validateNormalCone(cone: { axis: [number, number, number]; angleDeg: number } | undefined): string | null {
     if (cone === undefined) return null;
     if (typeof cone !== 'object' || cone === null) return 'normalCone must be { axis: [x,y,z], angleDeg: number }';
@@ -4573,6 +4652,39 @@ async function main() {
     return validateNormalCone(cone);
   }
 
+  /** Compute the world-space area of a single triangle. Shared by the
+   *  selector `maxTriangleArea` filter, the region-stats walker, and the
+   *  normal-histogram weighter so they stay byte-consistent. */
+  function triangleArea(t: number, mesh: MeshData): number {
+    const { triVerts, vertProperties, numProp } = mesh;
+    const v0 = triVerts[t * 3], v1 = triVerts[t * 3 + 1], v2 = triVerts[t * 3 + 2];
+    const ax = vertProperties[v0 * numProp],     ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
+    const bx = vertProperties[v1 * numProp],     by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
+    const cx = vertProperties[v2 * numProp],     cy = vertProperties[v2 * numProp + 1], cz = vertProperties[v2 * numProp + 2];
+    const e1x = bx - ax, e1y = by - ay, e1z = bz - az;
+    const e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
+    const crx = e1y * e2z - e1z * e2y;
+    const cry = e1z * e2x - e1x * e2z;
+    const crz = e1x * e2y - e1y * e2x;
+    return 0.5 * Math.sqrt(crx * crx + cry * cry + crz * crz);
+  }
+
+  /** Summarize the area distribution of a triangle set without walking
+   *  the mesh twice. The `largestTriangleArea / (totalArea / count)`
+   *  ratio is the diagnostic for fan-topology bleed — anything > ~10×
+   *  means one or more long radial triangles are dragging the selector
+   *  beyond its intended footprint. */
+  function summarizeTriangleAreas(triangles: Iterable<number>, mesh: MeshData): { totalArea: number; largestTriangleArea: number } {
+    let total = 0;
+    let largest = 0;
+    for (const t of triangles) {
+      const a = triangleArea(t, mesh);
+      total += a;
+      if (a > largest) largest = a;
+    }
+    return { totalArea: total, largestTriangleArea: largest };
+  }
+
   /** Collect triangle ids whose centroid lies inside `box` and (optionally)
    *  whose face normal aligns with `cone.axis` within `cone.angleDeg`.
    *  `regionFilter`, when non-null, restricts to ids in that set. */
@@ -4581,6 +4693,8 @@ async function main() {
     box: { min: [number, number, number]; max: [number, number, number] },
     cone: { axis: [number, number, number]; angleDeg: number } | undefined,
     regionFilter: Set<number> | null,
+    coverage: CoverageMode = 'centroid',
+    maxArea: number | undefined = undefined,
   ): Set<number> {
     const adjacency = cone ? buildAdjacency(mesh) : null;
     let coneAxis: [number, number, number] | null = null;
@@ -4592,17 +4706,31 @@ async function main() {
     }
     const result = new Set<number>();
     const { triVerts, vertProperties, numProp, numTri } = mesh;
+    const [bMinX, bMinY, bMinZ] = box.min;
+    const [bMaxX, bMaxY, bMaxZ] = box.max;
     for (let t = 0; t < numTri; t++) {
       if (regionFilter && !regionFilter.has(t)) continue;
       const v0 = triVerts[t * 3];
       const v1 = triVerts[t * 3 + 1];
       const v2 = triVerts[t * 3 + 2];
-      const cx = (vertProperties[v0 * numProp] + vertProperties[v1 * numProp] + vertProperties[v2 * numProp]) / 3;
-      const cy = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3;
-      const cz = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3;
-      if (cx < box.min[0] || cx > box.max[0]) continue;
-      if (cy < box.min[1] || cy > box.max[1]) continue;
-      if (cz < box.min[2] || cz > box.max[2]) continue;
+      const ax = vertProperties[v0 * numProp], ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
+      const bx = vertProperties[v1 * numProp], by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
+      const cx = vertProperties[v2 * numProp], cy = vertProperties[v2 * numProp + 1], cz = vertProperties[v2 * numProp + 2];
+
+      if (coverage === 'fully_inside') {
+        if (ax < bMinX || ax > bMaxX || ay < bMinY || ay > bMaxY || az < bMinZ || az > bMaxZ) continue;
+        if (bx < bMinX || bx > bMaxX || by < bMinY || by > bMaxY || bz < bMinZ || bz > bMaxZ) continue;
+        if (cx < bMinX || cx > bMaxX || cy < bMinY || cy > bMaxY || cz < bMinZ || cz > bMaxZ) continue;
+      } else if (coverage === 'any_vertex_inside') {
+        const a = ax >= bMinX && ax <= bMaxX && ay >= bMinY && ay <= bMaxY && az >= bMinZ && az <= bMaxZ;
+        const b = bx >= bMinX && bx <= bMaxX && by >= bMinY && by <= bMaxY && bz >= bMinZ && bz <= bMaxZ;
+        const c = cx >= bMinX && cx <= bMaxX && cy >= bMinY && cy <= bMaxY && cz >= bMinZ && cz <= bMaxZ;
+        if (!a && !b && !c) continue;
+      } else {
+        const ccx = (ax + bx + cx) / 3, ccy = (ay + by + cy) / 3, ccz = (az + bz + cz) / 3;
+        if (ccx < bMinX || ccx > bMaxX || ccy < bMinY || ccy > bMaxY || ccz < bMinZ || ccz > bMaxZ) continue;
+      }
+
       if (coneAxis && adjacency) {
         const nx = adjacency.normals[t * 3];
         const ny = adjacency.normals[t * 3 + 1];
@@ -4610,6 +4738,9 @@ async function main() {
         const dot = coneAxis[0] * nx + coneAxis[1] * ny + coneAxis[2] * nz;
         if (dot < coneCos) continue;
       }
+
+      if (maxArea !== undefined && triangleArea(t, mesh) > maxArea) continue;
+
       result.add(t);
     }
     return result;
@@ -4621,6 +4752,8 @@ async function main() {
     point: [number, number, number],
     radius: number,
     cone: { axis: [number, number, number]; angleDeg: number } | undefined,
+    coverage: CoverageMode = 'centroid',
+    maxArea: number | undefined = undefined,
   ): Set<number> {
     const adjacency = cone ? buildAdjacency(mesh) : null;
     let coneAxis: [number, number, number] | null = null;
@@ -4633,15 +4766,30 @@ async function main() {
     const r2 = radius * radius;
     const result = new Set<number>();
     const { triVerts, vertProperties, numProp, numTri } = mesh;
+    const [px, py, pz] = point;
     for (let t = 0; t < numTri; t++) {
       const v0 = triVerts[t * 3];
       const v1 = triVerts[t * 3 + 1];
       const v2 = triVerts[t * 3 + 2];
-      const cx = (vertProperties[v0 * numProp] + vertProperties[v1 * numProp] + vertProperties[v2 * numProp]) / 3;
-      const cy = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3;
-      const cz = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3;
-      const dx = cx - point[0], dy = cy - point[1], dz = cz - point[2];
-      if (dx * dx + dy * dy + dz * dz > r2) continue;
+      const ax = vertProperties[v0 * numProp], ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
+      const bx = vertProperties[v1 * numProp], by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
+      const cx = vertProperties[v2 * numProp], cy = vertProperties[v2 * numProp + 1], cz = vertProperties[v2 * numProp + 2];
+
+      if (coverage === 'fully_inside') {
+        if ((ax - px) ** 2 + (ay - py) ** 2 + (az - pz) ** 2 > r2) continue;
+        if ((bx - px) ** 2 + (by - py) ** 2 + (bz - pz) ** 2 > r2) continue;
+        if ((cx - px) ** 2 + (cy - py) ** 2 + (cz - pz) ** 2 > r2) continue;
+      } else if (coverage === 'any_vertex_inside') {
+        const dA = (ax - px) ** 2 + (ay - py) ** 2 + (az - pz) ** 2;
+        const dB = (bx - px) ** 2 + (by - py) ** 2 + (bz - pz) ** 2;
+        const dC = (cx - px) ** 2 + (cy - py) ** 2 + (cz - pz) ** 2;
+        if (dA > r2 && dB > r2 && dC > r2) continue;
+      } else {
+        const ccx = (ax + bx + cx) / 3, ccy = (ay + by + cy) / 3, ccz = (az + bz + cz) / 3;
+        const dx = ccx - px, dy = ccy - py, dz = ccz - pz;
+        if (dx * dx + dy * dy + dz * dz > r2) continue;
+      }
+
       if (coneAxis && adjacency) {
         const nx = adjacency.normals[t * 3];
         const ny = adjacency.normals[t * 3 + 1];
@@ -4649,6 +4797,9 @@ async function main() {
         const dot = coneAxis[0] * nx + coneAxis[1] * ny + coneAxis[2] * nz;
         if (dot < coneCos) continue;
       }
+
+      if (maxArea !== undefined && triangleArea(t, mesh) > maxArea) continue;
+
       result.add(t);
     }
     return result;

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,6 +134,10 @@ export interface ExampleEntry {
 let currentMeshData: MeshData | null = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let currentManifold: any = null;
+/** Per-run map from labels (assigned in user code via api.label(shape, name))
+ *  to the triangle ids that came from the labelled input. Rebuilt on every
+ *  successful run; null when no labels were registered or no code has run. */
+let currentLabelMap: Map<string, Set<number>> | null = null;
 
 // #geometry-data element — always-updated machine-readable state
 let geometryDataEl: HTMLElement;
@@ -505,6 +509,15 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): vo
     } else if (region.descriptor.kind === 'slab') {
       const { normal, offset, thickness } = region.descriptor;
       triangles = findSlabTriangles(mesh, normal, offset, thickness);
+    } else if (region.descriptor.kind === 'byLabel') {
+      // Labels are runtime state — manifold-3d assigns fresh
+      // originalIDs on every run, so we re-resolve by name from the
+      // labelMap the engine just built. If the user edited the code
+      // and the label no longer exists, the region drops silently
+      // (same graceful-skip path the coplanar descriptor uses when
+      // its seed no longer hits a face).
+      const ids = currentLabelMap?.get(region.descriptor.label);
+      if (ids) triangles = new Set(ids);
     }
 
     if (triangles.size > 0) {
@@ -3963,6 +3976,77 @@ async function main() {
       }
     },
 
+    /** List labels registered by `api.label(shape, name)` in the current
+     *  run's code. Returns `[{name, triangleCount, bbox}]`. The triangle
+     *  buckets survive boolean ops cleanly (manifold-3d propagates the
+     *  originalID of every input through `runOriginalID` on the result
+     *  mesh) — so for a model built as
+     *  `api.label(head, 'head').add(api.label(eye, 'eye'))` you get one
+     *  entry per labelled piece, no matter how they overlap. Empty list
+     *  when the code didn't use `api.label`. */
+    listLabels() {
+      if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
+      if (!currentLabelMap || currentLabelMap.size === 0) return { count: 0, labels: [] };
+      const mesh = currentMeshData;
+      const labels = [...currentLabelMap.entries()].map(([name, ids]) => {
+        const stats = regionTriangleStats(ids, mesh);
+        return {
+          name,
+          triangleCount: ids.size,
+          bbox: stats.bbox,
+          centroid: stats.centroid,
+        };
+      });
+      return { count: labels.length, labels };
+    },
+
+    /** Paint a labelled feature by name. The label must have been
+     *  registered in the current run's code via `api.label(shape, name)`
+     *  or `api.labeledUnion([{name, shape}, ...])`. This is the cleanest
+     *  paint primitive on agent-authored geometry — no coordinate
+     *  guessing, no bounding-box estimation, no fan-bleed: the
+     *  triangle set comes straight from manifold-3d's provenance
+     *  tracking and is exact even for overlapping inputs.
+     *
+     *  ```
+     *  // In user code:
+     *  return api.label(Manifold.sphere(10), 'head')
+     *    .add(api.label(Manifold.sphere(2).translate([3, 5, 7]), 'eyeL'));
+     *
+     *  // After running:
+     *  partwright.paintByLabel({ label: 'eyeL', color: [0, 0, 1] });
+     *  ```
+     *  Returns `{ id, name, triangles, bbox, centroid }` on success or
+     *  `{ error }` if no such label exists or no labels were registered. */
+    paintByLabel(opts: { label: string; color: [number, number, number]; name?: string }) {
+      if (!opts || typeof opts !== 'object') return { error: 'paintByLabel requires { label, color }' };
+      if (typeof opts.label !== 'string' || opts.label.length === 0) return { error: 'paintByLabel.label must be a non-empty string' };
+      if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'paintByLabel.color must be [r,g,b] in 0..1' };
+      if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
+      if (!currentLabelMap || currentLabelMap.size === 0) {
+        return { error: 'No labels registered in the current run. Wrap features with api.label(shape, "name") in your code, then runAndSave, then call paintByLabel.' };
+      }
+      const ids = currentLabelMap.get(opts.label);
+      if (!ids || ids.size === 0) {
+        const known = [...currentLabelMap.keys()].map(k => `"${k}"`).join(', ');
+        return { error: `paintByLabel: no label "${opts.label}". Known labels: ${known}.` };
+      }
+      const triangles = new Set(ids);
+      const mesh = currentMeshData;
+      const regionName = opts.name ?? opts.label;
+      const region = addRegion(
+        regionName,
+        opts.color as [number, number, number],
+        'paintbrush',
+        { kind: 'byLabel', label: opts.label },
+        triangles,
+      );
+      scheduleColorRefresh();
+      syncLockState();
+      const stats = regionTriangleStats(triangles, mesh);
+      return { id: region.id, name: region.name, triangles: triangles.size, bbox: stats.bbox, centroid: stats.centroid };
+    },
+
     // === Annotations API ===
 
     /** List all freehand annotation strokes drawn on the model surface.
@@ -4225,6 +4309,8 @@ async function main() {
         'clearColors':     { signature: 'clearColors() -- Remove ALL color regions (use undoLastPaint to reverse just one)', docs: '/ai.md#color-regions' },
         'listComponents':  { signature: 'listComponents() -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- Decompose the manifold into boolean-distinct parts. For "paint each feature" workflows (e.g. unioned head + eyes + mouth).', docs: '/ai.md#color-regions' },
         'paintComponent':  { signature: 'paintComponent({index, color, name?, topOnly?}) -- One-call shortcut: listComponents + paintInBox for the Nth piece.', docs: '/ai.md#color-regions' },
+        'listLabels':      { signature: 'listLabels() -> {count, labels: [{name, triangleCount, bbox, centroid}]} -- Labels registered in the current run via api.label(shape, name). Survives boolean ops; the cleanest paint primitive on agent-authored geometry.', docs: '/ai.md#color-regions' },
+        'paintByLabel':    { signature: 'paintByLabel({label, color, name?}) -- Paint a labelled feature by name. Pair with api.label/labeledUnion in your code. No coordinate guessing.', docs: '/ai.md#color-regions' },
         'getFeatureCentroids': { signature: 'getFeatureCentroids({maxGroups?, withinBox?}?) -- Token-cheap: face-group centroids + normals + bbox, no triangleIds. Use to plan paint targets.', docs: '/ai.md#color-regions' },
         'removeRegion':    { signature: 'removeRegion(id) -- Remove ONE color region by id from listRegions(). Use this to fix a single mistake without nuking the rest.', docs: '/ai.md#color-regions' },
         'undoLastPaint':   { signature: 'undoLastPaint() -- Undo the most recent paint op. Removed region goes on a redo stack.', docs: '/ai.md#color-regions' },
@@ -4743,6 +4829,10 @@ async function main() {
         try { currentManifold.delete(); } catch { /* already deleted */ }
       }
       currentManifold = result.manifold;
+      // Capture the labelled-construction map for this run. byLabel
+      // region descriptors look up their triangles here; rehydrating a
+      // saved version re-runs the code first, which rebuilds the map.
+      currentLabelMap = result.labelMap ?? null;
 
       // Apply any existing color regions to the mesh
       const displayMesh = hasColorRegions() ? applyTriColorsIfVisible(result.mesh) : result.mesh;

--- a/src/renderer/multiview.ts
+++ b/src/renderer/multiview.ts
@@ -23,6 +23,14 @@ export const STANDARD_VIEWS = {
 } as const;
 export type StandardViewAngle = typeof STANDARD_VIEWS[keyof typeof STANDARD_VIEWS];
 
+/** Solid-shaded grey applied to triangles that have no color region.
+ *  Sits between the white render background and the brightest painted
+ *  RGB so silhouettes stay visible without overpowering painted
+ *  features. ~0.85 is roughly halfway in perceptual luminance between
+ *  white and middle-gray (#bfbfbf). Picking a value too dark obscures
+ *  pastel paints; too light and the mesh disappears against the bg. */
+const UNPAINTED_BASE = 0.85;
+
 interface ViewConfig {
   name: string;
   position: (d: number) => [number, number, number];
@@ -63,9 +71,14 @@ function meshDataToGeometry(meshData: MeshData): THREE.BufferGeometry {
       const b = triColors[t * 3 + 2] / 255;
       const painted = (triColors as Uint8Array & { _painted?: Uint8Array })._painted;
       const isPainted = painted ? painted[t] === 1 : (r !== 0 || g !== 0 || b !== 0);
-      const cr = isPainted ? r : 1;
-      const cg = isPainted ? g : 1;
-      const cb = isPainted ? b : 1;
+      // Unpainted base is light gray, NOT pure white, so the mesh
+      // silhouette is visible against the white render background.
+      // Pure white made unpainted parts of a model invisible against
+      // the bg — only the painted patches showed, which read as
+      // "the renderer is broken" to a model reasoning from the image.
+      const cr = isPainted ? r : UNPAINTED_BASE;
+      const cg = isPainted ? g : UNPAINTED_BASE;
+      const cb = isPainted ? b : UNPAINTED_BASE;
 
       for (let v = 0; v < 3; v++) {
         colors[t * 9 + v * 3] = cr;
@@ -367,9 +380,18 @@ function createElevationScene(geometry: THREE.BufferGeometry, bgColor: number): 
   scene.add(dir2);
   const hasColors = geometry.hasAttribute('color');
   const solidMesh = new THREE.Mesh(geometry, createWhiteMaterial(hasColors));
-  const wireMesh = new THREE.Mesh(geometry, createBlackWireframeMaterial());
   scene.add(solidMesh);
-  scene.add(wireMesh);
+  // Wireframe overlay obscures vertex-color verification on dense
+  // organic meshes — at 320px tile size, the 30% black edges of tens
+  // of thousands of triangles compound into a dark mass that washes
+  // out painted regions. Skip the wireframe when the mesh carries
+  // per-triangle colors (the user is in a paint workflow and wants
+  // to read colors, not topology). Keep it for uncolored renders
+  // where topology IS the subject.
+  if (!hasColors) {
+    const wireMesh = new THREE.Mesh(geometry, createBlackWireframeMaterial());
+    scene.add(wireMesh);
+  }
   return scene;
 }
 

--- a/src/renderer/multiview.ts
+++ b/src/renderer/multiview.ts
@@ -552,24 +552,36 @@ export function renderElevationsToContainer(container: HTMLElement, meshData: Me
  *  For orthographic views, pass ortho: true.
  *  elevation/azimuth are in degrees: elevation 0 = horizon, 90 = top-down.
  *  azimuth 0 = front (-Y), 90 = right (+X), 180 = back (+Y), 270 = left (-X). */
-export function renderSingleView(meshData: MeshData, options: {
+/** Build the same THREE.Camera that `renderSingleView` would render
+ *  through for these options. Exported so `probePixel` (in
+ *  geometry/rayCast.ts) can replay the camera exactly and unproject
+ *  pixel coordinates back to world rays that hit the same triangles
+ *  the agent sees in the rendered image. Camera setup MUST match
+ *  renderSingleView byte-for-byte — both call sites read from this
+ *  function so they can't drift. */
+export function buildViewCamera(meshData: MeshData, options: {
   elevation?: number;
   azimuth?: number;
   ortho?: boolean;
-  size?: number;
-} = {}): string {
+}): THREE.Camera {
   const elevation = (options.elevation ?? 30) * Math.PI / 180;
   const azimuth = (options.azimuth ?? 315) * Math.PI / 180;
-  const viewSize = options.size ?? 500;
 
-  const geometry = meshDataToGeometry(meshData);
-  const scene = createElevationScene(geometry, 0xffffff);
-
-  const box = new THREE.Box3().setFromBufferAttribute(
-    geometry.getAttribute('position') as THREE.BufferAttribute,
-  );
-  const center = box.getCenter(new THREE.Vector3());
-  const bsize = box.getSize(new THREE.Vector3());
+  // Bounding box from the raw vertProperties — same numbers
+  // renderSingleView computes after constructing the BufferGeometry.
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  const { vertProperties, numVert, numProp } = meshData;
+  for (let i = 0; i < numVert; i++) {
+    const x = vertProperties[i * numProp];
+    const y = vertProperties[i * numProp + 1];
+    const z = vertProperties[i * numProp + 2];
+    if (x < minX) minX = x; if (x > maxX) maxX = x;
+    if (y < minY) minY = y; if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+  }
+  const center = new THREE.Vector3((minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2);
+  const bsize = new THREE.Vector3(maxX - minX, maxY - minY, maxZ - minZ);
   const maxDim = Math.max(bsize.x, bsize.y, bsize.z);
   const dist = maxDim * 2;
 
@@ -595,7 +607,20 @@ export function renderSingleView(meshData: MeshData, options: {
     perspCamera.updateProjectionMatrix();
     camera = perspCamera;
   }
+  return camera;
+}
 
+export function renderSingleView(meshData: MeshData, options: {
+  elevation?: number;
+  azimuth?: number;
+  ortho?: boolean;
+  size?: number;
+} = {}): string {
+  const viewSize = options.size ?? 500;
+
+  const geometry = meshDataToGeometry(meshData);
+  const scene = createElevationScene(geometry, 0xffffff);
+  const camera = buildViewCamera(meshData, options);
   const renderer = getOffscreenRenderer(viewSize);
 
   const annotations = buildStrokesGroup(new THREE.Vector2(viewSize, viewSize));

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -59,8 +59,15 @@ import {
  *           {@link ExportOptions.includeThumbnails}. Importers prefer the
  *           embedded thumbnail when present and fall back to regenerating from
  *           code; older readers ignore the field.
+ *  - `1.5` — color regions support `{kind: 'connectedFromSeed', seedPoint,
+ *           seedNormal, maxDeviationDeg}` descriptors that resolve at
+ *           runtime via BFS from the closest triangle to the seed,
+ *           gated by per-neighbor deviation from the seed normal.
+ *           Persists the seed only; the triangle set is rebuilt on each
+ *           load by re-running the seed resolution + flood-fill.
+ *           Older readers ignore the new discriminant variant.
  */
-export const SCHEMA_VERSION = '1.4';
+export const SCHEMA_VERSION = '1.5';
 
 const CURRENT_MAJOR = 1;
 

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -59,8 +59,13 @@ import {
  *           {@link ExportOptions.includeThumbnails}. Importers prefer the
  *           embedded thumbnail when present and fall back to regenerating from
  *           code; older readers ignore the field.
+ *  - `1.5` — color regions support `{kind: 'byLabel', label: string}`
+ *           descriptors that resolve at runtime from manifold-js's
+ *           `runOriginalID` provenance. Persists the label name only;
+ *           the triangle set is rebuilt on each load by re-running the
+ *           code. Older readers ignore the new discriminant variant.
  */
-export const SCHEMA_VERSION = '1.4';
+export const SCHEMA_VERSION = '1.5';
 
 const CURRENT_MAJOR = 1;
 

--- a/tests/labelled-construction.spec.ts
+++ b/tests/labelled-construction.spec.ts
@@ -1,0 +1,124 @@
+// Verifies api.label / api.labeledUnion + paintByLabel end-to-end:
+// labels survive boolean ops, resolve to non-empty triangle sets, and
+// the painted region carries the right counts. The Phase 0 verification
+// (tests/manifold-id-verify.spec.ts) already confirms manifold-3d's
+// runOriginalID semantics — this is the integration test on top.
+
+import { test, expect } from 'playwright/test';
+
+test.describe('labelled construction', () => {
+  test('api.label registers names and paintByLabel resolves them', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // Three-feature model: head sphere + two eye spheres that overlap
+    // the head. After boolean union, each triangle is attributed to
+    // exactly one input by runOriginalID — so paintByLabel('eyeL')
+    // should pick up only the visible eye-surface triangles, even
+    // though the eye geometry sticks into the head.
+    const ran = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const r = await pw.run(`
+        const { Manifold } = api;
+        const head = api.label(Manifold.sphere(20, 64), 'head');
+        const eyeL = api.label(Manifold.sphere(5, 32).translate([-8, 14, 5]), 'eyeL');
+        const eyeR = api.label(Manifold.sphere(5, 32).translate([ 8, 14, 5]), 'eyeR');
+        return head.add(eyeL).add(eyeR);
+      `);
+      return r;
+    });
+    expect(ran.error, ran.error ? ran.error : 'expected clean run').toBeUndefined();
+
+    const labels = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.listLabels();
+    });
+    expect(labels.count).toBe(3);
+    const byName = Object.fromEntries(
+      (labels.labels as { name: string; triangleCount: number }[]).map(l => [l.name, l]),
+    );
+    expect(byName.head).toBeDefined();
+    expect(byName.eyeL).toBeDefined();
+    expect(byName.eyeR).toBeDefined();
+    expect(byName.head.triangleCount).toBeGreaterThan(0);
+    expect(byName.eyeL.triangleCount).toBeGreaterThan(0);
+    expect(byName.eyeR.triangleCount).toBeGreaterThan(0);
+    // Head is the dominant input; eyes are small spheres mostly
+    // hidden inside the head. Head triangles >> eye triangles.
+    expect(byName.head.triangleCount).toBeGreaterThan(byName.eyeL.triangleCount);
+
+    const painted = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintByLabel({ label: 'eyeL', color: [0, 0, 1] });
+    });
+    expect(painted.error).toBeUndefined();
+    expect(painted.triangles).toBe(byName.eyeL.triangleCount);
+    expect(painted.name).toBe('eyeL');
+
+    // Unknown label produces an instructive error mentioning known labels.
+    const miss = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintByLabel({ label: 'mouth', color: [1, 0, 0] });
+    });
+    expect(typeof miss.error).toBe('string');
+    expect(miss.error).toContain('mouth');
+    expect(miss.error).toMatch(/head|eyeL|eyeR/);
+  });
+
+  test('unlabeled model returns empty label list', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run('return api.Manifold.cube([10, 10, 10]);');
+    });
+    const labels = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.listLabels();
+    });
+    expect(labels.count).toBe(0);
+    expect(labels.labels).toEqual([]);
+
+    const painted = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintByLabel({ label: 'anything', color: [1, 0, 0] });
+    });
+    expect(painted.error).toContain('No labels registered');
+  });
+
+  test('api.labeledUnion is sugar for label + add chain', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const ran = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.run(`
+        const { Manifold } = api;
+        return api.labeledUnion([
+          { name: 'base',    shape: Manifold.cube([20, 20, 5], true) },
+          { name: 'pillarA', shape: Manifold.cylinder(15, 2, 2, 16).translate([-6, 0, 2.5]) },
+          { name: 'pillarB', shape: Manifold.cylinder(15, 2, 2, 16).translate([ 6, 0, 2.5]) },
+        ]);
+      `);
+    });
+    expect(ran.error).toBeUndefined();
+
+    const labels = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.listLabels();
+    });
+    expect(labels.count).toBe(3);
+    const names = (labels.labels as { name: string }[]).map(l => l.name).sort();
+    expect(names).toEqual(['base', 'pillarA', 'pillarB']);
+  });
+});

--- a/tests/paint-by-vision.spec.ts
+++ b/tests/paint-by-vision.spec.ts
@@ -1,0 +1,116 @@
+// Verifies the "paint by visual reasoning" workflow:
+//   render -> identify pixel -> probePixel -> paintConnected
+//
+// The agent uses this to autonomously translate "what I can see in the
+// rendered image" into a world-space hit, then flood-fill from there
+// gated by seed-normal deviation.
+
+import { test, expect } from 'playwright/test';
+
+test.describe('paint by vision', () => {
+  test('probePixel round-trips a known top-face pixel back to a hit on +Z', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // Cube centered at origin: top face at z=10, normal (0,0,1). Render
+    // the top view orthographically — the cube's top face fills the
+    // entire square. Center pixel projects onto the surface at z=10.
+    const probe = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run('return api.Manifold.cube([20, 20, 20], true);');
+      const view = { elevation: 90, azimuth: 0, ortho: true, size: 200 };
+      return pw.probePixel({ pixel: [100, 100], view });
+    });
+
+    expect(probe).not.toBeNull();
+    expect(probe.error).toBeUndefined();
+    expect(probe.point[2]).toBeCloseTo(10, 1);
+    // Top-face normal is +Z (within numerical tolerance, and dependent on
+    // which triangle of the top face split the ray hits).
+    expect(probe.normal[2]).toBeGreaterThan(0.95);
+    expect(probe.triangleId).toBeGreaterThanOrEqual(0);
+  });
+
+  test('probePixel returns null for a background pixel', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // Small sphere at origin rendered in a large viewport — corners
+    // should miss the mesh and return null.
+    const probe = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run('return api.Manifold.sphere(2, 32);');
+      const view = { elevation: 30, azimuth: 0, ortho: false, size: 200 };
+      return pw.probePixel({ pixel: [5, 5], view });
+    });
+    expect(probe).toBeNull();
+  });
+
+  test('paintConnected floods from a seed gated by deviation from the seed normal', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // Cube: 6 flat faces each 90° from the next. paintConnected with
+    // a 30° deviation from the top-face seed should pick up the entire
+    // top face but NOT the side or bottom faces.
+    const painted = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run('return api.Manifold.cube([20, 20, 20], true);');
+      return pw.paintConnected({
+        seed: { point: [0, 0, 10], normal: [0, 0, 1] },
+        maxDeviationDeg: 30,
+        color: [1, 0, 0],
+      });
+    });
+
+    expect(painted.error).toBeUndefined();
+    expect(painted.triangles).toBeGreaterThan(0);
+
+    // Top face on a cube is 2 triangles. paintConnected with a 30°
+    // tolerance from the +Z seed should NOT cross to the sides (which
+    // are at 90° from +Z) — so we should see exactly 2 triangles, the
+    // top face. Don't enforce the exact count (manifold-3d may emit
+    // more triangles per face on some configurations); just bound it.
+    expect(painted.triangles).toBeLessThanOrEqual(8);
+
+    // Verify the painted region's normal histogram is dominated by +Z.
+    const explain = await page.evaluate(async (id: number) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const result = pw.paintExplain?.({ region: id, withImage: false });
+      return result ?? null;
+    }, painted.id);
+    // paintExplain is in a separate PR; if not on this branch, skip.
+    if (explain && explain.normalHistogram) {
+      expect(explain.normalHistogram.zPos).toBeGreaterThan(0.9);
+    }
+  });
+
+  test('probePixel + paintConnected: end-to-end visual paint workflow', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      // Centered cube. Top face faces +Z; render orthographically from
+      // straight up so center-pixel hits the top.
+      await pw.run('return api.Manifold.cube([20, 20, 20], true);');
+      const view = { elevation: 90, azimuth: 0, ortho: true, size: 200 };
+      const hit = pw.probePixel({ pixel: [100, 100], view });
+      if (!hit || hit.error) return { stage: 'probe', hit };
+      return pw.paintConnected({
+        seed: { point: hit.point, normal: hit.normal },
+        maxDeviationDeg: 15,
+        color: [0, 0, 1],
+        name: 'top via probe',
+      });
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.triangles).toBeGreaterThan(0);
+    expect(result.name).toBe('top via probe');
+  });
+});

--- a/tests/paint-coverage.spec.ts
+++ b/tests/paint-coverage.spec.ts
@@ -1,0 +1,89 @@
+// Verifies the new selector options (coverageMode, maxTriangleArea) on
+// paintPreview actually change which triangles get selected. Uses a
+// cylinder so the mesh has known fan topology — the top face's triangles
+// each span from center to rim, so a small box around the center catches
+// many by *centroid* but few by *fully_inside*.
+
+import { test, expect } from 'playwright/test';
+
+test.describe('paint coverage filters', () => {
+  test('coverageMode and area stats defang fan-topology bleed', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // Build a 12-segment cylinder of radius 10 centered at origin. The top
+    // face at z=2 is a fan of 12 triangles, each one a thin wedge from
+    // (0,0,2) out to two adjacent rim vertices ~10 units away.
+    const ran = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const r = await pw.run('return api.Manifold.cylinder(2, 10, 10, 12);');
+      return r;
+    });
+    expect(ran.error).toBeUndefined();
+
+    // Box covering only the central column of the top face. With centroid
+    // mode, the fan wedges whose centroid is inside (centroid is ~1/3 of
+    // the way from center to rim — about 3.3 units out) get picked up,
+    // even though their rim vertices extend to ~10 units. With
+    // fully_inside the same box catches strictly fewer triangles.
+    const centroid = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintPreview({ box: { min: [-4, -4, 1.9], max: [4, 4, 2.1] } });
+    });
+    const fullyInside = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintPreview({
+        box: { min: [-4, -4, 1.9], max: [4, 4, 2.1] },
+        coverageMode: 'fully_inside',
+      });
+    });
+
+    expect(centroid.triangleCount, 'centroid mode catches fan wedges').toBeGreaterThan(0);
+    expect(fullyInside.triangleCount, 'fully_inside strictly narrower than centroid').toBeLessThan(centroid.triangleCount);
+
+    // The new area stats are present and the centroid-mode largest is
+    // visibly bigger than the fully_inside one (because the long wedges
+    // got filtered out).
+    expect(centroid).toHaveProperty('totalArea');
+    expect(centroid).toHaveProperty('largestTriangleArea');
+    expect(centroid.largestTriangleArea).toBeGreaterThan(0);
+    expect(centroid.totalArea).toBeGreaterThan(0);
+    if (fullyInside.triangleCount > 0) {
+      expect(centroid.largestTriangleArea).toBeGreaterThanOrEqual(fullyInside.largestTriangleArea);
+    }
+
+    // maxTriangleArea backstop: passing a value smaller than the fan
+    // wedges' area should drop them entirely. The wedges in this
+    // 12-segment cylinder have area ~13 sq units; capping at 1 drops them.
+    const capped = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintPreview({
+        box: { min: [-4, -4, 1.9], max: [4, 4, 2.1] },
+        maxTriangleArea: 1,
+      });
+    });
+    expect(capped.triangleCount, 'maxTriangleArea filters fan wedges').toBeLessThan(centroid.triangleCount);
+  });
+
+  test('paintExplain reports largestTriangleArea', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run('return api.Manifold.cube([10, 10, 10]);');
+      const painted = pw.paintInBox({ box: { min: [-1, -1, -1], max: [11, 11, 11] }, color: [1, 0, 0] });
+      return pw.paintExplain({ region: painted.id, withImage: false });
+    });
+    expect(result.error).toBeUndefined();
+    expect(result).toHaveProperty('largestTriangleArea');
+    expect(result.largestTriangleArea).toBeGreaterThan(0);
+    expect(result.area).toBeGreaterThan(0);
+    expect(result.normalHistogram).toBeDefined();
+  });
+});

--- a/tests/paint-render-color.spec.ts
+++ b/tests/paint-render-color.spec.ts
@@ -1,0 +1,68 @@
+// Visual smoke test: build a mesh, paint a region, render via the same
+// path the AI uses, and confirm the PNG actually shows the painted
+// color. Exists specifically to refute / confirm the AI feedback that
+// "renderViews shows black for painted regions on imported meshes."
+
+import { test, expect } from 'playwright/test';
+
+test('renderViews shows painted colors on the resulting PNG', async ({ page }) => {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+  const result = await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.run('return api.Manifold.cube([20, 20, 20]);');
+    const painted = pw.paintInBox({
+      box: { min: [-1, -1, 19], max: [21, 21, 21] },
+      color: [1, 0, 0],
+    });
+    if (painted.error) return { stage: 'paint', error: painted.error };
+    // Render the top view via renderViews — this is the same path the
+    // AI tool exercises.
+    const composite = await pw.renderViews({ views: 'tri', size: 200 });
+    return { stage: 'render', dataUrl: composite, painted };
+  });
+
+  expect(result.error).toBeUndefined();
+  expect(typeof result.dataUrl).toBe('string');
+  expect(result.dataUrl.startsWith('data:image/png;base64,')).toBe(true);
+
+  // Decode the PNG in the test page, sample pixels, and look for red.
+  // If the renderer were dropping vertex colors, no pixel would be
+  // dominantly red — every visible mesh pixel would be white-ish.
+  const stats = await page.evaluate(async (dataUrl: string) => {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image();
+      el.onload = () => resolve(el);
+      el.onerror = () => reject(new Error('decode'));
+      el.src = dataUrl;
+    });
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d')!;
+    ctx.drawImage(img, 0, 0);
+    const data = ctx.getImageData(0, 0, img.width, img.height).data;
+    let redDominant = 0;
+    let total = 0;
+    let darkSum = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      const r = data[i], g = data[i + 1], b = data[i + 2];
+      total++;
+      // Heuristic: a pixel is "red-dominant" when r is meaningfully
+      // higher than both g and b. Anti-aliasing + lighting tint mean
+      // pure (255,0,0) is rare; require a 40-point margin.
+      if (r > 100 && r - g > 40 && r - b > 40) redDominant++;
+      darkSum += (r + g + b) / 3;
+    }
+    return { total, redDominant, meanBrightness: darkSum / total, width: img.width, height: img.height };
+  }, result.dataUrl);
+
+  // The composite contains 3 angles in a grid (front, top, iso). The
+  // top face was painted red on a 20×20×20 cube, so the top and iso
+  // tiles should each show a red region. Expect at least ~1% of pixels
+  // to be red-dominant — a generous lower bound that proves the
+  // renderer IS emitting colors.
+  expect(stats.redDominant / stats.total, `mean brightness ${stats.meanBrightness.toFixed(1)} / ${stats.total} pixels, ${stats.redDominant} red-dominant`).toBeGreaterThan(0.01);
+});

--- a/tests/render-color-readability.spec.ts
+++ b/tests/render-color-readability.spec.ts
@@ -1,0 +1,143 @@
+// Pins the two render-readability fixes against regression:
+//
+//  1. Unpainted triangles render as light gray (not pure white) so the
+//     mesh silhouette is visible against the white background.
+//  2. When the mesh carries paint, the wireframe overlay is skipped —
+//     dense organic meshes otherwise compound 30%-black wireframe into
+//     a dark mass that washes painted regions out.
+//
+// Both were diagnosed from agent feedback that "renderViews shows
+// black for painted regions on imported meshes." The rendering
+// pipeline always honored vertex colors; the actual problem was
+// readability of the resulting PNG.
+
+import { test, expect } from 'playwright/test';
+
+interface PixelStats {
+  total: number;
+  meanBrightness: number;
+  meanRed: number;
+  meanGreen: number;
+  meanBlue: number;
+  redDominant: number;
+  greenDominant: number;
+  blueDominant: number;
+  nearBlack: number;       // pixels with mean brightness < 0.15
+  pureWhite: number;       // pixels with all channels > 0.97
+}
+
+async function decodeAndSample(page: import('playwright/test').Page, dataUrl: string): Promise<PixelStats> {
+  return page.evaluate(async (url: string) => {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image();
+      el.onload = () => resolve(el);
+      el.onerror = () => reject(new Error('decode'));
+      el.src = url;
+    });
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d')!;
+    ctx.drawImage(img, 0, 0);
+    const data = ctx.getImageData(0, 0, img.width, img.height).data;
+    let total = 0, rSum = 0, gSum = 0, bSum = 0;
+    let redDominant = 0, greenDominant = 0, blueDominant = 0;
+    let nearBlack = 0, pureWhite = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      const r = data[i] / 255, g = data[i + 1] / 255, b = data[i + 2] / 255;
+      total++;
+      rSum += r; gSum += g; bSum += b;
+      const mean = (r + g + b) / 3;
+      if (mean < 0.15) nearBlack++;
+      if (r > 0.97 && g > 0.97 && b > 0.97) pureWhite++;
+      if (r > 0.4 && r - g > 0.15 && r - b > 0.15) redDominant++;
+      if (g > 0.4 && g - r > 0.10 && g - b > 0.10) greenDominant++;
+      if (b > 0.4 && b - r > 0.15 && b - g > 0.15) blueDominant++;
+    }
+    return {
+      total,
+      meanBrightness: (rSum + gSum + bSum) / (3 * total),
+      meanRed: rSum / total,
+      meanGreen: gSum / total,
+      meanBlue: bSum / total,
+      redDominant, greenDominant, blueDominant,
+      nearBlack, pureWhite,
+    };
+  }, dataUrl);
+}
+
+test.describe('render-color readability', () => {
+  test('unpainted mesh silhouette is visible against the white background', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const dataUrl = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run('return api.Manifold.sphere(10, 32);');
+      return pw.renderView({ elevation: 30, azimuth: 0, ortho: false, size: 240 });
+    });
+    expect(typeof dataUrl).toBe('string');
+
+    const stats = await decodeAndSample(page, dataUrl);
+    // The sphere covers a meaningful portion of the frame; if it
+    // rendered as pure white against a white background, almost every
+    // pixel would be (255,255,255). With the UNPAINTED_BASE = 0.85
+    // fix, the sphere reads as a lighter gray with shaded sides — far
+    // fewer pixels are pure white.
+    const pureWhiteFraction = stats.pureWhite / stats.total;
+    expect(pureWhiteFraction, `pure-white fraction ${pureWhiteFraction.toFixed(3)} — silhouette should NOT be invisible against the background`).toBeLessThan(0.7);
+  });
+
+  test('painted-region color reads cleanly above 5% of the composite', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // Paint the top face of a cube red. Render the top view ortho —
+    // the painted face fills the entire tile, so most pixels in that
+    // tile should be red-dominant. Without the wireframe-suppression
+    // fix, the 30%-black wireframe would crosshatch the red surface
+    // and drag the red-dominant pixel count way down.
+    const dataUrl = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run('return api.Manifold.cube([20, 20, 20], true);');
+      pw.paintInBox({ box: { min: [-12, -12, 9], max: [12, 12, 11] }, color: [1, 0, 0] });
+      return pw.renderView({ elevation: 90, azimuth: 0, ortho: true, size: 240 });
+    });
+    expect(typeof dataUrl).toBe('string');
+
+    const stats = await decodeAndSample(page, dataUrl);
+    const redFraction = stats.redDominant / stats.total;
+    expect(redFraction, `red-dominant pixels ${redFraction.toFixed(3)} of ${stats.total}; mean brightness ${stats.meanBrightness.toFixed(2)}; near-black ${stats.nearBlack}`).toBeGreaterThan(0.05);
+
+    // And the render should NOT be dominated by near-black — that
+    // would mean wireframe is still bleeding over the painted face.
+    const nearBlackFraction = stats.nearBlack / stats.total;
+    expect(nearBlackFraction, `near-black pixel fraction ${nearBlackFraction.toFixed(3)} — wireframe overlay should be suppressed on colored renders`).toBeLessThan(0.05);
+  });
+
+  test('renderViews on a multi-color paint job preserves each color distinctly', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const dataUrl = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run('return api.Manifold.cube([20, 20, 20], true);');
+      pw.paintInBox({ box: { min: [-12, -12, 9], max: [12, 12, 11] }, color: [1, 0, 0] }); // top: red
+      pw.paintInBox({ box: { min: [9, -12, -12], max: [11, 12, 12] }, color: [0, 0.7, 0] }); // +X: green
+      pw.paintInBox({ box: { min: [-12, -12, -11], max: [12, 12, -9] }, color: [0, 0, 1] }); // bottom: blue
+      return pw.renderViews({ views: 'all', size: 200 });
+    });
+    expect(typeof dataUrl).toBe('string');
+
+    const stats = await decodeAndSample(page, dataUrl);
+    // Each painted face should show up in at least one tile of the
+    // composite. Don't enforce per-tile counts (the auto-angle picker
+    // could vary), just require each color to be visibly present.
+    expect(stats.redDominant, `red ${stats.redDominant}/${stats.total}`).toBeGreaterThan(50);
+    expect(stats.greenDominant, `green ${stats.greenDominant}/${stats.total}`).toBeGreaterThan(50);
+    expect(stats.blueDominant, `blue ${stats.blueDominant}/${stats.total}`).toBeGreaterThan(50);
+  });
+});


### PR DESCRIPTION
## Summary

Integration branch combining **#124 + #125 + #126 + #127** for end-to-end testing of the painting improvements together. Not intended to merge — once you've validated, the individual PRs are what you'd actually land (so they stay independently reviewable / revertable).

## What's included

| PR | Feature | Label |
|----|---------|-------|
| #124 | `coverageMode` + `maxTriangleArea` selector filters (defang fan-topology bleed on cylinder/revolve meshes) | `enhancement` |
| #125 | Labelled construction — `api.label(shape, name)` in user code + `paintByLabel({label, color})` | `enhancement` |
| #126 | `probePixel({pixel, view})` + `paintConnected({seed, maxDeviationDeg, color})` for vision-driven painting | `enhancement` |
| #127 | Render-color readability — visible silhouette + suppress wireframe on colored renders | `bug` |

## Conflict resolution

The four PRs touch overlapping surfaces but the conflicts were all additive — each contributing different items to the same lists or descriptor unions. Resolved manually:

- `src/color/regions.ts` — `RegionDescriptor` union now carries both `'byLabel'` (from #125) and `'connectedFromSeed'` (from #126) alongside the existing three kinds.
- `src/storage/sessionManager.ts` — single consolidated `1.5` history entry describing both new descriptor variants instead of two competing 1.5 bumps.
- `src/main.ts` — rehydration switch handles all five `kind` cases (coplanar / triangles / slab / byLabel / connectedFromSeed). Help-table entries union.
- `src/ai/tools.ts` — tool definitions, `ALWAYS_AVAILABLE`, `PAINT_GATED`, and dispatch all combine `listLabels` / `paintByLabel` / `probePixel` / `paintConnected`.

## What to test together

The four features compose into a coherent paint workflow tree:

1. **Agent-authored multi-feature models** → `api.label` + `paintByLabel` (#125). Deterministic, no coordinate guessing.
2. **Cylinder/revolve/linear_extrude surfaces** → `coverageMode: 'fully_inside'` or `maxTriangleArea` on the geometric selectors (#124). Defangs fan-bleed.
3. **Organic / user-imported meshes without labels** → `renderView` → `probePixel({pixel, view})` → `paintConnected({seed, ...})` (#126). Vision-driven loop.
4. **Verification renders** are now readable on dense colored meshes (#127) — colors visible, silhouette visible, no wireframe noise crowding the painted regions.

## Test results

- `npm run build` — green
- `npm run test:e2e` — **25/25 passing** across all suites:
  - 12 smoke
  - 1 manifold-3d ID verification
  - 2 coverageMode (#124)
  - 3 labelled construction (#125)
  - 4 paint-by-vision (#126)
  - 1 paint-render-color (#126)
  - 3 render-color readability (#127)

## Manual test plan

- [ ] Open a session with an organic mesh (e.g. Yoda). Use the AI panel to:
  - Ask the agent to paint specific features using the new tools. Confirm `paintByLabel` works if the code is re-authored with `api.label`. Confirm the visual loop (`renderView` → `probePixel` → `paintConnected`) works otherwise.
  - Verify `renderViews` returns a legible PNG with colored regions clearly visible against a light-gray silhouette and no wireframe overpaint.
- [ ] Build a cylinder-based model, paint with `coverageMode: 'fully_inside'`, confirm no fan-bleed.
- [ ] After validating, close this PR and land the four feature PRs individually so each retains its own review history.

https://claude.ai/code/session_018RSDXQg6Px1JD2RHHHmWcK

---
_Generated by [Claude Code](https://claude.ai/code/session_018RSDXQg6Px1JD2RHHHmWcK)_