### PR TITLE
feat: edge smoothing for slab & shape paint + live triangle count

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -267,9 +267,9 @@ partwright.paintNearestRegion({point, color, searchRadius?, name?})       // sna
 partwright.paintNear({point, radius, normalCone?, color, name?})          // sphere selector
 partwright.paintStroke({points, radius, resolution?, maxEdge?, shape?, color, name?}) // SMOOTH brush: subdivides mesh for a rounded painted edge (see note below)
 partwright.paintInBox({box, normalCone?, color, name?})                   // AABB selector
-partwright.paintInOrientedBox({box: {center, size, quaternion?}, color})  // rotated box selector (same as UI Box tool)
+partwright.paintInOrientedBox({box: {center, size, quaternion?}, color, smooth?, resolution?, maxEdge?})  // rotated box selector (same as UI Box tool); SMOOTH edges by default
 partwright.paintFaces({triangleIds, color, name?})                        // explicit triangle ids
-partwright.paintSlab({axis|normal, offset, thickness, color, name?})      // planar range
+partwright.paintSlab({axis|normal, offset, thickness, color, name?, smooth?, resolution?, maxEdge?})  // planar range; SMOOTH edges by default
 partwright.paintByLabel({label, color, name?})                            // by api.label() name (manifold-js only)
 partwright.paintByLabels([{label, color, name?}, ...])                    // batch sibling
 partwright.paintComponent({index, color, name?, topOnly?})                // by listComponents() index
