### PR TITLE
feat(paint): batch paintByLabels, lifecycle clarity, runIsolated view spec

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -161,7 +161,7 @@ partwright.downloadRecentExport(id)
 partwright.clearRecentExports()
 
 // Isolated execution -- test code without changing editor/viewport state
-await partwright.runIsolated(code)       // -> {geometryData, thumbnail}
+await partwright.runIsolated(code, view?)  // -> {geometryData, thumbnail}. Default thumbnail is 4-iso composite; pass `view` ({elevation, azimuth, ortho, size}) for a single-angle preview.
 await partwright.runAndAssert(code, assertions) // -> {passed, failures?, stats}
 await partwright.runAndExplain(code)     // -> {stats, components[], hints[]} (debug disconnects)
 await partwright.modifyAndTest(patchFn, assertions?) // Modify current code + test in isolation
@@ -184,7 +184,7 @@ await partwright.runAndSave(code, label?, assertions?) // Assert+save in one cal
 await partwright.createSessionWithVersions(name, [{code, label},...]) // Batch create
 await partwright.saveVersion(label?)     // Save current state as version
 await partwright.listVersions()          // -> [{id, index, label, timestamp, status}]
-await partwright.loadVersion({index} | {id})  // Load version into editor -> {id, index, label, code, geometryData} or {error}
+await partwright.loadVersion({index} | {id})  // Load version into editor -> {id, index, label, code, geometryData, labelsAvailable, labelCount} or {error}
 await partwright.forkVersion({index} | {id}, transformFn, label?, assertions?) // Load + modify + validate + save in one call
 partwright.getGalleryUrl()               // -> URL for gallery view (human review)
 partwright.getSessionUrl()               // -> URL for this session
@@ -212,6 +212,7 @@ partwright.listComponents()              // -> {count, components: [{index, cent
 partwright.paintComponent({index, color, name?, topOnly?}) // One-call: paint the Nth boolean-distinct piece
 partwright.listLabels()                  // -> {count, labels: [{name, triangleCount, bbox, centroid}]} -- labels registered via api.label(shape, name) in the current run
 partwright.paintByLabel({label, color, name?}) // Paint a labelled feature by name. Exact, survives boolean ops. manifold-js only.
+partwright.paintByLabels([{label, color, name?}, ...]) // Batch sibling. N features in one call -> {results, failed}. Coalesces viewport refresh under one rAF.
 partwright.getFeatureCentroids({maxGroups?, withinBox?}?)  // Lightweight planning: centroids + normals + bbox per face group, NO triangleIds
 partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, coverageMode?, maxTriangleArea?, withImage?, view?}) // DRY-RUN -> {triangleCount, bbox, centroid, totalArea, largestTriangleArea, [thumbnail]}
 partwright.undoLastPaint()               // Reverse the SINGLE most recent paint op -> {undone, id, ...}
@@ -557,11 +558,17 @@ const eyeL = api.label(api.Manifold.sphere(2).translate([-3, 5, 7]), 'eyeL');
 const eyeR = api.label(api.Manifold.sphere(2).translate([ 3, 5, 7]), 'eyeR');
 return head.add(eyeL).add(eyeR);
 
