### PR TITLE
feat: generalize AI connect flow and add per-key model loading

### DIFF
--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -74,6 +74,27 @@ export async function validateKey(apiKey: string): Promise<string | null> {
   }
 }
 
+/** Fetch the models this key can actually use, newest first. Mirrors the
+ *  Gemini/OpenAI list helpers so the settings modal can offer "Load models
+ *  from your key" for every hosted provider — handy for dated snapshots and
+ *  brand-new releases that aren't in the curated `ANTHROPIC_MODEL_OPTIONS`
+ *  list yet. Returns `{ id, label }` pairs; throws on a non-OK response. */
+export async function listModels(apiKey: string): Promise<{ id: string; label: string }[]> {
+  const client = getClient(apiKey);
+  try {
+    const page = await client.models.list({ limit: 1000 });
+    const out: { id: string; label: string }[] = [];
+    for (const m of page.data) {
+      out.push({ id: m.id, label: m.display_name ? `${m.display_name} (${m.id})` : m.id });
+    }
+    return out; // API already returns most-recently-released first.
+  } catch (err) {
+    if (err instanceof Anthropic.AuthenticationError) throw new Error('Invalid API key.');
+    if (err instanceof Anthropic.APIError) throw new Error(`${err.status ?? 'API'}: ${err.message}`);
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}
+
 export interface StreamCallbacks {
   /** Called for each text delta as it arrives. Use to incrementally update
    *  the in-progress assistant bubble. */

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -73,6 +73,35 @@ export async function validateKey(apiKey: string): Promise<string | null> {
   }
 }
 
+/** Fetch the chat-capable models this key can use. OpenAI's /v1/models
+ *  endpoint returns everything (embeddings, audio, image, moderation…), so
+ *  we filter to the gpt-/o-series chat families and drop the non-chat
+ *  variants. Mirrors the Gemini/Anthropic helpers so the settings modal can
+ *  offer "Load models from your key" for every hosted provider. Throws on a
+ *  non-OK response. */
+export async function listModels(apiKey: string): Promise<{ id: string; label: string }[]> {
+  const res = await fetch('https://api.openai.com/v1/models', {
+    method: 'GET',
+    headers: authHeaders(apiKey),
+  });
+  if (!res.ok) {
+    if (res.status === 401) throw new Error('Invalid API key.');
+    const body = await res.text().catch(() => '');
+    throw new Error(`OpenAI ${res.status}: ${body.slice(0, 200) || res.statusText}`);
+  }
+  const data = await res.json() as { data?: Array<{ id?: string }> };
+  const out: { id: string; label: string }[] = [];
+  for (const m of data.data ?? []) {
+    if (!m.id) continue;
+    if (!/^(gpt-|o1|o3|o4|chatgpt)/i.test(m.id)) continue;
+    // Drop non-chat variants that share the gpt- prefix.
+    if (/embedding|whisper|tts|audio|dall-e|image|moderation|realtime|transcribe/i.test(m.id)) continue;
+    out.push({ id: m.id, label: m.id });
+  }
+  out.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
+  return out;
+}
+
 export interface StreamCallbacks {
   onText?: (delta: string) => void;
   onToolStart?: (toolUseId: string, toolName: string) => void;

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -396,8 +396,8 @@ function mergeWithDefaults(partial: LegacyAiSettings): AiSettings {
   const requestedProvider = tgls.provider ?? (legacyIsLocal ? 'local' : DEFAULT_SETTINGS.toggles.provider);
   // If we had to drop a saved local-model id (curated list pruned it), also
   // revert the provider. Otherwise the AI panel sticks on "No local model
-  // picked" instead of offering the dual "Connect Anthropic API or run a
-  // local model" prompt that fresh users get.
+  // picked" instead of offering the generic "Connect an AI agent" prompt
+  // that fresh users get.
   const localModelCleared = rawLocalModel !== null && validLocalModel === null;
   const provider = localModelCleared && requestedProvider === 'local'
     ? DEFAULT_SETTINGS.toggles.provider

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1040,11 +1040,10 @@ function panelStatusUpdate(): void {
     panelStatusEl.appendChild(hint);
     return;
   }
-  // Hosted providers (anthropic / openai / gemini) all need a key. The
-  // banner is provider-aware: Anthropic keeps the literal "Connect
-  // Anthropic API" label (the stale-model smoke test anchors on it),
-  // OpenAI/Gemini show their own labels. The "or run a local model"
-  // fallback is offered in every case.
+  // Hosted providers (anthropic / openai / gemini) all need a key. When the
+  // active provider has none, surface a single generic CTA that opens the
+  // full AI settings modal — every provider (incl. the no-key local option)
+  // lives there, so we no longer push one provider over the others.
   const activeProvider = settings.toggles.provider as Exclude<Provider, 'local'>;
   void getKey(activeProvider).then(key => {
     if (!panelStatusEl) return;
@@ -1055,21 +1054,11 @@ function panelStatusUpdate(): void {
       panelStatusEl.appendChild(document.createTextNode('Not connected. '));
       const link = document.createElement('button');
       link.className = 'underline text-amber-200 hover:text-amber-100';
-      link.textContent = activeProvider === 'anthropic'
-        ? 'Connect Anthropic API'
-        : `Connect ${providerLabel(activeProvider)}`;
+      link.textContent = 'Connect an AI agent';
       link.addEventListener('click', () => {
-        void showAiKeyModal({ provider: activeProvider, onConnected: () => { panelStatusUpdate(); } });
+        void showAiSettingsModal({ onChange: () => { renderTranscript(); renderToggleStrip(); renderCostMeter(); renderModelPicker(); renderPromptChip(); panelStatusUpdate(); } });
       });
       panelStatusEl.appendChild(link);
-      panelStatusEl.appendChild(document.createTextNode(' or '));
-      const local = document.createElement('button');
-      local.className = 'underline text-amber-200 hover:text-amber-100';
-      local.textContent = 'run a local model';
-      local.addEventListener('click', () => {
-        void showAiLocalModal({ onChange: () => { panelStatusUpdate(); renderToggleStrip(); renderCostMeter(); renderModelPicker(); renderPromptChip(); } });
-      });
-      panelStatusEl.appendChild(local);
       panelStatusEl.appendChild(document.createTextNode('.'));
     } else {
       panelStatusEl.classList.add('hidden');

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1021,14 +1021,14 @@ function panelStatusUpdate(): void {
       panelStatusEl.classList.add('text-zinc-400');
     }
     // Quality hint — always shown when local is the active provider so the
-    // user knows Anthropic exists and is sharper. Click opens settings on
-    // the Anthropic tab where the explicit Enable button lives.
+    // user knows cloud providers exist and are sharper. Click opens AI
+    // Settings (on a cloud tab) where the Enable buttons live.
     const hint = document.createElement('div');
     hint.className = 'text-zinc-400 mt-0.5';
-    hint.appendChild(document.createTextNode('Switch to the '));
+    hint.appendChild(document.createTextNode('Choose a '));
     const switchLink = document.createElement('button');
     switchLink.className = 'underline text-zinc-200 hover:text-zinc-50';
-    switchLink.textContent = 'Anthropic provider';
+    switchLink.textContent = 'non-local AI provider';
     switchLink.addEventListener('click', () => {
       void showAiSettingsModal(
         { onChange: () => { renderTranscript(); renderToggleStrip(); renderCostMeter(); renderModelPicker(); renderPromptChip(); panelStatusUpdate(); } },

--- a/src/ui/aiSettingsModal.ts
+++ b/src/ui/aiSettingsModal.ts
@@ -4,8 +4,8 @@
 // once at the bottom.
 
 import { deleteKey, getKey } from '../ai/db';
-import { resetClient } from '../ai/anthropic';
-import { resetClient as resetOpenaiClient } from '../ai/openai';
+import { resetClient, listModels as listAnthropicModels } from '../ai/anthropic';
+import { resetClient as resetOpenaiClient, listModels as listOpenaiModels } from '../ai/openai';
 import { resetClient as resetGeminiClient, listModels as listGeminiModels } from '../ai/gemini';
 import { formatUsd } from '../ai/cost';
 import { showAiKeyModal } from './aiKeyModal';
@@ -115,7 +115,7 @@ async function renderTabContent(
   cb: AiSettingsCallbacks,
   rerender: () => void,
 ): Promise<void> {
-  container.appendChild(buildEnableRow(viewedTab, cb, rerender));
+  container.appendChild(await buildEnableRow(viewedTab, cb, rerender));
 
   if (viewedTab === 'anthropic') {
     container.appendChild(buildAnthropicIntro());
@@ -147,12 +147,18 @@ async function renderTabContent(
 /** Row beneath the tab strip that surfaces whether the viewed provider is
  *  the active one — and, when it isn't, the "Enable" button that actually
  *  switches. Making this a deliberate click step fixes the prior bug where
- *  users couldn't tell that tab clicks already changed the provider. */
-function buildEnableRow(viewedTab: Provider, cb: AiSettingsCallbacks, rerender: () => void): HTMLElement {
+ *  users couldn't tell that tab clicks already changed the provider.
+ *
+ *  A hosted provider can't be enabled until its key is connected (you'd just
+ *  switch to a provider that 401s on the first turn), so the button stays
+ *  disabled until then. Local needs no key, so it's always enabled. */
+async function buildEnableRow(viewedTab: Provider, cb: AiSettingsCallbacks, rerender: () => void): Promise<HTMLElement> {
   const settings = loadSettings();
   const activeProvider = settings.toggles.provider;
   const isActive = activeProvider === viewedTab;
   const otherLabel = providerLabel(viewedTab);
+  const needsKey = viewedTab !== 'local';
+  const hasKey = needsKey ? !!(await getKey(viewedTab)) : true;
 
   const wrap = document.createElement('div');
   wrap.className = 'flex items-center justify-between gap-3 rounded border px-3 py-2 ' + (
@@ -171,22 +177,31 @@ function buildEnableRow(viewedTab: Provider, cb: AiSettingsCallbacks, rerender: 
   sub.className = 'text-[11px] text-zinc-400';
   sub.textContent = isActive
     ? 'Chat turns are sent to this provider.'
-    : `Viewing settings only — click Enable to send chat turns through ${otherLabel}.`;
+    : hasKey
+      ? `Viewing settings only — click Enable to send chat turns through ${otherLabel}.`
+      : `Connect your ${otherLabel} key below to enable it.`;
   left.appendChild(sub);
   wrap.appendChild(left);
 
   if (!isActive) {
     const btn = document.createElement('button');
-    btn.className = 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white';
+    btn.className = hasKey
+      ? 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white'
+      : 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-zinc-700 text-zinc-500 cursor-not-allowed';
     btn.textContent = `Enable ${otherLabel}`;
-    btn.title = `Switch the active provider to ${otherLabel}. You can switch back any time.`;
-    btn.addEventListener('click', () => {
-      saveSettings(setProvider(loadSettings(), viewedTab));
-      cb.onChange();
-      // Re-render the modal in place so the Active pill lands on the
-      // right tab and the Enable row flips to its "active" state.
-      rerender();
-    });
+    btn.disabled = !hasKey;
+    btn.title = hasKey
+      ? `Switch the active provider to ${otherLabel}. You can switch back any time.`
+      : `Connect your ${otherLabel} key before enabling it.`;
+    if (hasKey) {
+      btn.addEventListener('click', () => {
+        saveSettings(setProvider(loadSettings(), viewedTab));
+        cb.onChange();
+        // Re-render the modal in place so the Active pill lands on the
+        // right tab and the Enable row flips to its "active" state.
+        rerender();
+      });
+    }
     wrap.appendChild(btn);
   }
   return wrap;
@@ -220,10 +235,61 @@ function buildLocalIntro(): HTMLElement {
   return wrap;
 }
 
+/** "Load models from your key" button shared by all three hosted providers.
+ *  Calls the provider's list endpoint and hands the live list to `onLoaded`
+ *  so the caller can swap its option buttons. Reports counts / errors inline
+ *  (no modal). Model ids rev fast and a hard-coded list goes stale, so this
+ *  is the reliable way to surface the account's current lineup with exact
+ *  ids (new GPT / o-series snapshots, Gemini 3 / Nano Banana, dated Claude
+ *  snapshots) that aren't in the curated starter lists yet. */
+function buildLoadModelsRow(
+  provider: Exclude<Provider, 'local'>,
+  onLoaded: (models: { id: string; label: string }[]) => void,
+): HTMLElement {
+  const listModels = provider === 'anthropic'
+    ? listAnthropicModels
+    : provider === 'openai'
+      ? listOpenaiModels
+      : listGeminiModels;
+  const row = document.createElement('div');
+  row.className = 'flex items-center gap-2';
+  const btn = document.createElement('button');
+  btn.className = 'px-2 py-1 rounded text-[11px] text-zinc-200 bg-zinc-700 hover:bg-zinc-600';
+  btn.textContent = 'Load models from your key';
+  const status = document.createElement('span');
+  status.className = 'text-[10px] text-zinc-500';
+  btn.addEventListener('click', async () => {
+    const key = await getKey(provider);
+    if (!key) { status.textContent = `Connect your ${providerLabel(provider)} key first.`; return; }
+    btn.disabled = true;
+    status.textContent = 'Loading…';
+    try {
+      const live = await listModels(key.apiKey);
+      if (live.length === 0) {
+        status.textContent = 'No chat models returned for this key.';
+      } else {
+        onLoaded(live);
+        status.textContent = `${live.length} model(s) loaded.`;
+      }
+    } catch (err) {
+      status.textContent = err instanceof Error ? err.message : String(err);
+    } finally {
+      btn.disabled = false;
+    }
+  });
+  row.appendChild(btn);
+  row.appendChild(status);
+  return row;
+}
+
 /** Default Anthropic model picker. The toggle-strip chip in the panel
  *  header drives the same setting; surfacing it here makes "change my
  *  default model" findable in the Settings dialog where users look. */
 function buildAnthropicModelSection(cb: AiSettingsCallbacks): HTMLElement {
+  // Starts from the curated tiers; "Load models from your key" can replace
+  // it with the account's real lineup (incl. dated snapshots).
+  let optionList: { id: string; label: string }[] = ANTHROPIC_MODEL_OPTIONS;
+
   const wrap = document.createElement('div');
   wrap.className = 'flex flex-col gap-2';
   const head = document.createElement('div');
@@ -233,7 +299,7 @@ function buildAnthropicModelSection(cb: AiSettingsCallbacks): HTMLElement {
 
   const desc = document.createElement('div');
   desc.className = 'text-[11px] text-zinc-400 leading-snug';
-  desc.innerHTML = 'Claude tier used for new turns. <strong>Haiku</strong> is fast and cheap; <strong>Sonnet</strong> is the balanced default; <strong>Opus</strong> is the smartest and most expensive. You can also switch on the fly from the dropdown in the chat header.';
+  desc.innerHTML = 'Claude tier used for new turns. <strong>Haiku</strong> is fast and cheap; <strong>Sonnet</strong> is the balanced default; <strong>Opus</strong> is the smartest and most expensive. Click <strong>Load models from your key</strong> to pull your account\'s full current lineup with exact ids. You can also switch on the fly from the dropdown in the chat header.';
   wrap.appendChild(desc);
 
   const seg = document.createElement('div');
@@ -241,9 +307,11 @@ function buildAnthropicModelSection(cb: AiSettingsCallbacks): HTMLElement {
   const renderButtons = () => {
     seg.replaceChildren();
     const current = loadSettings().toggles.anthropicModel;
-    for (const opt of ANTHROPIC_MODEL_OPTIONS) {
+    let matched = false;
+    for (const opt of optionList) {
       const b = document.createElement('button');
       const active = current === opt.id;
+      if (active) matched = true;
       b.className = active
         ? 'px-2 py-1 rounded text-[11px] bg-zinc-700 text-zinc-100 border border-zinc-600'
         : 'px-2 py-1 rounded text-[11px] text-zinc-300 border border-zinc-700 hover:bg-zinc-700/60';
@@ -255,9 +323,23 @@ function buildAnthropicModelSection(cb: AiSettingsCallbacks): HTMLElement {
       });
       seg.appendChild(b);
     }
+    // Surface a selected id that isn't in the current list (e.g. a loaded
+    // dated snapshot picked on a previous open) as a selected pill.
+    if (!matched && current) {
+      const b = document.createElement('button');
+      b.className = 'px-2 py-1 rounded text-[11px] bg-zinc-700 text-zinc-100 border border-zinc-600';
+      b.textContent = `${current} (custom)`;
+      seg.appendChild(b);
+    }
   };
   renderButtons();
   wrap.appendChild(seg);
+
+  wrap.appendChild(buildLoadModelsRow('anthropic', live => {
+    optionList = live;
+    renderButtons();
+  }));
+
   return wrap;
 }
 
@@ -314,7 +396,7 @@ function buildHostedModelSection(provider: HostedProvider, cb: AiSettingsCallbac
   desc.className = 'text-[11px] text-zinc-400 leading-snug';
   desc.innerHTML = provider === 'gemini'
     ? 'Model used for new turns. The starter list is the GA 2.5 family; click <strong>Load models from your key</strong> to pull your account\'s full current lineup (Gemini 3, Nano Banana, previews) with their exact ids. You can also switch on the fly from the chat header.'
-    : 'Model used for new turns. You can also switch on the fly from the dropdown in the chat header.';
+    : 'Model used for new turns. The starter list is curated; click <strong>Load models from your key</strong> to pull your account\'s full current lineup with exact ids. You can also switch on the fly from the dropdown in the chat header.';
   wrap.appendChild(desc);
 
   const seg = document.createElement('div');
@@ -349,42 +431,14 @@ function buildHostedModelSection(provider: HostedProvider, cb: AiSettingsCallbac
   renderButtons();
   wrap.appendChild(seg);
 
-  // Gemini-only: pull the key's actual available models. Model ids rev
-  // fast and a hard-coded list goes stale (guessed Gemini 3 ids 404'd),
-  // so this is the reliable way to surface current models like Gemini 3
-  // / Nano Banana with whatever id the account was granted.
-  if (provider === 'gemini') {
-    const loadRow = document.createElement('div');
-    loadRow.className = 'flex items-center gap-2';
-    const loadBtn = document.createElement('button');
-    loadBtn.className = 'px-2 py-1 rounded text-[11px] text-zinc-200 bg-zinc-700 hover:bg-zinc-600';
-    loadBtn.textContent = 'Load models from your key';
-    const loadStatus = document.createElement('span');
-    loadStatus.className = 'text-[10px] text-zinc-500';
-    loadBtn.addEventListener('click', async () => {
-      const key = await getKey('gemini');
-      if (!key) { loadStatus.textContent = 'Connect a Gemini key first.'; return; }
-      loadBtn.disabled = true;
-      loadStatus.textContent = 'Loading…';
-      try {
-        const live = await listGeminiModels(key.apiKey);
-        if (live.length === 0) {
-          loadStatus.textContent = 'No chat models returned for this key.';
-        } else {
-          optionList = live;
-          loadStatus.textContent = `${live.length} model(s) loaded.`;
-          renderButtons();
-        }
-      } catch (err) {
-        loadStatus.textContent = err instanceof Error ? err.message : String(err);
-      } finally {
-        loadBtn.disabled = false;
-      }
-    });
-    loadRow.appendChild(loadBtn);
-    loadRow.appendChild(loadStatus);
-    wrap.appendChild(loadRow);
-  }
+  // Pull the key's actual available models. Model ids rev fast and a
+  // hard-coded list goes stale (guessed Gemini 3 ids 404'd), so this is the
+  // reliable way to surface current models — Gemini 3 / Nano Banana, new
+  // GPT / o-series snapshots — with whatever id the account was granted.
+  wrap.appendChild(buildLoadModelsRow(provider, live => {
+    optionList = live;
+    renderButtons();
+  }));
 
   // Custom-id input.
   const customRow = document.createElement('div');

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -521,7 +521,7 @@ export function createToolbar(
   _aiBtn.id = 'btn-ai';
   _aiBtn.className = 'flex items-center gap-1.5 px-2 py-1 rounded text-xs text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 transition-colors ml-1';
   _aiBtn.innerHTML = '<span>✦ Connect AI</span>';
-  _aiBtn.title = 'Connect an Anthropic API key to chat with the AI';
+  _aiBtn.title = 'Connect an API key or download a local model to chat with the AI.';
   _aiBtn.addEventListener('click', callbacks.onToggleAi);
   toolbar.appendChild(_aiBtn);
 

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -443,8 +443,8 @@ test.describe('Multi-provider AI', () => {
     expect(tabLabels.some(l => /^Gemini \(cloud\)/.test(l))).toBe(true);
     expect(tabLabels.some(l => /^Local \(WebGPU\)/.test(l))).toBe(true);
 
-    // Scope to the modal shell — "Connect Anthropic API" also appears in
-    // the panel's not-connected banner, which would trip strict mode.
+    // Scope to the modal shell so the assertions can't accidentally match
+    // any same-named control elsewhere on the page.
     const modal = page.locator('.bg-zinc-800.rounded-xl').filter({ hasText: 'AI Settings' });
     // Anthropic tab is shown by default (fresh user → active provider).
     await expect(modal.locator('button:has-text("Connect Anthropic API")')).toBeVisible();
@@ -454,6 +454,69 @@ test.describe('Multi-provider AI', () => {
     // Switch to the Gemini tab → its Connect button appears.
     await page.locator('button:has-text("Gemini (cloud)")').dispatchEvent('click');
     await expect(modal.locator('button:has-text("Connect Google Gemini")')).toBeVisible();
+  });
+
+  test('Enable is gated on a connected key, except local', async ({ page }) => {
+    await page.goto('/editor');
+    await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch {} });
+    await page.reload();
+    await page.waitForSelector('#ai-panel');
+    await page.locator('#btn-ai').dispatchEvent('click');
+    await page.locator('#ai-panel button[title^="AI settings"]').dispatchEvent('click');
+    await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
+
+    // OpenAI tab with no key → Enable is disabled.
+    await page.locator('button:has-text("OpenAI (cloud)")').dispatchEvent('click');
+    await expect(page.locator('button:has-text("Enable OpenAI")')).toBeDisabled();
+
+    // Local needs no key → Enable is always available.
+    await page.locator('button:has-text("Local (WebGPU)")').dispatchEvent('click');
+    await expect(page.locator('button:has-text("Enable Local model")')).toBeEnabled();
+
+    // Plant an OpenAI key, return to the OpenAI tab → Enable flips on.
+    await page.evaluate(async () => {
+      await new Promise<void>((resolve, reject) => {
+        const open = indexedDB.open('partwright');
+        open.onsuccess = () => {
+          const db = open.result;
+          const txn = db.transaction('aiKeys', 'readwrite');
+          txn.objectStore('aiKeys').put({
+            provider: 'openai',
+            apiKey: 'sk-test-planted-key-0000000000',
+            createdAt: Date.now(),
+            lastUsed: Date.now(),
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+            totalCostUsd: 0,
+          });
+          txn.oncomplete = () => { db.close(); resolve(); };
+          txn.onerror = () => reject(txn.error);
+        };
+        open.onerror = () => reject(open.error);
+      });
+    });
+    await page.locator('button:has-text("OpenAI (cloud)")').dispatchEvent('click');
+    await expect(page.locator('button:has-text("Enable OpenAI")')).toBeEnabled();
+  });
+
+  test('every hosted provider can load models from the key', async ({ page }) => {
+    await page.goto('/editor');
+    await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch {} });
+    await page.reload();
+    await page.waitForSelector('#ai-panel');
+    await page.locator('#btn-ai').dispatchEvent('click');
+    await page.locator('#ai-panel button[title^="AI settings"]').dispatchEvent('click');
+    await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
+    const modal = page.locator('.bg-zinc-800.rounded-xl').filter({ hasText: 'AI Settings' });
+
+    // Anthropic tab (default) exposes the loader.
+    await expect(modal.locator('button:has-text("Load models from your key")')).toBeVisible();
+    // OpenAI tab too (was Gemini-only before).
+    await page.locator('button:has-text("OpenAI (cloud)")').dispatchEvent('click');
+    await expect(modal.locator('button:has-text("Load models from your key")')).toBeVisible();
+    // And Gemini.
+    await page.locator('button:has-text("Gemini (cloud)")').dispatchEvent('click');
+    await expect(modal.locator('button:has-text("Load models from your key")')).toBeVisible();
   });
 
   test('panel header model picker switches per provider', async ({ page }) => {
@@ -536,6 +599,30 @@ test.describe('Multi-provider AI', () => {
     await page.locator('#btn-ai').dispatchEvent('click');
     // Header shows OpenAI's chosen model.
     await expect(page.locator('#ai-panel select').first()).toHaveValue('gpt-5-nano');
+    // Enabling a provider now requires its key to be connected, so plant a
+    // dummy Anthropic key directly in IndexedDB (the app's DB already exists
+    // by now). Without it, "Enable Anthropic Claude" stays disabled.
+    await page.evaluate(async () => {
+      await new Promise<void>((resolve, reject) => {
+        const open = indexedDB.open('partwright');
+        open.onsuccess = () => {
+          const db = open.result;
+          const txn = db.transaction('aiKeys', 'readwrite');
+          txn.objectStore('aiKeys').put({
+            provider: 'anthropic',
+            apiKey: 'sk-ant-test-planted-key-0000000000',
+            createdAt: Date.now(),
+            lastUsed: Date.now(),
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+            totalCostUsd: 0,
+          });
+          txn.oncomplete = () => { db.close(); resolve(); };
+          txn.onerror = () => reject(txn.error);
+        };
+        open.onerror = () => reject(open.error);
+      });
+    });
     // Flip the active provider to Anthropic via the tabbed settings modal:
     // view the Anthropic tab, then click its "Enable" button.
     await page.locator('#ai-panel button[title^="AI settings"]').dispatchEvent('click');

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -111,8 +111,12 @@ test.describe('AI chat panel', () => {
     // late ?session= navigation doesn't tear down the modal mid-test.
     await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
     await page.click('#btn-ai');
+    // The panel CTA now opens the generic AI Settings modal; the per-provider
+    // key modal is one click deeper (Anthropic tab → Connect Anthropic API).
     // dispatchEvent — same flex-child viewport quirk as the toggle pills.
-    await page.locator('#ai-panel button:has-text("Connect Anthropic API")').dispatchEvent('click');
+    await page.locator('#ai-panel button:has-text("Connect an AI agent")').dispatchEvent('click');
+    await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
+    await page.locator('button:has-text("Connect Anthropic API")').click();
     await expect(page.locator('input[type="password"]')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Connect Anthropic API' })).toBeVisible();
 
@@ -122,12 +126,12 @@ test.describe('AI chat panel', () => {
     await expect(page.locator('#btn-ai')).toContainText(/Connect AI/);
   });
 
-  test('stale local-model id falls back to the dual connect prompt', async ({ page }) => {
+  test('stale local-model id falls back to the connect prompt', async ({ page }) => {
     // Regression: when the curated local-model list is pruned, a user whose
     // saved provider was 'local' would get stuck on "No local model picked.
-    // Choose a model" instead of the friendlier "Connect Anthropic API or
-    // run a local model" dual prompt. Simulate by planting localStorage with
-    // a provider=local + bogus model id before the app boots.
+    // Choose a model" instead of the friendlier generic "Connect an AI agent"
+    // prompt that fresh users get. Simulate by planting localStorage with a
+    // provider=local + bogus model id before the app boots.
     await page.addInitScript(() => {
       localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({
         toggles: { provider: 'local', localModel: 'Bogus-Removed-Model-MLC' },
@@ -136,8 +140,7 @@ test.describe('AI chat panel', () => {
     await page.goto('/editor');
     await page.click('#btn-ai');
     const panel = page.locator('#ai-panel');
-    await expect(panel.locator('button:has-text("Connect Anthropic API")')).toBeVisible();
-    await expect(panel.locator('button:has-text("run a local model")')).toBeVisible();
+    await expect(panel.locator('button:has-text("Connect an AI agent")')).toBeVisible();
   });
 
   test('toggle pills flip state on click', async ({ page }) => {


### PR DESCRIPTION
## Summary

- **Generic connect CTA.** The AI chat panel's "not connected" banner no longer pushes Anthropic specifically. It now reads **"Connect an AI agent"** and opens the full **AI Settings** modal, where every provider (including the no-key local option) lives. (`src/ui/aiPanel.ts`)
- **Key-gated Enable.** In the settings modal, each **"Enable &lt;provider&gt;"** button stays **disabled until that provider's API key is connected** — you can't switch to a provider that would 401 on the first turn. Local (WebGPU) is exempt since it needs no key. The row's subtext explains what to do. (`src/ui/aiSettingsModal.ts`)
- **Load models from your key — now for every hosted provider.** Previously Gemini-only. Added `listModels` to `anthropic.ts` (SDK `models.list`) and `openai.ts` (`GET /v1/models`, filtered to the gpt-/o-series chat families). Extracted a shared `buildLoadModelsRow` helper used by all three hosted tabs, so the curated starter lists can be replaced with the account's real current lineup (dated snapshots, brand-new releases) with exact ids.
- Minor: aligned the initial toolbar AI-button tooltip with the existing generic disconnected-state wording.

## Test plan

- [x] `npm run build` — clean (tsc + vite)
- [x] `npm run test:e2e` — 127 passed; 1 unrelated paint-mode flake (`paint-camera-passthrough.spec.ts`) that passes on isolated re-run
- [x] Updated 2 smoke tests + 2 provider tests for the new flow; added 2 new tests (Enable gating, load-models presence across providers)
- [x] Visual check: panel shows "Connect an AI agent"; OpenAI tab shows a disabled "Enable OpenAI" with no key; "Load models from your key" present on Anthropic/OpenAI/Gemini tabs
- [ ] Live model-loading network calls (Anthropic/OpenAI) can't be exercised offline — covered by mirroring the working Gemini path; verify with a real key on staging

https://claude.ai/code/session_01G8E3yXtMFrP49ixh1GeYgX

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8E3yXtMFrP49ixh1GeYgX)_