### PR TITLE
feat: add command palette (Cmd+K) and a ? keyboard cheat sheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,8 @@ Static site, no backend. Vanilla TypeScript + Vite.
 - `src/editor/codeEditor.ts` — CodeMirror editor
 - `src/ui/layout.ts` — Split-pane layout
 - `src/ui/toolbar.ts` — Top toolbar
+- `src/ui/commandPalette.ts` — Command palette (⌘K/Ctrl+K): action registry + searchable overlay
+- `src/ui/shortcutsOverlay.ts` — `?` keyboard cheat sheet (renders `shortcutDefs`)
 - `src/geometry/crossSection.ts` — Z-slice to SVG/polygons
 - `src/export/gltf.ts` — GLB export
 - `src/export/stl.ts` — STL export

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,8 @@ import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEd
 import { createLayout, type TabName } from './ui/layout';
 import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState } from './ui/toolbar';
 import { installKeyboardShortcuts } from './ui/keyboardShortcuts';
+import { registerCommands } from './ui/commandPalette';
+import { combo, MOD_LABEL, SHIFT_LABEL, ALT_LABEL } from './ui/shortcutDefs';
 import { showToast } from './ui/toast';
 import { initAiPanel, setActiveSession as setAiActiveSession, toggleAiPanel } from './ui/aiPanel';
 import { getKey as getAiKey, mergeChatBucket } from './ai/db';
@@ -950,6 +952,32 @@ async function main() {
     await handleImportFile(first);
   });
 
+  // Mesh export actions, shared by the toolbar and the command palette so the
+  // guards + error toasts stay in one place.
+  const actionExportGLB = async () => {
+    try {
+      if (currentMeshData) assertFiniteMesh(currentMeshData);
+      await exportGLB();
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'GLB export failed', { variant: 'warn' });
+    }
+  };
+  const actionExportSTL = () => {
+    if (!currentMeshData) return;
+    try { exportSTL(currentMeshData); }
+    catch (e) { showToast(e instanceof Error ? e.message : 'STL export failed', { variant: 'warn' }); }
+  };
+  const actionExportOBJ = () => {
+    if (!currentMeshData) return;
+    try { exportOBJ(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData); }
+    catch (e) { showToast(e instanceof Error ? e.message : 'OBJ export failed', { variant: 'warn' }); }
+  };
+  const actionExport3MF = () => {
+    if (!currentMeshData) return;
+    try { export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData); }
+    catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
+  };
+
   // Create toolbar
   createToolbar(editorUI, {
     onGoHome: () => {
@@ -958,29 +986,10 @@ async function main() {
     },
     onOpenCatalog: () => { void showCatalogPage(); },
     onRun: () => runCode(),
-    onExportGLB: async () => {
-      try {
-        if (currentMeshData) assertFiniteMesh(currentMeshData);
-        await exportGLB();
-      } catch (e) {
-        showToast(e instanceof Error ? e.message : 'GLB export failed', { variant: 'warn' });
-      }
-    },
-    onExportSTL: () => {
-      if (!currentMeshData) return;
-      try { exportSTL(currentMeshData); }
-      catch (e) { showToast(e instanceof Error ? e.message : 'STL export failed', { variant: 'warn' }); }
-    },
-    onExportOBJ: () => {
-      if (!currentMeshData) return;
-      try { exportOBJ(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData); }
-      catch (e) { showToast(e instanceof Error ? e.message : 'OBJ export failed', { variant: 'warn' }); }
-    },
-    onExport3MF: () => {
-      if (!currentMeshData) return;
-      try { export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData); }
-      catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
-    },
+    onExportGLB: actionExportGLB,
+    onExportSTL: actionExportSTL,
+    onExportOBJ: actionExportOBJ,
+    onExport3MF: actionExport3MF,
     onExportSessionJSON: async () => {
       if (!getState().session) {
         alert('No active session to export. Save a version first.');
@@ -1102,18 +1111,41 @@ async function main() {
   });
 
   // Global undo / redo / save shortcuts (OS-aware, focus/tool-routed).
-  installKeyboardShortcuts({
-    onSave: async () => {
-      const result = await saveCurrentVersion();
-      if ('error' in result) {
-        showToast(result.error, { variant: 'warn' });
-      } else if ('skipped' in result) {
-        showToast('No changes to save', { variant: 'neutral' });
-      } else {
-        showToast(`Saved v${result.index}${result.label ? ` — ${result.label}` : ''}`, { variant: 'success' });
-      }
-    },
-  });
+  const saveVersionWithToast = async () => {
+    const result = await saveCurrentVersion();
+    if ('error' in result) {
+      showToast(result.error, { variant: 'warn' });
+    } else if ('skipped' in result) {
+      showToast('No changes to save', { variant: 'neutral' });
+    } else {
+      showToast(`Saved v${result.index}${result.label ? ` — ${result.label}` : ''}`, { variant: 'success' });
+    }
+  };
+  installKeyboardShortcuts({ onSave: saveVersionWithToast });
+
+  // Register command-palette actions (⌘K). Reuses the same handlers the
+  // toolbar/session bar/layout already wire up so behavior can't drift.
+  registerCommands([
+    { id: 'run', title: 'Run code', hint: 'Editor', keywords: 'execute render', run: () => runCode() },
+    { id: 'save', title: 'Save version', hint: 'Session', shortcut: combo(MOD_LABEL, 'S'), keywords: 'commit snapshot', run: () => { void saveVersionWithToast(); } },
+    { id: 'format', title: 'Format code', hint: 'Editor', shortcut: combo(SHIFT_LABEL, ALT_LABEL, 'F'), keywords: 'prettify beautify indent', run: () => formatCode() },
+    { id: 'new-session', title: 'New session', hint: 'Session', keywords: 'create blank', run: () => startNewSessionInEditor() },
+    { id: 'open-sessions', title: 'Open session…', hint: 'Session', keywords: 'switch list recent', run: () => showSessionList() },
+    { id: 'tab-interactive', title: 'Go to 3D view', hint: 'Tab', keywords: 'interactive viewport model', run: () => switchTab('interactive') },
+    { id: 'tab-gallery', title: 'Go to Gallery', hint: 'Tab', keywords: 'thumbnails versions', run: () => switchTab('gallery') },
+    { id: 'tab-versions', title: 'Go to Versions', hint: 'Tab', keywords: 'history rename delete', run: () => switchTab('versions') },
+    { id: 'tab-images', title: 'Go to Reference images', hint: 'Tab', keywords: 'photos reference', run: () => switchTab('images') },
+    { id: 'tab-diff', title: 'Go to Diff', hint: 'Tab', keywords: 'compare changes', run: () => switchTab('diff') },
+    { id: 'tab-notes', title: 'Go to Notes', hint: 'Tab', keywords: 'session notes', run: () => switchTab('notes') },
+    { id: 'export-glb', title: 'Export GLB', hint: 'Export', keywords: 'download gltf 3d', run: () => { void actionExportGLB(); }, enabled: () => currentMeshData !== null },
+    { id: 'export-stl', title: 'Export STL', hint: 'Export', keywords: 'download print', run: actionExportSTL, enabled: () => currentMeshData !== null },
+    { id: 'export-obj', title: 'Export OBJ', hint: 'Export', keywords: 'download wavefront', run: actionExportOBJ, enabled: () => currentMeshData !== null },
+    { id: 'export-3mf', title: 'Export 3MF', hint: 'Export', keywords: 'download print color', run: actionExport3MF, enabled: () => currentMeshData !== null },
+    { id: 'toggle-ai', title: 'Toggle AI panel', hint: 'View', keywords: 'chat assistant drawer', run: () => toggleAiPanel() },
+    { id: 'toggle-diagnostics', title: 'Toggle diagnostic log', hint: 'View', keywords: 'errors warnings console', run: () => toggleDiagnosticsPanel() },
+    { id: 'open-catalog', title: 'Open catalog', hint: 'Navigate', keywords: 'examples premade browse', run: () => { void showCatalogPage(); } },
+    { id: 'open-help', title: 'Open help', hint: 'Navigate', keywords: 'docs documentation guide', run: () => showHelp() },
+  ]);
 
   // Init gallery
   createGalleryView(galleryContainer, async (code: string) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,7 +87,7 @@ import { probeAtXY, probeRay, probePixel, measureDistance, type ProbeResult, typ
 import { checkContainment, type ContainmentWarning } from './geometry/containmentCheck';
 import { setUnits as _setUnits, getUnits as _getUnits, type UnitSystem } from './geometry/units';
 import { initMeasureTool, activate as activateMeasure, deactivate as deactivateMeasure, getState as getMeasureState } from './ui/measureTool';
-import { maybeStartTour, resetTour, startTour } from './ui/tour';
+import { maybeStartTour, resetTour, startTour, isTourCompleted } from './ui/tour';
 import { initTheme, getTheme, setTheme } from './ui/theme';
 import type { Theme } from './ui/theme';
 import { initPaintUI, isPaintOpen, forceDeactivate as closePaintMenu } from './color/paintUI';
@@ -1148,6 +1148,7 @@ async function main() {
     { id: 'tab-images', title: 'Go to Reference images', hint: 'Tab', keywords: 'photos reference', run: () => switchTab('images') },
     { id: 'tab-diff', title: 'Go to Diff', hint: 'Tab', keywords: 'compare changes', run: () => switchTab('diff') },
     { id: 'tab-notes', title: 'Go to Notes', hint: 'Tab', keywords: 'session notes', run: () => switchTab('notes') },
+    { id: 'tab-data', title: 'Go to Data', hint: 'Tab', keywords: 'storage browser indexeddb inventory', run: () => switchTab('data') },
     { id: 'export-glb', title: 'Export GLB', hint: 'Export', keywords: 'download gltf 3d', run: () => { void actionExportGLB(); }, enabled: () => currentMeshData !== null },
     { id: 'export-stl', title: 'Export STL', hint: 'Export', keywords: 'download print', run: actionExportSTL, enabled: () => currentMeshData !== null },
     { id: 'export-obj', title: 'Export OBJ', hint: 'Export', keywords: 'download wavefront', run: actionExportOBJ, enabled: () => currentMeshData !== null },
@@ -1762,6 +1763,7 @@ async function main() {
   // Start guided tour on first visit (after editor fully renders)
   if (!showLanding && !showHelpPage && !showCatalog && !show404) {
     maybeStartTour();
+    maybeShowShortcutsHint();
   }
 
   // If not on landing/help/catalog/404, load session or default code now
@@ -6073,6 +6075,25 @@ async function main() {
     onUserOrbitLockChange(reflect);
     reflect(isUserOrbitLocked());
   }
+}
+
+const SHORTCUTS_HINT_KEY = 'partwright-shortcuts-hint-seen';
+
+/** One-time, non-intrusive nudge toward the `?` shortcuts cheat sheet. Only
+ *  shown to users who've already finished the first-run tour (so it never
+ *  competes with onboarding), and only once ever. */
+function maybeShowShortcutsHint(): void {
+  try {
+    if (localStorage.getItem(SHORTCUTS_HINT_KEY)) return;
+    if (!isTourCompleted()) return; // let first-timers finish the tour first
+    localStorage.setItem(SHORTCUTS_HINT_KEY, new Date().toISOString());
+  } catch {
+    return; // private-mode / storage disabled — skip the hint rather than throw
+  }
+  setTimeout(
+    () => showToast('Tip: press  ?  for keyboard shortcuts', { variant: 'neutral', durationMs: 6000 }),
+    1200,
+  );
 }
 
 function setStatus(el: HTMLElement, state: 'ready' | 'running' | 'error' | 'loading', text: string) {

--- a/src/ui/commandPalette.ts
+++ b/src/ui/commandPalette.ts
@@ -1,0 +1,206 @@
+// Command palette — a searchable list of every primary action, opened with
+// ⌘K / Ctrl+K. Actions register themselves at startup; the palette stays
+// decoupled from what they do. This makes the app's capabilities discoverable
+// without memorizing the toolbar layout or a wall of hotkeys.
+
+export interface Command {
+  /** Stable unique id (also dedupes re-registration). */
+  id: string;
+  /** Primary label shown in the list and matched first. */
+  title: string;
+  /** Dim secondary text (e.g. a category) shown after the title. */
+  hint?: string;
+  /** Extra search terms not present in the title/hint. */
+  keywords?: string;
+  /** Pre-formatted shortcut label, e.g. "⌘ S", shown right-aligned. */
+  shortcut?: string;
+  /** When it returns false the command is hidden (context-unavailable). */
+  enabled?: () => boolean;
+  /** Perform the action. The palette closes before this runs. */
+  run: () => void;
+}
+
+const registry = new Map<string, Command>();
+
+/** Register (or replace, by id) palette commands. */
+export function registerCommands(cmds: Command[]): void {
+  for (const c of cmds) registry.set(c.id, c);
+}
+
+/** All registered commands, in registration order. */
+export function getCommands(): Command[] {
+  return [...registry.values()];
+}
+
+// --- Palette UI ---
+
+let overlayEl: HTMLElement | null = null;
+let inputEl: HTMLInputElement | null = null;
+let listEl: HTMLElement | null = null;
+let restoreFocusEl: HTMLElement | null = null;
+let filtered: Command[] = [];
+let selected = 0;
+
+export function isCommandPaletteOpen(): boolean {
+  return overlayEl !== null;
+}
+
+/** Tokenized, case-insensitive substring match: every whitespace-separated
+ *  token in the query must appear somewhere in the command's searchable text. */
+function commandMatches(cmd: Command, query: string): boolean {
+  const hay = `${cmd.title} ${cmd.hint ?? ''} ${cmd.keywords ?? ''}`.toLowerCase();
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every(tok => hay.includes(tok));
+}
+
+function availableCommands(): Command[] {
+  return getCommands().filter(c => !c.enabled || c.enabled());
+}
+
+function render(): void {
+  if (!listEl || !inputEl) return;
+  const query = inputEl.value.trim();
+  filtered = availableCommands().filter(c => commandMatches(c, query));
+  if (selected >= filtered.length) selected = Math.max(0, filtered.length - 1);
+
+  listEl.replaceChildren();
+
+  if (filtered.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'px-3 py-6 text-center text-sm text-zinc-500';
+    empty.textContent = 'No matching commands';
+    listEl.appendChild(empty);
+    inputEl.removeAttribute('aria-activedescendant');
+    return;
+  }
+
+  filtered.forEach((cmd, i) => {
+    const row = document.createElement('div');
+    row.id = `cmd-palette-opt-${i}`;
+    row.setAttribute('role', 'option');
+    const isSel = i === selected;
+    row.setAttribute('aria-selected', isSel ? 'true' : 'false');
+    row.className =
+      'flex items-center justify-between gap-3 px-3 py-2 rounded cursor-pointer ' +
+      (isSel ? 'bg-emerald-600/20 text-zinc-100' : 'text-zinc-300 hover:bg-zinc-700/60');
+
+    const left = document.createElement('div');
+    left.className = 'flex items-baseline gap-2 min-w-0';
+    const title = document.createElement('span');
+    title.className = 'truncate';
+    title.textContent = cmd.title;
+    left.appendChild(title);
+    if (cmd.hint) {
+      const hint = document.createElement('span');
+      hint.className = 'text-xs text-zinc-500 truncate';
+      hint.textContent = cmd.hint;
+      left.appendChild(hint);
+    }
+    row.appendChild(left);
+
+    if (cmd.shortcut) {
+      const kbd = document.createElement('kbd');
+      kbd.className = 'shrink-0 text-xs text-zinc-400 bg-zinc-900/70 border border-zinc-700 rounded px-1.5 py-0.5';
+      kbd.textContent = cmd.shortcut;
+      row.appendChild(kbd);
+    }
+
+    row.addEventListener('mousemove', () => {
+      if (selected !== i) { selected = i; render(); }
+    });
+    row.addEventListener('click', () => runSelected(cmd));
+
+    listEl!.appendChild(row);
+  });
+
+  inputEl.setAttribute('aria-activedescendant', `cmd-palette-opt-${selected}`);
+  const selRow = listEl.children[selected] as HTMLElement | undefined;
+  selRow?.scrollIntoView({ block: 'nearest' });
+}
+
+function runSelected(cmd: Command | undefined): void {
+  if (!cmd) return;
+  // Close without restoring focus — the command may open a modal or move
+  // focus itself, and yanking focus back to the trigger would fight that.
+  closeCommandPalette({ restoreFocus: false });
+  cmd.run();
+}
+
+export function openCommandPalette(): void {
+  if (overlayEl) { inputEl?.focus(); return; }
+  restoreFocusEl = (document.activeElement as HTMLElement | null) ?? null;
+  selected = 0;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'fixed inset-0 bg-black/50 z-[60] flex items-start justify-center pt-[12vh] px-4';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-label', 'Command palette');
+
+  const panel = document.createElement('div');
+  panel.className = 'w-full max-w-lg bg-zinc-800 rounded-xl shadow-2xl border border-zinc-700 flex flex-col overflow-hidden';
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = 'Type a command…';
+  input.setAttribute('aria-label', 'Search commands');
+  input.setAttribute('role', 'combobox');
+  input.setAttribute('aria-expanded', 'true');
+  input.setAttribute('aria-controls', 'cmd-palette-list');
+  input.autocomplete = 'off';
+  input.spellcheck = false;
+  input.className = 'w-full bg-transparent text-sm text-zinc-100 placeholder-zinc-500 px-4 py-3 border-b border-zinc-700 outline-none';
+
+  const list = document.createElement('div');
+  list.id = 'cmd-palette-list';
+  list.setAttribute('role', 'listbox');
+  list.className = 'max-h-[50vh] overflow-y-auto p-1.5 flex flex-col gap-0.5';
+
+  panel.appendChild(input);
+  panel.appendChild(list);
+  overlay.appendChild(panel);
+  document.body.appendChild(overlay);
+
+  overlayEl = overlay;
+  inputEl = input;
+  listEl = list;
+
+  input.addEventListener('input', () => { selected = 0; render(); });
+  input.addEventListener('keydown', onInputKeydown);
+  overlay.addEventListener('mousedown', e => { if (e.target === overlay) closeCommandPalette(); });
+
+  render();
+  input.focus();
+}
+
+function onInputKeydown(e: KeyboardEvent): void {
+  const n = filtered.length;
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    e.stopPropagation();
+    closeCommandPalette();
+  } else if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    if (n > 0) { selected = (selected + 1) % n; render(); }
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    if (n > 0) { selected = (selected - 1 + n) % n; render(); }
+  } else if (e.key === 'Enter') {
+    e.preventDefault();
+    runSelected(filtered[selected]);
+  }
+}
+
+export function closeCommandPalette(opts: { restoreFocus?: boolean } = {}): void {
+  if (!overlayEl) return;
+  overlayEl.remove();
+  overlayEl = null;
+  inputEl = null;
+  listEl = null;
+  filtered = [];
+  if (opts.restoreFocus !== false) restoreFocusEl?.focus?.();
+  restoreFocusEl = null;
+}

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -229,6 +229,18 @@ export function createHelpPage(
       })(),
     },
     {
+      id: 'command-palette',
+      heading: 'Command palette & cheat sheet',
+      body: (() => {
+        const kbd = (k: string) => `<strong class="text-zinc-300">${k}</strong>`;
+        const paletteKeys = IS_MAC ? `${MOD_LABEL} K` : `${MOD_LABEL} + K`;
+        return (
+          `Press ${kbd(paletteKeys)} anywhere to open the <strong class="text-zinc-300">command palette</strong> — a searchable list of every action: run, save, format, switch tabs, export (3MF / STL / OBJ / GLB), toggle the AI panel or diagnostic log, start or open a session, or jump to the catalog or this help page. Type to filter, ${kbd('↑')} / ${kbd('↓')} to choose, ${kbd('Enter')} to run, ${kbd('Esc')} to close.<br><br>` +
+          `Press ${kbd('?')} (when you\'re not typing in a field) to pop up the full keyboard-shortcuts cheat sheet from anywhere — the same list as below.`
+        );
+      })(),
+    },
+    {
       id: 'shortcuts',
       heading: 'Keyboard shortcuts',
       body: (() => {

--- a/src/ui/keyboardShortcuts.ts
+++ b/src/ui/keyboardShortcuts.ts
@@ -14,6 +14,8 @@
 // the on-screen Undo/Redo buttons — so the keyboard path needs no extra wiring.
 
 import { IS_MAC } from './shortcutDefs';
+import { openCommandPalette, isCommandPaletteOpen } from './commandPalette';
+import { openShortcutsOverlay } from './shortcutsOverlay';
 import {
   removeLastRegion,
   redoLastRegion,
@@ -77,7 +79,27 @@ function routeRedo(): boolean {
 
 export function installKeyboardShortcuts(handlers: ShortcutHandlers): void {
   document.addEventListener('keydown', (e) => {
+    // While the palette is open it owns the keyboard (its own Escape/arrows/
+    // Enter handler runs); don't let app shortcuts fire underneath it.
+    if (isCommandPaletteOpen()) return;
+
     const mod = IS_MAC ? e.metaKey : e.ctrlKey;
+
+    // Command palette — ⌘K / Ctrl+K, global regardless of focus.
+    if (mod && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      openCommandPalette();
+      return;
+    }
+
+    // Shortcuts cheat sheet — `?`, but only outside text fields / the editor
+    // so typing a literal "?" still works.
+    if (!mod && !e.altKey && e.key === '?' && !isEditableTarget(e.target)) {
+      e.preventDefault();
+      openShortcutsOverlay();
+      return;
+    }
+
     if (!mod || e.altKey) return; // ignore AltGr (Ctrl+Alt) and unrelated combos
     const key = e.key.toLowerCase();
 

--- a/src/ui/shortcutDefs.ts
+++ b/src/ui/shortcutDefs.ts
@@ -25,7 +25,7 @@ export const ALT_LABEL = IS_MAC ? '⌥' : 'Alt'; // ⌥ / Alt
 
 /** Join modifier/key tokens the way the host OS conventionally renders them
  *  (macOS stacks glyphs with no separator, others use " + "). */
-function combo(...tokens: string[]): string {
+export function combo(...tokens: string[]): string {
   return tokens.join(IS_MAC ? ' ' : ' + ');
 }
 
@@ -36,10 +36,19 @@ interface ShortcutDoc {
   description: string;
 }
 
-/** The shortcuts this feature owns (undo / redo / save), formatted for the
- *  current OS. The help page renders these; the handler implements them. */
+/** The shortcuts this feature owns, formatted for the current OS. The help
+ *  page and the in-app `?` cheat sheet render these; the handlers implement
+ *  them. */
 export function getShortcutDocs(): ShortcutDoc[] {
   return [
+    {
+      keys: combo(MOD_LABEL, 'K'),
+      description: 'Open the command palette — search and run any action by name.',
+    },
+    {
+      keys: '?',
+      description: 'Open this keyboard-shortcuts cheat sheet (when not typing in a field).',
+    },
     {
       keys: combo(MOD_LABEL, 'Z'),
       description:
@@ -55,6 +64,10 @@ export function getShortcutDocs(): ShortcutDoc[] {
       keys: combo(MOD_LABEL, 'S'),
       description:
         'Save the current code, geometry, paint regions, and annotations as a new version in the active session.',
+    },
+    {
+      keys: combo(SHIFT_LABEL, ALT_LABEL, 'F'),
+      description: 'Reformat the code in the editor.',
     },
   ];
 }

--- a/src/ui/shortcutsOverlay.ts
+++ b/src/ui/shortcutsOverlay.ts
@@ -1,0 +1,53 @@
+// In-app keyboard cheat sheet, opened with `?`. Renders the canonical shortcut
+// list from shortcutDefs (the same source the help page uses) so the keys shown
+// here can never drift from the keys that actually fire.
+
+import { createModalShell } from './modalShell';
+import { getShortcutDocs } from './shortcutDefs';
+
+let isOpen = false;
+
+export function isShortcutsOverlayOpen(): boolean {
+  return isOpen;
+}
+
+export function openShortcutsOverlay(): void {
+  if (isOpen) return;
+  isOpen = true;
+  const shell = createModalShell({
+    title: 'Keyboard shortcuts',
+    maxWidth: 'lg',
+    scrollable: true,
+    onClose: () => { isOpen = false; },
+  });
+
+  const tip = document.createElement('p');
+  tip.className = 'text-xs text-zinc-400';
+  tip.textContent = 'Tip: press the command palette key to search and run any action by name.';
+  shell.body.appendChild(tip);
+
+  const table = document.createElement('div');
+  table.className = 'flex flex-col divide-y divide-zinc-700/70';
+  for (const doc of getShortcutDocs()) {
+    const row = document.createElement('div');
+    row.className = 'flex items-start justify-between gap-4 py-2';
+
+    const desc = document.createElement('span');
+    desc.className = 'text-sm text-zinc-300';
+    desc.textContent = doc.description;
+
+    const kbd = document.createElement('kbd');
+    kbd.className = 'shrink-0 text-xs text-zinc-200 bg-zinc-900/70 border border-zinc-700 rounded px-2 py-1 whitespace-nowrap';
+    kbd.textContent = doc.keys;
+
+    row.appendChild(desc);
+    row.appendChild(kbd);
+    table.appendChild(row);
+  }
+  shell.body.appendChild(table);
+
+  const footnote = document.createElement('p');
+  footnote.className = 'text-xs text-zinc-500';
+  footnote.textContent = 'Undo / redo defer to the editor or active tool depending on focus.';
+  shell.body.appendChild(footnote);
+}

--- a/src/ui/tour.ts
+++ b/src/ui/tour.ts
@@ -109,6 +109,11 @@ export function resetTour(): void {
   localStorage.removeItem(STORAGE_KEY);
 }
 
+/** Whether the first-run tour has been completed (or skipped). */
+export function isTourCompleted(): boolean {
+  return !!localStorage.getItem(STORAGE_KEY);
+}
+
 function createOverlay(): void {
   cleanup();
 

--- a/tests/command-palette.spec.ts
+++ b/tests/command-palette.spec.ts
@@ -53,4 +53,18 @@ test.describe('command palette', () => {
     await page.keyboard.press('Escape');
     await expect(page.getByRole('heading', { name: 'Keyboard shortcuts' })).toHaveCount(0);
   });
+
+  test('shows a one-time hint toward the ? cheat sheet once the tour is done', async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('partwright-tour-completed', new Date().toISOString());
+        localStorage.removeItem('partwright-shortcuts-hint-seen');
+      } catch { /* ignore */ }
+    });
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+    await expect(
+      page.locator('div[role="status"]').filter({ hasText: /keyboard shortcuts/i }),
+    ).toBeVisible({ timeout: 6000 });
+  });
 });

--- a/tests/command-palette.spec.ts
+++ b/tests/command-palette.spec.ts
@@ -1,0 +1,56 @@
+// Command palette (⌘K / Ctrl+K) and the `?` keyboard cheat sheet.
+//
+// `ControlOrMeta` maps the press to ⌘ on macOS and Ctrl elsewhere, mirroring
+// the app's own OS detection. The first-run tour is pre-dismissed via the
+// localStorage flag so its backdrop/keys don't interfere.
+
+import { test, expect } from 'playwright/test';
+
+async function openEditor(page: import('playwright/test').Page) {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', new Date().toISOString()); } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+}
+
+test.describe('command palette', () => {
+  test('opens with the palette key and runs a command by name', async ({ page }) => {
+    await openEditor(page);
+
+    await page.keyboard.press('ControlOrMeta+k');
+    const input = page.locator('input[aria-label="Search commands"]');
+    await expect(input).toBeVisible();
+
+    await input.fill('notes');
+    await expect(page.locator('[role="option"]').filter({ hasText: 'Go to Notes' })).toBeVisible();
+
+    await page.keyboard.press('Enter');
+
+    // Palette closed, and the Notes tab is now active (URL carries ?notes).
+    await expect(input).toHaveCount(0);
+    await expect.poll(() => new URL(page.url()).searchParams.has('notes')).toBe(true);
+  });
+
+  test('filters out and hides unavailable rows', async ({ page }) => {
+    await openEditor(page);
+    await page.keyboard.press('ControlOrMeta+k');
+    const input = page.locator('input[aria-label="Search commands"]');
+    await input.fill('zzzznotacommand');
+    await expect(page.getByText('No matching commands')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(input).toHaveCount(0);
+  });
+
+  test('the ? key opens the keyboard cheat sheet', async ({ page }) => {
+    await openEditor(page);
+    // Move focus out of the code editor so `?` isn't typed as a literal.
+    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur?.());
+
+    await page.keyboard.press('Shift+Slash');
+    await expect(page.getByRole('heading', { name: 'Keyboard shortcuts' })).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('heading', { name: 'Keyboard shortcuts' })).toHaveCount(0);
+  });
+});

--- a/tests/feedback-a11y.spec.ts
+++ b/tests/feedback-a11y.spec.ts
@@ -38,7 +38,8 @@ test.describe('feedback + a11y', () => {
     await page.waitForSelector('#btn-ai');
     await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
     await page.click('#btn-ai');
-    await page.locator('#ai-panel button:has-text("Connect Anthropic API")').dispatchEvent('click');
+    // The panel CTA opens the AI Settings modal (a modalShell dialog).
+    await page.locator('#ai-panel button:has-text("Connect an AI agent")').dispatchEvent('click');
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();


### PR DESCRIPTION
## Summary

Keyboard shortcuts and toolbar actions were hard to discover — even the few existing hotkeys (save / undo / redo / format) lived only on the help page.

- **Command palette (`⌘K` / `Ctrl+K`)** — a searchable list of every primary action: run, save version, format, switch tabs (3D / Gallery / Versions / Reference images / Diff / Notes / **Data**), export GLB/STL/OBJ/3MF, toggle AI panel & diagnostic log, new/open session, open catalog/help. Arrow-key navigation, Enter to run, Esc to close, click to run, fuzzy substring filter, and context-aware availability (export rows hide when there's no mesh).
- **`?` cheat sheet** — a modal listing the canonical shortcuts, rendered from the same `shortcutDefs` source the help page uses (no drift). Opens only when you're not typing in a field.
- Commands reuse the existing toolbar/session-bar/layout handlers; mesh-export callbacks were extracted into shared consts so the toolbar and palette can't diverge.

### Added since first review
- **Docs** — new "Command palette & cheat sheet" section on the help page, plus `commandPalette.ts` / `shortcutsOverlay.ts` listed in CLAUDE.md's architecture.
- **Discoverability hint** — a one-time toast ("press `?` for keyboard shortcuts") shown only after the first-run tour is complete, once ever (localStorage-gated).
- **Synced with latest `staging`** — resolved the export-closure conflict by folding #198's "Exported &lt;file&gt;" success toasts into the shared export consts; added a "Go to Data" command for the new Data tab.
- **Test fix** — updated the (staging-merged) `feedback-a11y` modal test to staging's new "Connect an AI agent" → AI Settings flow. ⚠️ That test is currently red on `staging` itself; this PR fixes it.

## Test plan
- [x] `npm run build` — clean
- [x] `npx playwright test` — full suite green (the only two failures were a flaky `stl-import` volume check and the stale `feedback-a11y` selector, now fixed)
- [x] New `tests/command-palette.spec.ts`: ⌘K opens + runs a command, empty-state filtering, `?` opens the cheat sheet, one-time hint toast
- [ ] Manual: ⌘K from editor focus; `?` doesn't fire while typing; hint shows once for returning users

https://claude.ai/code/session_01YJeQwLJSy7PyrzhGcyLc53