### PR TITLE
docs: post-PR review pass + CI auto-fix, reconciled with staging PR guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ Hosted on **Cloudflare Pages** with production custom domain `www.partwrightstud
 
 ### Pull Requests — always open one when a task is complete
 
-When you finish an agent task, **create a pull request into `staging` as the final step.** This is a standing instruction that overrides any default "don't open a PR unless explicitly asked" behavior: treat task completion as the authorization to open the PR. Don't pause to ask whether to create one, and don't report a task as done without it. Skip the PR only when the user explicitly says not to, or for a pure throwaway experiment. Follow the [commit & PR conventions](#commit--pr-conventions) below for the title, prefix, and labels.
+When you finish an agent task, **create a pull request into `staging` as the final step.** This is a standing instruction that overrides any default "don't open a PR unless explicitly asked" behavior: treat task completion as the authorization to open the PR. Don't pause to ask whether to create one, and don't report a task as done without it.
+
+Skip the PR only when the user explicitly scoped you away from it — a request to "just commit" or "push to the branch" is *not* a request for a PR — or for a pure throwaway experiment. If you genuinely can't tell whether the work is a complete, reviewable unit, ask. Follow the [commit & PR conventions](#commit--pr-conventions) below for the title, prefix, and labels, and [After Opening a PR](#after-opening-a-pr) for the review pass and CI follow-up once it's up.
 
 - **Build command:** `npm run build`
 - **Output directory:** `dist/`
@@ -311,15 +313,20 @@ Subject is imperative and lowercase after the prefix: `feat: add light/dark mode
 
 Anything unlabeled lands in "Other Changes." That's fine for occasional internal cleanup, but features and fixes should always be labeled.
 
-### Open a PR When Your Task Is Done
+### After Opening a PR
 
-**By default, finish a task by opening a PR — you don't need to be asked.** Once you've completed a unit of work on a feature branch, the normal final step is to commit, push, and open a PR targeting `staging` (per the Deployment workflow). Follow the conventions above: re-sync with `origin/staging` first, give the PR a Conventional Commits title, and apply at least one release-note label.
+Opening the PR (see [the standing instruction](#pull-requests--always-open-one-when-a-task-is-complete) in Deployment) isn't the finish line. Once it's up, do two things — they can run in parallel:
 
-**Exception:** if the user tells you not to open a PR — or asks you only to commit/push, or to hold off — then don't. "Just commit" or "push to the branch" is not a request for a PR. If you're unsure whether the work is a complete, reviewable unit, ask before opening one.
+**1. Kick off an automated review pass.** Right after pushing the initial PR, launch a review subagent (the Agent tool) over your branch diff against `origin/staging` and the code it touches. Have it hunt specifically for problems your change may have introduced:
 
-### Following Up on PRs You Open
+- **Defects** — logic errors, unhandled cases, broken or orphaned call sites in the new code.
+- **Functionality dropped in a merge** — features or code paths silently lost while resolving conflicts or re-syncing with `origin/staging`. Diff against what was there before, not just your own edits.
+- **Backwards-incompatible changes** — anything that breaks existing persisted data or files. Watch session/schema changes most closely: old sessions saved in IndexedDB, and previously exported files (GLB/3MF and any versioned schema), must still import and load. A schema bump needs a migration or back-compat read path, not a hard break.
+- **Security issues** — injection (command/SQL), XSS or unsafe HTML insertion, leaked API keys/secrets, or weakened CSP/COEP/COOP headers.
 
-When you (an AI agent) open a PR, follow it through CI rather than walking away. Watch the PR's checks — the `npm run build` / `npm run test:e2e` workflow and the Cloudflare Pages deployment — and **auto-fix build or deployment failures when you can** by pushing a fix straight to the PR branch:
+Surface the results on the PR (a review comment, or fold clear fixes straight into the branch). If the pass turns up something ambiguous or large, raise it with the user rather than silently reworking.
+
+**2. Follow CI and auto-fix what you can.** Watch the PR's checks — the `npm run build` / `npm run test:e2e` workflow and the Cloudflare Pages deployment — and **auto-fix build or deployment failures when you can** by pushing a fix straight to the PR branch:
 
 1. Reproduce the failure locally first (`npm run build`, `npm run test:e2e`) so you're fixing the real cause, not guessing from the log.
 2. Re-sync with the latest `origin/staging` if the branch has drifted (see the Deployment workflow), then commit and push the fix to the same PR branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,6 +307,12 @@ Subject is imperative and lowercase after the prefix: `feat: add light/dark mode
 
 Anything unlabeled lands in "Other Changes." That's fine for occasional internal cleanup, but features and fixes should always be labeled.
 
+### Open a PR When Your Task Is Done
+
+**By default, finish a task by opening a PR — you don't need to be asked.** Once you've completed a unit of work on a feature branch, the normal final step is to commit, push, and open a PR targeting `staging` (per the Deployment workflow). Follow the conventions above: re-sync with `origin/staging` first, give the PR a Conventional Commits title, and apply at least one release-note label.
+
+**Exception:** if the user tells you not to open a PR — or asks you only to commit/push, or to hold off — then don't. "Just commit" or "push to the branch" is not a request for a PR. If you're unsure whether the work is a complete, reviewable unit, ask before opening one.
+
 ### Following Up on PRs You Open
 
 When you (an AI agent) open a PR, follow it through CI rather than walking away. Watch the PR's checks — the `npm run build` / `npm run test:e2e` workflow and the Cloudflare Pages deployment — and **auto-fix build or deployment failures when you can** by pushing a fix straight to the PR branch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,6 +307,16 @@ Subject is imperative and lowercase after the prefix: `feat: add light/dark mode
 
 Anything unlabeled lands in "Other Changes." That's fine for occasional internal cleanup, but features and fixes should always be labeled.
 
+### Following Up on PRs You Open
+
+When you (an AI agent) open a PR, follow it through CI rather than walking away. Watch the PR's checks — the `npm run build` / `npm run test:e2e` workflow and the Cloudflare Pages deployment — and **auto-fix build or deployment failures when you can** by pushing a fix straight to the PR branch:
+
+1. Reproduce the failure locally first (`npm run build`, `npm run test:e2e`) so you're fixing the real cause, not guessing from the log.
+2. Re-sync with the latest `origin/staging` if the branch has drifted (see the Deployment workflow), then commit and push the fix to the same PR branch.
+3. Re-check CI after the push, and keep iterating until the checks are green.
+
+Only push fixes you're confident in — failures clearly caused by your own changes. If a failure is ambiguous, unrelated to your changes, or would require a large refactor or a risky/destructive change to resolve, stop and ask the user instead of pushing speculative fixes.
+
 ## Common Errors
 
 | Error | Cause |


### PR DESCRIPTION
## Summary

Rounds out the agent guide's PR workflow in `CLAUDE.md`, reconciled with the "always open a PR" instruction that recently merged to `staging` (#935a9ae) so there's a single, non-duplicated source of truth.

- **One mandate, in Deployment** — kept staging's "Pull Requests — always open one when a task is complete" as the canonical standing instruction, and folded in this branch's exception nuances (a scoped "just commit" / "push to the branch" is *not* a PR request; ask if you can't tell the work is a complete unit). Removed the duplicate mandate this branch had added under Commit & PR Conventions.
- **New "After Opening a PR" section** consolidating post-PR follow-up:
  1. **Automated review pass** — right after pushing, launch a review subagent over the branch diff to hunt for defects, functionality silently dropped during a merge/re-sync, backwards-incompatible changes (esp. session/schema changes that would break importing old IndexedDB sessions or previously exported GLB/3MF files), and security issues (injection, unsafe HTML, leaked secrets, weakened CSP/COEP/COOP).
  2. **CI auto-fix** — watch `build`/`test:e2e` + the Cloudflare Pages deploy and push confident fixes to the PR branch; stop and ask when a failure is ambiguous, unrelated, or needs a large/risky change.
- Merged latest `origin/staging` into the branch so the diff is clean.

## Test plan

- [ ] Docs-only change to `CLAUDE.md` (repo-root markdown, not part of the build/test bundle) — no code paths affected.

https://claude.ai/code/session_01XsExRLKmcQxg1gMofx9HjQ