### PR TITLE
feat: carry colors across version forks and harden patch tooling

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -229,7 +229,8 @@ await partwright.createSessionWithVersions(name, [{code, label},...]) // Batch c
 await partwright.saveVersion(label?)     // Save current state as version
 await partwright.listVersions()          // -> [{id, index, label, timestamp, status}]
 await partwright.loadVersion({index} | {id})  // Load version into editor -> {id, index, label, code, geometryData, labelsAvailable, labelCount} or {error}
-await partwright.forkVersion({index} | {id}, transformFn, label?, assertions?) // Load + modify + validate + save in one call
+await partwright.forkVersion({index} | {id}, transformFn, label?, assertions?, carryColors=true) // Load + modify + validate + save atomically; carries parent colors -> {..., codeDiff, colors}
+await partwright.copyColorsFromVersion({index} | {id}) // Re-apply a prior version's colors onto the current mesh -> {source, carried, dropped}
 partwright.getGalleryUrl()               // -> URL for gallery view (human review)
 partwright.getSessionUrl()               // -> URL for this session
 await partwright.listSessions()          // -> [{id, name, updated}]
@@ -518,7 +519,7 @@ If your rotated geometry looks mirrored, negate the angle. This burned 10+ minut
 
 ### Painting locks the editor — `clearColors()` to iterate
 
-Once any region exists, the editor goes read-only and `runAndSave` is rejected. To change the geometry mid-session, call `partwright.clearColors()` first, *then* run new code. To preserve a colored version while iterating, call `forkVersion(...)` instead — it loads, transforms, validates, and saves a fresh uncolored child without touching the colored one.
+Once any region exists, the editor goes read-only and `runAndSave` is rejected. To change the geometry mid-session, call `partwright.clearColors()` first, *then* run new code. To preserve a colored version while iterating, call `forkVersion(...)` instead — it loads, transforms, validates, and saves a child without touching the parent, and re-applies the parent's colors to the new geometry (pass `carryColors: false` for an uncolored child).
 
 ### Verify before you commit
 
@@ -625,7 +626,8 @@ const r = await partwright.forkVersion(
   { index: 11 },                       // or { id: "Kx3Pq9mA2wEr" } from listVersions()
   code => code.replace('towerH = 28', 'towerH = 35'),
   "v11a - taller towers",              // label for the new version
-  { isManifold: true, maxComponents: 1 } // optional assertions (validated before saving)
+  { isManifold: true, maxComponents: 1 }, // optional assertions (validated before saving)
+  true                                  // carryColors (default true) — re-apply parent colors
 );
 // On success:
 //   r.passed       = true (only when assertions provided)
