### PR TITLE
Add API call duration and turn elapsed time tracking

### DIFF
--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -146,6 +146,7 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
   let workingHistory: ChatMessage[] = [...history, userMsg];
   let totalCostUsd = 0;
   let totalToolCalls = 0;
+  let turnApiTimeMs = 0;
   const maxIter = ITERATION_CAP[toggles.maxIterations];
   const maxSpend = SPEND_CAP_USD[toggles.maxSpend];
   // Spend cap is a session budget — count what prior turns already
@@ -184,6 +185,7 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
       },
     };
 
+    const apiCallStart = Date.now();
     let result;
     try {
       if (toggles.provider === 'anthropic') {
@@ -218,6 +220,9 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
       return workingHistory;
     }
 
+    const durationMs = Date.now() - apiCallStart;
+    turnApiTimeMs += durationMs;
+
     const turnCost = turnCostUsd(model, result.usage);
     totalCostUsd += turnCost;
 
@@ -233,6 +238,8 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
       costUsd: turnCost,
       createdAt: Date.now(),
       seq: seqStart + 1 + iter * 2,
+      durationMs,
+      turnElapsedMs: turnApiTimeMs,
       ...(aborted ? { aborted: true } : {}),
     };
     await putMessages([assistantMsg]);

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -141,6 +141,11 @@ export interface ChatMessage {
    *  a red border so it stands out from a normal reply, and offers a
    *  Retry button next to it. Not persisted to IndexedDB. */
   errored?: boolean;
+  /** Wall-clock milliseconds for this single model request/response cycle. */
+  durationMs?: number;
+  /** Cumulative model time in milliseconds across all API calls since the
+   *  user triggered this turn (resets each time the user sends a message). */
+  turnElapsedMs?: number;
 }
 
 export type ChatBlock =

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -949,6 +949,10 @@ async function clearCurrentChat(): Promise<void> {
   setTransientStatus('Chat cleared.');
 }
 
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
 // === Transcript rendering ===
 
 function renderTranscript(): void {
@@ -1047,10 +1051,19 @@ function renderMessage(msg: ChatMessage): HTMLElement {
     }
   }
 
-  if (msg.role === 'assistant' && msg.costUsd !== undefined) {
+  if (msg.role === 'assistant' && (msg.costUsd !== undefined || msg.durationMs !== undefined)) {
     const meta = document.createElement('div');
     meta.className = 'text-[10px] text-zinc-600';
-    meta.textContent = `${formatUsd(msg.costUsd)}${msg.usage ? ` · ${msg.usage.outputTokens}t out` : ''}`;
+    const parts: string[] = [];
+    if (msg.costUsd !== undefined) parts.push(formatUsd(msg.costUsd));
+    if (msg.usage) parts.push(`${msg.usage.outputTokens}t out`);
+    if (msg.durationMs !== undefined) {
+      parts.push(formatDuration(msg.durationMs));
+      if (msg.turnElapsedMs !== undefined && msg.turnElapsedMs > msg.durationMs) {
+        parts.push(`Σ${formatDuration(msg.turnElapsedMs)}`);
+      }
+    }
+    meta.textContent = parts.join(' · ');
     wrap.appendChild(meta);
   }
 


### PR DESCRIPTION
## Summary
Track and display wall-clock timing metrics for AI model API calls. Each assistant message now records the duration of its individual API request and the cumulative time elapsed since the user triggered the turn.

## Changes
- **New `formatDuration()` utility** in `aiPanel.ts` to format milliseconds as human-readable strings (e.g., "1234ms" or "1.2s")
- **Enhanced message metadata display** to show duration and cumulative turn time alongside cost and token counts
- **Timing instrumentation in `runTurn()`** to measure API call duration and accumulate total turn time across iterations
- **New `ChatMessage` fields**:
  - `durationMs`: Wall-clock milliseconds for a single model request/response cycle
  - `turnElapsedMs`: Cumulative model time in milliseconds across all API calls since the user triggered the turn

## Implementation Details
- API call timing is measured using `Date.now()` before and after each provider call (Anthropic/OpenAI)
- Turn elapsed time accumulates across all iterations within a single `runTurn()` call and resets when the user sends a new message
- UI displays duration as a separate metric; if `turnElapsedMs` exceeds `durationMs`, it's shown as "Σ{time}" to indicate cumulative time
- Metrics are rendered in the transcript with the same styling as cost/token information (small, muted text)

https://claude.ai/code/session_013pEuGtFyLwAr7CcHXpvzME