### PR TITLE
feat: paint-by-shape (sphere/cylinder/cone), brush ring, brush shapes, undo clear

### DIFF
--- a/src/color/boxDrag.ts
+++ b/src/color/boxDrag.ts
@@ -22,6 +22,7 @@ let active = false;
 let mode: BoxMode = 'translate';
 let shapeType: ShapeType = 'box';
 let boxCommitted = false; // true after a paint — dims the shape until next interaction
+let shapeVisible = true;
 
 let proxy: THREE.Object3D | null = null; // invisible — TransformControls attaches here
 let shapeMesh: THREE.Mesh | null = null; // translucent shape rendered in the viewport
@@ -30,6 +31,7 @@ let gizmo: TransformControls | null = null;
 let gizmoHelper: THREE.Object3D | null = null;
 
 const changeListeners: Array<(box: OrientedBox) => void> = [];
+const visibilityListeners: Array<() => void> = [];
 
 export function isBoxActive(): boolean { return active; }
 
@@ -41,9 +43,31 @@ export function onBoxChange(fn: (box: OrientedBox) => void): () => void {
   };
 }
 
+export function onShapeVisibilityChange(fn: () => void): () => void {
+  visibilityListeners.push(fn);
+  return () => {
+    const i = visibilityListeners.indexOf(fn);
+    if (i >= 0) visibilityListeners.splice(i, 1);
+  };
+}
+
 function notifyChange(): void {
   const box = getBox();
   for (const fn of changeListeners) fn(box);
+}
+
+function notifyVisibility(): void {
+  for (const fn of visibilityListeners) fn();
+}
+
+export function getShapeVisible(): boolean { return shapeVisible; }
+
+export function setShapeVisible(v: boolean): void {
+  if (shapeVisible === v) return;
+  shapeVisible = v;
+  if (proxy) proxy.visible = v;
+  if (gizmoHelper) gizmoHelper.visible = v;
+  notifyVisibility();
 }
 
 export function setBoxMode(m: BoxMode): void {
@@ -87,9 +111,11 @@ export function setBox(box: Partial<OrientedBox>): void {
 export function activate(): void {
   if (active) return;
   active = true;
+  shapeVisible = true;
   buildShape();
   buildGizmo();
   notifyChange();
+  notifyVisibility();
 }
 
 export function deactivate(): void {
@@ -99,6 +125,7 @@ export function deactivate(): void {
   disposeGizmo();
   disposeShape();
   boxCommitted = false;
+  shapeVisible = true;
 }
 
 export function onMeshChanged(): void {

--- a/src/color/boxDrag.ts
+++ b/src/color/boxDrag.ts
@@ -9,7 +9,7 @@
 import * as THREE from 'three';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
 import type { MeshData } from '../geometry/types';
-import { getScene, getCamera, getRenderer, getMeshGroup, setGizmoLock } from '../renderer/viewport';
+import { getScene, getCamera, getRenderer, setGizmoLock } from '../renderer/viewport';
 import { addRegion, getRegions } from './regions';
 import { getColor, getCurrentMesh } from './paintMode';
 import { findShapeTriangles, type OrientedBox, type ShapeType } from './boxPaint';

--- a/src/color/boxDrag.ts
+++ b/src/color/boxDrag.ts
@@ -1,8 +1,10 @@
-// Box drag — interactive oriented-box paint tool. Spawns a translucent box
-// in the viewport sized to the model's bounding box, gives the user a
-// transform gizmo (translate / rotate / scale) to position it, and commits
-// every triangle whose centroid is inside the box when the user clicks
-// "Paint inside box".
+// Shape drag — interactive paint-by-shape tool. Spawns a translucent shape
+// (box, sphere, cylinder, or cone) in the viewport, gives the user a transform
+// gizmo to position/rotate/scale it, and paints every triangle whose centroid
+// is inside the shape when the user clicks "Paint inside shape".
+//
+// After painting the shape fades to low opacity so the user can see the result.
+// It brightens again the moment the user hovers a gizmo handle or starts a drag.
 
 import * as THREE from 'three';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
@@ -10,16 +12,20 @@ import type { MeshData } from '../geometry/types';
 import { getScene, getCamera, getRenderer, getMeshGroup, setGizmoLock } from '../renderer/viewport';
 import { addRegion, getRegions } from './regions';
 import { getColor, getCurrentMesh } from './paintMode';
-import { findBoxTriangles, type OrientedBox } from './boxPaint';
+import { findShapeTriangles, type OrientedBox, type ShapeType } from './boxPaint';
 import { meshBounds } from './slabPaint';
 
+export type { ShapeType };
 export type BoxMode = 'translate' | 'rotate' | 'scale';
 
 let active = false;
 let mode: BoxMode = 'translate';
+let shapeType: ShapeType = 'box';
+let boxCommitted = false; // true after a paint — dims the shape until next interaction
+
 let proxy: THREE.Object3D | null = null; // invisible — TransformControls attaches here
-let boxMesh: THREE.Mesh | null = null;   // translucent box rendered in the viewport
-let boxEdges: THREE.LineSegments | null = null;
+let shapeMesh: THREE.Mesh | null = null; // translucent shape rendered in the viewport
+let shapeEdges: THREE.LineSegments | null = null;
 let gizmo: TransformControls | null = null;
 let gizmoHelper: THREE.Object3D | null = null;
 
@@ -47,6 +53,18 @@ export function setBoxMode(m: BoxMode): void {
 
 export function getBoxMode(): BoxMode { return mode; }
 
+export function getShapeType(): ShapeType { return shapeType; }
+
+export function setShapeType(s: ShapeType): void {
+  if (shapeType === s) return;
+  shapeType = s;
+  boxCommitted = false;
+  if (active) {
+    rebuildShapeVisual();
+    notifyChange();
+  }
+}
+
 export function getBox(): OrientedBox {
   if (!proxy) return { center: [0, 0, 0], size: [1, 1, 1], quaternion: [0, 0, 0, 1] };
   return {
@@ -56,9 +74,9 @@ export function getBox(): OrientedBox {
   };
 }
 
-/** Programmatically set the box transform. Use for numeric-input edits. */
+/** Programmatically set the box transform (from numeric-input edits). */
 export function setBox(box: Partial<OrientedBox>): void {
-  if (!proxy || !boxMesh || !boxEdges) return;
+  if (!proxy || !shapeMesh || !shapeEdges) return;
   if (box.center) proxy.position.set(box.center[0], box.center[1], box.center[2]);
   if (box.size) proxy.scale.set(Math.max(0.001, box.size[0]), Math.max(0.001, box.size[1]), Math.max(0.001, box.size[2]));
   if (box.quaternion) proxy.quaternion.set(box.quaternion[0], box.quaternion[1], box.quaternion[2], box.quaternion[3]);
@@ -69,13 +87,9 @@ export function setBox(box: Partial<OrientedBox>): void {
 export function activate(): void {
   if (active) return;
   active = true;
-
-  // Orbit stays enabled — the gizmo locks it only while a handle is hovered
-  // or being dragged (see buildGizmo's axis-changed / dragging-changed
-  // handlers). Clicks outside the gizmo and box still rotate the camera.
-  buildBox();
+  buildShape();
   buildGizmo();
-  notifyChange(); // populate the panel's numeric readouts with initial values
+  notifyChange();
 }
 
 export function deactivate(): void {
@@ -83,17 +97,16 @@ export function deactivate(): void {
   active = false;
   setGizmoLock(false);
   disposeGizmo();
-  disposeBox();
+  disposeShape();
+  boxCommitted = false;
 }
 
 export function onMeshChanged(): void {
   if (!active) return;
-  // Reset the box to fit the new mesh, but preserve the user's chosen mode.
-  disposeBox();
-  buildBox();
+  disposeShape();
+  buildShape();
   if (gizmo && proxy) {
     gizmo.attach(proxy);
-    // Re-add the gizmo helper in case the mesh swap reset the scene.
     if (gizmoHelper && !gizmoHelper.parent) getScene().add(gizmoHelper);
   }
   syncVisuals();
@@ -107,9 +120,6 @@ function defaultBoxFor(mesh: MeshData): { center: THREE.Vector3; size: THREE.Vec
     (bb.min[1] + bb.max[1]) / 2,
     (bb.min[2] + bb.max[2]) / 2,
   );
-  // Default size = 110% of the model bbox so the box fully contains the
-  // model on activation. A "Paint" with default settings paints everything;
-  // the user shrinks/rotates/moves the box from there.
   const size = new THREE.Vector3(
     Math.max(0.1, (bb.max[0] - bb.min[0]) * 1.1),
     Math.max(0.1, (bb.max[1] - bb.min[1]) * 1.1),
@@ -118,7 +128,16 @@ function defaultBoxFor(mesh: MeshData): { center: THREE.Vector3; size: THREE.Vec
   return { center, size };
 }
 
-function buildBox(): void {
+function makeShapeGeometry(shape: ShapeType): THREE.BufferGeometry {
+  switch (shape) {
+    case 'sphere':   return new THREE.SphereGeometry(0.5, 16, 10);
+    case 'cylinder': return new THREE.CylinderGeometry(0.5, 0.5, 1, 24);
+    case 'cone':     return new THREE.ConeGeometry(0.5, 1, 24);
+    default:         return new THREE.BoxGeometry(1, 1, 1);
+  }
+}
+
+function buildShape(): void {
   const mesh = getCurrentMesh();
   if (!mesh) return;
 
@@ -129,10 +148,7 @@ function buildBox(): void {
   proxy.scale.copy(size);
   getMeshGroup().add(proxy);
 
-  // Box mesh is a unit cube; we scale it via the proxy. The proxy ALSO scales
-  // the gizmo handles unfortunately — so we make the renderable box a child
-  // of the proxy and apply our own visual scale to keep things clean.
-  const geo = new THREE.BoxGeometry(1, 1, 1);
+  const geo = makeShapeGeometry(shapeType);
   const hex = colorToHex(getColor());
   const mat = new THREE.MeshBasicMaterial({
     color: hex,
@@ -141,31 +157,47 @@ function buildBox(): void {
     side: THREE.DoubleSide,
     depthWrite: false,
   });
-  boxMesh = new THREE.Mesh(geo, mat);
-  boxMesh.name = 'paint-box';
-  boxMesh.renderOrder = 998;
-  proxy.add(boxMesh);
+  shapeMesh = new THREE.Mesh(geo, mat);
+  shapeMesh.name = 'paint-shape';
+  shapeMesh.renderOrder = 998;
+  proxy.add(shapeMesh);
 
   const edgeGeo = new THREE.EdgesGeometry(geo);
   const edgeMat = new THREE.LineBasicMaterial({ color: hex, transparent: true, opacity: 0.8, depthTest: false });
-  boxEdges = new THREE.LineSegments(edgeGeo, edgeMat);
-  boxEdges.name = 'paint-box-edges';
-  boxEdges.renderOrder = 999;
-  proxy.add(boxEdges);
+  shapeEdges = new THREE.LineSegments(edgeGeo, edgeMat);
+  shapeEdges.name = 'paint-shape-edges';
+  shapeEdges.renderOrder = 999;
+  proxy.add(shapeEdges);
 }
 
-function disposeBox(): void {
-  if (boxMesh) {
-    boxMesh.geometry.dispose();
-    (boxMesh.material as THREE.Material).dispose();
-    boxMesh.parent?.remove(boxMesh);
-    boxMesh = null;
+/** Swap out the visual geometry for the new shape type while preserving position/scale/rotation. */
+function rebuildShapeVisual(): void {
+  if (!proxy || !shapeMesh || !shapeEdges) return;
+  const oldGeo = shapeMesh.geometry;
+  const oldEdgeGeo = shapeEdges.geometry;
+
+  const newGeo = makeShapeGeometry(shapeType);
+  shapeMesh.geometry = newGeo;
+
+  const newEdgeGeo = new THREE.EdgesGeometry(newGeo);
+  shapeEdges.geometry = newEdgeGeo;
+
+  oldGeo.dispose();
+  oldEdgeGeo.dispose();
+}
+
+function disposeShape(): void {
+  if (shapeMesh) {
+    shapeMesh.geometry.dispose();
+    (shapeMesh.material as THREE.Material).dispose();
+    shapeMesh.parent?.remove(shapeMesh);
+    shapeMesh = null;
   }
-  if (boxEdges) {
-    boxEdges.geometry.dispose();
-    (boxEdges.material as THREE.Material).dispose();
-    boxEdges.parent?.remove(boxEdges);
-    boxEdges = null;
+  if (shapeEdges) {
+    shapeEdges.geometry.dispose();
+    (shapeEdges.material as THREE.Material).dispose();
+    shapeEdges.parent?.remove(shapeEdges);
+    shapeEdges = null;
   }
   if (proxy) {
     proxy.parent?.remove(proxy);
@@ -181,8 +213,6 @@ function buildGizmo(): void {
   gizmo.setMode(mode);
   gizmo.setSize(0.8);
   gizmo.attach(proxy);
-  // The visual helper is a separate Object3D returned by getHelper(); the
-  // TransformControls itself is event-only in the modern three.js API.
   gizmoHelper = gizmo.getHelper();
   getScene().add(gizmoHelper);
 
@@ -190,14 +220,12 @@ function buildGizmo(): void {
     syncVisuals();
     notifyChange();
   });
-  // Lock orbit the moment the cursor enters a handle (axis-changed fires
-  // before pointerdown) so OrbitControls never starts rotating, and again
-  // explicitly during the drag itself for any pointer that arrives without
-  // a hover (touch / pen).
   gizmo.addEventListener('axis-changed', (e) => {
+    if (e.value !== null) restoreFromCommitted();
     setGizmoLock(e.value !== null || gizmo!.dragging);
   });
   gizmo.addEventListener('dragging-changed', (e) => {
+    if (e.value === true) restoreFromCommitted();
     setGizmoLock(e.value === true || gizmo!.axis !== null);
   });
 }
@@ -214,38 +242,59 @@ function disposeGizmo(): void {
   }
 }
 
-/** Sync any visual props that depend on current state (e.g. paint color). */
-function syncVisuals(): void {
-  if (!boxMesh || !boxEdges) return;
-  const hex = colorToHex(getColor());
-  (boxMesh.material as THREE.MeshBasicMaterial).color.setHex(hex);
-  (boxEdges.material as THREE.LineBasicMaterial).color.setHex(hex);
+function restoreFromCommitted(): void {
+  if (!boxCommitted) return;
+  boxCommitted = false;
+  applyOpacity(0.18, 0.8);
 }
 
-/** Refresh visuals after the active paint color changed. */
+function applyOpacity(meshOpacity: number, edgeOpacity: number): void {
+  if (shapeMesh) (shapeMesh.material as THREE.MeshBasicMaterial).opacity = meshOpacity;
+  if (shapeEdges) (shapeEdges.material as THREE.LineBasicMaterial).opacity = edgeOpacity;
+}
+
+function syncVisuals(): void {
+  if (!shapeMesh || !shapeEdges) return;
+  const hex = colorToHex(getColor());
+  (shapeMesh.material as THREE.MeshBasicMaterial).color.setHex(hex);
+  (shapeEdges.material as THREE.LineBasicMaterial).color.setHex(hex);
+}
+
 export function refreshColor(): void {
   if (active) syncVisuals();
 }
 
-/** Commit the box's current footprint as a paint region. Returns the painted
- *  triangle count, or 0 if the box was empty or no mesh was loaded. */
+/** Commit the shape's current footprint as a paint region. Returns the painted
+ *  triangle count, or 0 if the shape was empty or no mesh was loaded. */
 export function commitBox(): number {
   const mesh = getCurrentMesh();
   if (!mesh || !proxy) return 0;
 
   const box = getBox();
-  const triangles = findBoxTriangles(mesh, box);
+  const triangles = findShapeTriangles(mesh, shapeType, box);
   if (triangles.size === 0) return 0;
 
   const existingCount = getRegions().length;
   addRegion(
-    `Box ${existingCount + 1}`,
+    `${shapeLabel(shapeType)} ${existingCount + 1}`,
     [...getColor()] as [number, number, number],
-    'slab', // reuse the 'slab' source bucket — region badges treat it the same
+    'slab',
     { kind: 'box', center: box.center, size: box.size, quaternion: box.quaternion },
     triangles,
   );
+
+  // Dim the shape so the user can see the painted result underneath.
+  boxCommitted = true;
+  applyOpacity(0.05, 0.25);
+
   return triangles.size;
+}
+
+function shapeLabel(s: ShapeType): string {
+  if (s === 'sphere')   return 'Sphere';
+  if (s === 'cylinder') return 'Cylinder';
+  if (s === 'cone')     return 'Cone';
+  return 'Box';
 }
 
 function colorToHex(color: [number, number, number]): number {

--- a/src/color/boxDrag.ts
+++ b/src/color/boxDrag.ts
@@ -146,7 +146,9 @@ function buildShape(): void {
   proxy = new THREE.Object3D();
   proxy.position.copy(center);
   proxy.scale.copy(size);
-  getMeshGroup().add(proxy);
+  // Attach to the scene (not meshGroup) so updateMesh() clearing meshGroup
+  // children doesn't wipe the proxy when a paint region is committed.
+  getScene().add(proxy);
 
   const geo = makeShapeGeometry(shapeType);
   const hex = colorToHex(getColor());
@@ -284,8 +286,9 @@ export function commitBox(): number {
   );
 
   // Dim the shape so the user can see the painted result underneath.
+  // Stays faint until the user hovers a gizmo handle or drags again.
   boxCommitted = true;
-  applyOpacity(0.05, 0.25);
+  applyOpacity(0.08, 0.4);
 
   return triangles.size;
 }

--- a/src/color/boxPaint.ts
+++ b/src/color/boxPaint.ts
@@ -1,14 +1,17 @@
-// Box painting — select all triangles whose centroid falls inside an
-// oriented bounding box (OBB). The box is defined by a world-space center,
-// a size (full lengths along its local X / Y / Z axes), and a quaternion
-// that rotates from box-local to world space.
+// Box/shape painting — select all triangles whose centroid falls inside the
+// chosen shape (box, sphere, cylinder, or cone). Each shape is defined by the
+// same OrientedBox descriptor (center, size, quaternion) but interprets those
+// fields differently:
 //
-// For a centroid C and box (center O, quaternion q, size s), the test is:
-//   local = q^-1 * (C - O)
-//   inside <=> |local.x| <= s.x/2 AND |local.y| <= s.y/2 AND |local.z| <= s.z/2
+//   box      — OBB: |local.x| ≤ sx/2, |local.y| ≤ sy/2, |local.z| ≤ sz/2
+//   sphere   — sphere of radius size[0]/2 around center (ignores quaternion)
+//   cylinder — radius size[0]/2 around local Y axis, height size[1]
+//   cone     — apex at +Y (local), base radius size[0]/2 at -Y, height size[1]
 
 import * as THREE from 'three';
 import type { MeshData } from '../geometry/types';
+
+export type ShapeType = 'box' | 'sphere' | 'cylinder' | 'cone';
 
 export interface OrientedBox {
   center: [number, number, number];
@@ -18,6 +21,14 @@ export interface OrientedBox {
 
 const tmpV = new THREE.Vector3();
 const tmpQ = new THREE.Quaternion();
+
+/** Dispatch to the correct containment test for the given shape type. */
+export function findShapeTriangles(mesh: MeshData, shape: ShapeType, box: OrientedBox): Set<number> {
+  if (shape === 'sphere')   return findSphereTriangles(mesh, box);
+  if (shape === 'cylinder') return findCylinderTriangles(mesh, box);
+  if (shape === 'cone')     return findConeTriangles(mesh, box);
+  return findBoxTriangles(mesh, box);
+}
 
 /** Return the set of triangle indices whose centroid lies inside the OBB. */
 export function findBoxTriangles(mesh: MeshData, box: OrientedBox): Set<number> {
@@ -30,7 +41,6 @@ export function findBoxTriangles(mesh: MeshData, box: OrientedBox): Set<number> 
   if (halfX <= 0 || halfY <= 0 || halfZ <= 0) return result;
 
   const cx = box.center[0], cy = box.center[1], cz = box.center[2];
-  // Inverse rotation = conjugate for unit quaternions: (-x, -y, -z, w).
   tmpQ.set(-box.quaternion[0], -box.quaternion[1], -box.quaternion[2], box.quaternion[3]);
 
   for (let t = 0; t < numTri; t++) {
@@ -48,5 +58,72 @@ export function findBoxTriangles(mesh: MeshData, box: OrientedBox): Set<number> 
     }
   }
 
+  return result;
+}
+
+function findSphereTriangles(mesh: MeshData, box: OrientedBox): Set<number> {
+  const { triVerts, vertProperties, numProp, numTri } = mesh;
+  const result = new Set<number>();
+  const radius = box.size[0] / 2;
+  if (radius <= 0) return result;
+  const r2 = radius * radius;
+  const cx = box.center[0], cy = box.center[1], cz = box.center[2];
+
+  for (let t = 0; t < numTri; t++) {
+    const v0 = triVerts[t * 3], v1 = triVerts[t * 3 + 1], v2 = triVerts[t * 3 + 2];
+    const dx = (vertProperties[v0 * numProp]     + vertProperties[v1 * numProp]     + vertProperties[v2 * numProp])     / 3 - cx;
+    const dy = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3 - cy;
+    const dz = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3 - cz;
+    if (dx * dx + dy * dy + dz * dz <= r2) result.add(t);
+  }
+  return result;
+}
+
+function findCylinderTriangles(mesh: MeshData, box: OrientedBox): Set<number> {
+  // Cylinder axis = local Y. size[0] = diameter (X/Z), size[1] = height.
+  const { triVerts, vertProperties, numProp, numTri } = mesh;
+  const result = new Set<number>();
+  const halfR = box.size[0] / 2;
+  const halfH = box.size[1] / 2;
+  if (halfR <= 0 || halfH <= 0) return result;
+  const r2 = halfR * halfR;
+  const cx = box.center[0], cy = box.center[1], cz = box.center[2];
+  tmpQ.set(-box.quaternion[0], -box.quaternion[1], -box.quaternion[2], box.quaternion[3]);
+
+  for (let t = 0; t < numTri; t++) {
+    const v0 = triVerts[t * 3], v1 = triVerts[t * 3 + 1], v2 = triVerts[t * 3 + 2];
+    const ax = (vertProperties[v0 * numProp]     + vertProperties[v1 * numProp]     + vertProperties[v2 * numProp])     / 3 - cx;
+    const ay = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3 - cy;
+    const az = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3 - cz;
+    tmpV.set(ax, ay, az).applyQuaternion(tmpQ);
+    if (Math.abs(tmpV.y) <= halfH && tmpV.x * tmpV.x + tmpV.z * tmpV.z <= r2) result.add(t);
+  }
+  return result;
+}
+
+function findConeTriangles(mesh: MeshData, box: OrientedBox): Set<number> {
+  // Cone: apex at local +Y (top), base at local -Y (bottom).
+  // size[0] = base diameter, size[1] = height.
+  // At depth d from apex (d in [0, height]): allowed radius = (size[0]/2) * d / height.
+  const { triVerts, vertProperties, numProp, numTri } = mesh;
+  const result = new Set<number>();
+  const halfR = box.size[0] / 2;
+  const halfH = box.size[1] / 2;
+  if (halfR <= 0 || halfH <= 0) return result;
+  const fullH = halfH * 2;
+  const cx = box.center[0], cy = box.center[1], cz = box.center[2];
+  tmpQ.set(-box.quaternion[0], -box.quaternion[1], -box.quaternion[2], box.quaternion[3]);
+
+  for (let t = 0; t < numTri; t++) {
+    const v0 = triVerts[t * 3], v1 = triVerts[t * 3 + 1], v2 = triVerts[t * 3 + 2];
+    const ax = (vertProperties[v0 * numProp]     + vertProperties[v1 * numProp]     + vertProperties[v2 * numProp])     / 3 - cx;
+    const ay = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3 - cy;
+    const az = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3 - cz;
+    tmpV.set(ax, ay, az).applyQuaternion(tmpQ);
+    if (tmpV.y < -halfH || tmpV.y > halfH) continue;
+    const depth = halfH - tmpV.y; // 0 at apex, fullH at base
+    const allowedR = halfR * depth / fullH;
+    if (tmpV.x * tmpV.x + tmpV.z * tmpV.z <= allowedR * allowedR) result.add(t);
+  }
   return result;
 }

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -30,9 +30,10 @@ let currentMesh: MeshData | null = null;
 let highlightMesh: THREE.Mesh | null = null;
 let hoveredTriangles: Set<number> | null = null;
 
-// Brush ring indicator — circle outline showing the brush radius in world space
+// Brush ring indicator — outline showing the brush footprint in world space
 let brushRingMesh: THREE.LineLoop | null = null;
 let brushRingBuiltRadius = -1;
+let brushRingBuiltShape: BrushShape | '' = '';
 
 // Brush drag state
 let brushPainting = false;
@@ -303,25 +304,46 @@ function addBrushFootprint(seedTri: number, seedPoint: [number, number, number],
 // Brush ring indicator
 // ---------------------------------------------------------------------------
 
+function buildRingPoints(shape: BrushShape, r: number): THREE.Vector3[] {
+  if (shape === 'square') {
+    return [
+      new THREE.Vector3(-r, -r, 0),
+      new THREE.Vector3( r, -r, 0),
+      new THREE.Vector3( r,  r, 0),
+      new THREE.Vector3(-r,  r, 0),
+    ];
+  }
+  if (shape === 'diamond') {
+    return [
+      new THREE.Vector3( 0, -r, 0),
+      new THREE.Vector3( r,  0, 0),
+      new THREE.Vector3( 0,  r, 0),
+      new THREE.Vector3(-r,  0, 0),
+    ];
+  }
+  // circle — LineLoop auto-closes, so stop before 2π
+  const pts: THREE.Vector3[] = [];
+  const segments = 48;
+  for (let i = 0; i < segments; i++) {
+    const a = (i / segments) * Math.PI * 2;
+    pts.push(new THREE.Vector3(Math.cos(a) * r, Math.sin(a) * r, 0));
+  }
+  return pts;
+}
+
 function showBrushRing(point: [number, number, number], normal: [number, number, number]): void {
   if (brushRadius <= 0) { clearBrushRing(); return; }
 
-  // Rebuild only when radius changes (avoids per-frame allocation).
-  if (!brushRingMesh || brushRingBuiltRadius !== brushRadius) {
+  // Rebuild when radius or shape changes.
+  if (!brushRingMesh || brushRingBuiltRadius !== brushRadius || brushRingBuiltShape !== brushShape) {
     clearBrushRing();
     brushRingBuiltRadius = brushRadius;
-    const segments = 48;
-    const pts: THREE.Vector3[] = [];
-    for (let i = 0; i <= segments; i++) {
-      const a = (i / segments) * Math.PI * 2;
-      pts.push(new THREE.Vector3(Math.cos(a) * brushRadius, Math.sin(a) * brushRadius, 0));
-    }
-    const geo = new THREE.BufferGeometry().setFromPoints(pts);
+    brushRingBuiltShape = brushShape;
+    const geo = new THREE.BufferGeometry().setFromPoints(buildRingPoints(brushShape, brushRadius));
     const mat = new THREE.LineBasicMaterial({ color: 0xffffff, opacity: 0.75, transparent: true, depthTest: false });
     brushRingMesh = new THREE.LineLoop(geo, mat);
     brushRingMesh.name = 'brush-ring';
     brushRingMesh.renderOrder = 1001;
-    // Use scene (not meshGroup) so updateMesh() clearing meshGroup doesn't remove it.
     getScene().add(brushRingMesh);
   }
 
@@ -337,6 +359,7 @@ function clearBrushRing(): void {
     (brushRingMesh.material as THREE.Material).dispose();
     brushRingMesh = null;
     brushRingBuiltRadius = -1;
+    brushRingBuiltShape = '';
   }
 }
 

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -6,7 +6,7 @@ import type { MeshData } from '../geometry/types';
 import { pickFace } from './facePicker';
 import { buildAdjacency, findCoplanarRegion, getTriangleNormal, type AdjacencyGraph } from './adjacency';
 import { addRegion, getRegions } from './regions';
-import { getMeshGroup, getRenderer, addPointerSuppressor, isPointerOverModel } from '../renderer/viewport';
+import { getScene, getMeshGroup, getRenderer, addPointerSuppressor, isPointerOverModel } from '../renderer/viewport';
 import { activate as activateSlabDrag, deactivate as deactivateSlabDrag, onMeshChanged as onSlabDragMeshChanged } from './slabDrag';
 import { activate as activateBoxDrag, deactivate as deactivateBoxDrag, onMeshChanged as onBoxDragMeshChanged } from './boxDrag';
 export { setSlabAxis, getSlabAxis } from './slabDrag';
@@ -205,7 +205,11 @@ function onMouseMove(event: MouseEvent): void {
     if (result) {
       addBrushFootprint(result.triangleIndex, result.point, brushSession);
       showHighlight(brushSession);
+      // Ring must come after showHighlight (which calls clearHighlight internally).
       if (brushRadius > 0) showBrushRing(result.point, result.normal);
+      else clearBrushRing();
+    } else {
+      clearBrushRing();
     }
     return;
   }
@@ -213,6 +217,7 @@ function onMouseMove(event: MouseEvent): void {
   const result = pickFace(event);
   if (!result) {
     clearHighlight();
+    clearBrushRing();
     return;
   }
 
@@ -220,17 +225,22 @@ function onMouseMove(event: MouseEvent): void {
   if (currentTool === 'brush') {
     region = new Set<number>();
     addBrushFootprint(result.triangleIndex, result.point, region);
-    if (brushRadius > 0) showBrushRing(result.point, result.normal);
-    else clearBrushRing();
   } else {
     clearBrushRing();
     region = findCoplanarRegion(result.triangleIndex, adjacency, bucketTolerance);
   }
 
-  if (hoveredTriangles && setsEqual(hoveredTriangles, region)) return;
+  if (hoveredTriangles && setsEqual(hoveredTriangles, region)) {
+    // Triangles unchanged — just update ring position without rebuilding highlight.
+    if (currentTool === 'brush' && brushRadius > 0) showBrushRing(result.point, result.normal);
+    return;
+  }
 
   hoveredTriangles = region;
   showHighlight(region);
+  // Ring must come after showHighlight.
+  if (currentTool === 'brush' && brushRadius > 0) showBrushRing(result.point, result.normal);
+  else if (currentTool === 'brush') clearBrushRing();
 }
 
 function onMouseDown(event: MouseEvent): void {
@@ -311,7 +321,8 @@ function showBrushRing(point: [number, number, number], normal: [number, number,
     brushRingMesh = new THREE.LineLoop(geo, mat);
     brushRingMesh.name = 'brush-ring';
     brushRingMesh.renderOrder = 1001;
-    getMeshGroup().add(brushRingMesh);
+    // Use scene (not meshGroup) so updateMesh() clearing meshGroup doesn't remove it.
+    getScene().add(brushRingMesh);
   }
 
   brushRingMesh.position.set(point[0], point[1], point[2]);
@@ -321,7 +332,7 @@ function showBrushRing(point: [number, number, number], normal: [number, number,
 
 function clearBrushRing(): void {
   if (brushRingMesh) {
-    getMeshGroup().remove(brushRingMesh);
+    brushRingMesh.parent?.remove(brushRingMesh);
     brushRingMesh.geometry.dispose();
     (brushRingMesh.material as THREE.Material).dispose();
     brushRingMesh = null;
@@ -467,7 +478,6 @@ function clearHighlight(): void {
     highlightMesh = null;
   }
   hoveredTriangles = null;
-  clearBrushRing();
 }
 
 function setsEqual(a: Set<number>, b: Set<number>): boolean {

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -12,6 +12,7 @@ import { activate as activateBoxDrag, deactivate as deactivateBoxDrag, onMeshCha
 export { setSlabAxis, getSlabAxis } from './slabDrag';
 
 export type PaintTool = 'bucket' | 'brush' | 'slab' | 'box';
+export type BrushShape = 'circle' | 'square' | 'diamond';
 
 let active = false;
 let currentColor: [number, number, number] = [1, 0.2, 0.2]; // default red
@@ -21,12 +22,17 @@ let bucketTolerance = 0.9995;
  *  every triangle whose centroid is within `brushRadius` of the picked surface
  *  point. */
 let brushRadius = 0;
+let brushShape: BrushShape = 'circle';
 let adjacency: AdjacencyGraph | null = null;
 let currentMesh: MeshData | null = null;
 
 // Hover highlight state
 let highlightMesh: THREE.Mesh | null = null;
 let hoveredTriangles: Set<number> | null = null;
+
+// Brush ring indicator — circle outline showing the brush radius in world space
+let brushRingMesh: THREE.LineLoop | null = null;
+let brushRingBuiltRadius = -1;
 
 // Brush drag state
 let brushPainting = false;
@@ -88,6 +94,14 @@ export function setBrushRadius(r: number): void {
 
 export function getBrushRadius(): number {
   return brushRadius;
+}
+
+export function setBrushShape(s: BrushShape): void {
+  brushShape = s;
+}
+
+export function getBrushShape(): BrushShape {
+  return brushShape;
 }
 
 export function setOnRegionPainted(fn: () => void): void {
@@ -162,6 +176,7 @@ export function deactivate(): void {
   canvas.removeEventListener('mouseleave', onMouseLeave);
   canvas.style.cursor = '';
   clearHighlight();
+  clearBrushRing();
   brushPainting = false;
   brushSession = null;
   mouseDownOffModel = false;
@@ -190,6 +205,7 @@ function onMouseMove(event: MouseEvent): void {
     if (result) {
       addBrushFootprint(result.triangleIndex, result.point, brushSession);
       showHighlight(brushSession);
+      if (brushRadius > 0) showBrushRing(result.point, result.normal);
     }
     return;
   }
@@ -204,7 +220,10 @@ function onMouseMove(event: MouseEvent): void {
   if (currentTool === 'brush') {
     region = new Set<number>();
     addBrushFootprint(result.triangleIndex, result.point, region);
+    if (brushRadius > 0) showBrushRing(result.point, result.normal);
+    else clearBrushRing();
   } else {
+    clearBrushRing();
     region = findCoplanarRegion(result.triangleIndex, adjacency, bucketTolerance);
   }
 
@@ -238,16 +257,19 @@ function onMouseDown(event: MouseEvent): void {
 }
 
 /** Expand a single picked triangle into the brush's full footprint.
- *  At brushRadius=0 this just adds the picked triangle (legacy behavior).
- *  At brushRadius>0 it adds every triangle whose centroid lies within
- *  `brushRadius` of the picked surface point. */
+ *  At brushRadius=0 this just adds the picked triangle.
+ *  At brushRadius>0 the footprint shape is controlled by brushShape:
+ *    circle  — sphere test: distance ≤ radius
+ *    square  — cube test:   |dx|, |dy|, |dz| all ≤ radius
+ *    diamond — L1 test:     |dx|+|dy|+|dz| ≤ radius */
 function addBrushFootprint(seedTri: number, seedPoint: [number, number, number], target: Set<number>): void {
   target.add(seedTri);
   if (brushRadius <= 0 || !adjacency) return;
 
   const { centroids } = adjacency;
   const numTri = centroids.length / 3;
-  const r2 = brushRadius * brushRadius;
+  const r = brushRadius;
+  const r2 = r * r;
   const sx = seedPoint[0], sy = seedPoint[1], sz = seedPoint[2];
 
   for (let t = 0; t < numTri; t++) {
@@ -255,7 +277,55 @@ function addBrushFootprint(seedTri: number, seedPoint: [number, number, number],
     const dx = centroids[t * 3]     - sx;
     const dy = centroids[t * 3 + 1] - sy;
     const dz = centroids[t * 3 + 2] - sz;
-    if (dx * dx + dy * dy + dz * dz <= r2) target.add(t);
+    let inside: boolean;
+    if (brushShape === 'square') {
+      inside = Math.abs(dx) <= r && Math.abs(dy) <= r && Math.abs(dz) <= r;
+    } else if (brushShape === 'diamond') {
+      inside = Math.abs(dx) + Math.abs(dy) + Math.abs(dz) <= r;
+    } else {
+      inside = dx * dx + dy * dy + dz * dz <= r2;
+    }
+    if (inside) target.add(t);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Brush ring indicator
+// ---------------------------------------------------------------------------
+
+function showBrushRing(point: [number, number, number], normal: [number, number, number]): void {
+  if (brushRadius <= 0) { clearBrushRing(); return; }
+
+  // Rebuild only when radius changes (avoids per-frame allocation).
+  if (!brushRingMesh || brushRingBuiltRadius !== brushRadius) {
+    clearBrushRing();
+    brushRingBuiltRadius = brushRadius;
+    const segments = 48;
+    const pts: THREE.Vector3[] = [];
+    for (let i = 0; i <= segments; i++) {
+      const a = (i / segments) * Math.PI * 2;
+      pts.push(new THREE.Vector3(Math.cos(a) * brushRadius, Math.sin(a) * brushRadius, 0));
+    }
+    const geo = new THREE.BufferGeometry().setFromPoints(pts);
+    const mat = new THREE.LineBasicMaterial({ color: 0xffffff, opacity: 0.75, transparent: true, depthTest: false });
+    brushRingMesh = new THREE.LineLoop(geo, mat);
+    brushRingMesh.name = 'brush-ring';
+    brushRingMesh.renderOrder = 1001;
+    getMeshGroup().add(brushRingMesh);
+  }
+
+  brushRingMesh.position.set(point[0], point[1], point[2]);
+  const nrm = new THREE.Vector3(normal[0], normal[1], normal[2]).normalize();
+  brushRingMesh.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), nrm);
+}
+
+function clearBrushRing(): void {
+  if (brushRingMesh) {
+    getMeshGroup().remove(brushRingMesh);
+    brushRingMesh.geometry.dispose();
+    (brushRingMesh.material as THREE.Material).dispose();
+    brushRingMesh = null;
+    brushRingBuiltRadius = -1;
   }
 }
 
@@ -318,7 +388,6 @@ function onMouseUp(event: MouseEvent): void {
 
 function onMouseLeave(): void {
   if (currentTool === 'brush' && brushPainting && brushSession && brushSession.size > 0) {
-    // Commit whatever the user has painted so far.
     const triangles = brushSession;
     const existingCount = getRegions().length;
     addRegion(
@@ -333,6 +402,7 @@ function onMouseLeave(): void {
   brushPainting = false;
   brushSession = null;
   clearHighlight();
+  clearBrushRing();
 }
 
 /** Public helper: render a hover-style highlight over a triangle set.
@@ -397,6 +467,7 @@ function clearHighlight(): void {
     highlightMesh = null;
   }
   hoveredTriangles = null;
+  clearBrushRing();
 }
 
 function setsEqual(a: Set<number>, b: Set<number>): boolean {

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -40,7 +40,7 @@ import {
 import { forceDeactivate as forceDeactivateAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as forceDeactivateAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as forceDeactivateAnnotateSelect } from '../annotations/selectMode';
-import { setBoxMode, getBoxMode, setBox, commitBox, onBoxChange, setShapeType, getShapeType, type BoxMode, type ShapeType } from './boxDrag';
+import { setBoxMode, getBoxMode, setBox, commitBox, onBoxChange, setShapeType, getShapeType, getShapeVisible, setShapeVisible, onShapeVisibilityChange, type BoxMode, type ShapeType } from './boxDrag';
 
 const PRESET_COLORS: [number, number, number][] = [
   // Warm
@@ -633,12 +633,15 @@ function createBoxControls(): HTMLElement {
   });
   wrap.appendChild(grid);
 
-  // Action: paint inside the current shape.
+  // Action: paint inside the current shape + eye toggle.
   const actionRow = document.createElement('div');
   actionRow.className = 'mt-2 flex flex-col gap-1';
 
+  const paintAndEyeRow = document.createElement('div');
+  paintAndEyeRow.className = 'flex items-center gap-1';
+
   paintShapeBtn = document.createElement('button');
-  paintShapeBtn.className = 'w-full px-2 py-1.5 rounded text-[11px] bg-blue-500/30 text-blue-200 hover:bg-blue-500/50 border border-blue-500/50 transition-colors font-medium';
+  paintShapeBtn.className = 'flex-1 px-2 py-1.5 rounded text-[11px] bg-blue-500/30 text-blue-200 hover:bg-blue-500/50 border border-blue-500/50 transition-colors font-medium';
   updatePaintShapeButton();
   paintShapeBtn.addEventListener('click', () => {
     const painted = commitBox();
@@ -647,11 +650,30 @@ function createBoxControls(): HTMLElement {
       window.setTimeout(() => { if (paintShapeBtn) updatePaintShapeButton(); }, 1200);
     }
   });
-  actionRow.appendChild(paintShapeBtn);
+  paintAndEyeRow.appendChild(paintShapeBtn);
+
+  const eyeToggleBtn = document.createElement('button');
+  eyeToggleBtn.className = 'shrink-0 w-7 h-7 flex items-center justify-center rounded bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 border border-zinc-600/40 transition-colors';
+  eyeToggleBtn.title = 'Hide/show the shape in the viewport';
+  eyeToggleBtn.innerHTML = eyeIconSVG();
+  eyeToggleBtn.addEventListener('click', () => {
+    setShapeVisible(!getShapeVisible());
+  });
+  paintAndEyeRow.appendChild(eyeToggleBtn);
+
+  actionRow.appendChild(paintAndEyeRow);
+
+  // Keep the eye button in sync with visibility state.
+  onShapeVisibilityChange(() => {
+    const vis = getShapeVisible();
+    eyeToggleBtn.innerHTML = vis ? eyeIconSVG() : eyeOffIconSVG();
+    eyeToggleBtn.title = vis ? 'Hide shape' : 'Show shape';
+    eyeToggleBtn.classList.toggle('opacity-50', !vis);
+  });
 
   const help = document.createElement('div');
   help.className = 'text-[10px] text-zinc-500 leading-relaxed';
-  help.textContent = 'Drag the gizmo handles in the viewport, or edit values above. The shape is rendered in the active paint color. It fades after painting and brightens when you interact with it again.';
+  help.textContent = 'Drag the gizmo handles in the viewport, or edit values above. The shape fades after painting and brightens when you interact with it again.';
   actionRow.appendChild(help);
 
   wrap.appendChild(actionRow);

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -12,21 +12,27 @@ import {
   getBucketTolerance,
   setBrushRadius,
   getBrushRadius,
+  setBrushShape,
+  getBrushShape,
   setSlabAxis,
   getSlabAxis,
   previewTriangles,
   type PaintTool,
+  type BrushShape,
 } from './paintMode';
 import {
   getRegions,
   onChange as onRegionsChange,
   onRedoChange,
   onVisibilityChange,
+  onClearSnapshotChange,
   isVisible as isPaintVisible,
   setVisible as setPaintVisible,
   removeLastRegion,
   redoLastRegion,
   canRedoRegion,
+  canUndoClear,
+  undoClear,
   clearRegions,
   removeRegion,
   setRegionVisibility,
@@ -34,7 +40,7 @@ import {
 import { forceDeactivate as forceDeactivateAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as forceDeactivateAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as forceDeactivateAnnotateSelect } from '../annotations/selectMode';
-import { setBoxMode, getBoxMode, setBox, commitBox, onBoxChange, type BoxMode } from './boxDrag';
+import { setBoxMode, getBoxMode, setBox, commitBox, onBoxChange, setShapeType, getShapeType, type BoxMode, type ShapeType } from './boxDrag';
 
 const PRESET_COLORS: [number, number, number][] = [
   // Warm
@@ -65,6 +71,8 @@ let regionCountBadge: HTMLElement | null = null;
 let visibilityBtn: HTMLButtonElement | null = null;
 let undoBtn: HTMLButtonElement | null = null;
 let redoBtn: HTMLButtonElement | null = null;
+let undoClearBtn: HTMLButtonElement | null = null;
+let paintShapeBtn: HTMLButtonElement | null = null; // "Paint inside shape" action button
 let toolButtons: Partial<Record<PaintTool, HTMLButtonElement>> = {};
 let bucketControls: HTMLElement | null = null;
 let brushControls: HTMLElement | null = null;
@@ -101,10 +109,12 @@ export function initPaintUI(controlsContainer: HTMLElement): void {
   });
   onRedoChange(updateRedoButton);
   onVisibilityChange(updateVisibilityButton);
+  onClearSnapshotChange(updateUndoClearButton);
   updateBadge();
   updateUndoButton();
   updateRedoButton();
   updateVisibilityButton();
+  updateUndoClearButton();
 }
 
 function togglePaintMode(): void {
@@ -161,7 +171,7 @@ function createPickerPanel(): HTMLElement {
   toolRow.appendChild(createToolButton('bucket', '\u{1FAA3} Bucket', 'Flood-fill across coplanar faces'));
   toolRow.appendChild(createToolButton('brush', '\u{1F58C}\uFE0F Brush', 'Paint individual triangles (drag to paint)'));
   toolRow.appendChild(createToolButton('slab', '\u{1F9F1} Slab', 'Paint all faces inside an axis-aligned range'));
-  toolRow.appendChild(createToolButton('box', '\u{1F4E6} Box', 'Paint everything inside a positionable, rotatable, scalable 3D box'));
+  toolRow.appendChild(createToolButton('box', '\u25C6 Shape', 'Paint everything inside a positionable, rotatable, scalable 3D shape (box, sphere, cylinder, or cone)'));
   panel.appendChild(toolRow);
 
   // === Color picker ===
@@ -245,13 +255,13 @@ function createPickerPanel(): HTMLElement {
 
   visibilityBtn = document.createElement('button');
   visibilityBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors';
-  visibilityBtn.title = 'Toggle paint region visibility in viewport (exports keep colors regardless)';
+  visibilityBtn.title = 'Toggle all paint region visibility in viewport (exports keep colors regardless)';
   visibilityBtn.addEventListener('click', () => { setPaintVisible(!isPaintVisible()); });
   actions.appendChild(visibilityBtn);
 
   undoBtn = document.createElement('button');
   undoBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors opacity-40 cursor-not-allowed';
-  undoBtn.textContent = 'Undo paint';
+  undoBtn.textContent = 'Undo';
   undoBtn.title = 'Remove the most recent paint region';
   undoBtn.disabled = true;
   undoBtn.addEventListener('click', () => { removeLastRegion(); });
@@ -259,11 +269,19 @@ function createPickerPanel(): HTMLElement {
 
   redoBtn = document.createElement('button');
   redoBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors opacity-40 cursor-not-allowed';
-  redoBtn.textContent = 'Redo paint';
+  redoBtn.textContent = 'Redo';
   redoBtn.title = 'Restore the most recently undone paint region';
   redoBtn.disabled = true;
   redoBtn.addEventListener('click', () => { redoLastRegion(); });
   actions.appendChild(redoBtn);
+
+  undoClearBtn = document.createElement('button');
+  undoClearBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors opacity-40 cursor-not-allowed';
+  undoClearBtn.textContent = 'Undo clear';
+  undoClearBtn.title = 'Restore all regions removed by the last Clear (only available until the next paint)';
+  undoClearBtn.disabled = true;
+  undoClearBtn.addEventListener('click', () => { undoClear(); });
+  actions.appendChild(undoClearBtn);
 
   const clearBtn = document.createElement('button');
   clearBtn.className = 'px-2 py-1 rounded text-[10px] bg-red-700/60 text-red-200 hover:bg-red-600/60 transition-colors';
@@ -444,6 +462,35 @@ function createBrushControls(): HTMLElement {
   help.textContent = 'Single triangle \u2190\u2014\u2014\u2192 Wider brush';
   wrap.appendChild(help);
 
+  // Brush shape selector
+  const shapeLabel = document.createElement('div');
+  shapeLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 mt-2 font-medium';
+  shapeLabel.textContent = 'Brush shape';
+  wrap.appendChild(shapeLabel);
+
+  const shapeRow = document.createElement('div');
+  shapeRow.className = 'grid grid-cols-3 gap-1';
+  const brushShapeButtons: Partial<Record<BrushShape, HTMLButtonElement>> = {};
+  for (const [s, icon, tip] of [
+    ['circle',  '\u25cf Circle',  'Circular brush (sphere test in 3D)'],
+    ['square',  '\u25a0 Square',  'Cubic brush (axis-aligned box test in 3D)'],
+    ['diamond', '\u25c6 Diamond', 'Diamond brush (L1 distance test in 3D)'],
+  ] as const) {
+    const btn = document.createElement('button');
+    btn.textContent = icon;
+    btn.title = tip;
+    btn.className = axisButtonClass(s === getBrushShape());
+    btn.addEventListener('click', () => {
+      setBrushShape(s);
+      for (const [k, b] of Object.entries(brushShapeButtons)) {
+        if (b) b.className = axisButtonClass(k === getBrushShape());
+      }
+    });
+    shapeRow.appendChild(btn);
+    brushShapeButtons[s] = btn;
+  }
+  wrap.appendChild(shapeRow);
+
   return wrap;
 }
 
@@ -515,10 +562,41 @@ function createBoxControls(): HTMLElement {
   const wrap = document.createElement('div');
   wrap.className = 'mt-2 pt-2 border-t border-zinc-700 hidden';
 
-  // Mode buttons — translate / rotate / scale, drives the gizmo.
+  // Shape type selector
+  const shapeTypeLabel = document.createElement('div');
+  shapeTypeLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium';
+  shapeTypeLabel.textContent = 'Shape';
+  wrap.appendChild(shapeTypeLabel);
+
+  const shapeRow = document.createElement('div');
+  shapeRow.className = 'grid grid-cols-4 gap-1 mb-2';
+  const shapeBtns: Partial<Record<ShapeType, HTMLButtonElement>> = {};
+  for (const [s, label, tip] of [
+    ['box',      '□ Box',    'Oriented bounding box'],
+    ['sphere',   '○ Sphere', 'Sphere centered on the gizmo origin; size X = diameter'],
+    ['cylinder', '⊖ Cyl',   'Cylinder aligned to local Y; size X = diameter, Y = height'],
+    ['cone',     '△ Cone',  'Cone: apex at top, base at bottom; size X = base diameter, Y = height'],
+  ] as const) {
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    btn.title = tip;
+    btn.className = axisButtonClass(s === getShapeType());
+    btn.addEventListener('click', () => {
+      setShapeType(s);
+      for (const [k, b] of Object.entries(shapeBtns)) {
+        if (b) b.className = axisButtonClass(k === getShapeType());
+      }
+      updatePaintShapeButton();
+    });
+    shapeRow.appendChild(btn);
+    shapeBtns[s] = btn;
+  }
+  wrap.appendChild(shapeRow);
+
+  // Transform mode buttons — translate / rotate / scale, drives the gizmo.
   const modeLabel = document.createElement('div');
   modeLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium';
-  modeLabel.textContent = 'Box transform';
+  modeLabel.textContent = 'Transform';
   wrap.appendChild(modeLabel);
 
   const modeRow = document.createElement('div');
@@ -547,7 +625,6 @@ function createBoxControls(): HTMLElement {
   const centerInputs = makeVectorRow(grid, 'Pos',  -1e6, 1e6, 0.1, (v) => setBox({ center: v }));
   const sizeInputs   = makeVectorRow(grid, 'Size',  0.001, 1e6, 0.1, (v) => setBox({ size: v }));
   const rotInputs    = makeVectorRow(grid, 'Rot°', -360, 360, 1, (v) => {
-    // Convert Euler degrees -> quaternion (XYZ order).
     const ex = v[0] * Math.PI / 180;
     const ey = v[1] * Math.PI / 180;
     const ez = v[2] * Math.PI / 180;
@@ -556,26 +633,25 @@ function createBoxControls(): HTMLElement {
   });
   wrap.appendChild(grid);
 
-  // Action: paint inside the current box.
+  // Action: paint inside the current shape.
   const actionRow = document.createElement('div');
   actionRow.className = 'mt-2 flex flex-col gap-1';
 
-  const paintBtn = document.createElement('button');
-  paintBtn.className = 'w-full px-2 py-1.5 rounded text-[11px] bg-blue-500/30 text-blue-200 hover:bg-blue-500/50 border border-blue-500/50 transition-colors font-medium';
-  paintBtn.textContent = 'Paint inside box';
-  paintBtn.title = 'Commit every triangle inside the box as a new color region';
-  paintBtn.addEventListener('click', () => {
+  paintShapeBtn = document.createElement('button');
+  paintShapeBtn.className = 'w-full px-2 py-1.5 rounded text-[11px] bg-blue-500/30 text-blue-200 hover:bg-blue-500/50 border border-blue-500/50 transition-colors font-medium';
+  updatePaintShapeButton();
+  paintShapeBtn.addEventListener('click', () => {
     const painted = commitBox();
     if (painted === 0) {
-      paintBtn.textContent = 'No triangles in box';
-      window.setTimeout(() => { paintBtn.textContent = 'Paint inside box'; }, 1200);
+      paintShapeBtn!.textContent = 'No triangles in shape';
+      window.setTimeout(() => { if (paintShapeBtn) updatePaintShapeButton(); }, 1200);
     }
   });
-  actionRow.appendChild(paintBtn);
+  actionRow.appendChild(paintShapeBtn);
 
   const help = document.createElement('div');
   help.className = 'text-[10px] text-zinc-500 leading-relaxed';
-  help.textContent = 'Drag the gizmo handles in the viewport, or edit values above. The box is rendered in the active paint color.';
+  help.textContent = 'Drag the gizmo handles in the viewport, or edit values above. The shape is rendered in the active paint color. It fades after painting and brightens when you interact with it again.';
   actionRow.appendChild(help);
 
   wrap.appendChild(actionRow);
@@ -591,6 +667,18 @@ function createBoxControls(): HTMLElement {
   });
 
   return wrap;
+}
+
+function updatePaintShapeButton(): void {
+  if (!paintShapeBtn) return;
+  const labels: Record<ShapeType, string> = {
+    box: 'Paint inside box',
+    sphere: 'Paint inside sphere',
+    cylinder: 'Paint inside cylinder',
+    cone: 'Paint inside cone',
+  };
+  paintShapeBtn.textContent = labels[getShapeType()];
+  paintShapeBtn.title = `Commit every triangle inside the ${getShapeType()} as a new color region`;
 }
 
 /** Build a label + 3 number inputs (X/Y/Z) for a vector property. */
@@ -668,7 +756,15 @@ function quatToEulerXYZ(q: [number, number, number, number]): [number, number, n
 
 function updateVisibilityButton(): void {
   if (!visibilityBtn) return;
-  visibilityBtn.textContent = isPaintVisible() ? 'Hide' : 'Show';
+  visibilityBtn.textContent = isPaintVisible() ? 'Hide all' : 'Show all';
+}
+
+function updateUndoClearButton(): void {
+  if (!undoClearBtn) return;
+  const can = canUndoClear();
+  undoClearBtn.disabled = !can;
+  undoClearBtn.classList.toggle('opacity-40', !can);
+  undoClearBtn.classList.toggle('cursor-not-allowed', !can);
 }
 
 function updateUndoButton(): void {

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -39,11 +39,16 @@ let visible = true;
 const listeners: ChangeListener[] = [];
 const visibilityListeners: ChangeListener[] = [];
 const redoListeners: ChangeListener[] = [];
+const clearSnapshotListeners: ChangeListener[] = [];
 
 // Redo stack — regions removed via `removeLastRegion()`. Any other mutation
 // (add, clear, deserialize) drops the stack so redo can never resurrect a
 // region into a state where the user wouldn't expect it.
 let regionRedoStack: ColorRegion[] = [];
+
+// Clear snapshot — saved when clearRegions() is called. Nulled when a new
+// region is added so undo-clear is only valid until the next paint operation.
+let clearSnapshot: ColorRegion[] | null = null;
 
 function notify(): void {
   for (const fn of listeners) fn();
@@ -55,6 +60,10 @@ function notifyVisibility(): void {
 
 function notifyRedo(): void {
   for (const fn of redoListeners) fn();
+}
+
+function notifyClearSnapshot(): void {
+  for (const fn of clearSnapshotListeners) fn();
 }
 
 function clearRedoStack(): void {
@@ -86,6 +95,28 @@ export function onRedoChange(fn: ChangeListener): () => void {
     const i = redoListeners.indexOf(fn);
     if (i >= 0) redoListeners.splice(i, 1);
   };
+}
+
+export function onClearSnapshotChange(fn: ChangeListener): () => void {
+  clearSnapshotListeners.push(fn);
+  return () => {
+    const i = clearSnapshotListeners.indexOf(fn);
+    if (i >= 0) clearSnapshotListeners.splice(i, 1);
+  };
+}
+
+export function canUndoClear(): boolean {
+  return clearSnapshot !== null;
+}
+
+export function undoClear(): void {
+  if (!clearSnapshot) return;
+  regions = [...clearSnapshot];
+  nextOrder = regions.reduce((max, r) => Math.max(max, r.order + 1), 1);
+  clearSnapshot = null;
+  clearRedoStack();
+  notify();
+  notifyClearSnapshot();
 }
 
 export function isVisible(): boolean {
@@ -127,6 +158,10 @@ export function addRegion(
   };
   regions.push(region);
   clearRedoStack();
+  if (clearSnapshot !== null) {
+    clearSnapshot = null;
+    notifyClearSnapshot();
+  }
   notify();
   return region;
 }
@@ -192,10 +227,12 @@ export function updateRegionColor(id: number, color: [number, number, number]): 
 
 export function clearRegions(): void {
   if (regions.length === 0) return;
+  clearSnapshot = [...regions];
   regions = [];
   nextOrder = 1;
   clearRedoStack();
   notify();
+  notifyClearSnapshot();
 }
 
 /** Build triColors (Uint8Array, numTri*3 RGB) from current regions.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Paint by Shape**: The "Box" tool is now a **Shape** selector with four options — Box, Sphere, Cylinder, and Cone. Each uses the same gizmo/proxy system but swaps the visual geometry and containment test.
- **Shape fades after painting**: After clicking "Paint inside [shape]", the shape dims to near-invisible so you can see the result. It brightens again the moment you hover a gizmo handle or start a new drag.
- **Brush ring indicator**: When brush radius > 0, a white circle ring renders at the cursor, oriented to the surface normal, showing the exact brush extent before you paint.
- **Brush footprint shapes**: Three modes below the radius slider — ● Circle (sphere distance), ■ Square (axis-aligned cube), ◆ Diamond (L1 norm).
- **Undo clear**: The "Clear" action is now undoable via a dedicated "Undo clear" button. It's enabled immediately after a clear and automatically disabled as soon as the next paint region is added.
- **"Hide all" / "Show all"**: Visibility toggle button label updated for clarity.

## Test plan

- [ ] Open editor, enter paint mode, select the **Shape** tool
- [ ] Switch between Box / Sphere / Cylinder / Cone — viewport shape visual should change each time
- [ ] Click "Paint inside sphere/cylinder/cone" — shape should dim; painted triangles appear correctly
- [ ] Hover a gizmo handle after painting — shape should brighten back
- [ ] Switch to **Brush** tool, set radius > 0 — move cursor over model and confirm a white ring appears at cursor, oriented to the surface
- [ ] Change brush shape to Square / Diamond — paint strokes should produce different footprints
- [ ] Paint several regions, click **Clear**, confirm "Undo clear" button becomes enabled
- [ ] Click "Undo clear" — all regions restored; button disables
- [ ] Paint a new region after clearing — "Undo clear" becomes disabled immediately
- [ ] Verify "Hide all" / "Show all" labels on the visibility toggle

https://claude.ai/code/session_01PfUAHnDdCypWDCSufbt58t
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfUAHnDdCypWDCSufbt58t)_