### PR TITLE
feat: add mesh-edge (wireframe) toggle to the viewport

### DIFF
--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -6,7 +6,7 @@ import type { MeshData } from '../geometry/types';
 import { pickFace } from './facePicker';
 import { buildAdjacency, findCoplanarRegion, getTriangleNormal, type AdjacencyGraph } from './adjacency';
 import { addRegion, getRegions } from './regions';
-import { getScene, getMeshGroup, getRenderer, addPointerSuppressor, isPointerOverModel } from '../renderer/viewport';
+import { getScene, getMeshGroup, getRenderer, addPointerSuppressor, isPointerOverModel, setWireframeVisible, isWireframeVisible } from '../renderer/viewport';
 import { activate as activateSlabDrag, deactivate as deactivateSlabDrag, onMeshChanged as onSlabDragMeshChanged } from './slabDrag';
 import { activate as activateBoxDrag, deactivate as deactivateBoxDrag, onMeshChanged as onBoxDragMeshChanged } from './boxDrag';
 export { setSlabAxis, getSlabAxis } from './slabDrag';
@@ -46,6 +46,10 @@ let mouseDownOffModel = false;
 
 // Teardown for the capture-phase pointer suppressor registered on activate.
 let removeSuppressor: (() => void) | null = null;
+
+// Wireframe edges are important for aiming paint, so paint mode forces them on
+// and restores whatever the user had when it deactivates.
+let wireframeBeforePaint = false;
 
 // Callbacks
 let onRegionPainted: (() => void) | null = null;
@@ -150,6 +154,9 @@ export function activate(): void {
   if (active) return;
   active = true;
 
+  wireframeBeforePaint = isWireframeVisible();
+  setWireframeVisible(true);
+
   if (currentMesh && !adjacency) {
     // Fallback: pre-warm callback hasn't fired yet (e.g. user opened paint
     // immediately after execution). Build synchronously now.
@@ -180,6 +187,8 @@ export function deactivate(): void {
   if (!active) return;
   active = false;
   adjacency = null;
+
+  setWireframeVisible(wireframeBeforePaint);
 
   if (removeSuppressor) { removeSuppressor(); removeSuppressor = null; }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ import { initDiagnosticsPanel, toggleDiagnosticsPanel } from './ui/diagnosticsPa
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, type Language } from './geometry/engine';
 import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
-import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible } from './renderer/viewport';
+import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange } from './renderer/viewport';
 import { renderCompositeCanvas, renderSingleView, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode } from './renderer/multiview';
 import { generateId } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
@@ -1491,6 +1491,7 @@ async function main() {
   initClipControls(clipControls);
 
   // Wire up viewport overlay buttons
+  initWireframeToggle(clipControls);
   initGridToggle(clipControls);
   initDimensionsToggle(clipControls);
   initAnnotateUI(clipControls);
@@ -5733,6 +5734,27 @@ async function main() {
       if (closeMeasureIfActive()) closed = true;
       if (getClipState().enabled) { setClipping(false); syncClipUI(); closed = true; }
       if (closed) e.preventDefault();
+    });
+  }
+
+  function initWireframeToggle(container: HTMLElement) {
+    const wireBtn = container.querySelector('#wireframe-toggle') as HTMLButtonElement;
+    if (!wireBtn) return;
+
+    const inactiveClass = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+    const activeClass = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-blue-500/20 backdrop-blur text-blue-400 [@media(hover:hover)]:hover:bg-blue-500/30 transition-colors border border-blue-500/30';
+
+    // Drive the button visuals from the viewport's change events so it stays in
+    // sync whether the user clicked it or paint mode forced edges on/off.
+    const applyState = (visible: boolean) => {
+      wireBtn.className = visible ? activeClass : inactiveClass;
+      wireBtn.title = visible ? 'Hide mesh edges' : 'Show mesh edges';
+    };
+    applyState(isWireframeVisible());
+    onWireframeChange(applyState);
+
+    wireBtn.addEventListener('click', () => {
+      setWireframeVisible(!isWireframeVisible());
     });
   }
 

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -48,6 +48,12 @@ const ndcForHit = new THREE.Vector2();
 // Grid plane
 let grid: THREE.GridHelper;
 
