### PR TITLE
test: lock down 3MF colorgroup format + investigate Bambu color-import complaint

### DIFF
--- a/src/export/meshClean.ts
+++ b/src/export/meshClean.ts
@@ -3,15 +3,8 @@
 import type { MeshData } from '../geometry/types';
 import { isPainted as checkPainted } from '../color/regions';
 
-/** Default model color used to fill unpainted faces in viewers / formats
- *  that require every face to carry an explicit material (e.g. OBJ's
- *  `usemtl`). 3MF export omits this — see `threemf.ts`. */
+/** Default model color used when faces have no paint. */
 export const DEFAULT_COLOR_HEX = '#4a9eff';
-
-/** True if this triangle carries a user-painted color. */
-export function isPaintedTri(triColors: Uint8Array, t: number): boolean {
-  return checkPainted(triColors, t);
-}
 
 /** Get the hex color string for a triangle (e.g. '#ff3333'), or DEFAULT_COLOR_HEX if unpainted. */
 export function triColorHex(triColors: Uint8Array, t: number): string {

--- a/src/export/meshClean.ts
+++ b/src/export/meshClean.ts
@@ -3,8 +3,15 @@
 import type { MeshData } from '../geometry/types';
 import { isPainted as checkPainted } from '../color/regions';
 
-/** Default model color used when faces have no paint. */
+/** Default model color used to fill unpainted faces in viewers / formats
+ *  that require every face to carry an explicit material (e.g. OBJ's
+ *  `usemtl`). 3MF export omits this — see `threemf.ts`. */
 export const DEFAULT_COLOR_HEX = '#4a9eff';
+
+/** True if this triangle carries a user-painted color. */
+export function isPaintedTri(triColors: Uint8Array, t: number): boolean {
+  return checkPainted(triColors, t);
+}
 
 /** Get the hex color string for a triangle (e.g. '#ff3333'), or DEFAULT_COLOR_HEX if unpainted. */
 export function triColorHex(triColors: Uint8Array, t: number): string {

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -3,7 +3,7 @@ import { get3MFUnitString } from '../geometry/units';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
 import type { BuiltExport } from './gltf';
 import { buildZip } from './zip';
-import { cleanMeshForExport, triColorHex, hasAnyPainted, isPaintedTri } from './meshClean';
+import { cleanMeshForExport, DEFAULT_COLOR_HEX, triColorHex, hasAnyPainted } from './meshClean';
 
 /** Build a 3MF export blob without triggering a download. */
 export function build3MF(meshData: MeshData, customName?: string): BuiltExport {
@@ -21,48 +21,49 @@ export function build3MF(meshData: MeshData, customName?: string): BuiltExport {
     vertices.push(`          <vertex x="${x}" y="${y}" z="${z}" />`);
   }
 
-  // Collect ONLY the colors the user actually painted. Bambu Studio (and
-  // similar slicers) create one filament slot per <m:color> entry in the
-  // colorgroup. Including the app's default model color here would surface
-  // as an unwanted extra filament the user never asked for.
+  // Reserve index 0 in the m:colorgroup for the app's default model color.
+  // Bambu Studio's "Standard 3MF Import Color" dialog only fires when the
+  // object's pid/pindex points at a valid colorgroup entry AND every
+  // unpainted triangle has an explicit pid/p1, so unpainted faces share
+  // this index. Trade-off: the user sees one extra "default" filament in
+  // Bambu they didn't paint; removing the entry skips the dialog entirely
+  // and the painted colors silently disappear on import.
   const hasColors = triColors != null && hasAnyPainted(triColors, validTris);
-  const colorMap = new Map<string, number>(); // hex -> index into m:colorgroup
+  const colorMap = new Map<string, number>(); // hex -> material index
   const materialColors: string[] = [];
 
   if (hasColors && triColors) {
+    colorMap.set(DEFAULT_COLOR_HEX, 0);
+    materialColors.push(DEFAULT_COLOR_HEX);
+
     for (const t of validTris) {
-      if (!isPaintedTri(triColors, t)) continue;
       const hex = triColorHex(triColors, t);
-      if (!colorMap.has(hex)) {
+      if (hex !== DEFAULT_COLOR_HEX && !colorMap.has(hex)) {
         colorMap.set(hex, materialColors.length);
         materialColors.push(hex);
       }
     }
   }
 
-  // Build triangles XML (remapped vertex indices, filtered for degenerates).
-  // Unpainted triangles get NO pid/p1 — they inherit the slicer's default
-  // print filament. This avoids inflating the filament list with a "default"
-  // slot the user didn't paint.
+  // Build triangles XML (remapped vertex indices, filtered for degenerates)
   const triangles: string[] = [];
   for (const t of validTris) {
     const v1 = remap[triVerts[t * 3]];
     const v2 = remap[triVerts[t * 3 + 1]];
     const v3 = remap[triVerts[t * 3 + 2]];
 
-    if (hasColors && triColors && isPaintedTri(triColors, t)) {
+    if (hasColors && triColors) {
       const hex = triColorHex(triColors, t);
-      const matIdx = colorMap.get(hex)!;
+      const matIdx = colorMap.get(hex) ?? 0;
       triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="2" p1="${matIdx}" />`);
     } else {
       triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
     }
   }
 
-  // Build m:colorgroup XML block — only emit when at least one color is
-  // present (i.e. the user actually painted something).
+  // Build m:colorgroup XML block
   let colorgroupXml = '';
-  if (materialColors.length > 0) {
+  if (hasColors) {
     const colors = materialColors.map(hex =>
       `      <m:color color="${hex.toUpperCase()}FF" />`
     ).join('\n');
@@ -75,15 +76,14 @@ ${colors}
   // Escape XML special chars in title
   const title = getExportTitle().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
-  const emitMaterialNs = materialColors.length > 0;
-  const nsAttr = emitMaterialNs ? ' xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"' : '';
+  const nsAttr = hasColors ? ' xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"' : '';
 
   const modelXml = `<?xml version="1.0" encoding="UTF-8"?>
 <model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"${nsAttr}>
   <metadata name="Title">${title}</metadata>
   <metadata name="Application">Partwright</metadata>
   <resources>${colorgroupXml}
-    <object id="1" type="model">
+    <object id="1" type="model"${hasColors ? ' pid="2" pindex="0"' : ''}>
       <mesh>
         <vertices>
 ${vertices.join('\n')}

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -3,7 +3,7 @@ import { get3MFUnitString } from '../geometry/units';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
 import type { BuiltExport } from './gltf';
 import { buildZip } from './zip';
-import { cleanMeshForExport, DEFAULT_COLOR_HEX, triColorHex, hasAnyPainted } from './meshClean';
+import { cleanMeshForExport, triColorHex, hasAnyPainted, isPaintedTri } from './meshClean';
 
 /** Build a 3MF export blob without triggering a download. */
 export function build3MF(meshData: MeshData, customName?: string): BuiltExport {
@@ -21,43 +21,48 @@ export function build3MF(meshData: MeshData, customName?: string): BuiltExport {
     vertices.push(`          <vertex x="${x}" y="${y}" z="${z}" />`);
   }
 
-  // Collect distinct colors for m:colorgroup
+  // Collect ONLY the colors the user actually painted. Bambu Studio (and
+  // similar slicers) create one filament slot per <m:color> entry in the
+  // colorgroup. Including the app's default model color here would surface
+  // as an unwanted extra filament the user never asked for.
   const hasColors = triColors != null && hasAnyPainted(triColors, validTris);
-  const colorMap = new Map<string, number>(); // hex -> material index
+  const colorMap = new Map<string, number>(); // hex -> index into m:colorgroup
   const materialColors: string[] = [];
 
   if (hasColors && triColors) {
-    colorMap.set(DEFAULT_COLOR_HEX, 0);
-    materialColors.push(DEFAULT_COLOR_HEX);
-
     for (const t of validTris) {
+      if (!isPaintedTri(triColors, t)) continue;
       const hex = triColorHex(triColors, t);
-      if (hex !== DEFAULT_COLOR_HEX && !colorMap.has(hex)) {
+      if (!colorMap.has(hex)) {
         colorMap.set(hex, materialColors.length);
         materialColors.push(hex);
       }
     }
   }
 
-  // Build triangles XML (remapped vertex indices, filtered for degenerates)
+  // Build triangles XML (remapped vertex indices, filtered for degenerates).
+  // Unpainted triangles get NO pid/p1 — they inherit the slicer's default
+  // print filament. This avoids inflating the filament list with a "default"
+  // slot the user didn't paint.
   const triangles: string[] = [];
   for (const t of validTris) {
     const v1 = remap[triVerts[t * 3]];
     const v2 = remap[triVerts[t * 3 + 1]];
     const v3 = remap[triVerts[t * 3 + 2]];
 
-    if (hasColors && triColors) {
+    if (hasColors && triColors && isPaintedTri(triColors, t)) {
       const hex = triColorHex(triColors, t);
-      const matIdx = colorMap.get(hex) ?? 0;
+      const matIdx = colorMap.get(hex)!;
       triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="2" p1="${matIdx}" />`);
     } else {
       triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
     }
   }
 
-  // Build m:colorgroup XML block
+  // Build m:colorgroup XML block — only emit when at least one color is
+  // present (i.e. the user actually painted something).
   let colorgroupXml = '';
-  if (hasColors) {
+  if (materialColors.length > 0) {
     const colors = materialColors.map(hex =>
       `      <m:color color="${hex.toUpperCase()}FF" />`
     ).join('\n');
@@ -70,14 +75,15 @@ ${colors}
   // Escape XML special chars in title
   const title = getExportTitle().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
-  const nsAttr = hasColors ? ' xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"' : '';
+  const emitMaterialNs = materialColors.length > 0;
+  const nsAttr = emitMaterialNs ? ' xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"' : '';
 
   const modelXml = `<?xml version="1.0" encoding="UTF-8"?>
 <model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"${nsAttr}>
   <metadata name="Title">${title}</metadata>
   <metadata name="Application">Partwright</metadata>
   <resources>${colorgroupXml}
-    <object id="1" type="model"${hasColors ? ' pid="2" pindex="0"' : ''}>
+    <object id="1" type="model">
       <mesh>
         <vertices>
 ${vertices.join('\n')}

--- a/tests/threemf-color-export.spec.ts
+++ b/tests/threemf-color-export.spec.ts
@@ -1,10 +1,16 @@
-// Verify that exporting a model with N painted regions produces exactly N
-// colors in the 3MF m:colorgroup — no extra "default" filament slot.
+// 3MF color export regression tests.
 //
-// Regression test for: "exported 3MF imported into Bambu Studio with many
-// more colors than I actually painted." Bambu Studio (and similar slicers)
-// create one filament per <m:color> entry. Including a default color the
-// user never painted with would surface as an unwanted extra filament.
+// History:
+//   - User reported: exported 3MF imported into Bambu Studio with "many
+//     more colors than I actually painted." Suspected over-counting in the
+//     m:colorgroup.
+//   - First fix attempt removed the default color from the colorgroup so
+//     only painted colors remained. That broke Bambu's import-color dialog
+//     entirely — Bambu's "Standard 3MF Import Color" trigger requires the
+//     object to carry pid/pindex pointing at a valid colorgroup entry, and
+//     unpainted triangles must have an explicit pid too. Reverted.
+//   - These tests lock down the current behavior and double as a record of
+//     what the format looks like, so the next iteration can refer to them.
 
 import { test, expect } from 'playwright/test';
 
@@ -37,7 +43,7 @@ function readZip(bytes: Uint8Array): ZipEntry[] {
   return entries;
 }
 
-async function exportPaintedCube(page: import('playwright/test').Page, recipe: string) {
+async function exportPainted(page: import('playwright/test').Page, recipe: string) {
   await page.goto('/editor');
   await page.waitForSelector('text=Ready', { timeout: 15000 });
   return page.evaluate(async (script) => {
@@ -53,7 +59,7 @@ async function exportPaintedCube(page: import('playwright/test').Page, recipe: s
   }, recipe);
 }
 
-function inspectColorgroup(base64: string) {
+function inspectModelXml(base64: string) {
   const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
   const entries = readZip(bytes);
   const modelEntry = entries.find(e => e.name === '3D/3dmodel.model');
@@ -63,27 +69,38 @@ function inspectColorgroup(base64: string) {
   return { xml, colorMatches };
 }
 
-test('two distinct painted colors → exactly 2 colorgroup entries', async ({ page }) => {
-  const result = await exportPaintedCube(page, `
+// Bambu Studio's import dialog requires the colorgroup to be referenced
+// from the <object>. Verify we still emit that pid/pindex when colors exist.
+test('object carries pid/pindex pointing at colorgroup when colors are present', async ({ page }) => {
+  const result = await exportPainted(page, `
     await pw.run('return api.Manifold.cube([20, 20, 20]);');
     const top = pw.paintInBox({ box: { min: [-1, -1, 19], max: [21, 21, 21] }, color: [1, 0, 0] });
     if (top.error) return top;
-    const bottom = pw.paintInBox({ box: { min: [-1, -1, -1], max: [21, 21, 1] }, color: [0, 0, 1] });
-    if (bottom.error) return bottom;
   `);
 
   expect(result.error, JSON.stringify(result)).toBeUndefined();
-  const { xml, colorMatches } = inspectColorgroup(result.base64!);
-  expect(colorMatches.length, `expected 2 colors, got ${colorMatches.length}\n${xml.slice(0, 2000)}`).toBe(2);
-
-  // Both painted colors are present, in any order.
-  const hexes = colorMatches.map(m => m.match(/"([^"]+)"/)![1].toUpperCase()).sort();
-  expect(hexes).toEqual(['#0000FFFF', '#FF0000FF']);
+  const { xml } = inspectModelXml(result.base64!);
+  expect(xml).toMatch(/<object\s+id="1"\s+type="model"\s+pid="2"\s+pindex="0"/);
+  expect(xml).toMatch(/<m:colorgroup\s+id="2">/);
 });
 
-// Repeat the same color across multiple regions and verify dedup.
-test('three regions sharing one color → exactly 1 colorgroup entry', async ({ page }) => {
-  const result = await exportPaintedCube(page, `
+// No paint regions → no colorgroup at all (and no pid on object).
+test('plain mesh has no colorgroup and no pid on the object', async ({ page }) => {
+  const result = await exportPainted(page, `
+    await pw.run('return api.Manifold.cube([20, 20, 20]);');
+  `);
+
+  expect(result.error, JSON.stringify(result)).toBeUndefined();
+  const { xml, colorMatches } = inspectModelXml(result.base64!);
+  expect(colorMatches.length).toBe(0);
+  expect(xml).toMatch(/<object\s+id="1"\s+type="model">/);
+  expect(xml).not.toMatch(/pid=/);
+});
+
+// Same color painted across N regions → dedup to 1 painted entry in the
+// colorgroup (plus the default at index 0).
+test('same color across three regions dedupes to one painted entry', async ({ page }) => {
+  const result = await exportPainted(page, `
     await pw.run('return api.Manifold.cube([20, 20, 20]);');
     const a = pw.paintInBox({ box: { min: [-1, -1, 19], max: [21, 21, 21] }, color: [1, 0, 0] });
     if (a.error) return a;
@@ -94,26 +111,15 @@ test('three regions sharing one color → exactly 1 colorgroup entry', async ({ 
   `);
 
   expect(result.error, JSON.stringify(result)).toBeUndefined();
-  const { xml, colorMatches } = inspectColorgroup(result.base64!);
-  expect(colorMatches.length, `expected 1 color, got ${colorMatches.length}\n${xml.slice(0, 800)}`).toBe(1);
+  const { xml, colorMatches } = inspectModelXml(result.base64!);
+  // 1 default + 1 unique painted color = 2 entries.
+  expect(colorMatches.length, `expected 2 colors (default + 1 painted), got ${colorMatches.length}\n${xml.slice(0, 1200)}`).toBe(2);
 });
 
-test('hi-poly sphere with one painted region → exactly 1 colorgroup entry', async ({ page }) => {
-  // A sphere triangulates into many small faces. Painting one cap region
-  // should still produce a single colorgroup entry.
-  const result = await exportPaintedCube(page, `
-    await pw.run('return api.Manifold.sphere(15, 64);');
-    const r = pw.paintInBox({ box: { min: [-16, -16, 5], max: [16, 16, 16] }, color: [0.92, 0.26, 0.21] });
-    if (r.error) return r;
-  `);
-
-  expect(result.error, JSON.stringify(result)).toBeUndefined();
-  const { xml, colorMatches } = inspectColorgroup(result.base64!);
-  expect(colorMatches.length, `expected 1 color, got ${colorMatches.length}\nfirst 1500 chars:\n${xml.slice(0, 1500)}`).toBe(1);
-});
-
-test('every entry in colorgroup is referenced by some triangle', async ({ page }) => {
-  const result = await exportPaintedCube(page, `
+// Two distinct painted colors → 3 entries (default + 2 painted). Order:
+// default first, painted in iteration order.
+test('two distinct painted colors produce default + 2 entries', async ({ page }) => {
+  const result = await exportPainted(page, `
     await pw.run('return api.Manifold.cube([20, 20, 20]);');
     const top = pw.paintInBox({ box: { min: [-1, -1, 19], max: [21, 21, 21] }, color: [1, 0, 0] });
     if (top.error) return top;
@@ -122,56 +128,24 @@ test('every entry in colorgroup is referenced by some triangle', async ({ page }
   `);
 
   expect(result.error, JSON.stringify(result)).toBeUndefined();
-  const { xml, colorMatches } = inspectColorgroup(result.base64!);
-
-  // Collect every p1 value referenced by triangles in the model.
-  const used = new Set<string>();
-  for (const m of xml.matchAll(/p1="(\d+)"/g)) used.add(m[1]);
-
-  // Now check: is every index in the colorgroup actually used?
-  const unused: number[] = [];
-  for (let i = 0; i < colorMatches.length; i++) {
-    if (!used.has(String(i))) unused.push(i);
-  }
-
-  expect(unused, `colorgroup entries ${unused.join(',')} are NEVER referenced by any triangle, yet still appear in the file:\n${xml.slice(0, 1500)}`).toEqual([]);
+  const { xml, colorMatches } = inspectModelXml(result.base64!);
+  expect(colorMatches.length, `expected 3 colors, got ${colorMatches.length}\n${xml.slice(0, 2000)}`).toBe(3);
+  // Default is always the first entry.
+  expect(colorMatches[0]).toContain('#4A9EFF');
 });
 
-// Unpainted regions must NOT carry pid="2" attributes — that would put the
-// triangle in the colorgroup and effectively assign it a filament slot.
-test('unpainted triangles have no pid/p1 attributes', async ({ page }) => {
-  const result = await exportPaintedCube(page, `
+// Every triangle must have an explicit pid/p1 when colors are present —
+// otherwise Bambu loses the color assignment for unpainted faces.
+test('every triangle has pid/p1 when colors are present', async ({ page }) => {
+  const result = await exportPainted(page, `
     await pw.run('return api.Manifold.cube([20, 20, 20]);');
     const top = pw.paintInBox({ box: { min: [-1, -1, 19], max: [21, 21, 21] }, color: [1, 0, 0] });
     if (top.error) return top;
   `);
 
   expect(result.error, JSON.stringify(result)).toBeUndefined();
-  const bytes = Uint8Array.from(atob(result.base64!), c => c.charCodeAt(0));
-  const xml = new TextDecoder().decode(readZip(bytes).find(e => e.name === '3D/3dmodel.model')!.data);
-
+  const { xml } = inspectModelXml(result.base64!);
   const allTris = xml.match(/<triangle\b[^/]*\/>/g) ?? [];
-  const taggedTris = allTris.filter(t => t.includes('pid="'));
-  const untaggedTris = allTris.filter(t => !t.includes('pid="'));
-
-  // A 20×20×20 cube has 6 faces × 2 = 12 triangles. The top face is 2
-  // painted; the remaining 10 should be untagged.
-  expect(taggedTris.length, `expected 2 painted triangles, got ${taggedTris.length}\n${xml}`).toBe(2);
-  expect(untaggedTris.length, `expected 10 untagged triangles, got ${untaggedTris.length}\n${xml}`).toBe(10);
-});
-
-test('cube with subtract + 1 painted region → exactly 1 colorgroup entry', async ({ page }) => {
-  const result = await exportPaintedCube(page, `
-    await pw.run(\`
-      const a = api.Manifold.cube([20, 20, 20], true);
-      const b = api.Manifold.cube([10, 10, 30], true);
-      return a.subtract(b);
-    \`);
-    const p = pw.paintInBox({ box: { min: [-11, -11, 9], max: [11, 11, 11] }, color: [1, 0, 0] });
-    if (p.error) return p;
-  `);
-
-  expect(result.error, JSON.stringify(result)).toBeUndefined();
-  const { xml, colorMatches } = inspectColorgroup(result.base64!);
-  expect(colorMatches.length, `expected 1 color, got ${colorMatches.length}\n${xml.slice(0, 1500)}`).toBe(1);
+  const taggedTris = allTris.filter(t => t.includes('pid="') && t.includes('p1="'));
+  expect(taggedTris.length, `expected every triangle tagged; got ${taggedTris.length} of ${allTris.length}\n${xml.slice(0, 1500)}`).toBe(allTris.length);
 });

--- a/tests/threemf-color-export.spec.ts
+++ b/tests/threemf-color-export.spec.ts
@@ -1,0 +1,177 @@
+// Verify that exporting a model with N painted regions produces exactly N
+// colors in the 3MF m:colorgroup — no extra "default" filament slot.
+//
+// Regression test for: "exported 3MF imported into Bambu Studio with many
+// more colors than I actually painted." Bambu Studio (and similar slicers)
+// create one filament per <m:color> entry. Including a default color the
+// user never painted with would surface as an unwanted extra filament.
+
+import { test, expect } from 'playwright/test';
+
+interface ZipEntry {
+  name: string;
+  data: Uint8Array;
+}
+
+// Minimal STORE-method ZIP reader. Our 3MF builder uses no compression, so
+// this is enough — we never compile DEFLATE here.
+function readZip(bytes: Uint8Array): ZipEntry[] {
+  const entries: ZipEntry[] = [];
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let off = 0;
+  while (off + 30 < bytes.length) {
+    const sig = view.getUint32(off, true);
+    if (sig !== 0x04034b50) break; // end of local file headers
+    const compression = view.getUint16(off + 8, true);
+    const compressedSize = view.getUint32(off + 18, true);
+    const nameLen = view.getUint16(off + 26, true);
+    const extraLen = view.getUint16(off + 28, true);
+    const nameStart = off + 30;
+    const dataStart = nameStart + nameLen + extraLen;
+    const name = new TextDecoder().decode(bytes.subarray(nameStart, nameStart + nameLen));
+    if (compression !== 0) throw new Error(`unsupported compression ${compression}`);
+    const data = bytes.subarray(dataStart, dataStart + compressedSize);
+    entries.push({ name, data });
+    off = dataStart + compressedSize;
+  }
+  return entries;
+}
+
+async function exportPaintedCube(page: import('playwright/test').Page, recipe: string) {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  return page.evaluate(async (script) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    const fn = new Function('pw', 'api', `return (async () => { ${script} })();`);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await fn(pw, (pw as any));
+    if (out && out.error) return out;
+    const exported = await pw.export3MFData();
+    if (exported.error) return { stage: 'export', error: exported.error };
+    return { stage: 'done', base64: exported.base64 };
+  }, recipe);
+}
+
+function inspectColorgroup(base64: string) {
+  const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+  const entries = readZip(bytes);
+  const modelEntry = entries.find(e => e.name === '3D/3dmodel.model');
+  if (!modelEntry) throw new Error('missing 3D/3dmodel.model entry');
+  const xml = new TextDecoder().decode(modelEntry.data);
+  const colorMatches = xml.match(/<m:color\s+color="([^"]+)"/g) ?? [];
+  return { xml, colorMatches };
+}
+
+test('two distinct painted colors → exactly 2 colorgroup entries', async ({ page }) => {
+  const result = await exportPaintedCube(page, `
+    await pw.run('return api.Manifold.cube([20, 20, 20]);');
+    const top = pw.paintInBox({ box: { min: [-1, -1, 19], max: [21, 21, 21] }, color: [1, 0, 0] });
+    if (top.error) return top;
+    const bottom = pw.paintInBox({ box: { min: [-1, -1, -1], max: [21, 21, 1] }, color: [0, 0, 1] });
+    if (bottom.error) return bottom;
+  `);
+
+  expect(result.error, JSON.stringify(result)).toBeUndefined();
+  const { xml, colorMatches } = inspectColorgroup(result.base64!);
+  expect(colorMatches.length, `expected 2 colors, got ${colorMatches.length}\n${xml.slice(0, 2000)}`).toBe(2);
+
+  // Both painted colors are present, in any order.
+  const hexes = colorMatches.map(m => m.match(/"([^"]+)"/)![1].toUpperCase()).sort();
+  expect(hexes).toEqual(['#0000FFFF', '#FF0000FF']);
+});
+
+// Repeat the same color across multiple regions and verify dedup.
+test('three regions sharing one color → exactly 1 colorgroup entry', async ({ page }) => {
+  const result = await exportPaintedCube(page, `
+    await pw.run('return api.Manifold.cube([20, 20, 20]);');
+    const a = pw.paintInBox({ box: { min: [-1, -1, 19], max: [21, 21, 21] }, color: [1, 0, 0] });
+    if (a.error) return a;
+    const b = pw.paintInBox({ box: { min: [-1, -1, -1], max: [21, 21, 1] }, color: [1, 0, 0] });
+    if (b.error) return b;
+    const c = pw.paintInBox({ box: { min: [-1, -1, -1], max: [1, 21, 21] }, color: [1, 0, 0] });
+    if (c.error) return c;
+  `);
+
+  expect(result.error, JSON.stringify(result)).toBeUndefined();
+  const { xml, colorMatches } = inspectColorgroup(result.base64!);
+  expect(colorMatches.length, `expected 1 color, got ${colorMatches.length}\n${xml.slice(0, 800)}`).toBe(1);
+});
+
+test('hi-poly sphere with one painted region → exactly 1 colorgroup entry', async ({ page }) => {
+  // A sphere triangulates into many small faces. Painting one cap region
+  // should still produce a single colorgroup entry.
+  const result = await exportPaintedCube(page, `
+    await pw.run('return api.Manifold.sphere(15, 64);');
+    const r = pw.paintInBox({ box: { min: [-16, -16, 5], max: [16, 16, 16] }, color: [0.92, 0.26, 0.21] });
+    if (r.error) return r;
+  `);
+
+  expect(result.error, JSON.stringify(result)).toBeUndefined();
+  const { xml, colorMatches } = inspectColorgroup(result.base64!);
+  expect(colorMatches.length, `expected 1 color, got ${colorMatches.length}\nfirst 1500 chars:\n${xml.slice(0, 1500)}`).toBe(1);
+});
+
+test('every entry in colorgroup is referenced by some triangle', async ({ page }) => {
+  const result = await exportPaintedCube(page, `
+    await pw.run('return api.Manifold.cube([20, 20, 20]);');
+    const top = pw.paintInBox({ box: { min: [-1, -1, 19], max: [21, 21, 21] }, color: [1, 0, 0] });
+    if (top.error) return top;
+    const bottom = pw.paintInBox({ box: { min: [-1, -1, -1], max: [21, 21, 1] }, color: [0, 0, 1] });
+    if (bottom.error) return bottom;
+  `);
+
+  expect(result.error, JSON.stringify(result)).toBeUndefined();
+  const { xml, colorMatches } = inspectColorgroup(result.base64!);
+
+  // Collect every p1 value referenced by triangles in the model.
+  const used = new Set<string>();
+  for (const m of xml.matchAll(/p1="(\d+)"/g)) used.add(m[1]);
+
+  // Now check: is every index in the colorgroup actually used?
+  const unused: number[] = [];
+  for (let i = 0; i < colorMatches.length; i++) {
+    if (!used.has(String(i))) unused.push(i);
+  }
+
+  expect(unused, `colorgroup entries ${unused.join(',')} are NEVER referenced by any triangle, yet still appear in the file:\n${xml.slice(0, 1500)}`).toEqual([]);
+});
+
+// Unpainted regions must NOT carry pid="2" attributes — that would put the
+// triangle in the colorgroup and effectively assign it a filament slot.
+test('unpainted triangles have no pid/p1 attributes', async ({ page }) => {
+  const result = await exportPaintedCube(page, `
+    await pw.run('return api.Manifold.cube([20, 20, 20]);');
+    const top = pw.paintInBox({ box: { min: [-1, -1, 19], max: [21, 21, 21] }, color: [1, 0, 0] });
+    if (top.error) return top;
+  `);
+
+  expect(result.error, JSON.stringify(result)).toBeUndefined();
+  const bytes = Uint8Array.from(atob(result.base64!), c => c.charCodeAt(0));
+  const xml = new TextDecoder().decode(readZip(bytes).find(e => e.name === '3D/3dmodel.model')!.data);
+
+  const allTris = xml.match(/<triangle\b[^/]*\/>/g) ?? [];
+  const taggedTris = allTris.filter(t => t.includes('pid="'));
+  const untaggedTris = allTris.filter(t => !t.includes('pid="'));
+
+  // A 20×20×20 cube has 6 faces × 2 = 12 triangles. The top face is 2
+  // painted; the remaining 10 should be untagged.
+  expect(taggedTris.length, `expected 2 painted triangles, got ${taggedTris.length}\n${xml}`).toBe(2);
+  expect(untaggedTris.length, `expected 10 untagged triangles, got ${untaggedTris.length}\n${xml}`).toBe(10);
+});
+
+test('cube with subtract + 1 painted region → exactly 1 colorgroup entry', async ({ page }) => {
+  const result = await exportPaintedCube(page, `
+    await pw.run(\`
+      const a = api.Manifold.cube([20, 20, 20], true);
+      const b = api.Manifold.cube([10, 10, 30], true);
+      return a.subtract(b);
+    \`);
+    const p = pw.paintInBox({ box: { min: [-11, -11, 9], max: [11, 11, 11] }, color: [1, 0, 0] });
+    if (p.error) return p;
+  `);
+
+  expect(result.error, JSON.stringify(result)).toBeUndefined();
+  const { xml, colorMatches } = inspectColorgroup(result.base64!);
+  expect(colorMatches.length, `expected 1 color, got ${colorMatches.length}\n${xml.slice(0, 1500)}`).toBe(1);
+});


### PR DESCRIPTION
## Summary

Investigation of "exported 3MF imported into Bambu Studio with many more colors than I actually painted." The functional fix I tried (drop the default color from `<m:colorgroup>`) silently disabled Bambu Studio's "Standard 3MF Import Color" dialog — painted colors didn't make it across at all. Reverted that change in the follow-up commit; the export is back to the prior baseline.

What's still in the PR after the revert:
- **`tests/threemf-color-export.spec.ts`** — new Playwright regression coverage that exports through `partwright.export3MFData()`, unzips the 3MF, and asserts the colorgroup shape. Pins down today's format (default + N painted, `<object pid="2" pindex="0">`, every triangle tagged) so the next iteration has something concrete to push against.

Parked per user — the root cause needs a sample 3MF + Bambu screenshot to diagnose properly (whether the "many more" report was the +1 default we can see in the file, or something Bambu does on top during import).

## Test plan

- [x] `npm run build` clean
- [x] `npx playwright test tests/threemf-color-export.spec.ts` — 5/5 pass
- [x] `npx playwright test tests/smoke.spec.ts tests/paint-render-color.spec.ts` — 12/12 still pass

## Notes for whoever picks this up

- Bambu Studio's color-import trigger is in `bbs_3mf.cpp` — `m_group_id_to_color` map populated from `m:colorgroup` parsing. From the source it looks like the colorgroup alone should be enough, but in practice removing the object's `pid="2" pindex="0"` (or removing per-triangle `pid` on unpainted faces) skipped the dialog entirely. Worth digging into Plater.cpp / ObjColorDialog invocation to find the exact gate.
- Promising alternative not yet tested: emit both `<basematerials id="1">` (default, ignored by Bambu) and `<m:colorgroup id="2">` (painted colors). Object points at basematerial via `pid="1" pindex="0"`; painted triangles override with `pid="2" p1="N"`; unpainted inherit the basematerial. Bambu should see N painted colors only — but needs a Bambu round-trip to confirm.

https://claude.ai/code/session_01NF4L1WfSMXmEVo3uE1fzET