### PR TITLE
fix: revert provider when stale local model id is cleared

### DIFF
--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -283,6 +283,20 @@ function mergeWithDefaults(partial: LegacyAiSettings): AiSettings {
     : undefined;
 
   const overrides = partial.systemPromptOverrides ?? {};
+  const rawLocalModel = tgls.localModel ?? (legacyIsLocal ? (legacyModel as string) : null);
+  const validLocalModel = resolveValidLocalModel(
+    rawLocalModel,
+    Array.isArray(partial.customLocalModels) ? partial.customLocalModels : [],
+  );
+  const requestedProvider = tgls.provider ?? (legacyIsLocal ? 'local' : DEFAULT_SETTINGS.toggles.provider);
+  // If we had to drop a saved local-model id (curated list pruned it), also
+  // revert the provider. Otherwise the AI panel sticks on "No local model
+  // picked" instead of offering the dual "Connect Anthropic API or run a
+  // local model" prompt that fresh users get.
+  const localModelCleared = rawLocalModel !== null && validLocalModel === null;
+  const provider = localModelCleared && requestedProvider === 'local'
+    ? DEFAULT_SETTINGS.toggles.provider
+    : requestedProvider;
   return {
     preset: partial.preset ?? DEFAULT_SETTINGS.preset,
     autoCompactMode: partial.autoCompactMode ?? DEFAULT_SETTINGS.autoCompactMode,
@@ -293,12 +307,9 @@ function mergeWithDefaults(partial: LegacyAiSettings): AiSettings {
       autoRetry: tgls.autoRetry ?? DEFAULT_SETTINGS.toggles.autoRetry,
       maxIterations: tgls.maxIterations ?? DEFAULT_SETTINGS.toggles.maxIterations,
       maxSpend: tgls.maxSpend ?? DEFAULT_SETTINGS.toggles.maxSpend,
-      provider: tgls.provider ?? (legacyIsLocal ? 'local' : DEFAULT_SETTINGS.toggles.provider),
+      provider,
       anthropicModel: tgls.anthropicModel ?? legacyAnthropic ?? DEFAULT_SETTINGS.toggles.anthropicModel,
-      localModel: resolveValidLocalModel(
-        tgls.localModel ?? (legacyIsLocal ? (legacyModel as string) : null),
-        Array.isArray(partial.customLocalModels) ? partial.customLocalModels : [],
-      ),
+      localModel: validLocalModel,
     },
     systemPromptOverrides: {
       anthropic: overrides.anthropic ?? null,

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -99,6 +99,24 @@ test.describe('AI chat panel', () => {
     await expect(page.locator('#btn-ai')).toContainText(/Connect AI/);
   });
 
+  test('stale local-model id falls back to the dual connect prompt', async ({ page }) => {
+    // Regression: when the curated local-model list is pruned, a user whose
+    // saved provider was 'local' would get stuck on "No local model picked.
+    // Choose a model" instead of the friendlier "Connect Anthropic API or
+    // run a local model" dual prompt. Simulate by planting localStorage with
+    // a provider=local + bogus model id before the app boots.
+    await page.addInitScript(() => {
+      localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({
+        toggles: { provider: 'local', localModel: 'Bogus-Removed-Model-MLC' },
+      }));
+    });
+    await page.goto('/editor?view=ai');
+    await page.click('#btn-ai');
+    const panel = page.locator('#ai-panel');
+    await expect(panel.locator('button:has-text("Connect Anthropic API")')).toBeVisible();
+    await expect(panel.locator('button:has-text("run a local model")')).toBeVisible();
+  });
+
   test('toggle pills flip state on click', async ({ page }) => {
     await page.goto('/editor?view=ai');
     await page.click('#btn-ai');


### PR DESCRIPTION
## Summary

- A user reported that loading the AI panel only shows "No local model picked. Choose a model" instead of the dual "Connect Anthropic API or run a local model" prompt that fresh users used to see.
- Root cause: the recent "clear stale localModel id at settings load time" fix (4869615) nulls out an unresolvable local-model id but leaves `provider: 'local'` intact. Users who had picked a model that's since been pruned from the curated list (commits 8c98c6e / f461b34) end up with `{ provider: 'local', localModel: null }`, and the panel's local branch sticks on "No local model picked."
- Fix in `mergeWithDefaults` (src/ai/settings.ts): when validation actually cleared a non-null saved id and the saved provider was `'local'`, revert the provider to the default (`'anthropic'`) too. A user who legitimately toggled to local without ever picking a model (rawLocalModel was null all along) is left alone — only the stale-id case is touched.

## Test plan

- [x] `npm run build` passes
- [x] New regression test in `tests/smoke.spec.ts` plants a bogus `provider: 'local'` + stale id in localStorage before boot and asserts both "Connect Anthropic API" and "run a local model" buttons render in the panel
- [x] Full AI chat panel test suite (11 tests) still passes
- [ ] Manual verification on the staging deploy — open the editor in a browser that previously had a now-pruned local model selected (or simulate via DevTools localStorage) and confirm the AI panel shows the dual prompt

https://claude.ai/code/session_01E4W4RXExwVysNhTxjngHdy

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4W4RXExwVysNhTxjngHdy)_