### PR TITLE
feat: expand in-app AI tool bridge with missing capabilities

### DIFF
--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -228,7 +228,70 @@ export function buildApiMessages(history: ChatMessage[]): Anthropic.MessageParam
       if (content.length > 0) out.push({ role: 'assistant', content });
     }
   }
-  return out;
+  return sanitizeToolUse(out);
+}
+
+/** Repair dangling tool_use/tool_result invariant violations before the
+ *  messages array is sent to the API. When a turn is aborted or stalls
+ *  mid-tool-call, the history can contain an assistant message with
+ *  tool_use blocks that has no matching tool_result in the next message —
+ *  the API rejects this with a 400.
+ *
+ *  Two cases:
+ *  1. Orphaned tool_use at the tail (no following user message at all) —
+ *     strip the assistant message entirely so the conversation ends cleanly
+ *     on the last complete user message.
+ *  2. Orphaned tool_use mid-conversation (next message is a user message
+ *     that doesn't carry the matching tool_results) — inject synthetic
+ *     tool_result blocks marked is_error so the invariant is satisfied and
+ *     the model understands those tools didn't complete. */
+function sanitizeToolUse(messages: Anthropic.MessageParam[]): Anthropic.MessageParam[] {
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role !== 'assistant' || !Array.isArray(msg.content)) continue;
+
+    const content = msg.content as Anthropic.ContentBlockParam[];
+    const toolUseIds = content
+      .filter(b => b.type === 'tool_use')
+      .map(b => (b as { type: 'tool_use'; id: string }).id);
+    if (toolUseIds.length === 0) continue;
+
+    const next = messages[i + 1];
+
+    if (!next) {
+      // Trailing assistant message with unexecuted tool calls — strip it so
+      // the conversation ends on a user message the model can respond to.
+      messages.splice(i, 1);
+      i--;
+      continue;
+    }
+
+    const nextContent = (Array.isArray(next.content) ? next.content : []) as Anthropic.ContentBlockParam[];
+    const coveredIds = new Set(
+      nextContent
+        .filter(b => b.type === 'tool_result')
+        .map(b => (b as { type: 'tool_result'; tool_use_id: string }).tool_use_id)
+    );
+    const missing = toolUseIds.filter(id => !coveredIds.has(id));
+    if (missing.length === 0) continue;
+
+    // Inject synthetic results for the missing IDs, prepended so tool_results
+    // appear before any user text (required by the API).
+    const synthetic: Anthropic.ContentBlockParam[] = missing.map(id => ({
+      type: 'tool_result' as const,
+      tool_use_id: id,
+      content: 'Tool call was interrupted and did not complete.',
+      is_error: true,
+    }));
+
+    if (next.role === 'user' && Array.isArray(next.content)) {
+      (next.content as Anthropic.ContentBlockParam[]).unshift(...synthetic);
+    } else {
+      messages.splice(i + 1, 0, { role: 'user', content: synthetic });
+      i++;
+    }
+  }
+  return messages;
 }
 
 function userBlocksToApi(blocks: ChatBlock[], toolResults: PersistedToolResult[]): Anthropic.ContentBlockParam[] {

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -220,18 +220,39 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
     // flight, but we check the signal between calls so a stop request
     // takes effect within ~one tool's duration.
     callbacks.onProgress?.({ phase: 'tool', detail: `running ${result.toolCalls.length} tool(s)...` });
-    const toolResults = await executeAllWithRetry(result.toolCalls, toggles, callbacks, signal);
-    totalToolCalls += result.toolCalls.length;
 
+    // Persist a placeholder tool-result message immediately after the assistant
+    // message so that a page kill (tab switch, browser GC, system sleep) between
+    // now and when tools finish doesn't leave orphaned tool_use blocks in
+    // IndexedDB. Orphaned blocks cause a synthetic "interrupted" error on every
+    // future resume of this session. Each slot is updated in-place as its tool
+    // completes; the final await below writes the authoritative copy.
     const toolResultMsg: ChatMessage = {
       id: generateId(),
       sessionId,
       role: 'user',
       blocks: [],
-      toolResults,
+      toolResults: result.toolCalls.map(tc => ({
+        toolUseId: tc.id,
+        content: '[Tool call was interrupted and did not complete]',
+        isError: true,
+      })),
       createdAt: Date.now(),
       seq: seqStart + 2 + iter * 2,
     };
+    await putMessages([toolResultMsg]);
+
+    const toolResults = await executeAllWithRetry(
+      result.toolCalls, toggles, callbacks, signal,
+      (eachResult, i) => {
+        toolResultMsg.toolResults![i] = eachResult;
+        void putMessages([toolResultMsg]);
+      },
+    );
+    totalToolCalls += result.toolCalls.length;
+
+    // Final authoritative persist: same id, complete result set.
+    toolResultMsg.toolResults = toolResults;
     await putMessages([toolResultMsg]);
     workingHistory = [...workingHistory, toolResultMsg];
 
@@ -268,9 +289,11 @@ async function executeAllWithRetry(
   toggles: ChatToggles,
   callbacks: RunTurnCallbacks,
   signal?: AbortSignal,
+  onEachResult?: (result: PersistedToolResult, index: number) => void,
 ): Promise<PersistedToolResult[]> {
   const results: PersistedToolResult[] = [];
-  for (const tc of toolCalls) {
+  for (let i = 0; i < toolCalls.length; i++) {
+    const tc = toolCalls[i];
     // If the user hit Stop, every remaining tool call gets a synthetic
     // "aborted by user" result. The API requires every tool_use to have a
     // matching tool_result on the next turn, so we can't just drop them.
@@ -282,6 +305,7 @@ async function executeAllWithRetry(
       };
       results.push(aborted);
       callbacks.onToolResult?.(tc.id, tc.name, aborted);
+      onEachResult?.(aborted, i);
       continue;
     }
     let attempt = 0;
@@ -298,6 +322,7 @@ async function executeAllWithRetry(
     };
     results.push(persisted);
     callbacks.onToolResult?.(tc.id, tc.name, persisted);
+    onEachResult?.(persisted, i);
     // Yield BETWEEN tool calls so the browser can flush a frame and the
     // user can interact (click Stop, scroll the transcript). A run of 5
     // paint tools without yields is enough to trigger Chrome's "page

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -36,6 +36,13 @@ undoLastPaint() to reverse just the most recent paint, or removeRegion(id)
 to delete a specific older mistake (get the id from listRegions). Save
 clearColors for "start completely over from scratch" requests.
 
+When a tool call result shows "Tool call was interrupted and did not
+complete", do NOT assume the operation failed. The underlying call may
+have completed just before the stream was cut. Verify actual state with
+getSessionContext() (includes currentCode and version list) and
+getGeometryData() before re-running anything — re-running a runAndSave
+that actually succeeded creates a duplicate version.
+
 Paint workflow for any non-trivial selector:
 1. paintPreview({box / point+radius / etc.}) — ALWAYS call before
    committing. Count alone is essentially free and catches most bad
@@ -45,13 +52,14 @@ Paint workflow for any non-trivial selector:
    count or ratio looks off, call again with withImage: true for a
    yellow-highlighted thumbnail — the yellow streaks show real bleed,
    not a rendering artifact.
-2. paintInBox / paintNear / paintSlab to commit. On meshes built from
-   cylinder / revolve / linear_extrude (radial-fan topology), pass
-   coverageMode: 'fully_inside' so only triangles whose vertices ALL
-   lie in the selection are painted; or pass maxTriangleArea: <N> as
-   a backstop. Either one prevents fan-bleed at the cost of one extra
-   parameter. For meshes built from sphere / cube / hull (small local
-   triangles), the default 'centroid' mode is fine.
+2. paintInBox / paintNear / paintSlab / paintInCylinder to commit.
+   Use paintInCylinder for inner walls of hollow cylinders, mugs, or
+   any revolved shape (rMin = inner radius, rMax = outer radius, set
+   zMin/zMax to the height range of the inner surface). On meshes built
+   from cylinder / revolve / linear_extrude (radial-fan topology), pass
+   coverageMode: 'fully_inside' or maxTriangleArea to avoid fan-bleed.
+   For meshes built from sphere / cube / hull, the default 'centroid'
+   mode is fine.
 3. renderViews() to visually verify. The default views: 'auto' picks
    angles by the model's bounding box (flat disks get [Top, Iso],
    tall columns get [Front, Right, Iso], otherwise [Front, Top, Iso])
@@ -96,6 +104,22 @@ fan-bleed, survives boolean ops. listLabels() returns what's available
 in the current run. api.labeledUnion([{name, shape}, ...]) is sugar
 when you have an array of features.
 
+IMPORTANT label limitation: api.label tracks surfaces that existed in
+the ORIGINAL labeled shape. Boolean subtraction (.subtract()) creates
+NEW triangles at the cut surface — these new triangles inherit NO label.
+Example: label the outer body, subtract an inner void to hollow it out
+→ the inner wall surface is unlabeled. Don't waste attempts calling
+paintByLabel('inner') on a subtraction surface. Instead:
+- Use probePixel + paintConnected for inner surfaces from boolean ops.
+- Or design around it: label a thin shell geometry that approximates
+  the inner surface, then subtract separately.
+- Or use paintInCylinder for cylindrical inner walls (e.g. mug interiors).
+
+Labels are version-specific: loadVersion(N) re-runs that version's code,
+so listLabels() after loadVersion returns THAT version's labels — not
+the current version's. If v1 didn't use api.label but v3 did, loading
+v1 gives empty labels. This is correct behavior.
+
 For models you didn't author with labels (or for SCAD), fall back to
 paintComponent(index, color) — it decomposes the union and paints the
 Nth piece in one call. Use listComponents() FIRST only when you need
@@ -105,6 +129,9 @@ For multi-feature labelled models, batch with paintByLabels([...]) —
 one tool call paints all features and coalesces the viewport refresh
 under a single rAF, so a 9-feature smiley costs one round-trip instead
 of nine. Reach for paintByLabel only when you need just one feature.
+paintByLabel and paintByLabels now support optional topOnly/normalCone
+per-item to filter the label's triangles by face direction — useful when
+a label covers both top and side faces and you only want the top surface.
 
 Paint tools are SEPARATE tool calls — they cannot be invoked from
 inside runCode / runAndSave / runIsolated model code. The model code

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -84,12 +84,39 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'runAndSave',
-    description: 'Run code and commit the result as a new gallery version in the current session. The preferred way to make progress — leaves a versioned record. Returns geometry stats and the saved version number.',
+    description: 'Run code and commit the result as a new gallery version in the current session. The preferred way to make progress — leaves a versioned record. Returns geometry stats and the saved version number. Optionally pass `assertions` to validate before saving — the version is NOT saved if assertions fail.',
     input_schema: {
       type: 'object',
       properties: {
         code: { type: 'string', description: 'Code to run (overwrites the editor with the run-passing variant).' },
         label: { type: 'string', description: 'Short label for the gallery (e.g. "tapered legs"). Defaults to v<index>.' },
+        assertions: {
+          type: 'object',
+          description: 'Optional geometry assertions. Version is NOT saved if any assertion fails.',
+          properties: {
+            isManifold: { type: 'boolean', description: 'Must be a valid manifold.' },
+            maxComponents: { type: 'integer', description: 'Max component count.' },
+            minVolume: { type: 'number', description: 'Minimum volume.' },
+            maxVolume: { type: 'number', description: 'Maximum volume.' },
+            genus: { type: 'integer', description: 'Exact genus.' },
+            minGenus: { type: 'integer', description: 'Minimum genus.' },
+            maxGenus: { type: 'integer', description: 'Maximum genus.' },
+            minBounds: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Minimum bounding box dimensions [x,y,z].' },
+            maxBounds: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Maximum bounding box dimensions [x,y,z].' },
+            minTriangles: { type: 'integer', description: 'Minimum triangle count.' },
+            maxTriangles: { type: 'integer', description: 'Maximum triangle count.' },
+            boundsRatio: {
+              type: 'object',
+              description: 'Proportion assertions.',
+              properties: {
+                widthToDepth: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2, description: '[min, max] ratio of width to depth.' },
+                widthToHeight: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2, description: '[min, max] ratio of width to height.' },
+                depthToHeight: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2, description: '[min, max] ratio of depth to height.' },
+              },
+            },
+            notes: { type: 'string', description: 'Optional note text attached to the saved version.' },
+          },
+        },
       },
       required: ['code'],
     },
