### PR TITLE
docs: keep PR description in sync when pushing new work to a PR branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,7 +315,7 @@ Anything unlabeled lands in "Other Changes." That's fine for occasional internal
 
 ### After Opening a PR
 
-Opening the PR (see [the standing instruction](#pull-requests--always-open-one-when-a-task-is-complete) in Deployment) isn't the finish line. Once it's up, do two things — they can run in parallel:
+Opening the PR (see [the standing instruction](#pull-requests--always-open-one-when-a-task-is-complete) in Deployment) isn't the finish line. Once it's up, do the following (the first two can run in parallel):
 
 **1. Kick off an automated review pass.** Right after pushing the initial PR, launch a review subagent (the Agent tool) over your branch diff against `origin/staging` and the code it touches. Have it hunt specifically for problems your change may have introduced:
 
@@ -333,6 +333,8 @@ Surface the results on the PR (a review comment, or fold clear fixes straight in
 3. Re-check CI after the push, and keep iterating until the checks are green.
 
 Only push fixes you're confident in — failures clearly caused by your own changes. If a failure is ambiguous, unrelated to your changes, or would require a large refactor or a risky/destructive change to resolve, stop and ask the user instead of pushing speculative fixes.
+
+**3. Keep the PR description in sync with the branch.** Any time you push new work to an open PR — review fixes, CI fixes, or follow-up commits that go beyond the PR's original scope — re-check the PR description and update it to cover the *totality* of the work now on the branch, not just what existed when the PR was first opened. Fold the new changes into the Summary, refresh the Test plan, and bring the title, prefix, and labels back in line with the [commit & PR conventions](#commit--pr-conventions) if the scope has grown. The description and the branch diff should never tell different stories — don't let the description silently drift behind the work.
 
 ## Common Errors
 

--- a/tests/feedback-a11y.spec.ts
+++ b/tests/feedback-a11y.spec.ts
@@ -38,7 +38,7 @@ test.describe('feedback + a11y', () => {
     await page.waitForSelector('#btn-ai');
     await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
     await page.click('#btn-ai');
-    await page.locator('#ai-panel button:has-text("Connect Anthropic API")').dispatchEvent('click');
+    await page.locator('#ai-panel button:has-text("Connect an AI agent")').dispatchEvent('click');
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();


### PR DESCRIPTION
## Summary

Adds a third item — **"Keep the PR description in sync with the branch"** — to the **After Opening a PR** section of `CLAUDE.md`. Whenever new work is pushed to an open PR branch (review fixes, CI fixes, or follow-up commits beyond the original scope), the PR description must be re-checked and updated so it reflects the *totality* of the work on the branch, not just what existed when the PR was first opened — folding new changes into the Summary, refreshing the Test plan, and re-aligning title/prefix/labels with the commit & PR conventions if scope has grown. The section intro was reworded ("do two things" → "do the following (the first two can run in parallel)") to accommodate the new item.

**Net diff against `staging` is `CLAUDE.md` only.** (Fittingly, this PR description has itself been kept in sync per the rule it adds.)

While re-syncing, an inherited `tests/feedback-a11y.spec.ts` failure (the generalized AI connect flow renamed the panel CTA) was also fixed — but staging landed an identical fix independently via #202, so on the latest merge that change is no longer part of this PR's net diff.

## Test plan

- [x] `npm run build` passes on the merged tree.
- [x] Full `npm run test:e2e` — **140/140 pass** on the merged tree (suite grew as staging added editor-autocomplete / live-error / saveVersion tests). The `paint-camera-passthrough` test, which is cold-start flaky, passed warm in this full run.

## Notes

- Docs-only net change; no production code modified.
- Branch re-synced through the latest `origin/staging` (editor autocomplete, live-error overlay, saveVersion chat tool); all merges conflict-free except the `feedback-a11y` overlap noted above, resolved by taking staging's canonical version.