@@ -512,6 +512,8 @@ partwright.paintStroke({ points: [a.point, b.point], radius: 3, resolution: 256,
 ```
 
 `resolution` is the smoothness detail (target triangle edge = radius / resolution; higher = smoother + more triangles), default **256**, range 2–1024. For absolute control pass `maxEdge` instead (target edge in mesh units, e.g. `maxEdge: 0.1` for crisp 0.1-unit edges) — it overrides resolution. A single point stamps a rounded dot.
+
+`paintSlab` and `paintInOrientedBox` share the same subdivision pipeline: their analytic boundary (slab planes / box faces) is **smoothed by default**, so a slab band or box patch gets a clean edge across coarse faces and reconstructs deterministically on reload. Same knobs — `smooth` (default true), `resolution` (model bbox diagonal / resolution, default 256), and `maxEdge` (absolute override). Pass `smooth: false` for the old blocky behavior. The id-baking selectors (`paintInBox`, `paintNear`, `paintInCylinder`, `paintFaces`, …) can't be smoothed — they lock onto existing triangles; refine the model mesh first if you need a finer edge from them.
 
 ## Common gotchas
 

--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -354,6 +354,11 @@ partwright.paintSlab({
   thickness: 5,
   color: [1, 0.4, 0],
   name: "Bottom 5mm",
+  // Smoothing is ON by default: the two slab edges are subdivided so the band
+  // has clean straight edges even across coarse faces. Tune or disable it:
+  // resolution: 256,  // target edge = model bbox diagonal / resolution (2–1024)
+  // maxEdge: 0.1,     // OR absolute target edge length (overrides resolution)
+  // smooth: false,    // keep the raw blocky tessellation
 });
 
 // Tilted/oblique slab — pass an arbitrary normal vector. Doesn't need to be
@@ -365,7 +370,18 @@ partwright.paintSlab({
   thickness: 8,
   color: [0.8, 0, 0.5],
 });
+
+// Oriented shape: paint inside a rotated box (same selector as the UI Box tool).
+// Edge smoothing is ON by default here too (subdivides the mesh near the box
+// faces). smooth / resolution / maxEdge work exactly as for paintSlab.
+partwright.paintInOrientedBox({
+  box: { center: [10, 0, 5], size: [8, 4, 2], quaternion: [0, 0, 0.3827, 0.9239] },
+  color: [0.2, 0.7, 0.9],
+  // smooth: false, resolution: 256, maxEdge: ...
+});
 ```
+
+**Smoothing applies to the analytic shape tools.** `paintSlab` and `paintInOrientedBox` persist a *re-resolvable* descriptor (the slab plane / oriented box), so their boundary can be subdivided for a clean edge and reconstructed deterministically on reload — smoothing is on by default, exactly like `paintStroke`. The id-baking selectors (`paintInBox`, `paintNear`, `paintInCylinder`, `paintFaces`, `paintConnected`, …) lock onto the existing tessellation, so they cannot be smoothed; refine the mesh first (`.refine(n)` in the model code) if you need a finer edge from those.
 
 **Verifying paint before you commit it.** `paintPreview` accepts the same selectors as `paintInBox` / `paintNear` / `paintFaces`, *without* adding a region. Default: count-only (free sanity check). Pass `withImage: true` to also get a thumbnail with the candidate triangles tinted bright yellow on top of any existing paint.
 

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -494,7 +494,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintInOrientedBox',
-    description: 'Paint every triangle whose centroid lies inside a rotated oriented bounding box (OBB). Same selector as the UI Box paint tool. Reach for this when paintInBox catches the wrong faces because the feature is at an angle to the world axes — diagonal handles, tilted lids, rotated wings, etc. Defaults to the identity quaternion (no rotation) when `quaternion` is omitted, making it equivalent to paintInBox with the same center+size.',
+    description: 'Paint every triangle whose centroid lies inside a rotated oriented bounding box (OBB). Same selector as the UI Box paint tool. Reach for this when paintInBox catches the wrong faces because the feature is at an angle to the world axes — diagonal handles, tilted lids, rotated wings, etc. Defaults to the identity quaternion (no rotation) when `quaternion` is omitted, making it equivalent to paintInBox with the same center+size. The painted edge is SMOOTHED by default — the mesh is subdivided near the box faces so the edge follows the box, not the coarse tessellation. Pass `smooth: false` to keep the blocky edge, or tune `resolution` / `maxEdge`.',
     input_schema: {
       type: 'object',
       properties: {
@@ -510,13 +510,16 @@ const ALL_TOOLS: ToolDefinition[] = [
         },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
+        smooth: { type: 'boolean', description: 'Smooth the painted edge by subdividing the mesh near the box faces. Default true; pass false for the raw (blocky) tessellation.' },
+        resolution: { type: 'number', description: 'Smoothing detail: target boundary edge = model bbox diagonal / resolution. Higher = smoother + more triangles. Default 256, range 2–1024.' },
+        maxEdge: { type: 'number', description: 'Optional absolute override for the target boundary edge length (mesh units). Takes precedence over resolution.' },
       },
       required: ['box', 'color'],
     },
   },
   {
     name: 'paintSlab',
-    description: 'Paint everything in a Z-slab (or arbitrary-axis slab). One call. Use for "paint the rim of this disk", "paint the side walls", "paint the top 5mm". Same coverageMode / maxTriangleArea options as the other selectors.',
+    description: 'Paint everything in a Z-slab (or arbitrary-axis slab). One call. Use for "paint the rim of this disk", "paint the side walls", "paint the top 5mm". Same coverageMode / maxTriangleArea options as the other selectors. The two slab edges are SMOOTHED by default — the mesh is subdivided along them so the painted band has clean straight edges across coarse faces. Pass `smooth: false` to keep the blocky edge, or tune `resolution` / `maxEdge`.',
     input_schema: {
       type: 'object',
       properties: {
@@ -528,6 +531,9 @@ const ALL_TOOLS: ToolDefinition[] = [
         maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
+        smooth: { type: 'boolean', description: 'Smooth the slab edges by subdividing the mesh along them. Default true; pass false for the raw (blocky) tessellation.' },
+        resolution: { type: 'number', description: 'Smoothing detail: target boundary edge = model bbox diagonal / resolution. Higher = smoother + more triangles. Default 256, range 2–1024.' },
+        maxEdge: { type: 'number', description: 'Optional absolute override for the target boundary edge length (mesh units). Takes precedence over resolution.' },
       },
       required: ['offset', 'thickness', 'color'],
     },

--- a/src/color/boxDrag.ts
+++ b/src/color/boxDrag.ts
@@ -11,7 +11,7 @@ import { TransformControls } from 'three/addons/controls/TransformControls.js';
 import type { MeshData } from '../geometry/types';
 import { getScene, getCamera, getRenderer, setGizmoLock } from '../renderer/viewport';
 import { addRegion, getRegions } from './regions';
-import { getColor, getCurrentMesh } from './paintMode';
+import { getColor, getCurrentMesh, shapeSmoothDescriptorFields } from './paintMode';
 import { findShapeTriangles, type OrientedBox, type ShapeType } from './boxPaint';
 import { meshBounds } from './slabPaint';
 
@@ -304,11 +304,12 @@ export function commitBox(): number {
   if (triangles.size === 0) return 0;
 
   const existingCount = getRegions().length;
+  const { smooth, maxEdge } = shapeSmoothDescriptorFields(mesh);
   addRegion(
     `${shapeLabel(shapeType)} ${existingCount + 1}`,
     [...getColor()] as [number, number, number],
     'slab',
-    { kind: 'box', center: box.center, size: box.size, quaternion: box.quaternion, shape: shapeType },
+    { kind: 'box', center: box.center, size: box.size, quaternion: box.quaternion, shape: shapeType, smooth, maxEdge },
     triangles,
   );
 

--- a/src/color/boxPaint.ts
+++ b/src/color/boxPaint.ts
@@ -10,6 +10,8 @@
 
 import * as THREE from 'three';
 import type { MeshData } from '../geometry/types';
+import { closestPointOnTriangle } from './adjacency';
+import type { RefineRegion, TriClass, Aabb } from './subdivide';
 
 export type ShapeType = 'box' | 'sphere' | 'cylinder' | 'cone';
 
@@ -126,4 +128,116 @@ function findConeTriangles(mesh: MeshData, box: OrientedBox): Set<number> {
     if (tmpV.x * tmpV.x + tmpV.z * tmpV.z <= allowedR * allowedR) result.add(t);
   }
   return result;
+}
+
+const tmpL = new THREE.Vector3();
+
+/** Bounding radius of a shape about its center — used to size the spatial-reject
+ *  AABB for refinement. A loose sphere bound is plenty for rejection. */
+function shapeBoundingRadius(shape: ShapeType, box: OrientedBox): number {
+  const [sx, sy, sz] = box.size;
+  if (shape === 'sphere') return sx / 2;
+  if (shape === 'cylinder' || shape === 'cone') return Math.hypot(sx / 2, sy / 2);
+  return 0.5 * Math.hypot(sx, sy, sz); // box (OBB half-diagonal)
+}
+
+function shapeAabb(shape: ShapeType, box: OrientedBox): Aabb {
+  const r = shapeBoundingRadius(shape, box);
+  const [cx, cy, cz] = box.center;
+  return { min: [cx - r, cy - r, cz - r], max: [cx + r, cy + r, cz + r] };
+}
+
+/** Make a function that maps a world point to the shape's local frame (centered,
+ *  un-rotated). The shape predicates below all work in that frame. */
+function localizer(box: OrientedBox): (p: number[]) => THREE.Vector3 {
+  const [cx, cy, cz] = box.center;
+  const inv = new THREE.Quaternion(-box.quaternion[0], -box.quaternion[1], -box.quaternion[2], box.quaternion[3]);
+  return (p) => tmpL.set(p[0] - cx, p[1] - cy, p[2] - cz).applyQuaternion(inv);
+}
+
+/** Squared distance from the origin to the triangle projected onto the local XZ
+ *  plane (used for the radial separation test of cylinders/cones). */
+function xzDist2ToOrigin(la: THREE.Vector3, lb: THREE.Vector3, lc: THREE.Vector3): number {
+  const cp = closestPointOnTriangle(0, 0, 0, la.x, 0, la.z, lb.x, 0, lb.z, lc.x, 0, lc.z);
+  return cp[0] * cp[0] + cp[2] * cp[2];
+}
+
+/** Per-shape boundary classifier for refinement. Each is conservative — it never
+ *  reports `outside` for a triangle the shape actually crosses (so no boundary
+ *  band is left coarse), at the cost of occasionally subdividing a triangle just
+ *  outside a corner. Shapes are convex, so "all 3 vertices inside" ⇒ inside. */
+function shapeClassifier(shape: ShapeType, box: OrientedBox): (a: number[], b: number[], c: number[]) => TriClass {
+  const [sx, sy] = box.size;
+
+  if (shape === 'sphere') {
+    const r2 = (sx / 2) * (sx / 2);
+    const [cx, cy, cz] = box.center;
+    const d2 = (p: number[]): number => {
+      const dx = p[0] - cx, dy = p[1] - cy, dz = p[2] - cz;
+      return dx * dx + dy * dy + dz * dz;
+    };
+    return (a, b, c) => {
+      if (d2(a) <= r2 && d2(b) <= r2 && d2(c) <= r2) return 'inside';
+      // Exact: the sphere intersects the triangle iff its closest point is within r.
+      const cp = closestPointOnTriangle(cx, cy, cz, a[0], a[1], a[2], b[0], b[1], b[2], c[0], c[1], c[2]);
+      const ex = cp[0] - cx, ey = cp[1] - cy, ez = cp[2] - cz;
+      return (ex * ex + ey * ey + ez * ez <= r2) ? 'straddle' : 'outside';
+    };
+  }
+
+  const toLocal = localizer(box);
+
+  if (shape === 'cylinder') {
+    const r2 = (sx / 2) * (sx / 2);
+    const hH = sy / 2;
+    const inCyl = (p: THREE.Vector3): boolean => Math.abs(p.y) <= hH && (p.x * p.x + p.z * p.z) <= r2;
+    return (a, b, c) => {
+      const la = toLocal(a).clone(), lb = toLocal(b).clone(), lc = toLocal(c).clone();
+      if (inCyl(la) && inCyl(lb) && inCyl(lc)) return 'inside';
+      if ((la.y > hH && lb.y > hH && lc.y > hH) || (la.y < -hH && lb.y < -hH && lc.y < -hH)) return 'outside';
+      if (xzDist2ToOrigin(la, lb, lc) > r2) return 'outside';
+      return 'straddle';
+    };
+  }
+
+  if (shape === 'cone') {
+    const halfR = sx / 2;
+    const hH = sy / 2;
+    const fullH = hH * 2;
+    const inCone = (p: THREE.Vector3): boolean => {
+      if (p.y < -hH || p.y > hH) return false;
+      const allowedR = halfR * (hH - p.y) / fullH;
+      return (p.x * p.x + p.z * p.z) <= allowedR * allowedR;
+    };
+    return (a, b, c) => {
+      const la = toLocal(a).clone(), lb = toLocal(b).clone(), lc = toLocal(c).clone();
+      if (inCone(la) && inCone(lb) && inCone(lc)) return 'inside';
+      if ((la.y > hH && lb.y > hH && lc.y > hH) || (la.y < -hH && lb.y < -hH && lc.y < -hH)) return 'outside';
+      // Cone ⊂ bounding cylinder of radius halfR → outside that cylinder ⇒ outside cone.
+      if (xzDist2ToOrigin(la, lb, lc) > halfR * halfR) return 'outside';
+      return 'straddle';
+    };
+  }
+
+  // box (OBB)
+  const hx = sx / 2, hy = box.size[1] / 2, hz = box.size[2] / 2;
+  return (a, b, c) => {
+    const la = toLocal(a).clone(), lb = toLocal(b).clone(), lc = toLocal(c).clone();
+    const inA = Math.abs(la.x) <= hx && Math.abs(la.y) <= hy && Math.abs(la.z) <= hz;
+    const inB = Math.abs(lb.x) <= hx && Math.abs(lb.y) <= hy && Math.abs(lb.z) <= hz;
+    const inC = Math.abs(lc.x) <= hx && Math.abs(lc.y) <= hy && Math.abs(lc.z) <= hz;
+    if (inA && inB && inC) return 'inside';
+    if ((la.x > hx && lb.x > hx && lc.x > hx) || (la.x < -hx && lb.x < -hx && lc.x < -hx)) return 'outside';
+    if ((la.y > hy && lb.y > hy && lc.y > hy) || (la.y < -hy && lb.y < -hy && lc.y < -hy)) return 'outside';
+    if ((la.z > hz && lb.z > hz && lc.z > hz) || (la.z < -hz && lb.z < -hz && lc.z < -hz)) return 'outside';
+    return 'straddle';
+  };
+}
+
+/** Build a refine region for an oriented shape so its boundary can be smoothed.
+ *  The mesh is subdivided near the shape surface until boundary triangles fall
+ *  below `maxEdge`; the centroid selector (`findShapeTriangles`) then paints a
+ *  smooth edge on the refined mesh. */
+export function shapeRefineRegion(shape: ShapeType, box: OrientedBox, maxEdge: number): RefineRegion {
+  return { aabb: shapeAabb(shape, box), maxEdge, classify: shapeClassifier(shape, box) };
 }

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -9,6 +9,7 @@ import { addRegion, getRegions } from './regions';
 import { getScene, getMeshGroup, getRenderer, addPointerSuppressor, isPointerOverModel } from '../renderer/viewport';
 import { activate as activateSlabDrag, deactivate as deactivateSlabDrag, onMeshChanged as onSlabDragMeshChanged } from './slabDrag';
 import { activate as activateBoxDrag, deactivate as deactivateBoxDrag, onMeshChanged as onBoxDragMeshChanged } from './boxDrag';
+import { smoothEdgeForResolution } from './slabPaint';
 import type { BrushShape } from './subdivide';
 export { setSlabAxis, getSlabAxis } from './slabDrag';
 
@@ -150,6 +151,29 @@ export function getBrushSmoothDivisor(): number {
 /** True when the active brush settings will subdivide the mesh on commit. */
 export function brushWillSubdivide(): boolean {
   return brushSmooth && brushRadius > 0;
+}
+
+/** Slab / oriented-shape smoothing. When on, the slab and box tools subdivide
+ *  the mesh near the painted region's boundary so its edge follows the analytic
+ *  shape instead of the coarse base tessellation. On by default, mirroring the
+ *  brush. The resolution sets the target boundary edge length = model bbox
+ *  diagonal / resolution (higher = finer), sharing the brush's min/max bounds. */
+let shapeSmooth = true;
+let shapeSmoothResolution = 256;
+
+export function setShapeSmooth(on: boolean): void { shapeSmooth = on; }
+export function isShapeSmooth(): boolean { return shapeSmooth; }
+export function setShapeSmoothResolution(n: number): void {
+  shapeSmoothResolution = Math.max(SMOOTH_DIVISOR_MIN, Math.min(SMOOTH_DIVISOR_MAX, Math.round(n)));
+}
+export function getShapeSmoothResolution(): number { return shapeSmoothResolution; }
+
+/** Smoothing fields to stamp onto a slab/box descriptor at paint time, resolved
+ *  against `mesh` at the current shape-smoothing settings. With smoothing off
+ *  the fields refine nothing (preserving the original blocky edge). */
+export function shapeSmoothDescriptorFields(mesh: MeshData): { smooth: boolean; maxEdge: number } {
+  if (!shapeSmooth) return { smooth: false, maxEdge: 0 };
+  return { smooth: true, maxEdge: smoothEdgeForResolution(mesh, shapeSmoothResolution) };
 }
 
 export function setOnRegionPainted(fn: () => void): void {

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -20,6 +20,10 @@ import {
   getBrushSmoothDivisor,
   SMOOTH_DIVISOR_MIN,
   SMOOTH_DIVISOR_MAX,
+  setShapeSmooth,
+  isShapeSmooth,
+  setShapeSmoothResolution,
+  getShapeSmoothResolution,
   setSlabAxis,
   getSlabAxis,
   previewTriangles,
@@ -85,6 +89,9 @@ let bucketControls: HTMLElement | null = null;
 let brushControls: HTMLElement | null = null;
 let slabControls: HTMLElement | null = null;
 let boxControls: HTMLElement | null = null;
+// Shape-smoothing controls appear in both the slab and box panels but share one
+// state; re-sync each instance's display on tool switch so neither goes stale.
+const shapeSmoothSyncs: (() => void)[] = [];
 
 /** Initialize the paint UI inside the clip-controls overlay area. */
 export function initPaintUI(controlsContainer: HTMLElement): void {
@@ -332,6 +339,7 @@ function syncToolPanels(): void {
   if (brushControls) brushControls.classList.toggle('hidden', tool !== 'brush');
   if (slabControls) slabControls.classList.toggle('hidden', tool !== 'slab');
   if (boxControls) boxControls.classList.toggle('hidden', tool !== 'box');
+  for (const sync of shapeSmoothSyncs) sync();
 }
 
 function createBucketControls(): HTMLElement {
@@ -626,6 +634,8 @@ function createSlabControls(): HTMLElement {
   hint.innerHTML = 'Hover the model to preview the slab plane.<br>Click and drag to extend the slab along the chosen axis. Release to paint.';
   wrap.appendChild(hint);
 
+  wrap.appendChild(createShapeSmoothControls());
+
   return wrap;
 }
 
@@ -634,6 +644,88 @@ function axisButtonClass(active: boolean): string {
     return 'px-2 py-1 rounded text-[11px] bg-blue-500/30 text-blue-200 border border-blue-500/50 transition-colors';
   }
   return 'px-2 py-1 rounded text-[11px] bg-zinc-700/40 text-zinc-300 hover:bg-zinc-600/60 border border-transparent transition-colors';
+}
+
+/** Edge-smoothing toggle + detail slider shared by the slab and shape tools.
+ *  Mirrors the brush's smoothing controls, but the detail is a resolution: the
+ *  target boundary edge length is the model's bbox diagonal ÷ this value. The
+ *  state is shared across both tools (see `setShapeSmooth` in paintMode). */
+function createShapeSmoothControls(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'mt-2 pt-2 border-t border-zinc-700';
+
+  const label = document.createElement('div');
+  label.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium';
+  label.textContent = 'Edge smoothing';
+
+  const toggle = document.createElement('button');
+  toggle.title = 'Subdivide the mesh near the painted region boundary so its edge is smooth instead of following triangle boundaries. Adds triangles near the edge.';
+
+  const fineRow = document.createElement('div');
+  fineRow.className = 'flex items-center gap-2 mt-1';
+
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.min = String(SMOOTH_DIVISOR_MIN);
+  slider.max = String(SMOOTH_DIVISOR_MAX);
+  slider.step = '1';
+  slider.value = String(getShapeSmoothResolution());
+  slider.className = 'flex-1 accent-blue-500 min-w-0';
+  slider.title = 'Smooth-edge detail: model bbox diagonal ÷ this = target triangle edge. Higher = smoother edge, more triangles.';
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = String(SMOOTH_DIVISOR_MIN);
+  input.max = String(SMOOTH_DIVISOR_MAX);
+  input.step = '1';
+  input.value = String(getShapeSmoothResolution());
+  input.className = 'w-16 px-1 py-0.5 text-[11px] bg-zinc-900/70 border border-zinc-600/60 rounded text-zinc-200 text-right tabular-nums';
+  input.title = `Detail (model size ÷ this = target edge). ${SMOOTH_DIVISOR_MIN}–${SMOOTH_DIVISOR_MAX}.`;
+
+  slider.addEventListener('input', () => {
+    setShapeSmoothResolution(parseInt(slider.value, 10));
+    input.value = String(getShapeSmoothResolution());
+    for (const sync of shapeSmoothSyncs) sync();
+  });
+  const apply = (): void => {
+    const raw = parseInt(input.value, 10);
+    if (!Number.isFinite(raw)) { input.value = String(getShapeSmoothResolution()); return; }
+    setShapeSmoothResolution(raw);
+    slider.value = String(getShapeSmoothResolution());
+    input.value = String(getShapeSmoothResolution());
+    for (const sync of shapeSmoothSyncs) sync();
+  };
+  input.addEventListener('change', apply);
+  input.addEventListener('keydown', (e) => { if (e.key === 'Enter') { apply(); input.blur(); } });
+
+  fineRow.appendChild(slider);
+  fineRow.appendChild(input);
+
+  const help = document.createElement('div');
+  help.className = 'text-[10px] text-zinc-500 mt-1';
+  help.textContent = 'Smooth-edge detail · higher → smoother, more triangles';
+
+  const sync = (): void => {
+    const on = isShapeSmooth();
+    toggle.className = on
+      ? 'w-full px-2 py-1 rounded text-[10px] bg-blue-500/30 text-blue-200 border border-blue-500/50 transition-colors text-center'
+      : 'w-full px-2 py-1 rounded text-[10px] bg-zinc-700/40 text-zinc-300 hover:bg-zinc-600/60 border border-transparent transition-colors text-center';
+    toggle.textContent = on ? '◉ Smooth edges: On' : '○ Smooth edges: Off';
+    fineRow.classList.toggle('hidden', !on);
+    help.classList.toggle('hidden', !on);
+    slider.value = String(getShapeSmoothResolution());
+    input.value = String(getShapeSmoothResolution());
+  };
+  toggle.addEventListener('click', () => { setShapeSmooth(!isShapeSmooth()); for (const s of shapeSmoothSyncs) s(); });
+
+  wrap.appendChild(label);
+  wrap.appendChild(toggle);
+  wrap.appendChild(fineRow);
+  wrap.appendChild(help);
+  shapeSmoothSyncs.push(sync);
+  sync();
+
+  return wrap;
 }
 
 function createBoxControls(): HTMLElement {
@@ -754,6 +846,7 @@ function createBoxControls(): HTMLElement {
   help.textContent = 'Drag the gizmo handles in the viewport, or edit values above. The shape fades after painting and brightens when you interact with it again.';
   actionRow.appendChild(help);
 
+  wrap.appendChild(createShapeSmoothControls());
   wrap.appendChild(actionRow);
 
   // Keep the numeric inputs in sync when the gizmo moves.

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -17,8 +17,13 @@ export interface ColorRegion {
 
 export type RegionDescriptor =
   | { kind: 'coplanar'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; normalTolerance: number }
-  | { kind: 'slab'; normal: [number, number, number]; offset: number; thickness: number }
-  | { kind: 'box'; center: [number, number, number]; size: [number, number, number]; quaternion: [number, number, number, number]; shape?: ShapeType }
+  // Slab / oriented-shape descriptors carry optional smoothing: when `smooth`
+  // is set, the mesh is locally subdivided near the region's boundary until
+  // boundary triangles fall below `maxEdge`, so the painted edge follows the
+  // analytic boundary instead of the coarse base tessellation. Descriptors
+  // saved before smoothing existed simply omit both fields (no subdivision).
+  | { kind: 'slab'; normal: [number, number, number]; offset: number; thickness: number; smooth?: boolean; maxEdge?: number }
+  | { kind: 'box'; center: [number, number, number]; size: [number, number, number]; quaternion: [number, number, number, number]; shape?: ShapeType; smooth?: boolean; maxEdge?: number }
   | { kind: 'triangles'; ids: number[] }
   | { kind: 'byLabel'; label: string }
   | { kind: 'connectedFromSeed'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; maxDeviationDeg: number }

--- a/src/color/slabDrag.ts
+++ b/src/color/slabDrag.ts
@@ -9,7 +9,7 @@ import type { MeshData } from '../geometry/types';
 import { getMeshGroup, getRenderer, getCamera } from '../renderer/viewport';
 import { addRegion, getRegions } from './regions';
 import { findSlabTriangles, projectionRange, AXIS_NORMALS } from './slabPaint';
-import { getColor, getCurrentMesh } from './paintMode';
+import { getColor, getCurrentMesh, shapeSmoothDescriptorFields } from './paintMode';
 
 export type SlabAxis = 'x' | 'y' | 'z';
 
@@ -298,11 +298,12 @@ function commitSlab(offset: number, thickness: number): void {
 
   const existingCount = getRegions().length;
   const name = `Slab ${axis.toUpperCase()} ${existingCount + 1}`;
+  const { smooth, maxEdge } = shapeSmoothDescriptorFields(mesh);
   addRegion(
     name,
     [...getColor()] as [number, number, number],
     'slab',
-    { kind: 'slab', normal: [...normal] as [number, number, number], offset, thickness },
+    { kind: 'slab', normal: [...normal] as [number, number, number], offset, thickness, smooth, maxEdge },
     triangles,
   );
 }

--- a/src/color/slabPaint.ts
+++ b/src/color/slabPaint.ts
@@ -7,6 +7,7 @@
 
 import type { MeshData } from '../geometry/types';
 import { getTriangleCentroid } from './adjacency';
+import type { RefineRegion, TriClass } from './subdivide';
 
 export interface AxisAlignedNormal {
   axis: 'x' | 'y' | 'z';
@@ -112,4 +113,42 @@ function normalize(v: [number, number, number]): [number, number, number] {
   const len = Math.hypot(v[0], v[1], v[2]);
   if (len === 0) return [0, 0, 1];
   return [v[0] / len, v[1] / len, v[2] / len];
+}
+
+/** Absolute target edge length for smoothing a slab/shape boundary on `mesh` at
+ *  the given resolution: the model's bounding-box diagonal divided by resolution
+ *  (a scale-relative target, so one resolution gives similar smoothness on
+ *  models of any size). Returns 0 for a non-positive resolution. */
+export function smoothEdgeForResolution(mesh: MeshData, resolution: number): number {
+  if (!(resolution > 0)) return 0;
+  const b = meshBounds(mesh);
+  const diag = Math.hypot(b.max[0] - b.min[0], b.max[1] - b.min[1], b.max[2] - b.min[2]);
+  return diag / resolution;
+}
+
+/** Build a refine region for a slab so its two boundary planes can be smoothed.
+ *  A triangle straddles when its vertices' projections onto the normal span the
+ *  slab's `[offset, offset+thickness]` range without lying entirely inside it.
+ *  Because the projection is affine over a planar triangle, the per-vertex
+ *  min/max test is exact — it never misses a thin slab crossing a coarse face. */
+export function slabRefineRegion(
+  normal: [number, number, number],
+  offset: number,
+  thickness: number,
+  maxEdge: number,
+): RefineRegion {
+  const [nx, ny, nz] = normalize(normal);
+  const lo = offset;
+  const hi = offset + thickness;
+  const classify = (a: number[], b: number[], c: number[]): TriClass => {
+    const dA = a[0] * nx + a[1] * ny + a[2] * nz;
+    const dB = b[0] * nx + b[1] * ny + b[2] * nz;
+    const dC = c[0] * nx + c[1] * ny + c[2] * nz;
+    const minD = Math.min(dA, dB, dC);
+    const maxD = Math.max(dA, dB, dC);
+    if (maxD < lo || minD > hi) return 'outside';
+    if (minD >= lo && maxD <= hi) return 'inside';
+    return 'straddle';
+  };
+  return { aabb: null, maxEdge, classify };
 }

--- a/src/color/slabPaint.ts
+++ b/src/color/slabPaint.ts
@@ -7,7 +7,7 @@
 
 import type { MeshData } from '../geometry/types';
 import { getTriangleCentroid } from './adjacency';
-import type { RefineRegion, TriClass } from './subdivide';
+import type { RefineRegion, TriClass, Aabb } from './subdivide';
 
 export interface AxisAlignedNormal {
   axis: 'x' | 'y' | 'z';
@@ -150,5 +150,28 @@ export function slabRefineRegion(
     if (minD >= lo && maxD <= hi) return 'inside';
     return 'straddle';
   };
-  return { aabb: null, maxEdge, classify };
+  return { aabb: axisAlignedSlabAabb(nx, ny, nz, lo, hi), maxEdge, classify };
+}
+
+/** Cheap spatial-reject box for an axis-aligned slab (the UI's X/Y/Z slabs and
+ *  most API calls): the band only bounds the normal's own axis — the two in-plane
+ *  axes stay unbounded (±Infinity) so only triangles fully clear of the band are
+ *  rejected before the classify. Oblique slabs return null (no tight AABB without
+ *  the mesh bounds; the classify is just three dot products with a maxEdge
+ *  early-out, so a full scan stays cheap for a one-shot paint). */
+function axisAlignedSlabAabb(nx: number, ny: number, nz: number, lo: number, hi: number): Aabb | null {
+  const eps = 1e-9;
+  const ax = Math.abs(nx), ay = Math.abs(ny), az = Math.abs(nz);
+  const min: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  const max: [number, number, number] = [Infinity, Infinity, Infinity];
+  // For an axis k with n_k = ±1, P·n = ±P_k, so the slab lo ≤ ±P_k ≤ hi maps to
+  // P_k ∈ [lo, hi] (positive normal) or [-hi, -lo] (negative normal).
+  const bound = (k: number, sign: number): void => {
+    if (sign > 0) { min[k] = lo; max[k] = hi; } else { min[k] = -hi; max[k] = -lo; }
+  };
+  if (ax > 1 - eps && ay < eps && az < eps) bound(0, Math.sign(nx));
+  else if (ay > 1 - eps && ax < eps && az < eps) bound(1, Math.sign(ny));
+  else if (az > 1 - eps && ax < eps && ay < eps) bound(2, Math.sign(nz));
+  else return null;
+  return { min, max };
 }

--- a/src/color/subdivide.ts
+++ b/src/color/subdivide.ts
@@ -41,7 +41,7 @@ const MAX_TRIANGLES = 1_500_000;
 /** True when `p` is within the brush footprint of any of the stroke's samples,
  *  using the shape's distance metric (circle = Euclidean, square = Chebyshev,
  *  diamond = L1). */
-export function withinFootprint(
+function withinFootprint(
   px: number, py: number, pz: number,
   stroke: BrushStroke,
 ): boolean {
@@ -109,7 +109,7 @@ function maxEdgeLen2(a: number[], b: number[], c: number[]): number {
  *  the stopping condition). Catches the brush-smaller-than-a-triangle case via a
  *  closest-point test so a small brush in the middle of a big face still
  *  tessellates. */
-export function selectStrokeTriangles(mesh: MeshData, stroke: BrushStroke, maxEdge: number): Set<number> {
+function selectStrokeTriangles(mesh: MeshData, stroke: BrushStroke, maxEdge: number): Set<number> {
   const { triVerts, numTri } = mesh;
   const selected = new Set<number>();
   const r2 = stroke.radius * stroke.radius;
@@ -183,7 +183,7 @@ export function strokeFootprintTriangles(mesh: MeshData, stroke: BrushStroke): S
  *  Returns the new mesh plus `childToParent`: for each output triangle, the
  *  index of the input triangle it came from (so callers can carry per-triangle
  *  data — e.g. existing colour regions — across the split). */
-export function subdivideSelected(
+function subdivideSelected(
   mesh: MeshData,
   selected: Set<number>,
 ): { mesh: MeshData; childToParent: Int32Array } {
@@ -247,29 +247,32 @@ export function subdivideSelected(
 /** Rebuild a refined mesh from a pristine base mesh and an ordered list of
  *  brush strokes. Each stroke refines the (possibly already-refined) mesh near
  *  its own footprint until the boundary triangles fall below `stroke.maxEdge`.
- *  Returns the refined mesh and a `childToParent` map from each final triangle
- *  back to its base-mesh triangle index — used to carry non-stroke colour
- *  regions across the refinement. */
+ *  Returns the refined mesh, a `childToParent` map from each final triangle back
+ *  to its base-mesh triangle index (used to carry non-stroke colour regions
+ *  across the refinement), and `capped`: true when subdivision stopped early
+ *  because the mesh hit MAX_TRIANGLES (so a stroke couldn't reach its target
+ *  detail — the caller should surface that). */
 export function buildStrokeMesh(
   base: MeshData,
   strokes: BrushStroke[],
-): { mesh: MeshData; childToParent: Int32Array } {
+): { mesh: MeshData; childToParent: Int32Array; capped: boolean } {
   let mesh = base;
   let comp: Int32Array = new Int32Array(base.numTri);
   for (let i = 0; i < comp.length; i++) comp[i] = i;
+  let capped = false;
 
   for (const stroke of strokes) {
-    const target = stroke.maxEdge > 0 ? stroke.maxEdge : stroke.radius / 16;
+    const target = stroke.maxEdge > 0 ? stroke.maxEdge : stroke.radius / 256;
     for (let pass = 0; pass < MAX_PASSES; pass++) {
       const selected = selectStrokeTriangles(mesh, stroke, target);
       if (selected.size === 0) break;
       const { mesh: nm, childToParent } = subdivideSelected(mesh, selected);
       mesh = nm;
       comp = composeMaps(comp, childToParent);
-      if (nm.numTri > MAX_TRIANGLES) break;
+      if (nm.numTri > MAX_TRIANGLES) { capped = true; break; }
     }
   }
-  return { mesh, childToParent: comp };
+  return { mesh, childToParent: comp, capped };
 }
 
 function composeMaps(parentToBase: Int32Array, childToParent: Int32Array): Int32Array {

--- a/src/color/subdivide.ts
+++ b/src/color/subdivide.ts
@@ -32,11 +32,11 @@ export interface BrushStroke {
   maxEdge: number;
 }
 
-/** Hard ceilings so a tiny target edge on a coarse mesh can't run away.
- *  Straddle-only selection already bounds growth to the boundary length (not the
- *  area), but a pathological case shouldn't be able to lock the tab. */
-const MAX_PASSES = 12;
-const MAX_TRIANGLES = 1_500_000;
+/** Per-stroke depth bound so a single stroke can't run away (each pass ~doubles
+ *  the boundary triangle count). There is deliberately NO cumulative triangle
+ *  cap — the mesh may grow across many strokes; the UI surfaces a high-complexity
+ *  warning and a live triangle count instead of silently degrading quality. */
+const MAX_PASSES = 16;
 
 /** True when `p` is within the brush footprint of any of the stroke's samples,
  *  using the shape's distance metric (circle = Euclidean, square = Chebyshev,
@@ -247,19 +247,16 @@ function subdivideSelected(
 /** Rebuild a refined mesh from a pristine base mesh and an ordered list of
  *  brush strokes. Each stroke refines the (possibly already-refined) mesh near
  *  its own footprint until the boundary triangles fall below `stroke.maxEdge`.
- *  Returns the refined mesh, a `childToParent` map from each final triangle back
- *  to its base-mesh triangle index (used to carry non-stroke colour regions
- *  across the refinement), and `capped`: true when subdivision stopped early
- *  because the mesh hit MAX_TRIANGLES (so a stroke couldn't reach its target
- *  detail — the caller should surface that). */
+ *  Returns the refined mesh and a `childToParent` map from each final triangle
+ *  back to its base-mesh triangle index (used to carry non-stroke colour regions
+ *  across the refinement). */
 export function buildStrokeMesh(
   base: MeshData,
   strokes: BrushStroke[],
-): { mesh: MeshData; childToParent: Int32Array; capped: boolean } {
+): { mesh: MeshData; childToParent: Int32Array } {
   let mesh = base;
   let comp: Int32Array = new Int32Array(base.numTri);
   for (let i = 0; i < comp.length; i++) comp[i] = i;
-  let capped = false;
 
   for (const stroke of strokes) {
     const target = stroke.maxEdge > 0 ? stroke.maxEdge : stroke.radius / 256;
@@ -269,10 +266,9 @@ export function buildStrokeMesh(
       const { mesh: nm, childToParent } = subdivideSelected(mesh, selected);
       mesh = nm;
       comp = composeMaps(comp, childToParent);
-      if (nm.numTri > MAX_TRIANGLES) { capped = true; break; }
     }
   }
-  return { mesh, childToParent: comp, capped };
+  return { mesh, childToParent: comp };
 }
 
 function composeMaps(parentToBase: Int32Array, childToParent: Int32Array): Int32Array {

--- a/src/color/subdivide.ts
+++ b/src/color/subdivide.ts
@@ -32,6 +32,30 @@ export interface BrushStroke {
   maxEdge: number;
 }
 
+export interface Aabb {
+  min: [number, number, number];
+  max: [number, number, number];
+}
+
+export type TriClass = 'inside' | 'outside' | 'straddle';
+
+/** Classify a triangle (given its three world-space vertex coords) against a
+ *  paint region: fully inside, fully outside, or straddling the boundary.
+ *  Only `straddle` triangles get subdivided. A classifier must never report
+ *  `outside` for a triangle the region actually crosses (a missed straddle
+ *  leaves a coarse, blocky edge there) — reporting `straddle` for a triangle
+ *  that turns out to be just outside is harmless (a few extra triangles). */
+export type TriClassifier = (a: number[], b: number[], c: number[]) => TriClass;
+
+/** A region to refine the mesh around: its boundary classifier, the target edge
+ *  length near that boundary, and an optional AABB for cheap spatial rejection.
+ *  Brush strokes, slabs, and oriented shapes all reduce to one of these. */
+export interface RefineRegion {
+  aabb: Aabb | null;
+  maxEdge: number;
+  classify: TriClassifier;
+}
+
 /** Per-stroke depth bound so a single stroke can't run away (each pass ~doubles
  *  the boundary triangle count). There is deliberately NO cumulative triangle
  *  cap — the mesh may grow across many strokes; the UI surfaces a high-complexity
@@ -102,42 +126,20 @@ function maxEdgeLen2(a: number[], b: number[], c: number[]): number {
   return Math.max(e(a, b), e(b, c), e(c, a));
 }
 
-/** Triangles that the brush boundary crosses (partially, not fully covered)
- *  AND are still coarser than `maxEdge`. These are the ones worth subdividing:
- *  fully-inside triangles already paint solid, fully-outside ones never paint,
- *  and boundary triangles already finer than the target are left alone (that's
- *  the stopping condition). Catches the brush-smaller-than-a-triangle case via a
- *  closest-point test so a small brush in the middle of a big face still
- *  tessellates. */
-function selectStrokeTriangles(mesh: MeshData, stroke: BrushStroke, maxEdge: number): Set<number> {
-  const { triVerts, numTri } = mesh;
-  const selected = new Set<number>();
+/** Classify a triangle against a brush footprint: inside when all three
+ *  vertices are covered, straddle when some (but not all) are — or, for a brush
+ *  smaller than the face, when the footprint's closest point on the triangle is
+ *  within the radius (so a small brush in the middle of a big face still
+ *  tessellates). */
+function brushClassifier(stroke: BrushStroke): TriClassifier {
   const r2 = stroke.radius * stroke.radius;
-  const maxEdge2 = maxEdge * maxEdge;
-  const box = strokeAabb(stroke);
-
-  for (let t = 0; t < numTri; t++) {
-    const a = triVertex(mesh, triVerts[t * 3]);
-    const b = triVertex(mesh, triVerts[t * 3 + 1]);
-    const c = triVertex(mesh, triVerts[t * 3 + 2]);
-
-    // Cheap spatial reject: skip triangles nowhere near the stroke.
-    if (triOutsideAabb(a, b, c, box)) continue;
-
-    // Already fine enough → leave it (keeps the refined band tight and bounded).
-    if (maxEdgeLen2(a, b, c) <= maxEdge2) continue;
-
+  return (a, b, c) => {
     let inside = 0;
     if (withinFootprint(a[0], a[1], a[2], stroke)) inside++;
     if (withinFootprint(b[0], b[1], b[2], stroke)) inside++;
     if (withinFootprint(c[0], c[1], c[2], stroke)) inside++;
-
-    if (inside === 3) continue;       // fully inside — no edge crosses it
-    if (inside >= 1) { selected.add(t); continue; } // straddles the boundary
-
-    // No vertex inside: the footprint might still pass through this triangle
-    // (brush smaller than the face, or grazing an edge). Test the closest point
-    // on the triangle to each sample against the radius.
+    if (inside === 3) return 'inside';
+    if (inside >= 1) return 'straddle';
     for (let s = 0; s < stroke.samples.length; s++) {
       const sp = stroke.samples[s];
       const cp = closestPointOnTriangle(
@@ -145,8 +147,42 @@ function selectStrokeTriangles(mesh: MeshData, stroke: BrushStroke, maxEdge: num
         a[0], a[1], a[2], b[0], b[1], b[2], c[0], c[1], c[2],
       );
       const dx = cp[0] - sp[0], dy = cp[1] - sp[1], dz = cp[2] - sp[2];
-      if (dx * dx + dy * dy + dz * dz <= r2) { selected.add(t); break; }
+      if (dx * dx + dy * dy + dz * dz <= r2) return 'straddle';
     }
+    return 'outside';
+  };
+}
+
+/** Build a refine region for a brush stroke (its footprint classifier, AABB,
+ *  and target edge length). */
+export function brushRefineRegion(stroke: BrushStroke): RefineRegion {
+  const maxEdge = stroke.maxEdge > 0 ? stroke.maxEdge : stroke.radius / 256;
+  return { aabb: strokeAabb(stroke), maxEdge, classify: brushClassifier(stroke) };
+}
+
+/** Triangles a region's boundary crosses (partially, not fully covered) AND are
+ *  still coarser than `region.maxEdge`. These are the ones worth subdividing:
+ *  fully-inside triangles already paint solid, fully-outside ones never paint,
+ *  and boundary triangles already finer than the target are left alone (that's
+ *  the stopping condition). */
+function selectByClassify(mesh: MeshData, region: RefineRegion): Set<number> {
+  const { triVerts, numTri } = mesh;
+  const selected = new Set<number>();
+  const maxEdge2 = region.maxEdge * region.maxEdge;
+  const box = region.aabb;
+
+  for (let t = 0; t < numTri; t++) {
+    const a = triVertex(mesh, triVerts[t * 3]);
+    const b = triVertex(mesh, triVerts[t * 3 + 1]);
+    const c = triVertex(mesh, triVerts[t * 3 + 2]);
+
+    // Cheap spatial reject: skip triangles nowhere near the region.
+    if (box && triOutsideAabb(a, b, c, box)) continue;
+
+    // Already fine enough → leave it (keeps the refined band tight and bounded).
+    if (maxEdgeLen2(a, b, c) <= maxEdge2) continue;
+
+    if (region.classify(a, b, c) === 'straddle') selected.add(t);
   }
   return selected;
 }
@@ -245,23 +281,22 @@ function subdivideSelected(
 }
 
 /** Rebuild a refined mesh from a pristine base mesh and an ordered list of
- *  brush strokes. Each stroke refines the (possibly already-refined) mesh near
- *  its own footprint until the boundary triangles fall below `stroke.maxEdge`.
- *  Returns the refined mesh and a `childToParent` map from each final triangle
- *  back to its base-mesh triangle index (used to carry non-stroke colour regions
- *  across the refinement). */
-export function buildStrokeMesh(
+ *  refine regions (brush strokes, slabs, oriented shapes). Each region refines
+ *  the (possibly already-refined) mesh near its own boundary until the boundary
+ *  triangles fall below its `maxEdge`. Returns the refined mesh and a
+ *  `childToParent` map from each final triangle back to its base-mesh triangle
+ *  index (used to carry colour regions across the refinement). */
+export function buildRefinedMesh(
   base: MeshData,
-  strokes: BrushStroke[],
+  regions: RefineRegion[],
 ): { mesh: MeshData; childToParent: Int32Array } {
   let mesh = base;
   let comp: Int32Array = new Int32Array(base.numTri);
   for (let i = 0; i < comp.length; i++) comp[i] = i;
 
-  for (const stroke of strokes) {
-    const target = stroke.maxEdge > 0 ? stroke.maxEdge : stroke.radius / 256;
+  for (const region of regions) {
     for (let pass = 0; pass < MAX_PASSES; pass++) {
-      const selected = selectStrokeTriangles(mesh, stroke, target);
+      const selected = selectByClassify(mesh, region);
       if (selected.size === 0) break;
       const { mesh: nm, childToParent } = subdivideSelected(mesh, selected);
       mesh = nm;
@@ -269,6 +304,15 @@ export function buildStrokeMesh(
     }
   }
   return { mesh, childToParent: comp };
+}
+
+/** Convenience wrapper: refine a base mesh under an ordered list of brush
+ *  strokes (each mapped to its footprint refine region). */
+export function buildStrokeMesh(
+  base: MeshData,
+  strokes: BrushStroke[],
+): { mesh: MeshData; childToParent: Int32Array } {
+  return buildRefinedMesh(base, strokes.map(brushRefineRegion));
 }
 
 function composeMaps(parentToBase: Int32Array, childToParent: Int32Array): Int32Array {

--- a/src/main.ts
+++ b/src/main.ts
@@ -395,23 +395,39 @@ function applyVersionAnnotations(version: Version | null | undefined): void {
 function collectStrokeDescriptors(descriptors: RegionDescriptor[]): BrushStroke[] {
   const strokes: BrushStroke[] = [];
   for (const d of descriptors) {
-    if (d.kind === 'brushStroke') {
-      strokes.push({ samples: d.samples, radius: d.radius, shape: d.shape, maxEdge: d.maxEdge > 0 ? d.maxEdge : d.radius / 16 });
-    }
+    if (d.kind === 'brushStroke') strokes.push(descriptorToStroke(d));
   }
   return strokes;
 }
 
 /** Refine a base mesh under the given strokes. Returns the mesh unchanged with
  *  `parentToChildren: null` when there are no strokes (the common case — no
- *  subdivision, identity mapping). */
+ *  subdivision, identity mapping). `capped` is true when subdivision stopped at
+ *  the triangle ceiling (a stroke couldn't reach its requested detail). */
 function refineMeshForStrokes(
   base: MeshData,
   strokes: BrushStroke[],
-): { mesh: MeshData; parentToChildren: Map<number, number[]> | null } {
-  if (strokes.length === 0) return { mesh: base, parentToChildren: null };
-  const { mesh, childToParent } = buildStrokeMesh(base, strokes);
-  return { mesh, parentToChildren: childrenByParent(childToParent) };
+): { mesh: MeshData; parentToChildren: Map<number, number[]> | null; capped: boolean } {
+  if (strokes.length === 0) return { mesh: base, parentToChildren: null, capped: false };
+  const { mesh, childToParent, capped } = buildStrokeMesh(base, strokes);
+  return { mesh, parentToChildren: childrenByParent(childToParent), capped };
+}
+
+/** True when the last refine hit the triangle ceiling, so the console
+ *  `paintStroke` can report it. */
+let lastRefineCapped = false;
+let detailCappedWarnedAt = 0;
+
+/** Surface the "couldn't subdivide further — mesh is at the detail ceiling"
+ *  condition so the user understands why a stroke came out coarse (instead of it
+ *  silently happening). Debounced; goes to the diagnostic log (⚠ panel) via
+ *  console.warn. The actionable fix is to Clear colors or lower Edge smoothing. */
+function notifyDetailCapped(triangleCount: number): void {
+  const now = Date.now();
+  if (now - detailCappedWarnedAt < 4000) return;
+  detailCappedWarnedAt = now;
+  // eslint-disable-next-line no-console
+  console.warn(`Smooth paint: detail limit reached (~${triangleCount.toLocaleString()} triangles). Clear colors or lower "Edge smoothing" to keep painting at full resolution.`);
 }
 
 /** Map base-mesh triangle ids onto the refined mesh. With no subdivision
@@ -432,11 +448,12 @@ function remapTriangleIds(ids: Iterable<number>, parentToChildren: Map<number, n
 function resolveDescriptorTriangles(
   descriptor: RegionDescriptor,
   mesh: MeshData,
-  adjacency: AdjacencyGraph,
+  adjacency: AdjacencyGraph | null,
   parentToChildren: Map<number, number[]> | null,
 ): Set<number> {
   switch (descriptor.kind) {
     case 'coplanar': {
+      if (!adjacency) return new Set<number>();
       const { seedPoint, seedNormal, normalTolerance } = descriptor;
       const seedTri = resolveSeed(seedPoint, seedNormal, mesh, adjacency, normalTolerance);
       return seedTri >= 0 ? findCoplanarRegion(seedTri, adjacency, normalTolerance) : new Set<number>();
@@ -461,6 +478,7 @@ function resolveDescriptorTriangles(
       return ids ? remapTriangleIds(ids, parentToChildren) : new Set<number>();
     }
     case 'connectedFromSeed': {
+      if (!adjacency) return new Set<number>();
       const { seedPoint, seedNormal, maxDeviationDeg } = descriptor;
       // Find the closest triangle to the seed point — robust across re-runs
       // because triangle indices are unstable but world-space points are not.
@@ -486,8 +504,14 @@ function resolveDescriptorTriangles(
       return triangles;
     }
     case 'brushStroke':
-      return strokeFootprintTriangles(mesh, { samples: descriptor.samples, radius: descriptor.radius, shape: descriptor.shape, maxEdge: descriptor.maxEdge > 0 ? descriptor.maxEdge : descriptor.radius / 16 });
+      return strokeFootprintTriangles(mesh, descriptorToStroke(descriptor));
   }
+}
+
+/** Normalize a brushStroke descriptor to a BrushStroke, filling a sane default
+ *  maxEdge (matching the default detail divisor) for any malformed/legacy data. */
+function descriptorToStroke(d: Extract<RegionDescriptor, { kind: 'brushStroke' }>): BrushStroke {
+  return { samples: d.samples, radius: d.radius, shape: d.shape, maxEdge: d.maxEdge > 0 ? d.maxEdge : d.radius / 256 };
 }
 
 /** True when any in-memory region is a smooth brush stroke (which drives mesh
@@ -551,13 +575,15 @@ function rebuildPaintedGeometry(): void {
   const base = paintBaseMesh;
   if (!base) return;
   const strokes = collectStrokeDescriptors(getRegions().map(r => r.descriptor));
-  const { mesh, parentToChildren } = refineMeshForStrokes(base, strokes);
+  const { mesh, parentToChildren, capped } = refineMeshForStrokes(base, strokes);
   currentMeshData = mesh;
   updatePaintMesh(mesh);
   const adjacency = buildAdjacency(mesh);
   for (const region of getRegions()) {
     setRegionTriangles(region.id, resolveDescriptorTriangles(region.descriptor, mesh, adjacency, parentToChildren));
   }
+  lastRefineCapped = capped;
+  if (capped) notifyDetailCapped(mesh.numTri);
   paintedColorRefresh();
   syncLockState();
 }
@@ -568,21 +594,30 @@ function rebuildPaintedGeometry(): void {
  *  triangles)); only the new stroke is resolved by footprint. This is the hot
  *  path while painting and keeps each stroke ~constant-time regardless of how
  *  many strokes precede it. */
-function appendStrokeRefine(newRegionId: number, descriptor: Extract<RegionDescriptor, { kind: 'brushStroke' }>): void {
+function appendStrokeRefine(descriptor: Extract<RegionDescriptor, { kind: 'brushStroke' }>): void {
   if (!currentMeshData) return;
-  const stroke: BrushStroke = { samples: descriptor.samples, radius: descriptor.radius, shape: descriptor.shape, maxEdge: descriptor.maxEdge > 0 ? descriptor.maxEdge : descriptor.radius / 16 };
-  const { mesh, childToParent } = buildStrokeMesh(currentMeshData, [stroke]);
+  const { mesh, childToParent, capped } = buildStrokeMesh(currentMeshData, [descriptorToStroke(descriptor)]);
   const parentToChildren = childrenByParent(childToParent);
   currentMeshData = mesh;
   updatePaintMesh(mesh);
+  // Re-resolve regions exactly as a full rebuild / reload would, so the live
+  // result matches what reload reconstructs (determinism). Explicit sets
+  // (triangles/byLabel index the base tessellation / runtime labelMap) are
+  // carried forward across this split; every spatial/footprint/flood descriptor
+  // is re-resolved by descriptor — its children near the split may fall outside
+  // the region, which a naive parent→children carry would wrongly keep.
+  const needsAdj = getRegions().some(r => r.descriptor.kind === 'coplanar' || r.descriptor.kind === 'connectedFromSeed');
+  const adjacency = needsAdj ? buildAdjacency(mesh) : null;
   for (const region of getRegions()) {
-    if (region.id === newRegionId) {
-      setRegionTriangles(region.id, strokeFootprintTriangles(mesh, stroke));
-    } else {
-      // Carry the prior triangle set onto the locally-refined mesh.
+    const d = region.descriptor;
+    if (d.kind === 'triangles' || d.kind === 'byLabel') {
       setRegionTriangles(region.id, remapTriangleIds(region.triangles, parentToChildren));
+    } else {
+      setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, parentToChildren));
     }
   }
+  lastRefineCapped = capped;
+  if (capped) notifyDetailCapped(mesh.numTri);
   paintedColorRefresh();
   syncLockState();
 }
@@ -617,12 +652,9 @@ function reconcilePaintedGeometry(): void {
   // Pure append: exactly one new stroke on the end, prior strokes unchanged.
   if (strokesNow.length === lastStrokeList.length + 1 && prefixRefEqual(strokesNow, lastStrokeList)) {
     const newDesc = strokesNow[strokesNow.length - 1] as Extract<RegionDescriptor, { kind: 'brushStroke' }>;
-    const newRegion = getRegions().find(r => r.descriptor === newDesc);
-    if (newRegion) {
-      appendStrokeRefine(newRegion.id, newDesc);
-      lastStrokeList = strokesNow;
-      return;
-    }
+    appendStrokeRefine(newDesc);
+    lastStrokeList = strokesNow;
+    return;
   }
 
   rebuildPaintedGeometry();
@@ -4871,6 +4903,7 @@ async function main() {
       // maxEdge (absolute) overrides; otherwise radius / resolution, default 256.
       const res = Math.max(SMOOTH_DIVISOR_MIN, Math.min(SMOOTH_DIVISOR_MAX, resolution ?? 256));
       const target = maxEdge !== undefined ? maxEdge : radius / res;
+      lastRefineCapped = false;
       const region = addRegion(
         typeof name === 'string' && name ? name : `Region ${getRegions().length + 1}`,
         [color[0], color[1], color[2]],
@@ -4891,6 +4924,7 @@ async function main() {
         resolution: maxEdge !== undefined ? undefined : res,
         maxEdge: target,
         meshTriangleCount: currentMeshData?.numTri ?? 0,
+        ...(lastRefineCapped ? { capped: true, note: 'Mesh hit the triangle ceiling, so this stroke could not reach the requested detail. Clear colors or use fewer/coarser strokes.' } : {}),
       };
     },
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,11 +119,11 @@ import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontS
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
 import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, setRegionTriangles, buildTriColors, createEmptyTriColors, overlayPainted, type SerializedColorRegion, type RegionDescriptor } from './color/regions';
 import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as getPaintBucketTolerance, setBrushRadius as setPaintBrushRadius, getBrushRadius as getPaintBrushRadius, setBrushSmooth as setPaintBrushSmooth, isBrushSmooth as isPaintBrushSmooth, setBrushSmoothDivisor as setPaintBrushSmoothDivisor, getBrushSmoothDivisor as getPaintBrushSmoothDivisor, SMOOTH_DIVISOR_MIN, SMOOTH_DIVISOR_MAX } from './color/paintMode';
-import { buildStrokeMesh, strokeFootprintTriangles, childrenByParent, type BrushStroke, type BrushShape } from './color/subdivide';
+import { buildStrokeMesh, buildRefinedMesh, brushRefineRegion, strokeFootprintTriangles, childrenByParent, type BrushStroke, type BrushShape, type RefineRegion } from './color/subdivide';
 import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
 import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, resolveSeed, findNearestTriangle, type AdjacencyGraph } from './color/adjacency';
-import { findSlabTriangles } from './color/slabPaint';
-import { findBoxTriangles, findShapeTriangles } from './color/boxPaint';
+import { findSlabTriangles, slabRefineRegion, smoothEdgeForResolution } from './color/slabPaint';
+import { findBoxTriangles, findShapeTriangles, shapeRefineRegion } from './color/boxPaint';
 import { computeFaceGroups } from './color/faceGroups';
 import {
   getSessionIdFromURL,
@@ -391,24 +391,48 @@ function applyVersionAnnotations(version: Version | null | undefined): void {
  *  Returns the names of regions that resolved to ≥1 triangle (`carried`) vs.
  *  those whose descriptor no longer matches the current geometry (`dropped`),
  *  so callers transferring colors across versions can report what landed. */
-/** Pull the ordered `brushStroke` descriptors out of a descriptor list. */
-function collectStrokeDescriptors(descriptors: RegionDescriptor[]): BrushStroke[] {
-  const strokes: BrushStroke[] = [];
-  for (const d of descriptors) {
-    if (d.kind === 'brushStroke') strokes.push(descriptorToStroke(d));
-  }
-  return strokes;
+/** True when a descriptor drives mesh subdivision: any brush stroke, or a slab /
+ *  oriented shape with smoothing enabled (`smooth` + a positive `maxEdge`).
+ *  Descriptors saved before smoothing existed omit those fields and refine
+ *  nothing, preserving their original blocky edges. */
+function descriptorRefines(d: RegionDescriptor): boolean {
+  if (d.kind === 'brushStroke') return true;
+  if (d.kind === 'slab' || d.kind === 'box') return !!d.smooth && (d.maxEdge ?? 0) > 0;
+  return false;
 }
 
-/** Refine a base mesh under the given strokes. Returns the mesh unchanged with
- *  `parentToChildren: null` when there are no strokes (the common case — no
+/** Build the ordered refine regions (brush footprints, slab/shape boundaries)
+ *  from a descriptor list. Drives the local subdivision so painted edges follow
+ *  the analytic boundary rather than the coarse base tessellation. */
+function collectRefineRegions(descriptors: RegionDescriptor[]): RefineRegion[] {
+  const regions: RefineRegion[] = [];
+  for (const d of descriptors) {
+    if (d.kind === 'brushStroke') {
+      regions.push(brushRefineRegion(descriptorToStroke(d)));
+    } else if (d.kind === 'slab' && descriptorRefines(d)) {
+      regions.push(slabRefineRegion(d.normal, d.offset, d.thickness, d.maxEdge!));
+    } else if (d.kind === 'box' && descriptorRefines(d)) {
+      regions.push(shapeRefineRegion(d.shape ?? 'box', { center: d.center, size: d.size, quaternion: d.quaternion }, d.maxEdge!));
+    }
+  }
+  return regions;
+}
+
+/** True when any current region drives subdivision (see `descriptorRefines`). */
+function hasRefineDescriptors(): boolean {
+  return getRegions().some(r => descriptorRefines(r.descriptor));
+}
+
+/** Refine a base mesh under the given descriptors. Returns the mesh unchanged
+ *  with `parentToChildren: null` when nothing refines (the common case — no
  *  subdivision, identity mapping). */
-function refineMeshForStrokes(
+function refineMeshForRegions(
   base: MeshData,
-  strokes: BrushStroke[],
+  descriptors: RegionDescriptor[],
 ): { mesh: MeshData; parentToChildren: Map<number, number[]> | null } {
-  if (strokes.length === 0) return { mesh: base, parentToChildren: null };
-  const { mesh, childToParent } = buildStrokeMesh(base, strokes);
+  const regions = collectRefineRegions(descriptors);
+  if (regions.length === 0) return { mesh: base, parentToChildren: null };
+  const { mesh, childToParent } = buildRefinedMesh(base, regions);
   return { mesh, parentToChildren: childrenByParent(childToParent) };
 }
 
@@ -527,13 +551,12 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): { 
   const regions = geometryData.colorRegions as SerializedColorRegion[] | undefined;
   if (!regions || regions.length === 0) return report;
 
-  // Refine the pristine base mesh under any smooth strokes before resolving.
-  // Without strokes this is a no-op and currentMeshData is left untouched
-  // (identical to the pre-subdivision behavior).
+  // Refine the pristine base mesh under any smooth strokes/slabs/shapes before
+  // resolving. Without refine regions this is a no-op and currentMeshData is
+  // left untouched (identical to the pre-subdivision behavior).
   const base = paintBaseMesh ?? currentMeshData;
-  const strokes = collectStrokeDescriptors(regions.map(r => r.descriptor));
-  const { mesh, parentToChildren } = refineMeshForStrokes(base, strokes);
-  if (strokes.length > 0) {
+  const { mesh, parentToChildren } = refineMeshForRegions(base, regions.map(r => r.descriptor));
+  if (parentToChildren) {
     currentMeshData = mesh;
     updatePaintMesh(mesh);
   }
@@ -577,8 +600,7 @@ function paintedColorRefresh(): void {
 function rebuildPaintedGeometry(): void {
   const base = paintBaseMesh;
   if (!base) return;
-  const strokes = collectStrokeDescriptors(getRegions().map(r => r.descriptor));
-  const { mesh, parentToChildren } = refineMeshForStrokes(base, strokes);
+  const { mesh, parentToChildren } = refineMeshForRegions(base, getRegions().map(r => r.descriptor));
   currentMeshData = mesh;
   updatePaintMesh(mesh);
   const adjacency = buildAdjacency(mesh);
@@ -653,7 +675,7 @@ function reconcilePaintedGeometry(): void {
   syncLockState();
 
   const strokesNow = strokeDescriptors();
-  const refinedActive = currentMeshData !== paintBaseMesh || strokesNow.length > 0;
+  const refinedActive = currentMeshData !== paintBaseMesh || hasRefineDescriptors();
   if (!refinedActive) {
     lastStrokeList = [];
     if (isPaintActive()) paintedColorRefresh();
@@ -4225,7 +4247,7 @@ async function main() {
     /** Paint a slab — all faces whose centroid falls inside a planar slab.
      *  `axis` is shorthand for axis-aligned slabs ('x'/'y'/'z'). For oblique
      *  slabs, pass `normal` directly (does not need to be normalized). */
-    paintSlab(opts: { axis?: 'x' | 'y' | 'z'; normal?: [number, number, number]; offset: number; thickness: number; color: [number, number, number]; name?: string; coverageMode?: CoverageMode; maxTriangleArea?: number }) {
+    paintSlab(opts: { axis?: 'x' | 'y' | 'z'; normal?: [number, number, number]; offset: number; thickness: number; color: [number, number, number]; name?: string; coverageMode?: CoverageMode; maxTriangleArea?: number; smooth?: boolean; resolution?: number; maxEdge?: number }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintSlab requires {axis|normal, offset, thickness, color}' };
       const { axis, normal: rawNormal, offset, thickness, color, name, coverageMode, maxTriangleArea } = opts;
@@ -4250,6 +4272,8 @@ async function main() {
       if (coverageErr) return { error: coverageErr };
       const areaErr = validateMaxTriangleArea(maxTriangleArea);
       if (areaErr) return { error: areaErr };
+      const smoothErr = validateSmoothParams(opts);
+      if (smoothErr) return { error: smoothErr };
 
       let triangles = findSlabTriangles(currentMeshData, normal, offset, thickness, coverageMode);
       if (maxTriangleArea !== undefined && triangles.size > 0) {
@@ -4258,17 +4282,21 @@ async function main() {
       if (triangles.size === 0) return { error: 'No triangles found inside the slab' };
 
       const regionName = name ?? `Region ${getRegions().length + 1}`;
+      const { smooth, maxEdge } = resolveShapeSmoothFields(opts);
+      // Adding the region fires the change listener, which (when smoothing is on)
+      // rebuilds the refined mesh and re-resolves this region against it — so by
+      // the time addRegion returns, region.triangles holds the smoothed count.
       const region = addRegion(
         regionName,
         color as [number, number, number],
         'slab',
-        { kind: 'slab', normal, offset, thickness },
+        { kind: 'slab', normal, offset, thickness, smooth, maxEdge },
         triangles,
       );
       scheduleColorRefresh();
       syncLockState();
 
-      return { id: region.id, name: region.name, triangles: triangles.size };
+      return { id: region.id, name: region.name, triangles: region.triangles.size, smooth, maxEdge };
     },
 
     /** List all color regions on the current geometry. Each entry includes
@@ -4451,6 +4479,14 @@ async function main() {
       };
       color: [number, number, number];
       name?: string;
+      /** Smooth the box's painted edge by subdividing the mesh near its faces.
+       *  On by default — pass `false` to keep the blocky base tessellation. */
+      smooth?: boolean;
+      /** Smoothing detail: target boundary edge length = model bbox diagonal /
+       *  resolution (2..1024, default 256). Ignored when `maxEdge` is set. */
+      resolution?: number;
+      /** Absolute target boundary edge length (mesh units); overrides `resolution`. */
+      maxEdge?: number;
     }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintInOrientedBox requires { box, color }' };
@@ -4461,15 +4497,33 @@ async function main() {
       const q: [number, number, number, number] = quaternion ?? [0, 0, 0, 1];
       if (!Array.isArray(q) || q.length !== 4 || !q.every(Number.isFinite)) return { error: 'paintInOrientedBox.box.quaternion must be [x, y, z, w] of finite numbers (defaults to identity if omitted)' };
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r, g, b] with values 0..1' };
+      const smoothErr = validateSmoothParams(opts);
+      if (smoothErr) return { error: smoothErr };
 
-      const triangles = findBoxTriangles(currentMeshData, {
-        center: [center[0], center[1], center[2]],
-        size: [size[0], size[1], size[2]],
+      const box = {
+        center: [center[0], center[1], center[2]] as [number, number, number],
+        size: [size[0], size[1], size[2]] as [number, number, number],
         quaternion: q,
-      });
+      };
+      const triangles = findBoxTriangles(currentMeshData, box);
       if (triangles.size === 0) return { error: 'paintInOrientedBox: no triangles inside the box. Try a larger size, recheck the center, or use paintPreview to see what the box covers.' };
 
-      return commitPaintFromSet(triangles, opts.color, opts.name, 'paintbrush');
+      // Persist a re-resolvable box descriptor (not baked triangle ids) so the
+      // edge can be smoothed: adding it rebuilds the refined mesh and re-resolves
+      // this region against it before addRegion returns.
+      const { smooth, maxEdge } = resolveShapeSmoothFields(opts);
+      const regionName = opts.name ?? `Region ${getRegions().length + 1}`;
+      const region = addRegion(
+        regionName,
+        opts.color as [number, number, number],
+        'slab',
+        { kind: 'box', center: box.center, size: box.size, quaternion: box.quaternion, smooth, maxEdge },
+        triangles,
+      );
+      scheduleColorRefresh();
+      syncLockState();
+      const stats = regionTriangleStats(region.triangles, currentMeshData);
+      return { id: region.id, name: region.name, triangles: region.triangles.size, bbox: stats.bbox, centroid: stats.centroid, smooth, maxEdge };
     },
 
     /** Paint every triangle whose centroid lies within `radius` of `point`.
@@ -6013,6 +6067,29 @@ async function main() {
       return 'maxTriangleArea must be a positive finite number';
     }
     return null;
+  }
+
+  /** Validate the optional edge-smoothing params shared by slab/shape paint
+   *  methods (`smooth`, `resolution`, `maxEdge`). */
+  function validateSmoothParams(opts: { smooth?: unknown; resolution?: unknown; maxEdge?: unknown }): string | null {
+    if (opts.smooth !== undefined && typeof opts.smooth !== 'boolean') return 'smooth must be a boolean';
+    if (opts.resolution !== undefined && (typeof opts.resolution !== 'number' || !Number.isFinite(opts.resolution) || opts.resolution < SMOOTH_DIVISOR_MIN || opts.resolution > SMOOTH_DIVISOR_MAX)) {
+      return `resolution must be a number from ${SMOOTH_DIVISOR_MIN} to ${SMOOTH_DIVISOR_MAX}`;
+    }
+    if (opts.maxEdge !== undefined && (typeof opts.maxEdge !== 'number' || !Number.isFinite(opts.maxEdge) || opts.maxEdge <= 0)) return 'maxEdge must be a positive finite number';
+    return null;
+  }
+
+  /** Resolve smoothing fields for a slab/shape descriptor from API opts.
+   *  `smooth` defaults to true; an explicit positive `maxEdge` (absolute edge
+   *  length) wins over `resolution` (model bbox diagonal / resolution, default
+   *  256). With smoothing off, the fields refine nothing. */
+  function resolveShapeSmoothFields(opts: { smooth?: boolean; resolution?: number; maxEdge?: number }): { smooth: boolean; maxEdge: number } {
+    if (opts.smooth === false) return { smooth: false, maxEdge: 0 };
+    if (typeof opts.maxEdge === 'number' && opts.maxEdge > 0) return { smooth: true, maxEdge: opts.maxEdge };
+    const resolution = typeof opts.resolution === 'number' && opts.resolution > 0 ? opts.resolution : 256;
+    const maxEdge = currentMeshData ? smoothEdgeForResolution(currentMeshData, resolution) : 0;
+    return { smooth: maxEdge > 0, maxEdge };
   }
 
   function validateNormalCone(cone: { axis: [number, number, number]; angleDeg: number } | undefined): string | null {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ import { initDiagnosticsPanel, toggleDiagnosticsPanel } from './ui/diagnosticsPa
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, type Language } from './geometry/engine';
 import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
-import { initViewport, updateMesh, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange } from './renderer/viewport';
+import { initViewport, updateMesh, setOnMeshUpdate, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange } from './renderer/viewport';
 import { renderCompositeCanvas, renderSingleView, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode } from './renderer/multiview';
 import { generateId } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
@@ -402,32 +402,35 @@ function collectStrokeDescriptors(descriptors: RegionDescriptor[]): BrushStroke[
 
 /** Refine a base mesh under the given strokes. Returns the mesh unchanged with
  *  `parentToChildren: null` when there are no strokes (the common case — no
- *  subdivision, identity mapping). `capped` is true when subdivision stopped at
- *  the triangle ceiling (a stroke couldn't reach its requested detail). */
+ *  subdivision, identity mapping). */
 function refineMeshForStrokes(
   base: MeshData,
   strokes: BrushStroke[],
-): { mesh: MeshData; parentToChildren: Map<number, number[]> | null; capped: boolean } {
-  if (strokes.length === 0) return { mesh: base, parentToChildren: null, capped: false };
-  const { mesh, childToParent, capped } = buildStrokeMesh(base, strokes);
-  return { mesh, parentToChildren: childrenByParent(childToParent), capped };
+): { mesh: MeshData; parentToChildren: Map<number, number[]> | null } {
+  if (strokes.length === 0) return { mesh: base, parentToChildren: null };
+  const { mesh, childToParent } = buildStrokeMesh(base, strokes);
+  return { mesh, parentToChildren: childrenByParent(childToParent) };
 }
 
-/** True when the last refine hit the triangle ceiling, so the console
- *  `paintStroke` can report it. */
-let lastRefineCapped = false;
-let detailCappedWarnedAt = 0;
+/** Above this triangle count we warn (once) that the model is getting heavy.
+ *  There is no hard cap — painting keeps working; this is just a heads-up. */
+const HIGH_COMPLEXITY_TRIANGLES = 1_000_000;
+let complexityWarned = false;
 
-/** Surface the "couldn't subdivide further — mesh is at the detail ceiling"
- *  condition so the user understands why a stroke came out coarse (instead of it
- *  silently happening). Debounced; goes to the diagnostic log (⚠ panel) via
- *  console.warn. The actionable fix is to Clear colors or lower Edge smoothing. */
-function notifyDetailCapped(triangleCount: number): void {
-  const now = Date.now();
-  if (now - detailCappedWarnedAt < 4000) return;
-  detailCappedWarnedAt = now;
-  // eslint-disable-next-line no-console
-  console.warn(`Smooth paint: detail limit reached (~${triangleCount.toLocaleString()} triangles). Clear colors or lower "Edge smoothing" to keep painting at full resolution.`);
+/** Refresh the live triangle-count readout and, once, warn when the displayed
+ *  mesh gets heavy. Driven by every viewport mesh update (run, paint, simplify,
+ *  clear). Resets the warning when the mesh drops back below the threshold. */
+function refreshTriangleCount(numTri: number): void {
+  const el = document.getElementById('triangle-count');
+  if (el) el.textContent = `${numTri.toLocaleString()} tris`;
+  if (numTri >= HIGH_COMPLEXITY_TRIANGLES) {
+    if (!complexityWarned) {
+      complexityWarned = true;
+      showToast(`Model complexity is high (${numTri.toLocaleString()} triangles) — painting still works, but it may slow down. Clear colors or lower Edge smoothing to lighten it.`, { variant: 'warn', durationMs: 5000 });
+    }
+  } else if (numTri < HIGH_COMPLEXITY_TRIANGLES * 0.8) {
+    complexityWarned = false; // re-arm once well below the threshold
+  }
 }
 
 /** Map base-mesh triangle ids onto the refined mesh. With no subdivision
@@ -575,15 +578,13 @@ function rebuildPaintedGeometry(): void {
   const base = paintBaseMesh;
   if (!base) return;
   const strokes = collectStrokeDescriptors(getRegions().map(r => r.descriptor));
-  const { mesh, parentToChildren, capped } = refineMeshForStrokes(base, strokes);
+  const { mesh, parentToChildren } = refineMeshForStrokes(base, strokes);
   currentMeshData = mesh;
   updatePaintMesh(mesh);
   const adjacency = buildAdjacency(mesh);
   for (const region of getRegions()) {
     setRegionTriangles(region.id, resolveDescriptorTriangles(region.descriptor, mesh, adjacency, parentToChildren));
   }
-  lastRefineCapped = capped;
-  if (capped) notifyDetailCapped(mesh.numTri);
   paintedColorRefresh();
   syncLockState();
 }
@@ -596,7 +597,7 @@ function rebuildPaintedGeometry(): void {
  *  many strokes precede it. */
 function appendStrokeRefine(descriptor: Extract<RegionDescriptor, { kind: 'brushStroke' }>): void {
   if (!currentMeshData) return;
-  const { mesh, childToParent, capped } = buildStrokeMesh(currentMeshData, [descriptorToStroke(descriptor)]);
+  const { mesh, childToParent } = buildStrokeMesh(currentMeshData, [descriptorToStroke(descriptor)]);
   const parentToChildren = childrenByParent(childToParent);
   currentMeshData = mesh;
   updatePaintMesh(mesh);
@@ -628,8 +629,6 @@ function appendStrokeRefine(descriptor: Extract<RegionDescriptor, { kind: 'brush
       setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, parentToChildren));
     }
   }
-  lastRefineCapped = capped;
-  if (capped) notifyDetailCapped(mesh.numTri);
   paintedColorRefresh();
   syncLockState();
 }
@@ -1871,6 +1870,9 @@ async function main() {
 
   // Init viewport
   initViewport(viewportPane);
+  // Keep the live triangle-count readout (and high-complexity warning) in sync
+  // with every displayed mesh — runs, paint strokes, simplify, clear.
+  setOnMeshUpdate((mesh) => refreshTriangleCount(mesh.numTri));
 
   // Init measure tool
   initMeasureTool(getCanvas(), getCamera(), getMeshGroup(), viewportPane);
@@ -4915,7 +4917,6 @@ async function main() {
       // maxEdge (absolute) overrides; otherwise radius / resolution, default 256.
       const res = Math.max(SMOOTH_DIVISOR_MIN, Math.min(SMOOTH_DIVISOR_MAX, resolution ?? 256));
       const target = maxEdge !== undefined ? maxEdge : radius / res;
-      lastRefineCapped = false;
       const region = addRegion(
         typeof name === 'string' && name ? name : `Region ${getRegions().length + 1}`,
         [color[0], color[1], color[2]],
@@ -4936,7 +4937,6 @@ async function main() {
         resolution: maxEdge !== undefined ? undefined : res,
         maxEdge: target,
         meshTriangleCount: currentMeshData?.numTri ?? 0,
-        ...(lastRefineCapped ? { capped: true, note: 'Mesh hit the triangle ceiling, so this stroke could not reach the requested detail. Clear colors or use fewer/coarser strokes.' } : {}),
       };
     },
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -600,19 +600,31 @@ function appendStrokeRefine(descriptor: Extract<RegionDescriptor, { kind: 'brush
   const parentToChildren = childrenByParent(childToParent);
   currentMeshData = mesh;
   updatePaintMesh(mesh);
-  // Re-resolve regions exactly as a full rebuild / reload would, so the live
-  // result matches what reload reconstructs (determinism). Explicit sets
-  // (triangles/byLabel index the base tessellation / runtime labelMap) are
-  // carried forward across this split; every spatial/footprint/flood descriptor
-  // is re-resolved by descriptor — its children near the split may fall outside
-  // the region, which a naive parent→children carry would wrongly keep.
-  const needsAdj = getRegions().some(r => r.descriptor.kind === 'coplanar' || r.descriptor.kind === 'connectedFromSeed');
-  const adjacency = needsAdj ? buildAdjacency(mesh) : null;
+  // Triangles of the prior mesh that this stroke actually split (>1 child).
+  // Only regions touching those need descriptor re-resolution; everyone else is
+  // untouched, so forward-carrying their set (each unsplit triangle → its single
+  // child) equals what a reload would re-resolve — and is far cheaper.
+  const splitParents = new Set<number>();
+  for (const [parent, children] of parentToChildren) if (children.length > 1) splitParents.add(parent);
+
+  // A region must be re-resolved by descriptor when it's freshly added (no
+  // triangles yet, e.g. the new stroke) or overlaps the split — because a
+  // spatial/footprint/flood descriptor's split children can fall outside it,
+  // which a naive parent→children carry would wrongly keep. Explicit sets
+  // (triangles/byLabel) always carry forward. This keeps the live result
+  // identical to a reload (determinism) while staying ~O(painted) per stroke.
+  let adjacency: AdjacencyGraph | null = null;
+  const overlapsSplit = (region: { triangles: Set<number> }): boolean => {
+    if (region.triangles.size === 0) return true;
+    for (const t of region.triangles) if (splitParents.has(t)) return true;
+    return false;
+  };
   for (const region of getRegions()) {
     const d = region.descriptor;
-    if (d.kind === 'triangles' || d.kind === 'byLabel') {
+    if (d.kind === 'triangles' || d.kind === 'byLabel' || !overlapsSplit(region)) {
       setRegionTriangles(region.id, remapTriangleIds(region.triangles, parentToChildren));
     } else {
+      if (!adjacency && (d.kind === 'coplanar' || d.kind === 'connectedFromSeed')) adjacency = buildAdjacency(mesh);
       setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, parentToChildren));
     }
   }

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -218,6 +218,13 @@ export function initViewport(container: HTMLElement): {
   return { scene, camera, renderer };
 }
 
+/** Fired after every mesh update with the displayed mesh, so the host can keep
+ *  a live readout (e.g. triangle count) in sync without hooking every call site. */
+let onMeshUpdate: ((mesh: MeshData) => void) | null = null;
+export function setOnMeshUpdate(fn: (mesh: MeshData) => void): void {
+  onMeshUpdate = fn;
+}
+
 export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boolean }): void {
   // Clear previous
   while (meshGroup.children.length > 0) {
@@ -289,6 +296,8 @@ export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boole
       updateClipPlaneVisual();
     }
   }
+
+  onMeshUpdate?.(meshData);
 }
 
 // === Clipping API ===

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -453,6 +453,15 @@ function createClipControls(): HTMLElement {
   container.id = 'clip-controls';
   container.className = 'absolute top-2 right-2 z-10 flex flex-wrap justify-end items-center gap-2 max-w-[calc(100%-1rem)]';
 
+  // Live triangle count of the displayed model — sits at the left of the bar.
+  // Non-interactive readout, updated on every mesh change (run/paint/simplify).
+  const triCount = document.createElement('div');
+  triCount.id = 'triangle-count';
+  triCount.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 border border-zinc-600/50 tabular-nums select-none';
+  triCount.title = 'Triangle count of the current model (updates as you edit and paint)';
+  triCount.textContent = '— tris';
+  container.appendChild(triCount);
+
   // Mesh edge (wireframe) toggle (off by default) — sits left of the grid toggle
   const wireBtn = document.createElement('button');
   wireBtn.id = 'wireframe-toggle';

--- a/tests/paint-smooth-brush.spec.ts
+++ b/tests/paint-smooth-brush.spec.ts
@@ -1,12 +1,13 @@
 // Smooth paintbrush: subdivides the mesh under a brush stroke so the painted
 // region's edge is rounded instead of following the existing tessellation.
 //
-// Covers the UI controls (smooth toggle + fineness selector), the
+// Covers the UI controls (smooth toggle + detail slider), the
 // window.partwright config + paintStroke API, and the core invariants:
 //   - a stroke grows the triangle count (subdivision happened)
-//   - the refined mesh stays watertight (every edge shared by exactly 2 tris)
-//   - finer subdivision yields more triangles
+//   - refinement is rim-only (lean), with intentional hairline T-junctions
+//   - finer detail yields more triangles
 //   - clearing the stroke restores the original tessellation
+//   - a stroke overlapping another region resolves the same live and on reload
 //
 // Uses dispatchEvent('click') to dodge the first-run onboarding backdrop, and
 // drives painting through paintStroke (same code path as the UI smooth brush)
@@ -71,6 +72,9 @@ test.describe('smooth paintbrush', () => {
     await page.locator('#paint-toggle').dispatchEvent('click');
     await page.waitForSelector('#paint-picker-panel:not(.hidden)');
     await page.locator('#paint-picker-panel button:has-text("Brush")').dispatchEvent('click');
+    // Let the viewport auto-frame the new mesh so the centre ray reliably hits
+    // it (otherwise a synthetic mousedown can miss before the camera settles).
+    await page.waitForTimeout(150);
 
     const out = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -242,6 +246,33 @@ test.describe('smooth paintbrush', () => {
     expect(out.coarse.resolution).toBe(32);        // settable
     expect(out.defTri).toBeGreaterThan(out.coarseTri); // 256 is finer than 32
     expect(out.abs.maxEdge).toBe(0.5);             // maxEdge override wins
+  });
+
+  test('a region overlapping a smooth stroke resolves the same live and on reload', async ({ page }) => {
+    await openEditor(page);
+    const out = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('overlap-determinism');
+      await pw.run(`const { Manifold } = api; return Manifold.cube([40, 40, 6], true);`);
+      // A box region over the top half, then a smooth stroke straddling its edge
+      // (subdivides triangles the box's centroid test treats as in/out).
+      const boxRegion = pw.paintInBox({ box: { min: [-20, -20, 2.9], max: [20, 20, 3.1] }, color: [0, 0, 1], name: 'Top' });
+      pw.paintStroke({ points: [[0, 0, 3]], radius: 8, resolution: 64, color: [1, 0, 0] });
+      const liveBoxTris = pw.listRegions().find((r: { id: number }) => r.id === boxRegion.id).triangles;
+      const liveMeshTris = pw.getMesh().numTri;
+
+      const sv = await pw.runAndSave(pw.getCode(), 'overlap-v');
+      await pw.run(`const { Manifold } = api; return Manifold.cube([40, 40, 6], true);`);
+      await pw.loadVersion({ index: sv.version.index });
+      const reloaded = pw.listRegions();
+      const reloadBox = reloaded.find((r: { name: string }) => r.name === 'Top');
+      return { liveBoxTris, liveMeshTris, reloadBoxTris: reloadBox?.triangles ?? -1, reloadMeshTris: pw.getMesh().numTri };
+    });
+
+    // Incremental (live) append must match the full re-resolve on reload.
+    expect(out.reloadMeshTris).toBe(out.liveMeshTris);
+    expect(out.reloadBoxTris).toBe(out.liveBoxTris);
   });
 
   test('a smooth stroke survives save + reload', async ({ page }) => {

--- a/tests/paint-smooth-brush.spec.ts
+++ b/tests/paint-smooth-brush.spec.ts
@@ -32,13 +32,14 @@ test.describe('smooth paintbrush', () => {
     await page.waitForSelector('#paint-picker-panel:not(.hidden)');
 
     // Brush is the default tool, so the smooth toggle shows immediately and
-    // smoothing is on by default.
-    const smoothBtn = page.locator('#paint-picker-panel button:has-text("Smooth edges")');
+    // smoothing is on by default. Scope to the brush's own toggle (the slab and
+    // shape panels carry their own "Smooth edges" toggles too).
+    const smoothBtn = page.locator('#paint-picker-panel button[title*="under the brush"]');
     await expect(smoothBtn).toBeVisible();
     await expect(smoothBtn).toContainText('On');
 
     // The detail control is a typeable slider (range 2..1024), visible while on.
-    const detailSlider = page.locator('#paint-picker-panel input[type="range"][title*="Smooth-edge detail"]');
+    const detailSlider = page.locator('#paint-picker-panel input[type="range"][title*="brush radius"]');
     await expect(detailSlider).toBeVisible();
     await expect(detailSlider).toHaveAttribute('max', '1024');
     await expect(detailSlider).toHaveAttribute('min', '2');
@@ -325,5 +326,139 @@ test.describe('smooth paintbrush', () => {
     expect(out.reloadedTri).toBe(out.paintedTri);         // refined mesh reconstructed deterministically
     expect(out.reloadedColored).toBe(out.paintedColored); // same painted triangle set
     expect(out.reloadedRegions).toBe(1);
+  });
+});
+
+// Slab and oriented-shape painting reuse the same rim-subdivision pipeline as the
+// brush: their analytic boundary is smoothed by subdividing the coarse triangles
+// it crosses. Smoothing is on by default and controllable (UI toggle/slider; API
+// smooth/resolution/maxEdge params).
+test.describe('smooth slab & shape painting', () => {
+  test('paintSlab smooths its edges by default and smooth:false keeps the base mesh', async ({ page }) => {
+    await openEditor(page);
+    const out = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const base = pw.getMesh().numTri; // 10mm cube: 12 triangles
+      // Slab z ∈ [0,5] covers the top face + upper walls (so the coarse centroid
+      // test finds something), and its lower edge z=0 crosses the wall triangles.
+      const smooth = pw.paintSlab({ axis: 'z', offset: 0, thickness: 5, color: [0, 0.6, 1] });
+      const smoothTri = pw.getMesh().numTri;
+      pw.clearColors();
+      const cleared = pw.getMesh().numTri;
+      const blocky = pw.paintSlab({ axis: 'z', offset: 0, thickness: 5, color: [0, 0.6, 1], smooth: false });
+      const blockyTri = pw.getMesh().numTri;
+      return { base, smooth, smoothTri, cleared, blocky, blockyTri };
+    });
+
+    expect(out.smooth.error).toBeFalsy();
+    expect(out.smooth.smooth).toBe(true);
+    expect(out.smooth.maxEdge).toBeGreaterThan(0);
+    expect(out.smoothTri).toBeGreaterThan(out.base);  // boundary subdivided
+    expect(out.cleared).toBe(out.base);               // clear restores the base mesh
+    expect(out.blocky.smooth).toBe(false);
+    expect(out.blockyTri).toBe(out.base);             // smooth:false leaves tessellation untouched
+  });
+
+  test('slab resolution controls smoothness (finer → more triangles)', async ({ page }) => {
+    await openEditor(page);
+    const out = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run(`const { Manifold } = api; return Manifold.cube([60, 60, 60], true);`);
+      pw.paintSlab({ axis: 'z', offset: 0, thickness: 20, color: [1, 0, 0], resolution: 16 });
+      const coarse = pw.getMesh().numTri;
+      pw.clearColors();
+      pw.paintSlab({ axis: 'z', offset: 0, thickness: 20, color: [1, 0, 0], resolution: 128 });
+      const fine = pw.getMesh().numTri;
+      return { coarse, fine };
+    });
+    expect(out.fine).toBeGreaterThan(out.coarse);
+  });
+
+  test('paintInOrientedBox smooths by default; smooth:false keeps the base mesh', async ({ page }) => {
+    await openEditor(page);
+    const out = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const base = pw.getMesh().numTri;
+      // A box that pokes through the top face (z=5) — its faces cut across the
+      // two big top-face triangles, so smoothing has coarse triangles to refine.
+      const smooth = pw.paintInOrientedBox({ box: { center: [0, 0, 5], size: [6, 6, 6] }, color: [0.2, 0.9, 0.4] });
+      const smoothTri = pw.getMesh().numTri;
+      pw.clearColors();
+      const blocky = pw.paintInOrientedBox({ box: { center: [0, 0, 5], size: [6, 6, 6] }, color: [0.2, 0.9, 0.4], smooth: false });
+      const blockyTri = pw.getMesh().numTri;
+      return { base, smooth, smoothTri, blocky, blockyTri };
+    });
+
+    expect(out.smooth.error).toBeFalsy();
+    expect(out.smooth.smooth).toBe(true);
+    expect(out.smoothTri).toBeGreaterThan(out.base);
+    expect(out.blocky.smooth).toBe(false);
+    expect(out.blockyTri).toBe(out.base);
+  });
+
+  test('a smooth slab resolves the same live and on reload (determinism)', async ({ page }) => {
+    await openEditor(page);
+    const out = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('smooth-slab-persist');
+      await pw.run(`const { Manifold } = api; return Manifold.cube([30, 30, 30], true);`);
+      const region = pw.paintSlab({ axis: 'z', offset: 0, thickness: 10, color: [1, 0.4, 0], resolution: 48 });
+      const liveTri = pw.getMesh().numTri;
+      const liveColored = pw.listRegions().find((r: { id: number }) => r.id === region.id).triangles;
+
+      const sv = await pw.runAndSave(pw.getCode(), 'slab-v');
+      await pw.run(`const { Manifold } = api; return Manifold.cube([30, 30, 30], true);`);
+      const baseTri = pw.getMesh().numTri;
+      await pw.loadVersion({ index: sv.version.index });
+      const reloaded = pw.listRegions()[0];
+      return { liveTri, liveColored, baseTri, reloadTri: pw.getMesh().numTri, reloadColored: reloaded?.triangles ?? -1 };
+    });
+
+    expect(out.baseTri).toBe(12);                    // bare cube, no refinement
+    expect(out.liveTri).toBeGreaterThan(12);         // smoothing subdivided
+    expect(out.reloadTri).toBe(out.liveTri);         // refined mesh reconstructed deterministically
+    expect(out.reloadColored).toBe(out.liveColored); // same painted set
+  });
+
+  test('a stroke appended over a smooth slab matches a full reload (determinism)', async ({ page }) => {
+    await openEditor(page);
+    const out = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('slab-then-stroke');
+      await pw.run(`const { Manifold } = api; return Manifold.cube([30, 30, 30], true);`);
+      // Smooth slab first (full rebuild), then a stroke straddling its band
+      // (incremental append onto the slab-refined mesh).
+      const slab = pw.paintSlab({ axis: 'z', offset: 0, thickness: 10, color: [0, 0.5, 1], resolution: 48 });
+      pw.paintStroke({ points: [[15, 0, 5]], radius: 6, resolution: 48, color: [1, 0, 0] });
+      const liveMeshTris = pw.getMesh().numTri;
+      const liveSlabTris = pw.listRegions().find((r: { id: number }) => r.id === slab.id).triangles;
+
+      const sv = await pw.runAndSave(pw.getCode(), 'slab-stroke-v');
+      await pw.run(`const { Manifold } = api; return Manifold.cube([30, 30, 30], true);`);
+      await pw.loadVersion({ index: sv.version.index });
+      const reloadSlab = pw.listRegions().find((r: { name: string }) => r.name === slab.name);
+      return { liveMeshTris, liveSlabTris, reloadMeshTris: pw.getMesh().numTri, reloadSlabTris: reloadSlab?.triangles ?? -1 };
+    });
+
+    expect(out.reloadMeshTris).toBe(out.liveMeshTris);   // incremental append == full reload
+    expect(out.reloadSlabTris).toBe(out.liveSlabTris);
+  });
+
+  test('the slab and shape panels show an edge-smoothing toggle, on by default', async ({ page }) => {
+    await openEditor(page);
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    for (const tool of ['Slab', 'Shape']) {
+      await page.locator(`#paint-picker-panel button:has-text("${tool}")`).first().dispatchEvent('click');
+      const smoothBtn = page.locator('#paint-picker-panel button:visible:has-text("Smooth edges")');
+      await expect(smoothBtn).toBeVisible();
+      await expect(smoothBtn).toContainText('On');
+    }
   });
 });

--- a/tests/paint-smooth-brush.spec.ts
+++ b/tests/paint-smooth-brush.spec.ts
@@ -248,6 +248,24 @@ test.describe('smooth paintbrush', () => {
     expect(out.abs.maxEdge).toBe(0.5);             // maxEdge override wins
   });
 
+  test('triangle-count readout updates on run, paint, and clear (no hard cap)', async ({ page }) => {
+    await openEditor(page); // runs a 10mm cube (12 triangles)
+    const counter = page.locator('#triangle-count');
+    await expect(counter).toBeVisible();
+    const num = async () => parseInt((await counter.textContent() ?? '').replace(/[^0-9]/g, ''), 10);
+    const base = await num();
+    expect(base).toBe(12);
+
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).partwright.paintStroke({ points: [[0, 0, 5]], radius: 2, resolution: 64, color: [1, 0, 0] });
+    });
+    await expect.poll(num).toBeGreaterThan(base); // count rose with the stroke
+
+    await page.evaluate(() => (window as unknown as { partwright: { clearColors(): void } }).partwright.clearColors());
+    await expect.poll(num).toBe(base); // back to base after clear
+  });
+
   test('a region overlapping a smooth stroke resolves the same live and on reload', async ({ page }) => {
     await openEditor(page);
     const out = await page.evaluate(async () => {


### PR DESCRIPTION
## Summary

Follow-ups on the smooth-paintbrush feature (#203). Three things, all in the smooth-paint pipeline:

**1. Edge smoothing for slab & shape painting (new).** `paintSlab` and the oriented-shape tools (box / sphere / cylinder / cone) now subdivide the mesh along the region's analytic boundary so the painted edge follows the shape instead of the coarse base tessellation — the same rim-only refinement the smooth brush uses. **On by default.**
- `subdivide.ts` generalized: `buildStrokeMesh` → `buildRefinedMesh` over a `RefineRegion` (boundary classifier + AABB + target edge). Brush, slab, and each shape supply a conservative *never-miss* classifier (slab is exact via the projection range; sphere exact via closest-point; box never-misses via the 6 face planes; cylinder/cone use exact axis + radial separations).
- slab / box descriptors carry optional `smooth` + `maxEdge`; descriptors saved before this omit them and stay blocky (back-compat).
- UI: the slab and shape panels gain an edge-smoothing toggle + detail slider (shared state, on by default).
- API: `paintSlab` and `paintInOrientedBox` accept `smooth` / `resolution` / `maxEdge`. `paintInOrientedBox` now persists a re-resolvable box descriptor (not baked triangle ids) so its edge can be smoothed and it reloads deterministically.

**2. Drop the hard triangle cap; surface complexity instead** (replaces this PR's original "cap surfacing"). The internal `MAX_TRIANGLES` ceiling silently capped stroke detail mid-session — the reported "raising the detail slider stops working". Per follow-up direction the cap is now **removed**. In its place: a live triangle-count readout at the top-left of the interactive toolbar (updates on run / paint / simplify / clear) and a one-time toast when the model crosses ~1M triangles. `MAX_PASSES` raised 12 → 16.

**3. Determinism fix (review High).** The incremental stroke append carried non-stroke regions across the split by parent→children, but reload re-resolves by descriptor, so a stroke overlapping a box / slab / coplanar region could paint a different set live vs. on reload. `appendStrokeRefine` now re-resolves the regions a stroke actually split (matching reload) and forward-carries the rest — still ~O(painted) per stroke.

Plus: unify the missing-`maxEdge` fallback to `radius/256`; un-export internal `subdivide.ts` helpers; docs (`ai.md`, `colors.md`) note slab/shape smoothing + the new params.

## Test plan

- [x] `npm run build` clean
- [x] `paint-smooth-brush.spec.ts` — brush coverage **plus new** slab/shape smoothing, resolution control, live-vs-reload determinism (smooth slab, and a stroke appended over a smooth slab), triangle-count readout, and the slab/shape smoothing-toggle UI
- [x] Regression: `paint-controls-extended`, `paint-coverage`, `paint-batch-and-lifecycle`, `fork-color-carry`, `paint-render-color`, `paint-by-vision`, `render-color-readability`, `smoke`, `simplify` green
- [x] Re-synced with the latest `origin/staging`
- [ ] Heads-up: one new `simplify` test from staging (`Save as version preserves an unsaved edited original`) fails **identically on pristine `origin/staging`** in this sandbox — pre-existing, unrelated to this branch

https://claude.ai/code/session_017QcgmoypYepU3oA3mYEZKE

---
_Generated by [Claude Code](https://claude.ai/code/session_017QcgmoypYepU3oA3mYEZKE)_