### PR TITLE
Fix AI model claiming paint is disabled after toggle re-enabled

### DIFF
--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -29,7 +29,11 @@ version) over explaining what you would do.
 If a tool you would normally use isn't in your tool list, the user has
 turned it off in the cost-control toggle bar — don't ask for it back, and
 don't apologize for not having it. Acknowledge the constraint and continue
-with what you can do.
+with what you can do. These toggles can change between turns: the
+"Capabilities this turn" list in the per-turn suffix below is the live
+source of truth. If it shows a capability as ON — paint included — that
+tool is available right now; use it even if it was off earlier in this
+conversation, and never tell the user it's disabled.
 
 When you paint something incorrectly, do NOT call clearColors() —
 that nukes every region and forces you to repaint everything. Call
@@ -232,20 +236,23 @@ export function loadAiMd(): Promise<string> {
  *  Sticking the active language in the suffix flips the prompt-vs-suffix
  *  signal ratio so the more-recent + more-specific instruction wins. */
 export function toggleSuffix(toggles: ChatToggles): string {
-  const restrictions: string[] = [];
+  // Behavioural guidance for each capability that's currently OFF — tells the
+  // model what to do instead of reaching for the disabled tool.
+  const offGuidance: string[] = [];
   if (!toggles.scope.runCode) {
-    restrictions.push('You CANNOT run code. Suggest code in chat for the user to run themselves.');
+    offGuidance.push('Run code is OFF — suggest code in chat for the user to run themselves; do not call runCode / runAndSave.');
   }
   if (!toggles.scope.saveVersions) {
-    restrictions.push('You CANNOT save new versions. Run-and-test is allowed but not commit.');
+    offGuidance.push('Save versions is OFF — run-and-test is allowed, but do not commit new versions.');
   }
   if (!toggles.scope.paintFaces) {
-    restrictions.push('You CANNOT paint faces / set color regions.');
+    offGuidance.push('Paint is OFF — do not call paint tools or set color regions.');
   }
   if (!toggles.vision.views) {
-    restrictions.push('You CANNOT call renderView. The user disabled auto-render to save cost — reason from code, geometry stats, and any images the user explicitly attaches (Show AI). Do not ask for screenshots.');
+    offGuidance.push('Auto-render is OFF — the user disabled it to save cost. Reason from code, geometry stats, and any images the user explicitly attaches (Show AI); do not ask for screenshots.');
   }
 
+  const onOff = (on: boolean): string => (on ? 'ON' : 'OFF');
   const lang = currentLanguage();
   const capLabel = MAX_ITERATIONS[toggles.maxIterations].promptLabel;
   const spendLabel = MAX_SPEND[toggles.maxSpend].promptLabel;
@@ -264,11 +271,24 @@ export function toggleSuffix(toggles: ChatToggles): string {
     `Iteration cap (tool round-trips this turn): ${capLabel}. Pace your tool calls accordingly — if the cap is low, batch related work and prefer one-shot tools like paintComponent or paintInBox over verify-then-paint loops.`,
     `Spend cap (total USD this session): ${spendLabel}. Prior turns in this session count toward the same budget, so the cap can fire mid-turn even on a cheap iteration. Vision tool calls (renderView, paintPreview withImage) are the most expensive — skip them when stats alone are enough.`,
     qualityLine(),
+    '',
+    // Positive, explicit capability list. The user can flip these toggles
+    // mid-conversation; this suffix is regenerated every turn, so it is the
+    // live source of truth. Declaring each one ON/OFF — rather than only
+    // listing what's forbidden — stops the model from claiming a freshly
+    // enabled tool (paint especially) is still off just because nothing
+    // positively told it the state had changed.
+    'Capabilities this turn — the live, current state, which OVERRIDES anything said earlier in this conversation. If one shows ON that was OFF before, the user just enabled it: use it, and do not tell the user it is disabled.',
+    `- Run code: ${onOff(toggles.scope.runCode)}`,
+    `- Save versions: ${onOff(toggles.scope.saveVersions)}`,
+    `- Paint / color regions: ${onOff(toggles.scope.paintFaces)}`,
+    `- Session notes: ${onOff(toggles.scope.sessionNotes)}`,
+    `- Auto-render (renderView / renderViews): ${onOff(toggles.vision.views)}`,
   ];
-  if (restrictions.length > 0) {
+  if (offGuidance.length > 0) {
     lines.push('');
-    lines.push('User has restricted you this session:');
-    for (const r of restrictions) lines.push(`- ${r}`);
+    lines.push('Reminders for the capabilities that are OFF:');
+    for (const g of offGuidance) lines.push(`- ${g}`);
   }
   return lines.join('\n');
 }

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -638,3 +638,37 @@ test.describe('Multi-provider AI', () => {
     await expect(page.locator('a[href*="platform.openai.com"]')).toBeVisible();
   });
 });
