### PR TITLE
feat: expand paint palette to 16 colors with neutrals (incl. black)

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -202,6 +202,7 @@ partwright.paintRegion({point, normal, color, name?, tolerance?})         // buc
 partwright.paintNearestRegion({point, color, searchRadius?, name?, tolerance?}) // snap seed to nearest face, then flood-fill -> {id, name, triangles, snappedTo} or {error}
 partwright.paintNear({point, radius, normalCone?, topOnly?, coverageMode?, maxTriangleArea?, color, name?})    // sphere: paint triangles within radius -> {id, name, triangles, bbox, centroid} or {error}
 partwright.paintInBox({box, normalCone?, topOnly?, coverageMode?, maxTriangleArea?, color, name?})             // box: paint triangles inside an AABB -> {id, name, triangles, bbox, centroid} or {error}
+partwright.paintInOrientedBox({box: {center, size, quaternion?}, color, name?})                                 // rotated box: paint triangles inside an oriented bounding box. quaternion defaults to identity. Same selector as the UI Box tool.
 partwright.paintFaces({triangleIds, color, name?})                        // brush: paint specific triangle indices -> {id, name, triangles} or {error}
 partwright.paintSlab({axis|normal, offset, thickness, coverageMode?, maxTriangleArea?, color, name?})      // slab: paint a planar range -> {id, name, triangles} or {error}
 partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, coverageMode?, maxTriangleArea?, withImage?, view?}) // dry-run -> {triangleCount, bbox, centroid, totalArea, largestTriangleArea, [thumbnail]}

--- a/public/ai.md
+++ b/public/ai.md
@@ -210,7 +210,7 @@ partwright.assertPaint({region, expectedTriangleCount?, expectedBoundingBox?, ex
 partwright.findFaces({box?, normal?, normalTolerance?, color?, region?, maxResults?}) // query triangle ids by geometry/color -> {triangleIds, count, matched, truncated}
 partwright.getMesh()                     // -> {numVert, numTri, vertices, triangles, normals, centroids, boundingBox} (typed arrays)
 partwright.getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?, withinBox?}?) // -> {groups[{id, normal, centroid, area, triangleCount, bbox, triangleIds}], totalTriangles, groupCount, tolerance, unfiltered?}
-partwright.listRegions()                 // -> [{id, name, color, source, triangles, order, bbox, centroid}, ...]
+partwright.listRegions()                 // -> [{id, name, color, source, triangles, order, visible, bbox, centroid}, ...]
 partwright.listComponents()              // -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- per-piece bbox for unioned models
 partwright.paintComponent({index, color, name?, topOnly?}) // One-call: paint the Nth boolean-distinct piece
 partwright.listLabels()                  // -> {count, labels: [{name, triangleCount, bbox, centroid}]} -- labels registered via api.label(shape, name) in the current run
@@ -221,7 +221,14 @@ partwright.paintPreview({box?|point+radius?|triangleIds?, normalCone?, coverageM
 partwright.undoLastPaint()               // Reverse the SINGLE most recent paint op -> {undone, id, ...}
 partwright.redoLastPaint()               // Reapply the most recently undone paint -> {redone, id, ...}
 partwright.removeRegion(id)              // Delete ONE region by id from listRegions()
+partwright.setRegionVisibility(id, visible) // Show/hide ONE region in the viewport (hidden regions still export)
+partwright.hideRegion(id)                // Shorthand for setRegionVisibility(id, false)
+partwright.showRegion(id)                // Shorthand for setRegionVisibility(id, true)
 partwright.clearColors()                 // Remove ALL regions (destructive — prefer undoLastPaint/removeRegion for fixing single mistakes)
+partwright.getBucketTolerance()          // -> {tolerance} (cosine of max bend angle, -1..1)
+partwright.setBucketTolerance(t)         // Set the UI bucket tool's tolerance + the default for paintRegion
+partwright.getBrushSize()                // -> {radius} (mesh units, 0 = single triangle)
+partwright.setBrushSize(r)               // Set the UI brush radius (>= 0). Programmatic painting uses paintNear / paintFaces.
 
 // Notes -- track design context, decisions, and measurements
 await partwright.addSessionNote(text)    // -> {id, text, timestamp}
@@ -460,11 +467,16 @@ const r = partwright.paintRegion({
 });
 // r = { id, name, triangles } on success, or { error } if no matching face found
 
-partwright.listRegions()    // [{ id, name, color, source, triangles, order }, ...]
+partwright.listRegions()    // [{ id, name, color, source, triangles, order, visible }, ...]
 partwright.undoLastPaint()  // reverse just the most recent paint op
 partwright.removeRegion(id) // delete one region by id (older mistake)
+partwright.hideRegion(id)   // toggle a region off in the viewport without deleting it; exports still include it
+partwright.showRegion(id)   // re-show a previously hidden region
 partwright.clearColors()    // remove ALL regions — destructive, prefer the two above for single mistakes
 ```
+
+**Per-region visibility vs. delete.** `setRegionVisibility(id, false)` (or `hideRegion(id)`) toggles a region off in the *viewport* — the painted triangles render unpainted while the region is hidden, but the region itself stays in `listRegions()` and the `visible` flag is persisted across save/load. This is the right tool for "I want to see what the model looks like without this region" or "compare paint vs. no-paint." GLB / 3MF exports always include hidden regions — visibility is a viewer-state flag, not an export filter. Use `removeRegion(id)` when you actually want to delete a region permanently.
+
 
 **Preview before commit (default workflow).** `paintPreview()` accepts
 the same selector args as `paintInBox` / `paintNear` / `paintFaces` but

--- a/src/color/adjacency.ts
+++ b/src/color/adjacency.ts
@@ -7,6 +7,9 @@ export interface AdjacencyGraph {
   neighbors: Uint32Array[];
   /** Triangle normals — 3 floats per triangle (nx, ny, nz). */
   normals: Float32Array;
+  /** Triangle centroids — 3 floats per triangle (cx, cy, cz). Used by the
+   *  brush tool's radius expansion (sphere query against centroids). */
+  centroids: Float32Array;
 }
 
 /** Create a canonical edge key from two vertex indices (order-independent). */
@@ -83,9 +86,21 @@ export function buildAdjacency(mesh: MeshData): AdjacencyGraph {
     normals[t * 3 + 2] = nz;
   }
 
+  // Compute triangle centroids (mean of three vertex positions).
+  const centroids = new Float32Array(numTri * 3);
+  for (let t = 0; t < numTri; t++) {
+    const v0 = triVerts[t * 3];
+    const v1 = triVerts[t * 3 + 1];
+    const v2 = triVerts[t * 3 + 2];
+    centroids[t * 3]     = (vertProperties[v0 * numProp]     + vertProperties[v1 * numProp]     + vertProperties[v2 * numProp])     / 3;
+    centroids[t * 3 + 1] = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3;
+    centroids[t * 3 + 2] = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3;
+  }
+
   return {
     neighbors: neighbors.map(s => new Uint32Array(s)),
     normals,
+    centroids,
   };
 }
 

--- a/src/color/boxDrag.ts
+++ b/src/color/boxDrag.ts
@@ -1,0 +1,253 @@
+// Box drag — interactive oriented-box paint tool. Spawns a translucent box
+// in the viewport sized to the model's bounding box, gives the user a
+// transform gizmo (translate / rotate / scale) to position it, and commits
+// every triangle whose centroid is inside the box when the user clicks
+// "Paint inside box".
+
+import * as THREE from 'three';
+import { TransformControls } from 'three/addons/controls/TransformControls.js';
+import type { MeshData } from '../geometry/types';
+import { getScene, getCamera, getRenderer, getMeshGroup, setUserOrbitLock, isUserOrbitLocked } from '../renderer/viewport';
+import { addRegion, getRegions } from './regions';
+import { getColor, getCurrentMesh } from './paintMode';
+import { findBoxTriangles, type OrientedBox } from './boxPaint';
+import { meshBounds } from './slabPaint';
+
+export type BoxMode = 'translate' | 'rotate' | 'scale';
+
+let active = false;
+let mode: BoxMode = 'translate';
+let proxy: THREE.Object3D | null = null; // invisible — TransformControls attaches here
+let boxMesh: THREE.Mesh | null = null;   // translucent box rendered in the viewport
+let boxEdges: THREE.LineSegments | null = null;
+let gizmo: TransformControls | null = null;
+let gizmoHelper: THREE.Object3D | null = null;
+let priorOrbitLock = false;
+
+const changeListeners: Array<(box: OrientedBox) => void> = [];
+
+export function isBoxActive(): boolean { return active; }
+
+export function onBoxChange(fn: (box: OrientedBox) => void): () => void {
+  changeListeners.push(fn);
+  return () => {
+    const i = changeListeners.indexOf(fn);
+    if (i >= 0) changeListeners.splice(i, 1);
+  };
+}
+
+function notifyChange(): void {
+  const box = getBox();
+  for (const fn of changeListeners) fn(box);
+}
+
+export function setBoxMode(m: BoxMode): void {
+  mode = m;
+  if (gizmo) gizmo.setMode(m);
+}
+
+export function getBoxMode(): BoxMode { return mode; }
+
+export function getBox(): OrientedBox {
+  if (!proxy) return { center: [0, 0, 0], size: [1, 1, 1], quaternion: [0, 0, 0, 1] };
+  return {
+    center: [proxy.position.x, proxy.position.y, proxy.position.z],
+    size: [proxy.scale.x, proxy.scale.y, proxy.scale.z],
+    quaternion: [proxy.quaternion.x, proxy.quaternion.y, proxy.quaternion.z, proxy.quaternion.w],
+  };
+}
+
+/** Programmatically set the box transform. Use for numeric-input edits. */
+export function setBox(box: Partial<OrientedBox>): void {
+  if (!proxy || !boxMesh || !boxEdges) return;
+  if (box.center) proxy.position.set(box.center[0], box.center[1], box.center[2]);
+  if (box.size) proxy.scale.set(Math.max(0.001, box.size[0]), Math.max(0.001, box.size[1]), Math.max(0.001, box.size[2]));
+  if (box.quaternion) proxy.quaternion.set(box.quaternion[0], box.quaternion[1], box.quaternion[2], box.quaternion[3]);
+  syncVisuals();
+  notifyChange();
+}
+
+export function activate(): void {
+  if (active) return;
+  active = true;
+
+  // Reuse the global orbit lock the way other paint tools do. The gizmo also
+  // listens for its own dragging-changed event below to lock during a drag,
+  // but locking up-front matches the paint mode's "stop orbiting" contract.
+  priorOrbitLock = isUserOrbitLocked();
+  setUserOrbitLock(true);
+
+  buildBox();
+  buildGizmo();
+  notifyChange(); // populate the panel's numeric readouts with initial values
+}
+
+export function deactivate(): void {
+  if (!active) return;
+  active = false;
+  if (!priorOrbitLock) setUserOrbitLock(false);
+  disposeGizmo();
+  disposeBox();
+}
+
+export function onMeshChanged(): void {
+  if (!active) return;
+  // Reset the box to fit the new mesh, but preserve the user's chosen mode.
+  disposeBox();
+  buildBox();
+  if (gizmo && proxy) {
+    gizmo.attach(proxy);
+    // Re-add the gizmo helper in case the mesh swap reset the scene.
+    if (gizmoHelper && !gizmoHelper.parent) getScene().add(gizmoHelper);
+  }
+  syncVisuals();
+  notifyChange();
+}
+
+function defaultBoxFor(mesh: MeshData): { center: THREE.Vector3; size: THREE.Vector3 } {
+  const bb = meshBounds(mesh);
+  const center = new THREE.Vector3(
+    (bb.min[0] + bb.max[0]) / 2,
+    (bb.min[1] + bb.max[1]) / 2,
+    (bb.min[2] + bb.max[2]) / 2,
+  );
+  // Default size = 110% of the model bbox so the box fully contains the
+  // model on activation. A "Paint" with default settings paints everything;
+  // the user shrinks/rotates/moves the box from there.
+  const size = new THREE.Vector3(
+    Math.max(0.1, (bb.max[0] - bb.min[0]) * 1.1),
+    Math.max(0.1, (bb.max[1] - bb.min[1]) * 1.1),
+    Math.max(0.1, (bb.max[2] - bb.min[2]) * 1.1),
+  );
+  return { center, size };
+}
+
+function buildBox(): void {
+  const mesh = getCurrentMesh();
+  if (!mesh) return;
+
+  const { center, size } = defaultBoxFor(mesh);
+
+  proxy = new THREE.Object3D();
+  proxy.position.copy(center);
+  proxy.scale.copy(size);
+  getMeshGroup().add(proxy);
+
+  // Box mesh is a unit cube; we scale it via the proxy. The proxy ALSO scales
+  // the gizmo handles unfortunately — so we make the renderable box a child
+  // of the proxy and apply our own visual scale to keep things clean.
+  const geo = new THREE.BoxGeometry(1, 1, 1);
+  const hex = colorToHex(getColor());
+  const mat = new THREE.MeshBasicMaterial({
+    color: hex,
+    transparent: true,
+    opacity: 0.18,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+  });
+  boxMesh = new THREE.Mesh(geo, mat);
+  boxMesh.name = 'paint-box';
+  boxMesh.renderOrder = 998;
+  proxy.add(boxMesh);
+
+  const edgeGeo = new THREE.EdgesGeometry(geo);
+  const edgeMat = new THREE.LineBasicMaterial({ color: hex, transparent: true, opacity: 0.8, depthTest: false });
+  boxEdges = new THREE.LineSegments(edgeGeo, edgeMat);
+  boxEdges.name = 'paint-box-edges';
+  boxEdges.renderOrder = 999;
+  proxy.add(boxEdges);
+}
+
+function disposeBox(): void {
+  if (boxMesh) {
+    boxMesh.geometry.dispose();
+    (boxMesh.material as THREE.Material).dispose();
+    boxMesh.parent?.remove(boxMesh);
+    boxMesh = null;
+  }
+  if (boxEdges) {
+    boxEdges.geometry.dispose();
+    (boxEdges.material as THREE.Material).dispose();
+    boxEdges.parent?.remove(boxEdges);
+    boxEdges = null;
+  }
+  if (proxy) {
+    proxy.parent?.remove(proxy);
+    proxy = null;
+  }
+}
+
+function buildGizmo(): void {
+  if (!proxy) return;
+  const camera = getCamera();
+  const canvas = getRenderer().domElement;
+  gizmo = new TransformControls(camera, canvas);
+  gizmo.setMode(mode);
+  gizmo.setSize(0.8);
+  gizmo.attach(proxy);
+  // The visual helper is a separate Object3D returned by getHelper(); the
+  // TransformControls itself is event-only in the modern three.js API.
+  gizmoHelper = gizmo.getHelper();
+  getScene().add(gizmoHelper);
+
+  gizmo.addEventListener('change', () => {
+    syncVisuals();
+    notifyChange();
+  });
+  gizmo.addEventListener('dragging-changed', (e) => {
+    if (e.value === true) setUserOrbitLock(true);
+  });
+}
+
+function disposeGizmo(): void {
+  if (gizmo) {
+    gizmo.detach();
+    gizmo.dispose();
+    gizmo = null;
+  }
+  if (gizmoHelper) {
+    gizmoHelper.parent?.remove(gizmoHelper);
+    gizmoHelper = null;
+  }
+}
+
+/** Sync any visual props that depend on current state (e.g. paint color). */
+function syncVisuals(): void {
+  if (!boxMesh || !boxEdges) return;
+  const hex = colorToHex(getColor());
+  (boxMesh.material as THREE.MeshBasicMaterial).color.setHex(hex);
+  (boxEdges.material as THREE.LineBasicMaterial).color.setHex(hex);
+}
+
+/** Refresh visuals after the active paint color changed. */
+export function refreshColor(): void {
+  if (active) syncVisuals();
+}
+
+/** Commit the box's current footprint as a paint region. Returns the painted
+ *  triangle count, or 0 if the box was empty or no mesh was loaded. */
+export function commitBox(): number {
+  const mesh = getCurrentMesh();
+  if (!mesh || !proxy) return 0;
+
+  const box = getBox();
+  const triangles = findBoxTriangles(mesh, box);
+  if (triangles.size === 0) return 0;
+
+  const existingCount = getRegions().length;
+  addRegion(
+    `Box ${existingCount + 1}`,
+    [...getColor()] as [number, number, number],
+    'slab', // reuse the 'slab' source bucket — region badges treat it the same
+    { kind: 'box', center: box.center, size: box.size, quaternion: box.quaternion },
+    triangles,
+  );
+  return triangles.size;
+}
+
+function colorToHex(color: [number, number, number]): number {
+  const r = Math.round(Math.max(0, Math.min(1, color[0])) * 255);
+  const g = Math.round(Math.max(0, Math.min(1, color[1])) * 255);
+  const b = Math.round(Math.max(0, Math.min(1, color[2])) * 255);
+  return (r << 16) | (g << 8) | b;
+}

--- a/src/color/boxPaint.ts
+++ b/src/color/boxPaint.ts
@@ -1,0 +1,52 @@
+// Box painting — select all triangles whose centroid falls inside an
+// oriented bounding box (OBB). The box is defined by a world-space center,
+// a size (full lengths along its local X / Y / Z axes), and a quaternion
+// that rotates from box-local to world space.
+//
+// For a centroid C and box (center O, quaternion q, size s), the test is:
+//   local = q^-1 * (C - O)
+//   inside <=> |local.x| <= s.x/2 AND |local.y| <= s.y/2 AND |local.z| <= s.z/2
+
+import * as THREE from 'three';
+import type { MeshData } from '../geometry/types';
+
+export interface OrientedBox {
+  center: [number, number, number];
+  size: [number, number, number];
+  quaternion: [number, number, number, number]; // [x, y, z, w]
+}
+
+const tmpV = new THREE.Vector3();
+const tmpQ = new THREE.Quaternion();
+
+/** Return the set of triangle indices whose centroid lies inside the OBB. */
+export function findBoxTriangles(mesh: MeshData, box: OrientedBox): Set<number> {
+  const { triVerts, vertProperties, numProp, numTri } = mesh;
+  const result = new Set<number>();
+
+  const halfX = box.size[0] / 2;
+  const halfY = box.size[1] / 2;
+  const halfZ = box.size[2] / 2;
+  if (halfX <= 0 || halfY <= 0 || halfZ <= 0) return result;
+
+  const cx = box.center[0], cy = box.center[1], cz = box.center[2];
+  // Inverse rotation = conjugate for unit quaternions: (-x, -y, -z, w).
+  tmpQ.set(-box.quaternion[0], -box.quaternion[1], -box.quaternion[2], box.quaternion[3]);
+
+  for (let t = 0; t < numTri; t++) {
+    const v0 = triVerts[t * 3];
+    const v1 = triVerts[t * 3 + 1];
+    const v2 = triVerts[t * 3 + 2];
+
+    const ax = (vertProperties[v0 * numProp]     + vertProperties[v1 * numProp]     + vertProperties[v2 * numProp])     / 3 - cx;
+    const ay = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3 - cy;
+    const az = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3 - cz;
+
+    tmpV.set(ax, ay, az).applyQuaternion(tmpQ);
+    if (Math.abs(tmpV.x) <= halfX && Math.abs(tmpV.y) <= halfY && Math.abs(tmpV.z) <= halfZ) {
+      result.add(t);
+    }
+  }
+
+  return result;
+}

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -299,13 +299,16 @@ function onMouseLeave(): void {
 }
 
 /** Public helper: render a hover-style highlight over a triangle set.
- *  Used by the slab UI for live preview. Returns a teardown function. */
-export function previewTriangles(triangles: Set<number>): () => void {
-  showHighlight(triangles);
+ *  Used by the slab UI for live preview and by the region list for
+ *  hover-to-locate. Optional `color` overrides the active paint color
+ *  (defaults to whatever `setColor` last received). Returns a teardown
+ *  function. */
+export function previewTriangles(triangles: Set<number>, color?: [number, number, number]): () => void {
+  showHighlight(triangles, color);
   return () => clearHighlight();
 }
 
-function showHighlight(triangles: Set<number>): void {
+function showHighlight(triangles: Set<number>, colorOverride?: [number, number, number]): void {
   clearHighlight();
   if (!currentMesh) return;
   if (triangles.size === 0) return;
@@ -331,8 +334,9 @@ function showHighlight(triangles: Set<number>): void {
   geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   geo.computeVertexNormals();
 
+  const c = colorOverride ?? currentColor;
   const mat = new THREE.MeshBasicMaterial({
-    color: new THREE.Color(currentColor[0], currentColor[1], currentColor[2]),
+    color: new THREE.Color(c[0], c[1], c[2]),
     transparent: true,
     opacity: 0.4,
     side: THREE.DoubleSide,

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -16,6 +16,10 @@ let active = false;
 let currentColor: [number, number, number] = [1, 0.2, 0.2]; // default red
 let currentTool: PaintTool = 'bucket';
 let bucketTolerance = 0.9995;
+/** Brush radius in mesh units. 0 = single-triangle (legacy behavior); >0 = paint
+ *  every triangle whose centroid is within `brushRadius` of the picked surface
+ *  point. */
+let brushRadius = 0;
 let adjacency: AdjacencyGraph | null = null;
 let currentMesh: MeshData | null = null;
 
@@ -69,6 +73,14 @@ export function setBucketTolerance(tol: number): void {
 
 export function getBucketTolerance(): number {
   return bucketTolerance;
+}
+
+export function setBrushRadius(r: number): void {
+  brushRadius = Math.max(0, r);
+}
+
+export function getBrushRadius(): number {
+  return brushRadius;
 }
 
 export function setOnRegionPainted(fn: () => void): void {
@@ -151,7 +163,7 @@ function onMouseMove(event: MouseEvent): void {
   if (currentTool === 'brush' && brushPainting && brushSession) {
     const result = pickFace(event);
     if (result) {
-      brushSession.add(result.triangleIndex);
+      addBrushFootprint(result.triangleIndex, result.point, brushSession);
       showHighlight(brushSession);
     }
     return;
@@ -165,7 +177,8 @@ function onMouseMove(event: MouseEvent): void {
 
   let region: Set<number>;
   if (currentTool === 'brush') {
-    region = new Set([result.triangleIndex]);
+    region = new Set<number>();
+    addBrushFootprint(result.triangleIndex, result.point, region);
   } else {
     region = findCoplanarRegion(result.triangleIndex, adjacency, bucketTolerance);
   }
@@ -185,9 +198,32 @@ function onMouseDown(event: MouseEvent): void {
     const result = pickFace(event);
     if (!result) return;
     brushPainting = true;
-    brushSession = new Set([result.triangleIndex]);
+    brushSession = new Set<number>();
+    addBrushFootprint(result.triangleIndex, result.point, brushSession);
     showHighlight(brushSession);
     event.preventDefault();
+  }
+}
+
+/** Expand a single picked triangle into the brush's full footprint.
+ *  At brushRadius=0 this just adds the picked triangle (legacy behavior).
+ *  At brushRadius>0 it adds every triangle whose centroid lies within
+ *  `brushRadius` of the picked surface point. */
+function addBrushFootprint(seedTri: number, seedPoint: [number, number, number], target: Set<number>): void {
+  target.add(seedTri);
+  if (brushRadius <= 0 || !adjacency) return;
+
+  const { centroids } = adjacency;
+  const numTri = centroids.length / 3;
+  const r2 = brushRadius * brushRadius;
+  const sx = seedPoint[0], sy = seedPoint[1], sz = seedPoint[2];
+
+  for (let t = 0; t < numTri; t++) {
+    if (target.has(t)) continue;
+    const dx = centroids[t * 3]     - sx;
+    const dy = centroids[t * 3 + 1] - sy;
+    const dz = centroids[t * 3 + 2] - sz;
+    if (dx * dx + dy * dy + dz * dz <= r2) target.add(t);
   }
 }
 

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -8,9 +8,10 @@ import { buildAdjacency, findCoplanarRegion, getTriangleNormal, type AdjacencyGr
 import { addRegion, getRegions } from './regions';
 import { getMeshGroup, getRenderer, setUserOrbitLock, isUserOrbitLocked } from '../renderer/viewport';
 import { activate as activateSlabDrag, deactivate as deactivateSlabDrag, onMeshChanged as onSlabDragMeshChanged } from './slabDrag';
+import { activate as activateBoxDrag, deactivate as deactivateBoxDrag, onMeshChanged as onBoxDragMeshChanged } from './boxDrag';
 export { setSlabAxis, getSlabAxis } from './slabDrag';
 
-export type PaintTool = 'bucket' | 'brush' | 'slab';
+export type PaintTool = 'bucket' | 'brush' | 'slab' | 'box';
 
 let active = false;
 let currentColor: [number, number, number] = [1, 0.2, 0.2]; // default red
@@ -58,6 +59,8 @@ export function setTool(tool: PaintTool): void {
   if (active) {
     if (tool === 'slab') activateSlabDrag();
     else if (prev === 'slab') deactivateSlabDrag();
+    if (tool === 'box') activateBoxDrag();
+    else if (prev === 'box') deactivateBoxDrag();
   }
 
   if (onToolChange) onToolChange(tool);
@@ -105,6 +108,7 @@ export function updatePaintMesh(mesh: MeshData): void {
   if (active) {
     adjacency = buildAdjacency(mesh);
     onSlabDragMeshChanged();
+    onBoxDragMeshChanged();
   }
   clearHighlight();
 }
@@ -128,6 +132,7 @@ export function activate(): void {
   canvas.style.cursor = 'crosshair';
 
   if (currentTool === 'slab') activateSlabDrag();
+  if (currentTool === 'box') activateBoxDrag();
 }
 
 export function deactivate(): void {
@@ -138,6 +143,7 @@ export function deactivate(): void {
   if (!priorOrbitLock) setUserOrbitLock(false);
 
   deactivateSlabDrag();
+  deactivateBoxDrag();
 
   const canvas = getRenderer().domElement;
   canvas.removeEventListener('mousemove', onMouseMove);
@@ -153,8 +159,9 @@ export function deactivate(): void {
 function onMouseMove(event: MouseEvent): void {
   if (!adjacency || !currentMesh) return;
 
-  // Slab tool doesn't use viewport hover; controls are panel-based.
-  if (currentTool === 'slab') {
+  // Slab and box tools own their own gizmo / drag interactions; the
+  // bucket-vs-brush hover preview gets out of the way.
+  if (currentTool === 'slab' || currentTool === 'box') {
     clearHighlight();
     return;
   }
@@ -192,7 +199,7 @@ function onMouseMove(event: MouseEvent): void {
 function onMouseDown(event: MouseEvent): void {
   if (!adjacency || !currentMesh) return;
   if (event.button !== 0) return;
-  if (currentTool === 'slab') return;
+  if (currentTool === 'slab' || currentTool === 'box') return;
 
   if (currentTool === 'brush') {
     const result = pickFace(event);
@@ -230,7 +237,7 @@ function addBrushFootprint(seedTri: number, seedPoint: [number, number, number],
 function onMouseUp(event: MouseEvent): void {
   if (!adjacency || !currentMesh) return;
   if (event.button !== 0) return;
-  if (currentTool === 'slab') return;
+  if (currentTool === 'slab' || currentTool === 'box') return;
 
   if (currentTool === 'brush') {
     if (!brushPainting || !brushSession || brushSession.size === 0) {

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -14,6 +14,7 @@ import {
   getBrushRadius,
   setSlabAxis,
   getSlabAxis,
+  previewTriangles,
   type PaintTool,
 } from './paintMode';
 import {
@@ -538,8 +539,22 @@ function updateRegionList(container: HTMLElement): void {
 
   for (const region of regions) {
     const row = document.createElement('div');
-    row.className = 'flex items-center gap-1.5 py-0.5 group';
+    row.className = 'flex items-center gap-1.5 py-0.5 group rounded px-1 -mx-1 hover:bg-zinc-700/40 transition-colors cursor-default';
     row.dataset.regionId = String(region.id);
+
+    // Hover-to-locate: tint the painted triangles with the region's own color
+    // so the user can see at a glance where in the viewport this row lives.
+    // Uses the same translucent overlay the brush/bucket tools draw under the
+    // cursor — mirrored on the panel side. Teardown fires on mouseleave so a
+    // stale highlight never sticks.
+    let releaseHover: (() => void) | null = null;
+    row.addEventListener('mouseenter', () => {
+      if (region.triangles.size === 0) return;
+      releaseHover = previewTriangles(region.triangles, region.color);
+    });
+    row.addEventListener('mouseleave', () => {
+      if (releaseHover) { releaseHover(); releaseHover = null; }
+    });
 
     const dot = document.createElement('span');
     dot.className = 'w-3 h-3 rounded-sm shrink-0';

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -34,6 +34,7 @@ import {
 import { forceDeactivate as forceDeactivateAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as forceDeactivateAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as forceDeactivateAnnotateSelect } from '../annotations/selectMode';
+import { setBoxMode, getBoxMode, setBox, commitBox, onBoxChange, type BoxMode } from './boxDrag';
 
 const PRESET_COLORS: [number, number, number][] = [
   // Warm
@@ -68,6 +69,7 @@ let toolButtons: Partial<Record<PaintTool, HTMLButtonElement>> = {};
 let bucketControls: HTMLElement | null = null;
 let brushControls: HTMLElement | null = null;
 let slabControls: HTMLElement | null = null;
+let boxControls: HTMLElement | null = null;
 
 /** Initialize the paint UI inside the clip-controls overlay area. */
 export function initPaintUI(controlsContainer: HTMLElement): void {
@@ -155,10 +157,11 @@ function createPickerPanel(): HTMLElement {
   panel.appendChild(toolTitle);
 
   const toolRow = document.createElement('div');
-  toolRow.className = 'grid grid-cols-3 gap-1 mb-2.5';
+  toolRow.className = 'grid grid-cols-2 gap-1 mb-2.5';
   toolRow.appendChild(createToolButton('bucket', '\u{1FAA3} Bucket', 'Flood-fill across coplanar faces'));
   toolRow.appendChild(createToolButton('brush', '\u{1F58C}\uFE0F Brush', 'Paint individual triangles (drag to paint)'));
-  toolRow.appendChild(createToolButton('slab', '\u{1F9F1} Slab', 'Paint all faces inside a slab range'));
+  toolRow.appendChild(createToolButton('slab', '\u{1F9F1} Slab', 'Paint all faces inside an axis-aligned range'));
+  toolRow.appendChild(createToolButton('box', '\u{1F4E6} Box', 'Paint everything inside a positionable, rotatable, scalable 3D box'));
   panel.appendChild(toolRow);
 
   // === Color picker ===
@@ -223,6 +226,10 @@ function createPickerPanel(): HTMLElement {
   // === Slab tool controls ===
   slabControls = createSlabControls();
   panel.appendChild(slabControls);
+
+  // === Box tool controls ===
+  boxControls = createBoxControls();
+  panel.appendChild(boxControls);
 
   // === Region list ===
   const regionList = document.createElement('div');
@@ -298,6 +305,7 @@ function syncToolPanels(): void {
   if (bucketControls) bucketControls.classList.toggle('hidden', tool !== 'bucket');
   if (brushControls) brushControls.classList.toggle('hidden', tool !== 'brush');
   if (slabControls) slabControls.classList.toggle('hidden', tool !== 'slab');
+  if (boxControls) boxControls.classList.toggle('hidden', tool !== 'box');
 }
 
 function createBucketControls(): HTMLElement {
@@ -501,6 +509,161 @@ function axisButtonClass(active: boolean): string {
     return 'px-2 py-1 rounded text-[11px] bg-blue-500/30 text-blue-200 border border-blue-500/50 transition-colors';
   }
   return 'px-2 py-1 rounded text-[11px] bg-zinc-700/40 text-zinc-300 hover:bg-zinc-600/60 border border-transparent transition-colors';
+}
+
+function createBoxControls(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'mt-2 pt-2 border-t border-zinc-700 hidden';
+
+  // Mode buttons — translate / rotate / scale, drives the gizmo.
+  const modeLabel = document.createElement('div');
+  modeLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium';
+  modeLabel.textContent = 'Box transform';
+  wrap.appendChild(modeLabel);
+
+  const modeRow = document.createElement('div');
+  modeRow.className = 'grid grid-cols-3 gap-1 mb-2';
+  const modeBtns: Partial<Record<BoxMode, HTMLButtonElement>> = {};
+  for (const m of ['translate', 'rotate', 'scale'] as const) {
+    const btn = document.createElement('button');
+    btn.textContent = m === 'translate' ? 'Move' : m === 'rotate' ? 'Rotate' : 'Resize';
+    btn.className = axisButtonClass(m === getBoxMode());
+    btn.title = `Switch the gizmo to ${m} mode`;
+    btn.addEventListener('click', () => {
+      setBoxMode(m);
+      for (const [k, b] of Object.entries(modeBtns)) {
+        if (b) b.className = axisButtonClass(k === getBoxMode());
+      }
+    });
+    modeRow.appendChild(btn);
+    modeBtns[m] = btn;
+  }
+  wrap.appendChild(modeRow);
+
+  // Numeric readout — center / size / rotation. Two-way synced with the gizmo.
+  const grid = document.createElement('div');
+  grid.className = 'grid grid-cols-[auto_repeat(3,_minmax(0,_1fr))] gap-1 text-[10px] text-zinc-400 items-center';
+
+  const centerInputs = makeVectorRow(grid, 'Pos',  -1e6, 1e6, 0.1, (v) => setBox({ center: v }));
+  const sizeInputs   = makeVectorRow(grid, 'Size',  0.001, 1e6, 0.1, (v) => setBox({ size: v }));
+  const rotInputs    = makeVectorRow(grid, 'Rot°', -360, 360, 1, (v) => {
+    // Convert Euler degrees -> quaternion (XYZ order).
+    const ex = v[0] * Math.PI / 180;
+    const ey = v[1] * Math.PI / 180;
+    const ez = v[2] * Math.PI / 180;
+    const q = eulerXYZToQuat(ex, ey, ez);
+    setBox({ quaternion: q });
+  });
+  wrap.appendChild(grid);
+
+  // Action: paint inside the current box.
+  const actionRow = document.createElement('div');
+  actionRow.className = 'mt-2 flex flex-col gap-1';
+
+  const paintBtn = document.createElement('button');
+  paintBtn.className = 'w-full px-2 py-1.5 rounded text-[11px] bg-blue-500/30 text-blue-200 hover:bg-blue-500/50 border border-blue-500/50 transition-colors font-medium';
+  paintBtn.textContent = 'Paint inside box';
+  paintBtn.title = 'Commit every triangle inside the box as a new color region';
+  paintBtn.addEventListener('click', () => {
+    const painted = commitBox();
+    if (painted === 0) {
+      paintBtn.textContent = 'No triangles in box';
+      window.setTimeout(() => { paintBtn.textContent = 'Paint inside box'; }, 1200);
+    }
+  });
+  actionRow.appendChild(paintBtn);
+
+  const help = document.createElement('div');
+  help.className = 'text-[10px] text-zinc-500 leading-relaxed';
+  help.textContent = 'Drag the gizmo handles in the viewport, or edit values above. The box is rendered in the active paint color.';
+  actionRow.appendChild(help);
+
+  wrap.appendChild(actionRow);
+
+  // Keep the numeric inputs in sync when the gizmo moves.
+  onBoxChange((box) => {
+    if (!isInputFocused(centerInputs)) setVector(centerInputs, box.center, 2);
+    if (!isInputFocused(sizeInputs))   setVector(sizeInputs,   box.size,   2);
+    if (!isInputFocused(rotInputs)) {
+      const e = quatToEulerXYZ(box.quaternion);
+      setVector(rotInputs, [e[0] * 180 / Math.PI, e[1] * 180 / Math.PI, e[2] * 180 / Math.PI], 1);
+    }
+  });
+
+  return wrap;
+}
+
+/** Build a label + 3 number inputs (X/Y/Z) for a vector property. */
+function makeVectorRow(parent: HTMLElement, label: string, min: number, max: number, step: number, onChange: (v: [number, number, number]) => void): HTMLInputElement[] {
+  const labelEl = document.createElement('span');
+  labelEl.className = 'text-zinc-500 text-right pr-1 tabular-nums';
+  labelEl.textContent = label;
+  parent.appendChild(labelEl);
+
+  const inputs: HTMLInputElement[] = [];
+  for (let i = 0; i < 3; i++) {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.min = String(min);
+    input.max = String(max);
+    input.step = String(step);
+    input.value = '0';
+    input.className = 'min-w-0 px-1 py-0.5 text-[11px] bg-zinc-900/70 border border-zinc-600/60 rounded text-zinc-200 text-right tabular-nums';
+    const apply = (): void => {
+      const v = inputs.map(x => parseFloat(x.value));
+      if (v.every(Number.isFinite)) onChange([v[0], v[1], v[2]]);
+    };
+    input.addEventListener('change', apply);
+    input.addEventListener('keydown', (e) => { if (e.key === 'Enter') { apply(); input.blur(); } });
+    parent.appendChild(input);
+    inputs.push(input);
+  }
+  return inputs;
+}
+
+function setVector(inputs: HTMLInputElement[], vec: [number, number, number], decimals: number): void {
+  for (let i = 0; i < 3; i++) inputs[i].value = vec[i].toFixed(decimals);
+}
+
+function isInputFocused(inputs: HTMLInputElement[]): boolean {
+  return inputs.some(i => document.activeElement === i);
+}
+
+/** Convert XYZ Euler angles (radians) to a quaternion [x, y, z, w]. */
+function eulerXYZToQuat(x: number, y: number, z: number): [number, number, number, number] {
+  const c1 = Math.cos(x / 2), s1 = Math.sin(x / 2);
+  const c2 = Math.cos(y / 2), s2 = Math.sin(y / 2);
+  const c3 = Math.cos(z / 2), s3 = Math.sin(z / 2);
+  return [
+    s1 * c2 * c3 + c1 * s2 * s3,
+    c1 * s2 * c3 - s1 * c2 * s3,
+    c1 * c2 * s3 + s1 * s2 * c3,
+    c1 * c2 * c3 - s1 * s2 * s3,
+  ];
+}
+
+/** Convert a quaternion to XYZ Euler angles (radians). Matches THREE's
+ *  Euler.setFromQuaternion with order 'XYZ' so the gizmo readout stays
+ *  consistent with the gizmo input. */
+function quatToEulerXYZ(q: [number, number, number, number]): [number, number, number] {
+  const [x, y, z, w] = q;
+  const m11 = 1 - 2 * (y * y + z * z);
+  const m12 = 2 * (x * y - w * z);
+  const m13 = 2 * (x * z + w * y);
+  const m22 = 1 - 2 * (x * x + z * z);
+  const m23 = 2 * (y * z - w * x);
+  const m32 = 2 * (y * z + w * x);
+  const m33 = 1 - 2 * (x * x + y * y);
+  const ey = Math.asin(Math.max(-1, Math.min(1, m13)));
+  let ex: number, ez: number;
+  if (Math.abs(m13) < 0.99999) {
+    ex = Math.atan2(-m23, m33);
+    ez = Math.atan2(-m12, m11);
+  } else {
+    ex = Math.atan2(m32, m22);
+    ez = 0;
+  }
+  return [ex, ey, ez];
 }
 
 function updateVisibilityButton(): void {

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -31,14 +31,26 @@ import { forceDeactivate as forceDeactivateAnnotateText } from '../annotations/t
 import { forceDeactivate as forceDeactivateAnnotateSelect } from '../annotations/selectMode';
 
 const PRESET_COLORS: [number, number, number][] = [
+  // Warm
   [0.92, 0.26, 0.21], // red
-  [0.13, 0.59, 0.95], // blue
-  [0.30, 0.69, 0.31], // green
-  [1.00, 0.76, 0.03], // yellow
-  [0.61, 0.15, 0.69], // purple
   [1.00, 0.60, 0.00], // orange
+  [1.00, 0.76, 0.03], // yellow
+  [0.55, 0.36, 0.22], // brown
+  // Cool
+  [0.55, 0.85, 0.20], // lime
+  [0.30, 0.69, 0.31], // green
   [0.00, 0.74, 0.83], // teal
+  [0.13, 0.59, 0.95], // blue
+  // Purples / pinks
+  [0.10, 0.20, 0.55], // navy
+  [0.61, 0.15, 0.69], // purple
+  [0.93, 0.05, 0.65], // magenta
   [0.91, 0.12, 0.39], // pink
+  // Neutrals
+  [1.00, 1.00, 1.00], // white
+  [0.75, 0.75, 0.75], // light gray
+  [0.35, 0.35, 0.35], // dark gray
+  [0.00, 0.00, 0.00], // black
 ];
 
 let paintBtn: HTMLButtonElement | null = null;

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -10,6 +10,8 @@ import {
   getTool,
   setBucketTolerance,
   getBucketTolerance,
+  setBrushRadius,
+  getBrushRadius,
   setSlabAxis,
   getSlabAxis,
   type PaintTool,
@@ -25,6 +27,8 @@ import {
   redoLastRegion,
   canRedoRegion,
   clearRegions,
+  removeRegion,
+  setRegionVisibility,
 } from './regions';
 import { forceDeactivate as forceDeactivateAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as forceDeactivateAnnotateText } from '../annotations/textMode';
@@ -61,6 +65,7 @@ let undoBtn: HTMLButtonElement | null = null;
 let redoBtn: HTMLButtonElement | null = null;
 let toolButtons: Partial<Record<PaintTool, HTMLButtonElement>> = {};
 let bucketControls: HTMLElement | null = null;
+let brushControls: HTMLElement | null = null;
 let slabControls: HTMLElement | null = null;
 
 /** Initialize the paint UI inside the clip-controls overlay area. */
@@ -206,9 +211,13 @@ function createPickerPanel(): HTMLElement {
   customRow.appendChild(customLabel);
   panel.appendChild(customRow);
 
-  // === Bucket tool controls (tolerance slider) ===
+  // === Bucket tool controls (tolerance slider + number input) ===
   bucketControls = createBucketControls();
   panel.appendChild(bucketControls);
+
+  // === Brush tool controls (radius slider + number input) ===
+  brushControls = createBrushControls();
+  panel.appendChild(brushControls);
 
   // === Slab tool controls ===
   slabControls = createSlabControls();
@@ -286,6 +295,7 @@ function syncToolPanels(): void {
     if (btn) btn.className = toolButtonClass(t === tool);
   }
   if (bucketControls) bucketControls.classList.toggle('hidden', tool !== 'bucket');
+  if (brushControls) brushControls.classList.toggle('hidden', tool !== 'brush');
   if (slabControls) slabControls.classList.toggle('hidden', tool !== 'slab');
 }
 
@@ -294,36 +304,135 @@ function createBucketControls(): HTMLElement {
   wrap.className = 'mt-2 pt-2 border-t border-zinc-700';
 
   const label = document.createElement('div');
-  label.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium flex items-center justify-between';
-  const labelText = document.createElement('span');
-  labelText.textContent = 'Bucket tolerance';
-  const valueSpan = document.createElement('span');
-  valueSpan.className = 'text-zinc-400 normal-case tracking-normal';
-  valueSpan.textContent = formatTolerance(getBucketTolerance());
-  label.appendChild(labelText);
-  label.appendChild(valueSpan);
+  label.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium';
+  label.textContent = 'Bucket tolerance';
   wrap.appendChild(label);
 
-  // Slider exposes 1 - tolerance on a quasi-log scale so small changes near
-  // 1.0 (the strict end) are easy to dial in.
+  // Slider 0..100 maps to angle 0\u00B0..180\u00B0 (where tolerance = cos(angle)).
+  // Number input is the same angle in degrees, two-way synced with the slider
+  // so users who already know the angle they want (e.g. 5\u00B0) can just type it.
+  const row = document.createElement('div');
+  row.className = 'flex items-center gap-2';
+
   const slider = document.createElement('input');
   slider.type = 'range';
   slider.min = '0';
   slider.max = '100';
   slider.step = '1';
   slider.value = String(toleranceToSliderPct(getBucketTolerance()));
-  slider.className = 'w-full accent-blue-500';
+  slider.className = 'flex-1 accent-blue-500 min-w-0';
   slider.title = 'Maximum bend angle (0\u00B0\u2013180\u00B0) between adjacent faces the flood-fill is allowed to cross';
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = '0';
+  input.max = '180';
+  input.step = '0.1';
+  input.value = toleranceToAngleDeg(getBucketTolerance()).toFixed(1);
+  input.className = 'w-14 px-1 py-0.5 text-[11px] bg-zinc-900/70 border border-zinc-600/60 rounded text-zinc-200 text-right tabular-nums';
+  input.title = 'Bend angle in degrees (0\u2013180)';
+
+  const unit = document.createElement('span');
+  unit.className = 'text-[10px] text-zinc-500';
+  unit.textContent = '\u00B0';
+
   slider.addEventListener('input', () => {
     const tol = sliderPctToTolerance(parseInt(slider.value, 10));
     setBucketTolerance(tol);
-    valueSpan.textContent = formatTolerance(tol);
+    input.value = toleranceToAngleDeg(tol).toFixed(1);
   });
-  wrap.appendChild(slider);
+
+  const applyAngle = (): void => {
+    const raw = parseFloat(input.value);
+    if (!Number.isFinite(raw)) {
+      input.value = toleranceToAngleDeg(getBucketTolerance()).toFixed(1);
+      return;
+    }
+    const angle = Math.max(0, Math.min(180, raw));
+    const tol = Math.cos(angle * Math.PI / 180);
+    setBucketTolerance(tol);
+    slider.value = String(toleranceToSliderPct(tol));
+    input.value = angle.toFixed(1);
+  };
+  input.addEventListener('change', applyAngle);
+  input.addEventListener('keydown', (e) => { if (e.key === 'Enter') { applyAngle(); input.blur(); } });
+
+  row.appendChild(slider);
+  row.appendChild(input);
+  row.appendChild(unit);
+  wrap.appendChild(row);
 
   const help = document.createElement('div');
   help.className = 'text-[10px] text-zinc-500 mt-1';
   help.textContent = 'Coplanar only \u2190\u2014\u2014\u2192 Whole connected mesh';
+  wrap.appendChild(help);
+
+  return wrap;
+}
+
+function createBrushControls(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'mt-2 pt-2 border-t border-zinc-700 hidden';
+
+  const label = document.createElement('div');
+  label.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium';
+  label.textContent = 'Brush size';
+  wrap.appendChild(label);
+
+  // Slider 0..200 = radius in tenths-of-a-unit (0..20 mesh units). Number input
+  // accepts any non-negative value so users on larger meshes can type past the
+  // slider cap.
+  const row = document.createElement('div');
+  row.className = 'flex items-center gap-2';
+
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.min = '0';
+  slider.max = '200';
+  slider.step = '1';
+  slider.value = String(Math.round(Math.min(getBrushRadius(), 20) * 10));
+  slider.className = 'flex-1 accent-blue-500 min-w-0';
+  slider.title = 'Brush radius in mesh units (0 = single triangle)';
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = '0';
+  input.step = '0.1';
+  input.value = getBrushRadius().toFixed(1);
+  input.className = 'w-14 px-1 py-0.5 text-[11px] bg-zinc-900/70 border border-zinc-600/60 rounded text-zinc-200 text-right tabular-nums';
+  input.title = 'Brush radius in mesh units';
+
+  const unit = document.createElement('span');
+  unit.className = 'text-[10px] text-zinc-500';
+  unit.textContent = 'u';
+
+  slider.addEventListener('input', () => {
+    const radius = parseInt(slider.value, 10) / 10;
+    setBrushRadius(radius);
+    input.value = radius.toFixed(1);
+  });
+
+  const applyRadius = (): void => {
+    const raw = parseFloat(input.value);
+    if (!Number.isFinite(raw) || raw < 0) {
+      input.value = getBrushRadius().toFixed(1);
+      return;
+    }
+    setBrushRadius(raw);
+    slider.value = String(Math.round(Math.min(raw, 20) * 10));
+    input.value = raw.toFixed(1);
+  };
+  input.addEventListener('change', applyRadius);
+  input.addEventListener('keydown', (e) => { if (e.key === 'Enter') { applyRadius(); input.blur(); } });
+
+  row.appendChild(slider);
+  row.appendChild(input);
+  row.appendChild(unit);
+  wrap.appendChild(row);
+
+  const help = document.createElement('div');
+  help.className = 'text-[10px] text-zinc-500 mt-1';
+  help.textContent = 'Single triangle \u2190\u2014\u2014\u2192 Wider brush';
   wrap.appendChild(help);
 
   return wrap;
@@ -342,10 +451,8 @@ function sliderPctToTolerance(pct: number): number {
   return Math.cos(angleDeg * Math.PI / 180);
 }
 
-function formatTolerance(tol: number): string {
-  // Show as "θ ≤ N°" — the angle whose cosine is `tol`. Friendlier than 0.9995.
-  const angleDeg = Math.acos(Math.max(-1, Math.min(1, tol))) * 180 / Math.PI;
-  return `\u2264 ${angleDeg.toFixed(1)}\u00B0`;
+function toleranceToAngleDeg(tol: number): number {
+  return Math.acos(Math.max(-1, Math.min(1, tol))) * 180 / Math.PI;
 }
 
 function createSlabControls(): HTMLElement {
@@ -431,25 +538,61 @@ function updateRegionList(container: HTMLElement): void {
 
   for (const region of regions) {
     const row = document.createElement('div');
-    row.className = 'flex items-center gap-1.5 py-0.5';
+    row.className = 'flex items-center gap-1.5 py-0.5 group';
+    row.dataset.regionId = String(region.id);
 
     const dot = document.createElement('span');
     dot.className = 'w-3 h-3 rounded-sm shrink-0';
     dot.style.backgroundColor = rgbToCSS(region.color);
+    if (!region.visible) dot.classList.add('opacity-30');
 
     const label = document.createElement('span');
-    label.className = 'text-[11px] text-zinc-400 truncate flex-1';
+    label.className = `text-[11px] truncate flex-1 ${region.visible ? 'text-zinc-400' : 'text-zinc-600 line-through'}`;
     label.textContent = region.name;
 
     const count = document.createElement('span');
-    count.className = 'text-[10px] text-zinc-600';
+    count.className = 'text-[10px] text-zinc-600 tabular-nums';
     count.textContent = `${region.triangles.size}\u25B3`;
+
+    const eyeBtn = document.createElement('button');
+    eyeBtn.className = 'shrink-0 w-4 h-4 flex items-center justify-center text-zinc-500 hover:text-zinc-200 transition-colors';
+    eyeBtn.title = region.visible ? 'Hide this region' : 'Show this region';
+    eyeBtn.dataset.action = 'toggle-region-visibility';
+    eyeBtn.innerHTML = region.visible ? eyeIconSVG() : eyeOffIconSVG();
+    eyeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      setRegionVisibility(region.id, !region.visible);
+    });
+
+    const trashBtn = document.createElement('button');
+    trashBtn.className = 'shrink-0 w-4 h-4 flex items-center justify-center text-zinc-500 hover:text-red-400 transition-colors';
+    trashBtn.title = 'Delete this region';
+    trashBtn.dataset.action = 'delete-region';
+    trashBtn.innerHTML = trashIconSVG();
+    trashBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      removeRegion(region.id);
+    });
 
     row.appendChild(dot);
     row.appendChild(label);
     row.appendChild(count);
+    row.appendChild(eyeBtn);
+    row.appendChild(trashBtn);
     container.appendChild(row);
   }
+}
+
+function eyeIconSVG(): string {
+  return '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" class="w-3.5 h-3.5"><path d="M1 8c1.5-3 4-5 7-5s5.5 2 7 5c-1.5 3-4 5-7 5s-5.5-2-7-5z"/><circle cx="8" cy="8" r="2"/></svg>';
+}
+
+function eyeOffIconSVG(): string {
+  return '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" class="w-3.5 h-3.5"><path d="M1 8c1.5-3 4-5 7-5s5.5 2 7 5c-1.5 3-4 5-7 5s-5.5-2-7-5z"/><line x1="2" y1="2" x2="14" y2="14"/></svg>';
+}
+
+function trashIconSVG(): string {
+  return '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" class="w-3.5 h-3.5"><path d="M3 4h10M5 4V2.5a1 1 0 011-1h4a1 1 0 011 1V4m-6 0v9.5a1 1 0 001 1h4a1 1 0 001-1V4"/></svg>';
 }
 
 function rgbToCSS(color: [number, number, number]): string {

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -16,6 +16,7 @@ export interface ColorRegion {
 export type RegionDescriptor =
   | { kind: 'coplanar'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; normalTolerance: number }
   | { kind: 'slab'; normal: [number, number, number]; offset: number; thickness: number }
+  | { kind: 'box'; center: [number, number, number]; size: [number, number, number]; quaternion: [number, number, number, number] }
   | { kind: 'triangles'; ids: number[] }
   | { kind: 'byLabel'; label: string }
   | { kind: 'connectedFromSeed'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; maxDeviationDeg: number };

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -9,6 +9,7 @@ export interface ColorRegion {
   source: 'face-pick' | 'slab' | 'subtree' | 'paintbrush';
   descriptor: RegionDescriptor;
   order: number;
+  visible: boolean;
   triangles: Set<number>; // resolved triangle indices (transient, not persisted)
 }
 
@@ -26,6 +27,7 @@ export interface SerializedColorRegion {
   source: ColorRegion['source'];
   descriptor: RegionDescriptor;
   order: number;
+  visible?: boolean; // optional for backward compat — defaults to true on load
 }
 
 type ChangeListener = () => void;
@@ -109,6 +111,7 @@ export function addRegion(
   source: ColorRegion['source'],
   descriptor: RegionDescriptor,
   triangles: Set<number>,
+  visible: boolean = true,
 ): ColorRegion {
   const id = Date.now() + Math.floor(Math.random() * 1000);
   const region: ColorRegion = {
@@ -118,12 +121,31 @@ export function addRegion(
     source,
     descriptor,
     order: nextOrder++,
+    visible,
     triangles,
   };
   regions.push(region);
   clearRedoStack();
   notify();
   return region;
+}
+
+export function getRegion(id: number): ColorRegion | undefined {
+  return regions.find(r => r.id === id);
+}
+
+export function setRegionVisibility(id: number, visible: boolean): boolean {
+  const region = regions.find(r => r.id === id);
+  if (!region) return false;
+  if (region.visible === visible) return true;
+  region.visible = visible;
+  notify();
+  return true;
+}
+
+export function isRegionVisible(id: number): boolean | undefined {
+  const region = regions.find(r => r.id === id);
+  return region?.visible;
 }
 
 export function removeRegion(id: number): boolean {
@@ -176,8 +198,12 @@ export function clearRegions(): void {
 }
 
 /** Build triColors (Uint8Array, numTri*3 RGB) from current regions.
- *  Higher-order regions win on overlap. Returns null if no regions. */
-export function buildTriColors(numTri: number): Uint8Array | null {
+ *  Higher-order regions win on overlap. Returns null if no regions.
+ *
+ *  `respectPerRegionVisibility` (default false) skips regions with `visible:false`
+ *  so the viewport reflects per-region eye-toggle state. Exports leave it false
+ *  so a hidden-in-UI region still ships in the GLB/3MF. */
+export function buildTriColors(numTri: number, respectPerRegionVisibility = false): Uint8Array | null {
   if (regions.length === 0) return null;
 
   const buf = new Uint8Array(numTri * 3); // default 0,0,0 — will be ignored for unpainted tris
@@ -186,8 +212,9 @@ export function buildTriColors(numTri: number): Uint8Array | null {
   const triOrder = new Int32Array(numTri); // 0 = unpainted
   triOrder.fill(0);
 
-  // Sort by order ascending so higher-order regions overwrite lower
-  const sorted = [...regions].sort((a, b) => a.order - b.order);
+  // Sort by order ascending so higher-order regions overwrite lower.
+  const eligible = respectPerRegionVisibility ? regions.filter(r => r.visible) : regions;
+  const sorted = [...eligible].sort((a, b) => a.order - b.order);
 
   for (const region of sorted) {
     const r = Math.round(region.color[0] * 255);
@@ -260,29 +287,34 @@ export function serialize(): SerializedColorRegion[] {
     source: r.source,
     descriptor: r.descriptor,
     order: r.order,
+    visible: r.visible,
   }));
 }
 
 export function deserialize(data: SerializedColorRegion[]): void {
   regions = data.map(d => ({
     ...d,
+    visible: d.visible !== false, // older saves lack the field — default to visible
     triangles: new Set<number>(),
   }));
   nextOrder = regions.reduce((max, r) => Math.max(max, r.order + 1), 1);
   clearRedoStack();
 }
 
-/** Apply triColors to a MeshData, returning a new object (non-destructive). */
+/** Apply triColors to a MeshData, returning a new object (non-destructive).
+ *  Use for EXPORTS — all regions are baked in regardless of UI visibility flags. */
 export function applyTriColors(mesh: MeshData): MeshData {
-  const triColors = buildTriColors(mesh.numTri);
+  const triColors = buildTriColors(mesh.numTri, false);
   if (!triColors) return mesh;
   return { ...mesh, triColors };
 }
 
-/** Same as `applyTriColors` but returns the mesh unchanged when paint
- *  visibility is toggled off. Use this for viewport rendering; exports should
- *  call `applyTriColors` directly so colors persist regardless of UI state. */
+/** Viewport-facing variant: returns the mesh unchanged when the global paint
+ *  visibility is toggled off, and skips individual regions whose per-region
+ *  `visible` flag is false (eye-icon toggles in the region list). */
 export function applyTriColorsIfVisible(mesh: MeshData): MeshData {
   if (!visible) return mesh;
-  return applyTriColors(mesh);
+  const triColors = buildTriColors(mesh.numTri, true);
+  if (!triColors) return mesh;
+  return { ...mesh, triColors };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,8 @@ import {
 import { setColor as setAnnotateColor, setWidth as setAnnotateWidth, getWidth as getAnnotateWidth } from './annotations/annotateMode';
 import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontSize as getAnnotateFontSize } from './annotations/textMode';
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
-import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, buildTriColors, createEmptyTriColors, overlayPainted, type SerializedColorRegion } from './color/regions';
+import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, buildTriColors, createEmptyTriColors, overlayPainted, type SerializedColorRegion } from './color/regions';
+import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as getPaintBucketTolerance, setBrushRadius as setPaintBrushRadius, getBrushRadius as getPaintBrushRadius } from './color/paintMode';
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
 import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, resolveSeed, findNearestTriangle } from './color/adjacency';
 import { findSlabTriangles } from './color/slabPaint';
@@ -564,7 +565,7 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): vo
     }
 
     if (triangles.size > 0) {
-      addRegion(region.name, region.color, region.source, region.descriptor, triangles);
+      addRegion(region.name, region.color, region.source, region.descriptor, triangles, region.visible !== false);
     }
   }
 
@@ -3520,6 +3521,7 @@ async function main() {
           source: r.source,
           triangles: r.triangles.size,
           order: r.order,
+          visible: r.visible,
           bbox: stats?.bbox ?? null,
           centroid: stats?.centroid ?? null,
         };
@@ -3918,6 +3920,67 @@ async function main() {
       scheduleColorRefresh();
       syncLockState();
       return { removed: true, id };
+    },
+
+    /** Toggle whether a single region is rendered in the viewport. Hidden
+     *  regions still ship in GLB/3MF exports — visibility is a UI-only flag
+     *  meant for previewing the model without a region's overlay. Mirrors the
+     *  eye-icon button in the paint panel's region list. Returns
+     *  `{ id, visible }` on success or `{ error }` if no region matches. */
+    setRegionVisibility(id: number, visible: boolean) {
+      if (!Number.isFinite(id)) return { error: 'setRegionVisibility(id, visible) requires a finite integer id from listRegions()' };
+      if (typeof visible !== 'boolean') return { error: 'setRegionVisibility(id, visible): visible must be a boolean (true | false)' };
+      const ok = setRegionVisibility(id, visible);
+      if (!ok) return { error: `No region with id=${id}. Call listRegions() to see current ids.` };
+      scheduleColorRefresh();
+      return { id, visible };
+    },
+
+    /** Shorthand for `setRegionVisibility(id, false)`. */
+    hideRegion(id: number) {
+      return this.setRegionVisibility(id, false);
+    },
+
+    /** Shorthand for `setRegionVisibility(id, true)`. */
+    showRegion(id: number) {
+      return this.setRegionVisibility(id, true);
+    },
+
+    /** Read or write the bucket-tool tolerance used by the interactive paint
+     *  panel and by `paintRegion` when no `tolerance` argument is passed.
+     *  Value is the cosine of the maximum allowed bend angle (1 = strict
+     *  coplanar, -1 = whole connected component). Use the angle form via
+     *  `paintRegion({tolerance})` if you'd rather think in degrees.
+     *  Returns the previous + new value on set. */
+    getBucketTolerance() {
+      return { tolerance: getPaintBucketTolerance() };
+    },
+    setBucketTolerance(tolerance: number) {
+      if (typeof tolerance !== 'number' || !Number.isFinite(tolerance)) {
+        return { error: 'setBucketTolerance(tolerance): tolerance must be a finite number in [-1, 1] (cosine of max bend angle)' };
+      }
+      const clamped = Math.max(-1, Math.min(1, tolerance));
+      const previous = getPaintBucketTolerance();
+      setPaintBucketTolerance(clamped);
+      return { previous, tolerance: clamped };
+    },
+
+    /** Read or write the brush-tool radius (in mesh units) used by the
+     *  interactive paint panel. `0` means single-triangle (legacy behavior);
+     *  any positive value expands the brush footprint to every triangle whose
+     *  centroid lies within the radius of the click/drag point.
+     *  Programmatic painters should use `paintNear({point, radius})` or
+     *  `paintFaces({triangleIds})` — this setter only changes the UI brush. */
+    getBrushSize() {
+      return { radius: getPaintBrushRadius() };
+    },
+    setBrushSize(radius: number) {
+      if (typeof radius !== 'number' || !Number.isFinite(radius) || radius < 0) {
+        return { error: 'setBrushSize(radius): radius must be a non-negative finite number (mesh units)' };
+      }
+      const previous = getPaintBrushRadius();
+      setPaintBrushRadius(radius);
+      return { previous, radius };
     },
 
     /** Undo the most recent paint operation. The removed region goes onto
@@ -4627,8 +4690,15 @@ async function main() {
         'paintConnected':  { signature: 'paintConnected({seed: {point, normal?}, maxDeviationDeg?, color, name?}) -- BFS-flood from a surface seed, gated by deviation from SEED normal (not adjacent). Pairs with probePixel for "paint everything contiguous and facing this way".', docs: '/ai.md#color-regions' },
         'getFeatureCentroids': { signature: 'getFeatureCentroids({maxGroups?, withinBox?}?) -- Token-cheap: face-group centroids + normals + bbox, no triangleIds. Use to plan paint targets.', docs: '/ai.md#color-regions' },
         'removeRegion':    { signature: 'removeRegion(id) -- Remove ONE color region by id from listRegions(). Use this to fix a single mistake without nuking the rest.', docs: '/ai.md#color-regions' },
+        'setRegionVisibility': { signature: 'setRegionVisibility(id, visible) -- Show/hide ONE region in the viewport. Hidden regions still export.', docs: '/ai.md#color-regions' },
+        'hideRegion':      { signature: 'hideRegion(id) -- Shorthand for setRegionVisibility(id, false).', docs: '/ai.md#color-regions' },
+        'showRegion':      { signature: 'showRegion(id) -- Shorthand for setRegionVisibility(id, true).', docs: '/ai.md#color-regions' },
         'undoLastPaint':   { signature: 'undoLastPaint() -- Undo the most recent paint op. Removed region goes on a redo stack.', docs: '/ai.md#color-regions' },
         'redoLastPaint':   { signature: 'redoLastPaint() -- Reapply the most recently undone paint op.', docs: '/ai.md#color-regions' },
+        'getBucketTolerance': { signature: 'getBucketTolerance() -- Read the bucket flood-fill tolerance (cosine of max bend angle).', docs: '/ai.md#color-regions' },
+        'setBucketTolerance': { signature: 'setBucketTolerance(tolerance) -- Set the bucket flood-fill tolerance (-1..1). Affects the UI bucket tool and the default for paintRegion.', docs: '/ai.md#color-regions' },
+        'getBrushSize':    { signature: 'getBrushSize() -- Read the UI brush radius (mesh units). 0 = single triangle.', docs: '/ai.md#color-regions' },
+        'setBrushSize':    { signature: 'setBrushSize(radius) -- Set the UI brush radius (mesh units, >= 0). Affects only the interactive brush tool; programmatic painting uses paintNear / paintFaces.', docs: '/ai.md#color-regions' },
         // Annotations
         'listAnnotations':    { signature: 'listAnnotations() -- List freehand strokes -> [{id, color, width, points}]', docs: '/ai.md#annotations' },
         'listTextAnnotations':{ signature: 'listTextAnnotations() -- List pinned text labels -> [{id, text, color, fontSizePx, anchor}]', docs: '/ai.md#annotations' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,6 +87,7 @@ import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as ge
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
 import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, resolveSeed, findNearestTriangle } from './color/adjacency';
 import { findSlabTriangles } from './color/slabPaint';
+import { findBoxTriangles } from './color/boxPaint';
 import { computeFaceGroups } from './color/faceGroups';
 import {
   getSessionIdFromURL,
@@ -520,6 +521,9 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): vo
     } else if (region.descriptor.kind === 'slab') {
       const { normal, offset, thickness } = region.descriptor;
       triangles = findSlabTriangles(mesh, normal, offset, thickness);
+    } else if (region.descriptor.kind === 'box') {
+      const { center, size, quaternion } = region.descriptor;
+      triangles = findBoxTriangles(mesh, { center, size, quaternion });
     } else if (region.descriptor.kind === 'byLabel') {
       // Labels are runtime state — manifold-3d assigns fresh
       // originalIDs on every run, so we re-resolve by name from the
@@ -3655,6 +3659,56 @@ async function main() {
       return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
     },
 
+    /** Paint every triangle whose centroid lies inside an *oriented* bounding
+     *  box — same selector the UI's Box tool uses, but with explicit
+     *  center/size/quaternion instead of a gizmo. Use this when you need
+     *  arbitrary rotation that an AABB can't express (e.g. painting a tilted
+     *  panel on an oriented part).
+     *
+     *  `quaternion` defaults to identity `[0, 0, 0, 1]` if omitted, which
+     *  reduces to the same selector as `paintInBox` against an AABB centered
+     *  at `center` with the given `size`.
+     *
+     *  ```
+     *  partwright.paintInOrientedBox({
+     *    box: {
+     *      center: [10, 0, 5],
+     *      size: [8, 4, 2],
+     *      quaternion: [0, 0, Math.sin(Math.PI / 8), Math.cos(Math.PI / 8)], // 45° around Z
+     *    },
+     *    color: [0.2, 0.7, 0.9],
+     *  });
+     *  ```
+     *  Returns `{ id, name, triangles }` or `{ error }`. */
+    paintInOrientedBox(opts: {
+      box: {
+        center: [number, number, number];
+        size: [number, number, number];
+        quaternion?: [number, number, number, number];
+      };
+      color: [number, number, number];
+      name?: string;
+    }) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintInOrientedBox requires { box, color }' };
+      if (!opts.box || typeof opts.box !== 'object') return { error: 'paintInOrientedBox.box must be { center, size, quaternion? }' };
+      const { center, size, quaternion } = opts.box;
+      if (!Array.isArray(center) || center.length !== 3 || !center.every(Number.isFinite)) return { error: 'paintInOrientedBox.box.center must be [x, y, z] of finite numbers' };
+      if (!Array.isArray(size) || size.length !== 3 || !size.every(v => Number.isFinite(v) && v > 0)) return { error: 'paintInOrientedBox.box.size must be [sx, sy, sz] of positive finite numbers' };
+      const q: [number, number, number, number] = quaternion ?? [0, 0, 0, 1];
+      if (!Array.isArray(q) || q.length !== 4 || !q.every(Number.isFinite)) return { error: 'paintInOrientedBox.box.quaternion must be [x, y, z, w] of finite numbers (defaults to identity if omitted)' };
+      if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r, g, b] with values 0..1' };
+
+      const triangles = findBoxTriangles(currentMeshData, {
+        center: [center[0], center[1], center[2]],
+        size: [size[0], size[1], size[2]],
+        quaternion: q,
+      });
+      if (triangles.size === 0) return { error: 'paintInOrientedBox: no triangles inside the box. Try a larger size, recheck the center, or use paintPreview to see what the box covers.' };
+
+      return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
+    },
+
     /** Paint every triangle whose centroid lies within `radius` of `point`.
      *  Optional `normalCone` restricts by face normal direction. Use this for
      *  "paint a fingernail-sized patch around X" without picking edge tolerances.
@@ -4672,6 +4726,7 @@ async function main() {
         'paintNearestRegion': { signature: 'paintNearestRegion({point, color, searchRadius?, name?, tolerance?}) -- Snap seed to nearest face, then paint coplanar region', docs: '/ai.md#color-regions' },
         'paintNear':       { signature: 'paintNear({point, radius, normalCone?, color, name?}) -- Paint triangles whose centroid is within `radius` of `point`. Predictable, no flood-fill tolerance to tune.', docs: '/ai.md#color-regions' },
         'paintInBox':      { signature: 'paintInBox({box, normalCone?, color, name?}) -- Paint triangles whose centroid is inside an axis-aligned box (and optional normal cone).', docs: '/ai.md#color-regions' },
+        'paintInOrientedBox': { signature: 'paintInOrientedBox({box: {center, size, quaternion?}, color, name?}) -- Paint triangles whose centroid is inside a rotated oriented box. Same selector as the UI Box tool.', docs: '/ai.md#color-regions' },
         'paintFaces':      { signature: 'paintFaces({triangleIds, color, name?}) -- Paint specific triangle indices', docs: '/ai.md#color-regions' },
         'paintSlab':       { signature: 'paintSlab({axis|normal, offset, thickness, color, name?}) -- Paint planar slab range', docs: '/ai.md#color-regions' },
         'paintPreview':    { signature: 'paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) -- DRY-RUN -> {triangleCount, bbox, centroid, [thumbnail]}. Default count-only; pass withImage:true for the yellow-highlighted thumbnail.', docs: '/ai.md#color-regions' },

--- a/tests/paint-controls-extended.spec.ts
+++ b/tests/paint-controls-extended.spec.ts
@@ -1,0 +1,139 @@
+// Smoke tests for the extended paint UI:
+//  - brush size controls (slider + number input) appear when the brush tool is selected
+//  - bucket tolerance has a typeable degree input
+//  - per-region eye + trash icons appear in the region list and drive the API
+//  - partwright API exposes setBrushSize / setBucketTolerance / hideRegion / showRegion
+//
+// Uses `dispatchEvent('click')` instead of `.click()` to dodge the onboarding
+// tour backdrop that intercepts pointer events on first paint of the editor.
+
+import { test, expect } from 'playwright/test';
+
+async function openEditor(page: import('playwright/test').Page) {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  // Run a tiny model so paint operations have a real mesh to operate on.
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.run(`const { Manifold } = api; return Manifold.cube([10, 10, 10], true);`);
+  });
+}
+
+test.describe('extended paint controls', () => {
+  test('brush size controls appear when brush tool is selected', async ({ page }) => {
+    await openEditor(page);
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    // Brush controls should be hidden initially (bucket is default).
+    const brushHelp = page.locator('#paint-picker-panel >> text=Single triangle');
+    await expect(brushHelp).toBeHidden();
+
+    // Switch to brush tool.
+    await page.locator('#paint-picker-panel button:has-text("Brush")').dispatchEvent('click');
+
+    // Now the brush slider + number input should be visible.
+    await expect(brushHelp).toBeVisible();
+    const numberInput = page.locator('#paint-picker-panel input[type="number"][title*="mesh units"]');
+    await expect(numberInput).toBeVisible();
+    await expect(numberInput).toHaveValue('0.0');
+  });
+
+  test('typing a bucket tolerance angle updates the underlying value', async ({ page }) => {
+    await openEditor(page);
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    const angleInput = page.locator('#paint-picker-panel input[type="number"][title*="Bend angle"]');
+    await expect(angleInput).toBeVisible();
+
+    await angleInput.fill('45');
+    await angleInput.press('Enter');
+
+    const tol = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { getBucketTolerance(): { tolerance: number } } }).partwright;
+      return pw.getBucketTolerance().tolerance;
+    });
+    expect(tol).toBeCloseTo(Math.cos(45 * Math.PI / 180), 3);
+  });
+
+  test('setBrushSize partwright API rejects bad input and accepts good input', async ({ page }) => {
+    await openEditor(page);
+    const result = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: {
+        setBrushSize(n: unknown): { error?: string; previous?: number; radius?: number };
+        getBrushSize(): { radius: number };
+      } }).partwright;
+      const bad = pw.setBrushSize(-1 as unknown as number);
+      const good = pw.setBrushSize(2.5);
+      return { bad, good, current: pw.getBrushSize() };
+    });
+    expect(result.bad.error).toContain('non-negative');
+    expect(result.good.radius).toBe(2.5);
+    expect(result.current.radius).toBe(2.5);
+  });
+
+  test('per-region eye and trash buttons drive the regions store', async ({ page }) => {
+    await openEditor(page);
+    // Paint two regions via the API so the region list has content.
+    const ids = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: {
+        getMesh(): { triangles: Uint32Array; numTri: number };
+        paintFaces(opts: { triangleIds: number[]; color: [number, number, number]; name?: string }): { id: number };
+      } }).partwright;
+      const mesh = pw.getMesh();
+      const a = pw.paintFaces({ triangleIds: [0, 1, 2], color: [1, 0, 0], name: 'A' });
+      const b = pw.paintFaces({ triangleIds: [3, 4, 5], color: [0, 1, 0], name: 'B' });
+      return [a.id, b.id];
+    });
+    expect(ids).toHaveLength(2);
+
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    // Two region rows present, each with eye + trash buttons.
+    const rows = page.locator('#paint-region-list > div');
+    await expect(rows).toHaveCount(2);
+    await expect(rows.first().locator('button[data-action="toggle-region-visibility"]')).toBeVisible();
+    await expect(rows.first().locator('button[data-action="delete-region"]')).toBeVisible();
+
+    // Click eye on the first row -> region becomes hidden.
+    await rows.first().locator('button[data-action="toggle-region-visibility"]').dispatchEvent('click');
+    const afterHide = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { listRegions(): { id: number; visible: boolean }[] } }).partwright;
+      return pw.listRegions();
+    });
+    expect(afterHide[0].visible).toBe(false);
+    expect(afterHide[1].visible).toBe(true);
+
+    // Click trash on what is now the first row (region A is still there but hidden).
+    await rows.first().locator('button[data-action="delete-region"]').dispatchEvent('click');
+    const afterDelete = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { listRegions(): { id: number; visible: boolean }[] } }).partwright;
+      return pw.listRegions();
+    });
+    expect(afterDelete).toHaveLength(1);
+    expect(afterDelete[0].id).toBe(ids[1]);
+  });
+
+  test('hideRegion / showRegion partwright API toggles visibility flag', async ({ page }) => {
+    await openEditor(page);
+    const result = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: {
+        paintFaces(opts: { triangleIds: number[]; color: [number, number, number] }): { id: number };
+        hideRegion(id: number): unknown;
+        showRegion(id: number): unknown;
+        listRegions(): { id: number; visible: boolean }[];
+      } }).partwright;
+      const r = pw.paintFaces({ triangleIds: [0, 1, 2], color: [0, 0, 1] });
+      pw.hideRegion(r.id);
+      const hidden = pw.listRegions().find(x => x.id === r.id)?.visible;
+      pw.showRegion(r.id);
+      const shown = pw.listRegions().find(x => x.id === r.id)?.visible;
+      return { hidden, shown };
+    });
+    expect(result.hidden).toBe(false);
+    expect(result.shown).toBe(true);
+  });
+});

--- a/tests/paint-controls-extended.spec.ts
+++ b/tests/paint-controls-extended.spec.ts
@@ -117,6 +117,64 @@ test.describe('extended paint controls', () => {
     expect(afterDelete[0].id).toBe(ids[1]);
   });
 
+  test('box paint tool activates with a default box sized to the model and commits a region', async ({ page }) => {
+    await openEditor(page);
+
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+    await page.locator('button[title*="positionable, rotatable"]').dispatchEvent('click');
+
+    // Box controls panel should be visible with non-zero default size.
+    const sizeInput = page.locator('#paint-picker-panel input[type="number"]').nth(5);
+    await expect(sizeInput).toBeVisible();
+    const sizeValue = await sizeInput.inputValue();
+    expect(parseFloat(sizeValue)).toBeGreaterThan(0);
+
+    // Hit "Paint inside box" — default box wraps the model so all triangles get caught.
+    await page.locator('button[title="Commit every triangle inside the box as a new color region"]').dispatchEvent('click');
+
+    const regions = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.listRegions();
+    });
+    expect(regions.length).toBe(1);
+    expect(regions[0].triangles).toBeGreaterThan(0);
+    expect(regions[0].name).toContain('Box');
+  });
+
+  test('paintInOrientedBox API paints into a rotated box', async ({ page }) => {
+    await openEditor(page);
+
+    const result = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      // Identity quaternion should match an AABB centered at origin.
+      const identity = pw.paintInOrientedBox({
+        box: { center: [0, 0, 0], size: [22, 22, 22] },
+        color: [0.5, 0.2, 0.9],
+        name: 'Identity OBB',
+      });
+      pw.clearColors();
+      // 45° rotation around Z — same volume, same triangles caught for a centered cube.
+      const rotated = pw.paintInOrientedBox({
+        box: {
+          center: [0, 0, 0],
+          size: [22, 22, 22],
+          quaternion: [0, 0, Math.sin(Math.PI / 8), Math.cos(Math.PI / 8)],
+        },
+        color: [0.5, 0.2, 0.9],
+        name: 'Rotated OBB',
+      });
+      pw.clearColors();
+      const bad = pw.paintInOrientedBox({ box: { center: [0, 0, 0], size: [0, 1, 1] }, color: [1, 0, 0] });
+      return { identity, rotated, bad };
+    });
+    expect(result.identity.triangles).toBeGreaterThan(0);
+    expect(result.rotated.triangles).toBeGreaterThan(0);
+    expect(result.bad.error).toBeTruthy();
+  });
+
   test('hideRegion / showRegion partwright API toggles visibility flag', async ({ page }) => {
     await openEditor(page);
     const result = await page.evaluate(() => {


### PR DESCRIPTION
## Summary

Expands the paint mode color picker from 8 to 16 preset colors, arranged as a 4x4 grid grouped by hue family:

- **Warm:** red, orange, yellow, brown *(brown is new)*
- **Cool:** lime, green, teal, blue *(lime is new)*
- **Purples / pinks:** navy, purple, magenta, pink *(navy & magenta are new)*
- **Neutrals:** white, light gray, dark gray, **black** *(all four new)*

Red remains the default selected swatch, so existing muscle memory and tests are unaffected. Users who want black (or any common neutral) no longer need to reach for the custom-color picker.

## Test plan

- [x] `npm run build` — clean
- [x] Existing paint Playwright suites pass (`paint-batch-and-lifecycle`, `paint-coverage`, `paint-render-color`, `render-color-readability` — 11/11)
- [x] Manual verification via headless Chromium: paint panel renders all 16 swatches in a 4x4 grid; `#000000` and `#ffffff` both present; red still highlighted as default
- [ ] Reviewer: open `/editor`, click **Paint**, confirm the new neutrals row is visible and clicking the black swatch then a face produces a black region

Screenshot of the new picker is attached to the conversation that produced this PR.

https://claude.ai/code/session_01XeZhGpvDj23Apcyrf1RuZc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeZhGpvDj23Apcyrf1RuZc)_