### PR TITLE
docs: instruct agents to start from latest staging and always open a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,12 +21,16 @@ Hosted on **Cloudflare Pages** with production custom domain `www.partwrightstud
 
 **All work should be merged to `staging` first.** Do not push directly to `main`. The workflow is:
 
-1. Create a feature branch off the latest `staging`, develop and test locally
+1. **Start from the latest `staging`.** Before writing any code, run `git fetch origin staging` and base your feature branch on `origin/staging`. Do this at the *start* of the task, not just before the final push.
 2. Before your final push or PR, sync with the latest staging: `git fetch origin staging`, then merge `origin/staging` into your branch (or rebase onto it if the branch hasn't been pushed yet), resolve any conflicts, and re-run `npm run build` + `npm run test:e2e`
 3. Merge to `staging` — auto-deploys for verification
 4. Once validated on staging, open a PR from `staging` → `main` for production release
 
 > **Always start from — and re-sync against — the latest `origin/staging`.** Branches cut from a stale staging produce noisy diffs and merge conflicts, and can quietly clobber recently merged work. Re-fetch and merge/rebase `origin/staging` right before your final push, and again before opening any PR.
+
+### Pull Requests — always open one when a task is complete
+
+When you finish an agent task, **create a pull request into `staging` as the final step.** This is a standing instruction that overrides any default "don't open a PR unless explicitly asked" behavior: treat task completion as the authorization to open the PR. Don't pause to ask whether to create one, and don't report a task as done without it. Skip the PR only when the user explicitly says not to, or for a pure throwaway experiment. Follow the [commit & PR conventions](#commit--pr-conventions) below for the title, prefix, and labels.
 
 - **Build command:** `npm run build`
 - **Output directory:** `dist/`


### PR DESCRIPTION
## Summary

Updates the agent guide (`CLAUDE.md`, also surfaced as `AGENTS.md`/`GEMINI.md`) so AI sessions stop refusing to open PRs and stop starting from a stale base.

- **Standing instruction to always open a PR.** Adds a new "Pull Requests — always open one when a task is complete" subsection. Because `CLAUDE.md` instructions override default behavior, this grants agents standing authorization to create a PR into `staging` on task completion — overriding the harness default of "don't open a PR unless explicitly asked." This is the root cause of agents saying they "don't create a PR per the setup": there was no such block in any repo file; the behavior came from the harness default, and nothing in the guide overrode it.
- **Start from the latest `staging`.** Rewrites the deployment workflow so step 1 explicitly tells agents to `git fetch origin staging` and base their feature branch on `origin/staging` at the *start* of the task, not just before opening the PR. A stale base causes merge conflicts and can silently revert already-merged work.
- Links the new section to the existing commit & PR conventions for title/prefix/label guidance.

## Notes

- This branch was rebased onto the latest `origin/staging` so the PR contains only the doc change (the working branch had previously been based on `main`, which lacked recent staging work like the paint API).

## Test plan

- [ ] Confirm the rendered `CLAUDE.md` reads correctly and the `#commit--pr-conventions` anchor link resolves
- [ ] No code changes; no build/test impact

https://claude.ai/code/session_015qx31UVrSjH7AMaoBC9vCS

---
_Generated by [Claude Code](https://claude.ai/code/session_015qx31UVrSjH7AMaoBC9vCS)_