### PR TITLE
fix: register saveVersion as an in-app chat tool

### DIFF
--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -372,6 +372,16 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'saveVersion',
+    description: 'Snapshot the CURRENT editor code, geometry, color regions, and annotations as a new gallery version WITHOUT re-running the code. Use this to persist a painted/annotated state — unlike runAndSave it does NOT re-execute the code, so it won\'t re-resolve color regions against regenerated triangles (re-running new geometry with colors in memory misaligns them). For committing a code change, prefer runAndSave (runs + validates + saves in one call). Returns {id, index, label} on success, {skipped, reason} when nothing changed since the current version, or {error} if no session is active.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        label: { type: 'string', description: 'Short label for the gallery version. Defaults to v<index>.' },
+      },
+    },
+  },
+  {
     name: 'addSessionNote',
     description: 'Append a durable note to the session log. Notes survive compaction and are visible to future agents. Prefix with one of [REQUIREMENT], [DECISION], [FEEDBACK], [MEASUREMENT], [ATTEMPT], [TODO].',
     input_schema: {
@@ -852,7 +862,7 @@ const ALWAYS_AVAILABLE = new Set([
 ]);
 
 const RUN_GATED = new Set(['runCode']);
-const SAVE_GATED = new Set(['runAndSave', 'loadVersion']);
+const SAVE_GATED = new Set(['runAndSave', 'loadVersion', 'saveVersion']);
 const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);
 /** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
@@ -869,9 +879,12 @@ export function buildToolList(toggles: ChatToggles): ToolDefinition[] {
     if (ALWAYS_AVAILABLE.has(t.name)) return true;
     if (RUN_GATED.has(t.name)) return toggles.scope.runCode;
     if (SAVE_GATED.has(t.name)) {
-      // loadVersion is non-mutating but gating it under saveVersions keeps
-      // the model from rewinding state when the user has paused commits.
-      return t.name === 'loadVersion' ? toggles.scope.saveVersions : (toggles.scope.runCode && toggles.scope.saveVersions);
+      // loadVersion (rewind) and saveVersion (snapshot) don't execute code,
+      // so they only need the saveVersions scope. Gating loadVersion here also
+      // keeps the model from rewinding state when the user has paused commits.
+      // runAndSave runs first, so it additionally needs the runCode scope.
+      const nonRunning = t.name === 'loadVersion' || t.name === 'saveVersion';
+      return nonRunning ? toggles.scope.saveVersions : (toggles.scope.runCode && toggles.scope.saveVersions);
     }
     if (PAINT_GATED.has(t.name)) return toggles.scope.paintFaces;
     if (NOTES_GATED.has(t.name)) return toggles.scope.sessionNotes;
@@ -1125,6 +1138,8 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.listVersions();
     case 'loadVersion':
       return api.loadVersion({ index: input.index as number });
+    case 'saveVersion':
+      return api.saveVersion(input.label as string | undefined);
     case 'addSessionNote':
       return api.addSessionNote(input.text as string);
     case 'listSessionNotes':

--- a/tests/ai-saveversion-tool.spec.ts
+++ b/tests/ai-saveversion-tool.spec.ts
@@ -1,0 +1,78 @@
+// Regression: the in-app chat agent could call `saveVersion` (it's a
+// window.partwright console method documented in ai.md right next to
+// runAndSave), but it was never registered as a chat tool — so the call
+// fell through to dispatch()'s default branch and came back as
+// "Unknown tool: saveVersion". This covers both that the tool is now
+// listed (gated under the saveVersions scope) and that it dispatches to
+// the console API end to end.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+test.describe('saveVersion chat tool', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('is listed under the saveVersions scope and dispatches to the console API', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const result = await page.evaluate(async () => {
+      const tools = await import('/src/ai/tools.ts');
+      const baseToggles = {
+        vision: { views: true, resolution: 'medium', angles: 'auto' },
+        scope: { runCode: true, saveVersions: true, paintFaces: true, sessionNotes: true },
+        autoRetry: 0,
+        maxIterations: 'medium',
+        maxSpend: 'high',
+        thinking: 'off',
+        provider: 'anthropic',
+        anthropicModel: 'claude-haiku-4-5',
+        localModel: null,
+        openaiModel: 'gpt-5-mini',
+        geminiModel: 'gemini-flash-latest',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const listFor = (t: any) => tools.buildToolList(t).map((d) => d.name);
+      const withSave = listFor(baseToggles).includes('saveVersion');
+      const withoutSave = listFor({ ...baseToggles, scope: { ...baseToggles.scope, saveVersions: false } }).includes('saveVersion');
+
+      // End-to-end dispatch: a base version, then a divergent edit that
+      // saveVersion should snapshot as a fresh version (not a dedup skip).
+      const pw = (window as unknown as { partwright: {
+        createSession: (n?: string) => Promise<unknown>;
+        runAndSave: (code: string, label?: string) => Promise<unknown>;
+        setCode: (code: string) => unknown;
+        run: (code?: string) => Promise<unknown>;
+      } }).partwright;
+      await pw.createSession('saveversion-tool-test');
+      await pw.runAndSave('const { Manifold } = api; return Manifold.cube([10, 10, 10], true);', 'base');
+      const changed = 'const { Manifold } = api; return Manifold.cube([14, 14, 14], true);';
+      pw.setCode(changed);
+      await pw.run(changed);
+
+      const exec = await tools.executeTool('saveVersion', { label: 'snap' });
+      return { withSave, withoutSave, exec };
+    });
+
+    // Listed when commits are allowed, removed when the user pauses them.
+    expect(result.withSave).toBe(true);
+    expect(result.withoutSave).toBe(false);
+
+    // The call dispatched to window.partwright instead of throwing the
+    // old "Unknown tool" error, and persisted a real version.
+    expect(result.exec.isError).toBe(false);
+    expect(result.exec.content).not.toContain('Unknown tool');
+    const saved = JSON.parse(result.exec.content) as { index?: number; label?: string };
+    expect(saved.index).toBe(2);
+    expect(saved.label).toBe('snap');
+  });
+});


### PR DESCRIPTION
## Summary

An in-app AI agent calling `saveVersion` got back **"Unknown tool: saveVersion"**. Root cause: `saveVersion` is a real `window.partwright` console method (`src/main.ts`) and is documented to the agent in `public/ai.md` right next to `runAndSave`, but it was never registered as a chat tool. The call fell through `dispatch()`'s `default` branch in `src/ai/tools.ts` and surfaced the "Unknown tool" error.

This left a genuine functional gap, not just a doc mismatch: after painting, the recommended way to persist color regions is `saveVersion` (it snapshots current state **without re-running** the code — `runAndSave` re-executes and can re-resolve colors against regenerated triangles). With paint enabled (the `full` preset), the agent could paint but had no tool to commit the result cleanly.

## Changes

- Add the `saveVersion` tool definition to `ALL_TOOLS`, alongside `listVersions`/`loadVersion`.
- Add the `saveVersion` dispatch case → `api.saveVersion(label)`.
- Gate it under the `saveVersions` scope (like `loadVersion`, it doesn't execute code, so it doesn't also require `runCode`).
- Add a regression test (`tests/ai-saveversion-tool.spec.ts`) covering scope gating + end-to-end dispatch through `executeTool`.

## Test plan

- [x] `npm run build` — passes
- [x] `npm run test:e2e` — new test passes; full suite green except one **pre-existing, unrelated** failure (see below)
- [x] New test: `saveVersion` is listed when `saveVersions` is ON, absent when OFF, and `executeTool('saveVersion', {label})` persists a version (no "Unknown tool")
- [x] Cross-checked all 52 declared tools are wired in `dispatch` (no other "Unknown tool" gaps)

## Note: pre-existing unrelated test failure

`tests/feedback-a11y.spec.ts` › "modal dialogs expose dialog semantics and trap Tab focus" fails on this branch — but it **also fails on clean `origin/staging`** (verified via worktree at `2e0b411`). It looks for an AI-panel button labeled `"Connect Anthropic API"`, but the panel now renders `"Connect an AI agent"` (`src/ui/aiPanel.ts:1200`). This came in with PR #198 and is out of scope here; flagging rather than bundling a speculative fix.

https://claude.ai/code/session_01Jvdky4wUsB2rDowWdcdKnv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jvdky4wUsB2rDowWdcdKnv)_