### PR TITLE
Fix lost AI chat history and add chat export

### DIFF
--- a/src/ai/db.ts
+++ b/src/ai/db.ts
@@ -122,3 +122,32 @@ export async function clearChat(sessionId: string): Promise<void> {
   });
   await txComplete(txn);
 }
+
+/** Merge every chat message from bucket `from` into session `to`. The combined
+ *  transcript is re-sequenced chronologically (by createdAt, then prior seq) so
+ *  ordering is stable and seq values can't collide. Used to reunite a single
+ *  conversation that got split across buckets when the active session changed
+ *  mid-turn (chatLoop stamps each message with the session active at turn start,
+ *  so a mid-turn createSession strands the earlier turns under the old bucket).
+ *  Returns the number of messages moved out of `from`.
+ *
+ *  `onlyIfTargetEmpty` (used by the automatic post-turn reunite) restricts the
+ *  merge to a fresh session so a conversation is never auto-folded into one that
+ *  already has its own distinct chat; the manual recovery path leaves it off. */
+export async function mergeChatBucket(
+  from: string,
+  to: string,
+  opts: { onlyIfTargetEmpty?: boolean } = {},
+): Promise<number> {
+  if (from === to || to === GLOBAL_CHAT_BUCKET) return 0;
+  const fromMsgs = await listMessages(from);
+  if (fromMsgs.length === 0) return 0;
+  const toMsgs = await listMessages(to);
+  if (opts.onlyIfTargetEmpty && toMsgs.length > 0) return 0;
+  const combined = [...toMsgs, ...fromMsgs].sort(
+    (a, b) => (a.createdAt - b.createdAt) || (a.seq - b.seq),
+  );
+  combined.forEach((m, i) => { m.sessionId = to; m.seq = i; });
+  await putMessages(combined);
+  return fromMsgs.length;
+}

--- a/src/export/chat.ts
+++ b/src/export/chat.ts
@@ -1,0 +1,95 @@
+// AI chat transcript export. Renders a ChatMessage[] to a readable Markdown
+// document and triggers a download. Complements the structured chat embedded
+// in `.partwright.json` session exports (see exportSession): this is the
+// human-friendly, shareable form for a single conversation.
+
+import type { ChatMessage, PersistedToolCall, PersistedToolResult } from '../ai/types';
+import { downloadBlob, getExportFilename } from './download';
+
+function fmtTimestamp(ms: number): string {
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+}
+
+function roleHeading(msg: ChatMessage): string {
+  if (msg.role === 'user') {
+    // A user message carrying only tool results is the agent loop posting the
+    // previous turn's results back — label it as such so the transcript reads
+    // naturally instead of showing an empty "You" turn.
+    const onlyToolResults = msg.blocks.length === 0 && (msg.toolResults?.length ?? 0) > 0;
+    return onlyToolResults ? 'Tool results' : 'You';
+  }
+  if (msg.compacted) return 'Assistant (compaction summary)';
+  return 'Assistant';
+}
+
+function renderToolCall(tc: PersistedToolCall): string {
+  let input: string;
+  try {
+    input = JSON.stringify(tc.input, null, 2);
+  } catch {
+    input = String(tc.input);
+  }
+  return `**→ tool call: \`${tc.name}\`**\n\n\`\`\`json\n${input}\n\`\`\``;
+}
+
+function renderToolResult(tr: PersistedToolResult): string {
+  const tag = tr.isError ? '⚠ tool error' : '← tool result';
+  const parts = [`**${tag}**`];
+  const body = tr.content?.trim();
+  if (body) parts.push('```\n' + body + '\n```');
+  if (tr.image) parts.push(`_[image returned${tr.image.label ? `: ${tr.image.label}` : ''}]_`);
+  return parts.join('\n\n');
+}
+
+function renderMessage(msg: ChatMessage): string {
+  const parts: string[] = [`### ${roleHeading(msg)}`];
+
+  for (const block of msg.blocks) {
+    if (block.type === 'text') {
+      const text = block.text.trim();
+      if (text) parts.push(text);
+    } else {
+      parts.push(`_[image${block.source.label ? `: ${block.source.label}` : ''}]_`);
+    }
+  }
+
+  for (const tc of msg.toolCalls ?? []) parts.push(renderToolCall(tc));
+  for (const tr of msg.toolResults ?? []) parts.push(renderToolResult(tr));
+
+  if (msg.aborted) parts.push('_[stopped before completing]_');
+
+  // A bubble with no visible content (e.g. an assistant turn that only fired
+  // tool calls already rendered above) shouldn't print a dangling heading.
+  if (parts.length === 1) parts.push('_(no text)_');
+
+  return parts.join('\n\n');
+}
+
+/** Render a chat transcript to a Markdown string. */
+function chatToMarkdown(messages: ChatMessage[], title: string): string {
+  const header = [
+    `# Chat — ${title}`,
+    `_Exported ${fmtTimestamp(Date.now())} · ${messages.length} message${messages.length === 1 ? '' : 's'}_`,
+  ].join('\n\n');
+
+  const body = messages.map(renderMessage).join('\n\n---\n\n');
+  return `${header}\n\n---\n\n${body}\n`;
+}
+
+/**
+ * Export a chat transcript as a Markdown (`.md`) file download.
+ * `sessionName` is used for the document title and filename; pass null for the
+ * pre-session global chat. Returns false (no download) when there's nothing to
+ * export.
+ */
+export function exportChatMarkdown(messages: ChatMessage[], sessionName: string | null): boolean {
+  if (messages.length === 0) return false;
+  const title = sessionName ?? 'Global chat';
+  const md = chatToMarkdown(messages, title);
+  const blob = new Blob([md], { type: 'text/markdown' });
+  const filename = getExportFilename('md', `${sessionName ?? 'global'}-chat`);
+  downloadBlob(blob, filename, 'Chat');
+  return true;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEd
 import { createLayout, type TabName } from './ui/layout';
 import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState } from './ui/toolbar';
 import { initAiPanel, setActiveSession as setAiActiveSession, toggleAiPanel } from './ui/aiPanel';
