### PR TITLE
fix: replace deprecated THREE.Clock and enrich the diagnostic log

### DIFF
--- a/src/diagnostics/errorLog.ts
+++ b/src/diagnostics/errorLog.ts
@@ -49,6 +49,26 @@ function argsToString(args: unknown[]): string {
     .join(' ');
 }
 
+// Best-effort origin trace for an intercepted console.error/warn. Prefers the
+// stack of a real Error argument; otherwise synthesizes a call-site stack so
+// the log can answer "where did this come from" even for plain-string warnings
+// (e.g. a third-party library's deprecation notice). Frames inside this module
+// (the console override + this helper) are stripped so the trace starts at the
+// real caller.
+function detailFromArgs(args: unknown[]): string | undefined {
+  for (const a of args) {
+    if (a instanceof Error && a.stack) return a.stack;
+  }
+  const raw = new Error().stack;
+  if (!raw) return undefined;
+  const cleaned = raw
+    .split('\n')
+    .filter((l) => l.trim() && l.trim() !== 'Error' && !l.includes('errorLog'))
+    .join('\n')
+    .trim();
+  return cleaned || undefined;
+}
+
 class ErrorLogStore {
   private _entries: LogEntry[] = [];
   private _subscribers = new Set<Subscriber>();
@@ -62,11 +82,12 @@ class ErrorLogStore {
   /** Wire up global error handlers and console interception. Call once at startup. */
   install(): void {
     window.addEventListener('error', (e) => {
+      const where = e.filename ? `at ${e.filename}:${e.lineno}:${e.colno}` : undefined;
       this.capture({
         level: 'error',
         source: 'uncaught',
         message: e.message || 'Uncaught error',
-        detail: e.error instanceof Error ? e.error.stack : undefined,
+        detail: e.error instanceof Error ? e.error.stack : where,
       });
     });
 
@@ -90,14 +111,24 @@ class ErrorLogStore {
     console.error = function (...args: unknown[]) {
       origError(...args);
       if (!self._inNotify) {
-        self.capture({ level: 'error', source: 'app', message: argsToString(args) });
+        self.capture({
+          level: 'error',
+          source: 'app',
+          message: argsToString(args),
+          detail: detailFromArgs(args),
+        });
       }
     };
 
     console.warn = function (...args: unknown[]) {
       origWarn(...args);
       if (!self._inNotify) {
-        self.capture({ level: 'warn', source: 'app', message: argsToString(args) });
+        self.capture({
+          level: 'warn',
+          source: 'app',
+          message: argsToString(args),
+          detail: detailFromArgs(args),
+        });
       }
     };
   }

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { Clock } from 'three';
+import { Timer } from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import type { MeshData } from '../geometry/types';
 import { createDefaultMaterial, createWireframeMaterial } from './materials';
@@ -196,10 +196,11 @@ export function initViewport(container: HTMLElement): {
   );
 
   // Animate
-  const clock = new Clock();
-  function animate() {
+  const timer = new Timer();
+  function animate(timestamp?: number) {
     animationId = requestAnimationFrame(animate);
-    const delta = clock.getDelta();
+    timer.update(timestamp);
+    const delta = timer.getDelta();
     updateGizmo(delta);
     syncOrbitState();
     controls.update();

--- a/src/ui/diagnosticsPanel.ts
+++ b/src/ui/diagnosticsPanel.ts
@@ -13,6 +13,10 @@ let _isOpen = false;
 let _currentFilter: ErrorLevel | 'all' = 'all';
 let _unseenCount = 0;
 
+// Entry IDs the user has expanded. Tracked at module scope so an open row's
+// state survives the full list rebuild that happens when a new entry arrives.
+const _expandedIds = new Set<string>();
+
 // Filter chip elements stored so syncFilterChips() can update them.
 let _filterBtns: Array<{ el: HTMLButtonElement; value: ErrorLevel | 'all' }> = [];
 
@@ -46,10 +50,15 @@ function formatTime(ts: number): string {
 
 function buildEntryEl(entry: LogEntry): HTMLElement {
   const row = document.createElement('div');
-  row.className = 'border-b border-zinc-800/60 hover:bg-zinc-800/30 transition-colors';
+  row.className = 'border-b border-zinc-800/60';
 
   const top = document.createElement('div');
-  top.className = 'flex items-center gap-1.5 px-3 py-1.5 min-w-0';
+  top.className =
+    'flex items-center gap-1.5 px-3 py-1.5 min-w-0 cursor-pointer select-none hover:bg-zinc-800/30 transition-colors';
+
+  const caret = document.createElement('span');
+  caret.className = 'text-[10px] text-zinc-600 shrink-0';
+  top.appendChild(caret);
 
   const time = document.createElement('span');
   time.className = 'text-[10px] text-zinc-600 font-mono shrink-0 tabular-nums';
@@ -77,30 +86,56 @@ function buildEntryEl(entry: LogEntry): HTMLElement {
 
   row.appendChild(top);
 
-  if (entry.detail) {
-    const expandBtn = document.createElement('span');
-    expandBtn.className = 'text-[10px] text-zinc-600 shrink-0 cursor-pointer select-none';
-    expandBtn.textContent = '▸';
-    top.appendChild(expandBtn);
-    top.classList.add('cursor-pointer', 'select-none');
+  // Expanded view: the full (untruncated) message, a precise timestamp with
+  // source/level, and the captured stack or origin trace when available.
+  const expanded = document.createElement('div');
+  expanded.className = 'px-3 pb-2 pt-0.5 space-y-1.5';
 
+  const fullMsg = document.createElement('div');
+  fullMsg.className =
+    'text-[11px] text-zinc-300 whitespace-pre-wrap break-words leading-relaxed';
+  fullMsg.textContent = entry.message;
+  expanded.appendChild(fullMsg);
+
+  const meta = document.createElement('div');
+  meta.className = 'text-[10px] text-zinc-500 font-mono break-words';
+  meta.textContent = `${new Date(entry.timestamp).toLocaleString()} · ${entry.level.toUpperCase()} · source: ${entry.source}`;
+  expanded.appendChild(meta);
+
+  if (entry.detail) {
     const detail = document.createElement('pre');
     detail.className =
-      'hidden px-3 pb-2 text-[10px] font-mono text-zinc-500 whitespace-pre-wrap max-h-28 overflow-auto leading-4';
+      'text-[10px] font-mono text-zinc-400 whitespace-pre-wrap break-words max-h-48 overflow-auto leading-4 bg-zinc-950/60 rounded p-2 border border-zinc-800';
     detail.textContent = entry.detail;
-    row.appendChild(detail);
-
-    top.addEventListener('click', () => {
-      const nowHidden = detail.classList.toggle('hidden');
-      expandBtn.textContent = nowHidden ? '▸' : '▾';
-    });
+    expanded.appendChild(detail);
+  } else {
+    const none = document.createElement('div');
+    none.className = 'text-[10px] text-zinc-600 italic';
+    none.textContent = 'No stack trace or origin captured for this entry.';
+    expanded.appendChild(none);
   }
+
+  row.appendChild(expanded);
+
+  const sync = (open: boolean) => {
+    expanded.classList.toggle('hidden', !open);
+    caret.textContent = open ? '▾' : '▸';
+  };
+  sync(_expandedIds.has(entry.id));
+
+  top.addEventListener('click', () => {
+    const open = !_expandedIds.has(entry.id);
+    if (open) _expandedIds.add(entry.id);
+    else _expandedIds.delete(entry.id);
+    sync(open);
+  });
 
   return row;
 }
 
 function renderEntries(all: readonly LogEntry[]): void {
   if (!_listEl) return;
+  if (all.length === 0) _expandedIds.clear();
   const filtered =
     _currentFilter === 'all' ? all : all.filter((e) => e.level === _currentFilter);
 
@@ -122,7 +157,7 @@ function buildPanel(): HTMLElement {
   panel.className = [
     'hidden fixed bottom-0 left-0 right-0',
     'md:left-auto md:right-4 md:bottom-4 md:w-[480px] md:rounded-xl',
-    'h-[300px] bg-zinc-900 border border-zinc-700 shadow-2xl flex flex-col z-40',
+    'h-[300px] bg-zinc-900 border border-zinc-700 shadow-2xl flex flex-col z-[45]',
   ].join(' ');
 
   // Header

--- a/tests/diagnostics-panel.spec.ts
+++ b/tests/diagnostics-panel.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from 'playwright/test';
+
+// Covers the diagnostic-log fixes:
+//   1. The viewport no longer constructs THREE.Clock (deprecated in r183), so
+//      no deprecation warning is emitted on editor load.
+//   2. The diagnostics panel stacks above the AI drawer instead of behind it.
+//   3. Every log row expands on click to reveal the full message, a precise
+//      timestamp/source/level line, and the captured stack/origin trace.
+
+test.describe('Diagnostic log', () => {
+  test('no THREE.Clock deprecation warning on editor load', async ({ page }) => {
+    const consoleMsgs: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'warning' || msg.type() === 'error') consoleMsgs.push(msg.text());
+    });
+
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#btn-ai', { timeout: 10_000 });
+    // Let the viewport animation loop tick a few frames.
+    await page.waitForTimeout(500);
+
+    const clockWarnings = consoleMsgs.filter((t) => /Clock.*deprecated|THREE\.Clock/i.test(t));
+    expect(clockWarnings).toEqual([]);
+  });
+
+  test('panel stacks above the AI drawer', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#btn-ai');
+
+    await page.click('#btn-ai');
+    await expect(page.locator('#ai-panel')).toHaveClass(/translate-x-0/);
+
+    await page.click('#btn-diagnostics');
+    await expect(page.locator('#diagnostics-panel')).toBeVisible();
+
+    const zIndexOf = (sel: string) =>
+      page.locator(sel).evaluate((el) => parseInt(getComputedStyle(el).zIndex, 10) || 0);
+    const aiZ = await zIndexOf('#ai-panel');
+    const diagZ = await zIndexOf('#diagnostics-panel');
+    expect(diagZ).toBeGreaterThan(aiZ);
+  });
+
+  test('clicking a row expands it to show more detail', async ({ page }) => {
+    const marker = 'diagnostic-expand-test-marker';
+
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#btn-diagnostics');
+
+    // Seed an entry through the intercepted console.warn.
+    await page.evaluate((m) => console.warn(m), marker);
+
+    await page.click('#btn-diagnostics');
+    const panel = page.locator('#diagnostics-panel');
+    await expect(panel).toBeVisible();
+
+    const row = panel.locator('div.border-b', { hasText: marker }).first();
+    await expect(row).toBeVisible();
+
+    // The detail (source/level metadata) is collapsed until the row is clicked.
+    const meta = row.getByText(/source:/i);
+    await expect(meta).toBeHidden();
+
+    await row.locator('div.cursor-pointer').first().click();
+    await expect(meta).toBeVisible();
+    await expect(meta).toContainText(/WARN/);
+
+    // Toggling again collapses it.
+    await row.locator('div.cursor-pointer').first().click();
+    await expect(meta).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary

Addresses three issues with the diagnostic console:

- **THREE.Clock deprecation warning is back for good.** The viewport's animation loop used `THREE.Clock`, deprecated in three r183. PR #160 tried to fix this by importing `Clock` directly instead of via the `THREE` namespace — but the warning fires *inside the `Clock` constructor*, so referencing it differently changed nothing. This migrates to `THREE.Timer` (the recommended replacement), calling `timer.update(timestamp)` each frame before `getDelta()`. The warning is now actually gone.
- **Diagnostics panel rendered behind the AI drawer.** Both used `z-40`, so DOM order let the AI panel win. The diagnostics panel now sits at `z-[45]` — above the AI drawer, still below modal overlays (`z-50`).
- **Log rows now expand for more detail.** Every row is click-to-expand and reveals the full (untruncated) message, a precise timestamp, source/level, and a stack/origin trace. Console-intercepted `warn`/`error` calls and uncaught errors lacking an `Error` object now get a synthesized origin trace, so "where did this come from?" is answerable even for plain-string library warnings. Expansion state survives the list rebuild that happens when new entries arrive.

## Test plan

- [x] `npm run build` — passes, no TypeScript errors
- [x] `npx playwright test smoke` — 13/13 pass (no regressions)
- [x] `npx playwright test diagnostics-panel` — new spec, 3/3 pass:
  - no `THREE.Clock` deprecation warning on editor load
  - diagnostics panel z-index stacks above the AI drawer
  - clicking a row expands it to show the detail/metadata, and toggles closed

https://claude.ai/code/session_01TKkpmh5m1MtqN1FsU7tXH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKkpmh5m1MtqN1FsU7tXH1)_