### PR TITLE
fix: guard exports against non-finite (NaN/Infinity) coordinates

### DIFF
--- a/src/export/meshClean.ts
+++ b/src/export/meshClean.ts
@@ -6,6 +6,22 @@ import { isPainted as checkPainted } from '../color/regions';
 /** Default model color used when faces have no paint. */
 export const DEFAULT_COLOR_HEX = '#4a9eff';
 
+/** Throws if any vertex coordinate is non-finite (NaN/Infinity). Export
+ *  serializers call this up front so a broken model fails loudly instead of
+ *  writing an invalid file — NaN otherwise becomes literal "NaN" tokens in
+ *  OBJ/3MF and garbage floats in STL/GLB. */
+export function assertFiniteMesh(meshData: MeshData): void {
+  const { vertProperties, numVert, numProp } = meshData;
+  for (let i = 0; i < numVert; i++) {
+    const x = vertProperties[i * numProp];
+    const y = vertProperties[i * numProp + 1];
+    const z = vertProperties[i * numProp + 2];
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+      throw new Error(`Cannot export: vertex ${i} has a non-finite (NaN/Infinity) coordinate. Check the geometry before exporting.`);
+    }
+  }
+}
+
 /** Get the hex color string for a triangle (e.g. '#ff3333'), or DEFAULT_COLOR_HEX if unpainted. */
 export function triColorHex(triColors: Uint8Array, t: number): string {
   if (!checkPainted(triColors, t)) return DEFAULT_COLOR_HEX;

--- a/src/export/obj.ts
+++ b/src/export/obj.ts
@@ -2,7 +2,7 @@ import type { MeshData } from '../geometry/types';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
 import type { BuiltExport } from './gltf';
 import { buildZip } from './zip';
-import { cleanMeshForExport, DEFAULT_COLOR_HEX, triColorHex, hasAnyPainted } from './meshClean';
+import { assertFiniteMesh, cleanMeshForExport, DEFAULT_COLOR_HEX, triColorHex, hasAnyPainted } from './meshClean';
 
 /** Round a float to 6 decimal places (float32 has ~7 significant digits). */
 function f6(v: number): string {
@@ -15,6 +15,7 @@ function f6(v: number): string {
  * otherwise it's a plain text .obj.
  */
 export function buildOBJ(meshData: MeshData, customName?: string): BuiltExport {
+  assertFiniteMesh(meshData);
   const { triVerts, triColors } = meshData;
   const title = getExportTitle();
 

--- a/src/export/stl.ts
+++ b/src/export/stl.ts
@@ -1,9 +1,11 @@
 import type { MeshData } from '../geometry/types';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
+import { assertFiniteMesh } from './meshClean';
 import type { BuiltExport } from './gltf';
 
 /** Build the binary STL blob for a mesh without triggering a download. */
 export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
+  assertFiniteMesh(meshData);
   const { vertProperties, triVerts, numTri, numProp } = meshData;
 
   // Binary STL format

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -3,10 +3,11 @@ import { get3MFUnitString } from '../geometry/units';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
 import type { BuiltExport } from './gltf';
 import { buildZip } from './zip';
-import { cleanMeshForExport, DEFAULT_COLOR_HEX, triColorHex, hasAnyPainted } from './meshClean';
+import { assertFiniteMesh, cleanMeshForExport, DEFAULT_COLOR_HEX, triColorHex, hasAnyPainted } from './meshClean';
 
 /** Build a 3MF export blob without triggering a download. */
 export function build3MF(meshData: MeshData, customName?: string): BuiltExport {
+  assertFiniteMesh(meshData);
   const { triVerts, triColors } = meshData;
 
   const { remap, uniquePositions, validTris } = cleanMeshForExport(meshData);

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,7 @@ import { exportGLB, buildGLB } from './export/gltf';
 import { exportSTL, buildSTL } from './export/stl';
 import { exportOBJ, buildOBJ } from './export/obj';
 import { export3MF, build3MF } from './export/threemf';
+import { assertFiniteMesh } from './export/meshClean';
 import { exportSessionJSON, exportRawCode, buildSessionJSON, buildRawCode } from './export/session';
 import { blobToBase64, downloadBlob } from './export/download';
 import {
@@ -959,16 +960,27 @@ async function main() {
     onOpenCatalog: () => { void showCatalogPage(); },
     onRun: () => runCode(),
     onExportGLB: async () => {
-      try { await exportGLB(); } catch (e) { console.error('GLB export error:', e); }
+      try {
+        if (currentMeshData) assertFiniteMesh(currentMeshData);
+        await exportGLB();
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : 'GLB export failed', { variant: 'warn' });
+      }
     },
     onExportSTL: () => {
-      if (currentMeshData) exportSTL(currentMeshData);
+      if (!currentMeshData) return;
+      try { exportSTL(currentMeshData); }
+      catch (e) { showToast(e instanceof Error ? e.message : 'STL export failed', { variant: 'warn' }); }
     },
     onExportOBJ: () => {
-      if (currentMeshData) exportOBJ(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData);
+      if (!currentMeshData) return;
+      try { exportOBJ(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData); }
+      catch (e) { showToast(e instanceof Error ? e.message : 'OBJ export failed', { variant: 'warn' }); }
     },
     onExport3MF: () => {
-      if (currentMeshData) export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData);
+      if (!currentMeshData) return;
+      try { export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData); }
+      catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
     },
     onExportSessionJSON: async () => {
       if (!getState().session) {
@@ -1808,6 +1820,7 @@ async function main() {
     /** Export current model as GLB download. Optional filename override. */
     async exportGLB(filename?: string) {
       assertString(filename, 'exportGLB(filename)', { optional: true });
+      if (currentMeshData) assertFiniteMesh(currentMeshData);
       await exportGLB(filename);
     },
 
@@ -1838,6 +1851,7 @@ async function main() {
     /** Build a GLB and return its bytes as base64. Same blob as exportGLB(). */
     async exportGLBData(filename?: string) {
       assertString(filename, 'exportGLBData(filename)', { optional: true });
+      if (currentMeshData) assertFiniteMesh(currentMeshData);
       const built = await buildGLB(filename);
       registerExportFromBuilt(built, 'GLB');
       return {


### PR DESCRIPTION
## Summary
Pathological geometry can yield NaN/Infinity vertex coordinates. Today those serialize straight through: literal `NaN` tokens in OBJ/3MF (invalid files), garbage floats in STL/GLB — and nothing is surfaced to the user. Follow-up to the pre-`main` review on #173.

- Add `assertFiniteMesh(meshData)` to `meshClean.ts` (throws on the first non-finite coordinate, naming the vertex).
- Call it in `buildSTL` / `buildOBJ` / `build3MF` — covers both the export menu and the console/agent API for those formats.
- GLB has no `meshData` param (it serializes the live scene), so guard it at the call sites using `currentMeshData`.
- The export menu now catches the failure and shows a clear toast instead of silently writing a broken file (previously STL/OBJ/3MF threw unhandled; GLB swallowed to `console.error`).

It's a no-op on the normal (finite) path — a single linear scan of the vertex buffer.

## Design note
I chose **fail-loudly** over silently dropping non-finite triangles: dropping would leave a holey/non-manifold mesh that looks exported-fine but isn't. The deeper "detect at geometry-eval time and disable export pre-emptively" approach is a larger change left as a follow-up.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Confirmed no e2e exercises mesh export (only `chat-export.spec.ts`, unrelated), and the guard is a no-op on finite meshes
- [ ] Manual: export a normal model in all four formats (works as before); force a NaN (e.g. a degenerate curve) and confirm the toast fires instead of a download

https://claude.ai/code/session_01W9HkSfw3r8y8c5kh8NLoGS

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9HkSfw3r8y8c5kh8NLoGS)_