### PR TITLE
feat: show more, randomized featured catalog tiles on landing page

### DIFF
--- a/src/ui/landing.ts
+++ b/src/ui/landing.ts
@@ -35,7 +35,18 @@ interface FeaturedCatalogEntry {
   thumbnailUrl: string | null;
 }
 
-const FEATURED_CATALOG_IDS = ['twisted-vase', 'retro-rocket', 'chess-rook', 'christmas-tree'];
+/** Number of catalog entries to show in the "What you can build" section. */
+const FEATURED_CATALOG_COUNT = 8;
+
+/** Fisher-Yates shuffle — returns a new array in random order. */
+function shuffleArray<T>(arr: T[]): T[] {
+  const copy = arr.slice();
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
 
 export async function createLandingPage(
   container: HTMLElement,
@@ -253,11 +264,8 @@ async function loadFeaturedCatalogEntries(): Promise<FeaturedCatalogEntry[]> {
     const res = await fetch('/catalog/manifest.json', { cache: 'no-cache' });
     if (!res.ok) return [];
     const manifest = await res.json() as { entries: CatalogManifestEntry[] };
-    const byId = new Map(manifest.entries.map(e => [e.id, e]));
-    const featured = FEATURED_CATALOG_IDS
-      .map(id => byId.get(id))
-      .filter((e): e is CatalogManifestEntry => Boolean(e));
-    const list = featured.length > 0 ? featured : manifest.entries.slice(0, 4);
+    const shuffled = shuffleArray(manifest.entries);
+    const list = shuffled.slice(0, FEATURED_CATALOG_COUNT);
 
     return await Promise.all(list.map(async (manifestEntry) => {
       try {


### PR DESCRIPTION
## Summary

The landing page "What you can build" section showed a fixed set of 4 hardcoded catalog tiles. This makes it show more tiles, randomly sampled from the full catalog manifest on each page load.

## Changes (`src/ui/landing.ts` only)
- Replaced the hardcoded `FEATURED_CATALOG_IDS` (4 items) with a random sample.
- Added `FEATURED_CATALOG_COUNT = 8` (named constant, easy to tune).
- Added a Fisher–Yates `shuffleArray` helper; `loadFeaturedCatalogEntries()` now shuffles `manifest.entries` and takes the first N, degrading gracefully when the catalog has fewer than N entries.

## Notes
- On `staging` today the catalog has few entries so it shows all of them; once the gallery-models PR (#212) merges (25 entries) the section will display 8 random tiles per load.

## Test plan
- [x] `npm run build` succeeds (no TS errors)
- [x] Landing page renders the featured tiles with thumbnails, no console errors
- [x] Reloading several times shows a different random selection/order

https://claude.ai/code/session_01BjC3bmhM1dQzSbVcybs4aT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjC3bmhM1dQzSbVcybs4aT)_