### PR TITLE
feat: preserve the original model when saving a simplified version

### DIFF
--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -227,6 +227,16 @@ export function formatCode(): void {
   }
 }
 
+/** True when the editor's content has real edits relative to `code`, ignoring
+ *  pure formatting differences. `code` is run through the same auto-format pass
+ *  setValue() applies on load, so a freshly-loaded version reports "no edits"
+ *  even when its stored code was never formatted (e.g. saved raw via the
+ *  console API). When auto-format is off, compares the raw strings. */
+export function editorContentDiffersFrom(code: string): boolean {
+  const normalized = autoFormatEnabled ? applyFormat(code, currentLanguage) : code;
+  return getValue() !== normalized;
+}
+
 export function getAutoFormat(): boolean {
   return autoFormatEnabled;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCamer
 import { renderCompositeCanvas, renderSingleView, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode } from './renderer/multiview';
 import { generateId } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
-import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, getAutoFormat, setAutoFormat } from './editor/codeEditor';
+import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, getAutoFormat, setAutoFormat, editorContentDiffersFrom } from './editor/codeEditor';
 import { createLayout, type TabName } from './ui/layout';
 import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState } from './ui/toolbar';
 import { installKeyboardShortcuts } from './ui/keyboardShortcuts';
@@ -305,7 +305,19 @@ function clearEditorErrorPanel(panel: HTMLElement): void {
   panel.replaceChildren();
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// Surface session URLs in geometry-data so they're accessible even when
+// getGalleryUrl() is sandbox-blocked. Shared by the live geometry-data panel
+// and the off-screen version snapshot below so both carry the same context.
+function withSessionContext(data: Record<string, unknown>): Record<string, unknown> {
+  const state = getState();
+  if (state.session) {
+    data.sessionId = state.session.id;
+    data.sessionUrl = getSessionUrl();
+    data.galleryUrl = getGalleryUrl();
+  }
+  return data;
+}
+
 function updateGeometryData(executionTimeMs?: number, sourceCode?: string) {
   if (!currentMeshData) {
     geometryDataEl.textContent = JSON.stringify({ status: 'error', error: 'No geometry' });
@@ -314,26 +326,40 @@ function updateGeometryData(executionTimeMs?: number, sourceCode?: string) {
 
   // currentManifold may be null for render-only imports (sculpted STLs that
   // can't form a watertight manifold). computeGeometryStats degrades gracefully.
-  const data = computeGeometryStats(currentManifold, currentMeshData, executionTimeMs, sourceCode);
-  // Surface session URLs in geometry-data so they're accessible even when getGalleryUrl() is sandbox-blocked
-  const state = getState();
-  if (state.session) {
-    (data as Record<string, unknown>).sessionId = state.session.id;
-    (data as Record<string, unknown>).sessionUrl = getSessionUrl();
-    (data as Record<string, unknown>).galleryUrl = getGalleryUrl();
-  }
+  const data = withSessionContext(computeGeometryStats(currentManifold, currentMeshData, executionTimeMs, sourceCode));
   geometryDataEl.textContent = JSON.stringify(data, null, 2);
 }
 
-function captureThumbnail(): Promise<Blob | null> {
-  if (!currentMeshData) return Promise.resolve(null);
+function captureThumbnail(mesh: MeshData | null = currentMeshData): Promise<Blob | null> {
+  if (!mesh) return Promise.resolve(null);
   try {
-    const canvas = renderCompositeCanvas(applyTriColorsIfVisible(currentMeshData));
+    const canvas = renderCompositeCanvas(applyTriColorsIfVisible(mesh));
     return new Promise(resolve => {
       canvas.toBlob(b => resolve(b), 'image/png');
     });
   } catch {
     return Promise.resolve(null);
+  }
+}
+
+// Capture a thumbnail + geometry-data for an arbitrary `mesh` without touching
+// the live viewport (no updateMesh call → no flicker). Builds a throwaway
+// Manifold purely for the volumetric stats and releases it. Used to snapshot
+// the pre-simplify baseline as its own version during a simplify save.
+async function snapshotMeshAsVersion(
+  mesh: MeshData,
+  sourceCode: string,
+): Promise<{ thumbnail: Blob | null; geometryData: Record<string, unknown> | null }> {
+  const thumbnail = await captureThumbnail(mesh);
+  const mod = getModule();
+  const manifold = mod ? mod.Manifold.ofMesh(mesh) : null;
+  try {
+    const geometryData = withSessionContext(computeGeometryStats(manifold, mesh, undefined, sourceCode));
+    return { thumbnail, geometryData };
+  } finally {
+    if (manifold && typeof manifold.delete === 'function') {
+      try { manifold.delete(); } catch { /* already deleted */ }
+    }
   }
 }
 
@@ -1609,6 +1635,20 @@ async function main() {
       }
       try {
         const reduced = currentMeshData;
+
+        // Preserve the pre-simplify model as its own version first, so baking the
+        // reduced mesh (which overwrites the editor with an import wrapper) never
+        // silently discards the full-detail original. Skip when the editor already
+        // matches the current saved version (formatting-aware, so a version saved
+        // with raw code isn't re-saved just because the editor reformatted it).
+        const originalCode = getValue();
+        const current = getState().currentVersion;
+        let savedOriginal = false;
+        if (!current || editorContentDiffersFrom(current.code)) {
+          const original = await snapshotMeshAsVersion(baseline, originalCode);
+          savedOriginal = !!(await saveVersion(originalCode, original.geometryData, original.thumbnail));
+        }
+
         const baked = toImportedMesh(`simplified-${reduced.numTri}tri`, reduced);
         const code = generateImportCode([baked], { manifold: true });
         setActiveImports([baked]);
@@ -1620,7 +1660,13 @@ async function main() {
           force: true,
           importedMeshes: [baked],
         });
-        return { ok: true, message: `Saved as a new version (${reduced.numTri.toLocaleString()} triangles).` };
+        const tri = reduced.numTri.toLocaleString();
+        return {
+          ok: true,
+          message: savedOriginal
+            ? `Saved original + simplified (${tri} triangles).`
+            : `Saved as a new version (${tri} triangles).`,
+        };
       } catch (e) {
         return { ok: false, message: `Save failed: ${(e as Error).message}` };
       }

--- a/tests/simplify.spec.ts
+++ b/tests/simplify.spec.ts
@@ -120,4 +120,65 @@ test.describe('Simplify tool', () => {
     expect(versions.length).toBe(before + 1);
     expect(versions[versions.length - 1].label).toBe('simplified');
   });
+
+  test('Save as version preserves an unsaved edited original as its own version', async ({ page }) => {
+    const base = await openEditorWithSphere(page);
+
+    // Commit a baseline sphere as a saved version.
+    await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: { runAndSave(code: string, label?: string): Promise<unknown> } }).partwright;
+      await pw.runAndSave('const { Manifold } = api; return Manifold.sphere(10, 64);', 'sphere');
+    });
+
+    // Edit the model WITHOUT saving (different radius → different code, same
+    // triangle budget). This unsaved original is what should be preserved when
+    // the simplified mesh gets baked into a version.
+    await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: { run(code: string): Promise<unknown> } }).partwright;
+      await pw.run('const { Manifold } = api; return Manifold.sphere(12, 64);');
+    });
+
+    const before = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: { listVersions(): Promise<unknown[]> } }).partwright;
+      return (await pw.listVersions()).length;
+    });
+
+    await page.locator('#simplify-toggle').dispatchEvent('click');
+    await page.waitForSelector('#simplify-panel:not(.hidden)');
+
+    const target = Math.max(50, Math.round(base / 4));
+    await page.locator('#simplify-input').fill(String(target));
+    await page.waitForFunction(
+      (b) => {
+        const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
+        return (pw.getGeometryData().triangleCount ?? b) < b;
+      },
+      base,
+      { timeout: 10000 },
+    );
+
+    await page.locator('#simplify-save').dispatchEvent('click');
+    // The status line calls out that the original was preserved, not just saved.
+    await expect(page.locator('#simplify-status')).toContainText('original', { timeout: 10000 });
+
+    const indices = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: { listVersions(): Promise<{ index: number; label: string | null }[]> } }).partwright;
+      return (await pw.listVersions()).map(v => ({ index: v.index, label: v.label }));
+    });
+
+    // Two new versions: the preserved original, then the baked simplified import.
+    expect(indices.length).toBe(before + 2);
+    expect(indices[indices.length - 1].label).toBe('simplified');
+
+    // The second-newest version is the edited radius-12 sphere — a real geometry
+    // version, not an import, and distinct from the saved radius-10 baseline.
+    const originalIndex = indices[indices.length - 2].index;
+    const original = await page.evaluate(async (idx) => {
+      const pw = (window as unknown as { partwright: { loadVersion(t: { index: number }): Promise<{ code?: string }> } }).partwright;
+      return await pw.loadVersion({ index: idx });
+    }, originalIndex);
+    expect(original.code ?? '').toContain('Manifold.sphere');
+    expect(original.code ?? '').toContain('12');
+    expect(original.code ?? '').not.toContain('api.imports');
+  });
 });