@@ -633,6 +635,10 @@ const r = await partwright.forkVersion(
 //   r.geometry     = full geometry stats
 //   r.version      = { id, index, label } of the newly saved version
 //   r.diff         = stat diff vs. the previous current version
+//   r.codeDiff     = { changed, added, removed, diff } — what actually changed in the SOURCE.
+//                    Verify your transform landed here: changed:false means the code is
+//                    byte-identical to the parent (your edit was a no-op).
+//   r.colors       = { carried: [names], dropped: [names] } when the parent had colors
 //   r.galleryUrl   = gallery URL for human review
 // On failure:
 //   r.error        = "No version found with index ..." / "transformFn threw: ..." / etc.
@@ -643,6 +649,33 @@ const r = await partwright.forkVersion(
 `listVersions()[].id`). The two are never mixed, so there's no ambiguity about which field is being
 looked up. This is the recommended way to build parallel branches (v11a, v11b, ...) off a shared
 parent without a load/read/modify/save round-trip chain.
+
+**Color carry-over.** If the parent version has color regions, `forkVersion` re-applies them to the
+forked geometry automatically — each region's geometry-relative descriptor (box / slab / `byLabel` /
+coplanar / connected-from-seed) is re-resolved against the new mesh, so a dimension tweak does **not**
+force you to repaint. Regions whose descriptor no longer matches (a label the new code dropped, raw
+triangle ids on changed topology) are skipped and reported in `r.colors.dropped`. Pass `carryColors:
+false` for an intentionally uncolored fork.
+
+> When the AI tool form is used, pass `patches: [{find, replace}, ...]` instead of a `transformFn`.
+> Each `find` must occur **exactly once** in the parent code — a find that matches zero or multiple
+> times is rejected with an error rather than silently saving the parent unchanged, so copy the exact
+> text (whitespace included) from `getCode()`/`loadVersion()`.
+
+### Copying colors onto a rebuilt version
+
+When you rebuild geometry from scratch with `runAndSave` (rather than forking) but it matches an
+earlier *painted* version, transfer the colors in one call instead of repainting region by region:
+
+```js
+const r = await partwright.copyColorsFromVersion({ index: 7 }); // the painted version
+// r.source  = { index, label }
+// r.carried = [names] re-resolved onto the current mesh
+// r.dropped = [names] whose descriptor no longer matches — repaint those
+```
+
+This is in-memory like any paint op — call `runAndSave` or `saveVersion` afterward to persist. (You
+don't need it after `forkVersion`, which already carries colors.)
 
 ### Modify and test
 

--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -190,6 +190,13 @@ Calling `clearColors()` to fix a single mistake forces you to repaint
 every other region from scratch — multiple round-trips, multiple chances
 to introduce new mistakes. Don't do it.
 
+You also don't need to repaint when the **geometry** changes between
+versions: `forkVersion` re-applies the parent's color regions to the
+forked mesh automatically (each region's descriptor is re-resolved against
+the new geometry), and `copyColorsFromVersion({index})` transfers a painted
+version's colors onto the current mesh in one call. Regions whose descriptor
+no longer resolves are reported in `dropped` — repaint only those.
+
 **How face matching works.** `paintRegion` flood-fills outward from the seed triangle, including any neighbor whose normal is within `tolerance` of the seed's. Pick `point` slightly inside the model surface and pass the outward-pointing `normal` -- the seed resolver looks for the triangle whose plane the point lies on and whose normal aligns with yours.
 
 **Diagnostic on failure.** When `paintRegion` can't resolve a seed, the returned `error` string includes the position and normal of the *nearest* triangle, the angle off your requested normal, and a suggested tolerance value that would accept it. The same data is available structured under `{ error, nearest: { point, normal, distance, angleDeg, suggestedTolerance } }`. So a failed call tells you exactly what to change rather than leaving you guessing.
@@ -389,7 +396,7 @@ partwright.assertPaint({
 
 **Bucket tolerance.** `paintRegion`'s `tolerance` is a cosine threshold for the bend angle between adjacent faces (default `0.9995`, ≈ 1.8°). The flood-fill crosses an edge only when the bend at that edge is below the angle threshold — checked between the *parent* face and each *neighbor*, not against the seed. This means flood-fill follows curved surfaces: a 32-sided cylinder bends ~11° per face, so any tolerance ≥ cos(11°) ≈ `0.98` covers the whole cylinder. Set tolerance to `-1` (180°) to paint the entire connected mesh. The Paint UI exposes the same control as a slider labeled in degrees (0°–180°).
 
-**Editor lock.** When color regions exist, the editor is locked (the model can't be re-run, because new geometry would invalidate the saved triangle indices). To edit code, the user clicks "Unlock to edit" in the UI. Agents that need to iterate on the geometry should call `clearColors()` first, or fork a new uncolored version with `forkVersion`.
+**Editor lock.** When color regions exist, the editor is locked (the model can't be re-run, because new geometry would invalidate the saved triangle indices). To edit code, the user clicks "Unlock to edit" in the UI. Agents that need to iterate on the geometry should call `clearColors()` first, or fork with `forkVersion` — which by default carries the colors onto the new geometry (pass `carryColors: false` for an uncolored child).
 
 **Saving a colored version.** Calling `saveVersion(label)` after painting *will* persist the regions onto a new version — the dedupe check considers code, annotations, and color regions together. If nothing has changed, `saveVersion()` returns `{ skipped: true, reason: "..." }` instead of `null`, so a no-op is visible. If you want to be sure a save happened, check the return shape: `{ id, index, label }` on success, `{ skipped }` on no-op, `{ error }` if no session is open.
 

--- a/src/ai/patch.ts
+++ b/src/ai/patch.ts
@@ -1,0 +1,50 @@
+// Literal find/replace patching for the forkVersion / modifyAndTest tools.
+//
+// Kept dependency-free (no engine/three imports) so it is unit-testable in
+// isolation. The whole reason this module exists is that
+// `String.prototype.replace(string, string)` is a silent data-loss trap for
+// a patch API: it returns the input UNCHANGED when `find` is absent, and
+// replaces only the FIRST of several matches. Either case lets a fork
+// "succeed" having changed nothing — exactly the failure that made an agent
+// believe it had removed a feature when the saved version was untouched.
+// These helpers turn both cases into errors.
+
+export interface Patch {
+  find: string;
+  replace: string;
+}
+
+/** Collapse whitespace and clip a find-string for an error message so a
+ *  multi-line snippet doesn't dominate the tool result. */
+export function truncateForError(s: string, max = 80): string {
+  const oneLine = s.replace(/\s+/g, ' ').trim();
+  return oneLine.length > max ? `${oneLine.slice(0, max)}…` : oneLine;
+}
+
+/** Apply ONE literal find/replace, requiring `find` to occur exactly once.
+ *  Throws on a missing or ambiguous match. Replacement goes through
+ *  split/join so `$`-sequences in `replace` are treated literally (unlike
+ *  String.replace, which interprets `$&`, `$1`, etc.). */
+export function applyLiteralPatch(code: string, find: unknown, replace: unknown, idx?: number): string {
+  const where = idx === undefined ? 'patch' : `patches[${idx}]`;
+  if (typeof find !== 'string' || find.length === 0) {
+    throw new Error(`${where}.find must be a non-empty string.`);
+  }
+  if (typeof replace !== 'string') {
+    throw new Error(`${where}.replace must be a string.`);
+  }
+  const occurrences = code.split(find).length - 1;
+  if (occurrences === 0) {
+    throw new Error(`${where} find string not present in the code — nothing was changed. Read the current code and match the exact text including whitespace: "${truncateForError(find)}"`);
+  }
+  if (occurrences > 1) {
+    throw new Error(`${where} find string matches ${occurrences} places — it must be unique. Include more surrounding context to disambiguate: "${truncateForError(find)}"`);
+  }
+  return code.split(find).join(replace);
+}
+
+/** Apply a sequence of patches, each requiring a unique match against the
+ *  running result. Throws on the first patch that doesn't match exactly once. */
+export function applyPatches(patches: Patch[], code: string): string {
+  return patches.reduce((c, p, i) => applyLiteralPatch(c, p.find, p.replace, i), code);
+}

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -36,6 +36,12 @@ undoLastPaint() to reverse just the most recent paint, or removeRegion(id)
 to delete a specific older mistake (get the id from listRegions). Save
 clearColors for "start completely over from scratch" requests.
 
+When you change geometry and save a new version, you do NOT need to
+repaint: forkVersion carries the parent's colors onto the new mesh
+automatically, and copyColorsFromVersion({index}) transfers a painted
+version's colors onto a rebuilt mesh in one call (both report any regions
+that no longer resolve, so you only repaint those).
+
 When a tool call result shows "Tool call was interrupted and did not
 complete", do NOT assume the operation failed. The underlying call may
 have completed just before the stream was cut. Verify actual state with

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -17,6 +17,7 @@
 import type { ChatToggles } from './types';
 import type { Language } from '../geometry/engines/types';
 import { RENDER_VIEW_MODES } from '../renderer/multiview';
+import { applyLiteralPatch, applyPatches } from './patch';
 
 export interface ToolDefinition {
   name: string;
@@ -561,7 +562,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'forkVersion',
-    description: 'Fork a prior version: load version N, apply new code or patches, validate against optional assertions, and save as a new version — all atomically. Use this to branch off a known-good version without the fragile loadVersion → getCode → modify → runAndSave chain. Provide either `code` (full replacement) or `patches` (find/replace array applied to the parent\'s code — more concise when only a few values change). Returns {parent, version, geometry, diff, galleryUrl} on success, or {error} / {passed: false, failures} on failure.',
+    description: 'Fork a prior version: load version N, apply new code or patches, validate against optional assertions, and save as a new version — all atomically. Use this to branch off a known-good version without the fragile loadVersion → getCode → modify → runAndSave chain. Provide either `code` (full replacement) or `patches` (find/replace array applied to the parent\'s code — more concise when only a few values change). Each patch\'s `find` MUST occur exactly once in the parent code; a find that matches zero or multiple times is an ERROR (the fork is rejected, not silently saved unchanged), so read the parent code first and copy the exact text including whitespace. Color regions on the parent are re-applied to the forked geometry automatically (each region\'s descriptor is re-resolved against the new mesh) unless you pass `carryColors: false` — no need to repaint after a geometry tweak. Returns {parent, version, geometry, diff (geometry stats), codeDiff (what actually changed in the source — verify your patch landed here), colors: {carried, dropped}, galleryUrl} on success, or {error} / {passed: false, failures} on failure.',
     input_schema: {
       type: 'object',
       properties: {
@@ -569,16 +570,17 @@ const ALL_TOOLS: ToolDefinition[] = [
         code: { type: 'string', description: 'Full replacement code for the forked version. Provide this or patches, not both.' },
         patches: {
           type: 'array',
-          description: 'Find/replace substitutions applied in sequence to the parent version\'s code. More concise than providing the full program when only a few values change.',
+          description: 'Find/replace substitutions applied in sequence to the parent version\'s code. More concise than providing the full program when only a few values change. Each `find` must match exactly once or the call errors — include surrounding context to keep it unique.',
           items: {
             type: 'object',
             properties: {
-              find: { type: 'string', description: 'Exact string to find.' },
+              find: { type: 'string', description: 'Exact string to find. Must occur exactly once in the (running) code.' },
               replace: { type: 'string', description: 'Replacement string.' },
             },
             required: ['find', 'replace'],
           },
         },
+        carryColors: { type: 'boolean', description: 'Re-apply the parent version\'s color regions to the forked geometry. Default true. Pass false for an intentionally uncolored fork.' },
         label: { type: 'string', description: 'Short label for the new version.' },
         assertions: {
           type: 'object',
@@ -606,6 +608,17 @@ const ALL_TOOLS: ToolDefinition[] = [
             notes: { type: 'string' },
           },
         },
+      },
+      required: ['index'],
+    },
+  },
+  {
+    name: 'copyColorsFromVersion',
+    description: 'Transfer the color regions from a prior version onto the CURRENT geometry in one call — instead of repainting region by region after a geometry change. Each region\'s geometry-relative descriptor (box / slab / byLabel / coplanar / connectedFromSeed) is re-resolved against the current mesh; regions that no longer resolve (a dropped label, or raw-triangle regions on changed topology) are skipped and listed in `dropped`. Replaces any colors currently on the model. In-memory like any paint op — call runAndSave or saveVersion afterward to persist. (forkVersion already carries colors automatically; reach for this after a runAndSave when you rebuilt geometry that matches an earlier painted version.) Returns {source, carried, dropped}.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        index: { type: 'integer', description: '1-based version index to copy colors from (from listVersions).' },
       },
       required: ['index'],
     },
@@ -865,7 +878,7 @@ const ALWAYS_AVAILABLE = new Set([
 
 const RUN_GATED = new Set(['runCode']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
-const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);
 /** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
  *  vision spend in one place — when off, the agent has to reason from
@@ -1222,10 +1235,12 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
     case 'forkVersion': {
       const forkPatches = input.patches as Array<{ find: string; replace: string }> | undefined;
       const forkTransform = forkPatches
-        ? (code: string) => forkPatches.reduce((c, p) => c.replace(p.find, p.replace), code)
+        ? (code: string) => applyPatches(forkPatches, code)
         : (_code: string) => input.code as string;
-      return api.forkVersion({ index: input.index }, forkTransform, input.label as string | undefined, input.assertions as Record<string, unknown> | undefined);
+      return api.forkVersion({ index: input.index }, forkTransform, input.label as string | undefined, input.assertions as Record<string, unknown> | undefined, input.carryColors as boolean | undefined);
     }
+    case 'copyColorsFromVersion':
+      return api.copyColorsFromVersion({ index: input.index });
     case 'runAndAssert':
       return api.runAndAssert(input.code, input.assertions);
     case 'query':
@@ -1233,9 +1248,10 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
     case 'modifyAndTest': {
       const mtPatches = input.patches as Array<{ find: string; replace: string }> | undefined;
       return api.modifyAndTest((code: unknown) => {
-        let s = code as string;
-        if (mtPatches) return mtPatches.reduce((c, p) => c.replace(p.find, p.replace), s);
-        return s.replace(input.find as string, input.replace as string);
+        const s = code as string;
+        if (mtPatches) return applyPatches(mtPatches, s);
+        if (typeof input.find === 'string') return applyLiteralPatch(s, input.find, input.replace);
+        throw new Error('modifyAndTest requires either {find, replace} or {patches:[...]}.');
       }, input.assertions as Record<string, unknown> | undefined);
     }
     case 'probeRay':

--- a/src/main.ts
+++ b/src/main.ts
@@ -351,13 +351,17 @@ function applyVersionAnnotations(version: Version | null | undefined): void {
 }
 
 /** Rehydrate color regions from a version's geometryData.
- *  Rebuilds adjacency + BFS for coplanar descriptors against the current mesh. */
-function rehydrateColorRegions(geometryData: Record<string, unknown> | null): void {
+ *  Rebuilds adjacency + BFS for coplanar descriptors against the current mesh.
+ *  Returns the names of regions that resolved to ≥1 triangle (`carried`) vs.
+ *  those whose descriptor no longer matches the current geometry (`dropped`),
+ *  so callers transferring colors across versions can report what landed. */
+function rehydrateColorRegions(geometryData: Record<string, unknown> | null): { carried: string[]; dropped: string[] } {
   clearRegions();
 
-  if (!geometryData || !currentMeshData) return;
+  const report: { carried: string[]; dropped: string[] } = { carried: [], dropped: [] };
+  if (!geometryData || !currentMeshData) return report;
   const regions = geometryData.colorRegions as SerializedColorRegion[] | undefined;
-  if (!regions || regions.length === 0) return;
+  if (!regions || regions.length === 0) return report;
 
   const mesh = currentMeshData;
   const adjacency = buildAdjacency(mesh);
@@ -425,6 +429,9 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): vo
 
     if (triangles.size > 0) {
       addRegion(region.name, region.color, region.source, region.descriptor, triangles, region.visible !== false);
+      report.carried.push(region.name);
+    } else {
+      report.dropped.push(region.name);
     }
   }
 
@@ -435,6 +442,63 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): vo
     const colored = applyTriColorsIfVisible(currentMeshData);
     updateMesh(colored, { skipAutoFrame: true });
   }
+
+  return report;
+}
+
+/** Pull a version's serialized color regions out of its geometryData blob
+ *  (where saveVersion persists them via enrichGeometryDataWithColors).
+ *  Returns [] when the version has no colors. */
+function versionColorRegions(v: Version | null | undefined): SerializedColorRegion[] {
+  const nested = (v?.geometryData as Record<string, unknown> | null | undefined)?.colorRegions;
+  return Array.isArray(nested) ? (nested as SerializedColorRegion[]) : [];
+}
+
+/** Compact line-level diff for surfacing what a fork/transform actually
+ *  changed in the source — the cheapest way for an agent to confirm a
+ *  patch landed (a no-op patch shows `changed: false`). LCS-based so
+ *  insertions/deletions align; output is capped to keep the token cost of
+ *  a large rewrite bounded. */
+function computeCodeDiff(before: string, after: string, maxLines = 60): { changed: boolean; added: number; removed: number; diff: string | null } {
+  if (before === after) return { changed: false, added: 0, removed: 0, diff: null };
+  const a = before.split('\n');
+  const b = after.split('\n');
+  const n = a.length, m = b.length;
+  // The LCS table below is O(n·m). CAD scripts are small, but guard against a
+  // pathologically large rewrite by falling back to a cheap multiset line
+  // count (still surfaces "something changed" without allocating a huge table).
+  if (n * m > 2_000_000) {
+    const minus = (from: string[], against: string[]): number => {
+      const counts = new Map<string, number>();
+      for (const l of against) counts.set(l, (counts.get(l) ?? 0) + 1);
+      let extra = 0;
+      for (const l of from) {
+        const c = counts.get(l) ?? 0;
+        if (c > 0) counts.set(l, c - 1); else extra++;
+      }
+      return extra;
+    };
+    return { changed: true, added: minus(b, a), removed: minus(a, b), diff: '(diff too large to render line-by-line)' };
+  }
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const lines: string[] = [];
+  let added = 0, removed = 0, i = 0, j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) { i++; j++; }
+    else if (dp[i + 1][j] >= dp[i][j + 1]) { lines.push(`- ${a[i]}`); removed++; i++; }
+    else { lines.push(`+ ${b[j]}`); added++; j++; }
+  }
+  while (i < n) { lines.push(`- ${a[i]}`); removed++; i++; }
+  while (j < m) { lines.push(`+ ${b[j]}`); added++; j++; }
+  const diff = lines.length > maxLines
+    ? `${lines.slice(0, maxLines).join('\n')}\n… (${lines.length - maxLines} more changed lines)`
+    : lines.join('\n');
+  return { changed: true, added, removed, diff };
 }
 
 /** Include color regions in geometry data for saving. */
@@ -2376,6 +2440,7 @@ async function main() {
       transformFn: (code: string) => string,
       label?: string,
       assertions?: GeometryAssertions,
+      carryColors: boolean = true,
     ) {
       const parsed = parseVersionTarget(target, 'forkVersion');
       if ('error' in parsed) return parsed;
@@ -2422,13 +2487,27 @@ async function main() {
         }
       }
 
-      // Commit: update editor, run, save.
+      // Commit: update editor, run, (carry colors), save.
       const prevGeoData = getState().currentVersion?.geometryData as Record<string, unknown> | null;
+      const parentColors = carryColors ? versionColorRegions(parent) : [];
       setValue(newCode);
       await runCodeSync(newCode);
       const newGeoData = JSON.parse(geometryDataEl.textContent || '{}');
+
+      // Re-apply the parent's color regions to the forked geometry before
+      // snapshotting the thumbnail and saving, so a geometry tweak doesn't
+      // force the agent to repaint. Descriptors are re-resolved against the
+      // new mesh; non-matching regions drop out and are reported. When not
+      // carrying, clear any stale in-memory regions so the fork is clean.
+      let colorReport: { carried: string[]; dropped: string[] } = { carried: [], dropped: [] };
+      if (parentColors.length > 0) {
+        colorReport = rehydrateColorRegions({ colorRegions: parentColors });
+      } else {
+        clearRegions();
+      }
+
       const thumbnail = await captureThumbnail();
-      const version = await saveVersion(newCode, getGeometryDataObj(), thumbnail, label, assertions?.notes);
+      const version = await saveVersion(newCode, enrichGeometryDataWithColors(getGeometryDataObj()), thumbnail, label, assertions?.notes);
 
       let diff = null;
       if (prevGeoData && prevGeoData.status === 'ok' && newGeoData.status === 'ok') {
@@ -2442,8 +2521,48 @@ async function main() {
         geometry: newGeoData,
         version: version ? { id: version.id, index: version.index, label: version.label } : null,
         diff,
+        codeDiff: computeCodeDiff(parent.code, newCode),
+        ...(parentColors.length > 0 ? { colors: colorReport } : {}),
         galleryUrl: getGalleryUrl(),
         ...(forkWarnings.length > 0 ? { warnings: forkWarnings } : {}),
+      };
+    },
+
+    /** Transfer the color regions from a prior version onto the CURRENT
+     *  geometry by re-resolving each region's descriptor against the live
+     *  mesh — instead of repainting region by region after a rebuild. Any
+     *  colors currently on the model are replaced. Regions whose descriptor
+     *  no longer resolves (a dropped label, raw-triangle regions on changed
+     *  topology) are skipped and listed in `dropped`. In-memory like any
+     *  paint op: call runAndSave / saveVersion to persist. Returns
+     *  { source, carried, dropped } or { error }. */
+    async copyColorsFromVersion(target: { index?: number; id?: string }) {
+      const parsed = parseVersionTarget(target, 'copyColorsFromVersion');
+      if ('error' in parsed) return parsed;
+      if (!getState().session) {
+        return { error: 'No active session. Call openSession(id) or createSession() first.' };
+      }
+      if (!currentMeshData) {
+        return { error: 'No geometry loaded — run code first, then copy colors onto it.' };
+      }
+      const source = await peekVersion(parsed.value);
+      if (!source) {
+        return { error: `No version found with ${parsed.kind} "${parsed.value}" in the active session. Use listVersions() to see valid ${parsed.kind}s.` };
+      }
+      const regions = versionColorRegions(source);
+      if (regions.length === 0) {
+        return { error: `Version ${source.index} ("${source.label}") has no color regions to copy.` };
+      }
+      const report = rehydrateColorRegions({ colorRegions: regions });
+      scheduleColorRefresh();
+      syncLockState();
+      return {
+        source: { index: source.index, label: source.label },
+        carried: report.carried,
+        dropped: report.dropped,
+        note: report.dropped.length > 0
+          ? 'Some regions did not resolve on the current geometry and were skipped — repaint those, or check the labels/topology still match. Call runAndSave or saveVersion to persist the rest.'
+          : 'All regions transferred. Call runAndSave or saveVersion to persist.',
       };
     },
 
@@ -4352,7 +4471,7 @@ async function main() {
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'paintByLabel.color must be [r,g,b] in 0..1' };
       if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
       if (!currentLabelMap || currentLabelMap.size === 0) {
-        return { error: 'No labels registered in the current run. Wrap features with api.label(shape, "name") in your code, then runAndSave, then call paintByLabel.' };
+        return { error: 'No labels registered in the current run. Either wrap features with api.label(shape, "name") in your code, then runAndSave, then call paintByLabel — or, if you cannot edit the code, paint by coordinates instead: paintInBox / paintComponent (after listComponents) / paintConnected (after probePixel on a render).' };
       }
       const ids = currentLabelMap.get(opts.label);
       if (!ids || ids.size === 0) {
@@ -4418,7 +4537,7 @@ async function main() {
       if (items.length === 0) return { results: [], failed: [] };
       if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
       if (!currentLabelMap || currentLabelMap.size === 0) {
-        return { error: 'No labels registered in the current run. Wrap features with api.label(shape, "name") in your code, then runAndSave, then call paintByLabels.' };
+        return { error: 'No labels registered in the current run. Either wrap features with api.label(shape, "name") in your code, then runAndSave, then call paintByLabels — or, if you cannot edit the code, paint by coordinates instead: paintInBox / paintComponent (after listComponents) / paintConnected (after probePixel on a render).' };
       }
       const results: Array<Record<string, unknown>> = [];
       const failed: Array<{ label: string; error: string }> = [];
@@ -4634,7 +4753,8 @@ async function main() {
         'saveVersion':     { signature: 'await saveVersion(label?) -- Save current state as version', docs: '/ai.md#console-api--windowpartwright' },
         'listVersions':    { signature: 'await listVersions() -- List all versions in session', docs: '/ai.md#console-api--windowpartwright' },
         'loadVersion':     { signature: 'await loadVersion({index} | {id}) -- Load version into editor -> {id, index, label, code, geometryData} or {error}', docs: '/ai.md#console-api--windowpartwright' },
-        'forkVersion':     { signature: 'await forkVersion({index} | {id}, transformFn, label?, assertions?) -- Load + modify + validate + save in one call', docs: '/ai.md#forking-a-prior-version' },
+        'forkVersion':     { signature: 'await forkVersion({index} | {id}, transformFn, label?, assertions?, carryColors=true) -- Load + modify + validate + save in one call; carries parent colors -> {..., codeDiff, colors}', docs: '/ai.md#forking-a-prior-version' },
+        'copyColorsFromVersion': { signature: 'await copyColorsFromVersion({index} | {id}) -- Re-apply a prior version\'s color regions onto the current mesh -> {source, carried, dropped}', docs: '/ai.md#forking-a-prior-version' },
         'openSession':     { signature: 'await openSession(id) -- Open existing session', docs: '/ai.md#resuming-a-session' },
         'listSessions':    { signature: 'await listSessions() -- List all sessions', docs: '/ai.md#console-api--windowpartwright' },
         'getSessionContext': { signature: 'await getSessionContext() -- Get full session context (for resuming)', docs: '/ai.md#resuming-a-session' },

--- a/tests/fork-color-carry.spec.ts
+++ b/tests/fork-color-carry.spec.ts
@@ -1,0 +1,149 @@
+// Integration tests for the AI-session-feedback improvements:
+//  - forkVersion re-applies the parent version's color regions to the
+//    forked geometry (no repainting after a geometry tweak)
+//  - forkVersion returns a codeDiff so a no-op transform is visible
+//  - copyColorsFromVersion transfers a prior version's colors onto the
+//    current mesh and reports which regions dropped
+
+import { test, expect } from 'playwright/test';
+
+const LABELLED_CUBE = `
+  const { Manifold } = api;
+  const size = 20;
+  return api.label(Manifold.cube([size, size, size], true), 'body');
+`;
+
+test.describe('forkVersion color carry-over + codeDiff', () => {
+  test('carries the parent version colors onto the forked geometry', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async (code) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('fork-carry-colors');
+      const v1 = await pw.runAndSave(code, 'base');
+      pw.paintByLabel({ label: 'body', color: [0.8, 0.2, 0.2] });
+      const painted = await pw.saveVersion('painted');
+
+      // Grow the cube — geometry changes, but the 'body' label re-resolves.
+      const fork = await pw.forkVersion(
+        { index: painted.index },
+        (c: string) => c.replace('size = 20', 'size = 28'),
+        'bigger',
+      );
+      return { fork, regionsAfter: pw.listRegions() };
+    }, LABELLED_CUBE);
+
+    expect(result.fork.error).toBeUndefined();
+    expect(result.fork.version).not.toBeNull();
+    // Colors carried onto the new geometry, none dropped.
+    expect(result.fork.colors.carried).toContain('body');
+    expect(result.fork.colors.dropped).toEqual([]);
+    // The carried region resolved to real triangles on the forked mesh.
+    expect(result.regionsAfter).toHaveLength(1);
+    expect(result.regionsAfter[0].triangles).toBeGreaterThan(0);
+    // codeDiff reflects the one-line change.
+    expect(result.fork.codeDiff.changed).toBe(true);
+    expect(result.fork.codeDiff.added).toBeGreaterThan(0);
+    expect(result.fork.codeDiff.removed).toBeGreaterThan(0);
+  });
+
+  test('carryColors:false produces an uncolored fork', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async (code) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('fork-no-carry');
+      const v1 = await pw.runAndSave(code, 'base');
+      pw.paintByLabel({ label: 'body', color: [0.2, 0.2, 0.8] });
+      const painted = await pw.saveVersion('painted');
+
+      const fork = await pw.forkVersion(
+        { index: painted.index },
+        (c: string) => c.replace('size = 20', 'size = 28'),
+        'uncolored',
+        undefined,
+        false,
+      );
+      return { fork, regionsAfter: pw.listRegions() };
+    }, LABELLED_CUBE);
+
+    expect(result.fork.error).toBeUndefined();
+    expect(result.fork.colors).toBeUndefined();
+    expect(result.regionsAfter).toHaveLength(0);
+  });
+
+  test('codeDiff reports changed:false for a no-op transform', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const fork = await page.evaluate(async (code) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('fork-noop-diff');
+      const v1 = await pw.runAndSave(code, 'base');
+      return pw.forkVersion({ index: v1.version.index }, (c: string) => c, 'noop');
+    }, LABELLED_CUBE);
+
+    expect(fork.codeDiff.changed).toBe(false);
+    expect(fork.codeDiff.diff).toBeNull();
+  });
+});
+
+test.describe('copyColorsFromVersion', () => {
+  test('transfers colors when the descriptor still resolves, reports drops when it does not', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async (code) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('copy-colors');
+      const v1 = await pw.runAndSave(code, 'base');
+      pw.paintByLabel({ label: 'body', color: [0.3, 0.7, 0.3] });
+      const painted = await pw.saveVersion('painted');
+
+      // Rebuild with a DIFFERENT label — 'body' no longer exists, so the
+      // copied region should drop.
+      await pw.runAndSave(
+        'const { Manifold } = api; return api.label(Manifold.cube([15,15,15], true), "shell");',
+        'shell-only',
+      );
+      const missing = await pw.copyColorsFromVersion({ index: painted.index });
+
+      // Rebuild WITH the 'body' label — now the copy should resolve.
+      await pw.runAndSave(code, 'body-again');
+      const hit = await pw.copyColorsFromVersion({ index: painted.index });
+
+      return { missing, hit, regionsAfter: pw.listRegions() };
+    }, LABELLED_CUBE);
+
+    expect(result.missing.error).toBeUndefined();
+    expect(result.missing.carried).toEqual([]);
+    expect(result.missing.dropped).toContain('body');
+
+    expect(result.hit.error).toBeUndefined();
+    expect(result.hit.carried).toContain('body');
+    expect(result.hit.dropped).toEqual([]);
+    expect(result.regionsAfter).toHaveLength(1);
+    expect(result.regionsAfter[0].triangles).toBeGreaterThan(0);
+  });
+
+  test('errors clearly when the source version has no colors', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const res = await page.evaluate(async (code) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('copy-colors-empty');
+      const v1 = await pw.runAndSave(code, 'no-colors');
+      return pw.copyColorsFromVersion({ index: v1.version.index });
+    }, LABELLED_CUBE);
+
+    expect(res.error).toMatch(/no color regions/);
+  });
+});