@@ -476,6 +503,211 @@ const ALL_TOOLS: ToolDefinition[] = [
     description: 'Remove ALL color regions from the current version. Destructive — only use when you want a completely clean slate. To fix a single mistake, call undoLastPaint or removeRegion(id) instead.',
     input_schema: { type: 'object', properties: {} },
   },
+  {
+    name: 'forkVersion',
+    description: 'Fork a prior version: load version N, replace its code with the provided code, validate against optional assertions, and save as a new version — all atomically. Use this to branch off a known-good version without the fragile loadVersion → getCode → modify → runAndSave chain. Returns {parent, version, geometry, diff, galleryUrl} on success, or {error} / {passed: false, failures} on failure.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        index: { type: 'integer', description: '1-based version index to fork from (from listVersions).' },
+        code: { type: 'string', description: 'The new code for the forked version (complete program).' },
+        label: { type: 'string', description: 'Short label for the new version.' },
+        assertions: {
+          type: 'object',
+          description: 'Optional geometry assertions. Version is NOT saved if any assertion fails.',
+          properties: {
+            isManifold: { type: 'boolean' },
+            maxComponents: { type: 'integer' },
+            minVolume: { type: 'number' },
+            maxVolume: { type: 'number' },
+            genus: { type: 'integer' },
+            minGenus: { type: 'integer' },
+            maxGenus: { type: 'integer' },
+            minBounds: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+            maxBounds: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+            minTriangles: { type: 'integer' },
+            maxTriangles: { type: 'integer' },
+            boundsRatio: {
+              type: 'object',
+              properties: {
+                widthToDepth: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+                widthToHeight: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+                depthToHeight: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+              },
+            },
+            notes: { type: 'string' },
+          },
+        },
+      },
+      required: ['index', 'code'],
+    },
+  },
+  {
+    name: 'runAndAssert',
+    description: 'Run code and check geometry assertions WITHOUT saving a version. Returns {passed, failures?, stats}. Use for "does this code produce valid geometry?" checks before committing with runAndSave.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        code: { type: 'string', description: 'Code to run.' },
+        assertions: {
+          type: 'object',
+          description: 'Geometry assertions to check.',
+          properties: {
+            isManifold: { type: 'boolean' },
+            maxComponents: { type: 'integer' },
+            minVolume: { type: 'number' },
+            maxVolume: { type: 'number' },
+            genus: { type: 'integer' },
+            minGenus: { type: 'integer' },
+            maxGenus: { type: 'integer' },
+            minBounds: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+            maxBounds: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+            minTriangles: { type: 'integer' },
+            maxTriangles: { type: 'integer' },
+            boundsRatio: {
+              type: 'object',
+              properties: {
+                widthToDepth: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+                widthToHeight: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+                depthToHeight: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+              },
+            },
+            notes: { type: 'string' },
+          },
+        },
+      },
+      required: ['code', 'assertions'],
+    },
+  },
+  {
+    name: 'query',
+    description: 'Multi-query the current geometry in one call. Pass any combination of sliceAt (cross-section areas at given Z heights), decompose (component breakdown), boundingBox. Returns only the keys you asked for. Cheaper than separate calls.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        sliceAt: { type: 'array', items: { type: 'number' }, description: 'Z heights to slice at.' },
+        decompose: { type: 'boolean', description: 'Include component breakdown.' },
+        boundingBox: { type: 'boolean', description: 'Include bounding box.' },
+      },
+    },
+  },
+  {
+    name: 'modifyAndTest',
+    description: 'Apply a string substitution to the current editor code, run the result, and return stats — WITHOUT saving a version or changing the editor. Use to test a small tweak (e.g. change a dimension) before committing. Returns {modifiedCode, stats, passed?, failures?}.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        find: { type: 'string', description: 'Exact string to find in current code.' },
+        replace: { type: 'string', description: 'Replacement string.' },
+        assertions: {
+          type: 'object',
+          description: 'Optional geometry assertions.',
+          properties: {
+            isManifold: { type: 'boolean' },
+            maxComponents: { type: 'integer' },
+            minVolume: { type: 'number' },
+            maxVolume: { type: 'number' },
+            genus: { type: 'integer' },
+            minGenus: { type: 'integer' },
+            maxGenus: { type: 'integer' },
+            minBounds: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+            maxBounds: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+            minTriangles: { type: 'integer' },
+            maxTriangles: { type: 'integer' },
+            boundsRatio: {
+              type: 'object',
+              properties: {
+                widthToDepth: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+                widthToHeight: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+                depthToHeight: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+              },
+            },
+            notes: { type: 'string' },
+          },
+        },
+      },
+      required: ['find', 'replace'],
+    },
+  },
+  {
+    name: 'probeRay',
+    description: 'Cast a ray from `origin` in `direction` and return mesh intersection hits: [{point, normal, distance, triangleId}]. Use to find exact surface coordinates and normals when you know the ray but not the pixel. Pairs well with paintRegion (feed hit.point + hit.normal as seed).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        origin: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Ray origin in world space [x,y,z].' },
+        direction: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Ray direction (need not be normalized).' },
+      },
+      required: ['origin', 'direction'],
+    },
+  },
+  {
+    name: 'createSession',
+    description: 'Create a new named session and make it active. Returns {id, url, galleryUrl}. Call before runAndSave when there is no active session, or when starting a new design.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Session name (e.g. "Castle v2").' },
+      },
+    },
+  },
+  {
+    name: 'listSessions',
+    description: 'List all sessions saved in this browser. Returns [{id, name, updated}] newest first. Use to find a session to open, or to check what work exists.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'openSession',
+    description: 'Open an existing session by id (from listSessions). Makes it the active session. Always call getSessionContext() after opening to read notes and version history.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Session id from listSessions().' },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'assertPaint',
+    description: 'Verify a painted region matches expected geometry. Returns {passed, failures?}. Use after painting to catch regressions when the mesh changes. `region` is the region id (integer) or name (string) from listRegions().',
+    input_schema: {
+      type: 'object',
+      properties: {
+        region: { description: 'Region id (integer) or name (string) from listRegions().' },
+        expectedTriangleCount: { description: 'Exact integer or {min?, max?} object.' },
+        expectedBoundingBox: {
+          type: 'object',
+          description: 'Object with any subset of axis keys {x?, y?, z?} each [min, max].',
+          properties: {
+            x: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+            y: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+            z: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+          },
+        },
+        expectedCentroid: {
+          type: 'object',
+          description: 'Object with any subset of axis keys {x?, y?, z?} each [min, max].',
+          properties: {
+            x: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+            y: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+            z: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+          },
+        },
+      },
+      required: ['region'],
+    },
+  },
+  {
+    name: 'sliceAtZVisual',
+    description: 'Cross-section at height z. Returns {svg, area, contours} — area is the cross-sectional area, contours is the count of closed loops (1 = solid, >1 = hollow or multi-piece), svg is the SVG markup of the profile. Use to inspect wall thickness, hollow interiors, or layer profiles.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        z: { type: 'number', description: 'Height at which to slice.' },
+      },
+      required: ['z'],
+    },
+  },
 ];
 
 const ALWAYS_AVAILABLE = new Set([
@@ -497,6 +729,16 @@ const ALWAYS_AVAILABLE = new Set([
   'probePixel',
   'paintPreview',
   'paintExplain',
+  'forkVersion',
+  'runAndAssert',
+  'query',
+  'modifyAndTest',
+  'probeRay',
+  'createSession',
+  'listSessions',
+  'openSession',
+  'assertPaint',
+  'sliceAtZVisual',
 ]);
 
 const RUN_GATED = new Set(['runCode']);
@@ -640,11 +882,11 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
     case 'runCode':
       return api.run(input.code as string | undefined);
     case 'runAndSave':
-      return api.runAndSave(input.code as string, input.label as string | undefined);
+      return api.runAndSave(input.code as string, input.label as string | undefined, input.assertions as Record<string, unknown> | undefined);
     case 'getGeometryData':
       return api.getGeometryData();
     case 'getMeshSummary':
-      return api.getMeshSummary();
+      return api.getMeshSummary(input);
     case 'getSessionContext':
       return api.getSessionContext();
     case 'listVersions':
@@ -740,6 +982,26 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.removeRegion(input.id as number);
     case 'clearColors':
       return api.clearColors();
+    case 'forkVersion':
+      return api.forkVersion({ index: input.index }, () => input.code, input.label as string | undefined, input.assertions as Record<string, unknown> | undefined);
+    case 'runAndAssert':
+      return api.runAndAssert(input.code, input.assertions);
+    case 'query':
+      return api.query(input);
+    case 'modifyAndTest':
+      return api.modifyAndTest((code: unknown) => (code as string).replace(input.find as string, input.replace as string), input.assertions as Record<string, unknown> | undefined);
+    case 'probeRay':
+      return api.probeRay(input.origin, input.direction);
+    case 'createSession':
+      return api.createSession(input.name as string | undefined);
+    case 'listSessions':
+      return api.listSessions();
+    case 'openSession':
+      return api.openSession(input.id as string);
+    case 'assertPaint':
+      return api.assertPaint(input);
+    case 'sliceAtZVisual':
+      return api.sliceAtZVisual(input.z as number);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -166,32 +166,51 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintByLabel',
-    description: 'Paint a labelled feature by name. The label must have been registered in the current run via api.label(shape, name) or api.labeledUnion. This is the bullseye for "describe how to make and paint a model" workflows: write the geometry with labels, then paint by name — no coordinate guessing, no bounding-box estimation, no fan-bleed. Survives boolean ops because manifold-3d propagates originalID through runOriginalID on the result mesh. Only works for manifold-js (SCAD has no equivalent); falls back to paintComponent / paintInBox there. For multi-feature models, batch with paintByLabels in one round-trip instead of N sequential paintByLabel calls.',
+    description: 'Paint a labelled feature by name. The label must have been registered in the current run via api.label(shape, name) or api.labeledUnion. This is the bullseye for "describe how to make and paint a model" workflows: write the geometry with labels, then paint by name — no coordinate guessing, no bounding-box estimation, no fan-bleed. Survives boolean ops because manifold-3d propagates originalID through runOriginalID on the result mesh. Only works for manifold-js (SCAD has no equivalent); falls back to paintComponent / paintInBox there. For multi-feature models, batch with paintByLabels in one round-trip instead of N sequential paintByLabel calls. IMPORTANT: api.label only tracks surfaces that exist in the original labeled shape. Boolean subtraction creates NEW triangles at the cut surface (e.g. the inner wall of a mug after subtracting the void) — those new triangles have NO label. Use probePixel + paintConnected for inner surfaces created by boolean ops.',
     input_schema: {
       type: 'object',
       properties: {
         label: { type: 'string', description: 'Name passed to api.label() in the model code.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[r, g, b] in 0..1.' },
         name: { type: 'string', description: 'Optional region name; defaults to the label.' },
+        topOnly: { type: 'boolean', description: 'Restrict to upward-facing triangles only (normal within 30° of +Z). Useful when a label covers both top and side faces and you only want the top.' },
+        normalCone: {
+          type: 'object',
+          description: 'Restrict to triangles whose normal is within angleDeg of the given axis. Overrides topOnly.',
+          properties: {
+            axis: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+            angleDeg: { type: 'number' },
+          },
+          required: ['axis', 'angleDeg'],
+        },
       },
       required: ['label', 'color'],
     },
   },
   {
     name: 'paintByLabels',
-    description: 'Batch sibling of paintByLabel. Paint N labelled features in one tool call. Use this for any multi-feature paint job — a 9-feature smiley paints in 1 round-trip instead of 9. The viewport refresh coalesces under rAF so total cost is one frame regardless of batch size. Returns {results: [...], failed: [{label, error}]} — partial failures are reported per-label and do not abort the batch.',
+    description: 'Batch sibling of paintByLabel. Paint N labelled features in one tool call. Use this for any multi-feature paint job — a 9-feature smiley paints in 1 round-trip instead of 9. The viewport refresh coalesces under rAF so total cost is one frame regardless of batch size. Returns {results: [...], failed: [{label, error}]} — partial failures are reported per-label and do not abort the batch. Each item supports optional topOnly/normalCone to filter the label\'s triangle set — useful when a label spans top and side faces but you only want the top.',
     input_schema: {
       type: 'object',
       properties: {
         items: {
           type: 'array',
-          description: 'Array of paint specs, each {label, color, name?} — same shape as a single paintByLabel call.',
+          description: 'Array of paint specs, each {label, color, name?, topOnly?, normalCone?}.',
           items: {
             type: 'object',
             properties: {
               label: { type: 'string' },
               color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
               name: { type: 'string' },
+              topOnly: { type: 'boolean', description: 'Restrict to upward-facing triangles (normal within 30° of +Z).' },
+              normalCone: {
+                type: 'object',
+                properties: {
+                  axis: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+                  angleDeg: { type: 'number' },
+                },
+                required: ['axis', 'angleDeg'],
+              },
             },
             required: ['label', 'color'],
           },
@@ -505,12 +524,24 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'forkVersion',
-    description: 'Fork a prior version: load version N, replace its code with the provided code, validate against optional assertions, and save as a new version — all atomically. Use this to branch off a known-good version without the fragile loadVersion → getCode → modify → runAndSave chain. Returns {parent, version, geometry, diff, galleryUrl} on success, or {error} / {passed: false, failures} on failure.',
+    description: 'Fork a prior version: load version N, apply new code or patches, validate against optional assertions, and save as a new version — all atomically. Use this to branch off a known-good version without the fragile loadVersion → getCode → modify → runAndSave chain. Provide either `code` (full replacement) or `patches` (find/replace array applied to the parent\'s code — more concise when only a few values change). Returns {parent, version, geometry, diff, galleryUrl} on success, or {error} / {passed: false, failures} on failure.',
     input_schema: {
       type: 'object',
       properties: {
         index: { type: 'integer', description: '1-based version index to fork from (from listVersions).' },
-        code: { type: 'string', description: 'The new code for the forked version (complete program).' },
+        code: { type: 'string', description: 'Full replacement code for the forked version. Provide this or patches, not both.' },
+        patches: {
+          type: 'array',
+          description: 'Find/replace substitutions applied in sequence to the parent version\'s code. More concise than providing the full program when only a few values change.',
+          items: {
+            type: 'object',
+            properties: {
+              find: { type: 'string', description: 'Exact string to find.' },
+              replace: { type: 'string', description: 'Replacement string.' },
+            },
+            required: ['find', 'replace'],
+          },
+        },
         label: { type: 'string', description: 'Short label for the new version.' },
         assertions: {
           type: 'object',
@@ -539,7 +570,7 @@ const ALL_TOOLS: ToolDefinition[] = [
           },
         },
       },
-      required: ['index', 'code'],
+      required: ['index'],
     },
   },
   {
@@ -593,12 +624,24 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'modifyAndTest',
-    description: 'Apply a string substitution to the current editor code, run the result, and return stats — WITHOUT saving a version or changing the editor. Use to test a small tweak (e.g. change a dimension) before committing. Returns {modifiedCode, stats, passed?, failures?}.',
+    description: 'Apply string substitution(s) to the current editor code, run the result, and return stats — WITHOUT saving a version or changing the editor. Use to test a tweak before committing. Provide either a single `find`/`replace` pair or a `patches` array for multiple simultaneous substitutions. Returns {modifiedCode, stats, passed?, failures?}.',
     input_schema: {
       type: 'object',
       properties: {
-        find: { type: 'string', description: 'Exact string to find in current code.' },
-        replace: { type: 'string', description: 'Replacement string.' },
+        find: { type: 'string', description: 'Exact string to find in current code. Use this for a single substitution.' },
+        replace: { type: 'string', description: 'Replacement string (paired with find).' },
+        patches: {
+          type: 'array',
+          description: 'Multiple find/replace pairs applied in sequence. Use when adjusting several parameters at once.',
+          items: {
+            type: 'object',
+            properties: {
+              find: { type: 'string', description: 'Exact string to find.' },
+              replace: { type: 'string', description: 'Replacement string.' },
+            },
+            required: ['find', 'replace'],
+          },
+        },
         assertions: {
           type: 'object',
           description: 'Optional geometry assertions.',
@@ -626,7 +669,7 @@ const ALL_TOOLS: ToolDefinition[] = [
           },
         },
       },
-      required: ['find', 'replace'],
+      required: [],
     },
   },
   {
@@ -699,13 +742,52 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'sliceAtZVisual',
-    description: 'Cross-section at height z. Returns {svg, area, contours} — area is the cross-sectional area, contours is the count of closed loops (1 = solid, >1 = hollow or multi-piece), svg is the SVG markup of the profile. Use to inspect wall thickness, hollow interiors, or layer profiles.',
+    description: 'Cross-section at height z. Returns a rasterized PNG thumbnail of the profile (attached as an image) plus {area, contours} — area is the cross-sectional area, contours is the count of closed loops (1 = solid, >1 = hollow or multi-piece). Use to visually inspect wall thickness, hollow interiors, or layer profiles — you can actually see the cross-section shape.',
     input_schema: {
       type: 'object',
       properties: {
         z: { type: 'number', description: 'Height at which to slice.' },
       },
       required: ['z'],
+    },
+  },
+  {
+    name: 'paintInCylinder',
+    description: 'Paint triangles whose centroids fall within a cylindrical shell: rMin ≤ dist(centroid, axis) ≤ rMax AND zMin ≤ centroid.z ≤ zMax. The canonical tool for inner walls of hollow cylinders, mugs, vases, and any revolved shape where paintInBox catches too many faces. Set rMin > 0 to exclude the axis core; set rMax to the inner radius to select only the inner surface. Optional normalCone/topOnly for further filtering.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        center: {
+          type: 'array',
+          items: { type: 'number' },
+          minItems: 2,
+          maxItems: 2,
+          description: 'Center of the cylinder axis in the XY plane [cx, cy]. Use [0, 0] for Z-centered models.',
+        },
+        rMin: { type: 'number', description: 'Minimum radial distance from axis (0 to include everything up to rMax).' },
+        rMax: { type: 'number', description: 'Maximum radial distance from axis.' },
+        zMin: { type: 'number', description: 'Bottom of the cylindrical band.' },
+        zMax: { type: 'number', description: 'Top of the cylindrical band.' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[r, g, b] in 0..1.' },
+        name: { type: 'string', description: 'Optional region name.' },
+        normalCone: {
+          type: 'object',
+          description: 'Further restrict to triangles whose normal is within angleDeg of the given axis.',
+          properties: {
+            axis: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+            angleDeg: { type: 'number' },
+          },
+          required: ['axis', 'angleDeg'],
+        },
+        topOnly: { type: 'boolean', description: 'Shortcut: only upward-facing triangles (normal within 30° of +Z).' },
+        coverageMode: {
+          type: 'string',
+          enum: ['centroid', 'fully_inside', 'any_vertex_inside'],
+          description: 'centroid (default): centroid inside the shell. fully_inside: all 3 vertices inside. any_vertex_inside: at least 1 vertex inside.',
+        },
+        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this area. Use to avoid fan-bleed on cylinder topology.' },
+      },
+      required: ['rMin', 'rMax', 'zMin', 'zMax', 'color'],
     },
   },
 ];
@@ -739,6 +821,7 @@ const ALWAYS_AVAILABLE = new Set([
   'openSession',
   'assertPaint',
   'sliceAtZVisual',
+  'paintInCylinder',
 ]);
 
 const RUN_GATED = new Set(['runCode']);
@@ -789,6 +872,7 @@ export async function executeTool(name: string, input: Record<string, unknown>):
     if (name === 'renderView') return executeRenderView(api, input);
     if (name === 'renderViews') return await executeRenderViews(api, input);
     if (name === 'runIsolated') return await executeRunIsolated(api, input);
+    if (name === 'sliceAtZVisual') return await executeSliceAtZVisual(api, input);
 
     const result = await dispatch(api, name, input);
     if (result === undefined) return { content: '(ok)', isError: false };
@@ -842,6 +926,46 @@ async function executeRunIsolated(api: PartwrightAPI, input: Record<string, unkn
     isError: false,
     image: { ...img, label: 'runIsolated preview' },
   };
+}
+
+async function executeSliceAtZVisual(api: PartwrightAPI, input: Record<string, unknown>): Promise<ToolExecResult> {
+  const result = api.sliceAtZVisual(input.z as number) as { svg: string; area: number; contours: number } | null;
+  if (!result) return { content: 'sliceAtZVisual: no geometry loaded — run code first.', isError: true };
+  const contourDesc = result.contours === 1 ? 'solid' : result.contours > 1 ? 'hollow/multi-piece' : 'empty';
+  const summary = `Cross-section at z=${input.z}: area=${result.area.toFixed(3)}, contours=${result.contours} (${contourDesc})`;
+  try {
+    const pngBase64 = await rasterizeSvg(result.svg, 320);
+    return {
+      content: `${summary}\n\nProfile image attached — inspect for wall thickness, hollow interior shape, and contour count.`,
+      isError: false,
+      image: { data: pngBase64, mediaType: 'image/png', label: `slice z=${input.z}` },
+    };
+  } catch {
+    return { content: summary, isError: false };
+  }
+}
+
+function rasterizeSvg(svg: string, size: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) { reject(new Error('no canvas context')); return; }
+    const blob = new Blob([svg], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      ctx.fillStyle = '#1c1c1c';
+      ctx.fillRect(0, 0, size, size);
+      ctx.drawImage(img, 0, 0, size, size);
+      const dataUrl = canvas.toDataURL('image/png');
+      resolve(dataUrl.replace(/^data:image\/png;base64,/, ''));
+    };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('SVG rasterization failed')); };
+    img.src = url;
+  });
 }
 
 function wrapImageResult(result: string | { error: string } | null | undefined, toolName: string, label: string): ToolExecResult {
@@ -982,14 +1106,25 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.removeRegion(input.id as number);
     case 'clearColors':
       return api.clearColors();
-    case 'forkVersion':
-      return api.forkVersion({ index: input.index }, () => input.code, input.label as string | undefined, input.assertions as Record<string, unknown> | undefined);
+    case 'forkVersion': {
+      const forkPatches = input.patches as Array<{ find: string; replace: string }> | undefined;
+      const forkTransform = forkPatches
+        ? (code: string) => forkPatches.reduce((c, p) => c.replace(p.find, p.replace), code)
+        : (_code: string) => input.code as string;
+      return api.forkVersion({ index: input.index }, forkTransform, input.label as string | undefined, input.assertions as Record<string, unknown> | undefined);
+    }
     case 'runAndAssert':
       return api.runAndAssert(input.code, input.assertions);
     case 'query':
       return api.query(input);
-    case 'modifyAndTest':
-      return api.modifyAndTest((code: unknown) => (code as string).replace(input.find as string, input.replace as string), input.assertions as Record<string, unknown> | undefined);
+    case 'modifyAndTest': {
+      const mtPatches = input.patches as Array<{ find: string; replace: string }> | undefined;
+      return api.modifyAndTest((code: unknown) => {
+        let s = code as string;
+        if (mtPatches) return mtPatches.reduce((c, p) => c.replace(p.find, p.replace), s);
+        return s.replace(input.find as string, input.replace as string);
+      }, input.assertions as Record<string, unknown> | undefined);
+    }
     case 'probeRay':
       return api.probeRay(input.origin, input.direction);
     case 'createSession':
@@ -1000,8 +1135,8 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.openSession(input.id as string);
     case 'assertPaint':
       return api.assertPaint(input);
-    case 'sliceAtZVisual':
-      return api.sliceAtZVisual(input.z as number);
+    case 'paintInCylinder':
+      return api.paintInCylinder(input);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1592,7 +1592,9 @@ async function main() {
 
     /** Get current geometry stats without re-running */
     getGeometryData(): Record<string, unknown> {
-      return JSON.parse(geometryDataEl.textContent || '{}');
+      const geo = JSON.parse(geometryDataEl.textContent || '{}');
+      const warnings = geometryWarnings(geo);
+      return warnings.length > 0 ? { ...geo, warnings } : geo;
     },
 
     /** Get current editor code */
@@ -2303,12 +2305,14 @@ async function main() {
         diff = computeStatDiff(prevGeoData, newGeoData);
       }
 
+      const warnings = geometryWarnings(newGeoData);
       return {
         ...(assertions ? { passed: true } : {}),
         geometry: newGeoData,
         version: version ? { id: version.id, index: version.index, label: version.label } : null,
         diff,
         galleryUrl: getGalleryUrl(),
+        ...(warnings.length > 0 ? { warnings } : {}),
       };
     },
 
@@ -2383,6 +2387,7 @@ async function main() {
         diff = computeStatDiff(prevGeoData, newGeoData);
       }
 
+      const forkWarnings = geometryWarnings(newGeoData);
       return {
         ...(assertions ? { passed: true } : {}),
         parent: { id: parent.id, index: parent.index, label: parent.label },
@@ -2390,6 +2395,7 @@ async function main() {
         version: version ? { id: version.id, index: version.index, label: version.label } : null,
         diff,
         galleryUrl: getGalleryUrl(),
+        ...(forkWarnings.length > 0 ? { warnings: forkWarnings } : {}),
       };
     },
 
@@ -2452,9 +2458,13 @@ async function main() {
     async getSessionContext() {
       const ctx = await getSessionContext();
       if (!ctx) return { error: 'No active session' };
-      // Include the code currently in the editor so agents resuming after a
-      // stop don't need a separate getCode() call to know where things stand.
-      return { ...ctx, currentCode: getValue() };
+      const geo = JSON.parse(geometryDataEl.textContent || '{}');
+      const warnings = geometryWarnings(geo);
+      return {
+        ...ctx,
+        currentCode: getValue(),
+        ...(warnings.length > 0 ? { geometryWarnings: warnings } : {}),
+      };
     },
 
     /** Export a session as JSON (defaults to current session) */
@@ -5221,6 +5231,30 @@ async function main() {
       result.add(t);
     }
     return result;
+  }
+
+  /** Produce advisory warnings for geometry that was saved or queried.
+   *  Returns an empty array when the geometry is clean.
+   *  These are non-blocking — the save has already happened. */
+  function geometryWarnings(geo: Record<string, unknown>): string[] {
+    if (!geo || geo.status !== 'ok') return [];
+    const warnings: string[] = [];
+    if (geo.isManifold === false) {
+      warnings.push(
+        'isManifold: false — the mesh has non-manifold edges or gaps. ' +
+        'Export and slicing will fail with most tools. Fix the geometry ' +
+        'before finalizing: ensure boolean operands overlap by ≥ 0.5 units, ' +
+        'avoid zero-thickness walls, and check for duplicate faces.',
+      );
+    }
+    if (typeof geo.componentCount === 'number' && geo.componentCount > 1) {
+      warnings.push(
+        `componentCount: ${geo.componentCount} — model has ${geo.componentCount} disconnected pieces. ` +
+        'If unintentional, check that boolean union shapes overlap by ≥ 0.5 units. ' +
+        'If intentional (separate printable parts), ignore this warning.',
+      );
+    }
+    return warnings;
   }
 
   /** Commit a triangle set as a region and refresh the viewport — shared by

--- a/src/main.ts
+++ b/src/main.ts
@@ -2452,7 +2452,9 @@ async function main() {
     async getSessionContext() {
       const ctx = await getSessionContext();
       if (!ctx) return { error: 'No active session' };
-      return ctx;
+      // Include the code currently in the editor so agents resuming after a
+      // stop don't need a separate getCode() call to know where things stand.
+      return { ...ctx, currentCode: getValue() };
     },
 
     /** Export a session as JSON (defaults to current session) */
@@ -3598,6 +3600,49 @@ async function main() {
       return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
     },
 
+    /** Paint triangles whose centroids fall inside a cylindrical shell:
+     *  rMin ≤ dist(centroid, axis) ≤ rMax AND zMin ≤ centroid.z ≤ zMax.
+     *  The canonical tool for inner walls of hollow cylinders, mugs, vases,
+     *  and any revolved shape where `paintInBox` catches too many faces.
+     *  Set rMin > 0 to exclude the axis core and select only the inner surface. */
+    paintInCylinder(opts: {
+      center?: [number, number];
+      rMin: number;
+      rMax: number;
+      zMin: number;
+      zMax: number;
+      color: [number, number, number];
+      name?: string;
+      normalCone?: { axis: [number, number, number]; angleDeg: number };
+      topOnly?: boolean;
+      coverageMode?: CoverageMode;
+      maxTriangleArea?: number;
+    }) {
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintInCylinder requires { rMin, rMax, zMin, zMax, color }' };
+      if (typeof opts.rMin !== 'number' || typeof opts.rMax !== 'number') return { error: 'rMin and rMax must be numbers' };
+      if (typeof opts.zMin !== 'number' || typeof opts.zMax !== 'number') return { error: 'zMin and zMax must be numbers' };
+      if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] in 0..1' };
+      const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
+      const coneErr = validateNormalCone(cone);
+      if (coneErr) return { error: coneErr };
+      const areaErr = validateMaxTriangleArea(opts.maxTriangleArea);
+      if (areaErr) return { error: areaErr };
+      const triangles = collectTrianglesByCylinder(
+        currentMeshData,
+        opts.center ?? [0, 0],
+        opts.rMin, opts.rMax,
+        opts.zMin, opts.zMax,
+        cone,
+        opts.coverageMode,
+        opts.maxTriangleArea,
+      );
+      if (triangles.size === 0) {
+        return { error: `paintInCylinder: no triangles in cylindrical shell (rMin=${opts.rMin}, rMax=${opts.rMax}, z=${opts.zMin}..${opts.zMax})${cone ? ' with normalCone filter' : ''}. Try widening the shell, checking the center, or calling paintPreview with a box first to locate the geometry.` };
+      }
+      return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
+    },
+
     /** Render a preview of the current model with a candidate region tinted
      *  bright yellow, *without* committing the paint to the regions list.
      *  Accepts the same selectors as `paintInBox` / `paintNear` plus an
@@ -4243,7 +4288,7 @@ async function main() {
      *  ```
      *  Returns `{ id, name, triangles, bbox, centroid }` on success or
      *  `{ error }` if no such label exists or no labels were registered. */
