### PR TITLE
feat: make probePixel misses self-correcting with model bounds

### DIFF
--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -283,12 +283,15 @@ const hit = partwright.probePixel({
   pixel: [180, 220],
   view: { elevation: 0, azimuth: 0, ortho: true, size: 320 },
 });
-// hit = { point: [x, y, z], normal: [nx, ny, nz], distance, triangleId } or null
+// On a hit:  { point: [x,y,z], normal: [nx,ny,nz], distance, triangleId, nextStep }
+// On a miss: { hit: false, modelPixelBounds: {minX,minY,maxX,maxY}, reason, hint }
+//   — the miss tells you where the model projects, so re-aim inside those
+//   bounds and probe again rather than treating it as a failure.
 
 // 3. Flood from the seed, gated by 30° deviation from the seed normal.
 //    paintConnected stays on the feature where paintRegion (bimodal
 //    on smooth meshes) cannot.
-if (hit) {
+if ('point' in hit) {
   partwright.paintConnected({
     seed: { point: hit.point, normal: hit.normal },
     maxDeviationDeg: 30,

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -168,8 +168,10 @@ head), use the paint-by-vision loop:
 3. probePixel({pixel, view}) — translates the pixel back to an exact
    world-space surface point + normal + triangleId. The view object
    MUST match the renderView call's view (same elevation/azimuth/
-   ortho/size). Returns null if you picked a background pixel; try a
-   different pixel on the silhouette.
+   ortho/size). If you picked a background pixel it does NOT fail — it
+   returns {hit:false, modelPixelBounds, hint} telling you where the
+   model projects in this view, so re-aim inside those bounds and probe
+   again instead of giving up.
 4. paintConnected({seed: {point, normal}, maxDeviationDeg: 30, color})
    — flood-fills from the seed, gated by deviation from the SEED
    normal (not adjacent-face). Stays on the feature instead of bleeding

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -222,7 +222,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'probePixel',
-    description: 'Click in your own perception. Translates a pixel in a renderView image back to a world-space surface hit on the mesh: {point, normal, distance, triangleId} or null when the pixel is background. The view must match the renderView call (same elevation/azimuth/ortho/size). This is THE tool for organic geometry: render → identify the feature visually → probePixel to get exact coords → paintConnected or paintNear. The returned point is exactly on the mesh surface (raycast, not snap), so paintRegion-style seed-precision worries are gone. Front-most hit = occlusion correct.',
+    description: 'Click in your own perception. Translates a pixel in a renderView image back to a world-space surface hit on the mesh: {point, normal, distance, triangleId, nextStep}. The view must match the renderView call (same elevation/azimuth/ortho/size). This is THE tool for organic geometry: render → identify the feature visually → probePixel to get exact coords → paintConnected or paintNear. The returned point is exactly on the mesh surface (raycast, not snap), so paintRegion-style seed-precision worries are gone. Front-most hit = occlusion correct. A background pixel does NOT fail — it returns {hit:false, modelPixelBounds, hint} reporting where the model projects in this view, so just re-aim inside those bounds and probe again (pixel estimates off a render carry ±10-20px error, so the occasional miss is normal).',
     input_schema: {
       type: 'object',
       properties: {

--- a/src/geometry/rayCast.ts
+++ b/src/geometry/rayCast.ts
@@ -27,6 +27,26 @@ export interface PixelHit {
   triangleId: number;
 }
 
+/** Pixel-space axis-aligned bounds of the model's projected silhouette in
+ *  a given view. Values are rounded pixel coordinates and may fall outside
+ *  [0, size) when the model extends past the rendered frame. */
+export interface PixelBounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+/** Returned by `probePixel` when the pixel ray misses the mesh. Instead of
+ *  a bare null, it reports where the model actually projects in this view
+ *  so the caller can re-aim instead of concluding the tool is broken. */
+export interface PixelMiss {
+  hit: false;
+  /** Where the model's silhouette lands in pixel space for this view, or
+   *  null when the mesh has no vertices / projects degenerately. */
+  modelPixelBounds: PixelBounds | null;
+}
+
 function meshDataToBufferGeometry(mesh: MeshData): THREE.BufferGeometry {
   const geometry = new THREE.BufferGeometry();
   const positions = new Float32Array(mesh.numVert * 3);
@@ -152,20 +172,62 @@ export function measureDistance(
   return Math.round(Math.sqrt(dx * dx + dy * dy + dz * dz) * 1000) / 1000;
 }
 
+/** Project the mesh's world-space bounding box through `camera` and return
+ *  the pixel-space rectangle its silhouette occupies. Used to tell a caller
+ *  who missed the mesh where to re-aim. Returns null for an empty/degenerate
+ *  mesh. The NDC→pixel mapping is the exact inverse of the forward mapping in
+ *  `probePixel`, so the rectangle lines up with the rendered image. */
+function projectBoundsToPixels(
+  geometry: THREE.BufferGeometry,
+  camera: THREE.Camera,
+  size: number,
+): PixelBounds | null {
+  geometry.computeBoundingBox();
+  const box = geometry.boundingBox;
+  if (!box || !Number.isFinite(box.min.x)) return null;
+
+  // Camera matrices must be current for project(); buildViewCamera positions
+  // the camera but does not refresh matrixWorld/matrixWorldInverse.
+  camera.updateMatrixWorld();
+
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  const corner = new THREE.Vector3();
+  for (let i = 0; i < 8; i++) {
+    corner.set(
+      (i & 1) ? box.max.x : box.min.x,
+      (i & 2) ? box.max.y : box.min.y,
+      (i & 4) ? box.max.z : box.min.z,
+    );
+    corner.project(camera); // world → NDC in [-1, 1]
+    const px = (corner.x + 1) * 0.5 * size;
+    const py = (1 - corner.y) * 0.5 * size;
+    if (px < minX) minX = px; if (px > maxX) maxX = px;
+    if (py < minY) minY = py; if (py > maxY) maxY = py;
+  }
+  if (!Number.isFinite(minX)) return null;
+  return {
+    minX: Math.round(minX),
+    minY: Math.round(minY),
+    maxX: Math.round(maxX),
+    maxY: Math.round(maxY),
+  };
+}
+
 /** Cast a ray from a pixel in a rendered view back into the mesh and
  *  return the first hit (front-most along the ray — so occlusion is
  *  correct by construction). Pixel coordinates use the rendered image's
  *  convention: (0, 0) is top-left, (size-1, size-1) is bottom-right.
  *  `camera` must be the same camera the render was produced with; use
  *  `buildViewCamera` from the renderer module to construct it from the
- *  same view options passed to `renderView`. Returns null when the
- *  pixel ray misses the mesh entirely (background pixel). */
+ *  same view options passed to `renderView`. On a background pixel it
+ *  returns a `PixelMiss` carrying the model's pixel-space bounds so the
+ *  caller can re-aim, rather than a bare null with no recovery signal. */
 export function probePixel(
   meshData: MeshData,
   camera: THREE.Camera,
   pixel: [number, number],
   size: number,
-): PixelHit | null {
+): PixelHit | PixelMiss {
   const geometry = meshDataToBufferGeometry(meshData);
   const material = new THREE.MeshBasicMaterial({ side: THREE.DoubleSide });
   const tempMesh = new THREE.Mesh(geometry, material);
@@ -179,12 +241,15 @@ export function probePixel(
   raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
   const intersections = raycaster.intersectObject(tempMesh);
 
-  geometry.dispose();
-  material.dispose();
+  if (intersections.length === 0) {
+    const modelPixelBounds = projectBoundsToPixels(geometry, camera, size);
+    geometry.dispose();
+    material.dispose();
+    return { hit: false, modelPixelBounds };
+  }
 
-  if (intersections.length === 0) return null;
   const hit = intersections[0];
-  return {
+  const result: PixelHit = {
     point: [
       Math.round(hit.point.x * 1000) / 1000,
       Math.round(hit.point.y * 1000) / 1000,
@@ -196,4 +261,7 @@ export function probePixel(
     distance: Math.round(hit.distance * 1000) / 1000,
     triangleId: hit.faceIndex ?? -1,
   };
+  geometry.dispose();
+  material.dispose();
+  return result;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ function registerExportFromBuilt(built: BuiltExport, source: string): void {
 }
 import type { MeshData, SourceDiagnostic } from './geometry/types';
 import { analyzeZProfile, type ZProfile } from './geometry/profileAnalysis';
-import { probeAtXY, probeRay, probePixel, measureDistance, type ProbeResult, type GeneralRayResult, type PixelHit } from './geometry/rayCast';
+import { probeAtXY, probeRay, probePixel, measureDistance, type ProbeResult, type GeneralRayResult, type PixelHit, type PixelMiss } from './geometry/rayCast';
 import { checkContainment, type ContainmentWarning } from './geometry/containmentCheck';
 import { setUnits as _setUnits, getUnits as _getUnits, type UnitSystem } from './geometry/units';
 import { initMeasureTool, activate as activateMeasure, deactivate as deactivateMeasure, getState as getMeasureState } from './ui/measureTool';
@@ -3220,12 +3220,14 @@ async function main() {
      *    pixel: [180, 220],
      *    view:  { elevation: 0, azimuth: 0, ortho: true, size: 320 },
      *  });
-     *  if (hit) partwright.paintNear({ point: hit.point, radius: 4, color: [...] });
+     *  // On a miss, `hit.hint` reports the model's pixel bounds so you can
+     *  // re-aim; on a hit, `hit.point`/`hit.normal` carry the surface seed.
+     *  if ('point' in hit) partwright.paintNear({ point: hit.point, radius: 4, color: [...] });
      *  ``` */
     probePixel(opts: {
       pixel: [number, number];
       view: { elevation?: number; azimuth?: number; ortho?: boolean; size?: number };
-    }): PixelHit | { error: string } | null {
+    }): (PixelHit & { nextStep: string }) | (PixelMiss & { reason: string; hint: string }) | { error: string } | null {
       if (!opts || typeof opts !== 'object') return { error: 'probePixel requires { pixel, view }' };
       if (!Array.isArray(opts.pixel) || opts.pixel.length !== 2) return { error: 'probePixel.pixel must be [x, y]' };
       for (const c of opts.pixel) {
@@ -3245,7 +3247,22 @@ async function main() {
         return { error: `probePixel.pixel [${px}, ${py}] is outside the ${size}×${size} viewport. Pixel (0,0) is top-left, (${size - 1},${size - 1}) is bottom-right.` };
       }
       const camera = buildViewCamera(currentMeshData, opts.view);
-      return probePixel(currentMeshData, camera, [px, py], size);
+      const result = probePixel(currentMeshData, camera, [px, py], size);
+      if ('hit' in result) {
+        // Miss: instead of a bare null, tell the caller where the model
+        // actually projects so they can re-aim. Pixel estimation off a
+        // render carries ±10-20px error, so misses are an expected, common
+        // case — make them self-correcting rather than a dead end.
+        const b = result.modelPixelBounds;
+        const hint = b
+          ? `In this ${size}×${size} view the model occupies pixels x[${b.minX}..${b.maxX}], y[${b.minY}..${b.maxY}] (top-left is [0,0]). Re-aim inside that box and probe again.`
+          : 'The model does not project into this view (off-screen or degenerate). Render this exact view first to see where it sits, or try a different elevation/azimuth.';
+        return { ...result, reason: `Pixel [${px}, ${py}] missed the mesh (background).`, hint };
+      }
+      return {
+        ...result,
+        nextStep: 'To paint here, pass this point+normal to paintConnected({seed:{point,normal},color}) (follows the surface by normal) or paintNear({point,radius,normalCone:{axis:normal,angleDeg:35},color}) (bounded blob).',
+      };
     },
 
     /** Paint a connected patch starting from a seed point on the
@@ -4885,7 +4902,7 @@ async function main() {
         'renderViews':     { signature: 'await renderViews({views?: "tri"|"all", size?}) -- 3- or 4-angle labeled composite -> data URL. Use for verification when one angle could hide errors.', docs: '/ai.md#visual-verification' },
         'analyzeProfile':  { signature: 'analyzeProfile(sampleCount?) -- Z-profile feature summary', docs: '/ai.md#console-api--windowpartwright' },
         'measureAt':       { signature: 'measureAt([x,y]) -- Ray-cast probe at XY -> {hits, thickness, topZ, bottomZ}', docs: '/ai.md#console-api--windowpartwright' },
-        'probePixel':      { signature: 'probePixel({pixel: [x,y], view}) -- Translate a pixel in a rendered view back to a surface hit: {point, normal, distance, triangleId}. The view spec must match the renderView call. null when the pixel is background.', docs: '/ai.md#console-api--windowpartwright' },
+        'probePixel':      { signature: 'probePixel({pixel: [x,y], view}) -- Translate a pixel in a rendered view back to a surface hit: {point, normal, distance, triangleId, nextStep}. The view spec must match the renderView call. On a background pixel returns {hit:false, modelPixelBounds, reason, hint} telling you where the model projects so you can re-aim.', docs: '/ai.md#console-api--windowpartwright' },
         // Viewport controls
         'setGridVisible':       { signature: 'setGridVisible(on?) -- Show/hide grid plane (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
         'isGridVisible':        { signature: 'isGridVisible() -- Whether grid plane is visible', docs: '/ai.md#viewport-controls' },

--- a/tests/paint-by-vision.spec.ts
+++ b/tests/paint-by-vision.spec.ts
@@ -32,20 +32,62 @@ test.describe('paint by vision', () => {
     expect(probe.triangleId).toBeGreaterThanOrEqual(0);
   });
 
-  test('probePixel returns null for a background pixel', async ({ page }) => {
+  test('probePixel returns a re-aim diagnostic (not bare null) for a background pixel', async ({ page }) => {
     await page.goto('/editor');
     await page.waitForSelector('text=Ready', { timeout: 15000 });
 
-    // Small sphere at origin rendered in a large viewport — corners
-    // should miss the mesh and return null.
+    // Small sphere at origin rendered in a large viewport — the [5,5]
+    // corner misses the mesh. The miss must now report where the model
+    // actually projects so the caller can re-aim instead of giving up.
+    // Use an ortho view so the projected AABB bounds are deterministic
+    // (perspective near-corners overshoot the frame; ortho does not).
     const probe = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const pw = (window as any).partwright;
       await pw.run('return api.Manifold.sphere(2, 32);');
-      const view = { elevation: 30, azimuth: 0, ortho: false, size: 200 };
+      const view = { elevation: 90, azimuth: 0, ortho: true, size: 200 };
       return pw.probePixel({ pixel: [5, 5], view });
     });
-    expect(probe).toBeNull();
+
+    expect(probe).not.toBeNull();
+    expect(probe.hit).toBe(false);
+    expect(probe.point).toBeUndefined();
+    expect(typeof probe.hint).toBe('string');
+    expect(probe.hint).toContain('pixels');
+    const b = probe.modelPixelBounds;
+    expect(b).toBeTruthy();
+    expect(b.maxX).toBeGreaterThan(b.minX);
+    expect(b.maxY).toBeGreaterThan(b.minY);
+    // The sphere sits centered in the 200px frame, well clear of the
+    // [5,5] corner we probed — the reported bounds prove that.
+    expect(b.minX).toBeGreaterThan(5);
+    expect(b.minY).toBeGreaterThan(5);
+  });
+
+  test('probePixel hits the center of a model NOT centered on the origin', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // The session that motivated this work painted an imported model whose
+    // bbox was far from the origin. buildViewCamera frames the model's own
+    // bbox, so the center pixel must still land on the surface — confirming
+    // the "probePixel is broken on off-origin models" theory was a red
+    // herring (the real cause was missed aim with no recovery signal).
+    const probe = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run('return api.Manifold.cube([20, 20, 20], true).translate([40, 29, 40]);');
+      const view = { elevation: 90, azimuth: 0, ortho: true, size: 200 };
+      return pw.probePixel({ pixel: [100, 100], view });
+    });
+
+    expect(probe.error).toBeUndefined();
+    expect(probe.hit).toBeUndefined(); // a hit, not a miss
+    expect(probe.point).toBeDefined();
+    // Top face of the off-origin cube is at z = 40 + 10 = 50.
+    expect(probe.point[2]).toBeCloseTo(50, 1);
+    expect(probe.normal[2]).toBeGreaterThan(0.95);
+    expect(typeof probe.nextStep).toBe('string');
   });
 
   test('paintConnected floods from a seed gated by deviation from the seed normal', async ({ page }) => {


### PR DESCRIPTION
## Summary

- `probePixel` no longer returns a bare `null` when a pixel misses the mesh. It now returns `{ hit: false, modelPixelBounds, reason, hint }` reporting where the model's silhouette projects in that view, so the agent can **re-aim** instead of concluding the tool is broken.
- On a hit, the result carries a one-line `nextStep` naming the paint call to make with the returned point/normal (`paintConnected` / `paintNear`).
- Tool schema, console help registry, system prompt, and `public/ai/colors.md` updated to match the new contract.

## Context

This came out of a session painting an imported organic model that flailed: the agent guessed pixel coordinates, hit background, got `null` with no recovery signal, and gave up — its own feedback blamed "probePixel reliability."

Investigation showed the raycast machinery was fine — `buildViewCamera` frames the model's *own* bounding box and is shared byte-for-byte with rendering, so a center-pixel probe of an off-origin model still hits. The real failure was **missed aim with a dead-end response** (pixel estimates off a render carry ±10-20px error, so misses are an expected, common case). The new diagnostic turns that dead end into a self-correcting signal.

A regression test (`probePixel hits the center of a model NOT centered on the origin`) confirms off-origin framing works, refuting the "broken on off-origin models" theory.

## Test plan

- [x] `npx playwright test paint-by-vision` — 5/5 pass (incl. new off-origin-hit + miss-diagnostic tests)
- [x] `npx tsc --noEmit` clean
- [x] Full e2e suite: 77/78 — the single failure (`keyboard-shortcuts › mod+S`) is a pre-existing flake unrelated to this change, confirmed passing in isolation
- [x] Rebased onto latest `staging` (`7ba02c2`), deps reinstalled, re-validated

https://claude.ai/code/session_01AF7Nom3wDLq4mqe4PKj93W

---
_Generated by [Claude Code](https://claude.ai/code/session_01AF7Nom3wDLq4mqe4PKj93W)_