### PR TITLE
feat: add Ultra (1024) quality tier; make the preset drive curves

### DIFF
--- a/examples/basic_shapes.js
+++ b/examples/basic_shapes.js
@@ -3,7 +3,7 @@
 const { Manifold } = api;
 
 const box = Manifold.cube([10, 10, 10], true);
-const hole = Manifold.cylinder(6, 4, 4, 32);
+const hole = Manifold.cylinder(6, 4, 4);
 const result = box.subtract(hole);
 
 // Always return the final Manifold object

--- a/examples/boolean_demo.js
+++ b/examples/boolean_demo.js
@@ -2,16 +2,16 @@
 const { Manifold } = api;
 
 // Create base shapes
-const sphere = Manifold.sphere(6, 48);
+const sphere = Manifold.sphere(6);
 const cube = Manifold.cube([10, 10, 10], true);
 
 // Intersection: rounded cube
 const rounded = cube.intersect(sphere);
 
 // Subtract cylindrical holes along each axis
-const holeX = Manifold.cylinder(12, 2, 2, 32).rotate([0, 90, 0]).translate([-6, 0, 0]);
-const holeY = Manifold.cylinder(12, 2, 2, 32).rotate([90, 0, 0]).translate([0, -6, 0]);
-const holeZ = Manifold.cylinder(12, 2, 2, 32).translate([0, 0, -6]);
+const holeX = Manifold.cylinder(12, 2, 2).rotate([0, 90, 0]).translate([-6, 0, 0]);
+const holeY = Manifold.cylinder(12, 2, 2).rotate([90, 0, 0]).translate([0, -6, 0]);
+const holeZ = Manifold.cylinder(12, 2, 2).translate([0, 0, -6]);
 
 const result = rounded.subtract(holeX).subtract(holeY).subtract(holeZ);
 

--- a/examples/desk_organizer.js
+++ b/examples/desk_organizer.js
@@ -8,32 +8,33 @@ const penRo = penRi + penWall;
 const compW = 40, compD = 50, compH = 40, compWall = 2, compR = 3;
 
 // --- Rounded rectangle helper via hull of 4 corner circles ---