-// After runAndSave, paint by name:
-partwright.paintByLabel({ label: 'eyeL', color: [0, 0, 1] });
-partwright.paintByLabel({ label: 'eyeR', color: [0, 0, 1] });
-// listLabels() returns what's available; check it if a paintByLabel
-// returns "no label X".
+// After runAndSave, paint by name. For multiple features, BATCH —
+// one tool call paints them all and coalesces the viewport refresh:
+partwright.paintByLabels([
+  { label: 'head', color: [0.4, 0.7, 0.4] },
+  { label: 'eyeL', color: [0,   0,   0  ] },
+  { label: 'eyeR', color: [0,   0,   0  ] },
+]);
+// -> { results: [...], failed: [] }
+// Reach for paintByLabel({label, color}) only when painting a single
+// feature. listLabels() returns what's available; check it if a paint
+// call reports "no label X".
 ```
 
 `api.labeledUnion([{name, shape}, ...])` is sugar that labels each

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -101,6 +101,30 @@ paintComponent(index, color) — it decomposes the union and paints the
 Nth piece in one call. Use listComponents() FIRST only when you need
 to inspect bboxes before deciding what to paint.
 
+For multi-feature labelled models, batch with paintByLabels([...]) —
+one tool call paints all features and coalesces the viewport refresh
+under a single rAF, so a 9-feature smiley costs one round-trip instead
+of nine. Reach for paintByLabel only when you need just one feature.
+
+Paint tools are SEPARATE tool calls — they cannot be invoked from
+inside runCode / runAndSave / runIsolated model code. The model code
+runs in a sandboxed evaluator that exposes Manifold + CrossSection
+via the \`api\` object; \`partwright.paintByLabel(...)\` is not in scope
+there. Call paint tools between code runs. The engine catches and
+flags this specifically, but the saved round-trip is to know it up
+front.
+
+When verifying features on a flat face (a smile on a head, a logo on
+a panel, an eye sticking out of a sphere), default 4-iso composites
+hide top-facing detail at the corner angles. Either:
+ - call runIsolated with view: {elevation: 90, ortho: true} for a
+   top-down preview instead of the default iso composite, OR
+ - call renderView({elevation: 90, ortho: true}) for a one-shot
+   top-down render after a runAndSave.
+The renderViews({views: 'auto'}) mode picks top-down automatically
+only when the whole model is genuinely flat (a disc); for a flat
+feature on top of a tall body, you have to ask for it explicitly.
+
 For organic / character meshes where bounding boxes won't separate the
 features (a hand from a sleeve at the same Z height; an ear from a
 head), use the paint-by-vision loop:

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -128,7 +128,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintByLabel',
-    description: 'Paint a labelled feature by name. The label must have been registered in the current run via api.label(shape, name) or api.labeledUnion. This is the bullseye for "describe how to make and paint a model" workflows: write the geometry with labels, then paint by name — no coordinate guessing, no bounding-box estimation, no fan-bleed. Survives boolean ops because manifold-3d propagates originalID through runOriginalID on the result mesh. Only works for manifold-js (SCAD has no equivalent); falls back to paintComponent / paintInBox there.',
+    description: 'Paint a labelled feature by name. The label must have been registered in the current run via api.label(shape, name) or api.labeledUnion. This is the bullseye for "describe how to make and paint a model" workflows: write the geometry with labels, then paint by name — no coordinate guessing, no bounding-box estimation, no fan-bleed. Survives boolean ops because manifold-3d propagates originalID through runOriginalID on the result mesh. Only works for manifold-js (SCAD has no equivalent); falls back to paintComponent / paintInBox there. For multi-feature models, batch with paintByLabels in one round-trip instead of N sequential paintByLabel calls.',
     input_schema: {
       type: 'object',
       properties: {
@@ -137,6 +137,29 @@ const ALL_TOOLS: ToolDefinition[] = [
         name: { type: 'string', description: 'Optional region name; defaults to the label.' },
       },
       required: ['label', 'color'],
+    },
+  },
+  {
+    name: 'paintByLabels',
+    description: 'Batch sibling of paintByLabel. Paint N labelled features in one tool call. Use this for any multi-feature paint job — a 9-feature smiley paints in 1 round-trip instead of 9. The viewport refresh coalesces under rAF so total cost is one frame regardless of batch size. Returns {results: [...], failed: [{label, error}]} — partial failures are reported per-label and do not abort the batch.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          description: 'Array of paint specs, each {label, color, name?} — same shape as a single paintByLabel call.',
+          items: {
+            type: 'object',
+            properties: {
+              label: { type: 'string' },
+              color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+              name: { type: 'string' },
+            },
+            required: ['label', 'color'],
+          },
+        },
+      },
+      required: ['items'],
     },
   },
   {
@@ -219,11 +242,21 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'runIsolated',
-    description: 'Run code WITHOUT side effects — does not modify the editor, does not save a version, does not affect currentMeshData. Returns {geometryData, thumbnail}; the thumbnail is forwarded back to you as a multimodal image so you can see the result. Use to TEST unfamiliar primitives (revolve axis behavior, hull edge cases, decompose ordering) on a 3-line snippet before committing a full runAndSave. Much cheaper than running, undoing, and retrying.',
+    description: 'Run code WITHOUT side effects — does not modify the editor, does not save a version, does not affect currentMeshData. Returns {geometryData, thumbnail}; the thumbnail is forwarded back to you as a multimodal image so you can see the result. Use to TEST unfamiliar primitives (revolve axis behavior, hull edge cases, decompose ordering) on a 3-line snippet before committing a full runAndSave. Default thumbnail is a 4-iso composite; pass `view` for a single named angle — top-down (elevation: 90) is the right choice when verifying a feature on a flat face (a smile on a head, a logo on a panel) since iso angles hide top-facing geometry.',
     input_schema: {
       type: 'object',
       properties: {
         code: { type: 'string', description: 'Code to run in the active language. Must return a Manifold (manifold-js) or evaluate to one (SCAD).' },
+        view: {
+          type: 'object',
+          description: 'Optional view spec for a single-angle thumbnail. Same shape as renderView (elevation/azimuth/ortho/size). Omit for the default 4-iso composite.',
+          properties: {
+            elevation: { type: 'number' },
+            azimuth: { type: 'number' },
+            ortho: { type: 'boolean' },
+            size: { type: 'integer' },
+          },
+        },
       },
       required: ['code'],
     },
@@ -457,7 +490,7 @@ const ALWAYS_AVAILABLE = new Set([
 
 const RUN_GATED = new Set(['runCode']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
-const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
 /** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
  *  vision spend in one place — when off, the agent has to reason from
@@ -540,7 +573,8 @@ async function executeRenderViews(api: PartwrightAPI, input: Record<string, unkn
 
 async function executeRunIsolated(api: PartwrightAPI, input: Record<string, unknown>): Promise<ToolExecResult> {
   const code = input.code as string;
-  const result = await api.runIsolated(code) as { geometryData?: unknown; thumbnail?: string | null; error?: string } | undefined;
+  const view = input.view as Record<string, unknown> | undefined;
+  const result = await api.runIsolated(code, view) as { geometryData?: unknown; thumbnail?: string | null; error?: string } | undefined;
   if (!result || typeof result !== 'object') return { content: 'runIsolated returned no result', isError: true };
   if ('error' in result && typeof result.error === 'string') return { content: result.error, isError: true };
   const stats = result.geometryData ?? {};
@@ -632,6 +666,8 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.listLabels();
     case 'paintByLabel':
       return api.paintByLabel(input);
+    case 'paintByLabels':
+      return api.paintByLabels(input.items as unknown[]);
     case 'probePixel':
       return api.probePixel(input);
     case 'paintConnected':

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -95,6 +95,24 @@ export const manifoldJsEngine: Engine = {
       labeledUnion,
     };
 
+    // Catch the common misconception that paint tools can be called
+    // from inside model code. Paint operations are tool calls (run on
+    // window.partwright after the model executes); inside model code,
+    // `partwright` is undefined and the user gets a generic
+    // ReferenceError that doesn't explain the boundary. The agent's
+    // instinct to batch paint calls inside runCode/runAndSave to save
+    // round-trips is reasonable but wrong; this gives them an
+    // actionable error the first time they try.
+    if (/\bpartwright\s*\./.test(jsCode)) {
+      const error = 'Model code (runCode / runAndSave / runIsolated) cannot call paint tools like partwright.paintByLabel or partwright.paintInBox. Paint operations are separate tool calls — invoke them between code runs, not inside the code. For batch painting, use partwright.paintByLabels([...]) as a single tool call after runAndSave.';
+      return {
+        mesh: null,
+        manifold: null,
+        error,
+        diagnostics: runtimeDiagnostic(error, 'Remove the partwright.* call from the model code and invoke paint tools separately.', 'JavaScript'),
+      };
+    }
+
     let result: InstanceType<typeof Manifold> | null = null;
     try {
       const fn = new Function('api', `"use strict";\n${jsCode}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2378,12 +2378,19 @@ async function main() {
       await runCodeSync(version.code);
       rehydrateColorRegions(version.geometryData);
       applyVersionAnnotations(version);
+      // Labels are runtime state from the just-executed code. Surface
+      // whether any were registered so callers can decide between
+      // paintByLabel (when available) and paintComponent / paintInBox
+      // (when not) without a follow-up listLabels() round-trip.
+      const labelCount = currentLabelMap?.size ?? 0;
       return {
         id: version.id,
         index: version.index,
         label: version.label,
         code: version.code,
         geometryData: version.geometryData,
+        labelsAvailable: labelCount > 0,
+        labelCount,
       };
     },
 
@@ -2683,9 +2690,25 @@ async function main() {
       return _running;
     },
 
-    /** Run code without mutating editor, viewport, or session state. Returns geometry stats + thumbnail. */
-    async runIsolated(code: string) {
-      const check = guard(() => assertString(code, 'runIsolated(code)', { allowEmpty: false }));
+    /** Run code without mutating editor, viewport, or session state.
+     *  Returns geometry stats + thumbnail. By default the thumbnail is
+     *  the standard 4-iso composite; pass `view` to render a single
+     *  named angle instead — useful when the feature you're verifying
+     *  (a smile on a face, a logo on a flat panel) only reads from one
+     *  specific direction. Same shape `renderView` accepts. */
+    async runIsolated(code: string, view?: { elevation?: number; azimuth?: number; ortho?: boolean; size?: number }) {
+      const check = guard(() => {
+        assertString(code, 'runIsolated(code)', { allowEmpty: false });
+        if (view !== undefined) {
+          const v = assertObject(view, 'runIsolated(code, view)')!;
+          assertNoUnknownKeys(v, ['elevation', 'azimuth', 'ortho', 'size'], 'runIsolated(code, view)');
+          assertNumber(v.elevation, 'runIsolated(code, view).elevation', { optional: true, min: -90, max: 90 });
+          assertNumber(v.azimuth, 'runIsolated(code, view).azimuth', { optional: true });
+          assertBoolean(v.ortho, 'runIsolated(code, view).ortho', { optional: true });
+          assertNumber(v.size, 'runIsolated(code, view).size', { optional: true, min: 1, integer: true });
+        }
+        return true;
+      });
       if (typeof check === 'object' && check !== null && 'error' in check) {
         return { geometryData: { status: 'error', error: check.error }, thumbnail: null };
       }
@@ -2694,8 +2717,12 @@ async function main() {
       let thumbnail: string | null = null;
       if (meshData) {
         try {
-          const canvas = renderCompositeCanvas(meshData);
-          thumbnail = canvas.toDataURL('image/png');
+          if (view) {
+            thumbnail = renderSingleView(meshData, view);
+          } else {
+            const canvas = renderCompositeCanvas(meshData);
+            thumbnail = canvas.toDataURL('image/png');
+          }
         } catch { /* ignore */ }
       }
 
@@ -4281,6 +4308,50 @@ async function main() {
       return { id: region.id, name: region.name, triangles: triangles.size, bbox: stats.bbox, centroid: stats.centroid };
     },
 
+    /** Batch sibling of `paintByLabel`. Paints N labelled features in
+     *  one call, collapsing what would otherwise be N round-trips into
+     *  a single tool invocation. The viewport refresh fires once (the
+     *  existing `scheduleColorRefresh` rAF coalescing absorbs the
+     *  individual commits), so a 9-feature smiley paints in one frame
+     *  instead of nine.
+     *
+     *  Returns `{ results: [...], failed: [{label, error}] }`. Each
+     *  entry in `results` is the same shape `paintByLabel` returns; an
+     *  empty `failed` array means every label resolved.
+     *
+     *  ```
+     *  partwright.paintByLabels([
+     *    { label: 'head',  color: [0.4, 0.7, 0.4] },
+     *    { label: 'eyeL',  color: [0,   0,   0  ] },
+     *    { label: 'eyeR',  color: [0,   0,   0  ] },
+     *    { label: 'mouth', color: [0.8, 0.2, 0.2] },
+     *  ]);
+     *  ``` */
+    paintByLabels(items: Array<{ label: string; color: [number, number, number]; name?: string }>) {
+      if (!Array.isArray(items)) return { error: 'paintByLabels requires an array of { label, color, name? }' };
+      if (items.length === 0) return { results: [], failed: [] };
+      if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
+      if (!currentLabelMap || currentLabelMap.size === 0) {
+        return { error: 'No labels registered in the current run. Wrap features with api.label(shape, "name") in your code, then runAndSave, then call paintByLabels.' };
+      }
+      const results: Array<Record<string, unknown>> = [];
+      const failed: Array<{ label: string; error: string }> = [];
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (!item || typeof item !== 'object') {
+          failed.push({ label: `(item ${i})`, error: 'each entry must be { label, color, name? }' });
+          continue;
+        }
+        const r = partwrightAPI.paintByLabel(item) as Record<string, unknown>;
+        if (r && typeof r === 'object' && 'error' in r) {
+          failed.push({ label: typeof item.label === 'string' ? item.label : `(item ${i})`, error: String(r.error) });
+        } else {
+          results.push(r);
+        }
+      }
+      return { results, failed };
+    },
+
     // === Annotations API ===
 
     /** List all freehand annotation strokes drawn on the model surface.
@@ -4546,6 +4617,7 @@ async function main() {
         'paintComponent':  { signature: 'paintComponent({index, color, name?, topOnly?}) -- One-call shortcut: listComponents + paintInBox for the Nth piece.', docs: '/ai.md#color-regions' },
         'listLabels':      { signature: 'listLabels() -> {count, labels: [{name, triangleCount, bbox, centroid}]} -- Labels registered in the current run via api.label(shape, name). Survives boolean ops; the cleanest paint primitive on agent-authored geometry.', docs: '/ai.md#color-regions' },
         'paintByLabel':    { signature: 'paintByLabel({label, color, name?}) -- Paint a labelled feature by name. Pair with api.label/labeledUnion in your code. No coordinate guessing.', docs: '/ai.md#color-regions' },
+        'paintByLabels':   { signature: 'paintByLabels([{label, color, name?}, ...]) -- Batch sibling. N features painted in one call -> {results, failed}. Use for any multi-feature paint job.', docs: '/ai.md#color-regions' },
         'paintConnected':  { signature: 'paintConnected({seed: {point, normal?}, maxDeviationDeg?, color, name?}) -- BFS-flood from a surface seed, gated by deviation from SEED normal (not adjacent). Pairs with probePixel for "paint everything contiguous and facing this way".', docs: '/ai.md#color-regions' },
         'getFeatureCentroids': { signature: 'getFeatureCentroids({maxGroups?, withinBox?}?) -- Token-cheap: face-group centroids + normals + bbox, no triangleIds. Use to plan paint targets.', docs: '/ai.md#color-regions' },
         'removeRegion':    { signature: 'removeRegion(id) -- Remove ONE color region by id from listRegions(). Use this to fix a single mistake without nuking the rest.', docs: '/ai.md#color-regions' },

--- a/tests/paint-batch-and-lifecycle.spec.ts
+++ b/tests/paint-batch-and-lifecycle.spec.ts
@@ -1,0 +1,130 @@
+// Regression tests for the second-round paint workflow improvements:
+//  - paintByLabels batches N paint calls into one tool round-trip
+//  - loadVersion reports labelsAvailable / labelCount
+//  - runIsolated accepts a view spec for single-angle thumbnails
+//  - manifold-js engine rejects user code that calls partwright.* with
+//    a structured, instructive error instead of a generic ReferenceError
+
+import { test, expect } from 'playwright/test';
+
+test.describe('paint batch + lifecycle', () => {
+  test('paintByLabels paints multiple features in one call', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run(`
+        const { Manifold } = api;
+        const head = api.label(Manifold.sphere(10, 32), 'head');
+        const eyeL = api.label(Manifold.sphere(2, 16).translate([-3, 8, 5]), 'eyeL');
+        const eyeR = api.label(Manifold.sphere(2, 16).translate([ 3, 8, 5]), 'eyeR');
+        return head.add(eyeL).add(eyeR);
+      `);
+      return pw.paintByLabels([
+        { label: 'head', color: [0.4, 0.7, 0.4] },
+        { label: 'eyeL', color: [0, 0, 0] },
+        { label: 'eyeR', color: [0, 0, 0] },
+      ]);
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.results).toHaveLength(3);
+    expect(result.failed).toEqual([]);
+    for (const r of result.results) {
+      expect(r.triangles).toBeGreaterThan(0);
+      expect(typeof r.id).toBe('number');
+    }
+  });
+
+  test('paintByLabels reports per-label failures without aborting the batch', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run(`
+        const { Manifold } = api;
+        return api.label(Manifold.cube([10, 10, 10]), 'box');
+      `);
+      return pw.paintByLabels([
+        { label: 'box', color: [1, 0, 0] },
+        { label: 'nonexistent', color: [0, 1, 0] },
+      ]);
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.results).toHaveLength(1);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].label).toBe('nonexistent');
+    expect(result.failed[0].error).toMatch(/no label/);
+  });
+
+  test('loadVersion reports labelsAvailable for labelled and unlabelled versions', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('test-labels-lifecycle');
+      const v1 = await pw.runAndSave('return api.Manifold.cube([5, 5, 5]);', 'unlabelled');
+      const v2 = await pw.runAndSave(
+        'return api.label(api.Manifold.cube([5, 5, 5]), "box");',
+        'labelled',
+      );
+      const loadedUnlabelled = await pw.loadVersion({ index: v1.version.index });
+      const loadedLabelled = await pw.loadVersion({ index: v2.version.index });
+      return { loadedUnlabelled, loadedLabelled };
+    });
+    expect(result.loadedUnlabelled.error).toBeUndefined();
+    expect(result.loadedUnlabelled.labelsAvailable).toBe(false);
+    expect(result.loadedUnlabelled.labelCount).toBe(0);
+    expect(result.loadedLabelled.error).toBeUndefined();
+    expect(result.loadedLabelled.labelsAvailable).toBe(true);
+    expect(result.loadedLabelled.labelCount).toBeGreaterThan(0);
+  });
+
+  test('runIsolated with view: top-down renders the top face clearly', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const { topThumb, isoThumb } = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      // A short, wide cube — top face is the dominant visible surface
+      // from above. From the default iso angle the top is foreshortened.
+      const code = 'return api.Manifold.cube([20, 20, 2], true);';
+      const top = await pw.runIsolated(code, { elevation: 90, azimuth: 0, ortho: true, size: 200 });
+      const iso = await pw.runIsolated(code);
+      return { topThumb: top.thumbnail, isoThumb: iso.thumbnail };
+    });
+    // Both should produce thumbnails; they should differ (different
+    // angles → different pixel data). The top-down one is the cheap
+    // verification the agent feedback asked for.
+    expect(typeof topThumb).toBe('string');
+    expect(typeof isoThumb).toBe('string');
+    expect(topThumb).not.toBe(isoThumb);
+    expect(topThumb.startsWith('data:image/png;base64,')).toBe(true);
+  });
+
+  test('runCode rejects code that calls partwright.* with an instructive error', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const r = await pw.runIsolated(`
+        const cube = api.Manifold.cube([1, 1, 1]);
+        partwright.paintByLabel({ label: 'x', color: [1, 0, 0] });
+        return cube;
+      `);
+      return r;
+    });
+    // runIsolated returns geometryData with status: 'error' on failure
+    expect(result.geometryData.status).toBe('error');
+    expect(result.geometryData.error).toContain('paint tools');
+    expect(result.geometryData.error).toMatch(/separate tool calls|paintByLabels/);
+  });
+});


### PR DESCRIPTION
## Summary

Five small improvements from a real-session paint workflow report. Each addresses a specific friction the agent reported after a successful but inefficient labelled-smiley run:

1. **`partwright.paintByLabels([{label, color, name?}, ...])`** — batches N paint calls into one tool round-trip. A 9-feature smiley paints in one call instead of nine; the existing `scheduleColorRefresh` rAF coalescing means the viewport refresh fires once regardless of batch size. Partial failures reported per-label without aborting.
2. **`loadVersion` returns `labelsAvailable` + `labelCount`** — cheap signal that lets the caller pick between `paintByLabel(s)` and `paintComponent`/`paintInBox` without a `listLabels` round-trip.
3. **`runIsolated(code, view?)` accepts an optional view spec** — top-down preview (`elevation: 90`) for verifying flat features without the iso composite's foreshortening.
4. **manifold-js engine catches paint-tool calls in user code** — pre-scans the source for `partwright.` references and rejects with an explicit message pointing at `paintByLabels` as the batch primitive. Replaces the generic "partwright is not defined" with one-shot teaching.
5. **Prompt updates** (PREAMBLE + ai.md) — prefer-the-batch nudge for `paintByLabels`; explicit "paint tools are NOT callable from inside model code"; top-down verification guidance for flat features (the auto-angle mode only triggers when the whole model is flat; a flat feature on a tall body needs an explicit `elevation: 90`).

## Why

Direct agent feedback after PR #125 shipped:

> A `paintLabeledUnion([{label, color}, ...])` batch call would collapse 9 sequential `paintByLabel` round-trips into 1.

> I instinctively tried to batch all `paintByLabel` calls in a `runCode` block to save round-trips. That failed immediately. A cleaner error message would help future agents.

> When I called `loadVersion` and then tried to paint, the labels weren't available until I re-ran the code.

> The iso view angles hide top-facing geometry. A top-down view in the thumbnail (or a `renderView({elevation: 90})` as a cheap check) would have saved 3-4 `runIsolated` calls.

## Implementation notes

- `paintByLabels` delegates to the existing `paintByLabel` per-item, so error-message wording and rehydration descriptors stay consistent with the single-item path.
- `loadVersion`'s `labelsAvailable` is derived from `currentLabelMap` after the auto-rerun the load already performs — no new state, just surface what's there.
- `runIsolated`'s `view` is an optional second positional arg to preserve back-compat for existing `runIsolated(code)` console callers.
- The `partwright.` scan is a simple `/\bpartwright\s*\./.test(jsCode)` ahead of `new Function(...)`. Catches `partwright.paintByLabel(...)` but doesn't false-positive on variables named like `partwright_settings`. The structured error name-drops `paintByLabels` so the agent has somewhere to go next.

## Test plan

- [x] `npm run build` — green
- [x] `npm run test:e2e` — 30/30 (12 smoke + 1 ID verification + 12 from prior PRs + 5 new)
- [x] New `tests/paint-batch-and-lifecycle.spec.ts` — 5 cases:
  - `paintByLabels` paints multiple features in one call
  - `paintByLabels` reports per-label failures without aborting
  - `loadVersion` reports `labelsAvailable` for labelled vs unlabelled versions
  - `runIsolated` with `view` produces a different thumbnail than the default composite
  - `runCode` rejects `partwright.*` calls with the new structured error
- [ ] Manual: ask the AI to paint a multi-feature labelled smiley — verify it reaches for `paintByLabels` over sequential `paintByLabel`. Then load an older labelled version, confirm `labelsAvailable: true` and immediate `paintByLabels` works without a re-run.

https://claude.ai/code/session_018RSDXQg6Px1JD2RHHHmWcK

---
_Generated by [Claude Code](https://claude.ai/code/session_018RSDXQg6Px1JD2RHHHmWcK)_