### PR TITLE
feat: add Simplify tool to reduce model triangle count

### DIFF
--- a/src/annotations/annotateMode.ts
+++ b/src/annotations/annotateMode.ts
@@ -29,6 +29,7 @@ import {
   isUserOrbitLocked,
 } from '../renderer/viewport';
 import { forceDeactivate as forceDeactivatePaint } from '../color/paintUI';
+import { forceDeactivate as closeSimplifyMenu } from '../ui/simplifyUI';
 import { forceDeactivate as forceDeactivateText } from './textMode';
 import { forceDeactivate as forceDeactivateSelect } from './selectMode';
 
@@ -85,6 +86,7 @@ function notifyActiveChange(): void {
 export function activate(): void {
   if (active) return;
   forceDeactivatePaint();
+  closeSimplifyMenu();
   forceDeactivateSelect();
   // Detach text mode's handlers but keep the session plane alive — pen and
   // text share the plane within one Annotate activation.

--- a/src/annotations/selectMode.ts
+++ b/src/annotations/selectMode.ts
@@ -33,6 +33,7 @@ import {
   isUserOrbitLocked,
 } from '../renderer/viewport';
 import { forceDeactivate as forceDeactivatePaint } from '../color/paintUI';
+import { forceDeactivate as closeSimplifyMenu } from '../ui/simplifyUI';
 import { forceDeactivate as forceDeactivatePen } from './annotateMode';
 import { forceDeactivate as forceDeactivateText } from './textMode';
 
@@ -90,6 +91,7 @@ function notifySelectionChange(): void {
 export function activate(): void {
   if (active) return;
   forceDeactivatePaint();
+  closeSimplifyMenu();
   forceDeactivatePen({ keepSession: false });
   forceDeactivateText({ keepSession: false });
   // Select doesn't have a session plane — each annotation has its own.

--- a/src/annotations/textMode.ts
+++ b/src/annotations/textMode.ts
@@ -22,6 +22,7 @@ import {
   isUserOrbitLocked,
 } from '../renderer/viewport';
 import { forceDeactivate as forceDeactivatePaint } from '../color/paintUI';
+import { forceDeactivate as closeSimplifyMenu } from '../ui/simplifyUI';
 import { forceDeactivate as forceDeactivatePen } from './annotateMode';
 import { forceDeactivate as forceDeactivateSelect } from './selectMode';
 
@@ -73,6 +74,7 @@ function notifyActiveChange(): void {
 export function activate(): void {
   if (active) return;
   forceDeactivatePaint();
+  closeSimplifyMenu();
   forceDeactivateSelect();
 
   // Reuse existing session if there is one (pen→text switch); otherwise start.

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -41,6 +41,7 @@ import { forceDeactivate as forceDeactivateAnnotate } from '../annotations/annot
 import { forceDeactivate as forceDeactivateAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as forceDeactivateAnnotateSelect } from '../annotations/selectMode';
 import { setBoxMode, getBoxMode, setBox, commitBox, onBoxChange, setShapeType, getShapeType, getShapeVisible, setShapeVisible, onShapeVisibilityChange, type BoxMode, type ShapeType } from './boxDrag';
+import { forceDeactivate as closeSimplifyMenu } from '../ui/simplifyUI';
 
 const PRESET_COLORS: [number, number, number][] = [
   // Warm
@@ -126,6 +127,7 @@ function togglePaintMode(): void {
     forceDeactivateAnnotate();
     forceDeactivateAnnotateText();
     forceDeactivateAnnotateSelect();
+    closeSimplifyMenu();
     activate();
     updateButtonState(true);
     pickerPanel?.classList.remove('hidden');

--- a/src/geometry/simplify.ts
+++ b/src/geometry/simplify.ts
@@ -1,0 +1,136 @@
+// Mesh decimation: reduce a Manifold's triangle count to a target budget by
+// binary-searching the geometric tolerance fed to Manifold.simplify(). The UI
+// exposes this as a "max triangles" slider; this module turns that target into
+// the gentlest tolerance that meets it.
+
+import type { MeshData } from './types';
+
+/** The slice of the manifold-3d Manifold surface this search relies on. Kept
+ *  structural so we don't lean on the WASM module's loose `any` typing. The
+ *  caller owns the manifold passed in (it is never deleted here); every
+ *  intermediate manifold this module allocates is released before returning. */
+export interface SimplifiableManifold {
+  numTri(): number;
+  simplify(tolerance?: number): SimplifiableManifold;
+  getMesh(): {
+    vertProperties: Float32Array;
+    triVerts: Uint32Array;
+    numVert: number;
+    numTri: number;
+    numProp: number;
+    mergeFromVert?: Uint32Array;
+    mergeToVert?: Uint32Array;
+    runIndex?: Uint32Array;
+    runOriginalID?: Uint32Array;
+  };
+  delete?(): void;
+}
+
+export interface SimplifyResult {
+  mesh: MeshData;
+  /** Triangle count actually achieved (≤ target when the geometry allows). */
+  triangleCount: number;
+  /** Tolerance passed to Manifold.simplify() to reach this result. */
+  tolerance: number;
+}
+
+const SEARCH_ITERATIONS = 16;
+// A closed manifold needs at least four triangles; anything below that is a
+// collapsed/degenerate result we never want to hand back.
+const MIN_VALID_TRIANGLES = 4;
+
+function toMeshData(m: SimplifiableManifold): MeshData {
+  // getMesh() may hand back views into the WASM heap; slice() copies them onto
+  // the JS heap so they stay valid after the manifold is deleted.
+  const mesh = m.getMesh();
+  return {
+    vertProperties: mesh.vertProperties.slice(),
+    triVerts: mesh.triVerts.slice(),
+    numVert: mesh.numVert,
+    numTri: mesh.numTri,
+    numProp: mesh.numProp,
+    ...(mesh.mergeFromVert ? { mergeFromVert: mesh.mergeFromVert.slice() } : {}),
+    ...(mesh.mergeToVert ? { mergeToVert: mesh.mergeToVert.slice() } : {}),
+    ...(mesh.runIndex ? { runIndex: mesh.runIndex.slice() } : {}),
+    ...(mesh.runOriginalID ? { runOriginalID: mesh.runOriginalID.slice() } : {}),
+  };
+}
+
+function release(m: SimplifiableManifold | null): void {
+  if (m && typeof m.delete === 'function') {
+    try { m.delete(); } catch { /* already freed */ }
+  }
+}
+
+/** Find the gentlest simplification of `manifold` whose triangle count is at
+ *  most `targetTriangles`, by binary-searching the tolerance passed to
+ *  Manifold.simplify() (larger tolerance ⇒ fewer triangles).
+ *
+ *  `maxTolerance` bounds the search — pass roughly half the bounding-box
+ *  diagonal; beyond that the mesh collapses and there is nothing more to gain.
+ *
+ *  Returns null when no reduction is needed (target ≥ current triangle count)
+ *  or possible, signalling the caller to keep the original mesh. The input
+ *  manifold is borrowed, never deleted; every intermediate manifold allocated
+ *  during the search is released here. */
+export function simplifyToTriangleBudget(
+  manifold: SimplifiableManifold,
+  targetTriangles: number,
+  maxTolerance: number,
+): SimplifyResult | null {
+  const baseTri = manifold.numTri();
+  const target = Math.max(MIN_VALID_TRIANGLES, Math.floor(targetTriangles));
+  if (!Number.isFinite(target) || target >= baseTri) return null;
+  if (!(maxTolerance > 0)) return null;
+
+  let lo = 0;
+  let hi = maxTolerance;
+
+  // Smallest tolerance that lands within [MIN_VALID_TRIANGLES, target].
+  let bestTol = -1;
+  // Tolerance giving the fewest valid (≥ MIN_VALID_TRIANGLES) triangles seen —
+  // the fallback when the target sits below what the geometry can reach.
+  let fewestValidTol = -1;
+  let fewestValidCount = Infinity;
+
+  for (let i = 0; i < SEARCH_ITERATIONS; i++) {
+    const mid = (lo + hi) / 2;
+    let n: number;
+    try {
+      const candidate = manifold.simplify(mid);
+      n = candidate.numTri();
+      release(candidate);
+    } catch {
+      // A tolerance aggressive enough to collapse the mesh can throw — treat it
+      // as too aggressive and pull the search back toward more detail.
+      hi = mid;
+      continue;
+    }
+
+    if (n >= MIN_VALID_TRIANGLES && n < fewestValidCount) {
+      fewestValidCount = n;
+      fewestValidTol = mid;
+    }
+
+    if (n < MIN_VALID_TRIANGLES) {
+      hi = mid; // too aggressive — back off toward more triangles
+    } else if (n <= target) {
+      bestTol = mid; // within budget — try to keep more detail
+      hi = mid;
+    } else {
+      lo = mid; // not reduced enough yet
+    }
+  }
+
+  const tolerance = bestTol >= 0 ? bestTol : fewestValidTol;
+  if (tolerance < 0) return null;
+
+  const final = manifold.simplify(tolerance);
+  const result: SimplifyResult = {
+    mesh: toMeshData(final),
+    triangleCount: final.numTri(),
+    tolerance,
+  };
+  release(final);
+  return result;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,6 +87,8 @@ import { maybeStartTour, resetTour, startTour } from './ui/tour';
 import { initTheme, getTheme, setTheme } from './ui/theme';
 import type { Theme } from './ui/theme';
 import { initPaintUI, isPaintOpen, forceDeactivate as closePaintMenu } from './color/paintUI';
+import { initSimplifyUI, isSimplifyOpen, refreshSimplifyIfOpen, forceDeactivate as closeSimplifyMenu, type SimplifyHandlers } from './ui/simplifyUI';
+import { simplifyToTriangleBudget, type SimplifyResult } from './geometry/simplify';
 import { updatePaintMesh, setOnRegionPainted, isActive as isPaintActive } from './color/paintMode';
 import { initAnnotateUI, isAnnotateOpen, closeMenu as closeAnnotateMenu } from './annotations/annotateUI';
 import { isActive as isSelectActive, getSelectedId as getSelectedAnnotationId } from './annotations/selectMode';
@@ -1484,15 +1486,129 @@ async function main() {
   // Wire up clip controls
   initClipControls(clipControls);
 
+  // Declared up here (before the simplify bridge and initMeasureToggle that
+  // reference it) so neither the closure capture below nor the assignment inside
+  // initMeasureToggle hits a let-TDZ error.
+  let closeMeasureIfActive: () => boolean = () => false;
+
+  // === Simplify (mesh decimation) bridge ===
+  // The simplify panel reduces the live model's triangle count. Because that
+  // changes mesh topology — not something derivable from the parametric code —
+  // it operates on the rendered result: the baseline is the full-detail mesh
+  // captured when the panel opens, previews swap the live mesh in place (so
+  // exports use it), and "Save as version" bakes the reduced mesh into a new
+  // imported-style version. The baseline persists across panel open/close and
+  // is cleared whenever a code run replaces the geometry.
+  let simplifyBaselineMesh: MeshData | null = null;
+
+  // Replace the live geometry with `mesh`: rebuild the queryable Manifold and
+  // refresh the viewport, paint-adjacency map, stats, and clip bounds. Mirrors
+  // the tail of runCodeSync so exports / slicing / measurements stay correct.
+  function applyLiveGeometry(mesh: MeshData): void {
+    currentMeshData = mesh;
+    if (currentManifold && typeof currentManifold.delete === 'function') {
+      try { currentManifold.delete(); } catch { /* already deleted */ }
+    }
+    const mod = getModule();
+    currentManifold = mod && mesh ? mod.Manifold.ofMesh(mesh) : null;
+    updateMesh(mesh);
+    updatePaintMesh(mesh);
+    updateGeometryData();
+    syncClipSliderBounds();
+  }
+
+  const simplifyHandlers: SimplifyHandlers = {
+    open(userInitiated) {
+      if (userInitiated) {
+        // Don't let two overlay panels share the top-right slot.
+        if (isPaintOpen()) closePaintMenu();
+        if (isAnnotateOpen()) closeAnnotateMenu();
+        closeMeasureIfActive();
+      }
+      if (!currentMeshData) {
+        return { ok: false, reason: 'Run some code first — there’s no model to simplify.' };
+      }
+      if (!currentManifold) {
+        return { ok: false, reason: 'Simplify needs a solid (manifold) model. Render-only imports can’t be reduced.' };
+      }
+      if (hasColorRegions()) {
+        return { ok: false, reason: 'Clear paint regions before simplifying — reducing triangles would invalidate them.' };
+      }
+      if (!simplifyBaselineMesh) simplifyBaselineMesh = currentMeshData;
+      return {
+        ok: true,
+        info: {
+          baseTriangles: simplifyBaselineMesh.numTri,
+          currentTriangles: currentMeshData.numTri,
+        },
+      };
+    },
+
+    preview(targetTriangles) {
+      if (!simplifyBaselineMesh) return null;
+      const mod = getModule();
+      if (!mod) return null;
+      const bbox = bboxFromMesh(simplifyBaselineMesh);
+      const diag = bbox
+        ? Math.hypot(bbox.max[0] - bbox.min[0], bbox.max[1] - bbox.min[1], bbox.max[2] - bbox.min[2])
+        : 0;
+      if (!(diag > 0)) return null;
+
+      const baseManifold = mod.Manifold.ofMesh(simplifyBaselineMesh);
+      let result: SimplifyResult | null = null;
+      try {
+        result = simplifyToTriangleBudget(baseManifold, targetTriangles, diag * 0.5);
+      } finally {
+        if (baseManifold && typeof baseManifold.delete === 'function') {
+          try { baseManifold.delete(); } catch { /* already deleted */ }
+        }
+      }
+      if (!result) {
+        applyLiveGeometry(simplifyBaselineMesh);
+        return null;
+      }
+      applyLiveGeometry(result.mesh);
+      return { triangleCount: result.triangleCount };
+    },
+
+    reset() {
+      if (simplifyBaselineMesh) applyLiveGeometry(simplifyBaselineMesh);
+    },
+
+    async save() {
+      const baseline = simplifyBaselineMesh;
+      if (!getState().session) {
+        return { ok: false, message: 'Open a session before saving.' };
+      }
+      if (!currentMeshData || !baseline || currentMeshData.numTri >= baseline.numTri) {
+        return { ok: false, message: 'Reduce the model first, then save.' };
+      }
+      try {
+        const reduced = currentMeshData;
+        const baked = toImportedMesh(`simplified-${reduced.numTri}tri`, reduced);
+        const code = generateImportCode([baked], { manifold: true });
+        setActiveImports([baked]);
+        setValue(code);
+        await runCodeSync(code);
+        const thumbnail = await captureThumbnail();
+        const geometryData = getGeometryDataObj();
+        await saveVersion(code, geometryData, thumbnail, 'simplified', undefined, {
+          force: true,
+          importedMeshes: [baked],
+        });
+        return { ok: true, message: `Saved as a new version (${reduced.numTri.toLocaleString()} triangles).` };
+      } catch (e) {
+        return { ok: false, message: `Save failed: ${(e as Error).message}` };
+      }
+    },
+  };
+
   // Wire up viewport overlay buttons
   initGridToggle(clipControls);
   initDimensionsToggle(clipControls);
   initAnnotateUI(clipControls);
   initPaintUI(clipControls);
-  // Declared before initMeasureToggle is called so the assignment inside it
-  // doesn't hit a let-TDZ error (the same `let` lower in this function is
-  // hoisted to a binding, but only initialized when execution reaches it).
-  let closeMeasureIfActive: () => boolean = () => false;
+  initSimplifyUI(clipControls, simplifyHandlers);
   initMeasureToggle(clipControls);
   initOrbitLockToggle(clipControls);
   initEscapeMenuClose();
@@ -5613,6 +5729,10 @@ async function main() {
 
       updateGeometryData(elapsed, src);
       syncClipSliderBounds();
+      // A fresh run replaces the geometry, so any simplify baseline is stale.
+      // Drop it and let an open panel re-snapshot the new mesh.
+      simplifyBaselineMesh = null;
+      refreshSimplifyIfOpen();
       setStatus(statusBar, 'ready', 'Ready');
     }
     return true;
@@ -5703,6 +5823,7 @@ async function main() {
       if (getMeasureState().active) {
         close();
       } else {
+        closeSimplifyMenu();
         activateMeasure();
         setMeasureLock(true);
         measureBtn.className = activeClass;
@@ -5724,6 +5845,7 @@ async function main() {
       let closed = false;
       if (isAnnotateOpen()) { closeAnnotateMenu(); closed = true; }
       if (isPaintOpen()) { closePaintMenu(); closed = true; }
+      if (isSimplifyOpen()) { closeSimplifyMenu(); closed = true; }
       if (closeMeasureIfActive()) closed = true;
       if (getClipState().enabled) { setClipping(false); syncClipUI(); closed = true; }
       if (closed) e.preventDefault();

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -104,6 +104,7 @@ export function createHelpPage(
         '<li><strong class="text-zinc-300">Cross-section</strong> — Toggle a horizontal clipping plane. A Z slider appears; everything above the plane is hidden and the cut face renders in red.</li>' +
         '<li><strong class="text-zinc-300">Annotate</strong> — Draw freehand strokes or drop pinned text labels on the model. Annotations are saved per version and survive export to <code class="text-emerald-400 bg-zinc-800 px-1 rounded">.partwright.json</code>.</li>' +
         '<li><strong class="text-zinc-300">Paint</strong> — Color regions of the model for multi-material printing (full details below).</li>' +
+        '<li><strong class="text-zinc-300">Simplify</strong> — Reduce the model\'s triangle count. Drag the slider or type a max-triangle target; the model re-simplifies live and exports use the reduced mesh. "Save as version" bakes the lighter mesh into a new saved version, while "Reset" restores full detail.</li>' +
         '</ul>',
     },
     {

--- a/src/ui/simplifyUI.ts
+++ b/src/ui/simplifyUI.ts
@@ -1,0 +1,317 @@
+// Simplify mode UI — a viewport-overlay button (next to Measure) that opens a
+// popup panel for reducing the model's triangle count. The user drags a slider
+// or types an exact "max triangles" value; the model re-simplifies live. An
+// optional "Save as version" bakes the reduced mesh into a new saved version.
+//
+// This module is intentionally a leaf: it never imports the other overlay tools
+// (paint / annotate / measure). Those modules call forceDeactivate() here when
+// they open, and opening Simplify closes them via the injected handlers.open().
+
+export interface SimplifyOpenInfo {
+  baseTriangles: number;
+  currentTriangles: number;
+}
+
+export interface SimplifySaveResult {
+  ok: boolean;
+  message: string;
+}
+
+export interface SimplifyHandlers {
+  /** Snapshot the current model as the simplify baseline. Returns its triangle
+   *  count (and the count currently on screen), or a reason when the model
+   *  can't be simplified right now. When `userInitiated` is true (the user
+   *  clicked the toolbar button) the implementation should also close the other
+   *  overlay tools so panels don't stack. */
+  open(userInitiated: boolean): { ok: true; info: SimplifyOpenInfo } | { ok: false; reason: string };
+  /** Simplify the baseline down to at most `targetTriangles` and show it live.
+   *  Returns the achieved triangle count, or null if nothing changed. */
+  preview(targetTriangles: number): { triangleCount: number } | null;
+  /** Restore the un-simplified baseline mesh to the viewport. */
+  reset(): void;
+  /** Bake the mesh currently on screen into a new saved version. */
+  save(): Promise<SimplifySaveResult>;
+}
+
+const BTN_INACTIVE = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+const BTN_ACTIVE = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-blue-500/20 backdrop-blur text-blue-400 [@media(hover:hover)]:hover:bg-blue-500/30 transition-colors border border-blue-500/30';
+
+let simplifyBtn: HTMLButtonElement | null = null;
+let panel: HTMLElement | null = null;
+let slider: HTMLInputElement | null = null;
+let numberInput: HTMLInputElement | null = null;
+let originalEl: HTMLElement | null = null;
+let resultEl: HTMLElement | null = null;
+let statusEl: HTMLElement | null = null;
+let controlsEl: HTMLElement | null = null;
+let resetBtn: HTMLButtonElement | null = null;
+let saveBtn: HTMLButtonElement | null = null;
+
+let handlers: SimplifyHandlers | null = null;
+let info: SimplifyOpenInfo | null = null;
+let previewTimer: number | null = null;
+
+export function initSimplifyUI(controlsContainer: HTMLElement, h: SimplifyHandlers): void {
+  handlers = h;
+
+  simplifyBtn = document.createElement('button');
+  simplifyBtn.id = 'simplify-toggle';
+  simplifyBtn.className = BTN_INACTIVE;
+  simplifyBtn.textContent = '⬢ Simplify';
+  simplifyBtn.title = 'Reduce the model’s triangle count';
+  simplifyBtn.addEventListener('click', toggle);
+
+  // Sit immediately before Measure so the overlay reads Paint · Simplify · Measure.
+  const measureBtn = controlsContainer.querySelector('#measure-toggle');
+  if (measureBtn) {
+    controlsContainer.insertBefore(simplifyBtn, measureBtn);
+  } else {
+    controlsContainer.appendChild(simplifyBtn);
+  }
+
+  panel = buildPanel();
+  controlsContainer.appendChild(panel);
+}
+
+export function isSimplifyOpen(): boolean {
+  return !!panel && !panel.classList.contains('hidden');
+}
+
+/** Re-read the model into the panel if it's open. Call after the geometry
+ *  changes underneath the panel (a code run, version switch, or save). */
+export function refreshSimplifyIfOpen(): void {
+  if (isSimplifyOpen()) refresh(false);
+}
+
+/** Close the panel without touching the applied geometry. Other overlay tools
+ *  call this when they open; Escape calls it too. */
+export function forceDeactivate(): void {
+  if (!isSimplifyOpen()) return;
+  closePanel();
+}
+
+function toggle(): void {
+  if (isSimplifyOpen()) {
+    closePanel();
+  } else {
+    openPanel();
+  }
+}
+
+function openPanel(): void {
+  if (!handlers || !panel) return;
+  panel.classList.remove('hidden');
+  if (simplifyBtn) simplifyBtn.className = BTN_ACTIVE;
+  refresh(true);
+}
+
+/** (Re)read the current model as the baseline and populate the controls. Used
+ *  on open and again after a successful save (the baked mesh becomes the new
+ *  baseline). */
+function refresh(userInitiated: boolean): void {
+  if (!handlers) return;
+  const res = handlers.open(userInitiated);
+  if (!res.ok) {
+    info = null;
+    showUnavailable(res.reason);
+    return;
+  }
+
+  info = res.info;
+  showControls();
+
+  const base = info.baseTriangles;
+  // A small floor keeps the left end of the slider useful without offering
+  // targets so low the geometry can't possibly reach them.
+  const min = Math.max(4, Math.min(base, Math.round(base * 0.02) || 4));
+  if (slider) {
+    slider.min = String(min);
+    slider.max = String(base);
+    slider.value = String(info.currentTriangles);
+  }
+  if (numberInput) {
+    numberInput.min = String(min);
+    numberInput.max = String(base);
+    numberInput.value = String(info.currentTriangles);
+  }
+  if (originalEl) originalEl.textContent = `Original: ${base.toLocaleString()} triangles`;
+  if (statusEl) statusEl.textContent = '';
+  showResult(info.currentTriangles);
+}
+
+function closePanel(): void {
+  if (previewTimer !== null) { clearTimeout(previewTimer); previewTimer = null; }
+  panel?.classList.add('hidden');
+  if (simplifyBtn) simplifyBtn.className = BTN_INACTIVE;
+}
+
+function showUnavailable(reason: string): void {
+  if (controlsEl) controlsEl.classList.add('hidden');
+  if (statusEl) {
+    statusEl.classList.remove('hidden');
+    statusEl.textContent = reason;
+  }
+}
+
+function showControls(): void {
+  if (controlsEl) controlsEl.classList.remove('hidden');
+  if (statusEl) statusEl.textContent = '';
+}
+
+function showResult(count: number): void {
+  if (!info || !resultEl) return;
+  const base = info.baseTriangles;
+  const pct = base > 0 ? Math.round((1 - count / base) * 100) : 0;
+  resultEl.textContent = `Result: ${count.toLocaleString()} triangles (−${pct}%)`;
+  if (saveBtn) saveBtn.disabled = count >= base;
+}
+
+function clampTarget(raw: number): number {
+  if (!info) return raw;
+  const min = slider ? Number(slider.min) : 4;
+  const max = info.baseTriangles;
+  if (!Number.isFinite(raw)) return max;
+  return Math.max(min, Math.min(max, Math.round(raw)));
+}
+
+/** Apply a target triangle count to the live model. Debounced so dragging the
+ *  slider doesn't run the (synchronous) binary search on every tick. */
+function scheduleApply(target: number): void {
+  if (previewTimer !== null) clearTimeout(previewTimer);
+  previewTimer = window.setTimeout(() => {
+    previewTimer = null;
+    applyTarget(target);
+  }, 120);
+}
+
+function applyTarget(target: number): void {
+  if (!handlers || !info) return;
+  if (target >= info.baseTriangles) {
+    handlers.reset();
+    showResult(info.baseTriangles);
+    return;
+  }
+  const r = handlers.preview(target);
+  showResult(r ? r.triangleCount : info.baseTriangles);
+}
+
+function buildPanel(): HTMLElement {
+  const p = document.createElement('div');
+  p.id = 'simplify-panel';
+  p.className = 'hidden absolute top-10 right-2 z-20 bg-zinc-800/95 backdrop-blur border border-zinc-600/60 rounded-lg p-2.5 shadow-xl';
+  p.style.minWidth = '230px';
+  p.style.maxWidth = '270px';
+
+  const title = document.createElement('div');
+  title.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1.5 font-medium';
+  title.textContent = 'Simplify mesh';
+  p.appendChild(title);
+
+  originalEl = document.createElement('div');
+  originalEl.id = 'simplify-original';
+  originalEl.className = 'text-xs text-zinc-300 mb-2';
+  originalEl.textContent = 'Original: —';
+  p.appendChild(originalEl);
+
+  // Wrapper that hides everything interactive when the model can't be simplified.
+  controlsEl = document.createElement('div');
+
+  const label = document.createElement('label');
+  label.className = 'block text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium';
+  label.textContent = 'Max triangles';
+  label.htmlFor = 'simplify-input';
+  controlsEl.appendChild(label);
+
+  const row = document.createElement('div');
+  row.className = 'flex items-center gap-2 mb-2';
+
+  slider = document.createElement('input');
+  slider.type = 'range';
+  slider.id = 'simplify-slider';
+  slider.className = 'flex-1 accent-blue-400 cursor-pointer';
+  slider.min = '4';
+  slider.max = '100';
+  slider.step = '1';
+  slider.value = '100';
+  slider.addEventListener('input', () => {
+    const t = clampTarget(Number(slider!.value));
+    if (numberInput) numberInput.value = String(t);
+    scheduleApply(t);
+  });
+  // Snap to the precise value the instant the drag ends.
+  slider.addEventListener('change', () => applyTarget(clampTarget(Number(slider!.value))));
+  row.appendChild(slider);
+
+  numberInput = document.createElement('input');
+  numberInput.type = 'number';
+  numberInput.id = 'simplify-input';
+  numberInput.className = 'w-20 px-1.5 py-1 text-xs text-right rounded bg-zinc-900/80 border border-zinc-600/60 text-zinc-200 focus:outline-none focus:border-blue-500/60';
+  numberInput.min = '4';
+  numberInput.step = '1';
+  numberInput.addEventListener('input', () => {
+    const t = clampTarget(Number(numberInput!.value));
+    if (slider) slider.value = String(t);
+    scheduleApply(t);
+  });
+  numberInput.addEventListener('change', () => {
+    const t = clampTarget(Number(numberInput!.value));
+    numberInput!.value = String(t);
+    if (slider) slider.value = String(t);
+    applyTarget(t);
+  });
+  row.appendChild(numberInput);
+  controlsEl.appendChild(row);
+
+  resultEl = document.createElement('div');
+  resultEl.id = 'simplify-result';
+  resultEl.className = 'text-xs text-blue-300 mb-2.5';
+  resultEl.textContent = 'Result: —';
+  controlsEl.appendChild(resultEl);
+
+  const actions = document.createElement('div');
+  actions.className = 'flex items-center gap-2';
+
+  resetBtn = document.createElement('button');
+  resetBtn.id = 'simplify-reset';
+  resetBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-700/70 text-zinc-300 [@media(hover:hover)]:hover:bg-zinc-600/70 transition-colors border border-zinc-600/50';
+  resetBtn.textContent = 'Reset';
+  resetBtn.title = 'Restore the full-detail mesh';
+  resetBtn.addEventListener('click', () => {
+    if (!info) return;
+    if (previewTimer !== null) { clearTimeout(previewTimer); previewTimer = null; }
+    handlers?.reset();
+    if (slider) slider.value = String(info.baseTriangles);
+    if (numberInput) numberInput.value = String(info.baseTriangles);
+    showResult(info.baseTriangles);
+    if (statusEl) statusEl.textContent = '';
+  });
+  actions.appendChild(resetBtn);
+
+  saveBtn = document.createElement('button');
+  saveBtn.id = 'simplify-save';
+  saveBtn.className = 'px-2 py-1 rounded text-xs bg-blue-500/30 text-blue-200 [@media(hover:hover)]:hover:bg-blue-500/40 transition-colors border border-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed';
+  saveBtn.textContent = 'Save as version';
+  saveBtn.title = 'Bake the reduced mesh into a new saved version';
+  saveBtn.disabled = true;
+  saveBtn.addEventListener('click', async () => {
+    if (!handlers || !saveBtn) return;
+    saveBtn.disabled = true;
+    if (statusEl) statusEl.textContent = 'Saving…';
+    const res = await handlers.save();
+    // Re-baseline so the panel reflects the freshly saved (reduced) mesh, then
+    // surface the result message (refresh() clears the status line first).
+    if (res.ok) refresh(false);
+    if (statusEl) statusEl.textContent = res.message;
+  });
+  actions.appendChild(saveBtn);
+  controlsEl.appendChild(actions);
+
+  p.appendChild(controlsEl);
+
+  statusEl = document.createElement('div');
+  statusEl.id = 'simplify-status';
+  statusEl.className = 'text-xs text-zinc-400 mt-2';
+  p.appendChild(statusEl);
+
+  return p;
+}

--- a/tests/simplify.spec.ts
+++ b/tests/simplify.spec.ts
@@ -1,0 +1,123 @@
+// Smoke tests for the Simplify overlay tool:
+//  - the panel opens from the viewport overlay and shows a slider + a typeable
+//    "max triangles" input bounded by the model's current triangle count
+//  - dragging the target down reduces the live model; Reset restores it
+//  - "Save as version" bakes the reduced mesh into a new saved version
+//
+// Uses dispatchEvent('click') instead of .click() to dodge the onboarding tour
+// backdrop that can intercept pointer events on first load of the editor.
+
+import { test, expect, type Page } from 'playwright/test';
+
+// A sphere has plenty of triangles, so there's real headroom to simplify
+// (a cube's 12 triangles can't be reduced).
+const SPHERE = 'const { Manifold } = api; return Manifold.sphere(10, 64);';
+
+async function triangleCount(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
+    return pw.getGeometryData().triangleCount ?? 0;
+  });
+}
+
+async function openEditorWithSphere(page: Page): Promise<number> {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  await page.evaluate(async (code) => {
+    const pw = (window as unknown as { partwright: { createSession(name?: string): Promise<unknown>; run(code: string): Promise<unknown> } }).partwright;
+    await pw.createSession('simplify-test');
+    await pw.run(code);
+  }, SPHERE);
+  return triangleCount(page);
+}
+
+test.describe('Simplify tool', () => {
+  test('panel opens with a slider and triangle-count input bounded by the model', async ({ page }) => {
+    const base = await openEditorWithSphere(page);
+    expect(base).toBeGreaterThan(100);
+
+    await page.locator('#simplify-toggle').dispatchEvent('click');
+    await page.waitForSelector('#simplify-panel:not(.hidden)');
+
+    await expect(page.locator('#simplify-slider')).toBeVisible();
+    const input = page.locator('#simplify-input');
+    await expect(input).toBeVisible();
+    // The max triangles default to (and are capped at) the current count.
+    await expect(input).toHaveValue(String(base));
+    await expect(input).toHaveAttribute('max', String(base));
+    await expect(page.locator('#simplify-original')).toContainText(base.toLocaleString());
+  });
+
+  test('reducing the target lowers the live triangle count, and Reset restores it', async ({ page }) => {
+    const base = await openEditorWithSphere(page);
+
+    await page.locator('#simplify-toggle').dispatchEvent('click');
+    await page.waitForSelector('#simplify-panel:not(.hidden)');
+
+    const target = Math.max(50, Math.round(base / 4));
+    await page.locator('#simplify-input').fill(String(target));
+    // The input is debounced; wait for the model to actually shrink.
+    await page.waitForFunction(
+      (b) => {
+        const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
+        return (pw.getGeometryData().triangleCount ?? b) < b;
+      },
+      base,
+      { timeout: 10000 },
+    );
+
+    const reduced = await triangleCount(page);
+    expect(reduced).toBeLessThan(base);
+    expect(reduced).toBeLessThanOrEqual(target);
+    expect(reduced).toBeGreaterThanOrEqual(4);
+
+    // Reset puts the full-detail mesh back on screen.
+    await page.locator('#simplify-reset').dispatchEvent('click');
+    await page.waitForFunction(
+      (b) => {
+        const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
+        return (pw.getGeometryData().triangleCount ?? 0) === b;
+      },
+      base,
+      { timeout: 10000 },
+    );
+    expect(await triangleCount(page)).toBe(base);
+  });
+
+  test('Save as version bakes the reduced mesh into a new version', async ({ page }) => {
+    const base = await openEditorWithSphere(page);
+    // Commit the parametric sphere as v1 so we can see the count grow.
+    await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: { runAndSave(code: string, label?: string): Promise<unknown> } }).partwright;
+      await pw.runAndSave('const { Manifold } = api; return Manifold.sphere(10, 64);', 'sphere');
+    });
+    const before = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: { listVersions(): Promise<unknown[]> } }).partwright;
+      return (await pw.listVersions()).length;
+    });
+
+    await page.locator('#simplify-toggle').dispatchEvent('click');
+    await page.waitForSelector('#simplify-panel:not(.hidden)');
+
+    const target = Math.max(50, Math.round(base / 4));
+    await page.locator('#simplify-input').fill(String(target));
+    await page.waitForFunction(
+      (b) => {
+        const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
+        return (pw.getGeometryData().triangleCount ?? b) < b;
+      },
+      base,
+      { timeout: 10000 },
+    );
+
+    await page.locator('#simplify-save').dispatchEvent('click');
+    await expect(page.locator('#simplify-status')).toContainText('Saved', { timeout: 10000 });
+
+    const versions = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: { listVersions(): Promise<{ label: string | null }[]> } }).partwright;
+      return await pw.listVersions();
+    });
+    expect(versions.length).toBe(before + 1);
+    expect(versions[versions.length - 1].label).toBe('simplified');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **Simplify** tool to the viewport overlay (sitting between **Paint** and **Measure**, adjacent to the print/export and measure tools) for reducing a model's triangle count.

- New `⬢ Simplify` overlay button opens a popup panel with a **slider** and a typeable **"max triangles"** number input (kept in sync).
- The model **re-simplifies live** as you drag/type (debounced); the on-screen mesh and what gets **exported** (GLB/STL/3MF) both reflect the reduction.
- **Save as version** bakes the lighter mesh into a new saved version (import-style `ofMesh` wrapper, persists across reload). **Reset** restores full detail.
- Live readout shows the achieved triangle count and percentage (e.g. `Result: 784 triangles (−62%)`).

## How it works

Simplify changes mesh topology, so (unlike Paint) it can't be derived from the parametric code — it operates on the rendered result:

- `src/geometry/simplify.ts` — binary-searches the geometric tolerance fed to `Manifold.simplify()` to hit the requested triangle budget (gentlest tolerance that meets the target), with careful WASM-object cleanup and a guard against degenerate (<4-triangle) results.
- `src/ui/simplifyUI.ts` — the button + panel (a leaf module: the other overlay tools close it; opening it closes them).
- `src/main.ts` — bridges the panel to the live geometry: snapshots a baseline on open, swaps the live mesh on preview, rebuilds the queryable Manifold so slicing/measure/export stay correct, and bakes a new version on save. The baseline is dropped whenever a code run replaces the geometry.

The panel is mutually exclusive with the other top-right overlay tools (Paint / Annotate / Measure) so panels never stack.

## Test plan

- [x] `npx tsc --noEmit` and `npm run build` pass
- [x] New `tests/simplify.spec.ts` (3 tests): panel opens with slider + input bounded by the model; reducing the target lowers the live triangle count and Reset restores it; Save as version creates a new `simplified` version
- [x] Regression suite green: `smoke`, `paint-controls-extended`, `keyboard-shortcuts` (escape/mutual-exclusion paths)
- [x] Verified visually in-browser (button placement next to Paint/Measure; live `−62%` reduction on a sphere)
- [x] Rebased onto latest `staging`

https://claude.ai/code/session_01JVD9EtPrge1dga3GdVYuUL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVD9EtPrge1dga3GdVYuUL)_