### PR TITLE
fix: add HuggingFace XetHub CDN origin to CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,7 @@
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' https://api.anthropic.com https://huggingface.co https://*.huggingface.co https://raw.githubusercontent.com; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' https://api.anthropic.com https://huggingface.co https://*.huggingface.co https://*.xethub.hf.co https://raw.githubusercontent.com; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'
 
 /*.md
   Content-Type: text/markdown; charset=utf-8


### PR DESCRIPTION
## Summary

Follow-up to #154. HuggingFace routes large model file downloads through a XetHub CDN (`*.xethub.hf.co`) — a separate domain not covered by the `*.huggingface.co` wildcard added in the previous fix. The error seen after merging #154:

```
Connecting to 'https://cas-bridge.xethub.hf.co/xet-bridge-us/...' violates
Content Security Policy directive: "connect-src ... https://*.huggingface.co ..."
```

Adds `https://*.xethub.hf.co` to `connect-src` to cover the XetHub CDN subdomain.

## Test plan

- [ ] Deploy to staging and open AI panel → Local model picker
- [ ] Click "Download" on any model — should progress without CSP errors
- [ ] Confirm no `Refused to connect` or CSP violations in DevTools console

https://claude.ai/code/session_014foQ8N8asgycgMoZ4F5TfL

---
_Generated by [Claude Code](https://claude.ai/code/session_014foQ8N8asgycgMoZ4F5TfL)_