### PR TITLE
feat: carry annotations on fork and surface modifyAndTest's patched code

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -519,7 +519,7 @@ If your rotated geometry looks mirrored, negate the angle. This burned 10+ minut
 
 ### Painting locks the editor — `clearColors()` to iterate
 
-Once any region exists, the editor goes read-only and `runAndSave` is rejected. To change the geometry mid-session, call `partwright.clearColors()` first, *then* run new code. To preserve a colored version while iterating, call `forkVersion(...)` instead — it loads, transforms, validates, and saves a child without touching the parent, and re-applies the parent's colors to the new geometry (pass `carryColors: false` for an uncolored child).
+Once any region exists, the editor's Run button is disabled in the UI (re-running would change the triangle indices the colors were painted against). The programmatic `runAndSave` is *not* blocked, but re-running new geometry with colors still in memory leaves them resolved against the old triangles. So to change the geometry mid-session, call `partwright.clearColors()` first, *then* run new code — or use `forkVersion(...)`, which re-resolves the parent's colors onto the new geometry by descriptor (pass `carryColors: false` for an uncolored child).
 
 ### Verify before you commit
 
@@ -674,8 +674,8 @@ const r = await partwright.copyColorsFromVersion({ index: 7 }); // the painted v
 // r.dropped = [names] whose descriptor no longer matches — repaint those
 ```
 
-This is in-memory like any paint op — call `runAndSave` or `saveVersion` afterward to persist. (You
-don't need it after `forkVersion`, which already carries colors.)
+This is in-memory like any paint op — your next `runAndSave` serializes the current regions, so they
+persist with it. (You don't need this after `forkVersion`, which already carries colors.)
 
 ### Modify and test
 
@@ -686,10 +686,18 @@ const r = await partwright.modifyAndTest(
   { isManifold: true, maxComponents: 1 }
 );
 // r.modifiedCode = the transformed code string
+// r.codeDiff     = { changed, added, removed, diff } — confirm the tweak landed.
+//                  changed:false means your transform matched nothing (a no-op);
+//                  the stats below would then describe the UNCHANGED code.
 // r.stats        = geometry stats of the modified code
 // r.passed       = true/false (only if assertions given)
 // r.failures     = [...] (only if failed)
 ```
