### PR TITLE
Clear editor on new session and show thumbnails in session list

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1042,6 +1042,16 @@ async function main() {
   // Init diagnostic panel — attaches to document.body, registers badge subscriber.
   initDiagnosticsPanel();
 
+  // Reset the editor to a blank starting point for a freshly created session.
+  // Shared by the session bar's "+ New Session" button and the session modal's,
+  // so both clear the previous session's code instead of leaving it behind.
+  function startNewSessionInEditor() {
+    const freshCode = '// New session\nconst { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);';
+    setValue(freshCode);
+    runCode(freshCode);
+    _clearImages();
+  }
+
   // Create session bar
   createSessionBar(editorUI, {
     onSaveVersion: async () => ({
@@ -1060,12 +1070,7 @@ async function main() {
       applyVersionAnnotations(loadedVersion);
     },
     onOpenSessionList: () => showSessionList(),
-    onNewSession: () => {
-      const freshCode = '// New session\nconst { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);';
-      setValue(freshCode);
-      runCode(freshCode);
-      _clearImages();
-    },
+    onNewSession: startNewSessionInEditor,
   });
 
   // Create layout
@@ -1173,6 +1178,7 @@ async function main() {
       await runCodeSync(code);
       return captureThumbnail();
     },
+    startNewSessionInEditor,
   );
 
   // Assemble DOM early so landing/help pages can render before WASM loads

--- a/src/ui/sessionList.ts
+++ b/src/ui/sessionList.ts
@@ -11,7 +11,7 @@ import {
   type Session,
   type ExportedSession,
 } from '../storage/sessionManager';
-import { getVersionCount } from '../storage/db';
+import { getLatestVersion, getVersionCount } from '../storage/db';
 
 let modalEl: HTMLElement | null = null;
 let onLoadVersion: ((code: string) => void | Promise<void>) | null = null;
@@ -149,7 +149,10 @@ export async function showSessionList(): Promise<void> {
 }
 
 async function createSessionRow(session: Session): Promise<HTMLElement> {
-  const count = await getVersionCount(session.id);
+  const [count, latestVersion] = await Promise.all([
+    getVersionCount(session.id),
+    getLatestVersion(session.id),
+  ]);
 
   const row = document.createElement('div');
   row.className = 'flex items-center gap-3 px-5 py-3 hover:bg-zinc-700/50 cursor-pointer border-b border-zinc-700/50 transition-colors';
@@ -161,6 +164,25 @@ async function createSessionRow(session: Session): Promise<HTMLElement> {
     }
     closeModal();
   });
+
+  // Thumbnail preview (same render as the landing-page session tiles)
+  const thumb = document.createElement('div');
+  thumb.className = 'w-12 h-12 rounded bg-zinc-900 border border-zinc-700/50 flex items-center justify-center overflow-hidden shrink-0';
+  if (latestVersion?.thumbnail) {
+    const img = document.createElement('img');
+    img.className = 'w-full h-full object-contain';
+    img.src = URL.createObjectURL(latestVersion.thumbnail);
+    img.loading = 'lazy';
+    img.alt = session.name;
+    img.addEventListener('load', () => URL.revokeObjectURL(img.src));
+    thumb.appendChild(img);
+  } else {
+    const placeholder = document.createElement('span');
+    placeholder.className = 'text-lg text-zinc-700';
+    placeholder.textContent = '⬡';
+    thumb.appendChild(placeholder);
+  }
+  row.appendChild(thumb);
 
   // Info
   const info = document.createElement('div');

--- a/src/ui/sessionList.ts
+++ b/src/ui/sessionList.ts
@@ -16,13 +16,16 @@ import { getVersionCount } from '../storage/db';
 let modalEl: HTMLElement | null = null;
 let onLoadVersion: ((code: string) => void | Promise<void>) | null = null;
 let regenerateThumbnailFn: ((code: string) => Promise<Blob | null>) | null = null;
+let onNewSessionFn: (() => void) | null = null;
 
 export function initSessionList(
   loadCode: (code: string) => void | Promise<void>,
   regenerateThumbnail?: (code: string) => Promise<Blob | null>,
+  onNewSession?: () => void,
 ): void {
   onLoadVersion = loadCode;
   regenerateThumbnailFn = regenerateThumbnail ?? null;
+  onNewSessionFn = onNewSession ?? null;
 }
 
 export async function showSessionList(): Promise<void> {
@@ -99,6 +102,7 @@ export async function showSessionList(): Promise<void> {
     const name = prompt('Session name:');
     if (name === null) return;
     await createSession(name || undefined);
+    onNewSessionFn?.();
     closeModal();
   });
   headerActions.appendChild(newBtn);

--- a/tests/session-modal.spec.ts
+++ b/tests/session-modal.spec.ts
@@ -63,4 +63,55 @@ test.describe('Session modal', () => {
       MARKER,
     );
   });