+// Mesh edge (wireframe) overlay visibility. Hidden by default so the model
+// reads cleanly; paint mode forces it on (see paintMode.ts) and the viewport
+// toggle button lets the user override either way.
+let wireframeVisible = false;
+let wireframeChangeListener: ((visible: boolean) => void) | null = null;
+
 // Clipping plane state
 const clipPlane = new THREE.Plane(new THREE.Vector3(0, 0, -1), 0); // clips above Z
 let clippingEnabled = false;
@@ -239,6 +245,8 @@ export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boole
 
   const solidMesh = new THREE.Mesh(geometry, solidMat);
   const wireMesh = new THREE.Mesh(geometry, wireMat);
+  wireMesh.name = 'wireframe';
+  wireMesh.visible = wireframeVisible;
 
   meshGroup.add(solidMesh);
   meshGroup.add(wireMesh);
@@ -557,6 +565,27 @@ export function setGridVisible(visible: boolean): void {
 
 export function isGridVisible(): boolean {
   return grid.visible;
+}
+
+// === Wireframe (mesh edge) visibility API ===
+
+export function setWireframeVisible(visible: boolean): void {
+  if (wireframeVisible === visible) return;
+  wireframeVisible = visible;
+  meshGroup.children.forEach(child => {
+    if (child.name === 'wireframe') child.visible = visible;
+  });
+  wireframeChangeListener?.(visible);
+}
+
+export function isWireframeVisible(): boolean {
+  return wireframeVisible;
+}
+
+/** Subscribe to wireframe visibility changes so UI (the toggle button) stays
+ *  in sync whether the change came from the button or from paint mode. */
+export function onWireframeChange(cb: (visible: boolean) => void): void {
+  wireframeChangeListener = cb;
 }
 
 export function dispose(): void {

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -397,6 +397,14 @@ function createClipControls(): HTMLElement {
   container.id = 'clip-controls';
   container.className = 'absolute top-2 right-2 z-10 flex flex-wrap justify-end items-center gap-2 max-w-[calc(100%-1rem)]';
 
+  // Mesh edge (wireframe) toggle (off by default) — sits left of the grid toggle
+  const wireBtn = document.createElement('button');
+  wireBtn.id = 'wireframe-toggle';
+  wireBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  wireBtn.textContent = '△';
+  wireBtn.title = 'Show mesh edges';
+  container.appendChild(wireBtn);
+
   // Grid toggle (off by default)
   const gridBtn = document.createElement('button');
   gridBtn.id = 'grid-toggle';

--- a/tests/paint-controls-extended.spec.ts
+++ b/tests/paint-controls-extended.spec.ts
@@ -175,6 +175,61 @@ test.describe('extended paint controls', () => {
     expect(result.bad.error).toBeTruthy();
   });
 
+  test('mesh-edge toggle sits left of the grid toggle and defaults off', async ({ page }) => {
+    await openEditor(page);
+    const wireBtn = page.locator('#wireframe-toggle');
+    await expect(wireBtn).toBeVisible();
+    await expect(page.locator('#grid-toggle')).toBeVisible();
+    // Default: edges hidden, so the button invites showing them.
+    await expect(wireBtn).toHaveAttribute('title', 'Show mesh edges');
+    // DOM order places the wireframe button before the grid button (i.e. to its left).
+    const wireIsBeforeGrid = await page.evaluate(() => {
+      const w = document.querySelector('#wireframe-toggle')!;
+      const g = document.querySelector('#grid-toggle')!;
+      return Boolean(w.compareDocumentPosition(g) & Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+    expect(wireIsBeforeGrid).toBe(true);
+  });
+
+  test('clicking the mesh-edge toggle flips it on and back off', async ({ page }) => {
+    await openEditor(page);
+    const wireBtn = page.locator('#wireframe-toggle');
+    await wireBtn.dispatchEvent('click');
+    await expect(wireBtn).toHaveAttribute('title', 'Hide mesh edges');
+    await wireBtn.dispatchEvent('click');
+    await expect(wireBtn).toHaveAttribute('title', 'Show mesh edges');
+  });
+
+  test('paint mode forces mesh edges on and restores the prior state on exit', async ({ page }) => {
+    await openEditor(page);
+    const wireBtn = page.locator('#wireframe-toggle');
+    await expect(wireBtn).toHaveAttribute('title', 'Show mesh edges');
+
+    // Entering paint mode turns edges on (they matter for aiming paint).
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+    await expect(wireBtn).toHaveAttribute('title', 'Hide mesh edges');
+
+    // Leaving paint mode restores the previous (off) state.
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await expect(wireBtn).toHaveAttribute('title', 'Show mesh edges');
+  });
+
+  test('edges left on before painting stay on after exiting paint', async ({ page }) => {
+    await openEditor(page);
+    const wireBtn = page.locator('#wireframe-toggle');
+    // User turns edges on manually first.
+    await wireBtn.dispatchEvent('click');
+    await expect(wireBtn).toHaveAttribute('title', 'Hide mesh edges');
+
+    // Paint then exit — edges should remain on, matching the pre-paint state.
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+    await expect(wireBtn).toHaveAttribute('title', 'Hide mesh edges');
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await expect(wireBtn).toHaveAttribute('title', 'Hide mesh edges');
+  });
+
   test('hideRegion / showRegion partwright API toggles visibility flag', async ({ page }) => {
     await openEditor(page);
     const result = await page.evaluate(() => {


### PR DESCRIPTION
## Summary
- Adds a mesh-edge (wireframe) toggle button to the interactive viewport, placed **to the left of the grid-plane toggle** (the `△` button).
- Edges are **hidden by default** so the model reads cleanly; the button shows/hides them on demand.
- **Paint mode automatically turns edges on** while active (they help aim paint) and restores the prior state when you leave paint mode — so edges you turned on yourself stay on, and the auto-on reverts to off.

## Scope
- Affects the **interactive viewport only** (matching the grid toggle's scope), as chosen. The AI Views / elevation renders are intentionally untouched.
- The AI `renderView` / `renderViews` output is **unaffected** — those build their own offscreen scenes (`renderSingleView` → `createElevationScene`), independent of the interactive viewport's mesh group. Flagging this since you mentioned you may want a separate decision for the API side; it's easy to add a wireframe option there later.

## Implementation
- `renderer/viewport.ts`: wireframe visibility state + `setWireframeVisible` / `isWireframeVisible` / `onWireframeChange`; the wire mesh is tagged `'wireframe'` and its visibility re-applied on every mesh rebuild.
- `ui/layout.ts`: new `#wireframe-toggle` button inserted before `#grid-toggle`.
- `main.ts`: `initWireframeToggle` wires the click handler; the button's visuals are driven by viewport change events so it stays in sync when paint mode toggles edges.
- `color/paintMode.ts`: `activate()` saves the current state and forces edges on; `deactivate()` restores it (covers the toggle button, Escape, and tab-switch teardown paths).

## Test plan
- [x] `npm run build` passes (no TS errors)
- [x] 4 new Playwright tests in `paint-controls-extended.spec.ts`: button placement + default-off, click toggles on/off, paint forces edges on then restores, and edges-left-on-before-paint persist after exit — all pass
- [x] Full smoke suite passes **except** `quality-scad.spec.ts`, a pre-existing flaky SCAD quality-preset timing test. Verified unrelated: with my changes stashed, the clean baseline fails identically (`--repeat-each=5` → 5/5 fail on both trees). The toggle only affects viewport *display* and never feeds `triangleCount`.

https://claude.ai/code/session_01Pn2XNKw4sLKAGi9QR9KHQt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pn2XNKw4sLKAGi9QR9KHQt)_