-function roundedRect(w, h, r, segs) {
+// Circle segment count is left to the user's Modeling Quality preset.
+function roundedRect(w, h, r) {
   const hw = w / 2 - r, hh = h / 2 - r;
   return CrossSection.hull([
-    CrossSection.circle(r, segs).translate([hw, hh]),
-    CrossSection.circle(r, segs).translate([-hw, hh]),
-    CrossSection.circle(r, segs).translate([-hw, -hh]),
-    CrossSection.circle(r, segs).translate([hw, -hh]),
+    CrossSection.circle(r).translate([hw, hh]),
+    CrossSection.circle(r).translate([-hw, hh]),
+    CrossSection.circle(r).translate([-hw, -hh]),
+    CrossSection.circle(r).translate([hw, -hh]),
   ]);
 }
 
 // --- Base ---
-const base = roundedRect(baseW, baseD, baseR, 48).extrude(baseH);
+const base = roundedRect(baseW, baseD, baseR).extrude(baseH);
 
 // --- Pen holders (3 hollow cylinders) ---
 const penY = -5;
 const penHolders = [];
 for (let i = 0; i < penCount; i++) {
   const x = (i - 1) * penSpacing;
-  const outer = Manifold.cylinder(penH, penRo, penRo, 48).translate([x, penY, baseH]);
-  const inner = Manifold.cylinder(penH + 1, penRi, penRi, 48).translate([x, penY, baseH]);
+  const outer = Manifold.cylinder(penH, penRo, penRo).translate([x, penY, baseH]);
+  const inner = Manifold.cylinder(penH + 1, penRi, penRi).translate([x, penY, baseH]);
   penHolders.push(outer.subtract(inner));
 }
 
 // --- Wide compartment (hollow rounded box, open top) ---
 const compX = baseW / 2 - compW / 2 - 6;
-const compOuterCS = roundedRect(compW, compD, compR, 32);
+const compOuterCS = roundedRect(compW, compD, compR);
 const compInnerCS = compOuterCS.offset(-compWall);
 const compartment = compOuterCS.extrude(compH).translate([compX, 0, baseH])
   .subtract(compInnerCS.extrude(compH + 1).translate([compX, 0, baseH]));

--- a/public/ai.md
+++ b/public/ai.md
@@ -335,10 +335,14 @@ revolve(cs, n?, degrees?)
   -> around Y axis, then remaps so result is Z-up.
     Profile X=radial distance, Y=height -> after revolve, Y becomes Z automatically.
     Only positive-X side used. degrees defaults to 360.
-Segments guide: 6-8 low-poly, 32-48 smooth, 64+ high quality
+Segments: OMIT the segment argument so curves inherit the user's quality
+  preset (recommended). Pass an explicit 6-8 only for an intentional
+  low-poly look; only override upward when one specific feature needs more
+  resolution than the preset. Never hard-code a low count (e.g. 32) just to
+  "make it smooth" — that shadows the preset and looks chunky to the user.
 ```
 
-**Default segment count:** Partwright seeds `setCircularSegments()` from the user's Modeling Quality preset (gear icon in the toolbar) before each run. The default preset is **Highest** (128 segments), so curves render smooth out of the box without any explicit configuration. Users can drop to Low/Medium/High in the settings modal if they prefer faster renders. Your code can still call `setCircularSegments(n)` or pass an explicit segments argument to a primitive to override on a per-script or per-call basis.
+**Default segment count:** Partwright seeds `setCircularSegments()` (and `$fn` for OpenSCAD) from the user's Modeling Quality preset (gear icon in the toolbar) before each run. Presets are Low (16) / Medium (32) / High (64) / Very High (128, the default) / Ultra (1024). So curves render smooth out of the box without any explicit configuration — and a user who wants ultra-smooth output picks **Ultra** once and it persists. **An explicit segments argument always overrides this preset for that primitive**, so leave it off unless you specifically want a different resolution than the user chose. The current preset is reported in the per-turn "Session toggle state" suffix; honor it. You can still call `setCircularSegments(n)` or pass an explicit count to override on a per-script or per-call basis when a design genuinely needs it.
 
 ### All constructors
 

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -6,6 +6,7 @@
 
 import { MAX_ITERATIONS, MAX_SPEND, activeModel, type ChatToggles } from './types';
 import type { Language } from '../geometry/engines/types';
+import { loadQualitySettings, getDefaultCircularSegments, QUALITY_OPTIONS } from '../geometry/qualitySettings';
 
 let aiMdCache: string | null = null;
 let aiMdPromise: Promise<string> | null = null;
@@ -260,6 +261,7 @@ export function toggleSuffix(toggles: ChatToggles): string {
     `Auto-retry on tool error: ${toggles.autoRetry}`,
     `Iteration cap (tool round-trips this turn): ${capLabel}. Pace your tool calls accordingly — if the cap is low, batch related work and prefer one-shot tools like paintComponent or paintInBox over verify-then-paint loops.`,
     `Spend cap (total USD this session): ${spendLabel}. Prior turns in this session count toward the same budget, so the cap can fire mid-turn even on a cheap iteration. Vision tool calls (renderView, paintPreview withImage) are the most expensive — skip them when stats alone are enough.`,
+    qualityLine(),
   ];
   if (restrictions.length > 0) {
     lines.push('');
@@ -276,6 +278,17 @@ function currentLanguage(): Language {
   } catch {
     return 'manifold-js';
   }
+}
+
+/** Per-turn line telling the model the user's current curve-resolution
+ *  preference. The engine already seeds setCircularSegments()/$fn from this
+ *  preset before each run, so the model must NOT hard-code a lower count —
+ *  an explicit segments argument shadows the preset and silently overrides
+ *  the user's choice. */
+function qualityLine(): string {
+  const segs = getDefaultCircularSegments();
+  const label = QUALITY_OPTIONS.find(o => o.id === loadQualitySettings().quality)?.label ?? 'Very High';
+  return `Modeling quality: the user picked "${label}" (~${segs} segments per full circle), already applied before every run. OMIT the segments argument on cylinder/sphere/circle/revolve/extrude so curves inherit this preset — do NOT pass a smaller explicit count (e.g. 32) just to "make it smooth", as that shadows the user's choice and looks chunky to them. Pass an explicit count only for a deliberately faceted/low-poly look or a user-tunable parameter, or a HIGHER count when one specific feature needs extra resolution.`;
 }
 
 export function buildSystemPrompt(aiMd: string): string {
@@ -344,10 +357,11 @@ exports. The runtime gives you \`api.Manifold\` and \`api.CrossSection\`.
 \`\`\`js
 const { Manifold, CrossSection } = api;
 
-// Primitives (centred at origin by default; second arg true centres)
+// Primitives (cube's 2nd arg true centres). Omit segment counts so curves
+// inherit the user's Modeling Quality preset (see the per-turn note below).
 Manifold.cube([w, d, h], true);
-Manifold.sphere(r, segments);
-Manifold.cylinder(h, rBottom, rTop, segments, true);
+Manifold.sphere(r);
+Manifold.cylinder(h, rBottom, rTop);
 
 // Transforms (return a new Manifold; originals are immutable)
 shape.translate([x, y, z]);
@@ -407,10 +421,11 @@ Every program you pass to \`setCode\` / \`runAndSave\` must end with
 \`\`\`js
 const { Manifold, CrossSection } = api;
 
-// Primitives — second arg of cube/cylinder centres the shape at the origin.
+// Primitives — cube's second arg centres the shape at the origin. Omit
+// segment counts so curves follow the user's Modeling Quality preset.
 Manifold.cube([width, depth, height], true);
-Manifold.sphere(radius, segments);
-Manifold.cylinder(height, rBottom, rTop, segments, true);
+Manifold.sphere(radius);
+Manifold.cylinder(height, rBottom, rTop);
 
 // Transforms — return new Manifolds; the original is immutable.
 shape.translate([x, y, z]);
@@ -473,11 +488,11 @@ face — head with two eye sockets and a curved mouth." Done.
 Program to pass as \`code\`:
 
 const { Manifold } = api;
-const head  = Manifold.sphere(20, 64);
-const eye   = Manifold.sphere(3, 32);
+const head  = Manifold.sphere(20);
+const eye   = Manifold.sphere(3);
 const eyeL  = eye.translate([-7, -18, 5]);
 const eyeR  = eye.translate([ 7, -18, 5]);
-const mouth = Manifold.cylinder(4, 8, 8, 32)
+const mouth = Manifold.cylinder(4, 8, 8)
   .rotate([90, 0, 0])
   .translate([0, -18, -5]);
 return Manifold.difference([head, eyeL, eyeR, mouth]);

--- a/src/geometry/qualitySettings.ts
+++ b/src/geometry/qualitySettings.ts
@@ -7,7 +7,7 @@
 
 const STORAGE_KEY = 'partwright-quality-settings-v1';
 
-export type QualityLevel = 'low' | 'medium' | 'high' | 'highest';
+export type QualityLevel = 'low' | 'medium' | 'high' | 'highest' | 'ultra';
 
 export interface QualitySettings {
   quality: QualityLevel;
@@ -18,13 +18,15 @@ export const QUALITY_SEGMENTS: Record<QualityLevel, number> = {
   medium: 32,
   high: 64,
   highest: 128,
+  ultra: 1024,
 };
 
 export const QUALITY_OPTIONS: { id: QualityLevel; label: string; hint: string }[] = [
   { id: 'low', label: 'Low', hint: '16 segments — chunky facets, fastest' },
   { id: 'medium', label: 'Medium', hint: '32 segments — visibly smooth' },
   { id: 'high', label: 'High', hint: '64 segments — smooth curves' },
-  { id: 'highest', label: 'Highest', hint: '128 segments — ultra smooth, slower' },
+  { id: 'highest', label: 'Very High', hint: '128 segments — very smooth' },
+  { id: 'ultra', label: 'Ultra', hint: '1024 segments — near-perfect curves, slowest on complex models' },
 ];
 
 const DEFAULT_SETTINGS: QualitySettings = {

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -74,7 +74,7 @@ export function createHelpPage(
       id: 'quick-example',
       heading: 'Quick example',
       body:
-        '<pre class="bg-zinc-800 rounded-lg p-4 text-xs leading-relaxed overflow-x-auto mt-2"><code class="text-zinc-300">const { Manifold } = api;\n\n// Create a box and subtract a cylinder\nconst box = Manifold.cube([20, 20, 10], true);\nconst hole = Manifold.cylinder(12, 4, 4, 32);\n\nreturn box.subtract(hole);</code></pre>',
+        '<pre class="bg-zinc-800 rounded-lg p-4 text-xs leading-relaxed overflow-x-auto mt-2"><code class="text-zinc-300">const { Manifold } = api;\n\n// Create a box and subtract a cylinder\nconst box = Manifold.cube([20, 20, 10], true);\nconst hole = Manifold.cylinder(12, 4, 4);\n\nreturn box.subtract(hole);</code></pre>',
     },
     {
       id: 'tabs',
@@ -166,7 +166,7 @@ export function createHelpPage(
       id: 'quality-theme',
       heading: 'Quality settings & theme',
       body:
-        '<strong class="text-zinc-300">Quality</strong> — The ⚙ icon in the toolbar opens the modeling-quality modal. Pick a preset (Highest / High / Medium / Low) that controls how many segments approximate a circle. <em>Highest</em> is the default and gives the smoothest output; drop down if you\'re iterating on heavy geometry and want faster renders.<br><br>' +
+        '<strong class="text-zinc-300">Quality</strong> — The ⚙ icon in the toolbar opens the modeling-quality modal. Pick a preset (Ultra / Very High / High / Medium / Low) that controls how many segments approximate a circle. <em>Very High</em> (128 segments) is the default; <em>Ultra</em> (1024 segments) gives near-perfect curves for smooth final output, while lower presets render faster when you\'re iterating on heavy geometry. The preset only applies to curves that don\'t pass their own segment count, so it sticks across sessions and the AI assistant honors it too.<br><br>' +
         '<strong class="text-zinc-300">Theme</strong> — Toggle <strong class="text-zinc-300">Dark Mode</strong> in the toolbar to switch the entire UI, viewport background, and grid colors between dark and light. Your choice persists across sessions.',
     },
     {

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -544,8 +544,8 @@ export function createToolbar(
   toolbar.appendChild(themeBtn);
 
   // Modeling-quality settings — gear icon opens a modal where users
-  // pick the default curve resolution. Defaults to "Highest" so the
-  // out-of-the-box rendering is smooth.
+  // pick the default curve resolution. Defaults to "Very High" so the
+  // out-of-the-box rendering is smooth; "Ultra" goes up to 1024 segments.
   const qualityBtn = document.createElement('button');
   qualityBtn.id = 'btn-quality';
   qualityBtn.className = 'flex items-center justify-center w-10 h-10 md:w-6 md:h-6 rounded-full text-zinc-500 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700 transition-colors text-sm md:text-xs ml-2';

--- a/tests/quality-settings.spec.ts
+++ b/tests/quality-settings.spec.ts
@@ -76,4 +76,38 @@ test.describe('Modeling quality settings', () => {
     expect(low.triangleCount ?? 0).toBeLessThan(high.triangleCount ?? 0);
     expect(low.triangleCount ?? 0).toBeGreaterThan(0);
   });
+
+  test('Ultra preset persists and yields more triangles than the default', async ({ page }) => {
+    await page.goto('/editor?view=ai');
+    await page.waitForSelector('#btn-quality');
+    await page.waitForFunction(
+      () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+      { timeout: 20_000 },
+    );
+
+    type RunResult = { triangleCount?: number; error?: string };
+    type PartwrightApi = { run: (code: string) => Promise<RunResult> };
+    // A cylinder stays cheap at 1024 segments (~4k tris); a sphere would be
+    // ~2M and too heavy for a smoke test. Either way the count must climb.
+    const cylinderCode = 'const { Manifold } = api; return Manifold.cylinder(5, 3, 3);';
+
+    // Baseline at the default (Highest = 128 segments).
+    const high = await page.evaluate(async (code) => {
+      const api = (window as unknown as { partwright: PartwrightApi }).partwright;
+      return api.run(code);
+    }, cylinderCode);
+
+    // Switch to Ultra (1024 segments) and confirm it persists.
+    await page.locator('#btn-quality').click();
+    await page.locator('input[type=radio][value=ultra]').check();
+    const stored = await page.evaluate(() => localStorage.getItem('partwright-quality-settings-v1'));
+    expect(JSON.parse(stored!)).toEqual({ quality: 'ultra' });
+    await page.getByRole('button', { name: 'Done' }).click();
+
+    const ultra = await page.evaluate(async (code) => {
+      const api = (window as unknown as { partwright: PartwrightApi }).partwright;
+      return api.run(code);
+    }, cylinderCode);
+    expect(ultra.triangleCount ?? 0).toBeGreaterThan(high.triangleCount ?? 0);
+  });
 });


### PR DESCRIPTION
## Summary

The **Modeling Quality** preset looked like it did nothing because it was being silently shadowed. The engine *does* seed `setCircularSegments()` (and `$fn` for OpenSCAD) from the preset before every run, but an **explicit segments argument always overrides that** — and the default scene (`basic_shapes.js`) plus most examples, the help snippet, and the AI's own example programs hard-coded a count (e.g. `Manifold.cylinder(6, 4, 4, 32)`). So toggling the menu changed nothing visible; editing the `32` by hand did.

This PR makes the preset actually control curve smoothness, raises the ceiling, and teaches the AI to honor it:

- **New `Ultra` (1024) tier.** Ladder is now Low (16) / Medium (32) / High (64) / Very High (128) / Ultra (1024). The out-of-box default stays **Very High (128)** so the hosted site remains fast for new visitors; selecting Ultra persists per-browser.
- **Unshadowed the generic examples** (`basic_shapes`, `boolean_demo`, `desk_organizer`) and the help snippet — dropped hard-coded segment counts so curves inherit the preset. Intentionally faceted examples (christmas tree's 6–8, twisted vase's 6) and parametric ones (gear, l-bracket) are left untouched.
- **Taught the AI.** The per-turn system-prompt suffix now reports the user's live preset and instructs agents to omit segment args (never hard-code a low count just to "make it smooth"). `ai.md`, the canonical example program, and the local-model prompt sketches were updated to match.
- **Test coverage** for the new Ultra tier (persists + yields more triangles than the default).

Note on the default: I kept the hard default at Very High (128) rather than Ultra, since 1024-segments-on-everything is a heavy global default for all visitors of the hosted site. The owner gets 1024 by picking Ultra once (it persists), and the AI honors whatever is selected. Easy to flip the default to Ultra if preferred.

Suggested label: `enhancement`.

## Test plan

- [x] `npm run build` — clean (TypeScript + bundle)
- [x] `npm run test:e2e` — full suite green (73 passed), including `quality-settings` and `quality-scad`
- [x] New e2e: Ultra preset persists to localStorage and increases triangle count vs the default
- [ ] Manual: gear icon → modal shows the 5-tier ladder; picking Ultra re-renders the default cylinder noticeably smoother and sticks across reload

https://claude.ai/code/session_01NKqdPeu8vS6TmJr7troZQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKqdPeu8vS6TmJr7troZQU)_