+
+test.describe('Capability suffix', () => {
+  // Regression: when the user flipped the Paint toggle ON mid-conversation,
+  // the per-turn system suffix merely dropped its "you cannot paint"
+  // restriction line — it never positively asserted that paint was now
+  // available. The model kept claiming paint was off on the first request
+  // after enabling, only believing the user once told a second time. The
+  // suffix now declares each capability ON/OFF explicitly so a freshly
+  // enabled tool is unambiguous on the very next turn.
+  test('positively declares paint ON/OFF based on the toggle', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel');
+    const { offSuffix, onSuffix } = await page.evaluate(async () => {
+      const sp = await import('/src/ai/systemPrompt.ts');
+      const settings = await import('/src/ai/settings.ts');
+      const base = settings.loadSettings();
+      const off = settings.setToggles(base, { scope: { paintFaces: false } }).toggles;
+      const on = settings.setToggles(base, { scope: { paintFaces: true } }).toggles;
+      return { offSuffix: sp.toggleSuffix(off), onSuffix: sp.toggleSuffix(on) };
+    });
+
+    // OFF: explicit OFF in the capability list + a behavioural reminder.
+    expect(offSuffix).toContain('Paint / color regions: OFF');
+    expect(offSuffix).toContain('Paint is OFF');
+
+    // ON: explicit ON, and no lingering "off" signal for paint that the
+    // model could anchor on.
+    expect(onSuffix).toContain('Paint / color regions: ON');
+    expect(onSuffix).not.toContain('Paint / color regions: OFF');
+    expect(onSuffix).not.toContain('Paint is OFF');
+    // The override directive that tells the model the list beats earlier turns.
+    expect(onSuffix).toContain('OVERRIDES anything said earlier');
+  });
+});


### PR DESCRIPTION
## Summary

The AI model was incorrectly claiming that the paint tool was disabled on the first turn after the user re-enabled it mid-conversation. This happened because the system prompt suffix only listed disabled capabilities as restrictions, never positively asserting which tools were currently available. When a tool was toggled back ON, the model had no explicit signal that the state had changed.

## Changes

- **System prompt guidance**: Updated the main system prompt to clarify that the per-turn capability list is the authoritative source of truth and overrides any earlier statements about disabled tools.

- **Capability list format**: Restructured `toggleSuffix()` to generate an explicit "Capabilities this turn" section that declares each tool as either ON or OFF, rather than only listing disabled tools as restrictions. This ensures:
  - Freshly enabled tools are unambiguous on the very next turn
  - The model sees a positive ON/OFF state for each capability
  - The suffix is regenerated every turn, making it the live source of truth

- **Behavioral guidance**: Renamed `restrictions` to `offGuidance` and updated the messaging for disabled capabilities to be more specific about what the model should do instead (e.g., "Paint is OFF — do not call paint tools" instead of "You CANNOT paint faces").

- **Test coverage**: Added a regression test in `ai-providers.spec.ts` that verifies:
  - When paint is OFF: the suffix contains both the explicit OFF declaration and a behavioral reminder
  - When paint is ON: the suffix contains the explicit ON declaration and no lingering OFF signals
  - The OVERRIDES directive is present to reinforce that the capability list beats earlier turns

## Implementation Details

The new capability list format includes:
- Run code (ON/OFF)
- Save versions (ON/OFF)
- Paint / color regions (ON/OFF)
- Session notes (ON/OFF)
- Auto-render (ON/OFF)

Each is prefixed with an override directive explaining that this list supersedes anything said earlier in the conversation, preventing the model from anchoring on stale information about disabled tools.

https://claude.ai/code/session_01HdV4JpjZ4HQSmLQJDeAiDm