### PR TITLE
docs: add AI costs & risk disclaimer to help page and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Manifold.cube([10, 10, 10], true)
   .translate([0, 0, 5]);
 ```
 
+## A note on AI costs & risk
+
+Partwright is an experiment — a passion project exploring what happens when you put generative AI inside a browser-based 3D modeling tool. I've spent my own money building it; I'm not trying to make money from it, and I hope it brings others the same joy and curiosity it's brought me.
+
+That said: **when you connect your own AI agent, it uses your API tokens.** AI-driven CAD is genuinely hard — the agent may iterate many times before producing good geometry (or not). There are some guardrails in place to help limit runaway spend, but there's no guarantee they work perfectly in every situation. **By connecting your own AI agent, you accept responsibility for any API costs incurred, regardless of output quality.** Start small, run a quick test first, and go in eyes open.
+
 ## AI Agent Setup
 
 AI agents (Claude Code, etc.) interact with the app via `window.partwright` in the browser. The legacy `window.mainifold` alias still works for older prompts and tools. There are several ways to give an AI agent browser access:

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -60,6 +60,12 @@ export function createHelpPage(
       body: 'Partwright is designed to be driven by AI agents. An agent navigates to the app, writes geometry code, and uses the <code class="text-emerald-400 bg-zinc-800 px-1 rounded">window.partwright</code> console API to create sessions, run code, validate results, and save versions — all programmatically. The legacy <code class="text-emerald-400 bg-zinc-800 px-1 rounded">window.mainifold</code> alias still works during migration. <a href="/ai.md" class="text-blue-400 hover:underline">Full agent instructions \u2192</a>',
     },
     {
+      heading: 'A note on AI costs & risk',
+      body: 'Partwright is an experiment — a passion project exploring what happens when you put generative AI inside a 3D modeling tool, shared openly because I\'ve found real joy in building it and hope others find value in it too. I\'ve spent my own money on this and I\'m not trying to make money from it.<br><br>' +
+        'That said: <strong class="text-zinc-300">when you connect your own AI agent, it uses your API tokens.</strong> AI-driven CAD is genuinely hard and unpredictable — the agent might iterate many times before landing on something good (or give up trying). There are some guardrails in place to help limit runaway spend, but there\'s no guarantee they work perfectly in every situation. <strong class="text-zinc-300">By connecting your own AI agent, you accept responsibility for any API costs incurred, regardless of output quality.</strong><br><br>' +
+        'Go in eyes open, start with small experiments, and enjoy the ride.',
+    },
+    {
       heading: 'Connecting an AI agent',
       body: 'There are three ways to give an AI agent browser access:<br><br>' +
         '<strong class="text-zinc-300">Claude in Chrome extension</strong> — Install the extension and Claude Desktop can control your active tab directly. Best for interactive sessions.<br><br>' +


### PR DESCRIPTION
Adds a warm, honest notice that connecting your own AI agent means
spending your own API tokens, that output quality is unpredictable,
and that the builder is sharing this as a passion project with no
profit motive. Placed immediately before the "Connecting an AI agent"
section in the help page, and before "AI Agent Setup" in the README.

https://claude.ai/code/session_01VCx5CM3zNEAt6ap8qhidCy