### PR TITLE
fix: keep AI chat pane input reachable on mobile

### DIFF
--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -406,7 +406,13 @@ function upsertHistoryMessage(msg: ChatMessage): void {
 function buildDrawer(): void {
   const root = document.createElement('div');
   root.id = 'ai-panel';
-  root.className = 'fixed top-0 right-0 h-screen bg-zinc-900 border-l border-zinc-700 shadow-2xl z-40 flex flex-col transition-transform duration-200 translate-x-full';
+  // h-dvh (dynamic viewport height) rather than h-screen/100vh: on mobile
+  // browsers 100vh measures the viewport with the URL bar hidden, so a
+  // fixed-position panel pushes its bottom (input + Send button) behind the
+  // browser chrome where scrolling can't reach it. dvh tracks the actually
+  // visible height. max-w-[100vw] caps the inline px width so the drawer can't
+  // overflow a phone narrower than panelWidth (it has no effect on desktop).
+  root.className = 'fixed top-0 right-0 h-dvh max-w-[100vw] bg-zinc-900 border-l border-zinc-700 shadow-2xl z-40 flex flex-col transition-transform duration-200 translate-x-full';
   root.style.width = `${panelWidth}px`;
   drawerEl = root;
 


### PR DESCRIPTION
## Summary

- The AI chat drawer used `h-screen` (`100vh`) while `position: fixed`. On mobile browsers `100vh` measures the viewport as if the URL bar were hidden, so the bottom of the panel — the message textarea and **Send** button — rendered behind the browser chrome with no way to scroll to it.
- Switched the drawer to `h-dvh` (dynamic viewport height) so the panel matches the actually-visible viewport, keeping the input and Send button on screen. `dvh == vh` on desktop, so there is no desktop change.
- Added `max-w-[100vw]` so the fixed 420px drawer width can't overflow phones narrower than the panel.

Single file touched: `src/ui/aiPanel.ts` (drawer root className).

## Test plan

- [x] `npm run build` passes; built CSS contains the generated utilities (`h-dvh` → `height: 100dvh`, `max-w-[100vw]` → `max-width: 100vw`)
- [ ] On a real mobile browser: open the AI panel and confirm the textarea + Send button are visible and reachable without scrolling off-screen
- [ ] Desktop: AI panel still opens at its normal width and pushes content as before

> Note: this bug only reproduces on a real mobile browser with a dynamic URL bar — headless Chrome has no browser chrome, so `100vh` already equals the visible height there and the issue can't be demonstrated in an automated screenshot.

https://claude.ai/code/session_01Av1b2VSanpkq2w7XY3JkRN