### PR TITLE
feat: add diagnostic log panel for app-wide error and warning capture

### DIFF
--- a/src/diagnostics/errorLog.ts
+++ b/src/diagnostics/errorLog.ts
@@ -1,0 +1,163 @@
+// Central diagnostic log. Collects errors and warnings from all subsystems
+// into a single ring buffer, persisted to sessionStorage so entries survive
+// a page refresh within the same browser tab.
+//
+// Call errorLog.install() once at app startup to wire up:
+//   - window.onerror / unhandledrejection (uncaught JS errors)
+//   - console.error / console.warn interception (existing callsites free-ride)
+//
+// Subsystems that don't go through console (e.g. geometry engine, AI turns)
+// should call errorLog.capture() directly with an explicit source tag.
+
+export type ErrorLevel = 'error' | 'warn';
+export type ErrorSource =
+  | 'engine'
+  | 'ai'
+  | 'import'
+  | 'export'
+  | 'storage'
+  | 'network'
+  | 'app'
+  | 'uncaught';
+
+export interface LogEntry {
+  id: string;
+  timestamp: number;
+  level: ErrorLevel;
+  source: ErrorSource;
+  message: string;
+  /** Stack trace or extended diagnostic text. */
+  detail?: string;
+}
+
+type Subscriber = (entries: readonly LogEntry[]) => void;
+
+const MAX_ENTRIES = 200;
+const STORAGE_KEY = 'partwright-error-log-v1';
+
+function argsToString(args: unknown[]): string {
+  return args
+    .map((a) => {
+      if (typeof a === 'string') return a;
+      if (a instanceof Error) return a.message;
+      try {
+        return JSON.stringify(a);
+      } catch {
+        return String(a);
+      }
+    })
+    .join(' ');
+}
+
+class ErrorLogStore {
+  private _entries: LogEntry[] = [];
+  private _subscribers = new Set<Subscriber>();
+  // Prevents re-entrant console captures triggered during subscriber notification.
+  private _inNotify = false;
+
+  constructor() {
+    this._restore();
+  }
+
+  /** Wire up global error handlers and console interception. Call once at startup. */
+  install(): void {
+    window.addEventListener('error', (e) => {
+      this.capture({
+        level: 'error',
+        source: 'uncaught',
+        message: e.message || 'Uncaught error',
+        detail: e.error instanceof Error ? e.error.stack : undefined,
+      });
+    });
+
+    window.addEventListener('unhandledrejection', (e) => {
+      const r = e.reason;
+      this.capture({
+        level: 'error',
+        source: 'uncaught',
+        message:
+          r instanceof Error
+            ? r.message
+            : `Unhandled rejection: ${String(r)}`,
+        detail: r instanceof Error ? r.stack : undefined,
+      });
+    });
+
+    const origError = console.error.bind(console);
+    const origWarn = console.warn.bind(console);
+    const self = this;
+
+    console.error = function (...args: unknown[]) {
+      origError(...args);
+      if (!self._inNotify) {
+        self.capture({ level: 'error', source: 'app', message: argsToString(args) });
+      }
+    };
+
+    console.warn = function (...args: unknown[]) {
+      origWarn(...args);
+      if (!self._inNotify) {
+        self.capture({ level: 'warn', source: 'app', message: argsToString(args) });
+      }
+    };
+  }
+
+  /** Add an entry to the log and notify subscribers. */
+  capture(entry: Omit<LogEntry, 'id' | 'timestamp'>): void {
+    const full: LogEntry = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      timestamp: Date.now(),
+      ...entry,
+    };
+    this._entries.unshift(full);
+    if (this._entries.length > MAX_ENTRIES) this._entries.length = MAX_ENTRIES;
+    this._persist();
+    this._notify();
+  }
+
+  getEntries(): readonly LogEntry[] {
+    return this._entries;
+  }
+
+  clear(): void {
+    this._entries = [];
+    this._persist();
+    this._notify();
+  }
+
+  /** Subscribe to log changes. Returns an unsubscribe function. */
+  subscribe(fn: Subscriber): () => void {
+    this._subscribers.add(fn);
+    return () => {
+      this._subscribers.delete(fn);
+    };
+  }
+
+  private _notify(): void {
+    this._inNotify = true;
+    try {
+      for (const fn of this._subscribers) fn(this._entries);
+    } finally {
+      this._inNotify = false;
+    }
+  }
+
+  private _persist(): void {
+    try {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(this._entries));
+    } catch {
+      // Quota exceeded — silently drop persistence.
+    }
+  }
+
+  private _restore(): void {
+    try {
+      const raw = sessionStorage.getItem(STORAGE_KEY);
+      if (raw) this._entries = JSON.parse(raw) as LogEntry[];
+    } catch {
+      // Corrupt storage — start fresh.
+    }
+  }
+}
+
+export const errorLog = new ErrorLogStore();

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,8 @@
 // throughout that API are pure and live in the validation module above.
 
 import './style.css';
