### PR TITLE
fix(ai): make spend cap a session-total budget + $5/$20 + drop $$ in dropdown

### DIFF
--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -102,6 +102,10 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
   let totalToolCalls = 0;
   const maxIter = ITERATION_CAP[toggles.maxIterations];
   const maxSpend = SPEND_CAP_USD[toggles.maxSpend];
+  // Spend cap is a session budget — count what prior turns already
+  // burned so this turn stops when the running total tips over the cap,
+  // not when this single turn would exceed the whole cap on its own.
+  const priorSessionCost = totalCost(history);
 
   for (let iter = 0; Number.isFinite(maxIter) ? iter < maxIter : true; iter++) {
     // Give the browser a frame between iterations so an agent running
@@ -172,11 +176,11 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
       return workingHistory;
     }
 
-    // Spend cap — stop BEFORE the next iteration if we've already
-    // exceeded the user's per-turn budget. We check after persisting
-    // the current iteration so the assistant message they paid for
-    // still lands in the transcript.
-    if (Number.isFinite(maxSpend) && totalCostUsd > maxSpend) {
+    // Spend cap — stop BEFORE the next iteration if the running session
+    // total (prior turns + this turn so far) has tipped over the user's
+    // budget. Checked after persisting the current iteration so the
+    // assistant message they paid for still lands in the transcript.
+    if (Number.isFinite(maxSpend) && (priorSessionCost + totalCostUsd) > maxSpend) {
       callbacks.onTurnComplete?.({
         totalCostUsd,
         toolCalls: totalToolCalls,

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -143,7 +143,7 @@ export function toggleSuffix(toggles: ChatToggles): string {
     `Model: ${toggles.model}`,
     `Auto-retry on tool error: ${toggles.autoRetry}`,
     `Iteration cap (tool round-trips this turn): ${capLabel}. Pace your tool calls accordingly — if the cap is low, batch related work and prefer one-shot tools like paintComponent or paintInBox over verify-then-paint loops.`,
-    `Spend cap (USD this turn): ${spendLabel}. Vision tool calls (renderView, paintPreview withImage) are the most expensive — skip them when stats alone are enough.`,
+    `Spend cap (total USD this session): ${spendLabel}. Prior turns in this session count toward the same budget, so the cap can fire mid-turn even on a cheap iteration. Vision tool calls (renderView, paintPreview withImage) are the most expensive — skip them when stats alone are enough.`,
   ];
   if (restrictions.length > 0) {
     lines.push('');

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -33,12 +33,14 @@ export interface ChatToggles {
    *  turn. The agent stops with a "stopped at cap" banner if it would
    *  exceed this. 'low'=4, 'medium'=16, 'high'=64, 'infinity'=unlimited. */
   maxIterations: 'low' | 'medium' | 'high' | 'infinity';
-  /** Hard cap on USD spend per user turn. Sums input + output + cache
-   *  read/write across every iteration. When exceeded the loop stops
-   *  with a "stopped at spend cap" banner. Both this and maxIterations
-   *  apply — whichever trips first stops the turn. 'infinity' disables
-   *  the cap. */
-  maxSpend: 'cheap' | 'low' | 'medium' | 'high' | 'infinity';
+  /** Hard cap on total USD spent in this session. Sums input + output +
+   *  cache read/write across every iteration of every turn so far.
+   *  Enforced two ways: the active turn stops with a "stopped at spend
+   *  cap" banner when this iteration would push the session total over,
+   *  and the panel blocks further sends once the cap has been reached
+   *  until the user raises it. Both this and maxIterations apply —
+   *  whichever trips first stops the turn. 'infinity' disables the cap. */
+  maxSpend: 'cheap' | 'low' | 'medium' | 'medHigh' | 'high' | 'veryHigh' | 'infinity';
   model: ModelId;
 }
 
@@ -56,10 +58,12 @@ export const MAX_ITERATIONS: Record<ChatToggles['maxIterations'], { value: numbe
 /** Source of truth for the spend-cap dropdown. Same pattern as
  *  MAX_ITERATIONS. */
 export const MAX_SPEND: Record<ChatToggles['maxSpend'], { value: number; label: string; promptLabel: string; hint: string }> = {
-  cheap:    { value: 0.10,  label: '$0.10', promptLabel: '$0.10',     hint: 'Tight budget. Pairs well with Haiku and short turns.' },
+  cheap:    { value: 0.10,  label: '$0.10', promptLabel: '$0.10',     hint: 'Tight session budget. Pairs well with Haiku and short turns.' },
   low:      { value: 0.50,  label: '$0.50', promptLabel: '$0.50',     hint: 'Safety net for casual iteration.' },
-  medium:   { value: 2.00,  label: '$2',    promptLabel: '$2',        hint: 'Default. Comfortable for most Sonnet turns including a few vision calls.' },
+  medium:   { value: 2.00,  label: '$2',    promptLabel: '$2',        hint: 'Default. Comfortable for a Sonnet session with a few vision calls.' },
+  medHigh:  { value: 5.00,  label: '$5',    promptLabel: '$5',        hint: 'Multi-turn Sonnet session with steady vision verification.' },
   high:     { value: 10.00, label: '$10',   promptLabel: '$10',       hint: 'Long autonomous runs on Opus, lots of vision verification.' },
+  veryHigh: { value: 20.00, label: '$20',   promptLabel: '$20',       hint: 'Marathon Opus sessions. Watch the cost meter.' },
   infinity: { value: Number.POSITIVE_INFINITY, label: '∞', promptLabel: 'unlimited', hint: 'No budget cap. The model can spend whatever it wants.' },
 };
 

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -14,7 +14,7 @@ import { generateId } from '../storage/db';
 import { showAiKeyModal } from './aiKeyModal';
 import { showAiSettingsModal } from './aiSettingsModal';
 import { showCompactConfirmModal } from './aiCompactModal';
-import type { ChatBlock, ChatMessage, ChatToggles, ImageSource, ModelId, PersistedToolResult, TurnOutcomeReason } from '../ai/types';
+import { SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type ImageSource, type ModelId, type PersistedToolResult, type TurnOutcomeReason } from '../ai/types';
 
 interface PanelState {
   open: boolean;
@@ -433,11 +433,11 @@ function renderToggleStrip(): void {
   // iterations but spend $0.50+ each).
   const spendCap = document.createElement('select');
   spendCap.className = 'px-1.5 py-0.5 rounded text-[10px] bg-zinc-800 border border-zinc-700 text-zinc-300 focus:outline-none';
-  spendCap.title = 'Spend cap: max USD this turn can cost before the loop forces a stop. Applies alongside the iteration cap — whichever trips first wins. Useful when iteration count is unpredictable (a vision-heavy iteration may spend $0.50). Set ∞ to disable.';
+  spendCap.title = 'Spend cap: total USD this session can cost before the loop forces a stop and further sends are blocked until you raise the cap. Applies alongside the iteration cap — whichever trips first wins. Set ∞ to disable.';
   for (const opt of MAX_SPEND_OPTIONS) {
     const o = document.createElement('option');
     o.value = opt.id;
-    o.textContent = `$ ${opt.label}`;
+    o.textContent = opt.label;
     o.title = opt.hint;
     spendCap.appendChild(o);
   }
@@ -760,6 +760,20 @@ async function sendMessage(): Promise<void> {
     return;
   }
 
+  // Session spend gate. The dropdown is a session-total budget, so block
+  // a new turn once historical spend has reached it. The user has to
+  // raise the cap (or pick ∞) to keep going — otherwise the dropdown
+  // would be advisory only and continued prompting would silently sail
+  // past the chosen budget.
+  const sessionCap = SPEND_CAP_USD[loadSettings().toggles.maxSpend];
+  if (Number.isFinite(sessionCap)) {
+    const sessionTotal = totalCost(state.history);
+    if (sessionTotal >= sessionCap) {
+      setTransientStatus(`Session has spent ${formatUsd(sessionTotal)} — at or over the ${formatUsd(sessionCap)} cap. Raise the $ cap in the toggle strip to continue.`);
+      return;
+    }
+  }
+
   // The drawer is a fixed overlay on every page (landing, catalog, help),
   // but the AI's tools (runAndSave, setCode, paint*) target the editor.
   // If the user fires from anywhere else, navigate to /editor and give
@@ -824,7 +838,7 @@ function formatTurnOutcome(o: TurnOutcome): string {
     case 'iteration_cap':
       return `⚠ stopped at agent iteration cap (${o.iterations}) — try a more focused prompt, click Compact, or raise the ⟲ cap · ${cost}${tools}`;
     case 'spend_cap':
-      return `⚠ stopped at spend cap${o.detail ? ` (${o.detail})` : ''} — raise the $ cap or click Send to continue · ${cost} · ${iters}${tools}`;
+      return `⚠ stopped at session spend cap${o.detail ? ` (${o.detail})` : ''} — raise the $ cap to continue · ${cost} · ${iters}${tools}`;
     case 'max_tokens':
       return `⚠ hit max_tokens before finishing · ${cost} · ${iters}${tools} — ask the model to continue`;
     case 'refusal':


### PR DESCRIPTION
## Summary

The spend-cap dropdown was advertised as a price limit but only enforced **per turn**, so continued prompting silently sailed past the chosen budget — selecting `$2` could still rack up many dollars over a session. This PR makes the dropdown do what its label promises and fixes two smaller bugs alongside.

- **Session-total enforcement.** `chatLoop.ts` now reads `priorSessionCost = totalCost(history)` and stops the active turn when `priorSessionCost + totalCostUsd > cap`. `sendMessage()` in `aiPanel.ts` gates new turns: if the session has already hit the cap, the panel flashes "Session has spent $X — at or over the $Y cap. Raise the $ cap in the toggle strip to continue." and returns without sending. The user has to bump the dropdown (or pick ∞) to keep going.
- **Add `$5` and `$20` tiers.** Two new entries (`medHigh`, `veryHigh`) in `MAX_SPEND`. The dropdown picks them up automatically — full order is now `$0.10`, `$0.50`, `$2`, `$5`, `$10`, `$20`, `∞`. Existing presets (`cheap`/`medium`/`high`) are unchanged.
- **Drop the double `$$`.** `aiPanel.ts` was rendering ``$ ${opt.label}`` while the labels already contained `$`, producing `$ $2`. Now renders `opt.label` directly.
- **Wording sweep.** Dropdown tooltip, post-turn `spend_cap` banner, system-prompt suffix, and the `maxSpend` docstring all updated to reflect session-total semantics (the prompt suffix tells the model that prior turns count toward the same budget so it doesn't overspend on a single big iteration).

## Test plan

- [ ] `npm run build` succeeds (verified locally)
- [ ] Open `/editor?view=ai` and confirm the spend-cap dropdown shows `$0.10 / $0.50 / $2 / $5 / $10 / $20 / ∞` with no `$$` artifacts
- [ ] Select `$0.10`, send a couple of prompts, hit the cap mid-turn → banner reads "stopped at session spend cap ($0.10) — raise the $ cap to continue"
- [ ] With session total over the cap, attempt another send → status flashes "Session has spent $X — at or over the $Y cap…" and no turn is started
- [ ] Raise the cap (e.g. `$2`), click Send → turn runs normally
- [ ] Select `∞` → cap gate is disabled, turns run regardless of accumulated cost

---
_Generated by [Claude Code](https://claude.ai/code/session_015VxRqe6QFfUtc8ZwwaH9Cv)_