### PR TITLE
Add fast hover tooltips and expand onboarding tour

### DIFF
--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -84,9 +84,9 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
     autoRetry: 0,
     maxIterations: 'low',
     maxSpend: 'cheap',
-    // Thinking stays off across every preset so applying a preset never
-    // silently turns on (and starts billing for) extended reasoning — it's
-    // an opt-in the user picks deliberately with the Thinking pill.
+    // The cheap preset leaves extended reasoning off to minimize spend.
+    // Standard (the default) and Full enable it — thinking ships on by
+    // default now; users can still dial it back with the Thinking pill.
     thinking: 'off',
     anthropicModel: 'claude-haiku-4-5',
   },
@@ -99,7 +99,7 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
     autoRetry: 1,
     maxIterations: 'medium',
     maxSpend: 'medium',
-    thinking: 'off',
+    thinking: 'high',
     anthropicModel: 'claude-sonnet-4-6',
   },
   full: {
@@ -108,7 +108,7 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
     autoRetry: 3,
     maxIterations: 'high',
     maxSpend: 'high',
-    thinking: 'off',
+    thinking: 'high',
     anthropicModel: 'claude-opus-4-7',
   },
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,7 @@ import { checkContainment, type ContainmentWarning } from './geometry/containmen
 import { setUnits as _setUnits, getUnits as _getUnits, type UnitSystem } from './geometry/units';
 import { initMeasureTool, activate as activateMeasure, deactivate as deactivateMeasure, getState as getMeasureState } from './ui/measureTool';
 import { maybeStartTour, resetTour, startTour } from './ui/tour';
+import { initTooltips } from './ui/tooltip';
 import { initTheme, getTheme, setTheme } from './ui/theme';
 import type { Theme } from './ui/theme';
 import { initPaintUI, isPaintOpen, forceDeactivate as closePaintMenu } from './color/paintUI';
@@ -635,6 +636,9 @@ async function main() {
   const app = document.getElementById('app')!;
   geometryDataEl = createGeometryDataElement();
   installTitleGuard();
+
+  // Replace the slow native `title` tooltips with fast styled ones app-wide.
+  initTooltips();
 
   // Overlay container for landing/help pages (sits above the editor UI)
   const overlayContainer = document.createElement('div');

--- a/src/style.css
+++ b/src/style.css
@@ -122,3 +122,27 @@
   border-bottom: 8px solid transparent;
   border-left: 8px solid var(--color-zinc-600);
 }
+
+/* Fast hover tooltips (replaces the slow native title delay) */
+.pw-tooltip {
+  position: fixed;
+  z-index: 10000;
+  max-width: 280px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: var(--color-zinc-800);
+  color: var(--color-zinc-100);
+  border: 1px solid var(--color-zinc-600);
+  font-size: 11px;
+  line-height: 1.4;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.pw-tooltip.visible {
+  opacity: 1;
+}

--- a/src/ui/tooltip.ts
+++ b/src/ui/tooltip.ts
@@ -1,0 +1,101 @@
+// Fast hover tooltips. The browser's native `title` tooltip only appears
+// after a long, browser-controlled delay (~0.5–1.5s) that JS can't shorten.
+// This replaces it app-wide: a single delegated listener watches for hover
+// over any `[title]` element, suppresses the native tooltip by lifting the
+// attribute, and shows a styled bubble after a short delay — restoring the
+// attribute on leave so accessibility tools still see it.
+
+const SHOW_DELAY_MS = 150;
+
+let initialized = false;
+let bubble: HTMLElement | null = null;
+let activeEl: Element | null = null;
+let stashedTitle: string | null = null;
+let showTimer: ReturnType<typeof setTimeout> | undefined;
+
+export function initTooltips(): void {
+  if (initialized) return;
+  initialized = true;
+
+  bubble = document.createElement('div');
+  bubble.className = 'pw-tooltip';
+  bubble.setAttribute('role', 'tooltip');
+  document.body.appendChild(bubble);
+
+  document.addEventListener('pointerover', onPointerOver);
+  document.addEventListener('pointerout', onPointerOut);
+  // A click usually triggers an action that mutates layout, so drop the
+  // tooltip immediately rather than leaving it floating over new content.
+  document.addEventListener('pointerdown', hide, true);
+  // Any scroll invalidates the anchored position.
+  document.addEventListener('scroll', hide, true);
+}
+
+function onPointerOver(e: PointerEvent): void {
+  // Touch taps fire pointerover but there's no real hover — a tooltip would
+  // get stuck under the finger, so ignore touch entirely.
+  if (e.pointerType === 'touch') return;
+
+  const target = e.target as Element | null;
+  const el = target?.closest?.('[title]') as HTMLElement | null;
+  if (!el || el === activeEl) return;
+
+  const title = el.getAttribute('title');
+  if (!title || !title.trim()) return;
+
+  // Tear down any previous hover before adopting the new target.
+  hide();
+
+  activeEl = el;
+  stashedTitle = title;
+  el.removeAttribute('title'); // suppress the native (slow) tooltip
+  showTimer = setTimeout(() => show(el, title), SHOW_DELAY_MS);
+}
+
+function onPointerOut(e: PointerEvent): void {
+  if (!activeEl) return;
+  // Moving onto a descendant of the hovered element is not a real leave.
+  const related = e.relatedTarget as Node | null;
+  if (related && activeEl.contains(related)) return;
+  hide();
+}
+
+function show(el: Element, text: string): void {
+  if (!bubble || el !== activeEl || !el.isConnected) return;
+
+  bubble.textContent = text;
+
+  // Measure off-screen, then anchor below the element (flipping above when
+  // there isn't room) and clamp horizontally to the viewport.
+  bubble.style.visibility = 'hidden';
+  bubble.classList.add('visible');
+  const rect = el.getBoundingClientRect();
+  const gap = 6;
+  const margin = 8;
+  const tw = bubble.offsetWidth;
+  const th = bubble.offsetHeight;
+
+  let top = rect.bottom + gap;
+  if (top + th + margin > window.innerHeight) {
+    const above = rect.top - th - gap;
+    if (above >= margin) top = above;
+  }
+  let left = rect.left + rect.width / 2 - tw / 2;
+  left = Math.max(margin, Math.min(window.innerWidth - tw - margin, left));
+  top = Math.max(margin, top);
+
+  bubble.style.left = `${left}px`;
+  bubble.style.top = `${top}px`;
+  bubble.style.visibility = '';
+}
+
+function hide(): void {
+  clearTimeout(showTimer);
+  showTimer = undefined;
+  if (activeEl && stashedTitle !== null && !activeEl.hasAttribute('title')) {
+    activeEl.setAttribute('title', stashedTitle); // restore for a11y / reuse
+  }
+  activeEl = null;
+  stashedTitle = null;
+  bubble?.classList.remove('visible');
+}

--- a/src/ui/tour.ts
+++ b/src/ui/tour.ts
@@ -39,6 +39,27 @@ const STEPS: TourStep[] = [
     placement: 'left',
   },
   {
+    target: '#wireframe-toggle',
+    title: 'Mesh Edges',
+    description:
+      'Overlay the model’s mesh edges (wireframe) on the shaded surface to check topology and triangle density — useful before exporting or simplifying.',
+    placement: 'left',
+  },
+  {
+    target: '#paint-toggle',
+    title: 'Paint Colors',
+    description:
+      'Paint coplanar regions of the model in color for multi-color 3D prints (exported via 3MF or OBJ). Painting locks the version read-only until you unlock it; the AI can paint too when its Paint scope is on.',
+    placement: 'left',
+  },
+  {
+    target: '#simplify-toggle',
+    title: 'Simplify',
+    description:
+      'Reduce a dense model’s triangle count to a target budget — great for shrinking imported STLs or heavy booleans. Preview the reduction and save it as a new version.',
+    placement: 'left',
+  },
+  {
     target: '#session-bar',
     title: 'Sessions & Versions',
     description:
@@ -67,9 +88,30 @@ const STEPS: TourStep[] = [
     placement: 'bottom',
   },
   {
+    target: '#btn-catalog',
+    title: 'Catalog',
+    description:
+      'Browse a catalog of premade models. Open one as a starting point and tweak the code yourself — or hand it to the AI to remix.',
+    placement: 'bottom',
+  },
+  {
+    target: '#import-wrapper',
+    title: 'Import',
+    description:
+      'Import an .stl mesh, a .js / .scad source file, or a full .partwright.json session. Imported meshes render right away and can be edited or combined with new geometry.',
+    placement: 'bottom',
+  },
+  {
     target: '#export-wrapper',
     title: 'Export',
     description: 'Download your model as GLB, STL, OBJ, or 3MF for 3D printing or other tools.',
+    placement: 'bottom',
+  },
+  {
+    target: '#btn-ai',
+    title: 'AI Chat',
+    description:
+      'Chat with an AI to build and refine models for you. Use Anthropic, OpenAI, or Google Gemini with your own key — or run a model entirely in your browser with WebGPU, no key needed. Budget presets and the Thinking pill tune cost vs. quality, and the review button gets a second opinion from another provider.',
     placement: 'bottom',
   },
 ];

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -407,7 +407,7 @@ test.describe('Multi-provider AI', () => {
     expect(out.chatHigh.reasoning_effort).toBeUndefined();
   });
 
-  test('Thinking pill is in the toggle strip, defaults Off, and persists', async ({ page }) => {
+  test('Thinking pill is in the toggle strip, defaults High, and persists', async ({ page }) => {
     await page.goto('/editor');
     await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch {} });
     await page.reload();
@@ -415,12 +415,13 @@ test.describe('Multi-provider AI', () => {
     await page.locator('#btn-ai').dispatchEvent('click');
     const thinkSel = page.locator('#ai-panel select[title^="Thinking:"]');
     await expect(thinkSel).toBeVisible();
-    await expect(thinkSel).toHaveValue('off');
-    await thinkSel.selectOption('high');
+    // Thinking now ships on by default (the standard preset uses 'high').
+    await expect(thinkSel).toHaveValue('high');
+    await thinkSel.selectOption('off');
     const stored = await page.evaluate(() =>
       JSON.parse(localStorage.getItem('partwright-ai-settings-v1') || '{}').toggles?.thinking,
     );
-    expect(stored).toBe('high');
+    expect(stored).toBe('off');
   });
 
   test('settings modal has a tab per provider', async ({ page }) => {


### PR DESCRIPTION
## Summary
Replaces the slow native browser `title` tooltip (0.5–1.5s delay) with a fast, styled custom tooltip system that appears after 150ms. Also expands the onboarding tour with new steps for recently added features and enables extended reasoning (thinking) by default in standard and full presets.

## Key Changes

- **Fast tooltip system** (`src/ui/tooltip.ts`):
  - Single delegated listener watches for hover over `[title]` elements
  - Suppresses native tooltip by removing the attribute on hover, restores on leave (preserves accessibility)
  - Shows styled bubble after 150ms delay with smart positioning (flips above if no room below, clamps to viewport)
  - Dismisses on click, scroll, or touch (touch ignored entirely to avoid stuck tooltips)
  - Styled with dark background, border, shadow, and smooth fade transition

- **Tooltip styling** (`src/style.css`):
  - Fixed positioning, max-width 280px, high z-index (10000)
  - Dark zinc theme matching app palette
  - Opacity transition for smooth appear/disappear

- **Expanded onboarding tour** (`src/ui/tour.ts`):
  - Added steps for Mesh Edges (wireframe toggle)
  - Added steps for Paint Colors (paint toggle)
  - Added steps for Simplify (simplify toggle)
  - Added steps for Catalog and Import buttons
  - Added step for AI Chat button with provider and budget details

- **Extended reasoning defaults** (`src/ai/settings.ts`):
  - Changed `standard` preset: thinking now defaults to `'high'` (was `'off'`)
  - Changed `full` preset: thinking now defaults to `'high'` (was `'off'`)
  - `cheap` preset remains `'off'` to minimize spend
  - Updated comment to reflect that thinking ships on by default; users can dial it back with the Thinking pill

- **Test update** (`tests/ai-providers.spec.ts`):
  - Updated "Thinking pill" test to expect `'high'` as default instead of `'off'`
  - Adjusted test logic to verify persistence when toggling from high to off

- **Initialization** (`src/main.ts`):
  - Added `initTooltips()` call during app startup to enable the tooltip system app-wide

## Implementation Details

The tooltip system uses a single reusable bubble element with delegated event listeners for efficiency. The `pointerType` check filters out touch events to avoid tooltips getting stuck under fingers. The positioning logic measures the bubble off-screen first, then anchors it below the target element with a 6px gap, flipping above if there isn't room, and clamping horizontally to keep it in the viewport with an 8px margin.

The tour expansion provides better onboarding coverage for the Paint, Simplify, and Catalog features that were previously undocumented in the tour flow.

The thinking defaults change makes extended reasoning available by default in the standard and full presets, improving model quality while allowing users to opt down via the Thinking pill if they want to reduce cost.

https://claude.ai/code/session_01TuChmAP6aEgo6r3eKp7XCY