### PR TITLE
fix: keep ai turn-outcome banner visible until next turn

### DIFF
--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1871,9 +1871,10 @@ function renderProgress(): void {
   }
 }
 
-/** Display a sticky completion / failure status for ~6s after a turn
- *  ends. Replaces the silent hideProgress() that left users wondering
- *  whether the model finished, errored, or just stopped speaking. */
+/** Display a completion / failure status after a turn ends. The status
+ *  remains visible until the next turn starts (showProgress overwrites
+ *  the 'final' phase), so the user always sees the outcome of the most
+ *  recent turn instead of a banner that vanishes on a timer. */
 function showProgressFinal(detail: string): void {
   if (!progressEl) return;
   progressState.phase = 'final';
@@ -1885,11 +1886,6 @@ function showProgressFinal(detail: string): void {
     clearInterval(progressTickerId);
     progressTickerId = null;
   }
-  window.setTimeout(() => {
-    if (progressState.phase === 'final' && progressState.detail === detail) {
-      hideProgress();
-    }
-  }, 6000);
 }
 
 function triggerStallRetry(): void {


### PR DESCRIPTION
## Summary

The completion banner that shows after every AI turn (e.g. `✓ done · $0.127 · 7 iter, 6 tool calls`) was hidden after a 6-second timeout. Anyone who looked back at the panel a few seconds later had no way to tell what the last turn cost or how many iterations it took.

The banner now persists until the next turn starts — `showProgress('thinking', ...)` overwrites the `'final'` phase at the top of `runTurnWithStallRetry`, so the user always sees the outcome of the most recent turn until they kick off a new one.

Change is one function in `src/ui/aiPanel.ts` — `showProgressFinal` loses its trailing `setTimeout(hideProgress, 6000)`. No other call sites needed updating; `showProgressFinal` is only called from `runTurnWithStallRetry` after a turn finishes.

## Test plan

- [ ] Send an AI message, wait for the turn to finish, confirm the `✓ done · …` line stays visible past 6 seconds
- [ ] Send a second message, confirm the banner switches to `🧠 thinking…` and the previous outcome is replaced
- [ ] Trigger an error / abort / iteration-cap stop, confirm those final banners also persist
- [ ] `npm run build` succeeds

https://claude.ai/code/session_01SWYSvcR1iK9KM4ReHp5k39

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWYSvcR1iK9KM4ReHp5k39)_