### PR TITLE
fix: register listRegions as an in-app chat tool

### DIFF
--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -557,6 +557,11 @@ const ALL_TOOLS: ToolDefinition[] = [
     input_schema: { type: 'object', properties: {} },
   },
   {
+    name: 'listRegions',
+    description: 'List every committed color region on the current mesh, in paint order. Each entry: {id, name, color, source, triangles (count), order, visible, bbox, centroid}. Returns [] when nothing is painted. This is the inventory you read to get a region id/name for removeRegion, paintExplain, and assertPaint — sibling of listComponents (mesh pieces) and listLabels (api.label features).',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
     name: 'removeRegion',
     description: 'Remove ONE color region by id (from listRegions). Use to delete a specific mistake when it is not the most recent paint operation — undoLastPaint is faster for the most recent.',
     input_schema: {
@@ -848,6 +853,10 @@ const ALWAYS_AVAILABLE = new Set([
   'findFaces',
   'listComponents',
   'listLabels',
+  // listRegions is a pure read, not a paint mutation, so it stays always-on
+  // even when paintFaces is disabled — its consumers paintExplain/assertPaint
+  // are always-available and need a region id to target.
+  'listRegions',
   'probePixel',
   'paintPreview',
   'paintExplain',
@@ -1229,6 +1238,8 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.undoLastPaint();
     case 'redoLastPaint':
       return api.redoLastPaint();
+    case 'listRegions':
+      return api.listRegions();
     case 'removeRegion':
       return api.removeRegion(input.id as number);
     case 'clearColors':

--- a/tests/ai-listregions-tool.spec.ts
+++ b/tests/ai-listregions-tool.spec.ts
@@ -1,0 +1,81 @@
+// Regression: the in-app chat agent was repeatedly told to "get the id from
+// listRegions()" — removeRegion, assertPaint and paintExplain tool schemas
+// plus the system prompt all reference it — but `listRegions` was never
+// registered as a chat tool. The call fell through dispatch()'s default
+// branch and came back as "Unknown tool: listRegions", leaving the agent
+// with no way to discover region ids. This covers that the tool is now
+// listed (always-available, even when painting is paused — its consumers
+// paintExplain/assertPaint are always-available too) and that it dispatches
+// to the console API end to end.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+test.describe('listRegions chat tool', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('is always listed (even with paint paused) and dispatches to the console API', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const result = await page.evaluate(async () => {
+      const tools = await import('/src/ai/tools.ts');
+      const baseToggles = {
+        vision: { views: true, resolution: 'medium', angles: 'auto' },
+        scope: { runCode: true, saveVersions: true, paintFaces: true, sessionNotes: true },
+        autoRetry: 0,
+        maxIterations: 'medium',
+        maxSpend: 'high',
+        thinking: 'off',
+        provider: 'anthropic',
+        anthropicModel: 'claude-haiku-4-5',
+        localModel: null,
+        openaiModel: 'gpt-5-mini',
+        geminiModel: 'gemini-flash-latest',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const listFor = (t: any) => tools.buildToolList(t).map((d) => d.name);
+      const listedDefault = listFor(baseToggles).includes('listRegions');
+      // Still listed when painting is paused — it's a read, and the always-on
+      // consumers paintExplain/assertPaint need a region id to target.
+      const listedWithPaintOff = listFor({ ...baseToggles, scope: { ...baseToggles.scope, paintFaces: false } }).includes('listRegions');
+
+      // End-to-end dispatch: build geometry, paint one region by explicit
+      // triangle id (deterministic regardless of mesh resolution), then list.
+      const pw = (window as unknown as { partwright: {
+        createSession: (n?: string) => Promise<unknown>;
+        runAndSave: (code: string, label?: string) => Promise<unknown>;
+        paintFaces: (input: { triangleIds: number[]; color: number[]; name?: string }) => unknown;
+      } }).partwright;
+      await pw.createSession('listregions-tool-test');
+      await pw.runAndSave('const { Manifold } = api; return Manifold.cube([10, 10, 10], true);', 'base');
+      pw.paintFaces({ triangleIds: [0], color: [1, 0, 0], name: 't0' });
+
+      const exec = await tools.executeTool('listRegions', {});
+      return { listedDefault, listedWithPaintOff, exec };
+    });
+
+    // Always available — present with full scope and with painting paused.
+    expect(result.listedDefault).toBe(true);
+    expect(result.listedWithPaintOff).toBe(true);
+
+    // The call dispatched to window.partwright instead of throwing the old
+    // "Unknown tool" error, and returned the painted region with its id.
+    expect(result.exec.isError).toBe(false);
+    expect(result.exec.content).not.toContain('Unknown tool');
+    const regions = JSON.parse(result.exec.content) as Array<{ id?: number; name?: string }>;
+    expect(Array.isArray(regions)).toBe(true);
+    expect(regions.length).toBe(1);
+    expect(typeof regions[0].id).toBe('number');
+    expect(regions[0].name).toBe('t0');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the `saveVersion` fix (#0d21c3d), which surfaced a class of defect: `window.partwright` methods documented in `ai.md` as agent actions that were never registered as chat tools, so the in-app agent's call fell through `dispatch()`'s default branch as **"Unknown tool: X"**.

I audited all three surfaces — the 149 `window.partwright` methods (`main.ts`), the chat tools + dispatch (`src/ai/tools.ts`), and every method `ai.md` tells agents to call — and reconciled them. After verifying candidates against what existing tools *already* expose, **`listRegions` was the one genuine, uncovered gap** (details below). This PR fixes only that.

`listRegions` is the worst instance of the pattern: **five existing tool/prompt strings already instruct the agent to "get the id from `listRegions()`"** — the `removeRegion`, `assertPaint`, and `paintExplain` schemas plus the system prompt — yet the tool didn't exist. The agent had no way to discover region ids.

## Changes (`src/ai/tools.ts`, mirroring the saveVersion fix)
- Tool definition for `listRegions`
- Dispatch case → `api.listRegions()`
- Gated under `ALWAYS_AVAILABLE` (it's a pure read like its `listComponents`/`listLabels` siblings; its always-available consumers `paintExplain`/`assertPaint` need a region id to target)
- New regression test `tests/ai-listregions-tool.spec.ts`

## Candidates ruled out (already covered — no fix needed)
- **`validate`** — redundant: the run tools (`runIsolated`/`runAndAssert`/`runCode`) already execute and surface the same parse/exec error.
- **`runAndExplain`** — mostly covered: its `components[]` is field-identical to `listComponents()` (already a tool), and `getGeometryData` now emits `warnings` flagging `componentCount > 1`. Only its auto fix-hints are unique — convenience, not a broken reference.
- Session lifecycle, UI/view toggles, exports, images, annotations — intentionally console-only (`ai.md:231` explicitly states the in-app agent has no session create/open/list tools).

## Test plan
- [x] `npm run build` — green
- [x] `npm run test:e2e` — 141 passed, including the new `ai-listregions-tool` spec
- [x] New test asserts: tool is listed (and stays listed when `paintFaces` is off), dispatches end-to-end after painting a region, and no longer returns "Unknown tool"

https://claude.ai/code/session_01PxbmcYRzpiUedHQcoAFYVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxbmcYRzpiUedHQcoAFYVh)_