-    paintByLabel(opts: { label: string; color: [number, number, number]; name?: string }) {
+    paintByLabel(opts: { label: string; color: [number, number, number]; name?: string; topOnly?: boolean; normalCone?: { axis: [number, number, number]; angleDeg: number } }) {
       if (!opts || typeof opts !== 'object') return { error: 'paintByLabel requires { label, color }' };
       if (typeof opts.label !== 'string' || opts.label.length === 0) return { error: 'paintByLabel.label must be a non-empty string' };
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'paintByLabel.color must be [r,g,b] in 0..1' };
@@ -4256,9 +4301,28 @@ async function main() {
         const known = [...currentLabelMap.keys()].map(k => `"${k}"`).join(', ');
         return { error: `paintByLabel: no label "${opts.label}". Known labels: ${known}.` };
       }
-      const triangles = new Set(ids);
       const mesh = currentMeshData;
       const regionName = opts.name ?? opts.label;
+      const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
+      if (cone) {
+        // Filter the label's triangle set by normal direction. Use a
+        // triangles descriptor (not byLabel) so the exact filtered set
+        // is preserved on re-hydration rather than restoring the full set.
+        const adjacency = buildAdjacency(mesh);
+        const axLen = Math.hypot(cone.axis[0], cone.axis[1], cone.axis[2]);
+        const cax = cone.axis[0] / axLen, cay = cone.axis[1] / axLen, caz = cone.axis[2] / axLen;
+        const coneCos = Math.cos(cone.angleDeg * Math.PI / 180);
+        const filtered = new Set<number>();
+        for (const t of ids) {
+          const dot = cax * adjacency.normals[t * 3] + cay * adjacency.normals[t * 3 + 1] + caz * adjacency.normals[t * 3 + 2];
+          if (dot >= coneCos) filtered.add(t);
+        }
+        if (filtered.size === 0) {
+          return { error: `paintByLabel: label "${opts.label}" matched ${ids.size} triangles but none passed the ${opts.topOnly ? 'topOnly' : 'normalCone'} filter. Try widening angleDeg or removing the filter.` };
+        }
+        return commitPaintFromSet(filtered, opts.color as [number, number, number], regionName, 'paintbrush');
+      }
+      const triangles = new Set(ids);
       const region = addRegion(
         regionName,
         opts.color as [number, number, number],
@@ -4291,8 +4355,8 @@ async function main() {
      *    { label: 'mouth', color: [0.8, 0.2, 0.2] },
      *  ]);
      *  ``` */
-    paintByLabels(items: Array<{ label: string; color: [number, number, number]; name?: string }>) {
-      if (!Array.isArray(items)) return { error: 'paintByLabels requires an array of { label, color, name? }' };
+    paintByLabels(items: Array<{ label: string; color: [number, number, number]; name?: string; topOnly?: boolean; normalCone?: { axis: [number, number, number]; angleDeg: number } }>) {
+      if (!Array.isArray(items)) return { error: 'paintByLabels requires an array of { label, color, name?, topOnly?, normalCone? }' };
       if (items.length === 0) return { results: [], failed: [] };
       if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
       if (!currentLabelMap || currentLabelMap.size === 0) {
@@ -5094,6 +5158,66 @@ async function main() {
 
       if (maxArea !== undefined && triangleArea(t, mesh) > maxArea) continue;
 
+      result.add(t);
+    }
+    return result;
+  }
+
+  /** Collect triangle ids whose centroids fall within a cylindrical shell
+   *  (rMin ≤ radial dist from axis ≤ rMax, zMin ≤ z ≤ zMax). */
+  function collectTrianglesByCylinder(
+    mesh: MeshData,
+    center: [number, number],
+    rMin: number,
+    rMax: number,
+    zMin: number,
+    zMax: number,
+    cone: { axis: [number, number, number]; angleDeg: number } | undefined,
+    coverage: CoverageMode = 'centroid',
+    maxArea: number | undefined = undefined,
+  ): Set<number> {
+    const adjacency = cone ? buildAdjacency(mesh) : null;
+    let coneAxis: [number, number, number] | null = null;
+    let coneCos = -1;
+    if (cone) {
+      const len = Math.hypot(cone.axis[0], cone.axis[1], cone.axis[2]);
+      coneAxis = [cone.axis[0] / len, cone.axis[1] / len, cone.axis[2] / len];
+      coneCos = Math.cos(cone.angleDeg * Math.PI / 180);
+    }
+    const rMin2 = rMin * rMin, rMax2 = rMax * rMax;
+    const [cx, cy] = center;
+    const result = new Set<number>();
+    const { triVerts, vertProperties, numProp, numTri } = mesh;
+
+    function radial2(x: number, y: number): number {
+      const dx = x - cx, dy = y - cy;
+      return dx * dx + dy * dy;
+    }
+    function inShell(x: number, y: number, z: number): boolean {
+      const r2 = radial2(x, y);
+      return r2 >= rMin2 && r2 <= rMax2 && z >= zMin && z <= zMax;
+    }
+
+    for (let t = 0; t < numTri; t++) {
+      const v0 = triVerts[t * 3], v1 = triVerts[t * 3 + 1], v2 = triVerts[t * 3 + 2];
+      const ax = vertProperties[v0 * numProp], ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
+      const bx = vertProperties[v1 * numProp], by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
+      const cx2 = vertProperties[v2 * numProp], cy2 = vertProperties[v2 * numProp + 1], cz2 = vertProperties[v2 * numProp + 2];
+
+      if (coverage === 'fully_inside') {
+        if (!inShell(ax, ay, az) || !inShell(bx, by, bz) || !inShell(cx2, cy2, cz2)) continue;
+      } else if (coverage === 'any_vertex_inside') {
+        if (!inShell(ax, ay, az) && !inShell(bx, by, bz) && !inShell(cx2, cy2, cz2)) continue;
+      } else {
+        const ccx = (ax + bx + cx2) / 3, ccy = (ay + by + cy2) / 3, ccz = (az + bz + cz2) / 3;
+        if (!inShell(ccx, ccy, ccz)) continue;
+      }
+
+      if (coneAxis && adjacency) {
+        const nx = adjacency.normals[t * 3], ny = adjacency.normals[t * 3 + 1], nz = adjacency.normals[t * 3 + 2];
+        if (coneAxis[0] * nx + coneAxis[1] * ny + coneAxis[2] * nz < coneCos) continue;
+      }
+      if (maxArea !== undefined && triangleArea(t, mesh) > maxArea) continue;
       result.add(t);
     }
     return result;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2263,7 +2263,9 @@ async function main() {
     },
 
     /** Run code and save as a new version in one call. Returns stat diff vs previous version.
-     *  Optional assertions — if provided, validates before saving. Fails fast without saving if assertions don't pass. */
+     *  Optional assertions — if provided, validates after running. Saves only if assertions pass.
+     *  The editor and viewport always update to reflect the new code (including on assertion failure),
+     *  so the model can inspect the failing geometry. The version is NOT saved on failure. */
     async runAndSave(code: string, label?: string, assertions?: GeometryAssertions) {
       const check = guard(() => {
         assertString(code, 'runAndSave(code)', { allowEmpty: false });
@@ -2272,17 +2274,23 @@ async function main() {
         return true;
       });
       if (typeof check === 'object' && check !== null && 'error' in check) return check;
-      // If assertions provided, validate in isolation first (no side effects if it fails)
+
+      const prevGeoData = getState().currentVersion?.geometryData as Record<string, unknown> | null;
+
+      // Single execution — run the code, update editor + viewport, read geometry.
+      // Assertions are checked against the live result rather than a separate
+      // isolation run. This halves execution time for assertion-guarded saves.
+      setValue(code);
+      await runCodeSync(code);
+      const newGeoData = JSON.parse(geometryDataEl.textContent || '{}');
+
       if (assertions) {
-        const { geometryData: testData, manifold: testManifold } = await executeIsolated(code);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        try { (testManifold as any)?.delete?.(); } catch { /* ignore */ }
-        if (testData.status === 'error') {
-          return { passed: false, failures: [testData.error as string], geometry: testData, version: null, diff: null, galleryUrl: getGalleryUrl() };
+        if (newGeoData.status === 'error') {
+          return { passed: false, failures: [newGeoData.error as string], geometry: newGeoData, version: null, diff: null, galleryUrl: getGalleryUrl() };
         }
-        const failures = checkAssertions(testData, assertions);
+        const failures = checkAssertions(newGeoData, assertions);
         if (failures.length > 0) {
-          return { passed: false, failures, geometry: testData, version: null, diff: null, galleryUrl: getGalleryUrl() };
+          return { passed: false, failures, geometry: newGeoData, version: null, diff: null, galleryUrl: getGalleryUrl() };
         }
       }
 
@@ -2292,11 +2300,6 @@ async function main() {
         await createSession(sessionName, getActiveLanguage());
       }
 
-      const prevGeoData = getState().currentVersion?.geometryData as Record<string, unknown> | null;
-
-      setValue(code);
-      await runCodeSync(code);
-      const newGeoData = JSON.parse(geometryDataEl.textContent || '{}');
       const thumbnail = await captureThumbnail();
       const version = await saveVersion(code, enrichGeometryDataWithColors(getGeometryDataObj()), thumbnail, label, assertions?.notes);
 
@@ -2747,14 +2750,14 @@ async function main() {
         return true;
       });
       if (typeof check === 'object' && check !== null && 'error' in check) {
-        return { error: check.error, modifiedCode: null, stats: null };
+        return { error: check.error, stats: null };
       }
       const currentCode = getValue();
       let modifiedCode: string;
       try {
         modifiedCode = patchFn(currentCode);
       } catch (e: unknown) {
-        return { error: `Patch function failed: ${e instanceof Error ? e.message : String(e)}`, modifiedCode: null, stats: null };
+        return { error: `Patch function failed: ${e instanceof Error ? e.message : String(e)}`, stats: null };
       }
 
       const { geometryData, manifold } = await executeIsolated(modifiedCode);
@@ -2762,15 +2765,15 @@ async function main() {
       try { (manifold as any)?.delete?.(); } catch { /* ignore */ }
 
       if (geometryData.status === 'error') {
-        return { error: geometryData.error, modifiedCode, stats: geometryData, ...(assertions ? { passed: false, failures: [geometryData.error as string] } : {}) };
+        return { error: geometryData.error, stats: geometryData, ...(assertions ? { passed: false, failures: [geometryData.error as string] } : {}) };
       }
 
       if (assertions) {
         const failures = checkAssertions(geometryData, assertions);
-        return { modifiedCode, stats: geometryData, passed: failures.length === 0, failures: failures.length > 0 ? failures : undefined };
+        return { stats: geometryData, passed: failures.length === 0, failures: failures.length > 0 ? failures : undefined };
       }
 
-      return { modifiedCode, stats: geometryData };
+      return { stats: geometryData };
     },
 
     /** Query multiple properties of the current geometry in a single call. Avoids multiple round-trips. */

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -113,6 +113,12 @@ export async function setActiveSession(sessionId: string | null): Promise<void> 
     return;
   }
   state.sessionId = effective;
+  // If a turn is in flight the session change was triggered by the model
+  // calling createSession mid-turn. Don't reload/re-render now — the
+  // callbacks (onUserPersisted etc.) are keeping state.history current
+  // for the running turn. Reloading here would wipe the user's message
+  // from the transcript. The reload happens after the turn completes.
+  if (state.inFlight) return;
   // Drop any queued follow-ups — they were aimed at the prior chat bucket
   // and the human's instructions almost never make sense out of context.
   state.queuedBlocks = [];
@@ -188,26 +194,6 @@ function buildDrawer(): void {
   spacer.className = 'flex-1';
   header.appendChild(spacer);
 
-  const rewindBtn = document.createElement('button');
-  rewindBtn.className = 'px-2 py-1 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 text-sm disabled:cursor-not-allowed transition-opacity';
-  rewindBtn.textContent = '←';
-  rewindBtn.title = 'Rewind: remove the last turn from history (use → to restore it)';
-  rewindBtn.disabled = true;
-  rewindBtn.classList.add('opacity-30');
-  rewindBtn.addEventListener('click', () => { void rewindTurn(); });
-  rewindBtnRef = rewindBtn;
-  header.appendChild(rewindBtn);
-
-  const forwardBtn = document.createElement('button');
-  forwardBtn.className = 'px-2 py-1 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 text-sm disabled:cursor-not-allowed transition-opacity';
-  forwardBtn.textContent = '→';
-  forwardBtn.title = 'Fast-forward: restore the last rewound turn (cleared when you send a new message)';
-  forwardBtn.disabled = true;
-  forwardBtn.classList.add('opacity-30');
-  forwardBtn.addEventListener('click', () => { void fastForwardTurn(); });
-  forwardBtnRef = forwardBtn;
-  header.appendChild(forwardBtn);
-
   const closeBtn = document.createElement('button');
   closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 text-sm';
   closeBtn.textContent = '✕';
@@ -225,6 +211,31 @@ function buildDrawer(): void {
   transcriptEl = document.createElement('div');
   transcriptEl.className = 'flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-3';
   root.appendChild(transcriptEl);
+
+  // Rewind / fast-forward row — sits just above the controls so it's
+  // near the input and clearly associated with conversation history.
+  const rewindRow = document.createElement('div');
+  rewindRow.className = 'px-3 pt-1.5 pb-0.5 flex gap-2 shrink-0 border-t border-zinc-800';
+
+  const rewindBtn = document.createElement('button');
+  rewindBtn.className = 'flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium text-zinc-300 bg-zinc-800 hover:bg-zinc-700 hover:text-white border border-zinc-700 hover:border-zinc-500 disabled:opacity-30 disabled:cursor-not-allowed transition-all';
+  rewindBtn.innerHTML = '↩ Undo turn';
+  rewindBtn.title = 'Remove the last turn from history. Use ↪ Redo to restore it.';
+  rewindBtn.disabled = true;
+  rewindBtn.addEventListener('click', () => { void rewindTurn(); });
+  rewindBtnRef = rewindBtn;
+  rewindRow.appendChild(rewindBtn);
+
+  const forwardBtn = document.createElement('button');
+  forwardBtn.className = 'flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium text-zinc-300 bg-zinc-800 hover:bg-zinc-700 hover:text-white border border-zinc-700 hover:border-zinc-500 disabled:opacity-30 disabled:cursor-not-allowed transition-all';
+  forwardBtn.innerHTML = '↪ Redo turn';
+  forwardBtn.title = 'Restore the last undone turn. Cleared when you send a new message.';
+  forwardBtn.disabled = true;
+  forwardBtn.addEventListener('click', () => { void fastForwardTurn(); });
+  forwardBtnRef = forwardBtn;
+  rewindRow.appendChild(forwardBtn);
+
+  root.appendChild(rewindRow);
 
   // Toggle strip
   toggleStripEl = document.createElement('div');
@@ -971,14 +982,8 @@ function updateRewindButtons(): void {
   const canRewind = !state.inFlight &&
     state.history.some(m => m.role === 'user' && m.blocks.length > 0);
   const canForward = !state.inFlight && state.rewindStack.length > 0;
-  if (rewindBtnRef) {
-    rewindBtnRef.disabled = !canRewind;
-    rewindBtnRef.classList.toggle('opacity-30', !canRewind);
-  }
-  if (forwardBtnRef) {
-    forwardBtnRef.disabled = !canForward;
-    forwardBtnRef.classList.toggle('opacity-30', !canForward);
-  }
+  if (rewindBtnRef) rewindBtnRef.disabled = !canRewind;
+  if (forwardBtnRef) forwardBtnRef.disabled = !canForward;
 }
 
 // === Send message ===
@@ -1197,7 +1202,6 @@ async function runTurnWithStallRetry(apiKey: string, toggles: ChatToggles, userB
         // flash and vanish from the transcript.
         renderTranscript();
         renderCostMeter();
-        updateRewindButtons();
         lastTurnOutcome = info;
       },
     });
@@ -1205,6 +1209,7 @@ async function runTurnWithStallRetry(apiKey: string, toggles: ChatToggles, userB
     state.inFlight = false;
     state.inFlightController = null;
     setSendButtonMode('send');
+    updateRewindButtons();
 
     // Surface a sticky completion banner so the user knows the turn
     // actually ended and why — better than a silent hideProgress that

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -32,6 +32,10 @@ interface PanelState {
    *  exits with the queue still non-empty). In-memory only — lost on
    *  refresh, which matches the ephemeral "queue while running" use case. */
   queuedBlocks: ChatBlock[];
+  /** Undo stack for the rewind button. Each entry is the slice of messages
+   *  removed by one rewind operation. Popped by fast-forward to restore.
+   *  Cleared when the user sends a new message (conversation has diverged). */
+  rewindStack: ChatMessage[][];
 }
 
 const state: PanelState = {
@@ -43,11 +47,14 @@ const state: PanelState = {
   inFlight: false,
   inFlightController: null,
   queuedBlocks: [],
+  rewindStack: [],
 };
 
 let sendBtnRef: HTMLButtonElement | null = null;
 let stopBtnRef: HTMLButtonElement | null = null;
 let queuedBadgeRef: HTMLElement | null = null;
+let rewindBtnRef: HTMLButtonElement | null = null;
+let forwardBtnRef: HTMLButtonElement | null = null;
 
 let drawerEl: HTMLElement | null = null;
 let transcriptEl: HTMLElement | null = null;
@@ -139,6 +146,7 @@ function hideDrawer(): void {
 
 async function loadHistoryForCurrentSession(): Promise<void> {
   state.history = await listMessages(state.sessionId);
+  updateRewindButtons();
 }
 
 // === DOM construction ===
@@ -179,6 +187,26 @@ function buildDrawer(): void {
   const spacer = document.createElement('div');
   spacer.className = 'flex-1';
   header.appendChild(spacer);
+
+  const rewindBtn = document.createElement('button');
+  rewindBtn.className = 'px-2 py-1 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 text-sm disabled:cursor-not-allowed transition-opacity';
+  rewindBtn.textContent = '←';
+  rewindBtn.title = 'Rewind: remove the last turn from history (use → to restore it)';
+  rewindBtn.disabled = true;
+  rewindBtn.classList.add('opacity-30');
+  rewindBtn.addEventListener('click', () => { void rewindTurn(); });
+  rewindBtnRef = rewindBtn;
+  header.appendChild(rewindBtn);
+
+  const forwardBtn = document.createElement('button');
+  forwardBtn.className = 'px-2 py-1 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 text-sm disabled:cursor-not-allowed transition-opacity';
+  forwardBtn.textContent = '→';
+  forwardBtn.title = 'Fast-forward: restore the last rewound turn (cleared when you send a new message)';
+  forwardBtn.disabled = true;
+  forwardBtn.classList.add('opacity-30');
+  forwardBtn.addEventListener('click', () => { void fastForwardTurn(); });
+  forwardBtnRef = forwardBtn;
+  header.appendChild(forwardBtn);
 
   const closeBtn = document.createElement('button');
   closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 text-sm';
@@ -898,6 +926,61 @@ function drainQueuedBlocks(): ChatBlock[] {
   return drained;
 }
 
+// === Rewind / fast-forward ===
+
+/** Remove the last user-initiated turn (the last user message with actual
+ *  typed content, plus everything that follows it) from history and IndexedDB.
+ *  The removed slice is pushed onto rewindStack so fast-forward can restore it.
+ *  Clears itself when the user sends a new message (conversation has diverged). */
+async function rewindTurn(): Promise<void> {
+  if (state.inFlight) return;
+  // Find the last message the user actually typed (has blocks — not a pure
+  // tool_result carrier which has toolResults but empty blocks).
+  let cutIndex = -1;
+  for (let i = state.history.length - 1; i >= 0; i--) {
+    if (state.history[i].role === 'user' && state.history[i].blocks.length > 0) {
+      cutIndex = i;
+      break;
+    }
+  }
+  if (cutIndex < 0) return;
+  const removed = state.history.splice(cutIndex);
+  state.rewindStack.push(removed);
+  await deleteMessages(removed.map(m => m.id));
+  renderTranscript();
+  updateRewindButtons();
+}
+
+/** Restore the most recently rewound turn from the rewindStack back into
+ *  history and IndexedDB. */
+async function fastForwardTurn(): Promise<void> {
+  if (state.inFlight) return;
+  const toRestore = state.rewindStack.pop();
+  if (!toRestore?.length) return;
+  await putMessages(toRestore);
+  for (const msg of toRestore) {
+    const insertAt = state.history.findIndex(m => m.seq > msg.seq);
+    if (insertAt === -1) state.history.push(msg);
+    else state.history.splice(insertAt, 0, msg);
+  }
+  renderTranscript();
+  updateRewindButtons();
+}
+
+function updateRewindButtons(): void {
+  const canRewind = !state.inFlight &&
+    state.history.some(m => m.role === 'user' && m.blocks.length > 0);
+  const canForward = !state.inFlight && state.rewindStack.length > 0;
+  if (rewindBtnRef) {
+    rewindBtnRef.disabled = !canRewind;
+    rewindBtnRef.classList.toggle('opacity-30', !canRewind);
+  }
+  if (forwardBtnRef) {
+    forwardBtnRef.disabled = !canForward;
+    forwardBtnRef.classList.toggle('opacity-30', !canForward);
+  }
+}
+
 // === Send message ===
 
 async function sendMessage(): Promise<void> {
@@ -961,6 +1044,9 @@ async function sendMessage(): Promise<void> {
   inputEl.value = '';
   state.pendingImages = [];
   renderPendingImages();
+  // Sending a new message commits to this branch of the conversation —
+  // any rewound turns can no longer be re-applied.
+  state.rewindStack = [];
   progressState.retryCount = 0;
   stalledByWatchdog = false;
   await runTurnWithStallRetry(key.apiKey, settings.toggles, blocks);
@@ -1031,6 +1117,7 @@ async function runTurnWithStallRetry(apiKey: string, toggles: ChatToggles, userB
       onUserPersisted: msg => {
         state.history.push(msg);
         renderTranscript();
+        updateRewindButtons();
       },
       onUserMessageUpdated: msg => {
         // chatLoop persists tool_result user messages directly without
@@ -1110,6 +1197,7 @@ async function runTurnWithStallRetry(apiKey: string, toggles: ChatToggles, userB
         // flash and vanish from the transcript.
         renderTranscript();
         renderCostMeter();
+        updateRewindButtons();
         lastTurnOutcome = info;
       },
     });

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1099,10 +1099,17 @@ async function runTurnWithStallRetry(apiKey: string, toggles: ChatToggles, userB
         }
       },
       onTurnComplete: info => {
-        void loadHistoryForCurrentSession().then(() => {
-          renderTranscript();
-          renderCostMeter();
-        });
+        // Do NOT reload from IndexedDB here. Every message callback
+        // (onUserPersisted, onAssistantPersisted, onUserMessageUpdated) keeps
+        // state.history current throughout the turn, so the in-memory state is
+        // already correct. A DB reload races with the next queued turn: if the
+        // user queued a message mid-turn, turn 2 starts immediately after drain
+        // and its onUserPersisted write may not have committed before the reload
+        // transaction opened — IndexedDB snapshot isolation means the reload
+        // returns a stale snapshot that drops the new message, causing it to
+        // flash and vanish from the transcript.
+        renderTranscript();
+        renderCostMeter();
         lastTurnOutcome = info;
       },
     });


### PR DESCRIPTION
## Summary

Comprehensive AI agent API improvements based on a real session's feedback, plus earlier bug fixes and UX work.

### Tool bridge fixes & expansions (`src/ai/tools.ts`, `src/main.ts`)

**Bug fixes from earlier work:**
- `getMeshSummary` was ignoring all options (called with no args) — fixed
- `runAndSave` had no `assertions` field in schema — fixed

**From this week's agent session feedback:**
- **`getSessionContext` now includes `currentCode`** — agents resuming after a stop no longer need a separate `getCode()` call
- **`modifyAndTest` multi-patch** — accepts `patches: [{find, replace}]` array for multiple simultaneous substitutions; single `find`/`replace` still works
- **`forkVersion` patch mode** — accepts `patches: [{find, replace}]` as an alternative to full `code`; parent version's code is patched in-place, eliminating 50-line copy-paste forks that change 2 values
- **`sliceAtZVisual` PNG output** — rasterizes the SVG cross-section to a PNG thumbnail so vision-capable models can actually see the profile shape (was SVG text, unrenderable by agents)
- **`paintByLabel` / `paintByLabels` per-item `topOnly`/`normalCone`** — restrict a label's triangle set by face direction without a separate pass
- **`paintInCylinder`** — new tool for cylindrical shell selectors: `rMin ≤ dist(centroid, axis) ≤ rMax AND zMin ≤ z ≤ zMax`. The canonical primitive for inner walls of hollow cylinders, mugs, vases, and any revolved shape where `paintInBox` catches too many faces

**10 new session-management tools (earlier commit):** `forkVersion`, `runAndAssert`, `query`, `modifyAndTest`, `probeRay`, `createSession`, `listSessions`, `openSession`, `assertPaint`, `sliceAtZVisual` — all in `ALWAYS_AVAILABLE`

### Stall recovery (`src/ai/anthropic.ts`)
`sanitizeToolUse` post-processing in `buildApiMessages` repairs dangling `tool_use`/`tool_result` pairs: injects synthetic error results for unexecuted tool calls, strips trailing orphaned assistant messages. Eliminates the `400: tool_use ids found without tool_result` error on resume after a session stall.

### Rewind / fast-forward buttons (`src/ui/aiPanel.ts`)
`↩ Undo turn` / `↪ Redo turn` buttons in a row above the toggle strip. Rewind removes the last user-typed turn and everything after from history and IndexedDB (saved to in-memory `rewindStack`). Redo restores it. Stack is cleared on new message.

**UX fixes:**
- First message no longer disappears: `setActiveSession()` early-returns when `state.inFlight` is true, preventing mid-turn history reloads when AI calls `createSession()`
- Buttons no longer stay disabled after turn: `updateRewindButtons()` moved to after `state.inFlight = false`

### Documentation (`src/ai/systemPrompt.ts`)
- `api.label` boolean-subtraction limitation documented prominently: inner surfaces from `.subtract()` are unlabeled — use `probePixel` + `paintConnected` or `paintInCylinder`
- Interrupted-tool recovery guidance: verify state with `getSessionContext()` before re-running
- Labels are version-specific (clarified)
- `paintInCylinder` added to paint workflow guidance

## Test plan
- [ ] Queue a message while a turn runs — verify it appears and stays
- [ ] Stall a session (Stop mid-tool-call), send a new message — should NOT get a 400 error
- [ ] Send the first message in a fresh session — verify it stays visible after model responds
- [ ] Click ↩ Undo turn — transcript steps back; ↪ Redo restores; both re-enable after turn completes
- [ ] `getSessionContext()` — confirm result includes `currentCode`
- [ ] `modifyAndTest({patches: [{find: 'x', replace: 'y'}, {find: 'a', replace: 'b'}]})` — both subs applied
- [ ] `forkVersion({index: 1, patches: [{find: '10', replace: '20'}]})` — forks from v1 with patch
- [ ] `sliceAtZVisual({z: 0})` — returns PNG image in chat, not raw SVG
- [ ] `paintInCylinder({rMin: 3, rMax: 5, zMin: 0, zMax: 10, color: [1,0,0]})` on a hollow cylinder — inner wall paints correctly
- [ ] `paintByLabel` with `topOnly: true` — only top-facing triangles of that label get painted
- [ ] `getMeshSummary({maxGroups: 3, maxTrianglesPerGroup: 0})` — respects caps
- [ ] `runAndSave` with `assertions: {isManifold: true, maxComponents: 1}` — gates save on geometry validity