### PR TITLE
Add multi-part sessions: independent objects within one session

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -242,6 +242,18 @@ await partwright.listSessions()          // -> [{id, name, updated}]
 await partwright.openSession(id)         // Open existing session
 await partwright.clearAllSessions()      // Delete all sessions & versions
 
+// Parts -- multiple independent objects within one session. Each part has its
+// own code + version history; the CURRENT part is what every other method
+// (run, save, paint, export, listVersions, ...) acts on. Versions are scoped
+// per part. Use parts for several distinct objects in one session (e.g. a box
+// and its lid); save them as separate STLs/parts, or model each in isolation.
+partwright.listParts()                   // -> [{id, name, order, isCurrent}]
+partwright.getCurrentPart()              // -> {id, name, order} or null
+await partwright.createPart(name?)       // New empty part + switch to it -> {id, name, order}
+await partwright.changePart(id)          // Switch active part (loads its latest version)
+await partwright.renamePart(id, name)    // Rename a part
+await partwright.deletePart(id)          // Delete a part + its versions (refuses the last one)
+
 // Color regions -- tag face regions with a color. Full API in /ai/colors.md.
 // Quick reference (~30 methods total):
 partwright.probePixel({pixel, view})                                      // pixel-in-render -> {point, normal, distance, triangleId}

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -354,6 +354,13 @@ After a tool call returns, write ONE short sentence in chat ("Saved a
 smiley face — head with two eye sockets and a curved mouth.") and stop.
 Don't recap, don't echo the code, don't apologize for invoking tools.
 
+A session can hold multiple PARTS — separate objects, each with its own code
+and version history. listParts() lists them; createPart(name?) starts a new
+one and switches to it; changePart(id) switches which part is active. Every
+geometry, paint, and version tool acts on the current part ONLY. Reach for
+parts when the user wants several distinct objects in one session (e.g. a box
+and its lid) rather than cramming them into one program.
+
 ## The manifold-js API (the language you write inside runAndSave)
 
 Programs MUST end with \`return manifold;\` — no top-level await, no

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -763,6 +763,60 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'listParts',
+    description: 'List the parts in the active session: [{id, name, order, isCurrent}]. A session can hold multiple parts — independent objects, each with its own code and version history. The current part is what runCode / runAndSave / paint / export act on.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'getCurrentPart',
+    description: 'Return the active part {id, name, order}, or null when no session is open.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'createPart',
+    description: 'Create a new, empty part in the active session and switch to it. The editor resets to a starter snippet; call runAndSave to commit its first version. Use to model a second (third, …) object in the same session.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Optional part name (e.g. "Lid"). Auto-named "Part N" when omitted.' },
+      },
+    },
+  },
+  {
+    name: 'changePart',
+    description: "Switch the active part. Pass the part id from listParts(). Loads that part's latest version into the editor/viewport; all later code, paint, and version operations act on it.",
+    input_schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Part id from listParts().' },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'renamePart',
+    description: 'Rename a part. Pass its id (from listParts) and the new name.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Part id from listParts().' },
+        name: { type: 'string', description: 'New part name.' },
+      },
+      required: ['id', 'name'],
+    },
+  },
+  {
+    name: 'deletePart',
+    description: "Delete a part and all its versions. Refuses to delete a session's last remaining part. If the active part is deleted, an adjacent part becomes active.",
+    input_schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Part id from listParts().' },
+      },
+      required: ['id'],
+    },
+  },
+  {
     name: 'assertPaint',
     description: 'Verify a painted region matches expected geometry. Returns {passed, failures?}. Use after painting to catch regressions when the mesh changes. `region` is the region id (integer) or name (string) from listRegions().',
     input_schema: {
@@ -875,6 +929,12 @@ const ALWAYS_AVAILABLE = new Set([
   'createSession',
   'listSessions',
   'openSession',
+  'listParts',
+  'getCurrentPart',
+  'createPart',
+  'changePart',
+  'renamePart',
+  'deletePart',
   'assertPaint',
   'sliceAtZVisual',
   'paintInCylinder',
@@ -1277,6 +1337,18 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.listSessions();
     case 'openSession':
       return api.openSession(input.id as string);
+    case 'listParts':
+      return api.listParts();
+    case 'getCurrentPart':
+      return api.getCurrentPart();
+    case 'createPart':
+      return api.createPart(input.name as string | undefined);
+    case 'changePart':
+      return api.changePart(input.id as string);
+    case 'renamePart':
+      return api.renamePart(input.id as string, input.name as string);
+    case 'deletePart':
+      return api.deletePart(input.id as string);
     case 'assertPaint':
       return api.assertPaint(input);
     case 'paintInCylinder':

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ import { createCatalogPage, type CatalogManifestEntry } from './ui/catalog';
 import { createNotFoundPage } from './ui/notFound';
 import { applyRouteMeta, routeTitle, type RouteName } from './seo/meta';
 import { createSessionBar } from './ui/sessionBar';
+import { createPartList } from './ui/partList';
 import { createGalleryView, refreshGallery } from './ui/gallery';
 import { createVersionsView, refreshVersions } from './ui/versions';
 import { createImagesView, refreshImages } from './ui/imagesView';
@@ -139,6 +140,7 @@ import {
   changePart,
   renamePart,
   deletePart,
+  reorderParts,
   getState,
   getSessionUrl,
   getGalleryUrl,
@@ -1119,13 +1121,23 @@ async function main() {
     },
     onOpenSessionList: () => showSessionList(),
     onNewSession: startNewSessionInEditor,
-    onSwitchPart: async (partId: string) => {
+  });
+
+  // Create layout
+  const { editorContainer, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, statusBar, clipControls, formatBtn, autoFormatToggle, switchTab, partsRail, togglePartsRail } = createLayout(editorUI);
+
+  // Parts rail — IDE-style list of the session's parts.
+  createPartList(partsRail, {
+    onSelectPart: async (partId: string) => {
       const version = await changePart(partId);
       await loadPartIntoEditor(version);
     },
     onCreatePart: async () => {
       await createPart();
       startNewPartInEditor();
+    },
+    onRenamePart: async (partId: string, name: string) => {
+      await renamePart(partId, name);
     },
     onDeletePart: async (partId: string) => {
       const wasCurrent = getState().currentPart?.id === partId;
@@ -1134,10 +1146,24 @@ async function main() {
         await loadPartIntoEditor(getState().currentVersion);
       }
     },
+    onReorderParts: async (orderedIds: string[]) => {
+      await reorderParts(orderedIds);
+    },
+    onToggleCollapse: () => togglePartsRail(),
   });
 
-  // Create layout
-  const { editorContainer, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, statusBar, clipControls, formatBtn, autoFormatToggle, switchTab } = createLayout(editorUI);
+  // Keep the editor title showing the active part's name (falls back to the
+  // generic filename when no part/session is open). The element is looked up on
+  // each call rather than captured, since the editor root may not be mounted in
+  // the document when this wiring first runs.
+  function syncEditorTitle(state: ReturnType<typeof getState>): void {
+    const editorTitleEl = document.getElementById('editor-title');
+    if (!editorTitleEl) return;
+    const part = state.currentPart;
+    editorTitleEl.textContent = part ? part.name : (getActiveLanguage() === 'scad' ? 'editor.scad' : 'editor.js');
+  }
+  syncEditorTitle(getState());
+  onStateChange(syncEditorTitle);
 
   // Format button and auto-format toggle
   const AUTO_FORMAT_ON_CLASS = 'shrink-0 px-2 py-0.5 rounded text-xs leading-none border text-emerald-400 border-emerald-700 bg-emerald-950/40 hover:bg-emerald-900/40';
@@ -1760,9 +1786,9 @@ async function main() {
     setActiveLanguage(lang);
     setEditorLanguage(lang);
     setToolbarLanguage(lang);
-    // Update editor filename indicator
-    const titleEl = document.getElementById('editor-title');
-    if (titleEl) titleEl.textContent = lang === 'scad' ? 'editor.scad' : 'editor.js';
+    // Update the editor title (shows the active part name, or the filename
+    // fallback when no part is open).
+    syncEditorTitle(getState());
     setStatus(statusBar, 'running', lang === 'scad' ? 'Loading OpenSCAD...' : 'Switching...');
     try {
       await ensureEngineReady(lang);

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,6 +120,7 @@ import { computeFaceGroups } from './color/faceGroups';
 import {
   getSessionIdFromURL,
   getVersionFromURL,
+  getPartIdFromURL,
   openSession,
   createSession,
   closeSession,
@@ -132,6 +133,12 @@ import {
   loadVersion as loadVersionFromStore,
   peekVersion,
   listCurrentVersions,
+  listCurrentParts,
+  getCurrentPart,
+  createPart,
+  changePart,
+  renamePart,
+  deletePart,
   getState,
   getSessionUrl,
   getGalleryUrl,
@@ -151,7 +158,7 @@ import {
   type ExportedSession,
   type ExportOptions,
 } from './storage/sessionManager';
-import type { Version } from './storage/db';
+import type { Version, Part } from './storage/db';
 import {
   ValidationError,
   guard,
@@ -564,6 +571,36 @@ function parseVersionTarget(
     return { error: `${caller}: target.id must be a non-empty string (got ${typeof id}).` };
   }
   return { kind: 'id', value: id };
+}
+
+/** Resolve a part-target arg — a part id string, or { id } / { name } — to a
+ *  Part in the active session. Returns { error } (with guidance) on a miss. */
+function resolvePartTarget(target: unknown, caller: string): Part | { error: string } {
+  if (!getState().session) {
+    return { error: `${caller}: no active session. Call createSession() or openSession(id) first.` };
+  }
+  const parts = listCurrentParts();
+  let id: string | undefined;
+  let name: string | undefined;
+  if (typeof target === 'string') {
+    id = target;
+  } else if (target && typeof target === 'object') {
+    ({ id, name } = target as { id?: string; name?: string });
+  } else {
+    return { error: `${caller}(target): pass a part id string, or { id } / { name } from listParts().` };
+  }
+  let part: Part | undefined;
+  if (id !== undefined) {
+    if (typeof id !== 'string' || id.length === 0) return { error: `${caller}: id must be a non-empty string.` };
+    part = parts.find(p => p.id === id);
+  } else if (name !== undefined) {
+    if (typeof name !== 'string' || name.length === 0) return { error: `${caller}: name must be a non-empty string.` };
+    part = parts.find(p => p.name === name);
+  } else {
+    return { error: `${caller}(target): pass { id } or { name } from listParts().` };
+  }
+  if (!part) return { error: `${caller}: no matching part. Use listParts() to see available parts.` };
+  return part;
 }
 
 // Determine which page to show based on URL path and query params
@@ -1051,6 +1088,24 @@ async function main() {
     _clearImages();
   }
 
+  // Reset the editor for a freshly created part. Unlike a new session, parts
+  // share the session's reference images, so those are left intact.
+  function startNewPartInEditor() {
+    const freshCode = '// New part\nconst { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);';
+    setValue(freshCode);
+    runCode(freshCode);
+  }
+
+  // Load a part's active version into the editor, or reset to a blank part when
+  // the part has no saved versions yet.
+  async function loadPartIntoEditor(version: Version | null) {
+    if (version) {
+      await loadVersionIntoEditor(version);
+    } else {
+      startNewPartInEditor();
+    }
+  }
+
   // Create session bar
   createSessionBar(editorUI, {
     onSaveVersion: async () => ({
@@ -1070,6 +1125,21 @@ async function main() {
     },
     onOpenSessionList: () => showSessionList(),
     onNewSession: startNewSessionInEditor,
+    onSwitchPart: async (partId: string) => {
+      const version = await changePart(partId);
+      await loadPartIntoEditor(version);
+    },
+    onCreatePart: async () => {
+      await createPart();
+      startNewPartInEditor();
+    },
+    onDeletePart: async (partId: string) => {
+      const wasCurrent = getState().currentPart?.id === partId;
+      const result = await deletePart(partId);
+      if (result && wasCurrent) {
+        await loadPartIntoEditor(getState().currentVersion);
+      }
+    },
   });
 
   // Create layout
@@ -1403,11 +1473,13 @@ async function main() {
     const sessionId = getSessionIdFromURL();
     if (sessionId) {
       const versionIndex = getVersionFromURL();
+      const partId = getPartIdFromURL();
       const state = getState();
       const needsSessionLoad = state.session?.id !== sessionId;
+      const needsPartLoad = partId !== null && state.currentPart?.id !== partId;
       const needsVersionLoad = versionIndex !== null && state.currentVersion?.index !== versionIndex;
-      if (needsSessionLoad || needsVersionLoad) {
-        const version = await openSession(sessionId, versionIndex ?? undefined);
+      if (needsSessionLoad || needsPartLoad || needsVersionLoad) {
+        const version = await openSession(sessionId, versionIndex ?? undefined, partId ?? undefined);
         if (version) {
           await loadVersionIntoEditor(version);
           if (tab === 'gallery') refreshGallery();
@@ -2386,6 +2458,78 @@ async function main() {
       await deleteSession(id);
     },
 
+    // === Part API ===
+    // A session holds one or more parts; each part has its own code + version
+    // history. The "current part" determines what every other method (run,
+    // save, paint, export, …) acts on.
+
+    /** List the parts in the active session, each flagged with `isCurrent`. */
+    listParts() {
+      const current = getCurrentPart();
+      return listCurrentParts().map(p => ({ id: p.id, name: p.name, order: p.order, isCurrent: p.id === current?.id }));
+    },
+
+    /** The active part, or null when no session is open. */
+    getCurrentPart() {
+      const p = getCurrentPart();
+      return p ? { id: p.id, name: p.name, order: p.order } : null;
+    },
+
+    /** Create a new, empty part and switch to it. Resets the editor to a starter
+     *  snippet; call runAndSave/saveVersion to commit its first version. */
+    async createPart(name?: string) {
+      const check = guard(() => assertString(name, 'createPart(name)', { optional: true }));
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      if (!getState().session) {
+        return { error: 'No active session. Call createSession() or openSession(id) first.' };
+      }
+      const part = await createPart(name);
+      if (!part) return { error: 'Could not create part (no active session).' };
+      startNewPartInEditor();
+      return { id: part.id, name: part.name, order: part.order };
+    },
+
+    /** Switch the active part. Pass a part id string, or { id } / { name } from
+     *  listParts(). Loads that part's latest version into the editor. */
+    async changePart(target: string | { id?: string; name?: string }) {
+      const part = resolvePartTarget(target, 'changePart');
+      if ('error' in part) return part;
+      const version = await changePart(part.id);
+      await loadPartIntoEditor(version);
+      return {
+        id: part.id,
+        name: part.name,
+        currentVersion: version ? { id: version.id, index: version.index, label: version.label } : null,
+      };
+    },
+
+    /** Rename a part. Pass a part id string, or { id } / { name }. */
+    async renamePart(target: string | { id?: string; name?: string }, newName: string) {
+      const check = guard(() => assertString(newName, 'renamePart(newName)', { allowEmpty: false }));
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      const part = resolvePartTarget(target, 'renamePart');
+      if ('error' in part) return part;
+      await renamePart(part.id, newName);
+      return { id: part.id, name: newName };
+    },
+
+    /** Delete a part and its versions. Refuses to delete a session's last part.
+     *  Deleting the active part activates and loads an adjacent one. */
+    async deletePart(target: string | { id?: string; name?: string }) {
+      const part = resolvePartTarget(target, 'deletePart');
+      if ('error' in part) return part;
+      const wasCurrent = getCurrentPart()?.id === part.id;
+      const result = await deletePart(part.id);
+      if (!result) return { error: 'Cannot delete the last part of a session.' };
+      if (wasCurrent) {
+        await loadPartIntoEditor(getState().currentVersion);
+      }
+      return {
+        deleted: { id: result.deleted.id, name: result.deleted.name },
+        newCurrent: result.newCurrent ? { id: result.newCurrent.id, name: result.newCurrent.name } : null,
+      };
+    },
+
     /** Save current state as a new version in the active session.
      *  Returns `{ id, index, label }` on success, `{ error }` if no session is
      *  active, or `{ skipped: true, reason }` when nothing has changed since
@@ -2678,6 +2822,8 @@ async function main() {
       const state = getState();
       return {
         session: state.session ? { id: state.session.id, name: state.session.name } : null,
+        currentPart: state.currentPart ? { id: state.currentPart.id, name: state.currentPart.name } : null,
+        parts: state.parts.map(p => ({ id: p.id, name: p.name, order: p.order, isCurrent: p.id === state.currentPart?.id })),
         currentVersion: state.currentVersion ? { index: state.currentVersion.index, label: state.currentVersion.label } : null,
         versionCount: state.versionCount,
       };
@@ -4869,6 +5015,13 @@ async function main() {
         'openSession':     { signature: 'await openSession(id) -- Open existing session', docs: '/ai.md#resuming-a-session' },
         'listSessions':    { signature: 'await listSessions() -- List all sessions', docs: '/ai.md#console-api--windowpartwright' },
         'getSessionContext': { signature: 'await getSessionContext() -- Get full session context (for resuming)', docs: '/ai.md#resuming-a-session' },
+        // Parts (multiple objects per session)
+        'listParts':       { signature: 'listParts() -- List parts in the session -> [{id, name, order, isCurrent}]', docs: '/ai.md#console-api--windowpartwright' },
+        'getCurrentPart':  { signature: 'getCurrentPart() -- Active part -> {id, name, order} or null', docs: '/ai.md#console-api--windowpartwright' },
+        'createPart':      { signature: 'await createPart(name?) -- New empty part + switch to it -> {id, name, order}', docs: '/ai.md#console-api--windowpartwright' },
+        'changePart':      { signature: 'await changePart(id) -- Switch active part (loads its latest version)', docs: '/ai.md#console-api--windowpartwright' },
+        'renamePart':      { signature: 'await renamePart(id, name) -- Rename a part', docs: '/ai.md#console-api--windowpartwright' },
+        'deletePart':      { signature: 'await deletePart(id) -- Delete a part and its versions', docs: '/ai.md#console-api--windowpartwright' },
         'getGalleryUrl':   { signature: 'getGalleryUrl() -- URL for gallery view (human review)', docs: '/ai.md#console-api--windowpartwright' },
         // Notes
         'addSessionNote':  { signature: 'await addSessionNote(text) -- Add note with [PREFIX] tag', docs: '/ai.md#session-notes----tracking-design-context' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1021,24 +1021,10 @@ async function main() {
         alert('No active session to export. Save a version first.');
         return;
       }
-      // STL imports live on Version.importedMeshes (typed-array mesh bytes),
-      // which the .partwright.json export schema doesn't carry yet. Warn so
-      // the user knows the resulting file will reopen with empty `api.imports`
-      // and the wrapper code will fail until the STL is re-imported.
+      // Imported meshes (STL) ride along in the export from schema 1.7 (their
+      // buffers are base64-encoded in `versions[].importedMeshes`), so no
+      // re-import warning is needed.
       const versions = await listCurrentVersions();
-      const hasImports = versions.some(v => Array.isArray((v as { importedMeshes?: unknown[] }).importedMeshes) && ((v as { importedMeshes?: unknown[] }).importedMeshes!).length > 0);
-      if (hasImports) {
-        const proceed = await showInlineConfirm(
-          editorUI,
-          `This session uses imported meshes (STL).\n\nThe .partwright.json file will include the code but not the mesh data — anyone reopening it will need to re-import the STL for the version to render.\n\nExport an STL/GLB instead if you just need the geometry.`,
-          {
-            title: 'Imported meshes won\'t be included',
-            confirmLabel: 'Export anyway',
-            cancelLabel: 'Cancel',
-          }
-        );
-        if (!proceed) return;
-      }
       const opts = await showExportOptionsDialog(
         versions.map(v => ({ index: v.index, label: v.label })),
       );
@@ -1081,19 +1067,27 @@ async function main() {
   // Reset the editor to a blank starting point for a freshly created session.
   // Shared by the session bar's "+ New Session" button and the session modal's,
   // so both clear the previous session's code instead of leaving it behind.
-  function startNewSessionInEditor() {
-    const freshCode = '// New session\nconst { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);';
+  // Reset the editor to a starter snippet, dropping stale paint state. Color
+  // regions live in module state that the session/part layer doesn't own, so a
+  // fresh target must clear them here — otherwise the new (unpainted) session or
+  // part inherits the previous one's regions and is born with a locked editor.
+  function resetEditorToStarter(comment: string) {
+    clearRegions();
+    syncLockState();
+    const freshCode = `// ${comment}\nconst { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);`;
     setValue(freshCode);
     runCode(freshCode);
+  }
+
+  function startNewSessionInEditor() {
+    resetEditorToStarter('New session');
     _clearImages();
   }
 
   // Reset the editor for a freshly created part. Unlike a new session, parts
   // share the session's reference images, so those are left intact.
   function startNewPartInEditor() {
-    const freshCode = '// New part\nconst { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);';
-    setValue(freshCode);
-    runCode(freshCode);
+    resetEditorToStarter('New part');
   }
 
   // Load a part's active version into the editor, or reset to a blank part when
@@ -1486,12 +1480,20 @@ async function main() {
           if (tab === 'versions') refreshVersions();
           return;
         }
-        // openSession returned null — either the session ID in the URL
-        // doesn't exist in IndexedDB (e.g. a stale bookmark, or a URL
-        // shared from another browser/device), or the session exists
-        // but has no saved versions. Fall through to create a fresh
-        // session if needed and run defaults, so the viewport renders
-        // and the status doesn't stay stuck on "Loading WASM...".
+        // No version returned. If the session nonetheless opened (it exists but
+        // the active part has no saved versions yet), show that part's starter
+        // — loadPartIntoEditor also clears stale paint state — instead of the
+        // generic default example.
+        if (getState().session?.id === sessionId) {
+          await loadPartIntoEditor(getState().currentVersion);
+          if (tab === 'gallery') refreshGallery();
+          if (tab === 'versions') refreshVersions();
+          return;
+        }
+        // Otherwise the session ID in the URL doesn't exist in IndexedDB (a
+        // stale bookmark or a URL shared from another device). Fall through to
+        // create a fresh session and run defaults, so the viewport renders and
+        // the status doesn't stay stuck on "Loading WASM...".
       } else {
         return;
       }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -8,6 +8,26 @@ export interface Session {
   images?: AttachedImage[] | null;
   /** Modeling language for this session. Missing = 'manifold-js'. */
   language?: 'manifold-js' | 'scad';
+  /** Id of the part that is active when the session is (re)opened. Missing =
+   *  fall back to the first part by `order`. Set on every part switch so the
+   *  editor restores to the part the user last worked on. */
+  currentPartId?: string;
+}
+
+/** A modeling target within a session. A session holds one or more parts; each
+ *  part owns its own independent version history, code, color regions,
+ *  annotations, and imported meshes. The "current part" pointer (held in
+ *  {@link Session.currentPartId} and in the session-manager runtime state) sits
+ *  above the "current version" pointer, so the editor always shows one part at a
+ *  time. */
+export interface Part {
+  id: string;
+  sessionId: string;
+  name: string;
+  /** Display order within the session's part list (ascending). */
+  order: number;
+  created: number;
+  updated: number;
 }
 
 export interface AttachedImage {
@@ -45,6 +65,12 @@ const LEGACY_ANGLES: readonly LegacyImageAngle[] = ['front', 'right', 'back', 'l
 export interface Version {
   id: string;
   sessionId: string;
+  /** Owning part. Versions are indexed per-part, so each part has its own
+   *  v1, v2, … sequence. Denormalized `sessionId` is retained for
+   *  session-scoped queries (recent-session grids) and cascade deletes.
+   *  Legacy versions written before multi-part support are stamped with their
+   *  session's default part id by {@link migratePartsData}. */
+  partId: string;
   index: number;
   code: string;
   geometryData: Record<string, unknown> | null;
@@ -72,7 +98,8 @@ export interface SessionNote {
 const DB_NAME = 'partwright';
 const LEGACY_DB_NAME = 'mainifold';
 const LEGACY_MIGRATION_KEY = 'partwright-migrated-mainifold-db';
-const DB_VERSION = 4;
+const PARTS_MIGRATION_KEY = 'partwright-migrated-parts';
+const DB_VERSION = 5;
 
 /** Opens the partwright IndexedDB. Exposed so the AI subsystem can attach
  *  its own stores (`aiKeys`, `aiChats`) without duplicating the connection. */
@@ -117,11 +144,37 @@ function openDB(): Promise<IDBDatabase> {
         const store = db.createObjectStore('aiAttachments', { keyPath: 'id' });
         store.createIndex('lastUsedAt', 'lastUsedAt', { unique: false });
       }
+      // v5: multi-part support. Each session holds one or more parts; each part
+      // owns its own version history. Version uniqueness moves from
+      // [sessionId, index] to [partId, index] because two parts in the same
+      // session can both have a v1. The data backfill (one default part per
+      // existing session + stamping versions with partId) runs after open in
+      // migratePartsData(); here we only adjust structure.
+      if (!db.objectStoreNames.contains('parts')) {
+        const store = db.createObjectStore('parts', { keyPath: 'id' });
+        store.createIndex('sessionId', 'sessionId', { unique: false });
+      }
+      if (db.objectStoreNames.contains('versions')) {
+        const versionStore = req.transaction!.objectStore('versions');
+        if (!versionStore.indexNames.contains('partId')) {
+          versionStore.createIndex('partId', 'partId', { unique: false });
+        }
+        if (!versionStore.indexNames.contains('partId_index')) {
+          // Versions still missing `partId` (pre-backfill) are simply excluded
+          // from this index, so the unique constraint can't fire on them.
+          versionStore.createIndex('partId_index', ['partId', 'index'], { unique: true });
+        }
+        if (versionStore.indexNames.contains('sessionId_index')) {
+          versionStore.deleteIndex('sessionId_index');
+        }
+      }
     };
     req.onsuccess = () => {
       const db = req.result;
       migrateLegacyData(db)
         .catch(err => console.warn('Partwright: legacy session migration skipped:', err))
+        .then(() => migratePartsData(db))
+        .catch(err => console.warn('Partwright: parts migration skipped:', err))
         .finally(() => resolve(db));
     };
     req.onerror = () => reject(req.error);
@@ -170,6 +223,22 @@ function markLegacyMigrationRun(): void {
     localStorage.setItem(LEGACY_MIGRATION_KEY, 'true');
   } catch {
     // Ignore storage failures; migration is only a convenience for local sessions.
+  }
+}
+
+function hasPartsMigrationRun(): boolean {
+  try {
+    return localStorage.getItem(PARTS_MIGRATION_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function markPartsMigrationRun(): void {
+  try {
+    localStorage.setItem(PARTS_MIGRATION_KEY, 'true');
+  } catch {
+    // Ignore storage failures; the per-session backfill below is idempotent.
   }
 }
 
@@ -252,6 +321,71 @@ async function migrateLegacyData(targetDb: IDBDatabase): Promise<void> {
   }
 }
 
+/**
+ * Backfill multi-part structure onto pre-v5 data: give every session that has
+ * no parts a single default part and stamp that session's versions with the new
+ * part's id. Idempotent — sessions that already have a part are skipped — so a
+ * run interrupted partway is safely completed on the next open.
+ *
+ * Reads happen up front in their own (auto-committing) read-only transactions;
+ * the writes are batched into one read-write transaction containing only `put`s
+ * (no awaits between them) so the transaction can't auto-commit mid-migration.
+ */
+async function migratePartsData(targetDb: IDBDatabase): Promise<void> {
+  if (hasPartsMigrationRun()) return;
+  if (!targetDb.objectStoreNames.contains('parts')) return;
+
+  const sessions = await getAllFromStore<Session>(targetDb, 'sessions');
+  if (sessions.length === 0) {
+    markPartsMigrationRun();
+    return;
+  }
+
+  const parts = await getAllFromStore<Part>(targetDb, 'parts');
+  const sessionsWithParts = new Set(parts.map(p => p.sessionId));
+  const versions = await getAllFromStore<Version>(targetDb, 'versions');
+
+  const newParts: Part[] = [];
+  const versionUpdates: Version[] = [];
+  const sessionUpdates: Session[] = [];
+
+  for (const session of sessions) {
+    if (sessionsWithParts.has(session.id)) continue;
+    const partId = generateId();
+    newParts.push({
+      id: partId,
+      sessionId: session.id,
+      name: 'Part 1',
+      order: 0,
+      created: session.created,
+      updated: session.updated,
+    });
+    for (const v of versions) {
+      if (v.sessionId === session.id && !v.partId) {
+        v.partId = partId;
+        versionUpdates.push(v);
+      }
+    }
+    if (!session.currentPartId) {
+      session.currentPartId = partId;
+      sessionUpdates.push(session);
+    }
+  }
+
+  if (newParts.length === 0 && versionUpdates.length === 0 && sessionUpdates.length === 0) {
+    markPartsMigrationRun();
+    return;
+  }
+
+  const txn = targetDb.transaction(['sessions', 'versions', 'parts'], 'readwrite');
+  for (const p of newParts) txn.objectStore('parts').put(p);
+  for (const v of versionUpdates) txn.objectStore('versions').put(v);
+  for (const s of sessionUpdates) txn.objectStore('sessions').put(s);
+  await txComplete(txn);
+  console.info(`Partwright: migrated ${newParts.length} session(s) to multi-part storage.`);
+  markPartsMigrationRun();
+}
+
 // === Sessions ===
 
 export async function createSession(name?: string, language?: 'manifold-js' | 'scad'): Promise<Session> {
@@ -331,7 +465,7 @@ export function legacyImagesObjectToArray(obj: LegacyImagesObject): AttachedImag
   return result;
 }
 
-export async function updateSession(id: string, updates: Partial<Pick<Session, 'name' | 'created' | 'updated' | 'images' | 'language'>>): Promise<void> {
+export async function updateSession(id: string, updates: Partial<Pick<Session, 'name' | 'created' | 'updated' | 'images' | 'language' | 'currentPartId'>>): Promise<void> {
   const store = await tx('sessions', 'readwrite');
   // Read-modify-write inside one transaction: queue the put from the get's
   // callback (awaiting between them risks auto-commit), then await oncomplete.
@@ -349,11 +483,86 @@ export async function updateSession(id: string, updates: Partial<Pick<Session, '
 
 export async function deleteSession(id: string): Promise<void> {
   const db = await openDB();
-  const txn = db.transaction(['sessions', 'versions', 'notes'], 'readwrite');
+  const txn = db.transaction(['sessions', 'versions', 'notes', 'parts'], 'readwrite');
   txn.objectStore('sessions').delete(id);
-  // Delete all versions for this session
-  const versionStore = txn.objectStore('versions');
-  const vIdx = versionStore.index('sessionId');
+  // Delete all versions, notes, and parts belonging to this session.
+  const deleteByIndex = (storeName: string) => {
+    const idx = txn.objectStore(storeName).index('sessionId');
+    const req = idx.openCursor(IDBKeyRange.only(id));
+    return new Promise<void>((resolve, reject) => {
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (cursor) {
+          cursor.delete();
+          cursor.continue();
+        } else {
+          resolve();
+        }
+      };
+      req.onerror = () => reject(req.error);
+    });
+  };
+  await Promise.all([
+    deleteByIndex('versions'),
+    deleteByIndex('notes'),
+    deleteByIndex('parts'),
+  ]);
+  // Wait for the entire transaction to commit
+  await txComplete(txn);
+}
+
+// === Parts ===
+
+export async function createPart(sessionId: string, name: string, order: number): Promise<Part> {
+  const part: Part = {
+    id: generateId(),
+    sessionId,
+    name,
+    order,
+    created: Date.now(),
+    updated: Date.now(),
+  };
+  const store = await tx('parts', 'readwrite');
+  await reqToPromise(store.put(part));
+  return part;
+}
+
+export async function getPart(id: string): Promise<Part | null> {
+  const store = await tx('parts', 'readonly');
+  return reqToPromise(store.get(id)) as Promise<Part | null>;
+}
+
+export async function listParts(sessionId: string): Promise<Part[]> {
+  const store = await tx('parts', 'readonly');
+  const index = store.index('sessionId');
+  const parts = await reqToPromise(index.getAll(IDBKeyRange.only(sessionId))) as Part[];
+  return parts.sort((a, b) => a.order - b.order);
+}
+
+export async function getPartCount(sessionId: string): Promise<number> {
+  const store = await tx('parts', 'readonly');
+  const index = store.index('sessionId');
+  return reqToPromise(index.count(IDBKeyRange.only(sessionId)));
+}
+
+export async function updatePart(id: string, updates: Partial<Pick<Part, 'name' | 'order' | 'updated'>>): Promise<void> {
+  const store = await tx('parts', 'readwrite');
+  const getReq = store.get(id);
+  getReq.onsuccess = () => {
+    const part = getReq.result as Part | null;
+    if (!part) return;
+    Object.assign(part, updates);
+    store.put(part);
+  };
+  await txComplete(store.transaction);
+}
+
+export async function deletePart(id: string): Promise<void> {
+  const db = await openDB();
+  const txn = db.transaction(['parts', 'versions'], 'readwrite');
+  txn.objectStore('parts').delete(id);
+  // Cascade-delete the part's versions.
+  const vIdx = txn.objectStore('versions').index('partId');
   const vReq = vIdx.openCursor(IDBKeyRange.only(id));
   await new Promise<void>((resolve, reject) => {
     vReq.onsuccess = () => {
@@ -367,32 +576,13 @@ export async function deleteSession(id: string): Promise<void> {
     };
     vReq.onerror = () => reject(vReq.error);
   });
-  // Delete all notes for this session
-  const noteStore = txn.objectStore('notes');
-  const nIdx = noteStore.index('sessionId');
-  const nReq = nIdx.openCursor(IDBKeyRange.only(id));
-  await new Promise<void>((resolve, reject) => {
-    nReq.onsuccess = () => {
-      const cursor = nReq.result;
-      if (cursor) {
-        cursor.delete();
-        cursor.continue();
-      } else {
-        resolve();
-      }
-    };
-    nReq.onerror = () => reject(nReq.error);
-  });
-  // Wait for the entire transaction to commit
-  await new Promise<void>((resolve, reject) => {
-    txn.oncomplete = () => resolve();
-    txn.onerror = () => reject(txn.error);
-  });
+  await txComplete(txn);
 }
 
 // === Versions ===
 
 export async function saveVersion(
+  partId: string,
   sessionId: string,
   code: string,
   geometryData: Record<string, unknown> | null,
@@ -406,12 +596,13 @@ export async function saveVersion(
   /** External meshes imported into this version (opaque to the db layer). */
   importedMeshes?: unknown[],
 ): Promise<Version> {
-  const versions = await listVersions(sessionId);
+  const versions = await listVersions(partId);
   const nextIndex = versions.length > 0 ? Math.max(...versions.map(v => v.index)) + 1 : 1;
 
   const version: Version = {
     id: generateId(),
     sessionId,
+    partId,
     index: nextIndex,
     code,
     geometryData,
@@ -426,29 +617,33 @@ export async function saveVersion(
   const store = await tx('versions', 'readwrite');
   await reqToPromise(store.put(version));
 
-  // Bump session.updated unless the caller is restoring an earlier timestamp
-  // (an import that wants to preserve original session.updated will restore it after).
-  await updateSession(sessionId, { updated: timestamp ?? Date.now() });
+  // Bump part.updated and session.updated unless the caller is restoring an
+  // earlier timestamp (an import that wants to preserve original timestamps
+  // will restore them after).
+  const stamp = timestamp ?? Date.now();
+  await updatePart(partId, { updated: stamp });
+  await updateSession(sessionId, { updated: stamp });
 
   return version;
 }
 
-export async function listVersions(sessionId: string): Promise<Version[]> {
+/** List a part's versions (its own v1, v2, … sequence), sorted by index. */
+export async function listVersions(partId: string): Promise<Version[]> {
   const store = await tx('versions', 'readonly');
-  const index = store.index('sessionId');
-  const versions = await reqToPromise(index.getAll(IDBKeyRange.only(sessionId))) as Version[];
+  const index = store.index('partId');
+  const versions = await reqToPromise(index.getAll(IDBKeyRange.only(partId))) as Version[];
   return versions.sort((a, b) => a.index - b.index);
 }
 
-export async function getLatestVersion(sessionId: string): Promise<Version | null> {
-  const versions = await listVersions(sessionId);
+export async function getLatestVersion(partId: string): Promise<Version | null> {
+  const versions = await listVersions(partId);
   return versions.length > 0 ? versions[versions.length - 1] : null;
 }
 
-export async function getVersionByIndex(sessionId: string, index: number): Promise<Version | null> {
+export async function getVersionByIndex(partId: string, index: number): Promise<Version | null> {
   const store = await tx('versions', 'readonly');
-  const idx = store.index('sessionId_index');
-  return reqToPromise(idx.get([sessionId, index])) as Promise<Version | null>;
+  const idx = store.index('partId_index');
+  return reqToPromise(idx.get([partId, index])) as Promise<Version | null>;
 }
 
 export async function getVersionById(id: string): Promise<Version | null> {
@@ -456,10 +651,30 @@ export async function getVersionById(id: string): Promise<Version | null> {
   return reqToPromise(store.get(id)) as Promise<Version | null>;
 }
 
-export async function getVersionCount(sessionId: string): Promise<number> {
+export async function getVersionCount(partId: string): Promise<number> {
+  const store = await tx('versions', 'readonly');
+  const index = store.index('partId');
+  return reqToPromise(index.count(IDBKeyRange.only(partId)));
+}
+
+// === Session-scoped version helpers (aggregate across all parts) ===
+// Used by the recent-session grids (landing, session list) and empty-session
+// cleanup, which think in terms of whole sessions rather than individual parts.
+
+export async function getSessionVersionCount(sessionId: string): Promise<number> {
   const store = await tx('versions', 'readonly');
   const index = store.index('sessionId');
   return reqToPromise(index.count(IDBKeyRange.only(sessionId)));
+}
+
+/** The most recently saved version across all of a session's parts — a
+ *  representative record for thumbnails/labels in session grids. */
+export async function getSessionLatestVersion(sessionId: string): Promise<Version | null> {
+  const store = await tx('versions', 'readonly');
+  const index = store.index('sessionId');
+  const versions = await reqToPromise(index.getAll(IDBKeyRange.only(sessionId))) as Version[];
+  if (versions.length === 0) return null;
+  return versions.reduce((latest, v) => (v.timestamp > latest.timestamp ? v : latest));
 }
 
 export async function deleteVersion(id: string): Promise<void> {
@@ -539,12 +754,10 @@ export async function updateNote(id: string, text: string): Promise<void> {
 
 export async function clearAllData(): Promise<void> {
   const db = await openDB();
-  const txn = db.transaction(['sessions', 'versions', 'notes'], 'readwrite');
+  const txn = db.transaction(['sessions', 'versions', 'notes', 'parts'], 'readwrite');
   txn.objectStore('sessions').clear();
   txn.objectStore('versions').clear();
   txn.objectStore('notes').clear();
-  await new Promise<void>((resolve, reject) => {
-    txn.oncomplete = () => resolve();
-    txn.onerror = () => reject(txn.error);
-  });
+  txn.objectStore('parts').clear();
+  await txComplete(txn);
 }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -121,7 +121,9 @@ function openDB(): Promise<IDBDatabase> {
       if (!db.objectStoreNames.contains('versions')) {
         const store = db.createObjectStore('versions', { keyPath: 'id' });
         store.createIndex('sessionId', 'sessionId', { unique: false });
-        store.createIndex('sessionId_index', ['sessionId', 'index'], { unique: true });
+        // Per-part version uniqueness (`partId_index`) is added in the v5 block
+        // below; no `sessionId_index` is needed (two parts in one session can
+        // each have a v1).
       }
       if (!db.objectStoreNames.contains('notes')) {
         const store = db.createObjectStore('notes', { keyPath: 'id' });
@@ -527,22 +529,11 @@ export async function createPart(sessionId: string, name: string, order: number)
   return part;
 }
 
-export async function getPart(id: string): Promise<Part | null> {
-  const store = await tx('parts', 'readonly');
-  return reqToPromise(store.get(id)) as Promise<Part | null>;
-}
-
 export async function listParts(sessionId: string): Promise<Part[]> {
   const store = await tx('parts', 'readonly');
   const index = store.index('sessionId');
   const parts = await reqToPromise(index.getAll(IDBKeyRange.only(sessionId))) as Part[];
   return parts.sort((a, b) => a.order - b.order);
-}
-
-export async function getPartCount(sessionId: string): Promise<number> {
-  const store = await tx('parts', 'readonly');
-  const index = store.index('sessionId');
-  return reqToPromise(index.count(IDBKeyRange.only(sessionId)));
 }
 
 export async function updatePart(id: string, updates: Partial<Pick<Part, 'name' | 'order' | 'updated'>>): Promise<void> {

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -640,6 +640,36 @@ export async function deletePart(partId: string): Promise<DeletePartResult | nul
   return { deleted: target, newCurrent: null };
 }
 
+/**
+ * Persist a new display order for the active session's parts. `orderedIds` is
+ * the full list of part ids, first = top. Ids not present are appended in their
+ * existing relative order (defensive). No-op without an active session.
+ */
+export async function reorderParts(orderedIds: string[]): Promise<void> {
+  if (!currentState.session) return;
+  const byId = new Map(currentState.parts.map(p => [p.id, p]));
+  const ordered: Part[] = [];
+  for (const id of orderedIds) {
+    const p = byId.get(id);
+    if (p) { ordered.push(p); byId.delete(id); }
+  }
+  // Any parts the caller didn't mention keep their relative order at the end.
+  for (const p of currentState.parts) if (byId.has(p.id)) ordered.push(p);
+
+  const next = ordered.map((p, i) => ({ ...p, order: i }));
+  for (const p of next) await dbUpdatePart(p.id, { order: p.order });
+
+  currentState = {
+    ...currentState,
+    parts: next,
+    currentPart: currentState.currentPart
+      ? next.find(p => p.id === currentState.currentPart!.id) ?? currentState.currentPart
+      : null,
+  };
+  updateURL();
+  notify();
+}
+
 // === Version operations ===
 
 /** Stable structural comparison for annotation snapshots. Both are arrays of

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -11,11 +11,16 @@ import {
   getVersionByIndex,
   getVersionById,
   getVersionCount,
+  getSessionVersionCount,
   deleteVersion as dbDeleteVersion,
   putVersion as dbPutVersion,
   renameVersion as dbRenameVersion,
   clearAllData,
   updateSession as dbUpdateSession,
+  createPart as dbCreatePart,
+  listParts as dbListParts,
+  updatePart as dbUpdatePart,
+  deletePart as dbDeletePart,
   addNote as dbAddNote,
   listNotes as dbListNotes,
   deleteNote as dbDeleteNote,
@@ -23,6 +28,7 @@ import {
   legacyImagesObjectToArray,
   generateId,
   type Session,
+  type Part,
   type Version,
   type SessionNote,
   type AttachedImage,
@@ -85,10 +91,31 @@ import { setActiveImports, type ImportedMesh } from '../import/importedMesh';
  *           session round-trips with its chat. Only written when the caller
  *           opts in via {@link ExportOptions.includeChat}. On import each
  *           message is re-keyed to the new session; older readers ignore it.
+ *  - `1.7` — multi-part sessions. Additive and back-compatible: the flat
+ *           top-level `versions` list is retained (so pre-1.7 readers still
+ *           import every version, collapsed into one part), and two new fields
+ *           describe the part structure layered on top:
+ *             - `parts: {name, order}[]` — the session's parts.
+ *             - `versions[].part` — the `order` of the version's owning part
+ *               (absent ⇒ 0, the first part).
+ *           Also adds optional `versions[].importedMeshes` (base64-encoded
+ *           mesh buffers) so imported STL geometry finally round-trips through
+ *           export. Files with no `parts` import as a single default part.
  */
-export const SCHEMA_VERSION = '1.6';
+export const SCHEMA_VERSION = '1.7';
 
 const CURRENT_MAJOR = 1;
+
+/** Name given to the implicit first part of every session. */
+const DEFAULT_PART_NAME = 'Part 1';
+
+/** Suggest a unique "Part N" name for a new part, given the existing parts. */
+function suggestPartName(existing: Part[]): string {
+  let n = existing.length + 1;
+  const names = new Set(existing.map(p => p.name));
+  while (names.has(`Part ${n}`)) n++;
+  return `Part ${n}`;
+}
 
 export interface ExportedSession {
   /** Brand + schema version. Set to {@link SCHEMA_VERSION} on export. */
@@ -98,6 +125,12 @@ export interface ExportedSession {
   /** Images may be the array form or the legacy object map ({front, right, ...}).
    * Both also exist under `referenceImages` for pre-rename exports. */
   session: { name: string; created: number; updated: number; images?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; referenceImages?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; language?: 'manifold-js' | 'scad' };
+  /**
+   * The session's parts, ordered by `order`. Present from schema 1.7. Pre-1.7
+   * files omit this; on import they collapse into a single default part.
+   * @since 1.7
+   */
+  parts?: { name: string; order: number }[];
   versions: {
     index: number;
     code: string;
@@ -105,6 +138,20 @@ export interface ExportedSession {
     geometryData: Record<string, unknown> | null;
     timestamp: number;
     notes?: string;
+    /**
+     * `order` of the part this version belongs to. Absent ⇒ 0 (the first part).
+     * Lets the flat `versions` list be regrouped into parts on import while
+     * staying readable to pre-1.7 clients.
+     * @since 1.7
+     */
+    part?: number;
+    /**
+     * Imported meshes (e.g. STL) backing `api.imports`, with their typed-array
+     * buffers base64-encoded so they survive a JSON round-trip. Restored into
+     * the version's `importedMeshes` on import.
+     * @since 1.7
+     */
+    importedMeshes?: ExportedImportedMesh[];
     /**
      * Per-version color regions. Promoted to an explicit field in schema 1.1;
      * also mirrored inside `geometryData.colorRegions` for pre-1.1 readers.
@@ -148,6 +195,77 @@ export interface ExportedSession {
  *  regenerated/re-keyed on import, and `errored` is never persisted. */
 export type ExportedChatMessage = Omit<ChatMessage, 'id' | 'sessionId' | 'errored'>;
 
+/** An {@link ImportedMesh} with its typed-array buffers base64-encoded so it can
+ *  be embedded in JSON. Mirror of the runtime shape, minus the live arrays.
+ *  @since 1.7 */
+export interface ExportedImportedMesh {
+  id: string;
+  filename: string;
+  format: string;
+  numVert: number;
+  numTri: number;
+  numProp: number;
+  /** base64 of the Float32Array vertex-property buffer. */
+  vertProperties: string;
+  /** base64 of the Uint32Array triangle-index buffer. */
+  triVerts: string;
+}
+
+/** Encode a typed array's bytes as base64. */
+function typedArrayToBase64(arr: Float32Array | Uint32Array): string {
+  const bytes = new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
+  let bin = '';
+  const CHUNK = 0x8000; // avoid call-stack limits on String.fromCharCode.apply
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(bin);
+}
+
+/** Decode base64 into a fresh ArrayBuffer (copy, so it's tightly owned). */
+function base64ToArrayBuffer(b64: string): ArrayBuffer {
+  const bin = atob(b64);
+  const buf = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+  return buf.buffer;
+}
+
+function serializeImportedMeshes(meshes: ImportedMesh[] | undefined): ExportedImportedMesh[] | undefined {
+  if (!meshes || meshes.length === 0) return undefined;
+  return meshes.map(m => ({
+    id: m.id,
+    filename: m.filename,
+    format: m.format,
+    numVert: m.numVert,
+    numTri: m.numTri,
+    numProp: m.numProp,
+    vertProperties: typedArrayToBase64(m.vertProperties),
+    triVerts: typedArrayToBase64(m.triVerts),
+  }));
+}
+
+function deserializeImportedMeshes(meshes: ExportedImportedMesh[] | undefined): ImportedMesh[] | undefined {
+  if (!Array.isArray(meshes) || meshes.length === 0) return undefined;
+  const out: ImportedMesh[] = [];
+  for (const m of meshes) {
+    try {
+      out.push({
+        id: typeof m.id === 'string' ? m.id : generateId(),
+        filename: typeof m.filename === 'string' ? m.filename : 'imported',
+        format: (m.format as ImportedMesh['format']) ?? 'stl',
+        numVert: m.numVert,
+        numTri: m.numTri,
+        numProp: m.numProp,
+        vertProperties: new Float32Array(base64ToArrayBuffer(m.vertProperties)),
+        triVerts: new Uint32Array(base64ToArrayBuffer(m.triVerts)),
+      });
+    } catch {
+      // Skip a mesh we can't decode rather than failing the whole import.
+    }
+  }
+  return out.length > 0 ? out : undefined;
+}
+
 interface SchemaVersionInfo {
   raw: string;
   major: number;
@@ -183,11 +301,18 @@ export function getSchemaCompatibilityWarning(data: ExportedSession): string | n
   return null;
 }
 
-export type { Session, Version, SessionNote, AttachedImage } from './db';
+export type { Session, Part, Version, SessionNote, AttachedImage } from './db';
 
 export interface SessionState {
   session: Session | null;
+  /** All parts in the active session, ordered for display. Empty when no
+   *  session is open. */
+  parts: Part[];
+  /** The part currently shown in the editor/viewport. */
+  currentPart: Part | null;
+  /** The active version *of the current part*. */
   currentVersion: Version | null;
+  /** Version count *of the current part* (drives the version nav). */
   versionCount: number;
 }
 
@@ -195,6 +320,8 @@ type StateChangeListener = (state: SessionState) => void;
 
 let currentState: SessionState = {
   session: null,
+  parts: [],
+  currentPart: null,
   currentVersion: null,
   versionCount: 0,
 };
@@ -235,6 +362,13 @@ function updateURL() {
   const basePath = '/editor';
   if (currentState.session) {
     params.set('session', currentState.session.id);
+    // Only pin the part in the URL when the session has more than one — a
+    // single-part session is the common case and the param would be noise.
+    if (currentState.currentPart && currentState.parts.length > 1) {
+      params.set('part', currentState.currentPart.id);
+    } else {
+      params.delete('part');
+    }
     if (currentState.currentVersion) {
       params.set('v', String(currentState.currentVersion.index));
     } else {
@@ -242,6 +376,7 @@ function updateURL() {
     }
   } else {
     params.delete('session');
+    params.delete('part');
     params.delete('v');
   }
   const qs = params.toString().replace(/=(?=&|$)/g, '');
@@ -253,6 +388,10 @@ function updateURL() {
 
 export function getSessionIdFromURL(): string | null {
   return new URLSearchParams(window.location.search).get('session');
+}
+
+export function getPartIdFromURL(): string | null {
+  return new URLSearchParams(window.location.search).get('part');
 }
 
 export function getVersionFromURL(): number | null {
@@ -268,7 +407,11 @@ export async function createSession(name?: string, language?: 'manifold-js' | 's
     await deleteIfEmpty(currentState.session.id);
   }
   const session = await dbCreateSession(name, language);
-  currentState = { session, currentVersion: null, versionCount: 0 };
+  // Every session starts with one part; the current-part pointer references it.
+  const part = await dbCreatePart(session.id, DEFAULT_PART_NAME, 0);
+  await dbUpdateSession(session.id, { currentPartId: part.id });
+  session.currentPartId = part.id;
+  currentState = { session, parts: [part], currentPart: part, currentVersion: null, versionCount: 0 };
   // Annotations are per-version; a fresh session starts empty so nothing
   // bleeds in from the previously-active session.
   loadAnnotations([]);
@@ -278,7 +421,7 @@ export async function createSession(name?: string, language?: 'manifold-js' | 's
   return session;
 }
 
-export async function openSession(id: string, versionIndex?: number): Promise<Version | null> {
+export async function openSession(id: string, versionIndex?: number, partId?: string): Promise<Version | null> {
   // Clean up the previous session if it was empty (no versions, no notes)
   if (currentState.session && currentState.session.id !== id) {
     await deleteIfEmpty(currentState.session.id);
@@ -287,21 +430,45 @@ export async function openSession(id: string, versionIndex?: number): Promise<Ve
   const session = await getSession(id);
   if (!session) return null;
 
-  const count = await getVersionCount(id);
-  let version: Version | null = null;
+  const parts = await ensureParts(session);
+  // Prefer the explicitly requested part, then the session's remembered part,
+  // then the first part.
+  const targetPart =
+    (partId ? parts.find(p => p.id === partId) : undefined) ??
+    parts.find(p => p.id === session.currentPartId) ??
+    parts[0];
 
+  const count = await getVersionCount(targetPart.id);
+  let version: Version | null = null;
   if (versionIndex !== undefined) {
-    version = await getVersionByIndex(id, versionIndex);
+    version = await getVersionByIndex(targetPart.id, versionIndex);
   }
   if (!version) {
-    version = await getLatestVersion(id);
+    version = await getLatestVersion(targetPart.id);
   }
 
-  currentState = { session, currentVersion: version, versionCount: count };
+  if (session.currentPartId !== targetPart.id) {
+    await dbUpdateSession(id, { currentPartId: targetPart.id });
+    session.currentPartId = targetPart.id;
+  }
+
+  currentState = { session, parts, currentPart: targetPart, currentVersion: version, versionCount: count };
   setActiveImports((version?.importedMeshes ?? []) as ImportedMesh[]);
   updateURL();
   notify();
   return version;
+}
+
+/** Return a session's parts, lazily creating a default part for any (legacy or
+ *  pathological) session that has none. Keeps the rest of the code free of
+ *  "what if there are zero parts" branches. */
+async function ensureParts(session: Session): Promise<Part[]> {
+  const parts = await dbListParts(session.id);
+  if (parts.length > 0) return parts;
+  const part = await dbCreatePart(session.id, DEFAULT_PART_NAME, 0);
+  await dbUpdateSession(session.id, { currentPartId: part.id });
+  session.currentPartId = part.id;
+  return [part];
 }
 
 export async function closeSession(): Promise<void> {
@@ -309,7 +476,7 @@ export async function closeSession(): Promise<void> {
   if (currentState.session) {
     await deleteIfEmpty(currentState.session.id);
   }
-  currentState = { session: null, currentVersion: null, versionCount: 0 };
+  currentState = { session: null, parts: [], currentPart: null, currentVersion: null, versionCount: 0 };
   loadAnnotations([]);
   setActiveImports([]);
   updateURL();
@@ -341,6 +508,136 @@ export async function setSessionLanguage(id: string, language: 'manifold-js' | '
     currentState.session = { ...currentState.session, language, updated: Date.now() };
     notify();
   }
+}
+
+// === Part operations ===
+
+/** The parts of the active session (ascending by display order), or [] if no
+ *  session is open. Reads from current state — no DB round-trip. */
+export function listCurrentParts(): Part[] {
+  return currentState.parts;
+}
+
+export function getCurrentPart(): Part | null {
+  return currentState.currentPart;
+}
+
+/**
+ * Create a new, empty part in the active session and make it current. The new
+ * part has no versions yet; the caller is responsible for seeding the editor
+ * with starter code (mirroring how a fresh session presents the default
+ * example). Returns null if there is no active session.
+ */
+export async function createPart(name?: string): Promise<Part | null> {
+  if (!currentState.session) return null;
+  const order = currentState.parts.reduce((m, p) => Math.max(m, p.order), -1) + 1;
+  const partName = (name && name.trim()) || suggestPartName(currentState.parts);
+  const part = await dbCreatePart(currentState.session.id, partName, order);
+  await dbUpdateSession(currentState.session.id, { currentPartId: part.id });
+
+  currentState = {
+    ...currentState,
+    session: { ...currentState.session, currentPartId: part.id },
+    parts: [...currentState.parts, part],
+    currentPart: part,
+    currentVersion: null,
+    versionCount: 0,
+  };
+  loadAnnotations([]);
+  setActiveImports([]);
+  updateURL();
+  notify();
+  return part;
+}
+
+/**
+ * Switch the active part within the current session. Loads that part's latest
+ * version (or a specific version by index) into state. Returns the loaded
+ * version (which may be null if the part has no saved versions yet).
+ */
+export async function changePart(partId: string, versionIndex?: number): Promise<Version | null> {
+  if (!currentState.session) return null;
+  const part = currentState.parts.find(p => p.id === partId);
+  if (!part) return null;
+
+  const count = await getVersionCount(part.id);
+  let version: Version | null = null;
+  if (versionIndex !== undefined) {
+    version = await getVersionByIndex(part.id, versionIndex);
+  }
+  if (!version) {
+    version = await getLatestVersion(part.id);
+  }
+
+  await dbUpdateSession(currentState.session.id, { currentPartId: part.id });
+  currentState = {
+    ...currentState,
+    session: { ...currentState.session, currentPartId: part.id },
+    currentPart: part,
+    currentVersion: version,
+    versionCount: count,
+  };
+  // Annotations are per-version and re-applied by the editor load path; reset
+  // here so the previous part's strokes don't bleed across the switch.
+  loadAnnotations([]);
+  setActiveImports((version?.importedMeshes ?? []) as ImportedMesh[]);
+  updateURL();
+  notify();
+  return version;
+}
+
+export async function renamePart(partId: string, newName: string): Promise<void> {
+  await dbUpdatePart(partId, { name: newName, updated: Date.now() });
+  const idx = currentState.parts.findIndex(p => p.id === partId);
+  if (idx >= 0) {
+    const parts = currentState.parts.slice();
+    parts[idx] = { ...parts[idx], name: newName, updated: Date.now() };
+    currentState = {
+      ...currentState,
+      parts,
+      currentPart: currentState.currentPart?.id === partId ? parts[idx] : currentState.currentPart,
+    };
+    notify();
+  }
+}
+
+export interface DeletePartResult {
+  deleted: Part;
+  /** The part that became active after deletion (only set when the deleted part
+   *  was the current one). */
+  newCurrent: Part | null;
+}
+
+/**
+ * Delete a part and all its versions. Refuses to remove the last remaining part
+ * (a session always keeps at least one). When the active part is deleted, the
+ * adjacent part — preferring the previous one in display order — becomes active.
+ * Returns null if the delete was refused or the part wasn't found.
+ */
+export async function deletePart(partId: string): Promise<DeletePartResult | null> {
+  if (!currentState.session) return null;
+  const parts = currentState.parts;
+  const target = parts.find(p => p.id === partId);
+  if (!target) return null;
+  if (parts.length <= 1) return null; // keep at least one part
+
+  await dbDeletePart(partId);
+
+  const remaining = parts.filter(p => p.id !== partId);
+  const wasCurrent = currentState.currentPart?.id === partId;
+
+  if (wasCurrent) {
+    const pos = parts.findIndex(p => p.id === partId);
+    const next = remaining[pos - 1] ?? remaining[0];
+    currentState = { ...currentState, parts: remaining };
+    await changePart(next.id);
+    return { deleted: target, newCurrent: next };
+  }
+
+  currentState = { ...currentState, parts: remaining };
+  updateURL();
+  notify();
+  return { deleted: target, newCurrent: null };
 }
 
 // === Version operations ===
@@ -377,7 +674,7 @@ export async function saveVersion(
   notes?: string,
   options?: { force?: boolean; importedMeshes?: ImportedMesh[] },
 ): Promise<Version | null> {
-  if (!currentState.session) return null;
+  if (!currentState.session || !currentState.currentPart) return null;
 
   const annotationSnapshot = serializeAnnotations();
 
@@ -403,6 +700,7 @@ export async function saveVersion(
   }
 
   const version = await dbSaveVersion(
+    currentState.currentPart.id,
     currentState.session.id,
     code,
     geometryData,
@@ -426,12 +724,12 @@ export async function saveVersion(
 }
 
 export async function navigateVersion(direction: 'prev' | 'next'): Promise<Version | null> {
-  if (!currentState.session || !currentState.currentVersion) return null;
+  if (!currentState.session || !currentState.currentPart || !currentState.currentVersion) return null;
 
   // Step to the adjacent *existing* version. Walking the sorted list by
   // position (rather than index ± 1) keeps navigation correct after deletions
   // leave gaps in the index sequence.
-  const versions = await dbListVersions(currentState.session.id);
+  const versions = await dbListVersions(currentState.currentPart.id);
   const pos = versions.findIndex(v => v.id === currentState.currentVersion!.id);
   if (pos === -1) return null;
   const target = versions[pos + (direction === 'prev' ? -1 : 1)];
@@ -446,25 +744,25 @@ export async function navigateVersion(direction: 'prev' | 'next'): Promise<Versi
 
 /** Look up a version by index (number) or id (string) without mutating current state. */
 export async function peekVersion(target: number | string): Promise<Version | null> {
-  if (!currentState.session) return null;
+  if (!currentState.session || !currentState.currentPart) return null;
   if (typeof target === 'number') {
-    return getVersionByIndex(currentState.session.id, target);
+    return getVersionByIndex(currentState.currentPart.id, target);
   }
   const v = await getVersionById(target);
-  return v && v.sessionId === currentState.session.id ? v : null;
+  return v && v.partId === currentState.currentPart.id ? v : null;
 }
 
 /** Load a version by index (number) or id (string). */
 export async function loadVersion(target: number | string): Promise<Version | null> {
-  if (!currentState.session) return null;
+  if (!currentState.session || !currentState.currentPart) return null;
 
   let version: Version | null = null;
   if (typeof target === 'number') {
-    version = await getVersionByIndex(currentState.session.id, target);
+    version = await getVersionByIndex(currentState.currentPart.id, target);
   } else {
     const v = await getVersionById(target);
-    // Reject versions from other sessions to avoid cross-session pollution.
-    if (v && v.sessionId === currentState.session.id) version = v;
+    // Reject versions from other parts/sessions to avoid cross-part pollution.
+    if (v && v.partId === currentState.currentPart.id) version = v;
   }
   if (!version) return null;
 
@@ -476,8 +774,8 @@ export async function loadVersion(target: number | string): Promise<Version | nu
 }
 
 export async function listCurrentVersions(): Promise<Version[]> {
-  if (!currentState.session) return [];
-  return dbListVersions(currentState.session.id);
+  if (!currentState.currentPart) return [];
+  return dbListVersions(currentState.currentPart.id);
 }
 
 export interface DeleteVersionResult {
@@ -497,8 +795,8 @@ export interface DeleteVersionResult {
  * not found. Indices of surviving versions are left untouched (gaps are fine).
  */
 export async function deleteVersion(versionId: string): Promise<DeleteVersionResult | null> {
-  if (!currentState.session) return null;
-  const versions = await dbListVersions(currentState.session.id);
+  if (!currentState.session || !currentState.currentPart) return null;
+  const versions = await dbListVersions(currentState.currentPart.id);
   const target = versions.find(v => v.id === versionId);
   if (!target) return null;
   if (versions.length <= 1) return null; // keep at least one version
@@ -532,9 +830,9 @@ export async function deleteVersion(versionId: string): Promise<DeleteVersionRes
  * belong to the active session.
  */
 export async function restoreVersion(version: Version, makeCurrent: boolean): Promise<void> {
-  if (!currentState.session || version.sessionId !== currentState.session.id) return;
+  if (!currentState.session || !currentState.currentPart || version.partId !== currentState.currentPart.id) return;
   await dbPutVersion(version);
-  const versions = await dbListVersions(currentState.session.id);
+  const versions = await dbListVersions(currentState.currentPart.id);
   currentState = {
     ...currentState,
     currentVersion: makeCurrent ? version : currentState.currentVersion,
@@ -550,9 +848,9 @@ export async function restoreVersion(version: Version, makeCurrent: boolean): Pr
 /** Rename a version's display label. The index is immutable. Returns the
  *  updated record, or null if it isn't part of the active session. */
 export async function renameVersion(versionId: string, label: string): Promise<Version | null> {
-  if (!currentState.session) return null;
+  if (!currentState.session || !currentState.currentPart) return null;
   const target = await getVersionById(versionId);
-  if (!target || target.sessionId !== currentState.session.id) return null;
+  if (!target || target.partId !== currentState.currentPart.id) return null;
   await dbRenameVersion(versionId, label);
   const updated = { ...target, label };
   if (currentState.currentVersion?.id === versionId) {
@@ -641,6 +939,11 @@ export function getRecentErrors(): { error: string; timestamp: number }[] {
 
 export interface SessionContext {
   session: { id: string; name: string; created: number; updated: number; language: 'manifold-js' | 'scad' };
+  /** All parts in the session. The `versions`/`currentVersion` fields below are
+   *  scoped to {@link currentPart}; switch parts with `changePart` to inspect
+   *  another part's history. */
+  parts: { id: string; name: string; order: number; isCurrent: boolean }[];
+  currentPart: { id: string; name: string } | null;
   versions: {
     index: number;
     label: string;
@@ -674,7 +977,7 @@ export async function getSessionContext(): Promise<SessionContext | null> {
   if (!currentState.session) return null;
 
   const session = currentState.session;
-  const versions = await dbListVersions(session.id);
+  const versions = currentState.currentPart ? await dbListVersions(currentState.currentPart.id) : [];
   const notes = await dbListNotes(session.id);
 
   return {
@@ -685,6 +988,15 @@ export async function getSessionContext(): Promise<SessionContext | null> {
       updated: session.updated,
       language: session.language ?? 'manifold-js',
     },
+    parts: currentState.parts.map(p => ({
+      id: p.id,
+      name: p.name,
+      order: p.order,
+      isCurrent: p.id === currentState.currentPart?.id,
+    })),
+    currentPart: currentState.currentPart
+      ? { id: currentState.currentPart.id, name: currentState.currentPart.name }
+      : null,
     versions: versions.map(v => {
       const geo = v.geometryData as Record<string, unknown> | null;
       const bb = geo?.boundingBox as Record<string, unknown> | undefined;
@@ -724,13 +1036,15 @@ export async function getSessionContext(): Promise<SessionContext | null> {
 
 /** Delete a session if it has no versions and no notes (used for auto-created empty sessions) */
 export async function deleteIfEmpty(sessionId: string): Promise<boolean> {
-  const count = await getVersionCount(sessionId);
+  // Empty = no saved versions in any part and no notes. The auto-created part
+  // that every session carries doesn't count as content.
+  const count = await getSessionVersionCount(sessionId);
   if (count > 0) return false;
   const notes = await dbListNotes(sessionId);
   if (notes.length > 0) return false;
   await dbDeleteSession(sessionId);
   if (currentState.session?.id === sessionId) {
-    currentState = { session: null, currentVersion: null, versionCount: 0 };
+    currentState = { session: null, parts: [], currentPart: null, currentVersion: null, versionCount: 0 };
     setActiveImports([]);
   }
   return true;
@@ -740,7 +1054,7 @@ export async function deleteIfEmpty(sessionId: string): Promise<boolean> {
 
 export async function clearAllSessions(): Promise<void> {
   await clearAllData();
-  currentState = { session: null, currentVersion: null, versionCount: 0 };
+  currentState = { session: null, parts: [], currentPart: null, currentVersion: null, versionCount: 0 };
   loadAnnotations([]);
   setActiveImports([]);
   updateURL();
@@ -835,37 +1149,50 @@ export async function exportSession(
 
   const opts: Required<Omit<ExportOptions, 'versionIndices'>> = { ...DEFAULT_EXPORT_OPTIONS, ...options };
 
-  const allVersions = await dbListVersions(id);
-  const versions = options?.versionIndices
-    ? allVersions.filter(v => options.versionIndices!.includes(v.index))
-    : allVersions;
+  const parts = await dbListParts(id);
+  // Flatten all parts' versions into one list, tagging each with its part's
+  // `order`. Grouped by part (then version index) so that pre-1.7 readers, which
+  // ignore the `part` tag and import the flat list, still get a sensible order.
+  const flat: { v: Version; partOrder: number }[] = [];
+  for (const part of parts) {
+    let versions = await dbListVersions(part.id);
+    if (options?.versionIndices) {
+      versions = versions.filter(v => options.versionIndices!.includes(v.index));
+    }
+    for (const v of versions) flat.push({ v, partOrder: part.order });
+  }
+
   const notes = opts.includeNotes ? await dbListNotes(id) : [];
   const chat = opts.includeChat ? await dbListMessages(id) : [];
 
   // Thumbnail conversion: read each version's Blob and convert to base64 data URL.
   // Done in parallel since FileReader is async per-blob.
   const thumbnailDataUrls: (string | null)[] = await Promise.all(
-    versions.map(v => (opts.includeThumbnails && v.thumbnail) ? blobToDataURL(v.thumbnail) : Promise.resolve(null)),
+    flat.map(({ v }) => (opts.includeThumbnails && v.thumbnail) ? blobToDataURL(v.thumbnail) : Promise.resolve(null)),
   );
 
   return {
     partwright: SCHEMA_VERSION,
     session: { name: session.name, created: session.created, updated: session.updated, images: session.images ?? null, ...(session.language ? { language: session.language } : {}) },
-    versions: versions.map((v, i) => {
+    parts: parts.map(p => ({ name: p.name, order: p.order })),
+    versions: flat.map(({ v, partOrder }, i) => {
       const colorRegions = opts.includeColorRegions ? extractColorRegions(v.geometryData) : undefined;
       const geometryData = opts.includeColorRegions ? v.geometryData : stripColorRegions(v.geometryData);
       const versionAnnotations = opts.includeAnnotations ? ((v.annotations ?? []) as SerializedAnnotation[]) : [];
       const thumbDataUrl = thumbnailDataUrls[i];
+      const importedMeshes = serializeImportedMeshes(v.importedMeshes as ImportedMesh[] | undefined);
       return {
         index: v.index,
         code: v.code,
         label: v.label,
         geometryData,
         timestamp: v.timestamp,
+        ...(partOrder !== 0 ? { part: partOrder } : {}),
         ...(v.notes ? { notes: v.notes } : {}),
         ...(colorRegions ? { colorRegions } : {}),
         ...(versionAnnotations.length > 0 ? { annotations: versionAnnotations } : {}),
         ...(thumbDataUrl ? { thumbnail: thumbDataUrl } : {}),
+        ...(importedMeshes ? { importedMeshes } : {}),
       };
     }),
     ...(notes.length > 0 ? { notes: notes.map(n => ({ text: n.text, timestamp: n.timestamp })) } : {}),
@@ -899,47 +1226,78 @@ export async function importSession(
   // version was most recent at export time (assumed to be the highest index).
   const latestExportedIndex = data.versions.reduce((m, v) => Math.max(m, v.index), -Infinity);
 
-  for (const v of data.versions) {
-    // Normalize color regions: prefer the explicit (1.1+) field; fall back to the legacy
-    // nested location (`geometryData.colorRegions`) for pre-1.1 files. Mirror the result
-    // back into `geometryData` so existing read paths (e.g. rehydrateColorRegions, gallery
-    // badges) continue to find them in their historical location.
-    const explicitRegions = v.colorRegions;
-    const nestedRegions = extractColorRegions(v.geometryData);
-    const regions = explicitRegions ?? nestedRegions;
-
-    let geometryData = v.geometryData;
-    if (regions && (!geometryData || !Array.isArray((geometryData as Record<string, unknown>).colorRegions))) {
-      geometryData = { ...(geometryData ?? {}), colorRegions: regions };
-    }
-
-    // Prefer an embedded thumbnail (schema 1.3+) — avoids re-running WASM
-    // and gives us the exact image the exporter saw. Fall back to
-    // regenerating from code when the field is absent.
-    let thumbnail: Blob | null = null;
-    if (v.thumbnail) thumbnail = dataURLToBlob(v.thumbnail);
-    if (!thumbnail && regenerateThumbnail) {
-      thumbnail = await regenerateThumbnail(v.code);
-    }
-
-    // Annotations: prefer the per-version field (1.3+). Fall back to the
-    // top-level field (1.2) attached to the latest exported version only.
-    let versionAnnotations: SerializedAnnotation[] | undefined = v.annotations;
-    if (!versionAnnotations && data.annotations && data.annotations.length > 0 && v.index === latestExportedIndex) {
-      versionAnnotations = data.annotations;
-    }
-
-    await dbSaveVersion(
-      session.id,
-      v.code,
-      geometryData,
-      thumbnail,
-      v.label,
-      v.notes,
-      v.timestamp,
-      versionAnnotations,
-    );
+  // Reconstruct parts. Schema 1.7+ ships an explicit `parts` array; older files
+  // have none, so all their versions collapse into a single default part.
+  const partDefs = (Array.isArray(data.parts) && data.parts.length > 0)
+    ? [...data.parts].sort((a, b) => a.order - b.order)
+    : [{ name: DEFAULT_PART_NAME, order: 0 }];
+  const orderToPartId = new Map<number, string>();
+  let firstPartId = '';
+  for (let i = 0; i < partDefs.length; i++) {
+    const def = partDefs[i];
+    const part = await dbCreatePart(session.id, (def.name && def.name.trim()) || `Part ${i + 1}`, i);
+    orderToPartId.set(def.order, part.id);
+    if (i === 0) firstPartId = part.id;
   }
+
+  // Group versions by owning part, then save each group ordered by original
+  // index so the per-part indices we assign preserve the source sequence.
+  const versionsByPart = new Map<string, ExportedSession['versions']>();
+  for (const v of data.versions) {
+    const partId = orderToPartId.get(v.part ?? 0) ?? firstPartId;
+    const arr = versionsByPart.get(partId) ?? [];
+    arr.push(v);
+    versionsByPart.set(partId, arr);
+  }
+
+  for (const [partId, partVersions] of versionsByPart) {
+    const sorted = [...partVersions].sort((a, b) => a.index - b.index);
+    for (const v of sorted) {
+      // Normalize color regions: prefer the explicit (1.1+) field; fall back to the legacy
+      // nested location (`geometryData.colorRegions`) for pre-1.1 files. Mirror the result
+      // back into `geometryData` so existing read paths (e.g. rehydrateColorRegions, gallery
+      // badges) continue to find them in their historical location.
+      const explicitRegions = v.colorRegions;
+      const nestedRegions = extractColorRegions(v.geometryData);
+      const regions = explicitRegions ?? nestedRegions;
+
+      let geometryData = v.geometryData;
+      if (regions && (!geometryData || !Array.isArray((geometryData as Record<string, unknown>).colorRegions))) {
+        geometryData = { ...(geometryData ?? {}), colorRegions: regions };
+      }
+
+      // Prefer an embedded thumbnail (schema 1.3+) — avoids re-running WASM
+      // and gives us the exact image the exporter saw. Fall back to
+      // regenerating from code when the field is absent.
+      let thumbnail: Blob | null = null;
+      if (v.thumbnail) thumbnail = dataURLToBlob(v.thumbnail);
+      if (!thumbnail && regenerateThumbnail) {
+        thumbnail = await regenerateThumbnail(v.code);
+      }
+
+      // Annotations: prefer the per-version field (1.3+). Fall back to the
+      // top-level field (1.2) attached to the latest exported version only.
+      let versionAnnotations: SerializedAnnotation[] | undefined = v.annotations;
+      if (!versionAnnotations && data.annotations && data.annotations.length > 0 && v.index === latestExportedIndex) {
+        versionAnnotations = data.annotations;
+      }
+
+      await dbSaveVersion(
+        partId,
+        session.id,
+        v.code,
+        geometryData,
+        thumbnail,
+        v.label,
+        v.notes,
+        v.timestamp,
+        versionAnnotations,
+        deserializeImportedMeshes(v.importedMeshes),
+      );
+    }
+  }
+
+  await dbUpdateSession(session.id, { currentPartId: firstPartId });
 
   // Restore session notes
   if (data.notes) {
@@ -968,9 +1326,11 @@ export async function importSession(
   });
 
   const refreshedSession = (await getSession(session.id)) ?? session;
-  const count = await getVersionCount(session.id);
-  const latest = await getLatestVersion(session.id);
-  currentState = { session: refreshedSession, currentVersion: latest, versionCount: count };
+  const parts = await dbListParts(session.id);
+  const currentPart = parts.find(p => p.id === firstPartId) ?? parts[0] ?? null;
+  const count = currentPart ? await getVersionCount(currentPart.id) : 0;
+  const latest = currentPart ? await getLatestVersion(currentPart.id) : null;
+  currentState = { session: refreshedSession, parts, currentPart, currentVersion: latest, versionCount: count };
   setActiveImports((latest?.importedMeshes ?? []) as ImportedMesh[]);
   updateURL();
   notify();

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -1153,10 +1153,16 @@ export async function exportSession(
   // Flatten all parts' versions into one list, tagging each with its part's
   // `order`. Grouped by part (then version index) so that pre-1.7 readers, which
   // ignore the `part` tag and import the flat list, still get a sensible order.
+  //
+  // The version-prune picker (`versionIndices`) is sourced from the CURRENT
+  // part's versions, and indices are per-part — so only apply it to the current
+  // part. Other parts are always exported in full; filtering them by a different
+  // part's index set would silently drop versions.
+  const currentPartId = currentState.currentPart?.id;
   const flat: { v: Version; partOrder: number }[] = [];
   for (const part of parts) {
     let versions = await dbListVersions(part.id);
-    if (options?.versionIndices) {
+    if (options?.versionIndices && part.id === currentPartId) {
       versions = versions.filter(v => options.versionIndices!.includes(v.index));
     }
     for (const v of versions) flat.push({ v, partOrder: part.order });

--- a/src/ui/landing.ts
+++ b/src/ui/landing.ts
@@ -9,7 +9,7 @@
 //   7. Footer
 
 import { listSessions, type Session } from '../storage/sessionManager';
-import { getLatestVersion, getVersionCount } from '../storage/db';
+import { getSessionLatestVersion, getSessionVersionCount } from '../storage/db';
 import { partwrightMarkSvg } from './brand';
 import { getTheme, onThemeChange, toggleTheme } from './theme';
 import type { ExportedSession } from '../storage/sessionManager';
@@ -465,8 +465,8 @@ async function buildRecentSessions(callbacks: LandingCallbacks): Promise<HTMLEle
   const tileData = await Promise.all(
     sessions.slice(0, 12).map(async (session) => {
       const [latestVersion, versionCount] = await Promise.all([
-        getLatestVersion(session.id),
-        getVersionCount(session.id),
+        getSessionLatestVersion(session.id),
+        getSessionVersionCount(session.id),
       ]);
       return { session, latestVersion, versionCount };
     }),

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -4,6 +4,7 @@ export type TabName = 'interactive' | 'gallery' | 'versions' | 'images' | 'diff'
 
 export interface LayoutElements {
   editorPane: HTMLElement;
+  partsRail: HTMLElement;
   editorContainer: HTMLElement;
   editorErrorPanel: HTMLElement;
   viewportPane: HTMLElement;
@@ -17,6 +18,8 @@ export interface LayoutElements {
   formatBtn: HTMLButtonElement;
   autoFormatToggle: HTMLButtonElement;
   switchTab: (tab: TabName, options?: SwitchTabOptions) => void;
+  /** Collapse/expand the parts rail (wired to the rail's own collapse button). */
+  togglePartsRail: () => void;
 }
 
 export interface SwitchTabOptions {
@@ -28,18 +31,32 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   // Stack panes vertically on narrow viewports, side-by-side at md+.
   main.className = 'flex flex-col md:flex-row flex-1 min-h-0';
 
-  // === Left (or top on mobile): Editor pane ===
-  // Width is only applied via inline style at md+ (see syncEditorPaneWidth).
-  // On mobile the pane uses flex sizing so both panes share the vertical space.
+  // === Left (or top on mobile): Editor group = parts rail + editor pane ===
+  // The GROUP is the width-managed, resizable unit — the splitter and the
+  // collapse/expand logic act on it, and on mobile it stacks above the viewport
+  // as one block. Width is only applied via inline style at md+; on mobile the
+  // group uses flex sizing so it shares the vertical space with the viewport.
+  const editorGroup = document.createElement('div');
+  editorGroup.className = 'relative flex flex-row flex-1 md:flex-none min-h-0 border-b md:border-b-0 md:border-r border-zinc-700';
+
+  // Parts rail — IDE-style list of the session's parts (create / select /
+  // rename / delete / drag-reorder). Populated by createPartList() in main.ts.
+  const partsRail = document.createElement('div');
+  partsRail.id = 'parts-rail';
+  partsRail.className = 'flex flex-col shrink-0 w-32 md:w-48 min-h-0 border-r border-zinc-700 bg-zinc-900/60 overflow-hidden';
+
+  // The editor pane itself sits to the right of the rail and fills the rest.
   const editorPane = document.createElement('div');
-  editorPane.className = 'flex flex-col flex-1 md:flex-none min-h-0 border-b md:border-b-0 md:border-r border-zinc-700';
+  editorPane.className = 'flex flex-col flex-1 min-w-0 min-h-0';
 
   const editorHeader = document.createElement('div');
   editorHeader.className = 'flex items-center px-3 py-1.5 bg-zinc-800 border-b border-zinc-700 gap-2';
 
   const editorTitle = document.createElement('span');
   editorTitle.id = 'editor-title';
-  editorTitle.className = 'text-xs text-zinc-400 font-mono';
+  // truncate + min-w-0 so a long part name ellipsizes instead of pushing the
+  // status indicator and buttons out of the (now rail-narrowed) header.
+  editorTitle.className = 'text-xs text-zinc-400 font-mono truncate min-w-0';
   editorTitle.textContent = 'editor.js';
   editorHeader.appendChild(editorTitle);
 
@@ -62,7 +79,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
 
   const statusBar = document.createElement('span');
   statusBar.id = 'status-indicator';
-  statusBar.className = 'text-xs text-emerald-400 font-mono';
+  statusBar.className = 'text-xs text-emerald-400 font-mono shrink-0';
   statusBar.textContent = 'Ready';
   editorHeader.appendChild(statusBar);
 
@@ -93,7 +110,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   const splitterStripe = document.createElement('div');
   splitterStripe.className = 'absolute inset-y-0 left-1/2 -translate-x-1/2 w-px bg-zinc-700 group-hover:bg-blue-500 group-[.is-dragging]:bg-blue-500 transition-colors';
   splitter.appendChild(splitterStripe);
-  initSplitter(splitter, editorPane);
+  initSplitter(splitter, editorGroup);
 
   // === Right (or bottom on mobile): Tabbed viewport ===
   const rightPane = document.createElement('div');
@@ -205,8 +222,8 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
 
   function collapseEditor(): void {
     editorCollapsed = true;
-    editorPane.style.width = '0';
-    editorPane.style.overflow = 'hidden';
+    editorGroup.style.width = '0';
+    editorGroup.style.overflow = 'hidden';
     expandEditorBtn.classList.remove('hidden');
     splitter.classList.add('hidden');
     window.dispatchEvent(new Event('resize'));
@@ -214,8 +231,8 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
 
   function expandEditor(): void {
     editorCollapsed = false;
-    editorPane.style.width = '35%';
-    editorPane.style.overflow = '';
+    editorGroup.style.width = '40%';
+    editorGroup.style.overflow = '';
     expandEditorBtn.classList.add('hidden');
     syncPaneVisibility();
     window.dispatchEvent(new Event('resize'));
@@ -226,6 +243,24 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   });
   expandEditorBtn.addEventListener('click', expandEditor);
 
+  // === Parts rail collapse ===
+  // Mirrors the editor collapse: hide the rail to reclaim width, leaving a small
+  // floating button at the group's left edge to bring it back.
+  let railCollapsed = false;
+  const railExpandBtn = document.createElement('button');
+  railExpandBtn.className = 'absolute left-0 top-0 z-20 px-1.5 py-1 bg-zinc-800 text-zinc-300 hover:text-zinc-100 hover:bg-zinc-700 rounded-br border-r border-b border-zinc-700 text-xs leading-none hidden';
+  railExpandBtn.textContent = '»'; // »
+  railExpandBtn.title = 'Show parts';
+  editorGroup.appendChild(railExpandBtn);
+
+  function togglePartsRail(): void {
+    railCollapsed = !railCollapsed;
+    partsRail.classList.toggle('hidden', railCollapsed);
+    railExpandBtn.classList.toggle('hidden', !railCollapsed);
+    window.dispatchEvent(new Event('resize'));
+  }
+  railExpandBtn.addEventListener('click', togglePartsRail);
+
   function syncPaneVisibility() {
     const tab = _currentTab;
     const tabHidesEditor = tab === 'diff';
@@ -233,26 +268,26 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
 
     if (isDesktop) {
       // Restore inline width if it was cleared on mobile, but not if collapsed.
-      if (!editorCollapsed && !editorPane.style.width) editorPane.style.width = '35%';
-      editorPane.classList.toggle('hidden', tabHidesEditor);
+      if (!editorCollapsed && !editorGroup.style.width) editorGroup.style.width = '40%';
+      editorGroup.classList.toggle('hidden', tabHidesEditor);
       splitter.classList.toggle('hidden', tabHidesEditor || editorCollapsed);
       expandEditorBtn.classList.toggle('hidden', tabHidesEditor || !editorCollapsed);
       rightPane.classList.remove('hidden');
       mobilePaneToggle.classList.add('hidden');
     } else {
       // Mobile: clear inline width so flex sizing controls the editor's height.
-      editorPane.style.width = '';
-      editorPane.style.overflow = '';
+      editorGroup.style.width = '';
+      editorGroup.style.overflow = '';
       splitter.classList.add('hidden');
       expandEditorBtn.classList.add('hidden');
       if (tabHidesEditor) {
-        editorPane.classList.add('hidden');
+        editorGroup.classList.add('hidden');
         rightPane.classList.remove('hidden');
         // No choice to make — hide the toggle on Diff.
         mobilePaneToggle.classList.add('hidden');
       } else {
         const pane = getMobilePane();
-        editorPane.classList.toggle('hidden', pane !== 'editor');
+        editorGroup.classList.toggle('hidden', pane !== 'editor');
         rightPane.classList.toggle('hidden', pane !== 'viewport');
         mobilePaneToggle.classList.remove('hidden');
         syncMobileToggleUI(pane);
@@ -342,7 +377,9 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   rightPane.appendChild(diffContainer);
   rightPane.appendChild(notesContainer);
 
-  main.appendChild(editorPane);
+  editorGroup.appendChild(partsRail);
+  editorGroup.appendChild(editorPane);
+  main.appendChild(editorGroup);
   main.appendChild(splitter);
   main.appendChild(rightPane);
 
@@ -374,7 +411,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
     window.dispatchEvent(new Event('resize'));
   });
 
-  return { editorPane, editorContainer, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, statusBar, clipControls, formatBtn, autoFormatToggle, switchTab };
+  return { editorPane, partsRail, editorContainer, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, statusBar, clipControls, formatBtn, autoFormatToggle, switchTab, togglePartsRail };
 }
 
 const TAB_ACTIVE_CLASS = 'shrink-0 whitespace-nowrap px-4 py-2 md:py-1.5 text-sm md:text-xs font-medium text-zinc-100 border-b-2 border-blue-500 bg-zinc-900';

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -43,7 +43,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   // rename / delete / drag-reorder). Populated by createPartList() in main.ts.
   const partsRail = document.createElement('div');
   partsRail.id = 'parts-rail';
-  partsRail.className = 'flex flex-col shrink-0 w-32 md:w-48 min-h-0 border-r border-zinc-700 bg-zinc-900/60 overflow-hidden';
+  partsRail.className = 'flex flex-col shrink-0 w-36 md:w-48 min-h-0 border-r border-zinc-700 bg-zinc-900/60 overflow-hidden';
 
   // The editor pane itself sits to the right of the rail and fills the rest.
   const editorPane = document.createElement('div');
@@ -251,12 +251,17 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   railExpandBtn.className = 'absolute left-0 top-0 z-20 px-1.5 py-1 bg-zinc-800 text-zinc-300 hover:text-zinc-100 hover:bg-zinc-700 rounded-br border-r border-b border-zinc-700 text-xs leading-none hidden';
   railExpandBtn.textContent = '»'; // »
   railExpandBtn.title = 'Show parts';
+  railExpandBtn.setAttribute('aria-label', 'Show parts');
   editorGroup.appendChild(railExpandBtn);
 
   function togglePartsRail(): void {
     railCollapsed = !railCollapsed;
     partsRail.classList.toggle('hidden', railCollapsed);
     railExpandBtn.classList.toggle('hidden', !railCollapsed);
+    // The floating » chip sits at the group's top-left; when the rail is
+    // collapsed (but the editor open) pad the header so it doesn't overlap the
+    // title. Cleared when the rail returns.
+    editorHeader.style.paddingLeft = railCollapsed ? '1.75rem' : '';
     window.dispatchEvent(new Event('resize'));
   }
   railExpandBtn.addEventListener('click', togglePartsRail);

--- a/src/ui/partList.ts
+++ b/src/ui/partList.ts
@@ -1,0 +1,241 @@
+// Parts rail — an IDE-style list of the active session's parts. Supports
+// create, select, inline rename, delete, and pointer-based drag-to-reorder.
+// Renders into the rail container created by layout.ts and re-renders on every
+// session-state change.
+
+import { getState, onStateChange, type SessionState, type Part } from '../storage/sessionManager';
+
+export interface PartListCallbacks {
+  /** Switch the active part (loads its latest version into the editor). */
+  onSelectPart: (id: string) => void | Promise<void>;
+  /** Create a new part in the active session. */
+  onCreatePart: () => void | Promise<void>;
+  onRenamePart: (id: string, name: string) => void | Promise<void>;
+  onDeletePart: (id: string) => void | Promise<void>;
+  /** Persist a new part order (array of part ids, first = top). */
+  onReorderParts: (orderedIds: string[]) => void | Promise<void>;
+  /** Collapse the rail (handled by layout). */
+  onToggleCollapse: () => void;
+}
+
+let railEl: HTMLElement | null = null;
+let cb: PartListCallbacks;
+// True while a row is being dragged; suppresses re-render so the drag isn't
+// yanked out from under the pointer by a state-change event.
+let dragging = false;
+
+export function createPartList(container: HTMLElement, callbacks: PartListCallbacks): void {
+  railEl = container;
+  cb = callbacks;
+  render(getState());
+  onStateChange((state) => {
+    if (!dragging) render(state);
+  });
+}
+
+function render(state: SessionState): void {
+  if (!railEl) return;
+  railEl.innerHTML = '';
+
+  // Header: title + collapse + add.
+  const header = document.createElement('div');
+  header.className = 'flex items-center gap-1 px-2 py-1.5 border-b border-zinc-700/70 shrink-0';
+
+  const title = document.createElement('span');
+  title.className = 'text-[11px] font-semibold uppercase tracking-wide text-zinc-500 flex-1 truncate';
+  title.textContent = 'Parts';
+  header.appendChild(title);
+
+  const addBtn = iconBtn('＋', 'Add a new part');
+  addBtn.id = 'btn-add-part';
+  addBtn.disabled = !state.session;
+  if (!state.session) addBtn.classList.add('opacity-30', 'cursor-default');
+  addBtn.addEventListener('click', () => { if (state.session) void cb.onCreatePart(); });
+  header.appendChild(addBtn);
+
+  const collapseBtn = iconBtn('«', 'Hide parts panel'); // «
+  collapseBtn.addEventListener('click', () => cb.onToggleCollapse());
+  header.appendChild(collapseBtn);
+
+  railEl.appendChild(header);
+
+  // Body: the scrollable list of parts.
+  const list = document.createElement('div');
+  list.id = 'parts-list';
+  list.className = 'flex-1 min-h-0 overflow-y-auto overflow-x-hidden py-1';
+  railEl.appendChild(list);
+
+  if (!state.session) {
+    const empty = document.createElement('div');
+    empty.className = 'px-3 py-2 text-[11px] text-zinc-600 italic';
+    empty.textContent = 'No session';
+    list.appendChild(empty);
+    return;
+  }
+
+  for (const part of state.parts) {
+    list.appendChild(buildRow(part, part.id === state.currentPart?.id, state.parts.length, list));
+  }
+}
+
+function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLElement): HTMLElement {
+  const row = document.createElement('div');
+  row.dataset.partId = part.id;
+  row.className = [
+    'group flex items-center gap-1 px-1.5 py-2 mx-1 rounded cursor-pointer select-none',
+    isCurrent
+      ? 'bg-blue-500/15 text-zinc-100 border-l-2 border-blue-500'
+      : 'text-zinc-400 [@media(hover:hover)]:hover:bg-zinc-700/40 border-l-2 border-transparent',
+  ].join(' ');
+
+  // Drag handle (pointer-based reorder — works for mouse, touch, and pen).
+  const grip = document.createElement('span');
+  grip.className = 'shrink-0 text-zinc-600 [@media(hover:hover)]:group-hover:text-zinc-400 text-xs leading-none cursor-grab touch-none px-0.5';
+  grip.textContent = '⠿'; // ⠿ drag grip
+  grip.title = 'Drag to reorder';
+  attachDragHandlers(grip, row, list);
+  row.appendChild(grip);
+
+  const name = document.createElement('span');
+  name.className = 'flex-1 min-w-0 truncate text-xs';
+  name.textContent = part.name;
+  name.title = part.name;
+  row.appendChild(name);
+
+  // Select on click (ignored when this is already the current part).
+  row.addEventListener('click', () => {
+    if (!isCurrent) void cb.onSelectPart(part.id);
+  });
+
+  // Inline rename on double-click.
+  name.addEventListener('dblclick', (e) => {
+    e.stopPropagation();
+    beginRename(name, part);
+  });
+
+  // Delete (only when more than one part remains).
+  if (partCount > 1) {
+    const del = iconBtn('✕', 'Delete this part'); // ✕
+    del.className += ' opacity-0 [@media(hover:hover)]:group-hover:opacity-100 focus:opacity-100';
+    del.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (confirm(`Delete part "${part.name}" and all of its versions? This cannot be undone.`)) {
+        void cb.onDeletePart(part.id);
+      }
+    });
+    row.appendChild(del);
+  }
+
+  return row;
+}
+
+function beginRename(name: HTMLElement, part: Part): void {
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.value = part.name;
+  input.className = 'flex-1 min-w-0 bg-zinc-700 text-zinc-100 text-xs px-1 py-0.5 rounded border border-blue-500 outline-none';
+  name.replaceWith(input);
+  input.focus();
+  input.select();
+  let done = false;
+  const commit = (save: boolean) => {
+    if (done) return;
+    done = true;
+    const next = input.value.trim();
+    if (save && next && next !== part.name) {
+      void cb.onRenamePart(part.id, next);
+    } else {
+      render(getState()); // restore the row
+    }
+  };
+  input.addEventListener('click', (e) => e.stopPropagation());
+  input.addEventListener('blur', () => commit(true));
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); commit(true); }
+    if (e.key === 'Escape') { e.preventDefault(); commit(false); }
+  });
+}
+
+// === Pointer-based drag-to-reorder ===
+
+function attachDragHandlers(grip: HTMLElement, row: HTMLElement, list: HTMLElement): void {
+  let indicator: HTMLElement | null = null;
+  let activePointer: number | null = null;
+
+  const cleanup = () => {
+    activePointer = null;
+    dragging = false;
+    row.classList.remove('opacity-40');
+    indicator?.remove();
+    indicator = null;
+  };
+
+  grip.addEventListener('pointerdown', (e) => {
+    if (e.button !== 0 && e.pointerType === 'mouse') return;
+    e.preventDefault();
+    e.stopPropagation();
+    activePointer = e.pointerId;
+    dragging = true;
+    row.classList.add('opacity-40');
+    grip.setPointerCapture(e.pointerId);
+    indicator = document.createElement('div');
+    indicator.className = 'h-0.5 mx-2 my-0.5 bg-blue-500 rounded pointer-events-none';
+  });
+
+  grip.addEventListener('pointermove', (e) => {
+    if (e.pointerId !== activePointer || !indicator) return;
+    const beforeRow = rowAfterY(list, row, e.clientY);
+    if (beforeRow) list.insertBefore(indicator, beforeRow);
+    else list.appendChild(indicator);
+  });
+
+  const finish = (e: PointerEvent) => {
+    if (e.pointerId !== activePointer) return;
+    const draggedId = row.dataset.partId!;
+    // Build the new order from the indicator's position among the rows.
+    let order: string[] = [];
+    if (indicator && indicator.parentElement === list) {
+      for (const child of Array.from(list.children)) {
+        if (child === indicator) { order.push(draggedId); continue; }
+        const id = (child as HTMLElement).dataset.partId;
+        if (id && id !== draggedId) order.push(id);
+      }
+      if (!order.includes(draggedId)) order.push(draggedId);
+    }
+    try { grip.releasePointerCapture(e.pointerId); } catch { /* not captured */ }
+    cleanup();
+    const current = getState().parts.map(p => p.id);
+    if (order.length === current.length && order.some((id, i) => id !== current[i])) {
+      void cb.onReorderParts(order);
+    } else {
+      render(getState()); // no change — restore opacity/order cleanly
+    }
+  };
+
+  grip.addEventListener('pointerup', finish);
+  grip.addEventListener('pointercancel', (e) => {
+    if (e.pointerId !== activePointer) return;
+    try { grip.releasePointerCapture(e.pointerId); } catch { /* not captured */ }
+    cleanup();
+    render(getState());
+  });
+}
+
+/** The first part-row whose vertical midpoint is below `y` (i.e. the row the
+ *  dragged item should be inserted before), or null to append at the end. */
+function rowAfterY(list: HTMLElement, dragged: HTMLElement, y: number): HTMLElement | null {
+  for (const child of Array.from(list.children)) {
+    if (!(child instanceof HTMLElement) || !child.dataset.partId || child === dragged) continue;
+    const rect = child.getBoundingClientRect();
+    if (y < rect.top + rect.height / 2) return child;
+  }
+  return null;
+}
+
+function iconBtn(glyph: string, title: string): HTMLButtonElement {
+  const b = document.createElement('button');
+  b.className = 'shrink-0 w-5 h-5 flex items-center justify-center rounded text-zinc-500 hover:text-zinc-200 hover:bg-zinc-700 text-xs leading-none transition-colors';
+  b.textContent = glyph;
+  b.title = title;
+  return b;
+}

--- a/src/ui/partList.ts
+++ b/src/ui/partList.ts
@@ -23,13 +23,17 @@ let cb: PartListCallbacks;
 // True while a row is being dragged; suppresses re-render so the drag isn't
 // yanked out from under the pointer by a state-change event.
 let dragging = false;
+// Set when a state change arrives mid-drag (suppressed); flushed on drag end so
+// the rail never shows stale parts after an async update lands during a drag.
+let pendingRender = false;
 
 export function createPartList(container: HTMLElement, callbacks: PartListCallbacks): void {
   railEl = container;
   cb = callbacks;
   render(getState());
   onStateChange((state) => {
-    if (!dragging) render(state);
+    if (dragging) { pendingRender = true; return; }
+    render(state);
   });
 }
 
@@ -81,18 +85,22 @@ function render(state: SessionState): void {
 function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLElement): HTMLElement {
   const row = document.createElement('div');
   row.dataset.partId = part.id;
+  row.setAttribute('role', 'button');
+  if (isCurrent) row.setAttribute('aria-current', 'true');
   row.className = [
-    'group flex items-center gap-1 px-1.5 py-2 mx-1 rounded cursor-pointer select-none',
+    'group flex items-center gap-1 px-1.5 py-2.5 mx-1 rounded cursor-pointer select-none',
     isCurrent
       ? 'bg-blue-500/15 text-zinc-100 border-l-2 border-blue-500'
       : 'text-zinc-400 [@media(hover:hover)]:hover:bg-zinc-700/40 border-l-2 border-transparent',
   ].join(' ');
 
   // Drag handle (pointer-based reorder — works for mouse, touch, and pen).
+  // Always visible (not hover-gated) so it's discoverable on touch.
   const grip = document.createElement('span');
-  grip.className = 'shrink-0 text-zinc-600 [@media(hover:hover)]:group-hover:text-zinc-400 text-xs leading-none cursor-grab touch-none px-0.5';
+  grip.className = 'shrink-0 text-zinc-500 [@media(hover:hover)]:group-hover:text-zinc-300 text-sm leading-none cursor-grab touch-none px-1 py-1';
   grip.textContent = '⠿'; // ⠿ drag grip
   grip.title = 'Drag to reorder';
+  grip.setAttribute('aria-label', 'Drag to reorder');
   attachDragHandlers(grip, row, list);
   row.appendChild(grip);
 
@@ -116,7 +124,9 @@ function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLE
   // Delete (only when more than one part remains).
   if (partCount > 1) {
     const del = iconBtn('✕', 'Delete this part'); // ✕
-    del.className += ' opacity-0 [@media(hover:hover)]:group-hover:opacity-100 focus:opacity-100';
+    // Visible by default so it's reachable on touch (no hover); only fade-until-
+    // hover on hover-capable devices.
+    del.className += ' [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 focus:opacity-100';
     del.addEventListener('click', (e) => {
       e.stopPropagation();
       if (confirm(`Delete part "${part.name}" and all of its versions? This cannot be undone.`)) {
@@ -168,16 +178,28 @@ function attachDragHandlers(grip: HTMLElement, row: HTMLElement, list: HTMLEleme
     row.classList.remove('opacity-40');
     indicator?.remove();
     indicator = null;
+    // Apply any state change that arrived (and was suppressed) mid-drag.
+    if (pendingRender) {
+      pendingRender = false;
+      render(getState());
+    }
   };
 
   grip.addEventListener('pointerdown', (e) => {
     if (e.button !== 0 && e.pointerType === 'mouse') return;
     e.preventDefault();
     e.stopPropagation();
+    // Commit drag state only once capture succeeds — otherwise a thrown
+    // setPointerCapture (e.g. detached node) would wedge `dragging` true and
+    // freeze all future rail re-renders.
+    try {
+      grip.setPointerCapture(e.pointerId);
+    } catch {
+      return;
+    }
     activePointer = e.pointerId;
     dragging = true;
     row.classList.add('opacity-40');
-    grip.setPointerCapture(e.pointerId);
     indicator = document.createElement('div');
     indicator.className = 'h-0.5 mx-2 my-0.5 bg-blue-500 rounded pointer-events-none';
   });
@@ -234,8 +256,11 @@ function rowAfterY(list: HTMLElement, dragged: HTMLElement, y: number): HTMLElem
 
 function iconBtn(glyph: string, title: string): HTMLButtonElement {
   const b = document.createElement('button');
-  b.className = 'shrink-0 w-5 h-5 flex items-center justify-center rounded text-zinc-500 hover:text-zinc-200 hover:bg-zinc-700 text-xs leading-none transition-colors';
+  // 28px hit target — a pragmatic balance between the dense rail and touch use;
+  // the full-width row remains the primary (large) select target.
+  b.className = 'shrink-0 w-7 h-7 flex items-center justify-center rounded text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 text-sm leading-none transition-colors';
   b.textContent = glyph;
   b.title = title;
+  b.setAttribute('aria-label', title);
   return b;
 }

--- a/src/ui/sessionBar.ts
+++ b/src/ui/sessionBar.ts
@@ -10,6 +10,7 @@ import {
   navigateVersion,
   listCurrentVersions,
   renameSession,
+  renamePart,
   type SessionState,
 } from '../storage/sessionManager';
 import { onChange as onColorRegionsChange } from '../color/regions';
@@ -20,6 +21,12 @@ export interface SessionBarCallbacks {
   onLoadVersion: (code: string) => void;
   onOpenSessionList: () => void;
   onNewSession: () => void;
+  /** Switch the active part by id (loads its latest version into the editor). */
+  onSwitchPart: (partId: string) => void | Promise<void>;
+  /** Create a new part in the active session (resets editor to a starter). */
+  onCreatePart: () => void | Promise<void>;
+  /** Delete a part by id (an adjacent part becomes active). */
+  onDeletePart: (partId: string) => void | Promise<void>;
 }
 
 let barEl: HTMLElement | null = null;
@@ -121,6 +128,12 @@ function render(state: SessionState) {
   // Separator
   barEl.appendChild(el('span', 'text-zinc-600', '|'));
 
+  // Part switcher (a session always has at least one part)
+  renderPartControl(barEl, state);
+
+  // Separator
+  barEl.appendChild(el('span', 'text-zinc-600', '|'));
+
   // Version nav
   if (state.currentVersion && state.versionCount > 0) {
     // Position within the (gap-tolerant) index list, not raw index math.
@@ -207,6 +220,57 @@ function render(state: SessionState) {
   const closeBtn = btn('✕', () => closeSession());
   closeBtn.title = 'Close session';
   barEl.appendChild(closeBtn);
+}
+
+/** Render the part switcher: a dropdown of the session's parts plus add/rename/
+ *  delete controls. A session always has ≥1 part, so this always shows when a
+ *  session is active. */
+function renderPartControl(container: HTMLElement, state: SessionState): void {
+  const current = state.currentPart;
+  if (!current) return;
+
+  const icon = el('span', 'text-zinc-500', '▤'); // ▤ parts glyph
+  icon.title = 'Parts in this session';
+  container.appendChild(icon);
+
+  const select = document.createElement('select');
+  select.id = 'part-select';
+  select.className = 'bg-zinc-700 text-zinc-200 text-xs rounded px-1 py-0.5 border border-zinc-600 max-w-40 truncate cursor-pointer focus:outline-none focus:border-blue-500';
+  select.title = 'Switch part';
+  for (const p of state.parts) {
+    const opt = document.createElement('option');
+    opt.value = p.id;
+    opt.textContent = p.name;
+    if (p.id === current.id) opt.selected = true;
+    select.appendChild(opt);
+  }
+  select.addEventListener('change', () => { void callbacks.onSwitchPart(select.value); });
+  container.appendChild(select);
+
+  const addBtn = btn('＋', () => { void callbacks.onCreatePart(); }); // ＋
+  addBtn.id = 'btn-add-part';
+  addBtn.title = 'Add a new part to this session';
+  container.appendChild(addBtn);
+
+  const renameBtn = btn('✎', async () => { // ✎
+    const name = prompt('Rename part', current.name);
+    if (name && name.trim() && name.trim() !== current.name) {
+      await renamePart(current.id, name.trim());
+    }
+  });
+  renameBtn.title = 'Rename this part';
+  container.appendChild(renameBtn);
+
+  // Deleting is only possible when more than one part exists.
+  if (state.parts.length > 1) {
+    const delBtn = btn('\u{1F5D1}', async () => { // 🗑
+      if (confirm(`Delete part "${current.name}" and all of its versions? This cannot be undone.`)) {
+        await callbacks.onDeletePart(current.id);
+      }
+    });
+    delBtn.title = 'Delete this part';
+    container.appendChild(delBtn);
+  }
 }
 
 function el(tag: string, className: string, text: string): HTMLElement {

--- a/src/ui/sessionBar.ts
+++ b/src/ui/sessionBar.ts
@@ -10,7 +10,6 @@ import {
   navigateVersion,
   listCurrentVersions,
   renameSession,
-  renamePart,
   type SessionState,
 } from '../storage/sessionManager';
 import { onChange as onColorRegionsChange } from '../color/regions';
@@ -21,12 +20,6 @@ export interface SessionBarCallbacks {
   onLoadVersion: (code: string) => void;
   onOpenSessionList: () => void;
   onNewSession: () => void;
-  /** Switch the active part by id (loads its latest version into the editor). */
-  onSwitchPart: (partId: string) => void | Promise<void>;
-  /** Create a new part in the active session (resets editor to a starter). */
-  onCreatePart: () => void | Promise<void>;
-  /** Delete a part by id (an adjacent part becomes active). */
-  onDeletePart: (partId: string) => void | Promise<void>;
 }
 
 let barEl: HTMLElement | null = null;
@@ -128,12 +121,6 @@ function render(state: SessionState) {
   // Separator
   barEl.appendChild(el('span', 'text-zinc-600', '|'));
 
-  // Part switcher (a session always has at least one part)
-  renderPartControl(barEl, state);
-
-  // Separator
-  barEl.appendChild(el('span', 'text-zinc-600', '|'));
-
   // Version nav
   if (state.currentVersion && state.versionCount > 0) {
     // Position within the (gap-tolerant) index list, not raw index math.
@@ -220,57 +207,6 @@ function render(state: SessionState) {
   const closeBtn = btn('✕', () => closeSession());
   closeBtn.title = 'Close session';
   barEl.appendChild(closeBtn);
-}
-
-/** Render the part switcher: a dropdown of the session's parts plus add/rename/
- *  delete controls. A session always has ≥1 part, so this always shows when a
- *  session is active. */
-function renderPartControl(container: HTMLElement, state: SessionState): void {
-  const current = state.currentPart;
-  if (!current) return;
-
-  const icon = el('span', 'text-zinc-500', '▤'); // ▤ parts glyph
-  icon.title = 'Parts in this session';
-  container.appendChild(icon);
-
-  const select = document.createElement('select');
-  select.id = 'part-select';
-  select.className = 'bg-zinc-700 text-zinc-200 text-xs rounded px-1 py-0.5 border border-zinc-600 max-w-40 truncate cursor-pointer focus:outline-none focus:border-blue-500';
-  select.title = 'Switch part';
-  for (const p of state.parts) {
-    const opt = document.createElement('option');
-    opt.value = p.id;
-    opt.textContent = p.name;
-    if (p.id === current.id) opt.selected = true;
-    select.appendChild(opt);
-  }
-  select.addEventListener('change', () => { void callbacks.onSwitchPart(select.value); });
-  container.appendChild(select);
-
-  const addBtn = btn('＋', () => { void callbacks.onCreatePart(); }); // ＋
-  addBtn.id = 'btn-add-part';
-  addBtn.title = 'Add a new part to this session';
-  container.appendChild(addBtn);
-
-  const renameBtn = btn('✎', async () => { // ✎
-    const name = prompt('Rename part', current.name);
-    if (name && name.trim() && name.trim() !== current.name) {
-      await renamePart(current.id, name.trim());
-    }
-  });
-  renameBtn.title = 'Rename this part';
-  container.appendChild(renameBtn);
-
-  // Deleting is only possible when more than one part exists.
-  if (state.parts.length > 1) {
-    const delBtn = btn('\u{1F5D1}', async () => { // 🗑
-      if (confirm(`Delete part "${current.name}" and all of its versions? This cannot be undone.`)) {
-        await callbacks.onDeletePart(current.id);
-      }
-    });
-    delBtn.title = 'Delete this part';
-    container.appendChild(delBtn);
-  }
 }
 
 function el(tag: string, className: string, text: string): HTMLElement {

--- a/src/ui/sessionList.ts
+++ b/src/ui/sessionList.ts
@@ -11,7 +11,7 @@ import {
   type Session,
   type ExportedSession,
 } from '../storage/sessionManager';
-import { getLatestVersion, getVersionCount } from '../storage/db';
+import { getSessionLatestVersion, getSessionVersionCount } from '../storage/db';
 
 let modalEl: HTMLElement | null = null;
 let onLoadVersion: ((code: string) => void | Promise<void>) | null = null;
@@ -150,8 +150,8 @@ export async function showSessionList(): Promise<void> {
 
 async function createSessionRow(session: Session): Promise<HTMLElement> {
   const [count, latestVersion] = await Promise.all([
-    getVersionCount(session.id),
-    getLatestVersion(session.id),
+    getSessionVersionCount(session.id),
+    getSessionLatestVersion(session.id),
   ]);
 
   const row = document.createElement('div');

--- a/tests/chat-export.spec.ts
+++ b/tests/chat-export.spec.ts
@@ -97,7 +97,7 @@ test.describe('Chat export', () => {
         chat?: { id?: string; sessionId?: string; blocks: { type: string; text?: string }[] }[];
       };
     }, id);
-    expect(exported.partwright).toBe('1.6');
+    expect(exported.partwright).toBe('1.7');
     expect(exported.chat?.length).toBe(3);
     expect(exported.chat?.[0].blocks[0].text).toBe('Design a widget bracket');
     expect(exported.chat?.[0].id).toBeUndefined();

--- a/tests/parts.spec.ts
+++ b/tests/parts.spec.ts
@@ -1,0 +1,138 @@
+// E2E coverage for multi-part sessions: a session can hold several parts, each
+// with its own code and independent version history. Verifies the console API,
+// the session-bar part switcher, and that parts survive a reload (persistence +
+// the lazy parts migration). Network-free — all geometry is produced locally.
+
+import { test, expect, type Page } from 'playwright/test';
+
+interface PartsAPI {
+  createSession: (name?: string) => Promise<{ id: string }>;
+  runAndSave: (code: string, label?: string) => Promise<unknown>;
+  getCode: () => string;
+  setCode: (code: string) => void;
+  createPart: (name?: string) => Promise<{ id: string; name: string } | { error: string }>;
+  changePart: (target: string | { id?: string; name?: string }) => Promise<unknown>;
+  listParts: () => { id: string; name: string; order: number; isCurrent: boolean }[];
+  listVersions: () => Promise<{ index: number; label: string }[]>;
+  getSessionState: () => { currentPart: { id: string; name: string } | null; versionCount: number };
+}
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { createPart?: unknown } }).partwright?.createPart,
+    { timeout: 20_000 },
+  );
+}
+
+const cube = (s: number, marker: string) =>
+  `// ${marker}\nconst { Manifold } = api; return Manifold.cube([${s}, ${s}, ${s}], true);`;
+
+test.describe('Multi-part sessions', () => {
+  // Suppress the first-visit guided tour so its backdrop doesn't intercept clicks.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('parts carry independent code and version history', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const result = await page.evaluate(async ({ codeA1, codeA2, codeB1 }) => {
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      await pw.createSession('multi');
+      // Part 1 (default): two versions.
+      await pw.runAndSave(codeA1, 'a1');
+      await pw.runAndSave(codeA2, 'a2');
+
+      // A second part with its own single version.
+      const made = await pw.createPart('Lid');
+      const lidVersionsBeforeSave = (await pw.listVersions()).length; // fresh part: 0
+      await pw.runAndSave(codeB1, 'b1');
+
+      const partsAfter = pw.listParts();
+      const lidVersions = (await pw.listVersions()).length;
+
+      // Switch back to the first part and confirm its history is intact and
+      // the editor shows its code, not the lid's.
+      const first = partsAfter.find(p => p.name !== 'Lid')!;
+      await pw.changePart(first.id);
+      const firstVersions = (await pw.listVersions()).length;
+      const firstCode = pw.getCode();
+
+      return {
+        madeOk: !('error' in made),
+        partCount: partsAfter.length,
+        partNames: partsAfter.map(p => p.name),
+        lidVersionsBeforeSave,
+        lidVersions,
+        firstVersions,
+        firstCodeHasA2: firstCode.includes('A2'),
+        firstCodeHasLid: firstCode.includes('LID'),
+      };
+    }, { codeA1: cube(10, 'A1'), codeA2: cube(12, 'A2'), codeB1: cube(6, 'LID') });
+
+    expect(result.madeOk).toBe(true);
+    expect(result.partCount).toBe(2);
+    expect(result.partNames).toContain('Lid');
+    expect(result.lidVersionsBeforeSave).toBe(0);   // a new part starts empty
+    expect(result.lidVersions).toBe(1);             // independent history
+    expect(result.firstVersions).toBe(2);           // first part untouched
+    expect(result.firstCodeHasA2).toBe(true);       // editor restored first part's latest
+    expect(result.firstCodeHasLid).toBe(false);
+  });
+
+  test('parts persist across a reload', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const sessionId = await page.evaluate(async ({ codeA1, codeB1 }) => {
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      const s = await pw.createSession('persist');
+      await pw.runAndSave(codeA1, 'a1');
+      await pw.createPart('Handle');
+      await pw.runAndSave(codeB1, 'b1');
+      return s.id;
+    }, { codeA1: cube(10, 'A1'), codeB1: cube(6, 'HANDLE') });
+
+    // Reload by URL — bootstrap must re-open the session and its parts.
+    await page.goto(`/editor?session=${sessionId}`);
+    await waitForEngine(page);
+
+    const after = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      return { parts: pw.listParts().map(p => p.name).sort() };
+    });
+    expect(after.parts).toEqual(['Handle', 'Part 1']);
+  });
+
+  test('session-bar part switcher renders and switches parts', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    await page.evaluate(async ({ codeA1, codeB1 }) => {
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      await pw.createSession('switcher');
+      await pw.runAndSave(codeA1, 'a1');
+      await pw.createPart('Lid');
+      await pw.runAndSave(codeB1, 'b1');
+    }, { codeA1: cube(10, 'A1'), codeB1: cube(6, 'LID') });
+
+    // The part <select> lists both parts; the lid (current) is selected.
+    const select = page.locator('#part-select');
+    await expect(select).toBeVisible();
+    await expect(select.locator('option')).toHaveCount(2);
+
+    // Switch to "Part 1" via the dropdown; the editor should load its code.
+    await select.selectOption({ label: 'Part 1' });
+    await expect
+      .poll(() => page.evaluate(() => (window as unknown as { partwright: PartsAPI }).partwright.getCode()))
+      .toContain('A1');
+
+    // The add-part button increases the part count.
+    await page.locator('#btn-add-part').click();
+    await expect
+      .poll(() => page.evaluate(() => (window as unknown as { partwright: PartsAPI }).partwright.listParts().length))
+      .toBe(3);
+  });
+});

--- a/tests/parts.spec.ts
+++ b/tests/parts.spec.ts
@@ -108,7 +108,7 @@ test.describe('Multi-part sessions', () => {
     expect(after.parts).toEqual(['Handle', 'Part 1']);
   });
 
-  test('session-bar part switcher renders and switches parts', async ({ page }) => {
+  test('parts rail renders, switches, and adds parts; editor title shows the part', async ({ page }) => {
     await page.goto('/editor');
     await waitForEngine(page);
 
@@ -120,22 +120,60 @@ test.describe('Multi-part sessions', () => {
       await pw.runAndSave(codeB1, 'b1');
     }, { codeA1: cube(10, 'A1'), codeB1: cube(6, 'LID') });
 
-    // The part <select> lists both parts; the lid (current) is selected.
-    const select = page.locator('#part-select');
-    await expect(select).toBeVisible();
-    await expect(select.locator('option')).toHaveCount(2);
+    // The rail lists both parts; the editor title shows the current one (Lid).
+    const list = page.locator('#parts-list');
+    await expect(list.locator('[data-part-id]')).toHaveCount(2);
+    await expect(page.locator('#editor-title')).toHaveText('Lid');
 
-    // Switch to "Part 1" via the dropdown; the editor should load its code.
-    await select.selectOption({ label: 'Part 1' });
+    // Click "Part 1" in the rail to switch; editor + title update.
+    await list.getByText('Part 1', { exact: true }).click();
     await expect
       .poll(() => page.evaluate(() => (window as unknown as { partwright: PartsAPI }).partwright.getCode()))
       .toContain('A1');
+    await expect(page.locator('#editor-title')).toHaveText('Part 1');
 
-    // The add-part button increases the part count.
+    // The add-part button (rail header) increases the part count.
     await page.locator('#btn-add-part').click();
     await expect
       .poll(() => page.evaluate(() => (window as unknown as { partwright: PartsAPI }).partwright.listParts().length))
       .toBe(3);
+  });
+
+  test('parts can be drag-reordered in the rail', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    await page.evaluate(async ({ code }) => {
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      await pw.createSession('reorder');
+      await pw.runAndSave(code, 'a1');     // Part 1
+      await pw.createPart('Beta');
+      await pw.createPart('Gamma');
+    }, { code: cube(10, 'A1') });
+
+    const list = page.locator('#parts-list');
+    await expect(list.locator('[data-part-id]')).toHaveCount(3);
+    // Initial order: Part 1, Beta, Gamma.
+    const initial = await page.evaluate(() =>
+      (window as unknown as { partwright: PartsAPI }).partwright.listParts().map(p => p.name));
+    expect(initial).toEqual(['Part 1', 'Beta', 'Gamma']);
+
+    // Drag the first row's grip below the last row.
+    const firstGrip = list.locator('[data-part-id]').first().locator('[title="Drag to reorder"]');
+    const lastRow = list.locator('[data-part-id]').last();
+    const g = await firstGrip.boundingBox();
+    const l = await lastRow.boundingBox();
+    if (!g || !l) throw new Error('missing drag boxes');
+    await page.mouse.move(g.x + g.width / 2, g.y + g.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(l.x + l.width / 2, l.y + l.height + 6, { steps: 10 });
+    await page.mouse.up();
+
+    // Part 1 should now be last; order persists in state.
+    await expect
+      .poll(() => page.evaluate(() =>
+        (window as unknown as { partwright: PartsAPI }).partwright.listParts().map(p => p.name)))
+      .toEqual(['Beta', 'Gamma', 'Part 1']);
   });
 
   test('adding a part after painting clears stale regions and unlocks the editor', async ({ page }) => {

--- a/tests/parts.spec.ts
+++ b/tests/parts.spec.ts
@@ -15,6 +15,8 @@ interface PartsAPI {
   listParts: () => { id: string; name: string; order: number; isCurrent: boolean }[];
   listVersions: () => Promise<{ index: number; label: string }[]>;
   getSessionState: () => { currentPart: { id: string; name: string } | null; versionCount: number };
+  paintFaces: (o: { triangleIds: number[]; color: [number, number, number]; name?: string }) => unknown;
+  listRegions: () => unknown[];
 }
 
 async function waitForEngine(page: Page) {
@@ -134,5 +136,30 @@ test.describe('Multi-part sessions', () => {
     await expect
       .poll(() => page.evaluate(() => (window as unknown as { partwright: PartsAPI }).partwright.listParts().length))
       .toBe(3);
+  });
+
+  test('adding a part after painting clears stale regions and unlocks the editor', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    await page.evaluate(async ({ code }) => {
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      await pw.createSession('paint-part');
+      await pw.runAndSave(code, 'base');
+      pw.paintFaces({ triangleIds: [0, 1, 2], color: [1, 0, 0], name: 'A' });
+    }, { code: cube(10, 'BASE') });
+
+    // Painting locks the editor (banner shown) and registers one region.
+    await expect(page.locator('#editor-lock-overlay')).toBeVisible();
+
+    // Adding a part must NOT carry the previous part's regions, and must leave
+    // the new part's editor unlocked (regression: stale module-state colors).
+    const regionCount = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      await pw.createPart('Fresh');
+      return pw.listRegions().length;
+    });
+    expect(regionCount).toBe(0);
+    await expect(page.locator('#editor-lock-overlay')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

Implements multi-part sessions, allowing a single session to contain multiple independent modeling targets (parts), each with its own code, version history, color regions, and imported meshes. This enables users to model assemblies or related objects without creating separate sessions.

## Key Changes

**Schema & Storage (v1.6 → v1.7)**
- Bumped `SCHEMA_VERSION` to `1.7` with backward compatibility: pre-1.7 files import as a single default part
- Added `parts` table to IndexedDB (v5 migration) with `sessionId` index
- Added `partId` field to `Version` records; version uniqueness now per-part (`[partId, index]`) instead of per-session
- Added `currentPartId` to `Session` to remember the active part across reopens
- Lazy migration (`migratePartsData`) backfills one default part per legacy session and stamps existing versions with the part id

**Export Format**
- `ExportedSession` now includes optional `parts: {name, order}[]` array
- Each version gains optional `part` field (the owning part's `order`; absent ⇒ 0)
- Added `versions[].importedMeshes` (base64-encoded mesh buffers) so imported STL geometry round-trips through export
- Implemented `serializeImportedMeshes` / `deserializeImportedMeshes` with `typedArrayToBase64` / `base64ToArrayBuffer` helpers

**Session Manager API**
- `SessionState` now tracks `parts: Part[]`, `currentPart: Part | null` alongside `currentVersion`
- New part operations:
  - `listCurrentParts()` — list parts in active session
  - `getCurrentPart()` — get active part
  - `createPart(name?)` — create new empty part, make it current, reset editor to starter
  - `changePart(partId, versionIndex?)` — switch active part, load its version
  - `renamePart(partId, newName)` — rename a part
  - `deletePart(partId)` — delete part (refuses to remove last one; adjacent part becomes active)
- `openSession` now accepts optional `partId` parameter; URL state includes `?part=<id>` when session has >1 part
- `createSession` now creates a default "Part 1" and sets `currentPartId`
- `saveVersion` now writes to the current part's version history
- Version navigation (`navigateVersion`) and listing (`listCurrentVersions`) now scoped to current part

**UI & UX**
- Session bar now includes part switcher: dropdown to select part + buttons to create/rename/delete
- Part switcher only shows `?part=` in URL when session has >1 part (single-part sessions omit it as noise)
- `startNewPartInEditor()` resets editor to starter snippet when creating a new part (shares session's reference images)
- `loadPartIntoEditor()` loads a part's latest version or resets to blank if part has no versions yet
- Session bar callbacks: `onSwitchPart`, `onCreatePart`, `onDeletePart`

**AI Tools & Console API**
- Added tools: `listParts`, `getCurrentPart`, `createPart`, `changePart`, `renamePart`, `deletePart`
- Updated system prompt and `public/ai.md` to document multi-part workflow

**Database Helpers**
- Renamed `getVersionCount` → `getSessionVersionCount` (session-scoped, for recent-session grids)
- Added `getSessionLatestVersion` (session-scoped, for landing page)
- New part CRUD: `createPart`, `listParts`, `updatePart`, `deletePart`
- `deleteSession` now cascades to parts and versions via `sessionId` index

**Tests**
- Added `tests/parts.spec.ts` with E2E coverage:
  - Parts carry independent code and version history
  - Parts persist across reload (lazy migration works)
  - Session-bar part switcher renders and switches parts

## Notable Implementation Details

- **Backward compatibility**:

https://claude.ai/code/session_011CKEwiY5Bbyvk9b5GC8ng4