+
+  test('session rows render a thumbnail preview', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForApi(page);
+
+    const withThumb = await page.evaluate(
+      async () => (await (window as unknown as { partwright: PW }).partwright.createSession('Thumb Session')).id,
+    );
+    await page.evaluate(() => (window as unknown as { partwright: PW }).partwright.createSession('Empty Session'));
+
+    // Seed a saved version carrying a real 1×1 PNG thumbnail for the first
+    // session, straight into IndexedDB so the assertion doesn't depend on WebGL.
+    await page.evaluate(async (sessionId) => {
+      // Build the Blob from base64 directly — the app's CSP blocks fetch('data:').
+      const b64 =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+      const bin = atob(b64);
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      const blob = new Blob([bytes], { type: 'image/png' });
+      const db: IDBDatabase = await new Promise((res, rej) => {
+        const r = indexedDB.open('partwright');
+        r.onsuccess = () => res(r.result);
+        r.onerror = () => rej(r.error);
+      });
+      const tx = db.transaction('versions', 'readwrite');
+      tx.objectStore('versions').put({
+        id: 'seed-thumb-v1',
+        sessionId,
+        index: 1,
+        code: 'return Manifold.cube([1,1,1]);',
+        geometryData: null,
+        thumbnail: blob,
+        label: 'v1',
+        timestamp: Date.now(),
+      });
+      await new Promise<void>((res, rej) => {
+        tx.oncomplete = () => res();
+        tx.onerror = () => rej(tx.error);
+      });
+      db.close();
+    }, withThumb);
+
+    await page.locator('#session-bar button', { hasText: 'Sessions' }).click();
+    await expect(page.getByRole('heading', { name: 'Sessions' })).toBeVisible();
+
+    // The seeded session shows its thumbnail as an <img>; the version-less one
+    // falls back to the placeholder glyph.
+    await expect(page.locator('img[alt="Thumb Session"]')).toBeVisible();
+    await expect(page.getByText('⬡').first()).toBeVisible();
+  });
 });

--- a/tests/session-modal.spec.ts
+++ b/tests/session-modal.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, type Page } from 'playwright/test';
+
+// Network-free coverage for two session-modal changes:
+//   1. Creating a new session from the modal must clear the previous
+//      session's code from the editor (it used to leave the old code behind).
+//   2. Each session row shows a thumbnail preview of its latest version —
+//      an <img> when a thumbnail exists, a placeholder glyph otherwise —
+//      mirroring the landing-page session tiles.
+
+type PW = {
+  createSession: (name: string) => Promise<{ id: string }>;
+  getCode: () => string;
+  setCode: (code: string) => void;
+};
+
+function waitForApi(page: Page) {
+  return page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { createSession?: unknown } }).partwright?.createSession,
+  );
+}
+
+test.describe('Session modal', () => {
+  // Suppress the first-visit guided tour — its full-screen backdrop otherwise
+  // intercepts pointer events on the session bar.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('partwright-tour-completed', '1');
+      } catch {
+        /* storage may be unavailable */
+      }
+    });
+  });
+
+  test('creating a new session from the modal clears the previous code', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForApi(page);
+
+    // Open an active session so the only "+ New Session" button on screen is
+    // the modal's (the session bar only shows its own when there's no session).
+    await page.evaluate(() => (window as unknown as { partwright: PW }).partwright.createSession('Original Session'));
+
+    const MARKER = 'SENTINEL_OLD_SESSION_CODE_123';
+    await page.evaluate((m) => {
+      (window as unknown as { partwright: PW }).partwright.setCode(
+        `// ${m}\nconst { Manifold } = api;\nreturn Manifold.sphere(7);`,
+      );
+    }, MARKER);
+    expect(await page.evaluate(() => (window as unknown as { partwright: PW }).partwright.getCode())).toContain(MARKER);
+
+    // The modal's New Session button prompts for a name — accept it.
+    page.on('dialog', (d) => d.accept('Fresh Session'));
+
+    await page.locator('#session-bar button', { hasText: 'Sessions' }).click();
+    await expect(page.getByRole('heading', { name: 'Sessions' })).toBeVisible();
+    await page.locator('button', { hasText: '+ New Session' }).click();
+
+    // Editor now holds the fresh default, not the old session's code.
+    await expect
+      .poll(() => page.evaluate(() => (window as unknown as { partwright: PW }).partwright.getCode()))
+      .toContain('// New session');
+    expect(await page.evaluate(() => (window as unknown as { partwright: PW }).partwright.getCode())).not.toContain(
+      MARKER,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **Fix:** The Sessions modal's "+ New Session" button created the session but left the previous session's code in the editor — only the session bar's button reset it. The editor reset is now a shared helper that runs from the modal too.
- **Feature:** Each row in the Sessions modal now shows a thumbnail of its latest version (or a placeholder glyph when there isn't one), mirroring the landing-page session tiles.

## Changes
- `src/main.ts` — extract `startNewSessionInEditor` and pass it to both the session bar and `initSessionList`.
- `src/ui/sessionList.ts` — run the editor reset from the modal's "+ New Session" button; render a per-row thumbnail (revoking the blob URL on load), matching the landing page.
- `tests/session-modal.spec.ts` — new Playwright coverage for both behaviours.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] `npx playwright test session-modal` passes (2 new tests)
- [x] Full `npx playwright test` suite passes (112 tests, no regressions)

https://claude.ai/code/session_01JBDZkKbgGSwRdFeyrboQ8j

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBDZkKbgGSwRdFeyrboQ8j)_