### PR TITLE
fix: give Gemini thinking models token headroom for the answer

### DIFF
--- a/src/ai/gemini.ts
+++ b/src/ai/gemini.ts
@@ -139,7 +139,12 @@ export async function streamTurn(
   callbacks: StreamCallbacks = {},
   signal?: AbortSignal,
 ): Promise<StreamResult> {
-  const max_tokens = spec.maxTokens ?? 8192;
+  // For Gemini thinking models, maxOutputTokens is the COMBINED ceiling for
+  // reasoning + answer (we opt into thought parts below). At 8192 a heavy
+  // reasoning turn can spend the whole budget thinking and return an empty
+  // answer (finishReason MAX_TOKENS). Default to a generous ceiling so both
+  // fit — it's a cap, not a reservation, so normal turns cost the same.
+  const max_tokens = spec.maxTokens ?? 32768;
 
   const tools: GeminiToolDef[] = spec.tools.length > 0
     ? [{ functionDeclarations: spec.tools.map(t => ({


### PR DESCRIPTION
## Summary
`gemini.ts` opts thinking models into returning their reasoning as `thought` parts, but `maxOutputTokens` is the **combined** reasoning + answer ceiling. At the old `8192` default, a heavy reasoning turn can spend the entire budget thinking and come back `finishReason: MAX_TOKENS` with **empty answer text** — the chat then shows an empty bubble even though the thinking box streamed pages. Follow-up to the pre-`main` review on #173.

Fix: raise the default `maxOutputTokens` to `32768`. It's a ceiling, not a reservation, so normal turns generate (and cost) exactly the same — this just stops reasoning from starving the answer. The pre-turn cost estimate is unaffected (it uses a fixed expected-output figure, not this cap).

## Caveat / follow-up
The Google-recommended *root-cause* fix is to also set `thinkingConfig.thinkingBudget` to bound reasoning and guarantee answer room. I left that out deliberately: the valid budget range differs across 2.5 / 3.x / pro models and an out-of-range value returns a 400, and I can't reach the live Gemini API from this environment to validate it across the curated lineup. Recommend adding `thinkingBudget` + an explicit "reasoning exhausted the budget" outcome message as a fast-follow once it can be tested against a real thinking model.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `ai-providers.spec.ts` is network-free (asserts error surfacing, not live calls), so unaffected
- [ ] Manual (needs live key): run a Gemini 3 thinking model on a hard prompt and confirm it returns an answer instead of an empty bubble

https://claude.ai/code/session_01W9HkSfw3r8y8c5kh8NLoGS

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9HkSfw3r8y8c5kh8NLoGS)_