### PR TITLE
fix: harden worker error handling and add geometry execute timeout

### DIFF
--- a/src/ai/agentWorkerClient.ts
+++ b/src/ai/agentWorkerClient.ts
@@ -23,6 +23,16 @@ function getWorker(): Worker {
   if (worker) return worker;
   worker = new Worker(new URL('./agentWorker.ts', import.meta.url), { type: 'module' });
   worker.onmessage = handleMessage;
+  worker.onmessageerror = (ev) => {
+    // A Worker→Main message that fails structured-clone on receipt is dropped
+    // silently otherwise, so the in-flight turn would never settle.
+    rejectCurrentTurn?.(new Error('Agent Worker sent an undeserializable message'));
+    cleanup();
+    worker?.terminate();
+    worker = null;
+    // eslint-disable-next-line no-console
+    console.error('[AgentWorker] messageerror', ev);
+  };
   worker.onerror = (ev) => {
     const err = new Error(`Agent Worker crashed: ${ev.message}`);
     if (rejectCurrentTurn) {

--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -86,6 +86,25 @@ let callIdCounter = 0;
 const pendingExecutions  = new Map<string, { resolve: (r: MeshResult) => void; reject: (e: Error) => void }>();
 const pendingValidations = new Map<string, { resolve: (r: ValidateResult) => void; reject: (e: Error) => void }>();
 
+const EXECUTE_TIMEOUT_MS = 60_000;
+
+function rejectAllPending(err: Error): void {
+  for (const p of pendingExecutions.values()) p.reject(err);
+  for (const p of pendingValidations.values()) p.reject(err);
+  pendingExecutions.clear();
+  pendingValidations.clear();
+}
+
+/** Terminate an unresponsive Worker and reject everything in flight so the next
+ *  call boots a fresh instance instead of queueing behind a hang. */
+function restartEngineWorker(reason: string): void {
+  rejectAllPending(new Error(reason));
+  engineWorker?.terminate();
+  engineWorker = null;
+  // eslint-disable-next-line no-console
+  console.error('[EngineWorker]', reason);
+}
+
 function initEngineWorker(): void {
   if (engineWorker) return;
   // Fresh ready-gate so the restarted Worker's 'ready' message resolves it,
@@ -95,14 +114,19 @@ function initEngineWorker(): void {
   engineWorker.onmessage = handleEngineWorkerMessage;
   engineWorker.onerror = (ev) => {
     // Reject all pending calls if the Worker crashes.
-    const err = new Error(`Geometry Worker crashed: ${ev.message}`);
-    for (const p of pendingExecutions.values()) p.reject(err);
-    for (const p of pendingValidations.values()) p.reject(err);
-    pendingExecutions.clear();
-    pendingValidations.clear();
+    rejectAllPending(new Error(`Geometry Worker crashed: ${ev.message}`));
     engineWorker = null;
     // eslint-disable-next-line no-console
     console.error('[EngineWorker] crashed — next call will restart it', ev.message);
+  };
+  engineWorker.onmessageerror = (ev) => {
+    // A Worker→Main message that fails structured-clone on receipt is dropped
+    // silently otherwise, leaving every pending promise unsettled (UI hangs).
+    rejectAllPending(new Error('Geometry Worker sent an undeserializable message'));
+    engineWorker?.terminate();
+    engineWorker = null;
+    // eslint-disable-next-line no-console
+    console.error('[EngineWorker] messageerror', ev);
   };
   engineWorker.postMessage({ type: 'init' });
 }
@@ -184,7 +208,17 @@ export async function executeCodeAsync(source: string, lang?: Language): Promise
   }));
 
   return new Promise<MeshResult>((resolve, reject) => {
-    pendingExecutions.set(callId, { resolve, reject });
+    // A hung WASM evaluation never posts a result back. Without a timeout the
+    // promise (and the UI's "Running…" state) would wait forever.
+    const timer = setTimeout(() => {
+      if (pendingExecutions.has(callId)) {
+        restartEngineWorker(`Geometry evaluation timed out after ${EXECUTE_TIMEOUT_MS / 1000}s (the model may be too complex)`);
+      }
+    }, EXECUTE_TIMEOUT_MS);
+    pendingExecutions.set(callId, {
+      resolve: (r) => { clearTimeout(timer); resolve(r); },
+      reject:  (e) => { clearTimeout(timer); reject(e); },
+    });
     engineWorker!.postMessage({ type: 'execute', callId, code: source, lang: l, imports, circularSegments: getDefaultCircularSegments() });
   });
 }


### PR DESCRIPTION
## Summary
Hardens both Web Worker clients (geometry + AI agent) against two ways an in-flight call could hang forever. Follow-up to the pre-`main` review on #173.

- **`onmessageerror` on both clients** — a Worker→Main message that fails structured-clone *on receipt* was dropped silently, leaving the pending promise (and the UI's "Running…" / in-flight turn state) unsettled. Both clients now reject the relevant pending work and recreate the worker.
- **Geometry execute timeout (60s)** — `executeCodeAsync` had no timeout, so a hung WASM evaluation never rejected. It now restarts the worker and rejects with a clear "timed out (the model may be too complex)" message. 60s is deliberately generous so a legitimately slow Ultra-tier boolean isn't aborted.
- **Refactor:** extracted `rejectAllPending()` so the crash / messageerror / timeout paths share one cleanup (was duplicated in the existing `onerror`).

The happy path is unchanged — these only fire on deserialization failure or a true hang.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:e2e` — **102/102** (incl. `worker-error-propagation` + `worker-race-conditions`)
- [ ] Manual: confirm a normal run still resolves promptly (timeout never trips)

https://claude.ai/code/session_01W9HkSfw3r8y8c5kh8NLoGS

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9HkSfw3r8y8c5kh8NLoGS)_