+import { errorLog } from './diagnostics/errorLog';
+import { initDiagnosticsPanel, toggleDiagnosticsPanel } from './ui/diagnosticsPanel';
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, type Language } from './geometry/engine';
 import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
@@ -532,6 +534,10 @@ function showEditorUI(landingEl: HTMLElement | null, helpEl: HTMLElement | null,
 }
 
 async function main() {
+  // Install global error/warning capture as early as possible so nothing
+  // slips through before the rest of the app is ready.
+  errorLog.install();
+
   // Apply persisted theme before any UI renders
   initTheme();
 
@@ -910,6 +916,7 @@ async function main() {
     onImportFile: async (file) => { await handleImportFile(file); },
     onImportInboxEntry: handleReimportInboxEntry,
     onToggleAi: () => { toggleAiPanel(); },
+    onToggleDiagnostics: () => { toggleDiagnosticsPanel(); },
     onLanguageSwitch: async (lang: 'manifold-js' | 'scad') => {
       if (lang === getActiveLanguage()) return;
       // If current session has work, ask before switching
@@ -931,6 +938,9 @@ async function main() {
       runCode(code);
     },
   });
+
+  // Init diagnostic panel — attaches to document.body, registers badge subscriber.
+  initDiagnosticsPanel();
 
   // Create session bar
   createSessionBar(editorUI, {
@@ -1546,7 +1556,9 @@ async function main() {
     try {
       await ensureEngineReady(lang);
     } catch (e) {
-      setStatus(statusBar, 'error', `Failed to load ${lang}: ${e instanceof Error ? e.message : String(e)}`);
+      const msg = `Failed to load ${lang}: ${e instanceof Error ? e.message : String(e)}`;
+      setStatus(statusBar, 'error', msg);
+      errorLog.capture({ level: 'error', source: 'engine', message: msg });
       throw e;
     }
     // Persist the language to the active session so reopening it loads in the
@@ -5335,6 +5347,7 @@ async function main() {
 
     if (result.error) {
       recordError(result.error);
+      errorLog.capture({ level: 'error', source: 'engine', message: result.error });
       const diagnostics = result.diagnostics ?? [];
       setStatus(statusBar, 'error', summarizeDiagnostics(result.error, diagnostics));
       setEditorDiagnostics(diagnostics);

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -20,6 +20,7 @@ import { showAttachmentModal } from './aiAttachmentModal';
 import { putAttachment } from '../ai/attachments';
 import { ensureModelLoaded, effectiveContextCeiling, interruptLocal, isModelLoaded, resolveLocalModel } from '../ai/local';
 import { activeModel, SPEND_CAP_USD, type AnthropicModelId, type ChatBlock, type ChatMessage, type ChatToggles, type ImageSource, type PersistedToolResult, type TurnOutcomeReason } from '../ai/types';
+import { errorLog } from '../diagnostics/errorLog';
 
 interface PanelState {
   open: boolean;
@@ -1640,6 +1641,7 @@ async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatTo
         if (result.isError) setTransientStatus('A tool errored. The agent will retry or surface the issue.');
       },
       onError: err => {
+        errorLog.capture({ level: 'error', source: 'ai', message: err.message, detail: err.stack });
         // Replace the in-memory "Thinking…" placeholder with a visible
         // error bubble so the user can see what failed and recover via
         // the Retry button. The bubble is in-memory only (not persisted),

--- a/src/ui/diagnosticsPanel.ts
+++ b/src/ui/diagnosticsPanel.ts
@@ -1,0 +1,231 @@
+// Floating diagnostic log panel. Surfaces captured errors and warnings from
+// all subsystems in one place. Opened/closed via the toolbar ⚠ button.
+//
+// Call initDiagnosticsPanel() once after createToolbar() so the badge
+// setter is available when new entries arrive.
+
+import { errorLog, type LogEntry, type ErrorLevel } from '../diagnostics/errorLog';
+import { setDiagnosticsToolbarBadge } from './toolbar';
+
+let _panelEl: HTMLElement | null = null;
+let _listEl: HTMLElement | null = null;
+let _isOpen = false;
+let _currentFilter: ErrorLevel | 'all' = 'all';
+let _unseenCount = 0;
+
+// Filter chip elements stored so syncFilterChips() can update them.
+let _filterBtns: Array<{ el: HTMLButtonElement; value: ErrorLevel | 'all' }> = [];
+
+function syncFilterChips(): void {
+  for (const { el, value } of _filterBtns) {
+    const active = value === _currentFilter;
+    el.className = active
+      ? 'text-[10px] px-1.5 py-0.5 rounded bg-zinc-700 text-zinc-200 transition-colors'
+      : 'text-[10px] px-1.5 py-0.5 rounded text-zinc-500 hover:text-zinc-300 transition-colors';
+  }
+}
+
+function makeFilterChip(label: string, value: ErrorLevel | 'all'): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  btn.addEventListener('click', () => {
+    _currentFilter = value;
+    syncFilterChips();
+    renderEntries(errorLog.getEntries());
+  });
+  _filterBtns.push({ el: btn, value });
+  return btn;
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  return [d.getHours(), d.getMinutes(), d.getSeconds()]
+    .map((n) => String(n).padStart(2, '0'))
+    .join(':');
+}
+
+function buildEntryEl(entry: LogEntry): HTMLElement {
+  const row = document.createElement('div');
+  row.className = 'border-b border-zinc-800/60 hover:bg-zinc-800/30 transition-colors';
+
+  const top = document.createElement('div');
+  top.className = 'flex items-center gap-1.5 px-3 py-1.5 min-w-0';
+
+  const time = document.createElement('span');
+  time.className = 'text-[10px] text-zinc-600 font-mono shrink-0 tabular-nums';
+  time.textContent = formatTime(entry.timestamp);
+  top.appendChild(time);
+
+  const levelEl = document.createElement('span');
+  levelEl.className =
+    entry.level === 'error'
+      ? 'text-[9px] font-bold tracking-wider text-red-400 shrink-0'
+      : 'text-[9px] font-bold tracking-wider text-amber-400 shrink-0';
+  levelEl.textContent = entry.level === 'error' ? '● ERR' : '● WARN';
+  top.appendChild(levelEl);
+
+  const sourceEl = document.createElement('span');
+  sourceEl.className =
+    'text-[9px] uppercase tracking-wide text-zinc-500 border border-zinc-700 rounded px-1 shrink-0';
+  sourceEl.textContent = entry.source;
+  top.appendChild(sourceEl);
+
+  const msgEl = document.createElement('span');
+  msgEl.className = 'text-xs text-zinc-300 truncate flex-1 min-w-0';
+  msgEl.textContent = entry.message;
+  top.appendChild(msgEl);
+
+  row.appendChild(top);
+
+  if (entry.detail) {
+    const expandBtn = document.createElement('span');
+    expandBtn.className = 'text-[10px] text-zinc-600 shrink-0 cursor-pointer select-none';
+    expandBtn.textContent = '▸';
+    top.appendChild(expandBtn);
+    top.classList.add('cursor-pointer', 'select-none');
+
+    const detail = document.createElement('pre');
+    detail.className =
+      'hidden px-3 pb-2 text-[10px] font-mono text-zinc-500 whitespace-pre-wrap max-h-28 overflow-auto leading-4';
+    detail.textContent = entry.detail;
+    row.appendChild(detail);
+
+    top.addEventListener('click', () => {
+      const nowHidden = detail.classList.toggle('hidden');
+      expandBtn.textContent = nowHidden ? '▸' : '▾';
+    });
+  }
+
+  return row;
+}
+
+function renderEntries(all: readonly LogEntry[]): void {
+  if (!_listEl) return;
+  const filtered =
+    _currentFilter === 'all' ? all : all.filter((e) => e.level === _currentFilter);
+
+  if (filtered.length === 0) {
+    const empty = document.createElement('div');
+    empty.className =
+      'flex items-center justify-center h-full text-zinc-600 text-xs py-8';
+    empty.textContent = 'No entries to show.';
+    _listEl.replaceChildren(empty);
+    return;
+  }
+
+  _listEl.replaceChildren(...filtered.map(buildEntryEl));
+}
+
+function buildPanel(): HTMLElement {
+  const panel = document.createElement('div');
+  panel.id = 'diagnostics-panel';
+  panel.className = [
+    'hidden fixed bottom-0 left-0 right-0',
+    'md:left-auto md:right-4 md:bottom-4 md:w-[480px] md:rounded-xl',
+    'h-[300px] bg-zinc-900 border border-zinc-700 shadow-2xl flex flex-col z-40',
+  ].join(' ');
+
+  // Header
+  const header = document.createElement('div');
+  header.className =
+    'flex items-center gap-2 px-3 py-2 border-b border-zinc-700 shrink-0';
+
+  const titleEl = document.createElement('span');
+  titleEl.className = 'text-xs font-semibold text-zinc-300 shrink-0';
+  titleEl.textContent = 'Diagnostic Log';
+  header.appendChild(titleEl);
+
+  const filterGroup = document.createElement('div');
+  filterGroup.className = 'flex items-center gap-1 ml-2';
+  filterGroup.appendChild(makeFilterChip('All', 'all'));
+  filterGroup.appendChild(makeFilterChip('Errors', 'error'));
+  filterGroup.appendChild(makeFilterChip('Warnings', 'warn'));
+  header.appendChild(filterGroup);
+  syncFilterChips();
+
+  const spacer = document.createElement('div');
+  spacer.className = 'flex-1';
+  header.appendChild(spacer);
+
+  const copyBtn = document.createElement('button');
+  copyBtn.className =
+    'text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors px-1.5 py-0.5 rounded border border-zinc-700 hover:border-zinc-500';
+  copyBtn.textContent = 'Copy';
+  copyBtn.title = 'Copy log to clipboard';
+  copyBtn.addEventListener('click', () => {
+    const text = errorLog
+      .getEntries()
+      .map(
+        (e) =>
+          `[${formatTime(e.timestamp)}] ${e.level.toUpperCase()} (${e.source}) ${e.message}${e.detail ? '\n' + e.detail : ''}`,
+      )
+      .join('\n---\n');
+    void navigator.clipboard.writeText(text).then(() => {
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => {
+        copyBtn.textContent = 'Copy';
+      }, 1500);
+    });
+  });
+  header.appendChild(copyBtn);
+
+  const clearBtn = document.createElement('button');
+  clearBtn.className =
+    'text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors px-1.5 py-0.5 rounded border border-zinc-700 hover:border-zinc-500 ml-1';
+  clearBtn.textContent = 'Clear';
+  clearBtn.title = 'Clear all log entries';
+  clearBtn.addEventListener('click', () => {
+    errorLog.clear();
+  });
+  header.appendChild(clearBtn);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className =
+    'flex items-center justify-center w-5 h-5 rounded text-zinc-500 hover:text-zinc-200 hover:bg-zinc-700 transition-colors ml-1 text-base leading-none';
+  closeBtn.textContent = '×';
+  closeBtn.title = 'Close (Esc)';
+  closeBtn.addEventListener('click', toggleDiagnosticsPanel);
+  header.appendChild(closeBtn);
+
+  panel.appendChild(header);
+
+  _listEl = document.createElement('div');
+  _listEl.className = 'flex-1 overflow-y-auto';
+  panel.appendChild(_listEl);
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && _isOpen) toggleDiagnosticsPanel();
+  });
+
+  return panel;
+}
+
+export function initDiagnosticsPanel(): void {
+  _panelEl = buildPanel();
+  document.body.appendChild(_panelEl);
+
+  errorLog.subscribe((entries) => {
+    if (!_isOpen) {
+      // entries.length === 0 means the log was cleared.
+      if (entries.length === 0) {
+        _unseenCount = 0;
+      } else {
+        _unseenCount++;
+      }
+      setDiagnosticsToolbarBadge(_unseenCount);
+    } else {
+      renderEntries(entries);
+    }
+  });
+}
+
+export function toggleDiagnosticsPanel(): void {
+  if (!_panelEl) return;
+  _isOpen = !_isOpen;
+  _panelEl.classList.toggle('hidden', !_isOpen);
+  if (_isOpen) {
+    _unseenCount = 0;
+    setDiagnosticsToolbarBadge(0);
+    renderEntries(errorLog.getEntries());
+  }
+}

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -32,9 +32,25 @@ export interface ToolbarCallbacks {
   onGoHome: () => void;
   /** Toggle the AI chat side panel. */
   onToggleAi: () => void;
+  /** Toggle the diagnostic log panel. */
+  onToggleDiagnostics: () => void;
 }
 
 let _aiBtn: HTMLButtonElement | null = null;
+
+let _diagBadgeEl: HTMLElement | null = null;
+
+/** Update the unseen-error badge count on the diagnostics toolbar button.
+ *  Called by diagnosticsPanel when new entries arrive while the panel is closed. */
+export function setDiagnosticsToolbarBadge(count: number): void {
+  if (!_diagBadgeEl) return;
+  if (count === 0) {
+    _diagBadgeEl.classList.add('hidden');
+  } else {
+    _diagBadgeEl.classList.remove('hidden');
+    _diagBadgeEl.textContent = count > 99 ? '99+' : String(count);
+  }
+}
 
 export type AiToolbarMode = 'disconnected' | 'cloud' | 'local';
 
@@ -538,6 +554,21 @@ export function createToolbar(
   qualityBtn.setAttribute('aria-label', 'Modeling quality settings');
   qualityBtn.addEventListener('click', () => { showQualitySettingsModal(); });
   toolbar.appendChild(qualityBtn);
+
+  // Diagnostic log toggle — shows a badge when unseen errors/warnings exist.
+  const diagBtn = document.createElement('button');
+  diagBtn.id = 'btn-diagnostics';
+  diagBtn.className = 'relative flex items-center justify-center w-10 h-10 md:w-6 md:h-6 rounded-full text-zinc-500 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700 transition-colors text-sm md:text-xs ml-1';
+  diagBtn.title = 'Diagnostic log — errors and warnings';
+  diagBtn.setAttribute('aria-label', 'Diagnostic log');
+  diagBtn.innerHTML = '⚠';
+
+  _diagBadgeEl = document.createElement('span');
+  _diagBadgeEl.className = 'hidden absolute -top-0.5 -right-0.5 text-[8px] font-bold bg-red-500 text-white rounded-full min-w-[14px] h-[14px] flex items-center justify-center px-0.5 leading-none pointer-events-none';
+  diagBtn.appendChild(_diagBadgeEl);
+
+  diagBtn.addEventListener('click', callbacks.onToggleDiagnostics);
+  toolbar.appendChild(diagBtn);
 
   // Help button
   const helpBtn = document.createElement('button');


### PR DESCRIPTION
## Summary

- **Central error log** (`src/diagnostics/errorLog.ts`): singleton ring buffer (200 entries) persisted to `sessionStorage` so entries survive a page refresh within the same tab. Wires up `window.onerror`, `unhandledrejection`, and intercepts `console.error`/`console.warn` so all existing callsites are captured automatically with zero further changes.
- **Diagnostic panel** (`src/ui/diagnosticsPanel.ts`): fixed floating panel (bottom-right on desktop, full-width bottom sheet on mobile). Filter chips for All / Errors / Warnings. Each entry shows timestamp, level badge, source badge, and truncated message — click to expand stack trace / detail. Copy log to clipboard and Clear buttons. Escape to close.
- **Toolbar ⚠ button** with a red badge that increments for each unseen error/warning while the panel is closed, resets to zero when opened.
- **Explicit source-tagged captures** added at the two paths that previously bypassed console: geometry engine execution errors (`source: 'engine'`) and AI turn failures (`source: 'ai'`).

## Error sources captured

| Source tag | What it covers |
|---|---|
| `engine` | Geometry code execution errors, WASM/language load failures |
| `ai` | AI turn errors (API failures, local model failures) |
| `app` | All existing `console.error`/`console.warn` calls (GLB export, IDB writes, system-prompt fetch, etc.) |
| `uncaught` | Unhandled JS exceptions and unhandled promise rejections |
| `import` / `export` / `storage` / `network` | Available for explicit future use |

## Test plan

- [ ] Open the editor — toolbar should show a ⚠ button (no badge initially)
- [ ] Write invalid code (e.g. `return Manifold.notAFunction()`) — status bar turns red AND the ⚠ badge increments
- [ ] Click ⚠ — panel slides in from bottom-right, shows the engine error with source badge `engine`
- [ ] Badge resets to 0 after opening; closing and triggering another error increments it again
- [ ] Filter chips (Errors / Warnings / All) correctly hide/show entries
- [ ] Click an entry that has a stack trace — expands to show detail, ▸ becomes ▾
- [ ] Copy button copies the full log as plain text
- [ ] Clear button empties the list
- [ ] Escape key closes the panel
- [ ] Refresh the page — log entries from the previous session are restored from sessionStorage
- [ ] On a narrow viewport (mobile), panel is full-width at the bottom

https://claude.ai/code/session_01TefpTnTVuQi6Qaf3g64fYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TefpTnTVuQi6Qaf3g64fYG)_