+
+> Prefer the AI tool's `find`/`replace` (or `patches`) form over a bare `code => code.replace(...)`
+> transform: a string `replace` whose needle is absent returns the code **unchanged with no error**,
+> so the tweak silently no-ops. The `find`/`replace` form is rejected when the needle doesn't match
+> exactly once. Either way, check `codeDiff.changed` before trusting the result.
 
 ### Multi-query current geometry
 

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -614,7 +614,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'copyColorsFromVersion',
-    description: 'Transfer the color regions from a prior version onto the CURRENT geometry in one call — instead of repainting region by region after a geometry change. Each region\'s geometry-relative descriptor (box / slab / byLabel / coplanar / connectedFromSeed) is re-resolved against the current mesh; regions that no longer resolve (a dropped label, or raw-triangle regions on changed topology) are skipped and listed in `dropped`. Replaces any colors currently on the model. In-memory like any paint op — call runAndSave or saveVersion afterward to persist. (forkVersion already carries colors automatically; reach for this after a runAndSave when you rebuilt geometry that matches an earlier painted version.) Returns {source, carried, dropped}.',
+    description: 'Transfer the color regions from a prior version onto the CURRENT geometry in one call — instead of repainting region by region after a geometry change. Each region\'s geometry-relative descriptor (box / slab / byLabel / coplanar / connectedFromSeed) is re-resolved against the current mesh; regions that no longer resolve (a dropped label, or raw-triangle regions on changed topology) are skipped and listed in `dropped`. Replaces any colors currently on the model. In-memory like any paint op — your next runAndSave serializes the current regions, so they persist with it. (forkVersion already carries colors automatically; reach for this after a runAndSave when you rebuilt geometry that matches an earlier painted version.) Returns {source, carried, dropped}.',
     input_schema: {
       type: 'object',
       properties: {
@@ -674,7 +674,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'modifyAndTest',
-    description: 'Apply string substitution(s) to the current editor code, run the result, and return stats — WITHOUT saving a version or changing the editor. Use to test a tweak before committing. Provide either a single `find`/`replace` pair or a `patches` array for multiple simultaneous substitutions. Returns {modifiedCode, stats, passed?, failures?}.',
+    description: 'Apply string substitution(s) to the current editor code, run the result, and return stats — WITHOUT saving a version or changing the editor. Use to test a tweak before committing. Provide either a single `find`/`replace` pair or a `patches` array for multiple simultaneous substitutions; each `find` must match exactly once or the call errors (no silent no-op). Returns {modifiedCode, codeDiff: {changed, added, removed, diff}, stats, passed?, failures?} — check codeDiff.changed to confirm the tweak actually altered the code.',
     input_schema: {
       type: 'object',
       properties: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2459,8 +2459,7 @@ async function main() {
 
       const parent = await peekVersion(parsed.value);
       if (!parent) {
-        const kind = typeof target === 'number' ? 'index' : 'id';
-        return { error: `No version found with ${kind} "${target}" in the active session. Use listVersions() to see valid ${kind}s.` };
+        return { error: `No version found with ${parsed.kind} "${parsed.value}" in the active session. Use listVersions() to see valid ${parsed.kind}s.` };
       }
 
       let newCode: string;
@@ -2506,6 +2505,14 @@ async function main() {
         clearRegions();
       }
 
+      // Carry the PARENT's annotations onto the fork. saveVersion snapshots
+      // the in-memory annotation store, which still holds the previously
+      // active version's strokes — without this the fork would silently
+      // inherit the wrong annotations (or drop them). Mirrors how
+      // loadVersion swaps annotations to the version it loads.
+      applyVersionAnnotations(parent);
+      const annotationsCarried = (parent.annotations?.length ?? 0) > 0;
+
       const thumbnail = await captureThumbnail();
       const version = await saveVersion(newCode, enrichGeometryDataWithColors(getGeometryDataObj()), thumbnail, label, assertions?.notes);
 
@@ -2523,6 +2530,7 @@ async function main() {
         diff,
         codeDiff: computeCodeDiff(parent.code, newCode),
         ...(parentColors.length > 0 ? { colors: colorReport } : {}),
+        ...(annotationsCarried ? { annotationsCarried: parent.annotations?.length ?? 0 } : {}),
         galleryUrl: getGalleryUrl(),
         ...(forkWarnings.length > 0 ? { warnings: forkWarnings } : {}),
       };
@@ -2561,8 +2569,8 @@ async function main() {
         carried: report.carried,
         dropped: report.dropped,
         note: report.dropped.length > 0
-          ? 'Some regions did not resolve on the current geometry and were skipped — repaint those, or check the labels/topology still match. Call runAndSave or saveVersion to persist the rest.'
-          : 'All regions transferred. Call runAndSave or saveVersion to persist.',
+          ? 'Some regions did not resolve on the current geometry and were skipped — repaint those, or check the labels/topology still match. The rest are in-memory; your next runAndSave will persist them.'
+          : 'All regions transferred. They are in-memory like any paint op; your next runAndSave will persist them.',
       };
     },
 
@@ -2924,20 +2932,26 @@ async function main() {
         return { error: `Patch function failed: ${e instanceof Error ? e.message : String(e)}`, stats: null };
       }
 
+      // Surface what the patch actually changed. A transform that matched
+      // nothing returns the code unchanged (codeDiff.changed === false) —
+      // the cheapest way to catch a no-op tweak before reading stats that
+      // look identical for the wrong reason.
+      const codeDiff = computeCodeDiff(currentCode, modifiedCode);
+
       const { geometryData, manifold } = await executeIsolated(modifiedCode);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       try { (manifold as any)?.delete?.(); } catch { /* ignore */ }
 
       if (geometryData.status === 'error') {
-        return { error: geometryData.error, stats: geometryData, ...(assertions ? { passed: false, failures: [geometryData.error as string] } : {}) };
+        return { error: geometryData.error, modifiedCode, codeDiff, stats: geometryData, ...(assertions ? { passed: false, failures: [geometryData.error as string] } : {}) };
       }
 
       if (assertions) {
         const failures = checkAssertions(geometryData, assertions);
-        return { stats: geometryData, passed: failures.length === 0, failures: failures.length > 0 ? failures : undefined };
+        return { modifiedCode, codeDiff, stats: geometryData, passed: failures.length === 0, failures: failures.length > 0 ? failures : undefined };
       }
 
-      return { stats: geometryData };
+      return { modifiedCode, codeDiff, stats: geometryData };
     },
 
     /** Query multiple properties of the current geometry in a single call. Avoids multiple round-trips. */
@@ -4745,7 +4759,7 @@ async function main() {
         'runIsolated':     { signature: 'await runIsolated(code) -- Test without side effects -> {geometryData, thumbnail}', docs: '/ai.md#testing-without-side-effects' },
         'runAndAssert':    { signature: 'await runAndAssert(code, assertions) -- Validate geometry -> {passed, failures?, stats}', docs: '/ai.md#assertions----structured-validation' },
         'runAndExplain':   { signature: 'await runAndExplain(code) -- Debug disconnected components -> {stats, components[], hints[]}', docs: '/ai.md#debugging-disconnected-components' },
-        'modifyAndTest':   { signature: 'await modifyAndTest(patchFn, assertions?) -- Modify + test without committing', docs: '/ai.md#modify-and-test' },
+        'modifyAndTest':   { signature: 'await modifyAndTest(patchFn, assertions?) -- Modify + test without committing -> {modifiedCode, codeDiff, stats, passed?}', docs: '/ai.md#modify-and-test' },
         'query':           { signature: 'query({sliceAt?, decompose?, boundingBox?}) -- Multi-query current geometry', docs: '/ai.md#multi-query-current-geometry' },
         // Sessions
         'createSession':   { signature: 'await createSession(name?) -- Create session -> {id, url, galleryUrl}', docs: '/ai.md#console-api--windowpartwright' },

--- a/tests/fork-color-carry.spec.ts
+++ b/tests/fork-color-carry.spec.ts
@@ -91,6 +91,73 @@ test.describe('forkVersion color carry-over + codeDiff', () => {
     expect(fork.codeDiff.changed).toBe(false);
     expect(fork.codeDiff.diff).toBeNull();
   });
+
+  test('forked colors persist to the saved version and survive a reload', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const result = await page.evaluate(async (code) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('fork-persist-reload');
+      const v1 = await pw.runAndSave(code, 'base');
+      pw.paintByLabel({ label: 'body', color: [0.8, 0.2, 0.2] });
+      const painted = await pw.saveVersion('painted');
+      const fork = await pw.forkVersion(
+        { index: painted.index },
+        (c: string) => c.replace('size = 20', 'size = 28'),
+        'bigger',
+      );
+      // Navigate away, then reload the fork from storage — proves the colors
+      // were written to the saved geometryData blob, not just left in memory.
+      await pw.loadVersion({ index: v1.version.index });
+      await pw.loadVersion({ index: fork.version.index });
+      return { regionsAfterReload: pw.listRegions() };
+    }, LABELLED_CUBE);
+
+    expect(result.regionsAfterReload).toHaveLength(1);
+    expect(result.regionsAfterReload[0].triangles).toBeGreaterThan(0);
+  });
+});
+
+test.describe('modifyAndTest return', () => {
+  test('returns modifiedCode and a codeDiff that flags a real change', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const r = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('modify-and-test-return');
+      await pw.runAndSave('const { Manifold } = api; const h = 10; return Manifold.cube([5, 5, h], true);', 'base');
+      return pw.modifyAndTest((c: string) => c.replace('h = 10', 'h = 20'));
+    });
+
+    expect(r.error).toBeUndefined();
+    expect(typeof r.modifiedCode).toBe('string');
+    expect(r.modifiedCode).toContain('h = 20');
+    expect(r.codeDiff.changed).toBe(true);
+    expect(r.codeDiff.added).toBeGreaterThan(0);
+    expect(r.stats).toBeTruthy();
+  });
+
+  test('codeDiff.changed is false when the transform matches nothing', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const r = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('modify-and-test-noop');
+      await pw.runAndSave('const { Manifold } = api; return Manifold.cube([5, 5, 10], true);', 'base');
+      // A console transformFn that matches nothing returns the code unchanged;
+      // codeDiff is what makes that visible (the stats would look "fine").
+      return pw.modifyAndTest((c: string) => c.replace('DOES_NOT_EXIST', 'x'));
+    });
+
+    expect(r.codeDiff.changed).toBe(false);
+    expect(typeof r.modifiedCode).toBe('string');
+  });
 });
 
 test.describe('copyColorsFromVersion', () => {


### PR DESCRIPTION
## Summary

Round-2 follow-ups from a review of the merged AI-session-feedback work (#166). Two subagents double-checked that PR and hunted for the *same class* of issue ("does the operation actually do what it reports?"). The core changes verified clean; this PR closes the gaps they surfaced — biased, per request, toward improving the API for the agent rather than just fixing docs where the two diverged.

- **`forkVersion` carries annotations.** `saveVersion` auto-snapshots the in-memory annotation store, so a fork previously inherited the *previously-active* version's annotations (the wrong ones) and never the parent's — the annotation analogue of the color carry-over gap we just closed. Now it loads the parent's annotations before saving (mirrors `loadVersion`'s `applyVersionAnnotations`) and reports `annotationsCarried`.
- **`modifyAndTest` returns `modifiedCode` + `codeDiff`.** Both were documented (`ai.md`, tool description) but never returned — `ai.md` even told the agent to call `runAndSave(modifiedCode, …)` using a variable that didn't exist. Code now matches the (more useful) docs; `codeDiff.changed:false` makes a no-op transform visible — the same silent trap the patch guard closed for the tool's `find/replace` form.
- **Fix a pre-existing `forkVersion` error** that rendered `"[object Object]"` and always said `"id"` (the target is always an object, so the `typeof === 'number'` branch was dead).
- **Doc corrections:** the editor lock is UI-only, so the "`runAndSave` is rejected when colors exist" claim was false; a bare `code => code.replace(...)` transformFn silently no-ops (warned); and `copyColorsFromVersion`'s persistence note pointed at `saveVersion`, which isn't an agent tool (the next `runAndSave` serializes current regions).

### Decisions worth noting
- I did **not** gate `runAndSave` when colors exist (broad blast radius, and it would break the "next runAndSave persists current regions" path). Corrected the docs to describe actual behavior instead.
- No e2e test for annotation carry-over: there's no programmatic annotation-add API to build the fixture cleanly. The change mirrors the `applyVersionAnnotations` path already used in 5 load/navigate sites.

## Test plan

- [x] `fork-color-carry.spec.ts` — added: forked colors survive a reload (directly covers the #166 persistence fix the verification agent flagged as untested), and `modifyAndTest` returns `modifiedCode`/`codeDiff` incl. the no-op case. 8 tests pass.
- [x] `patch.spec.ts` (8) still green.
- [x] Regression: `paint-batch-and-lifecycle`, `labelled-construction`, `smoke` (21) pass — no regressions.
- [x] `npm run build` clean (tsc + vite).

https://claude.ai/code/session_01JSLkoyGoeAYkGrepuQfkDY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSLkoyGoeAYkGrepuQfkDY)_