### PR TITLE
docs: front-load visual verification and await in AI agent prompts

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -33,7 +33,9 @@ Partwright is a browser-based parametric CAD tool with two modeling engines: **m
 2. **Pick your engine:** manifold-js (default) or OpenSCAD. See [Choosing an engine](#choosing-an-engine).
 3. **manifold-js code must end with `return manifoldObject;`** -- a bare trailing expression won't work. OpenSCAD code uses standard SCAD syntax (no `return`).
 4. **Use `runAndSave(code, label, {isManifold: true, maxComponents: 1})`** to validate and commit a version.
-5. **Log decisions with `addSessionNote("[PREFIX] ...")`** -- prefixes: `[REQUIREMENT]`, `[DECISION]`, `[FEEDBACK]`, `[MEASUREMENT]`, `[ATTEMPT]`, `[TODO]`.
+5. **Verify visually after structural changes.** Stats alone can't catch warped roofs, twisted spires, or wrong proportions. Call `renderView({ortho: true})` from a few angles, or open the Elevations tab. See [Visual verification](#visual-verification).
+6. **Log decisions with `addSessionNote("[PREFIX] ...")`** -- prefixes: `[REQUIREMENT]`, `[DECISION]`, `[FEEDBACK]`, `[MEASUREMENT]`, `[ATTEMPT]`, `[TODO]`.
+7. **`await` every async method.** `createSession`, `runAndSave`, `runAndAssert`, `runIsolated`, `runAndExplain`, `loadVersion`, `forkVersion`, `getSessionContext`, every `*Data()` export, every notes/sessions call returns a Promise. Without `await` you'll inspect the Promise object instead of the result and silently work from stale or empty data.
 
 ## Choosing an engine
 
@@ -76,6 +78,7 @@ Selecting a SCAD example from the toolbar dropdown auto-switches to OpenSCAD mod
 - **Branching off a prior version by hand** -- don't chain `loadVersion` -> `getCode` -> modify -> `runAndSave`. A silent failure (blocked return value, stale buffer) can drop parts of the parent. Use [`forkVersion({index} | {id}, transformFn, label, assertions?)`](#forking-a-prior-version) instead -- it loads the parent's code server-side, applies your transform, validates, and saves atomically.
 - **Passing a bare index or id instead of `{index}` / `{id}`** -- `loadVersion` and `forkVersion` take an object with exactly one of `{index: number}` or `{id: string}`, e.g. `loadVersion({index: 2})` or `loadVersion({id: "Kx3Pq9mA2wEr"})`. Bare `loadVersion(2)` will return `{error: "...target must be { index: number } or { id: string }..."}`.
 - **Passing the wrong object shape to `setImages`, `setReferenceGeometry`, `query`, `runAndAssert`, etc.** -- the API rejects unknown keys and wrong-type values. See [Argument validation](#argument-validation).
+- **Doing `setCode` then `run` when you meant `runAndSave`.** `setCode` doesn't auto-run, `run` doesn't save and doesn't validate, and the gallery won't see the version. `runAndSave(code, label, assertions)` does all three atomically -- prefer it for committed iterations. See also [`runAndSave` is for committed iterations; `runIsolated` is for sanity checks](#runandsave-is-for-committed-iterations-runisolated-is-for-sanity-checks).
 
 ## Argument validation
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,6 +2,10 @@
 
 > AI-driven parametric CAD in the browser. Supports JavaScript (manifold-3d API) and OpenSCAD (.scad). All interaction is via the `window.partwright` console API. `window.mainifold` is a legacy alias.
 
+## Entrypoint
+
+Navigate to `/editor?view=ai` -- this bypasses the landing page and shows 4 isometric views so you can see your geometry from every angle without clicking any tabs.
+
 ## Quickstart
 
 ```js
@@ -13,6 +17,48 @@ await partwright.runAndSave(code, "v1 - description", {
 // JS code must end with: return <Manifold object>;
 // SCAD code uses standard OpenSCAD syntax (no return)
 ```
+
+`await` every async method. Without `await` you'll inspect a Promise object instead of the actual result.
+
+## Verify visually after structural changes
+
+Stats alone miss warped roofs, twisted spires, and wrong proportions:
+
+```js
+partwright.renderView({ elevation: 0,  azimuth: 0,  ortho: true })  // front
+partwright.renderView({ elevation: 0,  azimuth: 90, ortho: true })  // right
+partwright.renderView({ elevation: 90,              ortho: true })  // top
+```
+
+Or switch to the Elevations tab (`?view=elevations`) for a 6-view grid.
+
+## Resuming a session
+
+```js
+await partwright.openSession(id)
+const ctx = await partwright.getSessionContext()
+// ctx.notes -- [REQUIREMENT]/[DECISION]/[FEEDBACK] context from prior work
+// ctx.versions -- prior versions with geometry summary
+// ctx.agentHints.recentErrors -- last 5 validation errors (avoid repeating them)
+```
+
+## Tagging faces with color
+
+For a flat axis-aligned face, derive the seed from the bounding box:
+
+```js
+const bb = partwright.getBoundingBox();
+await partwright.paintRegion({
+  point:  [(bb.min[0]+bb.max[0])/2, (bb.min[1]+bb.max[1])/2, bb.max[2]],
+  normal: [0, 0, 1],          // outward-pointing normal of the top face
+  color:  [1, 0, 0],          // RGB 0..1
+  name:   "Top",
+})
+// Save the uncolored baseline first -- painting locks the editor for code edits.
+// Check {error} on the return and confirm with listRegions().
+```
+
+For organic shapes, code-authored features, or anything where flood-fill is unreliable, prefer `paintByLabels` (when you author the model with `api.label(...)`), `paintNear` / `paintInBox` (coordinate-driven), or `paintPreview` to dry-run a selector. See `/ai.md#color-regions`.
 
 ## Language switching
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2283,6 +2283,7 @@ async function main() {
       await addSessionNote(
         '[WORKFLOW] Drive this app via window.partwright (see /ai.md). ' +
         'Use runAndSave(code, label, assertions) for iterations; ' +
+        'after structural changes verify visually via renderView({ortho:true}) or the Elevations tab; ' +
         'addSessionNote with [REQUIREMENT]/[DECISION]/[MEASUREMENT]/[FEEDBACK]/[ATTEMPT]/[TODO] prefixes; ' +
         'getSessionContext() when resuming.',
       );


### PR DESCRIPTION
## Summary

After reading `public/ai.md` (1343 lines on staging — already very thorough after the recent paint API expansion), `public/llms.txt`, and the auto-inserted `[WORKFLOW]` session note, I found four gaps in the **early** sections where the rules an agent needs first weren't actually there. Everything in this PR is additive and complementary to the existing material — no rewrite of the comprehensive paint section, no new APIs.

### What changed and why

**`public/ai.md` "Before you start"** — adds two bullets:
- **Visual verification.** It's marked CRITICAL on line 1246 but absent from the top-of-doc rules where agents start reading. By the time an LLM gets to line 1246 it's already committed several un-verified versions.
- **`await` every async method.** Implied throughout but never stated. Forgetting `await` is a frequent LLM mistake that silently leaves you working from a Promise object instead of the actual result — none of the existing prose flags this.

**`public/ai.md` "Common agent mistakes"** — adds one bullet:
- **`setCode` + `run` instead of `runAndSave`.** Cross-linked to the new "lifecycle" section at the bottom. The bottom section is excellent but only matters if the agent doesn't make this mistake on the first try.

**`public/llms.txt`** — expands the landing file (the conventional first thing LLM tooling reads) from 27 → 73 lines:
- Adds the entrypoint URL (`/editor?view=ai`) so agents don't waste a turn on the landing page
- Adds a visual-verification recipe with `renderView({ortho: true})` calls
- Adds a session-resuming snippet with `getSessionContext()`
- Adds a brief paint section that uses `paintRegion` for the simple flat-face case and points to `paintByLabels` / `paintNear` / `paintInBox` / `paintPreview` in /ai.md for everything else

**`src/main.ts` auto-inserted `[WORKFLOW]` session note** — adds visual verification alongside the existing `runAndSave` and `addSessionNote` reminders. Every new session this note attaches to gets the visual-verification cue without needing the agent to re-read ai.md.

### What I deliberately did *not* change

I had a longer initial plan that included a "Painting without clicks" worked example and a "Common painting mistakes" subsection. After rebasing on staging I dropped both — staging's color regions section (lines 445-838) already covers `paintByLabels`, `paintNear`, `paintInBox`, `paintPreview`, `paintConnected`+`probePixel`, fan-bleed mitigation, the editor lock, and `assertPaint` in detail, and the new "Common gotchas" section (lines 840-921) covers `paintRegion` bimodality, the `probeRay`-hit-normal pattern, and the lifecycle gotchas. Re-stating any of that would have duplicated better-written content.

## Test plan

- [x] `npm run build` succeeds (TS + Vite)
- [x] Verified every async method I named in the new "await" bullet is actually `async` in `src/main.ts` (`createSession`, `runAndSave`, `runAndAssert`, `runIsolated`, `runAndExplain`, `loadVersion`, `forkVersion`, `getSessionContext`)
- [x] Verified the cross-link anchor `#runandsave-is-for-committed-iterations-runisolated-is-for-sanity-checks` matches the existing heading on staging
- [x] Verified the example `partwright.renderView({ elevation: 0, azimuth: 0, ortho: true })` matches the documented signature
- [ ] Smoke-test: open a new session in the staging preview and confirm the auto-inserted `[WORKFLOW]` note shows the visual-verification phrase

https://claude.ai/code/session_01Y5nwQ4H6G3yKYkyq7QFqqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5nwQ4H6G3yKYkyq7QFqqn)_