### PR TITLE
fix: allow WebLLM model download origins in CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,7 @@
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' https://api.anthropic.com; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' https://api.anthropic.com https://huggingface.co https://*.huggingface.co https://raw.githubusercontent.com; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'
 
 /*.md
   Content-Type: text/markdown; charset=utf-8


### PR DESCRIPTION
## Summary

- The local model feature fetches model weights from HuggingFace and WASM libs from `raw.githubusercontent.com`, but the production CSP `connect-src` only allowed `https://api.anthropic.com`
- Adds the three origins WebLLM 0.2.83 needs to `connect-src` in `public/_headers`
- The dev server (`vite.config.ts`) already uses `connect-src 'self' https:` so this was only broken on Cloudflare Pages deployments (staging/production)

**Domains added:**
- `https://huggingface.co` — model weights + `mlc-chat-config.json` fetches
- `https://*.huggingface.co` — HuggingFace LFS CDN subdomains that large file downloads redirect through
- `https://raw.githubusercontent.com` — compiled WebGPU WASM model library files

## Test plan

- [ ] Deploy to staging (`staging.mainifold.pages.dev`) and open the AI panel → Local model picker
- [ ] Click "Download" on any model (e.g. Hermes 3 3B at ~1.9 GB) — download should start without CSP errors in the console
- [ ] Verify no `Refused to connect` errors in DevTools → Console
- [ ] Verify Anthropic cloud provider still works (existing `api.anthropic.com` entry unchanged)

https://claude.ai/code/session_014foQ8N8asgycgMoZ4F5TfL

---
_Generated by [Claude Code](https://claude.ai/code/session_014foQ8N8asgycgMoZ4F5TfL)_