-import { getKey as getAiKey } from './ai/db';
+import { getKey as getAiKey, mergeChatBucket } from './ai/db';
 import { loadSettings as loadAiSettings } from './ai/settings';
 import { createLandingPage } from './ui/landing';
 import { createHelpPage } from './ui/help';
@@ -1778,6 +1778,22 @@ async function main() {
         sizeBytes: built.blob.size,
         data: built.data,
       };
+    },
+
+    /** Maintenance: merge a chat transcript from one session into another to
+     *  reunite a conversation that got split across sessions. Re-sequences the
+     *  combined transcript chronologically. Refresh the target session to see
+     *  the result. Returns { moved, into } or { error }. */
+    async mergeChatHistory(fromSessionId: string, toSessionId: string) {
+      const check = guard(() => {
+        assertString(fromSessionId, 'mergeChatHistory(fromSessionId)', { allowEmpty: false });
+        assertString(toSessionId, 'mergeChatHistory(toSessionId)', { allowEmpty: false });
+        return true;
+      });
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      const moved = await mergeChatBucket(fromSessionId, toSessionId);
+      if (moved === 0) return { error: 'No messages moved — check the source has chat and differs from the target.' };
+      return { moved, into: toSessionId };
     },
 
     /** Return the current editor source as text + metadata. */

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -18,11 +18,14 @@ import {
   deleteNote as dbDeleteNote,
   updateNote as dbUpdateNote,
   legacyImagesObjectToArray,
+  generateId,
   type Session,
   type Version,
   type SessionNote,
   type AttachedImage,
 } from './db';
+import { listMessages as dbListMessages, putMessages as dbPutMessages } from '../ai/db';
+import type { ChatMessage } from '../ai/types';
 
 /** Legacy angle keys preserved only for typing the on-disk shapes we still
  *  read for backward compatibility. */
@@ -73,8 +76,13 @@ import { setActiveImports, type ImportedMesh } from '../import/importedMesh';
  *           Older readers ignore unknown discriminant variants; the
  *           region drops silently if its descriptor doesn't match a
  *           known kind.
+ *  - `1.6` — optional AI chat transcript (`chat`) for the session. Holds the
+ *           persisted conversation (text, tool calls, tool results) so a
+ *           session round-trips with its chat. Only written when the caller
+ *           opts in via {@link ExportOptions.includeChat}. On import each
+ *           message is re-keyed to the new session; older readers ignore it.
  */
-export const SCHEMA_VERSION = '1.5';
+export const SCHEMA_VERSION = '1.6';
 
 const CURRENT_MAJOR = 1;
 
@@ -115,6 +123,13 @@ export interface ExportedSession {
   }[];
   notes?: { text: string; timestamp: number }[];
   /**
+   * The session's AI chat transcript, oldest first. Stored without the volatile
+   * `id`/`sessionId`/`errored` fields — those are regenerated/re-keyed on
+   * import. Only present when exported with {@link ExportOptions.includeChat}.
+   * @since 1.6
+   */
+  chat?: ExportedChatMessage[];
+  /**
    * **Deprecated in 1.3** — top-level annotations were the 1.2 location.
    * Still read on import (assigned to the latest version) for back-compat,
    * but no longer written. New writers attach annotations per-version under
@@ -123,6 +138,11 @@ export interface ExportedSession {
    */
   annotations?: SerializedAnnotation[];
 }
+
+/** A chat message as embedded in an exported session. The persisted shape
+ *  minus the fields that are environment-specific: `id` and `sessionId` are
+ *  regenerated/re-keyed on import, and `errored` is never persisted. */
+export type ExportedChatMessage = Omit<ChatMessage, 'id' | 'sessionId' | 'errored'>;
 
 interface SchemaVersionInfo {
   raw: string;
@@ -655,6 +675,7 @@ export interface ExportOptions {
   includeAnnotations?: boolean;
   includeNotes?: boolean;
   includeColorRegions?: boolean;
+  includeChat?: boolean;
 }
 
 const DEFAULT_EXPORT_OPTIONS: Required<ExportOptions> = {
@@ -662,6 +683,7 @@ const DEFAULT_EXPORT_OPTIONS: Required<ExportOptions> = {
   includeAnnotations: true,
   includeNotes: true,
   includeColorRegions: true,
+  includeChat: true,
 };
 
 /** Read a Blob as a base64 data URL (e.g. "data:image/png;base64,..."). */
@@ -690,6 +712,13 @@ function dataURLToBlob(dataUrl: string): Blob | null {
   }
 }
 
+/** Drop the environment-specific fields from a persisted chat message so it can
+ *  be embedded in an export (id/sessionId are regenerated on import). */
+function toExportedChatMessage(m: ChatMessage): ExportedChatMessage {
+  const { id: _id, sessionId: _sessionId, errored: _errored, ...rest } = m;
+  return rest;
+}
+
 /** Strip `colorRegions` from a geometryData blob without mutating the original. */
 function stripColorRegions(geometryData: Record<string, unknown> | null): Record<string, unknown> | null {
   if (!geometryData) return geometryData;
@@ -712,6 +741,7 @@ export async function exportSession(
 
   const versions = await dbListVersions(id);
   const notes = opts.includeNotes ? await dbListNotes(id) : [];
+  const chat = opts.includeChat ? await dbListMessages(id) : [];
 
   // Thumbnail conversion: read each version's Blob and convert to base64 data URL.
   // Done in parallel since FileReader is async per-blob.
@@ -740,6 +770,7 @@ export async function exportSession(
       };
     }),
     ...(notes.length > 0 ? { notes: notes.map(n => ({ text: n.text, timestamp: n.timestamp })) } : {}),
+    ...(chat.length > 0 ? { chat: chat.map(toExportedChatMessage) } : {}),
   };
 }
 
@@ -816,6 +847,17 @@ export async function importSession(
     for (const n of data.notes) {
       await dbAddNote(session.id, n.text);
     }
+  }
+
+  // Restore the AI chat transcript (schema 1.6+). Re-key every message to the
+  // new session and mint a fresh id so importing into a DB that still holds
+  // the original conversation can't overwrite it. seq is preserved for order.
+  if (Array.isArray(data.chat) && data.chat.length > 0) {
+    const messages: ChatMessage[] = data.chat
+      .filter((m): m is ExportedChatMessage =>
+        !!m && (m.role === 'user' || m.role === 'assistant') && Array.isArray(m.blocks))
+      .map(m => ({ ...m, id: generateId(), sessionId: session.id }));
+    if (messages.length > 0) await dbPutMessages(messages);
   }
 
   // Restore the session's original created/updated timestamps so the schema round-trips

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -18,6 +18,8 @@ import { showSystemPromptModal } from './aiSystemPromptModal';
 import { showCompactConfirmModal } from './aiCompactModal';
 import { showAttachmentModal } from './aiAttachmentModal';
 import { putAttachment } from '../ai/attachments';
+import { exportChatMarkdown } from '../export/chat';
+import { getState } from '../storage/sessionManager';
 import { ensureModelLoaded, effectiveContextCeiling, interruptLocal, isModelLoaded, resolveLocalModel } from '../ai/local';
 import { activeModel, SPEND_CAP_USD, type AnthropicModelId, type ChatBlock, type ChatMessage, type ChatToggles, type ImageSource, type PersistedToolResult, type TurnOutcomeReason } from '../ai/types';
 import { errorLog } from '../diagnostics/errorLog';
@@ -301,6 +303,11 @@ function buildDrawer(): void {
   compactBtn.title = 'Compact the conversation: summarize older turns and promote insights to session notes.';
   compactBtn.addEventListener('click', () => { void runCompact(); });
   header.appendChild(compactBtn);
+
+  const exportBtn = createIconButton('Export chat', '⬇ Chat');
+  exportBtn.title = 'Export this conversation as a Markdown (.md) file. Saves the whole transcript — text, tool calls, and results.';
+  exportBtn.addEventListener('click', exportCurrentChat);
+  header.appendChild(exportBtn);
 
   const clearBtn = createIconButton('Clear', '🗑');
   clearBtn.title = 'Clear the chat history for the current session. The conversation is removed from your browser; saved versions and notes are untouched.';
@@ -940,6 +947,18 @@ async function loadLocalModelInline(): Promise<void> {
   } catch (err) {
     setTransientStatus(`Failed to load: ${err instanceof Error ? err.message : String(err)}`);
   }
+}
+
+/** Download the current conversation as a Markdown transcript. In-memory
+ *  history is already the authoritative, seq-ordered view, so no DB read. */
+function exportCurrentChat(): void {
+  if (state.history.length === 0) {
+    setTransientStatus('Nothing to export — the chat is empty.');
+    return;
+  }
+  const sessionName = state.sessionId === GLOBAL_CHAT_BUCKET ? null : (getState().session?.name ?? null);
+  exportChatMarkdown(state.history, sessionName);
+  setTransientStatus('Chat exported as Markdown.');
 }
 
 /** Clear chat history for the current session. Confirms first; refuses to

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -235,6 +235,25 @@ async function loadHistoryForCurrentSession(): Promise<void> {
   updateRewindButtons();
 }
 
+/** Re-home every chat message persisted under `from` into session `to`,
+ *  preserving order (seq is untouched; the store is keyed by message id, so a
+ *  re-`put` just moves the sessionId index entry). Used after the model spins
+ *  up a session mid-conversation: the lead-up chat lives in the global bucket
+ *  and would otherwise be orphaned there — looking "lost" when the session is
+ *  later reopened. Skips the move when `to` already has chat so two
+ *  conversations are never merged (e.g. the model opened a pre-existing
+ *  session). Returns true when messages were actually moved. */
+async function migrateChatBucket(from: string, to: string): Promise<boolean> {
+  if (from === to) return false;
+  const existing = await listMessages(to);
+  if (existing.length > 0) return false;
+  const messages = await listMessages(from);
+  if (messages.length === 0) return false;
+  for (const m of messages) m.sessionId = to;
+  await putMessages(messages);
+  return true;
+}
+
 // === DOM construction ===
 
 function buildDrawer(): void {
@@ -1574,6 +1593,10 @@ function formatTurnOutcome(o: TurnOutcome): string {
 async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatToggles, userBlocks: ChatBlock[]): Promise<void> {
   let attempt = 0;
   let lastTurnOutcome: TurnOutcome | null = null;
+  // Bucket the conversation lives in as this turn begins. If the model creates
+  // a session mid-turn the active bucket changes out from under us, so we
+  // remember the starting bucket and re-home the chat once the turn settles.
+  let turnStartBucket = state.sessionId;
   while (true) {
     attempt++;
     const controller = new AbortController();
@@ -1715,6 +1738,23 @@ async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatTo
     state.inFlightController = null;
     setSendButtonMode('send');
     updateRewindButtons();
+
+    // Bug fix — re-home chat orphaned by a mid-turn session switch. When a
+    // conversation starts in the global bucket (no session open) and the model
+    // then creates a session — directly via createSession or indirectly via a
+    // runAndSave auto-create — every message of this turn was stamped with the
+    // starting bucket (chatLoop captures sessionId once at turn start). Without
+    // this, the lead-up turns stay under '__global__' and disappear from the
+    // session when it is reopened. Only fires on a global → fresh-session move.
+    if (turnStartBucket === GLOBAL_CHAT_BUCKET && state.sessionId !== turnStartBucket) {
+      const moved = await migrateChatBucket(turnStartBucket, state.sessionId);
+      if (moved) {
+        await loadHistoryForCurrentSession();
+        renderTranscript();
+        renderCostMeter();
+      }
+      turnStartBucket = state.sessionId;
+    }
 
     // Surface a sticky completion banner so the user knows the turn
     // actually ended and why — better than a silent hideProgress that

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -4,7 +4,7 @@
 // ai/* modules; this file is mostly DOM wiring.
 
 import { runTurn, totalCost, totalTokensEstimate, estimateCachedPrefixTokens } from '../ai/chatLoop';
-import { listMessages, GLOBAL_CHAT_BUCKET, putMessages, deleteMessages, getKey, clearChat } from '../ai/db';
+import { listMessages, GLOBAL_CHAT_BUCKET, putMessages, deleteMessages, getKey, clearChat, mergeChatBucket } from '../ai/db';
 import { proposeCompaction } from '../ai/compaction';
 import { captureIsoViews, fileToImageSource } from '../ai/images';
 import { loadSettings, saveSettings, setAnthropicModel, setToggles, ANTHROPIC_MODEL_OPTIONS, MAX_ITERATIONS_OPTIONS, MAX_SPEND_OPTIONS, type AiSettings } from '../ai/settings';
@@ -235,25 +235,6 @@ function hideDrawer(): void {
 async function loadHistoryForCurrentSession(): Promise<void> {
   state.history = await listMessages(state.sessionId);
   updateRewindButtons();
-}
-
-/** Re-home every chat message persisted under `from` into session `to`,
- *  preserving order (seq is untouched; the store is keyed by message id, so a
- *  re-`put` just moves the sessionId index entry). Used after the model spins
- *  up a session mid-conversation: the lead-up chat lives in the global bucket
- *  and would otherwise be orphaned there — looking "lost" when the session is
- *  later reopened. Skips the move when `to` already has chat so two
- *  conversations are never merged (e.g. the model opened a pre-existing
- *  session). Returns true when messages were actually moved. */
-async function migrateChatBucket(from: string, to: string): Promise<boolean> {
-  if (from === to) return false;
-  const existing = await listMessages(to);
-  if (existing.length > 0) return false;
-  const messages = await listMessages(from);
-  if (messages.length === 0) return false;
-  for (const m of messages) m.sessionId = to;
-  await putMessages(messages);
-  return true;
 }
 
 // === DOM construction ===
@@ -1758,16 +1739,17 @@ async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatTo
     setSendButtonMode('send');
     updateRewindButtons();
 
-    // Bug fix — re-home chat orphaned by a mid-turn session switch. When a
-    // conversation starts in the global bucket (no session open) and the model
-    // then creates a session — directly via createSession or indirectly via a
-    // runAndSave auto-create — every message of this turn was stamped with the
-    // starting bucket (chatLoop captures sessionId once at turn start). Without
-    // this, the lead-up turns stay under '__global__' and disappear from the
-    // session when it is reopened. Only fires on a global → fresh-session move.
-    if (turnStartBucket === GLOBAL_CHAT_BUCKET && state.sessionId !== turnStartBucket) {
-      const moved = await migrateChatBucket(turnStartBucket, state.sessionId);
-      if (moved) {
+    // Bug fix — reunite a conversation split by a mid-turn session switch.
+    // chatLoop stamps every message of a turn with the session active when the
+    // turn began, so when the model creates or switches sessions mid-turn (via
+    // createSession, or a runAndSave auto-create), the lead-up turns stay under
+    // the old bucket — the global bucket OR an earlier real session — and
+    // vanish from the new session on reload. Fold them forward into the session
+    // the user landed on. Restricted to a fresh target (onlyIfTargetEmpty) so
+    // two distinct conversations are never auto-merged.
+    if (state.sessionId !== turnStartBucket) {
+      const moved = await mergeChatBucket(turnStartBucket, state.sessionId, { onlyIfTargetEmpty: true });
+      if (moved > 0) {
         await loadHistoryForCurrentSession();
         renderTranscript();
         renderCostMeter();

--- a/src/ui/exportOptionsDialog.ts
+++ b/src/ui/exportOptionsDialog.ts
@@ -38,6 +38,12 @@ const OPTIONS: OptionDef[] = [
     description: 'Per-face color metadata (used for multi-color 3MF / OBJ exports).',
     defaultValue: true,
   },
+  {
+    key: 'includeChat',
+    label: 'Chat history',
+    description: 'The AI conversation for this session — text, tool calls, and results. Restored on import.',
+    defaultValue: true,
+  },
 ];
 
 /**

--- a/tests/chat-export.spec.ts
+++ b/tests/chat-export.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, type Page } from 'playwright/test';
+import { readFileSync } from 'fs';
+
+// Network-free coverage for the chat export feature:
+//   - the standalone "⬇ Chat" button in the AI panel header (Markdown), and
+//   - chat embedded in / restored from a `.partwright.json` session export.
+// Chat is seeded straight into IndexedDB so we never need a live AI provider.
+
+const EXPORT_BTN = 'button[title^="Export this conversation"]';
+
+/** Insert three representative chat rows (text, a tool call, a tool result)
+ *  into the app's `aiChats` store under the given session id. */
+async function seedChat(page: Page, sessionId: string): Promise<void> {
+  await page.evaluate(async (sid) => {
+    const db: IDBDatabase = await new Promise((res, rej) => {
+      const r = indexedDB.open('partwright');
+      r.onsuccess = () => res(r.result);
+      r.onerror = () => rej(r.error);
+    });
+    const tx = db.transaction('aiChats', 'readwrite');
+    const store = tx.objectStore('aiChats');
+    const now = Date.now();
+    store.put({ id: 'seed-1', sessionId: sid, role: 'user', blocks: [{ type: 'text', text: 'Design a widget bracket' }], createdAt: now, seq: 0 });
+    store.put({ id: 'seed-2', sessionId: sid, role: 'assistant', blocks: [{ type: 'text', text: 'Sure, building it now.' }], toolCalls: [{ id: 't1', name: 'runAndSave', input: { code: 'return Manifold.cube([10,10,10])', label: 'v1' } }], createdAt: now, seq: 1 });
+    store.put({ id: 'seed-3', sessionId: sid, role: 'user', blocks: [], toolResults: [{ toolUseId: 't1', content: '{"saved":true}' }], createdAt: now, seq: 2 });
+    await new Promise<void>((res, rej) => { tx.oncomplete = () => res(); tx.onerror = () => rej(tx.error); });
+    db.close();
+  }, sessionId);
+}
+
+async function createSession(page: Page, name: string): Promise<string> {
+  await page.waitForFunction(() => !!(window as unknown as { partwright?: { createSession?: unknown } }).partwright?.createSession);
+  return page.evaluate(async (n) => {
+    const w = window as unknown as { partwright: { createSession: (name: string) => Promise<{ id: string }> } };
+    return (await w.partwright.createSession(n)).id;
+  }, name);
+}
+
+test.describe('Chat export', () => {
+  test('Export button on an empty chat warns and downloads nothing', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#ai-panel');
+    await page.click('#btn-ai');
+    const panel = page.locator('#ai-panel');
+
+    let downloaded = false;
+    page.on('download', () => { downloaded = true; });
+
+    await panel.locator(EXPORT_BTN).dispatchEvent('click');
+    await expect(panel).toContainText('Nothing to export');
+    expect(downloaded).toBe(false);
+  });
+
+  test('Export button downloads a Markdown transcript of the conversation', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#ai-panel');
+    const id = await createSession(page, 'Export Test');
+    await seedChat(page, id);
+
+    await page.goto(`/editor?session=${id}&view=ai`);
+    await page.waitForSelector('#ai-panel');
+    await page.click('#btn-ai');
+    const panel = page.locator('#ai-panel');
+    await expect(panel).toContainText('Design a widget bracket');
+
+    const downloadPromise = page.waitForEvent('download');
+    await panel.locator(EXPORT_BTN).dispatchEvent('click');
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/\.md$/);
+    const path = await download.path();
+    const content = readFileSync(path, 'utf8');
+    expect(content).toContain('# Chat — Export Test');
+    expect(content).toContain('Design a widget bracket');
+    expect(content).toContain('Sure, building it now.');
+    expect(content).toContain('runAndSave');
+  });
+
+  test('session export embeds chat and import restores it under the new session', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#ai-panel');
+    const id = await createSession(page, 'Roundtrip');
+    await seedChat(page, id);
+
+    // Exported payload carries the chat with volatile fields stripped.
+    const exported = await page.evaluate(async (sid) => {
+      const w = window as unknown as { partwright: { exportSessionData: (id: string) => Promise<{ data: unknown }> } };
+      return (await w.partwright.exportSessionData(sid)).data as {
+        partwright: string;
+        chat?: { id?: string; sessionId?: string; blocks: { type: string; text?: string }[] }[];
+      };
+    }, id);
+    expect(exported.partwright).toBe('1.6');
+    expect(exported.chat?.length).toBe(3);
+    expect(exported.chat?.[0].blocks[0].text).toBe('Design a widget bracket');
+    expect(exported.chat?.[0].id).toBeUndefined();
+    expect(exported.chat?.[0].sessionId).toBeUndefined();
+
+    // Import mints a new session and re-homes the chat into it.
+    const newId = await page.evaluate(async (payload) => {
+      const w = window as unknown as { partwright: { importSession: (d: unknown) => Promise<{ id: string }> } };
+      return (await w.partwright.importSession(payload)).id;
+    }, exported);
+    expect(typeof newId).toBe('string');
+    expect(newId).not.toBe(id);
+
+    const restored = await page.evaluate(async (sid) => {
+      const db: IDBDatabase = await new Promise((res, rej) => {
+        const r = indexedDB.open('partwright');
+        r.onsuccess = () => res(r.result);
+        r.onerror = () => rej(r.error);
+      });
+      const tx = db.transaction('aiChats', 'readonly');
+      const idx = tx.objectStore('aiChats').index('sessionId');
+      const rows: { id: string; sessionId: string; seq: number }[] = await new Promise((res, rej) => {
+        const r = idx.getAll(IDBKeyRange.only(sid));
+        r.onsuccess = () => res(r.result);
+        r.onerror = () => rej(r.error);
+      });
+      db.close();
+      return rows;
+    }, newId);
+
+    expect(restored.length).toBe(3);
+    expect(restored.every(m => m.sessionId === newId)).toBe(true);
+    // Fresh ids minted on import — originals must not be reused (would clobber).
+    expect(restored.some(m => m.id === 'seed-1')).toBe(false);
+  });
+});

--- a/tests/chat-export.spec.ts
+++ b/tests/chat-export.spec.ts
@@ -127,3 +127,69 @@ test.describe('Chat export', () => {
     expect(restored.some(m => m.id === 'seed-1')).toBe(false);
   });
 });
+
+// Reproduces the reported bug: one continuous conversation persisted across two
+// real sessions (the lead-up turns stranded under an earlier session when the
+// model created a new one mid-turn), and the recovery that reunites them.
+async function seedSplit(page: Page, fromId: string, toId: string): Promise<void> {
+  await page.evaluate(async ([A, B]) => {
+    const db: IDBDatabase = await new Promise((res, rej) => {
+      const r = indexedDB.open('partwright');
+      r.onsuccess = () => res(r.result);
+      r.onerror = () => rej(r.error);
+    });
+    const t0 = 1_000_000;
+    const tx = db.transaction('aiChats', 'readwrite');
+    const os = tx.objectStore('aiChats');
+    // First half lives under session A (earlier in time, seq 0..1).
+    os.put({ id: 'a-0', sessionId: A, role: 'user', blocks: [{ type: 'text', text: 'first half one' }], createdAt: t0, seq: 0 });
+    os.put({ id: 'a-1', sessionId: A, role: 'assistant', blocks: [{ type: 'text', text: 'first half two' }], createdAt: t0 + 1000, seq: 1 });
+    // Second half under session B (later, seq 2..3) — the URL/landing session.
+    os.put({ id: 'b-0', sessionId: B, role: 'user', blocks: [{ type: 'text', text: 'second half one' }], createdAt: t0 + 10000, seq: 2 });
+    os.put({ id: 'b-1', sessionId: B, role: 'assistant', blocks: [{ type: 'text', text: 'second half two' }], createdAt: t0 + 11000, seq: 3 });
+    await new Promise<void>((res, rej) => { tx.oncomplete = () => res(); tx.onerror = () => rej(tx.error); });
+    db.close();
+  }, [fromId, toId]);
+}
+
+test.describe('Chat history recovery', () => {
+  test('mergeChatHistory reunites a conversation split across two sessions', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#ai-panel');
+    const a = await createSession(page, 'First half');
+    const b = await createSession(page, 'Second half');
+    await seedSplit(page, a, b);
+
+    const res = await page.evaluate(async ([from, to]) => {
+      const w = window as unknown as { partwright: { mergeChatHistory: (f: string, t: string) => Promise<{ moved?: number; error?: string }> } };
+      return w.partwright.mergeChatHistory(from, to);
+    }, [a, b]);
+    expect(res.error).toBeUndefined();
+    expect(res.moved).toBe(2);
+
+    const rows = await page.evaluate(async ([A, B]) => {
+      const db: IDBDatabase = await new Promise((res2, rej) => {
+        const r = indexedDB.open('partwright');
+        r.onsuccess = () => res2(r.result);
+        r.onerror = () => rej(r.error);
+      });
+      const getAll = (sid: string): Promise<{ id: string; sessionId: string; seq: number; createdAt: number }[]> =>
+        new Promise((res2, rej) => {
+          const r = db.transaction('aiChats', 'readonly').objectStore('aiChats').index('sessionId').getAll(IDBKeyRange.only(sid));
+          r.onsuccess = () => res2(r.result);
+          r.onerror = () => rej(r.error);
+        });
+      const out = { a: await getAll(A), b: await getAll(B) };
+      db.close();
+      return out;
+    }, [a, b]);
+
+    // Source emptied, everything reunited under the target, contiguous + ordered.
+    expect(rows.a.length).toBe(0);
+    expect(rows.b.length).toBe(4);
+    const ordered = rows.b.sort((x, y) => x.seq - y.seq);
+    expect(ordered.map(m => m.seq)).toEqual([0, 1, 2, 3]);
+    expect(ordered.map(m => m.id)).toEqual(['a-0', 'a-1', 'b-0', 'b-1']);
+    expect(ordered.every(m => m.sessionId === b)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

### 1. Bug fix — chat history "lost" for the first half of a conversation

**Root cause:** chat is bucketed by `sessionId`, and `chatLoop.runTurn` captures the `sessionId` **once** at turn start (`src/ai/chatLoop.ts:103`), stamping it on every message of that turn. When the active session changes **mid-conversation** — the model creating a session via `createSession`, or a `runAndSave` auto-create, or branching to a new session for a variant — the lead-up turns keep the *old* bucket. During the live session the in-memory transcript still shows everything, so nothing looks wrong; but a **refresh** re-reads IndexedDB by the current session id and the mis-filed half simply isn't returned. That's the "lost the first half" symptom.

Confirmed against a real split session: one continuous conversation (seq `0..9` then `10..21`) persisted across **two real sessions** — not just the `__global__` pre-session bucket.

**Fix:** after each turn, if the active session changed, fold the prior bucket's messages forward into the session the user landed on (`mergeChatBucket` in `src/ai/db.ts`, re-sequenced chronologically so order is stable and seq can't collide). Restricted to a *fresh* target so two distinct conversations are never auto-merged. Covers both `__global__ → session` and `session → session` splits.

**Recovery:** `window.partwright.mergeChatHistory(fromSessionId, toSessionId)` reunites conversations that were already split before this fix shipped.

### 2. Feature — export the chat

- Standalone **"⬇ Chat"** button in the AI panel header → downloads the conversation as a Markdown transcript.
- **"Chat history"** toggle on the session JSON export → embeds chat in `.partwright.json` (schema 1.5 → 1.6) and restores it on import (re-keyed to the new session).

## Test plan

- [x] `npm run build` passes; full Playwright suite green (54 tests)
- [x] `tests/chat-export.spec.ts` (network-free):
  - [x] Export button: empty-state guard + Markdown download
  - [x] Session export embeds chat and import restores it under a new session
  - [x] **`mergeChatHistory` reunites a conversation split across two sessions** (mirrors the reported bug: seq `0..1` under session A + `2..3` under session B → reunited, source emptied, contiguous + ordered)
- [ ] The automatic mid-turn reunite needs a live AI provider, so it isn't in the network-free suite — its core (`mergeChatBucket`) is covered via the recovery API test above; the turn-loop trigger is a thin caller.

https://claude.ai/code/session_01FhqS367YiCwayYYKvq3gau