### PR TITLE
feat: export toasts, live status region, and modal focus management

### DIFF
--- a/src/export/gltf.ts
+++ b/src/export/gltf.ts
@@ -55,7 +55,8 @@ export async function buildGLB(customName?: string): Promise<BuiltExport> {
   }
 }
 
-export async function exportGLB(customName?: string): Promise<void> {
+export async function exportGLB(customName?: string): Promise<string> {
   const built = await buildGLB(customName);
   downloadBlob(built.blob, built.filename, 'GLB');
+  return built.filename;
 }

--- a/src/export/obj.ts
+++ b/src/export/obj.ts
@@ -93,9 +93,10 @@ export function buildOBJ(meshData: MeshData, customName?: string): BuiltExport {
   return { blob, filename: getExportFilename('obj', customName), mimeType };
 }
 
-export function exportOBJ(meshData: MeshData, customName?: string): void {
+export function exportOBJ(meshData: MeshData, customName?: string): string {
   const built = buildOBJ(meshData, customName);
   downloadBlob(built.blob, built.filename, 'OBJ');
+  return built.filename;
 }
 
 function matName(hex: string): string {

--- a/src/export/stl.ts
+++ b/src/export/stl.ts
@@ -83,7 +83,8 @@ export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
   return { blob, filename: getExportFilename('stl', customName), mimeType };
 }
 
-export function exportSTL(meshData: MeshData, customName?: string): void {
+export function exportSTL(meshData: MeshData, customName?: string): string {
   const built = buildSTL(meshData, customName);
   downloadBlob(built.blob, built.filename, 'STL');
+  return built.filename;
 }

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -116,7 +116,8 @@ ${triangles.join('\n')}
   return { blob, filename: getExportFilename('3mf', customName), mimeType };
 }
 
-export function export3MF(meshData: MeshData, customName?: string): void {
+export function export3MF(meshData: MeshData, customName?: string): string {
   const built = build3MF(meshData, customName);
   downloadBlob(built.blob, built.filename, '3MF');
+  return built.filename;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -961,24 +961,25 @@ async function main() {
     onExportGLB: async () => {
       try {
         if (currentMeshData) assertFiniteMesh(currentMeshData);
-        await exportGLB();
+        const filename = await exportGLB();
+        showToast(`Exported ${filename}`, { variant: 'success' });
       } catch (e) {
         showToast(e instanceof Error ? e.message : 'GLB export failed', { variant: 'warn' });
       }
     },
     onExportSTL: () => {
       if (!currentMeshData) return;
-      try { exportSTL(currentMeshData); }
+      try { showToast(`Exported ${exportSTL(currentMeshData)}`, { variant: 'success' }); }
       catch (e) { showToast(e instanceof Error ? e.message : 'STL export failed', { variant: 'warn' }); }
     },
     onExportOBJ: () => {
       if (!currentMeshData) return;
-      try { exportOBJ(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData); }
+      try { showToast(`Exported ${exportOBJ(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData)}`, { variant: 'success' }); }
       catch (e) { showToast(e instanceof Error ? e.message : 'OBJ export failed', { variant: 'warn' }); }
     },
     onExport3MF: () => {
       if (!currentMeshData) return;
-      try { export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData); }
+      try { showToast(`Exported ${export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData)}`, { variant: 'success' }); }
       catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
     },
     onExportSessionJSON: async () => {
@@ -5981,6 +5982,9 @@ async function main() {
 }
 
 function setStatus(el: HTMLElement, state: 'ready' | 'running' | 'error' | 'loading', text: string) {
+  // Announce status changes (Ready / Running / Error) to assistive tech.
+  el.setAttribute('role', 'status');
+  el.setAttribute('aria-live', 'polite');
   el.textContent = text;
   el.title = text;
   el.className = 'text-xs font-mono max-w-[60%] truncate text-right ';

--- a/src/ui/modalShell.ts
+++ b/src/ui/modalShell.ts
@@ -32,6 +32,15 @@ export interface ModalShell {
 }
 
 let currentModal: HTMLElement | null = null;
+let modalSeq = 0;
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function focusableIn(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter(el => el.offsetParent !== null || el === document.activeElement);
+}
 
 export function createModalShell(opts: ModalShellOptions): ModalShell {
   // Only one shell modal at a time. Close any previous before showing
@@ -41,6 +50,9 @@ export function createModalShell(opts: ModalShellOptions): ModalShell {
     currentModal.dispatchEvent(new CustomEvent('shell:force-close'));
   }
 
+  // Remember what was focused so we can restore it when the modal closes.
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+
   const maxW = `max-w-${opts.maxWidth ?? 'md'}`;
   const maxH = opts.scrollable ? 'max-h-[calc(100vh-2rem)]' : '';
   const overlayPad = opts.scrollable ? 'p-4' : '';
@@ -48,12 +60,18 @@ export function createModalShell(opts: ModalShellOptions): ModalShell {
   const overlay = document.createElement('div');
   overlay.className = `fixed inset-0 bg-black/60 flex items-center justify-center z-50 ${overlayPad}`;
 
+  const titleId = `modal-title-${++modalSeq}`;
   const modal = document.createElement('div');
   modal.className = `bg-zinc-800 rounded-xl shadow-2xl border border-zinc-700 w-full ${maxW} ${maxH} flex flex-col`.replace(/\s+/g, ' ').trim();
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+  modal.setAttribute('aria-labelledby', titleId);
+  modal.tabIndex = -1;
 
   const header = document.createElement('div');
   header.className = 'px-5 py-3 border-b border-zinc-700 flex items-center justify-between';
   const titleEl = document.createElement('h2');
+  titleEl.id = titleId;
   titleEl.className = 'text-sm font-semibold text-zinc-100';
   titleEl.textContent = opts.title;
   header.appendChild(titleEl);
@@ -81,12 +99,42 @@ export function createModalShell(opts: ModalShellOptions): ModalShell {
   document.addEventListener('keydown', escHandler);
   overlay.addEventListener('shell:force-close', () => close());
 
+  // Keep Tab focus inside the dialog so keyboard users can't tab into the
+  // (inert) page behind it. Wraps both directions, and pulls focus in if it's
+  // currently on the container or has escaped the modal.
+  modal.addEventListener('keydown', (e: KeyboardEvent) => {
+    if (e.key !== 'Tab') return;
+    const focusables = focusableIn(modal);
+    if (focusables.length === 0) { e.preventDefault(); return; }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    const idx = active ? focusables.indexOf(active) : -1;
+    if (e.shiftKey && (active === first || idx === -1)) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && (active === last || idx === -1)) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
+
+  // Move focus into the dialog on open — but only if the caller hasn't already
+  // focused something inside it (e.g. an input via setTimeout), so we don't
+  // steal focus from a more intentional target.
+  requestAnimationFrame(() => {
+    if (closed || modal.contains(document.activeElement)) return;
+    (focusableIn(modal)[0] ?? modal).focus();
+  });
+
   function close(): void {
     if (closed) return;
     closed = true;
     document.removeEventListener('keydown', escHandler);
     overlay.remove();
     if (currentModal === overlay) currentModal = null;
+    // Restore focus to whatever opened the modal, if it's still in the document.
+    if (previouslyFocused && previouslyFocused.isConnected) previouslyFocused.focus();
     opts.onClose?.();
   }
 

--- a/tests/feedback-a11y.spec.ts
+++ b/tests/feedback-a11y.spec.ts
@@ -1,0 +1,60 @@
+// Feedback + accessibility polish:
+//  - export actions surface a success toast
+//  - the status indicator is an ARIA live region
+//  - modalShell dialogs expose dialog semantics and trap Tab focus
+
+import { test, expect } from 'playwright/test';
+
+async function openEditor(page: import('playwright/test').Page) {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', new Date().toISOString()); } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+}
+
+test.describe('feedback + a11y', () => {
+  test('exporting surfaces a success toast', async ({ page }) => {
+    await openEditor(page);
+    await page.click('#btn-export');
+    await page.locator('#export-dropdown').getByText('STL', { exact: true }).click();
+    await expect(
+      page.locator('div[role="status"]').filter({ hasText: /Exported .*\.stl/ }),
+    ).toBeVisible();
+  });
+
+  test('the status indicator is an ARIA live region', async ({ page }) => {
+    await openEditor(page);
+    const status = page.locator('#status-indicator');
+    await expect(status).toHaveAttribute('role', 'status');
+    await expect(status).toHaveAttribute('aria-live', 'polite');
+  });
+
+  test('modal dialogs expose dialog semantics and trap Tab focus', async ({ page }) => {
+    await page.addInitScript(() => {
+      try { localStorage.setItem('partwright-tour-completed', new Date().toISOString()); } catch { /* ignore */ }
+    });
+    await page.goto('/editor');
+    await page.waitForSelector('#btn-ai');
+    await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
+    await page.click('#btn-ai');
+    await page.locator('#ai-panel button:has-text("Connect Anthropic API")').dispatchEvent('click');
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+    // Focus lands inside the dialog on open.
+    await expect.poll(() => page.evaluate(() => {
+      const d = document.querySelector('[role="dialog"]');
+      return !!d && d.contains(document.activeElement);
+    })).toBe(true);
+
+    // Tabbing repeatedly keeps focus trapped inside the dialog.
+    for (let i = 0; i < 6; i++) await page.keyboard.press('Tab');
+    expect(await page.evaluate(() => {
+      const d = document.querySelector('[role="dialog"]');
+      return !!d && d.contains(document.activeElement);
+    })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Polish across action feedback and accessibility.

**Feedback**
- Mesh exports (GLB / STL / OBJ / 3MF) now show an `Exported <filename>` success toast. Previously a successful export was completely silent. The four `export*` functions now return their filename to drive the toast (error toasts already existed).

**Accessibility**
- The status indicator (`#status-indicator`) is now an `aria-live="polite"` / `role="status"` region, so screen readers announce Ready / Running / Error transitions.
- `modalShell` dialogs (AI key/settings, quality, export options, compaction, …) gain:
  - `role="dialog"` + `aria-modal="true"` + `aria-labelledby` (the title)
  - focus moved **into** the dialog on open — but only if the caller hasn't already focused something (e.g. an input), so we don't fight intentional focus
  - a **Tab focus trap** that wraps in both directions and pulls focus back if it escapes
  - **focus restoration** to the element that opened the modal, on close

Centralizing the modal changes in `modalShell` means every existing modal benefits at once.

Independent of #192 / #195 / #196.

### Deliberately deferred
Confirmation prompts on the remaining destructive actions (annotation "Clear all", note delete) are left out to keep this PR focused and avoid changing those flows' behavior — easy to add as a follow-up if you want them.

## Test plan
- [x] `npm run build` — clean
- [x] `npx playwright test` — 129 passed (no flakes this run), including the full modal suite (no regressions from the modalShell change)
- [x] New `tests/feedback-a11y.spec.ts`: export success toast, status live-region attributes, dialog semantics + Tab-trap + focus-on-open
- [ ] Manual: screen-reader announcement of status; Esc restores focus to the opener; Shift+Tab wraps backward

https://claude.ai/code/session_01YJeQwLJSy7PyrzhGcyLc53

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJeQwLJSy7PyrzhGcyLc53)_