### PR TITLE
fix: resolve pre-main review findings (paint, AI worker, STL, IndexedDB)

### DIFF
--- a/src/ai/agentWorker.ts
+++ b/src/ai/agentWorker.ts
@@ -96,6 +96,7 @@ self.onmessage = async (event: MessageEvent) => {
       onUserPersisted:      (m) => post('onUserPersisted', m),
       onAssistantStart:     (id) => post('onAssistantStart', id),
       onAssistantText:      (d) => post('onAssistantText', d),
+      onAssistantThinking:  (d) => post('onAssistantThinking', d),
       onToolStart:          (id, n) => post('onToolStart', id, n),
       onToolResult:         (id, n, r) => post('onToolResult', id, n, r),
       onAssistantPersisted: (m) => post('onAssistantPersisted', m),

--- a/src/ai/agentWorkerClient.ts
+++ b/src/ai/agentWorkerClient.ts
@@ -61,6 +61,7 @@ async function handleMessage(event: MessageEvent): Promise<void> {
       case 'onUserPersisted':      cb.onUserPersisted?.(args[0] as ChatMessage); break;
       case 'onAssistantStart':     cb.onAssistantStart?.(args[0] as string); break;
       case 'onAssistantText':      cb.onAssistantText?.(args[0] as string); break;
+      case 'onAssistantThinking':  cb.onAssistantThinking?.(args[0] as string); break;
       case 'onToolStart':          cb.onToolStart?.(args[0] as string, args[1] as string); break;
       case 'onToolResult':         cb.onToolResult?.(args[0] as string, args[1] as string, args[2] as PersistedToolResult); break;
       case 'onAssistantPersisted': cb.onAssistantPersisted?.(args[0] as ChatMessage); break;

--- a/src/ai/cost.ts
+++ b/src/ai/cost.ts
@@ -79,25 +79,7 @@ function pricingFor(provider: string, model: string): ModelPricing | null {
   return table[model] ?? FALLBACK_PRICING;
 }
 
-export function turnCostUsd(provider: string, model: string, usage: TurnUsage): number;
-export function turnCostUsd(model: string, usage: TurnUsage): number;
-export function turnCostUsd(...args: unknown[]): number {
-  // Two-arg form (legacy from the Anthropic-only era) infers Anthropic
-  // when the model id looks like one, falls back to Anthropic pricing
-  // anyway (the only thing that called this from staging was the
-  // Anthropic code path).
-  let provider: string;
-  let model: string;
-  let usage: TurnUsage;
-  if (args.length === 2) {
-    provider = 'anthropic';
-    model = args[0] as string;
-    usage = args[1] as TurnUsage;
-  } else {
-    provider = args[0] as string;
-    model = args[1] as string;
-    usage = args[2] as TurnUsage;
-  }
+export function turnCostUsd(provider: string, model: string, usage: TurnUsage): number {
   const p = pricingFor(provider, model);
   if (!p) return 0;
   const inputCost = (usage.inputTokens * p.input) / 1_000_000;

--- a/src/ai/db.ts
+++ b/src/ai/db.ts
@@ -62,14 +62,19 @@ export async function recordUsage(
   const db = await openPartwrightDB();
   const txn = db.transaction(KEYS_STORE, 'readwrite');
   const store = txn.objectStore(KEYS_STORE);
-  const existing = await reqToPromise(store.get(provider)) as KeyRecord | undefined;
-  if (existing) {
+  // Issue the put inside the get's callback so both requests live in the same
+  // transaction. Awaiting between get and put lets IndexedDB auto-commit the
+  // txn before the put is queued (TransactionInactiveError / lost update).
+  const getReq = store.get(provider);
+  getReq.onsuccess = () => {
+    const existing = getReq.result as KeyRecord | undefined;
+    if (!existing) return;
     existing.lastUsed = Date.now();
     existing.totalInputTokens += inputTokens;
     existing.totalOutputTokens += outputTokens;
     existing.totalCostUsd += costUsd;
     store.put(existing);
-  }
+  };
   await txComplete(txn);
 }
 

--- a/src/color/boxDrag.ts
+++ b/src/color/boxDrag.ts
@@ -308,7 +308,7 @@ export function commitBox(): number {
     `${shapeLabel(shapeType)} ${existingCount + 1}`,
     [...getColor()] as [number, number, number],
     'slab',
-    { kind: 'box', center: box.center, size: box.size, quaternion: box.quaternion },
+    { kind: 'box', center: box.center, size: box.size, quaternion: box.quaternion, shape: shapeType },
     triangles,
   );
 

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -66,6 +66,7 @@ export function setTool(tool: PaintTool): void {
   const prev = currentTool;
   currentTool = tool;
   clearHighlight();
+  if (tool !== 'brush') clearBrushRing(); // ring is brush-only; don't leave it in the scene
 
   if (active) {
     if (tool === 'slab') activateSlabDrag();

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -1,6 +1,7 @@
 // ColorRegionStore — manages per-face color regions for the current mesh
 
 import type { MeshData } from '../geometry/types';
+import type { ShapeType } from './boxPaint';
 
 export interface ColorRegion {
   id: number;
@@ -16,7 +17,7 @@ export interface ColorRegion {
 export type RegionDescriptor =
   | { kind: 'coplanar'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; normalTolerance: number }
   | { kind: 'slab'; normal: [number, number, number]; offset: number; thickness: number }
-  | { kind: 'box'; center: [number, number, number]; size: [number, number, number]; quaternion: [number, number, number, number] }
+  | { kind: 'box'; center: [number, number, number]; size: [number, number, number]; quaternion: [number, number, number, number]; shape?: ShapeType }
   | { kind: 'triangles'; ids: number[] }
   | { kind: 'byLabel'; label: string }
   | { kind: 'connectedFromSeed'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; maxDeviationDeg: number };
@@ -327,16 +328,6 @@ export function serialize(): SerializedColorRegion[] {
     order: r.order,
     visible: r.visible,
   }));
-}
-
-export function deserialize(data: SerializedColorRegion[]): void {
-  regions = data.map(d => ({
-    ...d,
-    visible: d.visible !== false, // older saves lack the field — default to visible
-    triangles: new Set<number>(),
-  }));
-  nextOrder = regions.reduce((max, r) => Math.max(max, r.order + 1), 1);
-  clearRedoStack();
 }
 
 /** Apply triColors to a MeshData, returning a new object (non-destructive).

--- a/src/export/stl.ts
+++ b/src/export/stl.ts
@@ -13,8 +13,13 @@ export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
   const buffer = new ArrayBuffer(bufferSize);
   const view = new DataView(buffer);
 
-  // Header (80 bytes) — include session name if available
-  const header = getExportTitle();
+  // Header (80 bytes) — include session name if available. The header must be
+  // plain ASCII: setUint8 truncates each code unit to one byte, so a multi-byte
+  // char (e.g. the em-dash getExportTitle puts between "name — label") would
+  // otherwise write garbage. Normalize dashes and drop other non-ASCII.
+  const header = getExportTitle()
+    .replace(/[‒-―]/g, '-')
+    .replace(/[^\x20-\x7E]/g, '?');
   for (let i = 0; i < Math.min(header.length, 80); i++) {
     view.setUint8(i, header.charCodeAt(i));
   }

--- a/src/import/parsers/stl.ts
+++ b/src/import/parsers/stl.ts
@@ -36,8 +36,12 @@ function isBinarySTL(bytes: Uint8Array): boolean {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const triCount = view.getUint32(80, true);
   const expectedSize = 84 + triCount * 50;
-  if (bytes.byteLength === expectedSize) return true;
-  // No size match — check the prefix; absence of `solid` is a strong binary signal.
+  // Exact match, or a binary file with trailing padding some exporters append.
+  // (An ASCII file's bytes 80..83 decode to a huge triCount, so its expectedSize
+  // dwarfs any real file — this branch can only be true for genuine binary STLs,
+  // even when the 80-byte header happens to start with "solid".)
+  if (triCount > 0 && bytes.byteLength >= expectedSize) return true;
+  // No size signal — check the prefix; absence of `solid` is a strong binary signal.
   const head = new TextDecoder('utf-8', { fatal: false }).decode(bytes.subarray(0, 5)).toLowerCase();
   return head !== ASCII_DETECT_PREFIX;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,7 +116,7 @@ import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as ge
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
 import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, resolveSeed, findNearestTriangle } from './color/adjacency';
 import { findSlabTriangles } from './color/slabPaint';
-import { findBoxTriangles } from './color/boxPaint';
+import { findBoxTriangles, findShapeTriangles } from './color/boxPaint';
 import { computeFaceGroups } from './color/faceGroups';
 import {
   getSessionIdFromURL,
@@ -383,8 +383,8 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): { 
       const { normal, offset, thickness } = region.descriptor;
       triangles = findSlabTriangles(mesh, normal, offset, thickness);
     } else if (region.descriptor.kind === 'box') {
-      const { center, size, quaternion } = region.descriptor;
-      triangles = findBoxTriangles(mesh, { center, size, quaternion });
+      const { center, size, quaternion, shape } = region.descriptor;
+      triangles = findShapeTriangles(mesh, shape ?? 'box', { center, size, quaternion });
     } else if (region.descriptor.kind === 'byLabel') {
       // Labels are runtime state — manifold-3d assigns fresh
       // originalIDs on every run, so we re-resolve by name from the
@@ -1064,7 +1064,7 @@ async function main() {
   const AUTO_FORMAT_OFF_CLASS = 'shrink-0 px-2 py-0.5 rounded text-xs leading-none border text-zinc-500 border-zinc-700 hover:text-zinc-300';
   function syncAutoFormatToggleUI(): void {
     const on = getAutoFormat();
-    autoFormatToggle.textContent = on ? 'Auto' : 'Auto';
+    autoFormatToggle.textContent = on ? 'Auto ✓' : 'Auto';
     autoFormatToggle.title = on ? 'Auto-format on — click to disable' : 'Auto-format off — click to enable';
     autoFormatToggle.className = on ? AUTO_FORMAT_ON_CLASS : AUTO_FORMAT_OFF_CLASS;
   }
@@ -1075,7 +1075,9 @@ async function main() {
     syncAutoFormatToggleUI();
   });
   document.addEventListener('keydown', (e) => {
-    if (e.shiftKey && e.altKey && e.key === 'F') {
+    // Use e.code (physical key) — on macOS, Option+Shift+F composes a dead-key
+    // character so e.key is no longer 'F' and the shortcut would never fire.
+    if (e.shiftKey && e.altKey && e.code === 'KeyF') {
       e.preventDefault();
       formatCode();
     }
@@ -3329,8 +3331,8 @@ async function main() {
     },
 
     /** Programmatic tab switching */
-    setView(tab: 'interactive' | 'ai' | 'elevations' | 'gallery' | 'diff' | 'notes'): void {
-      assertEnum(tab, ['interactive', 'ai', 'elevations', 'gallery', 'diff', 'notes'] as const, 'setView(tab)');
+    setView(tab: 'interactive' | 'ai' | 'elevations' | 'gallery' | 'images' | 'diff' | 'notes'): void {
+      assertEnum(tab, ['interactive', 'ai', 'elevations', 'gallery', 'images', 'diff', 'notes'] as const, 'setView(tab)');
       switchTab(tab);
     },
 

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -333,12 +333,18 @@ export function legacyImagesObjectToArray(obj: LegacyImagesObject): AttachedImag
 
 export async function updateSession(id: string, updates: Partial<Pick<Session, 'name' | 'created' | 'updated' | 'images' | 'language'>>): Promise<void> {
   const store = await tx('sessions', 'readwrite');
-  const session = await reqToPromise(store.get(id)) as Session | null;
-  if (!session) return;
-  Object.assign(session, updates);
-  // Strip legacy field if present so it doesn't shadow the new one on re-read
-  delete (session as { referenceImages?: unknown }).referenceImages;
-  await reqToPromise(store.put(session));
+  // Read-modify-write inside one transaction: queue the put from the get's
+  // callback (awaiting between them risks auto-commit), then await oncomplete.
+  const getReq = store.get(id);
+  getReq.onsuccess = () => {
+    const session = getReq.result as Session | null;
+    if (!session) return;
+    Object.assign(session, updates);
+    // Strip legacy field if present so it doesn't shadow the new one on re-read
+    delete (session as { referenceImages?: unknown }).referenceImages;
+    store.put(session);
+  };
+  await txComplete(store.transaction);
 }
 
 export async function deleteSession(id: string): Promise<void> {
@@ -485,11 +491,15 @@ export async function deleteNote(id: string): Promise<void> {
 
 export async function updateNote(id: string, text: string): Promise<void> {
   const store = await tx('notes', 'readwrite');
-  const note = await reqToPromise(store.get(id)) as SessionNote | null;
-  if (!note) return;
-  note.text = text;
-  note.timestamp = Date.now();
-  await reqToPromise(store.put(note));
+  const getReq = store.get(id);
+  getReq.onsuccess = () => {
+    const note = getReq.result as SessionNote | null;
+    if (!note) return;
+    note.text = text;
+    note.timestamp = Date.now();
+    store.put(note);
+  };
+  await txComplete(store.transaction);
 }
 
 // === Database reset ===


### PR DESCRIPTION
## Summary

A pre-`main` quality sweep of the ~180 commits that landed on `staging` this week. Six review agents audited the major domains (AI providers, Web Workers, paint/color, UI/UX, routing/storage, import/export/geometry). **No leftover merge-conflict markers** and the branch is in sync with `staging`. This PR lands the fixes I was confident in and verified against the actual code; the rest are written up below as an iterate-on list.

`npm run build` is clean and the full Playwright suite passes **102/102**.

## Fixes in this PR

**Paint / color**
- **Data corruption (was the most serious finding):** sphere/cylinder/cone brush regions were persisted as a plain `box` descriptor with no shape type, so on save/fork/reload they re-resolved with the *box* containment test — repainting the bounding-box corners the sphere/cone had excluded. Now the shape is stored on the descriptor and re-resolved via `findShapeTriangles`. Old saves default to `box` (backward compatible).
- Brush ring was orphaned in the scene when switching away from the brush tool (`setTool` cleared the highlight but not the ring).

**AI / Web Worker**
- Live "thinking" preview regression: `onAssistantThinking` was fired by `chatLoop` *inside* the agent worker but never forwarded across the worker boundary, so the streaming reasoning box went dark for Gemini thinking models. Wired it through `agentWorker` + `agentWorkerClient`. (Final reasoning text still persisted, so this was display-only.)

**IndexedDB integrity**
- `recordUsage`, `updateSession`, `updateNote` did `await get` then `put` in the same transaction. The await between the two requests can let IndexedDB auto-commit before the `put` is queued (lost update / `TransactionInactiveError`). Restructured to queue the `put` from the `get` callback and `await txn.oncomplete` (the pattern CLAUDE.md mandates).

**Import / export**
- STL export wrote the 80-byte header with `setUint8(charCodeAt(i))`; the em-dash in `getExportTitle()`'s `name — label` (and any non-ASCII session name) truncated to garbage bytes. Header is now ASCII-sanitized.
- STL import: a binary STL with trailing padding **and** a header starting with `solid` was misrouted to the ASCII parser (and failed). Detection now treats `triCount > 0 && byteLength >= expectedSize` as binary (an ASCII file's bytes 80–83 decode to an absurd triCount, so this can't false-positive).

**UI / API**
- `Shift+Alt+F` format shortcut used `e.key === 'F'`, which never matches on macOS (Option composes a dead key). Switched to `e.code === 'KeyF'`.
- Auto-format toggle showed the same `'Auto'` label in both states; on-state now reads `Auto ✓`.
- `setView()` console API was missing the `'images'` tab that `switchTab`/`TabName` support.

**Dead code**
- Removed the unused `turnCostUsd` 2-arg overload (a latent footgun that billed every provider at Anthropic rates) and the unused `regions.deserialize`.

## Test plan
- [x] `npm run build` — clean (tsc + vite)
- [x] `npm run test:e2e` — 102/102 passed (incl. STL import, worker race-conditions, quality-settings, paint, AI panel)
- [ ] Manual: paint a sphere/cone region → save v2 → reload session → confirm the region keeps its shape (the headline fix)
- [ ] Manual: export STL from a session whose name contains a non-ASCII char → header is clean ASCII
- [ ] Manual: drive a Gemini thinking model in the AI panel → live reasoning box streams

## Not in this PR — recommended iterate-on list

_Higher value:_
- **GLB export respects per-region eye-toggle visibility** (reads the live scene), unlike 3MF/OBJ which bake all regions. With global paint visibility off, GLB exports an all-default model. Fix = bake from `applyTriColors(meshData)` into a dedicated export mesh.
- **Gemini `maxOutputTokens: 8192` includes thinking tokens** with no `thinkingBudget` — a heavy reasoning turn can spend the whole budget and return an empty answer. Needs a budget split or higher cap.
- **Auto-reunite leaves a stale transcript** if a mid-turn session switch targets a session that already has chat (`moved === 0` skips the reload). Fix = always reload when `sessionId !== turnStartBucket`.
- **Ultra (1024) quality tier is uncapped** — a few unioned spheres at $fn=1024 (~2M tris each) can OOM the WASM heap. Consider a soft cap/warning.

_Hardening / defensive:_
- No `onmessageerror` handler on either worker client, and the geometry worker has no per-call timeout — a structured-clone failure or WASM hang leaves the promise unsettled.
- `circularSegmentsOverride` / `setActiveImports` are module globals reset in `finally`; overlapping **SCAD** executes can interleave (manifold-js is immune — synchronous).
- Export serialization has no NaN/Infinity guard — pathological geometry yields literal `NaN` tokens in OBJ/3MF. Needs a drop-or-error decision.
- `aiLocalModal` / `aiSystemPromptModal` predate `modalShell` and leak a `document` keydown listener when closed via ✕/backdrop; should migrate to `createModalShell`.
- Remaining `storage/db.ts` writers (`createSession`, `addNote`, `saveVersion`, `deleteNote`) resolve on the request promise without awaiting `txn.oncomplete`.

_Needs verification (flagged by review, not independently confirmed):_
- Destructive unlock may not strip `colorRegions` from the persisted version, so navigating away/back can re-lock the editor.
- `mergeChatBucket` re-sequences by `createdAt` with a cross-bucket `seq` tiebreak that could reorder a tool_result before its tool_use.
- `curves.ringCopy` has byte-identical `y`/`z` axis branches — possible copy-paste error in the radial-offset axis.

_QoL backlog:_ keyboard shortcut to toggle the AI panel; disabled state on the Send button for empty input; confirm/undo on Rewind (deletes a turn from DB immediately); numeric Z entry beside the cross-section slider; `aria-label`s on the model `<select>`; move focus into modals on open.

_Note: I debunked two agent-flagged "High" items by reading the code — a Gemini tool-name lookup that's actually a full-history scan (fine), and a "GLB ships no vertex colors" claim that's false (the material gets `vertexColors:true` when colors are present). Neither is included._

https://claude.ai/code/session_01W9HkSfw3r8y8c5kh8NLoGS

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9HkSfw3r8y8c5kh8NLoGS)_