### PR TITLE
feat: add OS-aware undo/redo/save keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ Manifold.cube([10, 10, 10], true)
   .translate([0, 0, 5]);
 ```
 
+## Keyboard shortcuts
+
+Shortcuts adapt to your OS — use **⌘** on macOS and **Ctrl** elsewhere.
+
+| Action | macOS | Windows / Linux | What it does |
+|--------|-------|-----------------|--------------|
+| Undo | ⌘ Z | Ctrl + Z | Undo the last paint region or annotation stroke (whichever tool is active). In the code editor, its built-in undo applies. |
+| Redo | ⇧ ⌘ Z | Ctrl + Shift + Z, or Ctrl + Y | Redo the last undone paint region or annotation stroke. |
+| Save version | ⌘ S | Ctrl + S | Snapshot the current code, geometry, paint, and annotations as a new version. |
+| Format code | ⇧ ⌥ F | Shift + Alt + F | Reformat the editor contents. |
+| Save notes | ⌘ Enter | Ctrl + Enter | Save the Notes textarea (when focused). |
+| Close / cancel | Escape | Escape | Close the open dropdown, modal, paint/annotate panel, cross-section overlay, or exit the tour. |
+
+Undo/redo route to whatever you're working on: paint regions while painting, annotation strokes while annotating, and the code editor's own history while editing code. Save works from anywhere.
+
 ## A note on AI costs & risk
 
 Partwright is an experiment — a passion project exploring what happens when you put generative AI inside a browser-based 3D modeling tool. I've spent my own money building it; I'm not trying to make money from it, and I hope it brings others the same joy and curiosity it's brought me.

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,8 @@ import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './ren
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, getAutoFormat, setAutoFormat } from './editor/codeEditor';
 import { createLayout, type TabName } from './ui/layout';
 import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState } from './ui/toolbar';
+import { installKeyboardShortcuts } from './ui/keyboardShortcuts';
+import { showToast } from './ui/toast';
 import { initAiPanel, setActiveSession as setAiActiveSession, toggleAiPanel } from './ui/aiPanel';
 import { getKey as getAiKey, mergeChatBucket } from './ai/db';
 import { loadSettings as loadAiSettings } from './ai/settings';
@@ -508,6 +510,28 @@ function enrichGeometryDataWithColors(geoData: Record<string, unknown> | null): 
     geoData.colorRegions = serializeRegions();
   }
   return geoData;
+}
+
+/** Snapshot the current editor code + geometry + paint regions + annotations
+ *  as a new version in the active session. Shared by the
+ *  window.partwright.saveVersion() API and the mod+S keyboard shortcut.
+ *  Returns `{ id, index, label }` on success, `{ error }` when no session is
+ *  active, or `{ skipped }` when nothing changed since the current version. */
+async function saveCurrentVersion(label?: string): Promise<
+  | { error: string }
+  | { id: string; index: number; label: string }
+  | { skipped: true; reason: string }
+> {
+  if (!getState().session) {
+    return { error: 'No active session. Call createSession() or openSession(id) first.' };
+  }
+  const thumbnail = await captureThumbnail();
+  const version = await saveVersion(getValue(), enrichGeometryDataWithColors(getGeometryDataObj()), thumbnail, label);
+  if (version) return { id: version.id, index: version.index, label: version.label };
+  return {
+    skipped: true as const,
+    reason: 'No changes since the current version (code, annotations, and color regions all match). Add a new region, edit code, or pass a different label to force a save.',
+  };
 }
 
 // ===========================================================================
@@ -1054,6 +1078,20 @@ async function main() {
       e.preventDefault();
       formatCode();
     }
+  });
+
+  // Global undo / redo / save shortcuts (OS-aware, focus/tool-routed).
+  installKeyboardShortcuts({
+    onSave: async () => {
+      const result = await saveCurrentVersion();
+      if ('error' in result) {
+        showToast(result.error, { variant: 'warn' });
+      } else if ('skipped' in result) {
+        showToast('No changes to save', { variant: 'neutral' });
+      } else {
+        showToast(`Saved v${result.index}${result.label ? ` — ${result.label}` : ''}`, { variant: 'success' });
+      }
+    },
   });
 
   // Init views panel
@@ -1618,12 +1656,7 @@ async function main() {
       agentUIWarningShown = true;
       const msg = 'Detected UI-driven input. This app expects programmatic control from AI agents. Use window.partwright.runAndSave() -- see /llms.txt';
       console.warn(msg);
-      // Show a non-blocking toast
-      const toast = document.createElement('div');
-      toast.textContent = msg;
-      toast.style.cssText = 'position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:#451a03;color:#fbbf24;padding:8px 16px;border-radius:6px;font-size:13px;z-index:9999;max-width:600px;text-align:center;pointer-events:none;';
-      document.body.appendChild(toast);
-      setTimeout(() => toast.remove(), 8000);
+      showToast(msg, { variant: 'warn', durationMs: 8000 });
     };
     // Listen on the editor and viewport containers
     editorUI.addEventListener('keydown', warnAgentUI, { once: true });
@@ -2316,16 +2349,7 @@ async function main() {
      *  the current version (code, annotations, and color regions all match). */
     async saveVersion(label?: string) {
       assertString(label, 'saveVersion(label)', { optional: true });
-      if (!getState().session) {
-        return { error: 'No active session. Call createSession() or openSession(id) first.' };
-      }
-      const thumbnail = await captureThumbnail();
-      const version = await saveVersion(getValue(), enrichGeometryDataWithColors(getGeometryDataObj()), thumbnail, label);
-      if (version) return { id: version.id, index: version.index, label: version.label };
-      return {
-        skipped: true,
-        reason: 'No changes since the current version (code, annotations, and color regions all match). Add a new region, edit code, or pass a different label to force a save.',
-      };
+      return saveCurrentVersion(label);
     },
 
     /** List all versions in the current session */

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -1,5 +1,7 @@
 // Help page — explains what Partwright is and how to use it
 
+import { getShortcutDocs, IS_MAC, MOD_LABEL, SHIFT_LABEL, ALT_LABEL } from './shortcutDefs';
+
 export interface HelpCallbacks {
   onBack: () => void;
   onStartTour: () => void;
@@ -231,14 +233,26 @@ export function createHelpPage(
     {
       id: 'shortcuts',
       heading: 'Keyboard shortcuts',
-      body:
-        '<ul class="list-disc list-inside mt-2 space-y-1 text-zinc-400">' +
-        '<li><strong class="text-zinc-300">Escape</strong> — Close the open dropdown, modal, paint or annotate panel, cross-section overlay, or exit the guided tour.</li>' +
-        '<li><strong class="text-zinc-300">Enter</strong> / <strong class="text-zinc-300">→</strong> — Next step during the guided tour.</li>' +
-        '<li><strong class="text-zinc-300">←</strong> — Previous step during the guided tour.</li>' +
-        '<li><strong class="text-zinc-300">Ctrl/Cmd + Enter</strong> — Save the current notes textarea.</li>' +
-        '<li><strong class="text-zinc-300">Enter</strong> in input modals (e.g. Connect AI, Import Preview) — Confirm.</li>' +
-        '</ul>',
+      body: (() => {
+        const kbd = (keys: string) => `<strong class="text-zinc-300">${keys}</strong>`;
+        const modEnter = IS_MAC ? `${MOD_LABEL} Enter` : `${MOD_LABEL} + Enter`;
+        const formatKeys = IS_MAC ? `${SHIFT_LABEL} ${ALT_LABEL} F` : `${SHIFT_LABEL} + ${ALT_LABEL} + F`;
+        const owned = getShortcutDocs()
+          .map(s => `<li>${kbd(s.keys)} — ${s.description}</li>`)
+          .join('');
+        return (
+          '<p class="text-zinc-400">Shortcuts adapt to your operating system (⌘ on macOS, Ctrl elsewhere).</p>' +
+          '<ul class="list-disc list-inside mt-2 space-y-1 text-zinc-400">' +
+          owned +
+          `<li>${kbd(formatKeys)} — Format the code in the editor.</li>` +
+          `<li>${kbd('Escape')} — Close the open dropdown, modal, paint or annotate panel, cross-section overlay, or exit the guided tour.</li>` +
+          `<li>${kbd('Enter')} / ${kbd('→')} — Next step during the guided tour.</li>` +
+          `<li>${kbd('←')} — Previous step during the guided tour.</li>` +
+          `<li>${kbd(modEnter)} — Save the current notes textarea.</li>` +
+          `<li>${kbd('Enter')} in input modals (e.g. Connect AI, Import Preview) — Confirm.</li>` +
+          '</ul>'
+        );
+      })(),
     },
   ];
 

--- a/src/ui/keyboardShortcuts.ts
+++ b/src/ui/keyboardShortcuts.ts
@@ -1,0 +1,103 @@
+// Global keyboard shortcuts: undo / redo / save.
+//
+// Routing is focus- and tool-aware:
+//   • Save (mod+S) fires everywhere — even inside the code editor or a text
+//     field — so it can always snapshot a version (and suppress the browser's
+//     "save page" dialog).
+//   • Undo/redo (mod+Z, mod+⇧Z / Ctrl+Y) are skipped whenever a text input or
+//     the CodeMirror editor (a contentEditable) is focused, leaving their
+//     native undo/redo intact. Otherwise they route to the active tool: paint
+//     regions when painting, annotation strokes when annotating.
+//
+// The store mutators (removeLastRegion, redoLastStroke, …) fan out through the
+// regions/annotations change listeners, which re-render the mesh and refresh
+// the on-screen Undo/Redo buttons — so the keyboard path needs no extra wiring.
+
+import { IS_MAC } from './shortcutDefs';
+import {
+  removeLastRegion,
+  redoLastRegion,
+  undoClear,
+  canUndoClear,
+} from '../color/regions';
+import { isActive as isPaintActive } from '../color/paintMode';
+import { isPaintOpen } from '../color/paintUI';
+import { removeLastStroke, redoLastStroke } from '../annotations/annotations';
+import { isActive as isSelectActive } from '../annotations/selectMode';
+import { isAnnotateOpen } from '../annotations/annotateUI';
+
+export interface ShortcutHandlers {
+  /** Persist the current code/geometry/paint/annotations as a new version. */
+  onSave: () => void;
+}
+
+function isEditableTarget(el: EventTarget | null): boolean {
+  const t = el as HTMLElement | null;
+  return (
+    !!t &&
+    (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)
+  );
+}
+
+function paintContextActive(): boolean {
+  return isPaintActive() || isPaintOpen();
+}
+
+function annotateContextActive(): boolean {
+  return isAnnotateOpen() || isSelectActive();
+}
+
+/** Returns true when an undo was actually performed (so the caller can
+ *  preventDefault only when we handled it). */
+function routeUndo(): boolean {
+  if (paintContextActive()) {
+    // A Clear is the most recent paint action when its snapshot is live;
+    // restore it before falling back to popping the last region.
+    if (canUndoClear()) {
+      undoClear();
+      return true;
+    }
+    return removeLastRegion() !== null;
+  }
+  if (annotateContextActive()) {
+    return removeLastStroke() !== null;
+  }
+  return false;
+}
+
+function routeRedo(): boolean {
+  if (paintContextActive()) {
+    return redoLastRegion() !== null;
+  }
+  if (annotateContextActive()) {
+    return redoLastStroke() !== null;
+  }
+  return false;
+}
+
+export function installKeyboardShortcuts(handlers: ShortcutHandlers): void {
+  document.addEventListener('keydown', (e) => {
+    const mod = IS_MAC ? e.metaKey : e.ctrlKey;
+    if (!mod || e.altKey) return; // ignore AltGr (Ctrl+Alt) and unrelated combos
+    const key = e.key.toLowerCase();
+
+    // Save — global, regardless of focus.
+    if (key === 's' && !e.shiftKey) {
+      e.preventDefault();
+      handlers.onSave();
+      return;
+    }
+
+    // Undo/redo defer to native handling inside text fields / the code editor.
+    if (isEditableTarget(e.target)) return;
+
+    if (key === 'z' && !e.shiftKey) {
+      if (routeUndo()) e.preventDefault();
+      return;
+    }
+    // Redo: ⇧+mod+Z everywhere, plus Ctrl+Y on non-mac platforms.
+    if ((key === 'z' && e.shiftKey) || (key === 'y' && !IS_MAC)) {
+      if (routeRedo()) e.preventDefault();
+    }
+  });
+}

--- a/src/ui/shortcutDefs.ts
+++ b/src/ui/shortcutDefs.ts
@@ -1,0 +1,60 @@
+// Canonical keyboard-shortcut definitions — shared by the global handler
+// (src/ui/keyboardShortcuts.ts) and the in-app help page (src/ui/help.ts) so
+// the documented keys can never drift from the keys that actually fire.
+//
+// This module is intentionally dependency-free (no app imports) so the help
+// page can render the list without pulling in the paint/annotation runtime.
+
+/** True when running on macOS / iPadOS / iOS, where the primary modifier is ⌘. */
+export const IS_MAC = detectMac();
+
+function detectMac(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return (
+    /Mac|iPhone|iPad|iPod/i.test(navigator.platform || '') ||
+    /Mac OS X/i.test(navigator.userAgent || '')
+  );
+}
+
+/** Display label for the platform's primary modifier key. */
+export const MOD_LABEL = IS_MAC ? '⌘' : 'Ctrl'; // ⌘ / Ctrl
+/** Display label for the Shift key. */
+export const SHIFT_LABEL = IS_MAC ? '⇧' : 'Shift'; // ⇧ / Shift
+/** Display label for the Alt/Option key. */
+export const ALT_LABEL = IS_MAC ? '⌥' : 'Alt'; // ⌥ / Alt
+
+/** Join modifier/key tokens the way the host OS conventionally renders them
+ *  (macOS stacks glyphs with no separator, others use " + "). */
+function combo(...tokens: string[]): string {
+  return tokens.join(IS_MAC ? ' ' : ' + ');
+}
+
+interface ShortcutDoc {
+  /** Human-readable key combo for the current OS, e.g. "⌘ Z" or "Ctrl + Z". */
+  keys: string;
+  /** What the shortcut does, including how it routes by focus/active tool. */
+  description: string;
+}
+
+/** The shortcuts this feature owns (undo / redo / save), formatted for the
+ *  current OS. The help page renders these; the handler implements them. */
+export function getShortcutDocs(): ShortcutDoc[] {
+  return [
+    {
+      keys: combo(MOD_LABEL, 'Z'),
+      description:
+        'Undo the last paint region or annotation stroke, depending on which tool is active. When the code editor is focused it uses its own built-in undo.',
+    },
+    {
+      keys: IS_MAC
+        ? combo(SHIFT_LABEL, MOD_LABEL, 'Z')
+        : `${combo(MOD_LABEL, SHIFT_LABEL, 'Z')} or ${combo(MOD_LABEL, 'Y')}`,
+      description: 'Redo the last undone paint region or annotation stroke.',
+    },
+    {
+      keys: combo(MOD_LABEL, 'S'),
+      description:
+        'Save the current code, geometry, paint regions, and annotations as a new version in the active session.',
+    },
+  ];
+}

--- a/src/ui/toast.ts
+++ b/src/ui/toast.ts
@@ -1,0 +1,29 @@
+// Lightweight, non-blocking toast. A single transient message pinned to the
+// bottom-center of the viewport — used for save confirmations and the
+// agent-UI warning.
+
+export type ToastVariant = 'neutral' | 'success' | 'warn';
+
+const VARIANT_STYLE: Record<ToastVariant, string> = {
+  neutral: 'background:#27272a;color:#e4e4e7;', // zinc-800 / zinc-200
+  success: 'background:#052e16;color:#86efac;', // green-950 / green-300
+  warn: 'background:#451a03;color:#fbbf24;', // amber-950 / amber-400
+};
+
+export function showToast(
+  message: string,
+  opts: { variant?: ToastVariant; durationMs?: number } = {},
+): void {
+  const { variant = 'neutral', durationMs = 2200 } = opts;
+  const toast = document.createElement('div');
+  toast.textContent = message;
+  toast.setAttribute('role', 'status');
+  toast.style.cssText =
+    'position:fixed;bottom:16px;left:50%;transform:translateX(-50%);' +
+    'padding:8px 16px;border-radius:6px;font-size:13px;z-index:9999;' +
+    'max-width:600px;text-align:center;pointer-events:none;' +
+    'box-shadow:0 4px 12px rgba(0,0,0,0.4);' +
+    VARIANT_STYLE[variant];
+  document.body.appendChild(toast);
+  setTimeout(() => toast.remove(), durationMs);
+}

--- a/tests/keyboard-shortcuts.spec.ts
+++ b/tests/keyboard-shortcuts.spec.ts
@@ -1,0 +1,97 @@
+// Keyboard shortcuts: save (mod+S) and focus/tool-routed undo/redo
+// (mod+Z, mod+Shift+Z). Uses Playwright's `ControlOrMeta` modifier so the
+// same press maps to ⌘ on macOS and Ctrl elsewhere — mirroring the app's
+// own OS detection in src/ui/shortcutDefs.ts.
+//
+// `dispatchEvent('click')` opens the paint panel to dodge the first-run tour
+// backdrop that intercepts real pointer events (same trick the paint specs use).
+
+import { test, expect } from 'playwright/test';
+
+async function openEditor(page: import('playwright/test').Page) {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.run(`const { Manifold } = api; return Manifold.cube([10, 10, 10], true);`);
+  });
+}
+
+test.describe('keyboard shortcuts', () => {
+  test('mod+S saves a version and reports no-op on a clean save', async ({ page }) => {
+    await openEditor(page);
+    await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('kbd-save-test');
+      // Make the editor content dirty so the first save always commits a version.
+      pw.setCode('return api.Manifold.cube([7, 7, 7], true);');
+    });
+
+    await page.keyboard.press('ControlOrMeta+s');
+    await expect(
+      page.locator('div[role="status"]').filter({ hasText: /Saved v\d+/ }),
+    ).toBeVisible();
+
+    // Second save with no further edits is a no-op.
+    await page.keyboard.press('ControlOrMeta+s');
+    await expect(
+      page.locator('div[role="status"]').filter({ hasText: 'No changes to save' }),
+    ).toBeVisible();
+  });
+
+  test('mod+Z / mod+Shift+Z undo and redo a paint region while painting', async ({ page }) => {
+    await openEditor(page);
+    await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: {
+        paintFaces(opts: { triangleIds: number[]; color: [number, number, number]; name?: string }): { id: number };
+      } }).partwright;
+      pw.paintFaces({ triangleIds: [0, 1, 2], color: [1, 0, 0], name: 'A' });
+      pw.paintFaces({ triangleIds: [3, 4, 5], color: [0, 1, 0], name: 'B' });
+    });
+
+    // Open the paint panel so undo/redo route to paint regions.
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    const count = () => page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { listRegions(): unknown[] } }).partwright;
+      return pw.listRegions().length;
+    });
+
+    expect(await count()).toBe(2);
+
+    await page.keyboard.press('ControlOrMeta+z');
+    await expect.poll(count).toBe(1);
+
+    await page.keyboard.press('ControlOrMeta+Shift+z');
+    await expect.poll(count).toBe(2);
+  });
+
+  test('undo is not hijacked while a text input is focused', async ({ page }) => {
+    await openEditor(page);
+    await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: {
+        paintFaces(opts: { triangleIds: number[]; color: [number, number, number] }): { id: number };
+      } }).partwright;
+      pw.paintFaces({ triangleIds: [0, 1, 2], color: [1, 0, 0] });
+      pw.paintFaces({ triangleIds: [3, 4, 5], color: [0, 1, 0] });
+    });
+
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    // Focus a numeric input inside the paint panel, then press undo. The handler
+    // must defer to the field's native editing and leave paint regions intact.
+    const angleInput = page.locator('#paint-picker-panel input[type="number"][title*="Bend angle"]');
+    await angleInput.focus();
+    await page.keyboard.press('ControlOrMeta+z');
+
+    const remaining = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { listRegions(): unknown[] } }).partwright;
+      return pw.listRegions().length;
+    });
+    expect(remaining).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds global keyboard shortcuts for **undo**, **redo**, and **save**, routed by what the user is focused on / actively doing. The modifier follows the OS (`⌘` on macOS, `Ctrl` elsewhere).

| Action | macOS | Windows / Linux | Behavior |
|--------|-------|-----------------|----------|
| Undo | `⌘ Z` | `Ctrl + Z` | Undo the last **paint region** while painting, or the last **annotation stroke** while annotating. In the code editor, its native undo applies. |
| Redo | `⇧ ⌘ Z` | `Ctrl + Shift + Z` or `Ctrl + Y` | Redo the last undone paint region / annotation stroke. |
| Save version | `⌘ S` | `Ctrl + S` | Snapshot current code + geometry + paint + annotations as a new version. Works from anywhere and suppresses the browser's save dialog. Shows a toast (`Saved v3`, `No changes to save`, or `No active session`). |

### Routing
- **Save** is global — fires even inside the code editor or a text field.
- **Undo/redo** defer to native handling when a text input or the CodeMirror editor (a `contentEditable`) is focused, so typing-undo is never hijacked. Otherwise they route to the active tool: paint regions when the paint panel is open, annotation strokes when annotating.
- Undo/redo reuse the existing store mutators (`removeLastRegion`, `redoLastStroke`, …), which fan out through the regions/annotations change listeners — so the mesh re-renders and the on-screen Undo/Redo buttons update with no extra wiring.

### Implementation notes
- `src/ui/shortcutDefs.ts` — single source of truth for OS detection + key labels, shared by the handler and the help page so the docs can't drift from the keys that actually fire.
- `src/ui/keyboardShortcuts.ts` — the global `keydown` handler with focus/tool routing.
- `src/ui/toast.ts` — small reusable toast (also de-duplicates the existing inline agent-UI-warning toast in `main.ts`).
- `main.ts` — extracts a shared `saveCurrentVersion()` helper used by both the `window.partwright.saveVersion()` API and the `⌘/Ctrl + S` shortcut (no API behavior change).
- Help page (`/help`) and `README.md` document the full, OS-aware shortcut list.

### Considered but not included
`⌘/Ctrl + Enter` to **run**: auto-run is on by default (so code already re-renders as you type), and `Enter`/`Cmd+Enter` already have owners (AI chat send, notes save). Happy to add it behind those guards if wanted.

## Test plan
- [x] `npm run build` — clean (TypeScript passes)
- [x] `npm run test:e2e` — full suite green (76 passed), including new `tests/keyboard-shortcuts.spec.ts`:
  - [x] `⌘/Ctrl + S` saves a version + toast; a second clean save reports "No changes to save"
  - [x] `⌘/Ctrl + Z` / `⌘/Ctrl + Shift + Z` undo & redo a paint region while the paint panel is open
  - [x] Undo is **not** hijacked while a text input is focused (regions left intact)

https://claude.ai/code/session_01Wsh1ppp5e1DYZB3Z96iWzQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wsh1ppp5e1DYZB3Z96iWzQ)_