### PR TITLE
feat: allow orbit camera rotation and zoom when cursor is over overlays or misses the model

### DIFF
--- a/src/color/boxDrag.ts
+++ b/src/color/boxDrag.ts
@@ -7,7 +7,7 @@
 import * as THREE from 'three';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
 import type { MeshData } from '../geometry/types';
-import { getScene, getCamera, getRenderer, getMeshGroup, setUserOrbitLock, isUserOrbitLocked } from '../renderer/viewport';
+import { getScene, getCamera, getRenderer, getMeshGroup, setGizmoLock } from '../renderer/viewport';
 import { addRegion, getRegions } from './regions';
 import { getColor, getCurrentMesh } from './paintMode';
 import { findBoxTriangles, type OrientedBox } from './boxPaint';
@@ -22,7 +22,6 @@ let boxMesh: THREE.Mesh | null = null;   // translucent box rendered in the view
 let boxEdges: THREE.LineSegments | null = null;
 let gizmo: TransformControls | null = null;
 let gizmoHelper: THREE.Object3D | null = null;
-let priorOrbitLock = false;
 
 const changeListeners: Array<(box: OrientedBox) => void> = [];
 
@@ -71,12 +70,9 @@ export function activate(): void {
   if (active) return;
   active = true;
 
-  // Reuse the global orbit lock the way other paint tools do. The gizmo also
-  // listens for its own dragging-changed event below to lock during a drag,
-  // but locking up-front matches the paint mode's "stop orbiting" contract.
-  priorOrbitLock = isUserOrbitLocked();
-  setUserOrbitLock(true);
-
+  // Orbit stays enabled — the gizmo locks it only while a handle is hovered
+  // or being dragged (see buildGizmo's axis-changed / dragging-changed
+  // handlers). Clicks outside the gizmo and box still rotate the camera.
   buildBox();
   buildGizmo();
   notifyChange(); // populate the panel's numeric readouts with initial values
@@ -85,7 +81,7 @@ export function activate(): void {
 export function deactivate(): void {
   if (!active) return;
   active = false;
-  if (!priorOrbitLock) setUserOrbitLock(false);
+  setGizmoLock(false);
   disposeGizmo();
   disposeBox();
 }
@@ -194,8 +190,15 @@ function buildGizmo(): void {
     syncVisuals();
     notifyChange();
   });
+  // Lock orbit the moment the cursor enters a handle (axis-changed fires
+  // before pointerdown) so OrbitControls never starts rotating, and again
+  // explicitly during the drag itself for any pointer that arrives without
+  // a hover (touch / pen).
+  gizmo.addEventListener('axis-changed', (e) => {
+    setGizmoLock(e.value !== null || gizmo!.dragging);
+  });
   gizmo.addEventListener('dragging-changed', (e) => {
-    if (e.value === true) setUserOrbitLock(true);
+    setGizmoLock(e.value === true || gizmo!.axis !== null);
   });
 }
 

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -6,7 +6,7 @@ import type { MeshData } from '../geometry/types';
 import { pickFace } from './facePicker';
 import { buildAdjacency, findCoplanarRegion, getTriangleNormal, type AdjacencyGraph } from './adjacency';
 import { addRegion, getRegions } from './regions';
-import { getMeshGroup, getRenderer, setUserOrbitLock, isUserOrbitLocked } from '../renderer/viewport';
+import { getMeshGroup, getRenderer, addPointerSuppressor, isPointerOverModel } from '../renderer/viewport';
 import { activate as activateSlabDrag, deactivate as deactivateSlabDrag, onMeshChanged as onSlabDragMeshChanged } from './slabDrag';
 import { activate as activateBoxDrag, deactivate as deactivateBoxDrag, onMeshChanged as onBoxDragMeshChanged } from './boxDrag';
 export { setSlabAxis, getSlabAxis } from './slabDrag';
@@ -32,9 +32,13 @@ let hoveredTriangles: Set<number> | null = null;
 let brushPainting = false;
 let brushSession: Set<number> | null = null;
 
-// Orbit lock — paint mode locks model rotation by default. The lock-toggle
-// button in the toolbar reflects this; users can unlock manually to reposition.
-let priorOrbitLock = false;
+// True when the active mousedown missed the model. We let OrbitControls
+// rotate in that case and skip the matching mouseup paint commit so a
+// rotation that happens to release over the model doesn't paint by accident.
+let mouseDownOffModel = false;
+
+// Teardown for the capture-phase pointer suppressor registered on activate.
+let removeSuppressor: (() => void) | null = null;
 
 // Callbacks
 let onRegionPainted: (() => void) | null = null;
@@ -121,8 +125,14 @@ export function activate(): void {
     adjacency = buildAdjacency(currentMesh);
   }
 
-  priorOrbitLock = isUserOrbitLocked();
-  setUserOrbitLock(true);
+  // Veto OrbitControls only for left-button pointerdowns that hit the model
+  // and only when a tool wants the click. Off-model clicks fall through so
+  // OrbitControls can rotate; the Box tool's gizmo owns its own drag.
+  removeSuppressor = addPointerSuppressor((event) => {
+    if (event.button !== 0) return false;
+    if (currentTool === 'box') return false;
+    return isPointerOverModel(event);
+  });
 
   const canvas = getRenderer().domElement;
   canvas.addEventListener('mousemove', onMouseMove);
@@ -140,7 +150,7 @@ export function deactivate(): void {
   active = false;
   adjacency = null;
 
-  if (!priorOrbitLock) setUserOrbitLock(false);
+  if (removeSuppressor) { removeSuppressor(); removeSuppressor = null; }
 
   deactivateSlabDrag();
   deactivateBoxDrag();
@@ -154,6 +164,7 @@ export function deactivate(): void {
   clearHighlight();
   brushPainting = false;
   brushSession = null;
+  mouseDownOffModel = false;
 }
 
 function onMouseMove(event: MouseEvent): void {
@@ -162,6 +173,13 @@ function onMouseMove(event: MouseEvent): void {
   // Slab and box tools own their own gizmo / drag interactions; the
   // bucket-vs-brush hover preview gets out of the way.
   if (currentTool === 'slab' || currentTool === 'box') {
+    clearHighlight();
+    return;
+  }
+
+  // Mid-rotation (mousedown landed off the model) — skip hover preview so
+  // the highlight doesn't flicker on top of the model as the camera spins.
+  if (mouseDownOffModel) {
     clearHighlight();
     return;
   }
@@ -201,9 +219,16 @@ function onMouseDown(event: MouseEvent): void {
   if (event.button !== 0) return;
   if (currentTool === 'slab' || currentTool === 'box') return;
 
+  // Off-model click → OrbitControls is rotating; remember so mouseup doesn't
+  // paint if the user happens to release over the model after a rotation.
+  const result = pickFace(event);
+  if (!result) {
+    mouseDownOffModel = true;
+    return;
+  }
+  mouseDownOffModel = false;
+
   if (currentTool === 'brush') {
-    const result = pickFace(event);
-    if (!result) return;
     brushPainting = true;
     brushSession = new Set<number>();
     addBrushFootprint(result.triangleIndex, result.point, brushSession);
@@ -238,6 +263,11 @@ function onMouseUp(event: MouseEvent): void {
   if (!adjacency || !currentMesh) return;
   if (event.button !== 0) return;
   if (currentTool === 'slab' || currentTool === 'box') return;
+
+  if (mouseDownOffModel) {
+    mouseDownOffModel = false;
+    return;
+  }
 
   if (currentTool === 'brush') {
     if (!brushPainting || !brushSession || brushSession.size === 0) {

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -29,9 +29,20 @@ let controls: OrbitControls;
 let meshGroup: THREE.Group;
 let animationId: number;
 
-// Orbit lock state — orbit is disabled when any lock source is active
+// Orbit lock state — when locked, rotate/pan are disabled but zoom always works,
+// so wheel/two-finger-scroll keeps zooming the camera in every mode.
 let measureLock = false;
 let userLock = false;
+let gizmoLock = false;
+
+// Pointer suppressors — capture-phase pointerdown veto for OrbitControls.
+// Lets paint mode let orbit handle clicks that miss the model while keeping
+// model-hit clicks for painting.
+type PointerSuppressor = (event: PointerEvent) => boolean;
+const pointerSuppressors: PointerSuppressor[] = [];
+
+const raycasterForHit = new THREE.Raycaster();
+const ndcForHit = new THREE.Vector2();
 
 // Grid plane
 let grid: THREE.GridHelper;
@@ -78,6 +89,45 @@ export function initViewport(container: HTMLElement): {
   controls.enableDamping = true;
   controls.dampingFactor = 0.1;
   controls.target.set(0, 0, 0);
+
+  // Capture-phase pointerdown gives paint tools the chance to veto OrbitControls'
+  // pointerdown per-event (e.g. let orbit handle clicks that miss the model).
+  canvas.addEventListener('pointerdown', (event) => {
+    for (const fn of pointerSuppressors) {
+      if (fn(event)) {
+        event.stopImmediatePropagation();
+        return;
+      }
+    }
+  }, { capture: true });
+
+  // Capture-phase wheel forwarder — re-dispatches wheel events that land on
+  // viewport overlays (paint picker panel, toolbar buttons, ...) onto the
+  // canvas so OrbitControls' zoom keeps working regardless of cursor location.
+  // Scrollable descendants still consume the wheel.
+  container.addEventListener('wheel', (event) => {
+    if (event.target === canvas) return; // OrbitControls owns canvas wheels
+    let el: HTMLElement | null = event.target as HTMLElement;
+    while (el && el !== container) {
+      if (isVerticallyScrollable(el)) return;
+      el = el.parentElement;
+    }
+    event.preventDefault();
+    canvas.dispatchEvent(new WheelEvent('wheel', {
+      deltaX: event.deltaX,
+      deltaY: event.deltaY,
+      deltaZ: event.deltaZ,
+      deltaMode: event.deltaMode,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      ctrlKey: event.ctrlKey,
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      metaKey: event.metaKey,
+      bubbles: true,
+      cancelable: true,
+    }));
+  }, { capture: true, passive: false });
 
   // Lighting
   const ambient = new THREE.AmbientLight(0xffffff, 0.6);
@@ -150,7 +200,7 @@ export function initViewport(container: HTMLElement): {
     animationId = requestAnimationFrame(animate);
     const delta = clock.getDelta();
     updateGizmo(delta);
-    controls.enabled = !measureLock && !userLock && !isGizmoAnimating();
+    syncOrbitState();
     controls.update();
     renderer.render(scene, camera);
     renderGizmo(renderer);
@@ -421,13 +471,20 @@ export function getMeshGroup(): THREE.Group {
 
 // === Orbit lock API ===
 
-function syncOrbitEnabled(): void {
-  controls.enabled = !measureLock && !userLock && !isGizmoAnimating();
+// Locks gate rotate + pan; zoom is intentionally always enabled so
+// wheel / two-finger-scroll zooms the camera in every mode.
+function syncOrbitState(): void {
+  const animating = isGizmoAnimating();
+  const rotatePanLocked = animating || measureLock || userLock || gizmoLock;
+  controls.enabled = !animating;
+  controls.enableRotate = !rotatePanLocked;
+  controls.enablePan = !rotatePanLocked;
+  controls.enableZoom = !animating;
 }
 
 export function setMeasureLock(locked: boolean): void {
   measureLock = locked;
-  syncOrbitEnabled();
+  syncOrbitState();
 }
 
 const userOrbitLockListeners: Array<(locked: boolean) => void> = [];
@@ -435,7 +492,7 @@ const userOrbitLockListeners: Array<(locked: boolean) => void> = [];
 export function setUserOrbitLock(locked: boolean): void {
   if (userLock === locked) return;
   userLock = locked;
-  syncOrbitEnabled();
+  syncOrbitState();
   for (const fn of userOrbitLockListeners) fn(locked);
 }
 
@@ -449,6 +506,43 @@ export function onUserOrbitLockChange(fn: (locked: boolean) => void): () => void
     const i = userOrbitLockListeners.indexOf(fn);
     if (i >= 0) userOrbitLockListeners.splice(i, 1);
   };
+}
+
+/** Transient lock raised by TransformControls (paint Box gizmo) while a handle
+ *  is being hovered or dragged so OrbitControls doesn't rotate at the same time. */
+export function setGizmoLock(locked: boolean): void {
+  if (gizmoLock === locked) return;
+  gizmoLock = locked;
+  syncOrbitState();
+}
+
+/** Register a capture-phase pointerdown veto. Returning true stops the event
+ *  from reaching OrbitControls so the caller can own the drag. */
+export function addPointerSuppressor(fn: PointerSuppressor): () => void {
+  pointerSuppressors.push(fn);
+  return () => {
+    const i = pointerSuppressors.indexOf(fn);
+    if (i >= 0) pointerSuppressors.splice(i, 1);
+  };
+}
+
+/** Raycast the visible model (first child of the mesh group) and report
+ *  whether the screen-space pointer lands on a triangle. */
+export function isPointerOverModel(event: { clientX: number; clientY: number }): boolean {
+  if (!meshGroup || meshGroup.children.length === 0) return false;
+  const solid = meshGroup.children[0];
+  if (!(solid instanceof THREE.Mesh)) return false;
+  const rect = renderer.domElement.getBoundingClientRect();
+  ndcForHit.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  ndcForHit.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycasterForHit.setFromCamera(ndcForHit, camera);
+  return raycasterForHit.intersectObject(solid).length > 0;
+}
+
+function isVerticallyScrollable(el: HTMLElement): boolean {
+  const style = getComputedStyle(el);
+  const overflowY = style.overflowY;
+  return (overflowY === 'auto' || overflowY === 'scroll') && el.scrollHeight > el.clientHeight;
 }
 
 export { setDimensionsVisible, isDimensionsVisible } from './dimensionLines';

--- a/tests/paint-camera-passthrough.spec.ts
+++ b/tests/paint-camera-passthrough.spec.ts
@@ -1,0 +1,142 @@
+// Verifies that paint mode lets the orbit camera handle drags that miss the
+// model, and that wheel/two-finger-scroll zooms the camera regardless of
+// whether the cursor is over the paint picker panel.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function openEditorWithCube(page: Page) {
+  // Dismiss the first-visit tour so its full-screen backdrop doesn't swallow
+  // pointer events targeted at the viewport canvas.
+  await page.addInitScript(() => {
+    localStorage.setItem('partwright-tour-completed', new Date().toISOString());
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.run(`const { Manifold } = api; return Manifold.cube([5, 5, 5], true);`);
+  });
+}
+
+async function getCamera(page: Page) {
+  return page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    return pw.getViewState().camera;
+  });
+}
+
+async function enablePaintMode(page: Page) {
+  await page.locator('#paint-toggle').dispatchEvent('click');
+  await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+}
+
+test.describe('paint mode camera passthrough', () => {
+  test('drag from off-model space rotates the camera', async ({ page }) => {
+    await openEditorWithCube(page);
+    await enablePaintMode(page);
+
+    const before = await getCamera(page);
+    const canvas = await page.locator('#viewport').boundingBox();
+    if (!canvas) throw new Error('viewport canvas missing');
+
+    // A small 5x5x5 cube near the center leaves the corners empty; pick a
+    // corner well outside the projected silhouette as the drag origin.
+    const startX = canvas.x + 30;
+    const startY = canvas.y + canvas.height - 30;
+    const endX = canvas.x + canvas.width - 30;
+    const endY = canvas.y + 30;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move((startX + endX) / 2, (startY + endY) / 2, { steps: 5 });
+    await page.mouse.move(endX, endY, { steps: 5 });
+    await page.mouse.up();
+
+    // Let damping resolve.
+    await page.waitForTimeout(300);
+
+    const after = await getCamera(page);
+    const azimuthDelta = Math.abs(after.azimuth - before.azimuth);
+    const elevationDelta = Math.abs(after.elevation - before.elevation);
+    expect(azimuthDelta + elevationDelta).toBeGreaterThan(5);
+  });
+
+  test('wheel over the paint picker panel zooms the camera', async ({ page }) => {
+    await openEditorWithCube(page);
+    await enablePaintMode(page);
+
+    const before = await getCamera(page);
+    const panel = await page.locator('#paint-picker-panel').boundingBox();
+    if (!panel) throw new Error('paint picker panel missing');
+
+    // Aim near the top of the panel (tool buttons / color title area)
+    // — definitely on the panel, not over the canvas.
+    await page.mouse.move(panel.x + panel.width / 2, panel.y + 12);
+    await page.mouse.wheel(0, 240);
+
+    await page.waitForTimeout(300);
+
+    const after = await getCamera(page);
+    expect(Math.abs(after.distance - before.distance)).toBeGreaterThan(0.5);
+  });
+
+  test('wheel over the clip-controls toolbar zooms the camera', async ({ page }) => {
+    await openEditorWithCube(page);
+    const before = await getCamera(page);
+    const toolbar = await page.locator('#clip-controls').boundingBox();
+    if (!toolbar) throw new Error('clip controls missing');
+
+    await page.mouse.move(toolbar.x + toolbar.width / 2, toolbar.y + toolbar.height / 2);
+    await page.mouse.wheel(0, 240);
+
+    await page.waitForTimeout(300);
+
+    const after = await getCamera(page);
+    expect(Math.abs(after.distance - before.distance)).toBeGreaterThan(0.5);
+  });
+
+  test('wheel zooms even when the camera is hard-locked', async ({ page }) => {
+    await openEditorWithCube(page);
+    // Toggle the orbit lock from the toolbar — rotate and pan are now off.
+    await page.locator('#orbit-lock-toggle').dispatchEvent('click');
+
+    const before = await getCamera(page);
+    const canvas = await page.locator('#viewport').boundingBox();
+    if (!canvas) throw new Error('viewport canvas missing');
+
+    await page.mouse.move(canvas.x + canvas.width / 2, canvas.y + canvas.height / 2);
+    await page.mouse.wheel(0, 240);
+
+    await page.waitForTimeout(300);
+
+    const after = await getCamera(page);
+    expect(Math.abs(after.distance - before.distance)).toBeGreaterThan(0.5);
+  });
+
+  test('drag that lands on the model after starting off-model does not paint', async ({ page }) => {
+    await openEditorWithCube(page);
+    await enablePaintMode(page);
+
+    const regionsBefore = await page.evaluate(() =>
+      (window as unknown as { partwright: { listRegions(): unknown[] } }).partwright.listRegions().length,
+    );
+
+    const canvas = await page.locator('#viewport').boundingBox();
+    if (!canvas) throw new Error('viewport canvas missing');
+
+    // Press in a corner (off-model), drag across the model, release over it.
+    await page.mouse.move(canvas.x + 20, canvas.y + canvas.height - 20);
+    await page.mouse.down();
+    await page.mouse.move(canvas.x + canvas.width / 2, canvas.y + canvas.height / 2, { steps: 5 });
+    await page.mouse.up();
+
+    await page.waitForTimeout(150);
+
+    const regionsAfter = await page.evaluate(() =>
+      (window as unknown as { partwright: { listRegions(): unknown[] } }).partwright.listRegions().length,
+    );
+    expect(regionsAfter).toBe(regionsBefore);
+  });
+});


### PR DESCRIPTION
## Summary

- Dragging from empty space (off-model) in paint mode now rotates the camera instead of being a no-op, and releasing over the model after an orbit drag does not accidentally paint a face
- Wheel/two-finger scroll zooms the camera regardless of where the cursor is — over the paint picker panel, the clip-controls toolbar, or any other overlay
- Zoom is never hard-locked; only rotate/pan are suppressed by the gizmo, measure, or user-lock flags

## Changes

### `src/renderer/viewport.ts`
- Replaced single `controls.enabled` gate with granular `enableRotate`/`enablePan`/`enableZoom` so zoom always works
- Added `gizmoLock` state (separate from `measureLock`/`userLock`) controlled by the box-drag gizmo
- Added `addPointerSuppressor()` — lets paint mode register a capture-phase veto that only blocks OrbitControls when the pointer hits the model
- Added `isPointerOverModel()` helper using a raycaster against the mesh group
- Added capture-phase wheel forwarder on the viewport container that re-dispatches events landing on non-scrollable overlays to the canvas

### `src/color/paintMode.ts`
- Removed hard `setUserOrbitLock(true)` on activate; replaced with a pointer suppressor that vetoes only on-model left-button clicks
- Added `mouseDownOffModel` flag: if mousedown misses the model, the matching mouseup skips the paint commit so orbit drags that end over the model don't paint

### `src/color/boxDrag.ts`
- Replaced `setUserOrbitLock` with `setGizmoLock`; orbit is now only locked while a gizmo handle is hovered or actively dragged (via `axis-changed`/`dragging-changed` events)

### `tests/paint-camera-passthrough.spec.ts`
- New Playwright spec with 5 tests verifying all four behaviors: off-model drag rotates camera, wheel over panel zooms, wheel over toolbar zooms, wheel zooms when hard-locked, off-model-to-on-model drag does not paint

## Test plan

- [ ] Enable paint mode → drag from empty corner of viewport → camera rotates
- [ ] Enable paint mode → scroll while hovering over the color picker panel → camera zooms
- [ ] Scroll while hovering over the clip-controls toolbar → camera zooms
- [ ] Enable orbit lock → scroll over the viewport → camera still zooms
- [ ] Enable paint mode → drag from empty corner across the model and release on it → no region is painted
- [ ] Enable paint mode → click directly on the model → face paints as expected (regression check)
- [ ] Box drag tool: hover a gizmo handle → orbit is locked; move off the handle → orbit is restored

https://claude.ai/code/session_012yUuCiEENLyzEXXxFK3D52

---
_Generated by [Claude Code](https://claude.ai/code/session_012yUuCiEENLyzEXXxFK3D52)_