### PR TITLE
fix: remove deprecated THREE.Clock namespace access

### DIFF
--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { Clock } from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import type { MeshData } from '../geometry/types';
 import { createDefaultMaterial, createWireframeMaterial } from './materials';
@@ -195,7 +196,7 @@ export function initViewport(container: HTMLElement): {
   );
 
   // Animate
-  const clock = new THREE.Clock();
+  const clock = new Clock();
   function animate() {
     animationId = requestAnimationFrame(animate);
     const delta = clock.getDelta();


### PR DESCRIPTION
## Summary

- Imports `Clock` directly from `'three'` instead of accessing it as `THREE.Clock`
- `THREE.Clock` was deprecated in Three.js r168 and produces a startup console warning: `THREE.THREE.Clock: This module has been deprecated`
- One-line change in `src/renderer/viewport.ts`

## Test plan

- [ ] Open `http://localhost:5173/editor` and check the browser console — the `THREE.THREE.Clock` deprecation warning should no longer appear on startup
- [ ] Confirm the 3D viewport still animates correctly (orbit controls, orientation gizmo rotation)
- [ ] `npm run build` passes with no TypeScript errors

https://claude.ai/code/session_01NwYX1oKtpXqsy6yaWr8xi8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwYX1oKtpXqsy6yaWr8xi8)_