### PR TITLE
fix: show tool-result renderings in the live chat transcript

### DIFF
--- a/src/ai/agentWorker.ts
+++ b/src/ai/agentWorker.ts
@@ -101,6 +101,7 @@ self.onmessage = async (event: MessageEvent) => {
       onToolResult:         (id, n, r) => post('onToolResult', id, n, r),
       onAssistantPersisted: (m) => post('onAssistantPersisted', m),
       onUserMessageUpdated: (m) => post('onUserMessageUpdated', m),
+      onToolResultsPersisted: (m) => post('onToolResultsPersisted', m),
       onProgress:           (i) => post('onProgress', i),
       onTurnComplete:       (i) => post('onTurnComplete', i),
       onAborted:            () => post('onAborted'),

--- a/src/ai/agentWorkerClient.ts
+++ b/src/ai/agentWorkerClient.ts
@@ -76,6 +76,7 @@ async function handleMessage(event: MessageEvent): Promise<void> {
       case 'onToolResult':         cb.onToolResult?.(args[0] as string, args[1] as string, args[2] as PersistedToolResult); break;
       case 'onAssistantPersisted': cb.onAssistantPersisted?.(args[0] as ChatMessage); break;
       case 'onUserMessageUpdated': cb.onUserMessageUpdated?.(args[0] as ChatMessage); break;
+      case 'onToolResultsPersisted': cb.onToolResultsPersisted?.(args[0] as ChatMessage); break;
       case 'onProgress':           cb.onProgress?.(args[0] as Parameters<NonNullable<RunTurnCallbacks['onProgress']>>[0]); break;
       case 'onTurnComplete':       cb.onTurnComplete?.(args[0] as Parameters<NonNullable<RunTurnCallbacks['onTurnComplete']>>[0]); break;
       case 'onAborted':            cb.onAborted?.(); break;

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -119,6 +119,13 @@ export interface RunTurnCallbacks {
    *  re-render the transcript so the user sees their queued message land
    *  immediately, without waiting for the turn to fully complete. */
   onUserMessageUpdated?: (msg: ChatMessage) => void;
+  /** The tool_result user turn for a completed tool batch has been
+   *  persisted, carrying any images the tools returned (renderView /
+   *  renderViews snapshots, slice profiles, paint previews). The panel
+   *  drops the result bubbles into the live transcript here so the user
+   *  sees what the agent saw as it works — without this, tool results
+   *  (and their renderings) only surface after a session reload. */
+  onToolResultsPersisted?: (msg: ChatMessage) => void;
   /** A "thinking" beat — fires when a turn begins, when each tool starts,
    *  and on a wall-clock interval while waiting for the first text delta.
    *  Use to keep an indicator alive so the user knows we haven't frozen. */
@@ -455,6 +462,7 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
     toolResultMsg.toolResults = toolResults;
     await putMessages([toolResultMsg]);
     workingHistory = [...workingHistory, toolResultMsg];
+    callbacks.onToolResultsPersisted?.(toolResultMsg);
 
     // Drain anything the human queued while we were thinking, streaming,
     // or running tools. Merging into the same user turn that carries the

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -247,6 +247,22 @@ async function loadHistoryForCurrentSession(): Promise<void> {
   updateRewindButtons();
 }
 
+/** Insert or replace a message in the in-memory transcript, keeping it
+ *  ordered by `seq`. Replaces in place when the id is already present
+ *  (re-persist of the same message), otherwise splices it into the right
+ *  slot. Used by the mid-turn callbacks that surface tool results and
+ *  drained queued messages before the turn fully completes. */
+function upsertHistoryMessage(msg: ChatMessage): void {
+  const idx = state.history.findIndex(m => m.id === msg.id);
+  if (idx >= 0) {
+    state.history[idx] = msg;
+    return;
+  }
+  const insertAt = state.history.findIndex(m => m.seq > msg.seq);
+  if (insertAt === -1) state.history.push(msg);
+  else state.history.splice(insertAt, 0, msg);
+}
+
 // === DOM construction ===
 
 function buildDrawer(): void {
@@ -1832,14 +1848,7 @@ async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatTo
         // insert it ourselves at the right seq position — otherwise
         // renderTranscript can't show the human's bubble until end-of-turn
         // reload, and the user thinks their message vanished.
-        const idx = state.history.findIndex(m => m.id === msg.id);
-        if (idx >= 0) {
-          state.history[idx] = msg;
-        } else {
-          const insertAt = state.history.findIndex(m => m.seq > msg.seq);
-          if (insertAt === -1) state.history.push(msg);
-          else state.history.splice(insertAt, 0, msg);
-        }
+        upsertHistoryMessage(msg);
         renderTranscript();
         setTransientStatus('Queued message delivered to the AI.');
       },
@@ -1904,6 +1913,16 @@ async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatTo
       },
       onToolResult: (_id, _name, result) => {
         if (result.isError) setTransientStatus('A tool errored. The agent will retry or surface the issue.');
+      },
+      onToolResultsPersisted: msg => {
+        // Surface tool result bubbles — including renderView / renderViews
+        // snapshots — in the live transcript as the agent works. The
+        // tool_result user message is persisted by chatLoop but isn't pushed
+        // through onUserPersisted, so without this it would only appear after
+        // a session reload. renderToolResultBubble auto-expands image-bearing
+        // results, so the rendering shows without the user expanding anything.
+        upsertHistoryMessage(msg);
+        renderTranscript();
       },
       onError: err => {
         errorLog.capture({ level: 'error', source: 'ai', message: err.message, detail: err.stack });

--- a/tests/ai-tool-result-images.spec.ts
+++ b/tests/ai-tool-result-images.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from 'playwright/test';
+
+// Coverage for surfacing tool-returned renderings (renderView / renderViews
+// snapshots) in the chat transcript. Two halves:
+//
+//  1. chatLoop fires onToolResultsPersisted with the image-bearing
+//     tool_result message as soon as a tool batch completes — this is what
+//     lets the panel drop the rendering into the LIVE transcript instead of
+//     only after a session reload.
+//  2. A persisted tool_result message that carries an image renders the
+//     image inline in the transcript, auto-expanded (no chip to open).
+
+// A 1x1 transparent PNG — enough to assert the bytes round-trip into an <img>.
+const TINY_PNG =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+test.describe('Tool-result renderings in the chat transcript', () => {
+  test('chatLoop surfaces the renderViews image to the panel as the turn runs', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel');
+
+    const captured = await page.evaluate(async ({ tinyPng }) => {
+      const cl = await import('/src/ai/chatLoop.ts');
+      const a = await import('/src/ai/anthropic.ts');
+
+      // Two canned Anthropic SSE responses: the first asks for a renderViews
+      // tool call, the second ends the turn. The agent loop runs the tool in
+      // between via the injected executeToolFn.
+      const toolUseStream = [
+        'event: message_start',
+        'data: {"type":"message_start","message":{"id":"msg_tool","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":20,"output_tokens":1}}}',
+        '',
+        'event: content_block_start',
+        'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_render","name":"renderViews","input":{}}}',
+        '',
+        'event: content_block_delta',
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"views\\": \\"all\\"}"}}',
+        '',
+        'event: content_block_stop',
+        'data: {"type":"content_block_stop","index":0}',
+        '',
+        'event: message_delta',
+        'data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":8}}',
+        '',
+        'event: message_stop',
+        'data: {"type":"message_stop"}',
+        '',
+        '',
+      ].join('\n');
+
+      const endTurnStream = [
+        'event: message_start',
+        'data: {"type":"message_start","message":{"id":"msg_end","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":30,"output_tokens":1}}}',
+        '',
+        'event: content_block_start',
+        'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+        '',
+        'event: content_block_delta',
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Verified the views."}}',
+        '',
+        'event: content_block_stop',
+        'data: {"type":"content_block_stop","index":0}',
+        '',
+        'event: message_delta',
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":4}}',
+        '',
+        'event: message_stop',
+        'data: {"type":"message_stop"}',
+        '',
+        '',
+      ].join('\n');
+
+      const origFetch = window.fetch;
+      let call = 0;
+      // @ts-expect-error test stub
+      window.fetch = async (input: unknown, init?: unknown) => {
+        const url = typeof input === 'string' ? input : String((input as { url?: string })?.url ?? input);
+        if (url.includes('anthropic')) {
+          const body = call === 0 ? toolUseStream : endTurnStream;
+          call++;
+          return new Response(new Blob([body]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+        }
+        // Delegate everything else (notably the /ai.md system-prompt fetch).
+        return origFetch(input as RequestInfo, init as RequestInit);
+      };
+
+      a.resetClient();
+      const toggles = {
+        vision: { views: true },
+        scope: { runCode: true, saveVersions: true, paintFaces: true },
+        autoRetry: 0,
+        maxIterations: 'medium',
+        maxSpend: 'high',
+        thinking: 'off',
+        provider: 'anthropic',
+        anthropicModel: 'claude-haiku-4-5',
+        localModel: null,
+        openaiModel: 'gpt-5-mini',
+        geminiModel: 'gemini-3.5-flash',
+      };
+
+      const persisted: Array<{ toolResults?: unknown }> = [];
+      try {
+        await cl.runTurn(
+          {
+            apiKey: 'test-key',
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            toggles: toggles as any,
+            sessionId: 'test-tool-result-images',
+            history: [],
+            userBlocks: [{ type: 'text', text: 'render the views and verify' }],
+            executeToolFn: async (name: string) => {
+              if (name === 'renderViews') {
+                return {
+                  content: 'Rendered views: all composite. The image is attached to this result.',
+                  isError: false,
+                  image: { data: tinyPng, mediaType: 'image/png', label: 'views: all composite' },
+                };
+              }
+              return { content: '(ok)', isError: false };
+            },
+          },
+          {
+            onToolResultsPersisted: (msg) => {
+              persisted.push({ toolResults: msg.toolResults });
+            },
+          },
+        );
+      } finally {
+        window.fetch = origFetch;
+      }
+      return persisted;
+    }, { tinyPng: TINY_PNG });
+
+    // The callback fired once, for the single renderViews tool batch, and the
+    // persisted tool_result carried the rendered image bytes + label.
+    expect(captured).toHaveLength(1);
+    const results = captured[0].toolResults as Array<{ content: string; image?: { data: string; label?: string } }>;
+    expect(results).toHaveLength(1);
+    expect(results[0].image).toBeTruthy();
+    expect(results[0].image!.data).toBe(TINY_PNG);
+    expect(results[0].image!.label).toBe('views: all composite');
+    expect(results[0].content).toContain('Rendered views');
+  });
+
+  test('a persisted tool_result image renders inline in the transcript', async ({ page }) => {
+    await page.goto('/editor');
+    await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ } });
+    await page.waitForSelector('#ai-panel');
+
+    await page.evaluate(async ({ tinyPng }) => {
+      const db = await import('/src/ai/db.ts');
+      const sm = await import('/src/storage/sessionManager.ts');
+      const sid = sm.getState().session?.id ?? db.GLOBAL_CHAT_BUCKET;
+      await db.putMessages([
+        {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          id: 'm-tc-1', sessionId: sid, role: 'assistant',
+          blocks: [{ type: 'text', text: 'Let me look at all four views.' }],
+          toolCalls: [{ id: 'toolu_render', name: 'renderViews', input: { views: 'all' } }],
+          createdAt: Date.now(), seq: 1,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          id: 'm-tr-1', sessionId: sid, role: 'user', blocks: [],
+          toolResults: [{
+            toolUseId: 'toolu_render',
+            content: 'Rendered views: all composite. The image is attached to this result.',
+            isError: false,
+            image: { data: tinyPng, mediaType: 'image/png', label: 'views: all composite' },
+          }],
+          createdAt: Date.now(), seq: 2,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+      ]);
+    }, { tinyPng: TINY_PNG });
+
+    await page.reload();
+    await page.waitForSelector('#ai-panel');
+    await page.locator('#btn-ai').dispatchEvent('click');
+
+    // The rendering shows as an <img> in the transcript, visible without the
+    // user expanding anything (image-bearing tool results auto-expand).
+    const rendering = page.locator(`#ai-panel img[src*="${TINY_PNG.slice(0, 24)}"]`);
+    await expect(rendering).toBeVisible();
+    // The result chip carrying it defaulted to open.
+    const resultChip = page.locator('#ai-panel details', { hasText: 'Rendered views' });
+    await expect(resultChip).toHaveAttribute('open', '');
+    // The tool call's parameters are still inspectable on its own chip.
+    const callChip = page.locator('#ai-panel details', { hasText: 'renderViews' }).first();
+    await callChip.locator('summary').dispatchEvent('click');
+    await expect(callChip.locator('pre')).toContainText('"views": "all"');
+  });
+});


### PR DESCRIPTION
## Summary

When an AI session calls `renderViews` (or `renderView`, `sliceAtZVisual`, paint previews, etc.), the rendered image is captured and sent to the model — but it didn't appear in the chat transcript during the turn. Expanding a tool-call bubble showed the request params (e.g. `"views": "all"`) with no sign of the image the agent actually looked at. The image only surfaced after a full session reload.

Root cause: `chatLoop` persists the `tool_result` user message (which carries the image) straight to IndexedDB and appends it to its internal working history, but it isn't pushed into the panel's in-memory `state.history` mid-turn (only the queued-follow-up path did that). The renderer (`renderToolResultBubble`) already knows how to show tool images and auto-expands them — it just never received the message live.

This change:
- Adds an `onToolResultsPersisted` callback to `RunTurnCallbacks`, fired right after each tool batch's result message is persisted. It's threaded through the agent Web Worker (`agentWorker.ts` → `agentWorkerClient.ts`) like the other callbacks.
- The panel handler upserts the message into `state.history` by `seq` and re-renders, so the result bubble — image auto-expanded — appears inline as the agent works, matching what a reload already shows.
- Extracts the insert-or-replace logic into a shared `upsertHistoryMessage` helper, reused by the existing queued-message path (`onUserMessageUpdated`).

The rewind logic and cost meter already account for `tool_result` carrier messages (empty `blocks`), so no spurious rewind points or cost changes.

## Test plan

- [x] `npm run build` (tsc + vite) succeeds with no type errors
- [x] New `tests/ai-tool-result-images.spec.ts`:
  - drives `chatLoop.runTurn` with a stubbed Anthropic tool-use stream and asserts `onToolResultsPersisted` fires with the `renderViews` image attached (fails without the fix)
  - seeds a persisted `tool_result` with an image, reloads, and asserts the `<img>` renders inline and the result chip is auto-expanded
- [x] Full Playwright suite green (109 passed), including the AI panel, worker, and chat-export suites

https://claude.ai/code/session_0149wsPTys98WJjceuRw173F

---
_Generated by [Claude Code](https://claude.ai/code/session_0149wsPTys98WJjceuRw173F)_