### PR TITLE
perf: cache tool schemas via Anthropic prompt caching

### DIFF
--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -114,10 +114,16 @@ export async function streamTurn(
     system.push({ type: 'text', text: spec.systemSuffix });
   }
 
-  const tools: Anthropic.Tool[] = spec.tools.map(t => ({
+  // Cache the tool list at the last entry. The Anthropic API treats everything
+  // up to and including the cache_control marker as one cacheable prefix, so
+  // a single marker on the last tool covers the entire list. The cache
+  // invalidates automatically whenever the list changes (e.g. toggles flip a
+  // tool on/off), so stale cache hits are not a concern.
+  const tools: Anthropic.Tool[] = spec.tools.map((t, i, arr) => ({
     name: t.name,
     description: t.description,
     input_schema: t.input_schema,
+    ...(i === arr.length - 1 ? { cache_control: { type: 'ephemeral' } } : {}),
   }));
 
   const stream = client.messages.stream({


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `cache_control: { type: 'ephemeral' }` to the last tool in the tools array passed to the Anthropic API each turn
- The system prompt was already cached; this extends the same prefix to cover the tool definitions, which are the next-largest static payload sent on every turn
- Cache invalidates automatically when the active tool list changes (e.g. user flips a toggle on/off), so no stale-cache risk

## Why

Tool schemas are large and nearly identical turn-to-turn. Without caching they're billed as fresh input tokens on every API call. With the marker on the last tool, Anthropic treats the full tool list as part of the cached prefix alongside the system prompt.

## Test plan

- [ ] Start a session, send several messages — confirm `cacheReadInputTokens` grows in subsequent turns (visible in browser devtools network tab on the `/v1/messages` response, or via the cost display in the UI)
- [ ] Flip a toggle (e.g. disable paint tools) and send another message — cache should miss on that turn then re-hit on the next
- [ ] No behavioral change expected; this is a billing optimization only

https://claude.ai/code/session_012TJNVWiX9w6bDzXgsRJRP8
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012TJNVWiX9w6bDzXgsRJRP8)_