### PR DESCRIPTION
## Summary

The Simplify tool's **Save as version** baked the reduced mesh into a new version and overwrote the editor with an import wrapper — silently discarding the full-detail original if it hadn't already been saved. Now the pre-simplify model is captured as its own version **first**, so the original is always preserved alongside the simplified one.

- Saves the original (pre-simplify) state as its own version before baking + saving the reduced mesh (`src/main.ts` simplify `save()` handler).
- **Skips the original-save when nothing changed**, so the common "open a saved version → simplify → save" path still produces just one new version. The check is formatting-aware (`editorContentDiffersFrom` in `src/editor/codeEditor.ts`) so a version stored with raw code (e.g. via the console API / `runAndSave`) isn't re-saved just because the editor auto-reformatted it on load.
- **No viewport flicker**: the original's thumbnail + geometry-data are rendered off-screen (`snapshotMeshAsVersion`) without swapping the live viewport geometry.
- Status line now reads `Saved original + simplified (…)` when an original was preserved, vs. the existing `Saved as a new version (…)` when it was already saved.
- Refactor: extracted the geometry-data session-context augmentation into a shared `withSessionContext` helper so the live panel and the off-screen snapshot stay consistent.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run test:e2e` — 151 passed
- [x] New test `tests/simplify.spec.ts` › *Save as version preserves an unsaved edited original as its own version*: edits the model without saving, then asserts the simplify save produces **two** versions (preserved original + simplified), and the preserved one is the real edited geometry (not an import).
- [x] Existing simplify tests still pass — the "nothing edited" case correctly yields just the one `simplified` version.
- [x] Re-synced with latest `origin/staging` (merge, rebuilt, full suite green).

https://claude.ai/code/session_01ArjnaniRiXYvZR6bH7BHpS

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArjnaniRiXYvZR6bH7BHpS)_