### PR TITLE
feat: add editor autocomplete for the manifold-js sandbox API

### DIFF
--- a/src/editor/apiCompletions.ts
+++ b/src/editor/apiCompletions.ts
@@ -1,0 +1,182 @@
+// Autocomplete for the manifold-js sandbox API.
+//
+// Signatures are transcribed from manifold-3d's encapsulated type defs and the
+// `api` object the engine injects (src/geometry/engines/manifoldJs.ts), so the
+// hints match what actually runs. The matcher is heuristic (no type inference):
+// `Manifold.`/`CrossSection.`/`api.` resolve to their own members; any other
+// `.` offers the union of instance methods (most chains are Manifold).
+
+import { snippetCompletion } from '@codemirror/autocomplete';
+import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
+import { javascriptLanguage } from '@codemirror/lang-javascript';
+
+/** A callable member — completes to `name()` with the cursor between the parens. */
+function fn(label: string, detail: string, info: string): Completion {
+  return snippetCompletion(`${label}(\${})`, { label, detail, info, type: 'function' });
+}
+
+/** A non-callable member (property / class / keyword). */
+function val(label: string, detail: string, info: string, type: Completion['type']): Completion {
+  return { label, detail, info, type };
+}
+
+const MANIFOLD_STATIC: Completion[] = [
+  fn('cube', '(size?, center?)', 'Axis-aligned box. size is [x,y,z] or a number; center shifts the box to the origin.'),
+  fn('cylinder', '(height, radiusLow, radiusHigh?, circularSegments?, center?)', 'Cylinder or cone along Z. Set radiusHigh for a cone.'),
+  fn('sphere', '(radius, circularSegments?)', 'Geodesic sphere of the given radius.'),
+  fn('tetrahedron', '()', 'Tetrahedron centered at the origin with a vertex at (1,1,1).'),
+  fn('extrude', '(polygons, height, nDivisions?, twistDegrees?, scaleTop?, center?)', 'Extrude a CrossSection / polygons along Z.'),
+  fn('revolve', '(polygons, circularSegments?, revolveDegrees?)', 'Revolve a CrossSection / polygons around the Y-axis (becomes Z).'),
+  fn('ofMesh', '(mesh)', 'Build a Manifold from a Mesh (e.g. api.imports[0]).'),
+  fn('smooth', '(mesh, sharpenedEdges?)', 'Create a smooth (tangent-carrying) Manifold from a mesh; refine() to interpolate.'),
+  fn('levelSet', '(sdf, bounds, edgeLength, level?, tolerance?)', 'Marching-tetrahedra surface from a signed-distance function.'),
+  fn('union', '(a, b)  |  (manifolds[])', 'Boolean union of two manifolds or a list.'),
+  fn('difference', '(a, b)  |  (manifolds[])', 'Boolean difference (subtract the tail of a list from its head).'),
+  fn('intersection', '(a, b)  |  (manifolds[])', 'Boolean intersection of two manifolds or a list.'),
+  fn('compose', '(manifolds[])', 'Topological compose (no boolean) — avoid overlaps. Inverse of decompose().'),
+  fn('hull', '(points[])', 'Convex hull of the given manifolds / [x,y,z] points.'),
+  fn('reserveIDs', '(count)', 'Reserve a run of unique original IDs for multi-material meshes.'),
+];
+
+const MANIFOLD_INSTANCE: Completion[] = [
+  fn('add', '(other)', 'Boolean union with another Manifold.'),
+  fn('subtract', '(other)', 'Boolean difference — remove other from this.'),
+  fn('intersect', '(other)', 'Boolean intersection with another Manifold.'),
+  fn('translate', '([x,y,z])  |  (x, y, z)', 'Move in space (chainable, lazy).'),
+  fn('rotate', '([x,y,z])  |  (x, y, z)', 'Euler rotation in degrees, applied X then Y then Z.'),
+  fn('scale', '([x,y,z] | n)', 'Scale per-component or uniformly.'),
+  fn('mirror', '(normal)', 'Mirror over the plane through the origin with this normal.'),
+  fn('transform', '(mat4)', 'Apply a column-major affine matrix (last row ignored).'),
+  fn('warp', '(fn)', 'Move each vertex via fn(vert) without changing topology.'),
+  fn('refine', '(n)', 'Split every edge into n pieces (n > 1).'),
+  fn('refineToLength', '(length)', 'Subdivide edges down to roughly the given length.'),
+  fn('refineToTolerance', '(tolerance)', 'Subdivide curved regions to within tolerance of the smooth surface.'),
+  fn('setProperties', '(numProp, fn)', 'Rewrite per-vertex properties via fn(newProp, position, oldProp).'),
+  fn('calculateCurvature', '(gaussianIdx, meanIdx)', 'Store Gaussian/mean curvature into property channels.'),
+  fn('calculateNormals', '(normalIdx, minSharpAngle)', 'Compute vertex normals into property channels.'),
+  fn('smoothByNormals', '(normalIdx)', 'Fill tangents from existing normal properties.'),
+  fn('smoothOut', '(minSharpAngle?, minSmoothness?)', 'Smooth edges below minSharpAngle (then refine()).'),
+  fn('split', '(cutter)', 'Returns [intersection, difference] with the cutter.'),
+  fn('splitByPlane', '(normal, originOffset)', 'Returns [above, below] split by a half-space.'),
+  fn('trimByPlane', '(normal, originOffset)', 'Remove everything behind the half-space plane.'),
+  fn('slice', '(height)', 'CrossSection of this solid at the given Z height.'),
+  fn('project', '()', 'CrossSection of the projected outline onto the XY plane.'),
+  fn('hull', '()', 'Convex hull of this Manifold.'),
+  fn('decompose', '()', 'Split into topologically disconnected Manifolds.'),
+  fn('getMesh', '(normalIdx?)', 'Return a renderer-friendly Mesh of this Manifold.'),
+  fn('asOriginal', '()', 'Reset IDs so this copy is referenced by descendants.'),
+  fn('originalID', '()', 'Original ID if this is an original, else -1.'),
+  fn('boundingBox', '()', 'Axis-aligned bounding box {min, max}.'),
+  fn('volume', '()', 'Volume of the solid.'),
+  fn('surfaceArea', '()', 'Total surface area.'),
+  fn('genus', '()', 'Topological genus (number of handles).'),
+  fn('numTri', '()', 'Triangle count.'),
+  fn('numVert', '()', 'Vertex count.'),
+  fn('numEdge', '()', 'Edge count.'),
+  fn('numProp', '()', 'Properties per vertex.'),
+  fn('isEmpty', '()', 'Whether the Manifold has no triangles.'),
+  fn('status', '()', 'Error status for an empty/invalid Manifold.'),
+  fn('tolerance', '()', 'Current epsilon tolerance.'),
+  fn('setTolerance', '(tolerance)', 'Copy with a new tolerance (simplifies when increased).'),
+  fn('simplify', '(tolerance?)', 'Copy simplified to within tolerance.'),
+  fn('minGap', '(other, searchLength)', 'Minimum gap to another Manifold (0..searchLength).'),
+];
+
+const CROSSSECTION_STATIC: Completion[] = [
+  fn('square', '(size?, center?)', 'Square/rectangle. size is [x,y] or a number; center shifts to the origin.'),
+  fn('circle', '(radius, circularSegments?)', 'Circle of the given radius.'),
+  fn('union', '(a, b)  |  (list)', 'Boolean union of cross-sections / polygons.'),
+  fn('difference', '(a, b)  |  (list)', 'Boolean difference of cross-sections / polygons.'),
+  fn('intersection', '(a, b)  |  (list)', 'Boolean intersection of cross-sections / polygons.'),
+  fn('hull', '(polygons[])', 'Convex hull of a list of polygons / cross-sections.'),
+  fn('compose', '(polygons[])', 'Batch-union a list into one CrossSection.'),
+  fn('ofPolygons', '(contours, fillRule?)', 'Build a CrossSection from contour polygons.'),
+];
+
+const CROSSSECTION_INSTANCE: Completion[] = [
+  fn('extrude', '(height, nDivisions?, twistDegrees?, scaleTop?, center?)', 'Extrude this cross-section along Z into a Manifold.'),
+  fn('revolve', '(circularSegments?, revolveDegrees?)', 'Revolve this cross-section into a Manifold.'),
+  fn('add', '(other)', 'Boolean union with another cross-section.'),
+  fn('subtract', '(other)', 'Boolean difference.'),
+  fn('intersect', '(other)', 'Boolean intersection.'),
+  fn('translate', '([x,y])  |  (x, y)', 'Move in the plane (chainable, lazy).'),
+  fn('rotate', '(degrees)', 'Rotate about Z, in degrees.'),
+  fn('scale', '([x,y] | n)', 'Scale per-component or uniformly.'),
+  fn('mirror', '(axis)', 'Mirror over the given axis vector.'),
+  fn('offset', '(delta, joinType?, miterLimit?, circularSegments?)', 'Inflate/deflate contours by delta.'),
+  fn('simplify', '(epsilon?)', 'Remove near-collinear vertices (clean up after offset).'),
+  fn('hull', '()', 'Convex hull of this cross-section.'),
+  fn('decompose', '()', 'Split into disconnected cross-sections.'),
+  fn('toPolygons', '()', 'Return the contours as simple polygons.'),
+  fn('area', '()', 'Total covered area.'),
+  fn('bounds', '()', 'Axis-aligned bounding rectangle.'),
+  fn('numVert', '()', 'Vertex count.'),
+  fn('numContour', '()', 'Contour count.'),
+  fn('isEmpty', '()', 'Whether there are no contours.'),
+];
+
+/** Union of instance methods, deduped by label, for `expr.` where the receiver
+ *  type is unknown. */
+const INSTANCE_ANY: Completion[] = (() => {
+  const seen = new Set<string>();
+  const out: Completion[] = [];
+  for (const c of [...MANIFOLD_INSTANCE, ...CROSSSECTION_INSTANCE]) {
+    if (seen.has(c.label)) continue;
+    seen.add(c.label);
+    out.push(c);
+  }
+  return out;
+})();
+
+const API_MEMBERS: Completion[] = [
+  val('Manifold', 'class', 'The Manifold (3D solid) class.', 'class'),
+  val('CrossSection', 'class', 'The CrossSection (2D) class.', 'class'),
+  val('Curves', 'namespace', 'Helpers for parametric curves / paths.', 'variable'),
+  val('imports', 'Mesh[]', 'Imported meshes (e.g. STL) — pass to Manifold.ofMesh(api.imports[i]).', 'variable'),
+  fn('label', '(shape, name)', 'Tag a shape so painted regions can target it by name.'),
+  fn('labeledUnion', '(parts)', 'Union [{name, shape}, …], tagging each part for later paint-by-label.'),
+  fn('setCircularSegments', '(segments)', 'Force the default circle/sphere/cylinder segment count.'),
+  fn('setMinCircularAngle', '(angle)', 'Set the minimum angle between circular segments (degrees).'),
+  fn('setMinCircularEdgeLength', '(length)', 'Set the minimum circular segment edge length.'),
+  fn('renderMesh', '(mesh)', 'Low-level: hand a raw mesh to the renderer.'),
+];
+
+const GLOBALS: Completion[] = [
+  val('api', 'sandbox', 'The injected sandbox API: { Manifold, CrossSection, Curves, imports, label, … }.', 'variable'),
+  val('Manifold', 'class', 'The Manifold (3D solid) class (via api).', 'class'),
+  val('CrossSection', 'class', 'The CrossSection (2D) class (via api).', 'class'),
+  val('return', 'keyword', 'Your code must return a Manifold.', 'keyword'),
+  val('const', 'keyword', 'Declare a constant, e.g. const { Manifold } = api;', 'keyword'),
+];
+
+/** CodeMirror completion source for the manifold-js sandbox API. */
+function manifoldCompletionSource(context: CompletionContext): CompletionResult | null {
+  const word = context.matchBefore(/[\w$]*$/);
+  const wordFrom = word ? word.from : context.pos;
+  const charBefore = wordFrom > 0 ? context.state.sliceDoc(wordFrom - 1, wordFrom) : '';
+
+  if (charBefore === '.') {
+    const line = context.state.doc.lineAt(context.pos);
+    const head = context.state.sliceDoc(line.from, wordFrom - 1); // text up to (excl.) the dot
+    const objMatch = /([A-Za-z_$][\w$]*)\s*$/.exec(head);
+    const obj = objMatch?.[1];
+    let options: Completion[];
+    if (obj === 'Manifold') options = MANIFOLD_STATIC;
+    else if (obj === 'CrossSection') options = CROSSSECTION_STATIC;
+    else if (obj === 'api') options = API_MEMBERS;
+    else options = INSTANCE_ANY; // unknown receiver or a call result like cube(…).
+    return { from: wordFrom, options, validFor: /^[\w$]*$/ };
+  }
+
+  // Top-level identifier: suggest globals while typing, or on explicit Ctrl+Space.
+  if ((word && word.from < word.to) || context.explicit) {
+    return { from: wordFrom, options: GLOBALS, validFor: /^[\w$]*$/ };
+  }
+  return null;
+}
+
+/** Editor extension registering the sandbox-API completions for JavaScript.
+ *  Scoped to the JS language, so OpenSCAD sessions are unaffected. */
+export const manifoldApiCompletion = javascriptLanguage.data.of({
+  autocomplete: manifoldCompletionSource,
+});

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -14,7 +14,11 @@ export type EditorLanguage = 'manifold-js' | 'scad';
 
 let editorView: EditorView | null = null;
 let debounceTimer: number | null = null;
+let idleTimer: number | null = null;
 let activeDiagnostics: Diagnostic[] = [];
+
+/** How long typing must be idle before deferred error UI is surfaced. */
+const ERROR_IDLE_MS = 800;
 let currentLanguage: EditorLanguage = 'manifold-js';
 let autoFormatEnabled: boolean = localStorage.getItem('editor-auto-format') !== 'false';
 const languageCompartment = new Compartment();
@@ -120,11 +124,25 @@ function hasEditorLocation(input: SourceDiagnostic): boolean {
   return input.from !== undefined || input.line !== undefined;
 }
 
+/** Optional lifecycle hooks for decoupling error surfacing from the live
+ *  preview run. `onChange` (debounced) still drives the preview; these let the
+ *  caller hide errors instantly while typing and re-surface them once typing
+ *  settles or focus leaves. */
+export interface EditorHooks {
+  /** Fires synchronously on every edit — hide transient error UI here. */
+  onEdit?: () => void;
+  /** Fires after typing has been idle for ~0.8s. */
+  onIdle?: (code: string) => void;
+  /** Fires when the editor loses focus. */
+  onBlur?: () => void;
+}
+
 export function initEditor(
   container: HTMLElement,
   initialCode: string,
   onChange: (code: string) => void,
   initialLanguage: EditorLanguage = 'manifold-js',
+  hooks: EditorHooks = {},
 ): EditorView {
   const state = EditorState.create({
     doc: initialCode,
@@ -140,11 +158,19 @@ export function initEditor(
           if (activeDiagnostics.length > 0) {
             window.queueMicrotask(() => clearEditorDiagnostics());
           }
+          hooks.onEdit?.();
           if (debounceTimer !== null) clearTimeout(debounceTimer);
           debounceTimer = window.setTimeout(() => {
             onChange(getValue());
           }, 300);
+          if (idleTimer !== null) clearTimeout(idleTimer);
+          idleTimer = window.setTimeout(() => {
+            hooks.onIdle?.(getValue());
+          }, ERROR_IDLE_MS);
         }
+      }),
+      EditorView.domEventHandlers({
+        blur: () => { hooks.onBlur?.(); return false; },
       }),
       EditorView.theme({
         '&': { height: '100%', fontSize: '13px' },

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -6,6 +6,7 @@ import { oneDark } from '@codemirror/theme-one-dark';
 import { basicSetup } from 'codemirror';
 import { lintGutter, setDiagnostics, type Diagnostic } from '@codemirror/lint';
 import { js as jsBeautify } from 'js-beautify';
+import { manifoldApiCompletion } from './apiCompletions';
 import type { SourceDiagnostic } from '../geometry/types';
 import { getTheme, onThemeChange, type Theme } from '../ui/theme';
 
@@ -129,6 +130,7 @@ export function initEditor(
     doc: initialCode,
     extensions: [
       basicSetup,
+      manifoldApiCompletion,
       languageCompartment.of(languageExt(initialLanguage)),
       lintGutter(),
       readOnlyCompartment.of(EditorState.readOnly.of(false)),

--- a/src/main.ts
+++ b/src/main.ts
@@ -1206,6 +1206,19 @@ async function main() {
   // result would overwrite the wrong mesh/manifold/colour state.
   let _runGeneration = 0;
 
+  // Last error from an auto-run, held back from the editor UI until typing
+  // settles or focus leaves (see surfacePendingError). `src` guards against
+  // surfacing an error for code the user has since edited.
+  let pendingEditorError: { error: string; diagnostics: SourceDiagnostic[]; src: string } | null = null;
+
+  /** Render a deferred auto-run error into the editor, but only if the code it
+   *  came from still matches the editor — used by the idle/blur triggers. */
+  function surfacePendingError(): void {
+    if (!pendingEditorError || pendingEditorError.src !== getValue()) return;
+    setEditorDiagnostics(pendingEditorError.diagnostics);
+    renderEditorError(editorErrorPanel, pendingEditorError.error, pendingEditorError.diagnostics);
+  }
+
   async function ensureEditorReady() {
     if (!editorReady) await editorReadyPromise;
   }
@@ -1498,9 +1511,15 @@ async function main() {
   // Init measure tool
   initMeasureTool(getCanvas(), getCamera(), getMeshGroup(), viewportPane);
 
-  // Init editor — only auto-run if auto-run is enabled
+  // Init editor — only auto-run if auto-run is enabled. Auto-runs drive the
+  // live preview but defer error surfacing (no panel/markers/log mid-keystroke);
+  // the idle + blur hooks surface the held-back error gently once typing settles.
   initEditor(editorContainer, defaultCode, (code: string) => {
-    if (isAutoRun()) runCode(code);
+    if (isAutoRun()) runCode(code, { surfaceErrors: false });
+  }, 'manifold-js', {
+    onEdit: () => clearEditorErrorPanel(editorErrorPanel),
+    onIdle: () => surfacePendingError(),
+    onBlur: () => surfacePendingError(),
   });
 
   // When the user changes the modeling-quality preset, re-render the
@@ -5704,7 +5723,7 @@ async function main() {
     });
   }
 
-  function runCode(code?: string) {
+  function runCode(code?: string, opts: { surfaceErrors?: boolean } = {}) {
     const src = code ?? getValue();
     setStatus(statusBar, 'running', 'Running...');
     clearEditorDiagnostics();
@@ -5715,11 +5734,15 @@ async function main() {
       // started synchronously before this RAF fired — if so, skip to avoid
       // racing: the explicit call owns _runGeneration and will apply results.
       if (_running) return;
-      await runCodeSync(src);
+      await runCodeSync(src, opts);
     });
   }
 
-  async function runCodeSync(src: string): Promise<boolean> {
+  async function runCodeSync(src: string, opts: { surfaceErrors?: boolean } = {}): Promise<boolean> {
+    // Manual runs (Run button, version load, partwright.run) surface errors
+    // immediately; auto-runs defer to the idle/blur triggers so the editor
+    // doesn't flicker an error on every keystroke.
+    const surfaceErrors = opts.surfaceErrors ?? true;
     const myGen = ++_runGeneration;
     _running = true;
     const t0 = performance.now();
@@ -5734,13 +5757,8 @@ async function main() {
     _running = false;
 
     if (result.error) {
-      recordError(result.error);
-      errorLog.capture({ level: 'error', source: 'engine', message: result.error });
       const diagnostics = result.diagnostics ?? [];
       setStatus(statusBar, 'error', summarizeDiagnostics(result.error, diagnostics));
-      setEditorDiagnostics(diagnostics);
-      renderEditorError(editorErrorPanel, result.error, diagnostics);
-      revealFirstDiagnostic();
       geometryDataEl.textContent = JSON.stringify({
         status: 'error',
         error: result.error,
@@ -5748,12 +5766,27 @@ async function main() {
         executionTimeMs: elapsed,
         codeHash: simpleHash(src),
       });
+      if (surfaceErrors) {
+        // Explicit run: record + show + log + jump to the first diagnostic now.
+        recordError(result.error);
+        errorLog.capture({ level: 'error', source: 'engine', message: result.error });
+        setEditorDiagnostics(diagnostics);
+        renderEditorError(editorErrorPanel, result.error, diagnostics);
+        revealFirstDiagnostic();
+        pendingEditorError = null;
+      } else {
+        // Auto-run: hold the error; the idle/blur trigger surfaces it quietly
+        // (no log, no caret jump, no error-history noise) if the code is still
+        // the same.
+        pendingEditorError = { error: result.error, diagnostics, src };
+      }
       return true;
     }
 
     if (result.mesh) {
       clearEditorDiagnostics();
       clearEditorErrorPanel(editorErrorPanel);
+      pendingEditorError = null;
       currentMeshData = result.mesh;
       // Release the previous Manifold's WASM-heap memory before overwriting.
       // Manifold objects live outside the JS heap and require manual .delete().

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -32,7 +32,7 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
   // Width is only applied via inline style at md+ (see syncEditorPaneWidth).
   // On mobile the pane uses flex sizing so both panes share the vertical space.
   const editorPane = document.createElement('div');
-  editorPane.className = 'flex flex-col flex-1 md:flex-none min-h-0 border-b md:border-b-0 md:border-r border-zinc-700';
+  editorPane.className = 'relative flex flex-col flex-1 md:flex-none min-h-0 border-b md:border-b-0 md:border-r border-zinc-700';
 
   const editorHeader = document.createElement('div');
   editorHeader.className = 'flex items-center px-3 py-1.5 bg-zinc-800 border-b border-zinc-700 gap-2';
@@ -74,9 +74,12 @@ export function createLayout(appContainer: HTMLElement): LayoutElements {
 
   editorPane.appendChild(editorHeader);
 
+  // Overlay (absolutely positioned) so showing/hiding it never reflows the code
+  // or moves the caret. Anchored to the bottom of the editor pane; long errors
+  // scroll within it.
   const editorErrorPanel = document.createElement('div');
   editorErrorPanel.id = 'editor-error-panel';
-  editorErrorPanel.className = 'hidden border-b border-red-500/30 bg-red-950/40 px-3 py-2 text-xs text-red-100';
+  editorErrorPanel.className = 'hidden absolute bottom-0 left-0 right-0 z-10 max-h-[45%] overflow-auto border-t border-red-500/40 bg-red-950/90 backdrop-blur-sm px-3 py-2 text-xs text-red-100 shadow-lg';
   editorPane.appendChild(editorErrorPanel);
 
   const editorContainer = document.createElement('div');

--- a/tests/editor-autocomplete.spec.ts
+++ b/tests/editor-autocomplete.spec.ts
@@ -1,0 +1,53 @@
+// Autocomplete for the manifold-js sandbox API. Drives the real CodeMirror
+// completion tooltip. The first-run tour is pre-dismissed so its backdrop
+// doesn't intercept the click into the editor.
+
+import { test, expect } from 'playwright/test';
+
+async function openEditor(page: import('playwright/test').Page) {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', new Date().toISOString()); } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+}
+
+async function replaceEditorWith(page: import('playwright/test').Page, text: string) {
+  await page.locator('.cm-content').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('Delete');
+  await page.keyboard.type(text, { delay: 15 });
+}
+
+test.describe('editor autocomplete', () => {
+  test('Manifold. suggests static constructors', async ({ page }) => {
+    await openEditor(page);
+    await replaceEditorWith(page, 'Manifold.c');
+    const tooltip = page.locator('.cm-tooltip-autocomplete');
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toContainText('cube');
+    await expect(tooltip).toContainText('cylinder');
+    // A CrossSection-only / instance method should NOT be in the static list.
+    await expect(tooltip).not.toContainText('offset');
+  });
+
+  test('accepting a completion inserts call parentheses', async ({ page }) => {
+    await openEditor(page);
+    await replaceEditorWith(page, 'Manifold.sph');
+    const tooltip = page.locator('.cm-tooltip-autocomplete');
+    await expect(tooltip).toBeVisible();
+    await tooltip.locator('[role="option"]').filter({ hasText: 'sphere' }).click();
+    await expect
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .poll(() => page.evaluate(() => (window as any).partwright.getCode()))
+      .toContain('Manifold.sphere(');
+  });
+
+  test('api. suggests injected sandbox members', async ({ page }) => {
+    await openEditor(page);
+    await replaceEditorWith(page, 'api.i');
+    const tooltip = page.locator('.cm-tooltip-autocomplete');
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toContainText('imports');
+  });
+});

--- a/tests/editor-live-errors.spec.ts
+++ b/tests/editor-live-errors.spec.ts
@@ -1,0 +1,62 @@
+// Live-error UX: auto-runs (typing) drive the preview but defer error surfacing
+// so the editor doesn't flicker an error / move the caret on every keystroke.
+// The error panel is a non-shifting overlay, and transient typing errors are
+// kept out of the diagnostic log.
+
+import { test, expect } from 'playwright/test';
+
+async function openEditor(page: import('playwright/test').Page) {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', new Date().toISOString()); } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+}
+
+async function replaceEditorWith(page: import('playwright/test').Page, text: string) {
+  await page.locator('.cm-content').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('Delete');
+  await page.keyboard.type(text, { delay: 10 });
+}
+
+// A distinctive runtime error so we can match it precisely in either panel.
+const BAD = 'return zzznotdefined123;';
+
+test.describe('editor live errors', () => {
+  test('errors are deferred while typing, then surface once idle', async ({ page }) => {
+    await openEditor(page);
+    const panel = page.locator('#editor-error-panel');
+    await replaceEditorWith(page, BAD);
+
+    // Not surfaced on the keystroke, nor mid-window before the idle delay.
+    await expect(panel).toBeHidden();
+    await page.waitForTimeout(450);
+    await expect(panel).toBeHidden();
+
+    // Surfaces after typing settles.
+    await expect(panel).toBeVisible({ timeout: 3000 });
+    await expect(panel).toContainText('zzznotdefined123');
+  });
+
+  test('the error panel is an overlay (does not reflow the editor)', async ({ page }) => {
+    await openEditor(page);
+    const panel = page.locator('#editor-error-panel');
+    await replaceEditorWith(page, BAD);
+    await expect(panel).toBeVisible({ timeout: 3000 });
+    await expect(panel).toHaveCSS('position', 'absolute');
+  });
+
+  test('transient typing errors stay out of the diagnostic log', async ({ page }) => {
+    await openEditor(page);
+    const panel = page.locator('#editor-error-panel');
+    await replaceEditorWith(page, BAD);
+    await expect(panel).toBeVisible({ timeout: 3000 });
+    await expect(panel).toContainText('zzznotdefined123');
+
+    await page.click('#btn-diagnostics');
+    const diag = page.locator('#diagnostics-panel');
+    await expect(diag).toBeVisible();
+    await expect(diag).not.toContainText('zzznotdefined123');
+  });
+});

--- a/tests/feedback-a11y.spec.ts
+++ b/tests/feedback-a11y.spec.ts
@@ -38,7 +38,8 @@ test.describe('feedback + a11y', () => {
     await page.waitForSelector('#btn-ai');
     await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
     await page.click('#btn-ai');
-    await page.locator('#ai-panel button:has-text("Connect Anthropic API")').dispatchEvent('click');
+    // The panel CTA opens the AI Settings modal (a modalShell dialog).
+    await page.locator('#ai-panel button:has-text("Connect an AI agent")').dispatchEvent('click');
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();


### PR DESCRIPTION
## Summary

Two editor-experience improvements, both scoped to the code editor.

### 1. Autocomplete for the manifold-js sandbox API
A CodeMirror completion source (`src/editor/apiCompletions.ts`) scoped to the JS language:
- `Manifold.` / `CrossSection.` → static constructors; `api.` → the exact injected members (`imports`, `label`, `labeledUnion`, `Curves`, the `setCircular*` knobs); any other `expr.` → the union of instance methods; bare identifiers → `Manifold` / `CrossSection` / `api` / `return`.
- Real signatures (the `detail`) + one-line docs (the `info` panel), transcribed from manifold-3d's type defs and the engine's `api` object. Callable members complete to `name()` with the cursor between the parens. OpenSCAD sessions unaffected.

### 2. Calmer live-error UX (addresses typing feedback)
Auto-running on every keystroke surfaced syntax errors mid-typing — the error panel (an in-flow block) reflowed the code and caret, the view jumped to the first diagnostic, and every transient failure spammed the diagnostic log.
- The error panel is now an **absolutely-positioned overlay** at the bottom of the editor pane — showing/hiding it never reflows the code.
- Auto-runs still drive the live 3D preview, but **error surfacing is deferred**: the held-back error appears only after typing is idle ~0.8s or the editor loses focus, and without jumping the caret.
- Transient auto-run errors no longer hit the **diagnostic log** or the AI error history. Explicit runs (Run, version load, `partwright.run`) still surface + log immediately.

Synced with the latest `staging`.

## Test plan
- [x] `npm run build` — clean
- [x] `npx playwright test` — full suite green (139 passed)
- [x] `tests/editor-autocomplete.spec.ts` — `Manifold.` lists constructors, accept inserts `sphere(`, `api.` lists `imports`
- [x] `tests/editor-live-errors.spec.ts` — errors deferred while typing then surface once idle; panel is `position: absolute`; transient errors stay out of the diagnostic log
- [ ] Manual: type broken code and confirm no caret jump / no layout shift; pause to see the gentle overlay; Run still jumps to the error

> Note: also carries the same one-line `feedback-a11y` test fix as #195 (staging's "Connect an AI agent" → AI Settings flow); identical change, merges cleanly.

https://claude.ai/code/session_01YJeQwLJSy7PyrzhGcyLc53