### PR TITLE
fix: stop leaking document keydown listeners from two AI modals

### DIFF
--- a/src/ui/aiLocalModal.ts
+++ b/src/ui/aiLocalModal.ts
@@ -26,6 +26,7 @@ import { getModelCeiling } from '../ai/modelMetadata';
 import { loadSettings, saveSettings, setLocalModel, setProvider, addCustomLocalModel, removeCustomLocalModel, BuiltInModelIdCollision, type CustomLocalModel } from '../ai/settings';
 
 let modalEl: HTMLElement | null = null;
+let escHandler: ((e: KeyboardEvent) => void) | null = null;
 let cachedSet: Set<string> = new Set();
 /** WebGPU probe status. Starts as `checking` so we don't render an
  *  optimistic green pill that flashes to red a tick later on browsers
@@ -89,11 +90,8 @@ export async function showAiLocalModal(cb: AiLocalModalCallbacks): Promise<void>
   // Re-render reactively when state changes (cache scan, download progress).
   await rerender(body, cb);
 
-  const escHandler = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      closeModal();
-      document.removeEventListener('keydown', escHandler);
-    }
+  escHandler = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') closeModal();
   };
   document.addEventListener('keydown', escHandler);
 }
@@ -862,6 +860,10 @@ function escapeHtml(s: string): string {
 }
 
 function closeModal(): void {
+  if (escHandler) {
+    document.removeEventListener('keydown', escHandler);
+    escHandler = null;
+  }
   modalEl?.remove();
   modalEl = null;
 }

--- a/src/ui/aiSystemPromptModal.ts
+++ b/src/ui/aiSystemPromptModal.ts
@@ -21,6 +21,7 @@ import { resolveLocalModel } from '../ai/local';
 import type { Provider } from '../ai/types';
 
 let modalEl: HTMLElement | null = null;
+let escHandler: ((e: KeyboardEvent) => void) | null = null;
 
 export interface SystemPromptModalCallbacks {
   onChange?: () => void;
@@ -294,11 +295,8 @@ export async function showSystemPromptModal(provider: Provider, cb: SystemPrompt
   document.body.appendChild(overlay);
   modalEl = overlay;
 
-  const escHandler = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      closeModal();
-      document.removeEventListener('keydown', escHandler);
-    }
+  escHandler = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') closeModal();
   };
   document.addEventListener('keydown', escHandler);
 }
@@ -315,6 +313,10 @@ function detectTierFromText(text: string, built: BuiltInPrompts): 'slim' | 'medi
 }
 
 function closeModal(): void {
+  if (escHandler) {
+    document.removeEventListener('keydown', escHandler);
+    escHandler = null;
+  }
   modalEl?.remove();
   modalEl = null;
 }


### PR DESCRIPTION
## Summary
`aiLocalModal` and `aiSystemPromptModal` add an Escape-key listener on `document` but only `removeEventListener` *inside* the handler when Escape is actually pressed. Closing via the ✕ button, backdrop click, Cancel/Save, or simply reopening the modal leaves the listener attached — one stale `document` listener accumulates per open.

Fix: hoist the handler to module scope and remove it in `closeModal()`, so every close path tears it down. Behavior is otherwise unchanged (Escape still closes).

(These two modals predate `createModalShell`, which already handles this correctly — migrating them to the shell is the longer-term cleanup, tracked separately.)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open "Run a local model" / system-prompt modal, close via ✕ and backdrop, reopen a few times — only one Escape listener active; Escape still closes

https://claude.ai/code/session_01W9HkSfw3r8y8c5kh8NLoGS

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9HkSfw3r8y8c5kh8NLoGS)_