--- a/tests/patch.spec.ts
+++ b/tests/patch.spec.ts
@@ -1,0 +1,61 @@
+// Unit tests for the literal find/replace patch helpers behind forkVersion
+// and modifyAndTest. These run in Node (no browser) — the module is kept
+// dependency-free precisely so it can be tested in isolation.
+
+import { test, expect } from 'playwright/test';
+import { applyLiteralPatch, applyPatches } from '../src/ai/patch';
+
+test.describe('applyLiteralPatch', () => {
+  test('replaces a unique match', () => {
+    expect(applyLiteralPatch('const size = 20;', 'size = 20', 'size = 24')).toBe('const size = 24;');
+  });
+
+  test('throws when the find string is absent (the silent-failure bug)', () => {
+    // Before the fix, String.replace returned the input unchanged and the
+    // fork "succeeded" having changed nothing. Now it must error.
+    expect(() => applyLiteralPatch('const a = 1;', 'const b = 2;', 'const b = 3;'))
+      .toThrow(/not present/);
+  });
+
+  test('throws when the find string matches more than once', () => {
+    expect(() => applyLiteralPatch('x = x + x;', 'x', 'y'))
+      .toThrow(/matches \d+ places/);
+  });
+
+  test('throws on an empty find string', () => {
+    expect(() => applyLiteralPatch('abc', '', 'z')).toThrow(/non-empty string/);
+  });
+
+  test('treats `$` sequences in the replacement literally', () => {
+    // String.replace would interpret `$&` as the matched text; split/join must not.
+    expect(applyLiteralPatch('cost = PRICE;', 'PRICE', '$5')).toBe('cost = $5;');
+    expect(applyLiteralPatch('a = TOKEN;', 'TOKEN', '$&b')).toBe('a = $&b;');
+  });
+});
+
+test.describe('applyPatches', () => {
+  test('applies a sequence of unique patches', () => {
+    const code = 'const w = 10;\nconst h = 20;';
+    const out = applyPatches([
+      { find: 'w = 10', replace: 'w = 15' },
+      { find: 'h = 20', replace: 'h = 25' },
+    ], code);
+    expect(out).toBe('const w = 15;\nconst h = 25;');
+  });
+
+  test('reports which patch index failed', () => {
+    const code = 'const w = 10;\nconst h = 20;';
+    expect(() => applyPatches([
+      { find: 'w = 10', replace: 'w = 15' },
+      { find: 'h = 99', replace: 'h = 25' },
+    ], code)).toThrow(/patches\[1\]/);
+  });
+
+  test('a later patch can match text introduced by an earlier one', () => {
+    const out = applyPatches([
+      { find: 'A', replace: 'B' },
+      { find: 'B', replace: 'C' },
+    ], 'A');
+    expect(out).toBe('C');
+  });
+});


### PR DESCRIPTION
## Summary

Improvements distilled from an AI modeling session that flailed while forking a painted version. Tracing the transcript against the code showed that three of the agent's five complaints collapse into one root-cause bug, plus one genuinely missing capability.

- **Fix silent patch failure (root cause).** `forkVersion` and `modifyAndTest` applied `{find, replace}` patches with `String.replace(string, string)`, which returns the code **unchanged** when `find` is absent (and replaces only the *first* of multiple matches). A fork could report success having saved the parent untouched — exactly what made the agent think it had removed a feature when v3 still had it, then misdiagnose it as a "stale editor." Patches now require each `find` to match **exactly once** or the call errors. Logic extracted to a dependency-free `src/ai/patch.ts` with unit tests.
- **Color carry-over across versions (new capability).** `forkVersion` now re-applies the parent version's color regions to the forked geometry by re-resolving each region's descriptor (box / slab / `byLabel` / coplanar / connected-from-seed) against the new mesh — `carryColors`, default `true`. New `copyColorsFromVersion({index})` tool transfers a painted version's colors onto a rebuilt mesh. Both report which regions no longer resolve (`dropped`) so only those need repainting. This eliminates the repeated manual repainting in the session.
- **Patch verification.** `forkVersion` returns a `codeDiff` (`{changed, added, removed, diff}`) so a no-op transform is visible (`changed:false`) instead of being mistaken for an editor that didn't update.
- **Minor:** `paintByLabel`/`paintByLabels` "no labels registered" errors now also point at the coordinate-based fallbacks (`paintInBox` / `paintComponent` / `paintConnected`).

Docs (`ai.md`, `ai/colors.md`), the agent tool schemas/descriptions, the console-API help registry, and the system prompt are updated to match.

## Test plan

- [x] `npx playwright test patch.spec.ts` — 8 unit tests for the strict patch helpers (no-match / multi-match / empty-find throw, `$`-literal safety, sequence application)
- [x] `npx playwright test fork-color-carry.spec.ts` — 5 integration tests (fork carries colors, `carryColors:false`, `codeDiff.changed:false` on no-op, `copyColorsFromVersion` carries + reports `dropped`, errors on a colorless source)
- [x] Existing suite: `paint-batch-and-lifecycle`, `labelled-construction`, `render-color-readability`, `paint-render-color`, `smoke` all pass (25 tests) — no regressions
- [x] `npm run build` succeeds (tsc + vite, no type errors)

https://claude.ai/code/session_01JSLkoyGoeAYkGrepuQfkDY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSLkoyGoeAYkGrepuQfkDY)_