### PR TITLE
fix: validate Gemini key via models-list endpoint, tolerate transient 5xx

### DIFF
--- a/src/ai/gemini.ts
+++ b/src/ai/gemini.ts
@@ -23,21 +23,31 @@ function generateUrl(model: string, apiKey: string): string {
   return `${API_BASE}/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 }
 
+function modelsUrl(apiKey: string, pageSize: number): string {
+  return `${API_BASE}/models?key=${encodeURIComponent(apiKey)}&pageSize=${pageSize}`;
+}
+
 export function resetClient(): void {
   // Stateless.
 }
 
 export async function validateKey(apiKey: string): Promise<string | null> {
+  // Validate against the lightweight models-list metadata endpoint, NOT a
+  // generateContent ping. A generation call depends on one specific model
+  // being up, so an overloaded model answers 503 UNAVAILABLE ("high demand")
+  // and a perfectly valid key looks rejected. Listing models only checks the
+  // key itself — no per-model availability, no generation quota, and no
+  // hard-coded model id to go stale (the same trap listModels warns about).
   try {
-    const res = await fetch(generateUrl('gemini-2.5-flash-lite', apiKey), {
-      method: 'POST',
+    const res = await fetch(modelsUrl(apiKey, 1), {
+      method: 'GET',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ role: 'user', parts: [{ text: 'ok' }] }],
-        generationConfig: { maxOutputTokens: 1 },
-      }),
     });
     if (res.ok) return null;
+    // 429/5xx are transient service hiccups (overload, maintenance) — the key
+    // is almost certainly fine, so don't block saving on Google's weather.
+    // This is the case the user hit: a 503 must never look like a bad key.
+    if (res.status === 429 || res.status >= 500) return null;
     const text = await res.text().catch(() => '');
     if ((res.status === 400 || res.status === 401 || res.status === 403)
         && /api[ _]key|unauthorized|forbidden|invalid/i.test(text)) {
@@ -56,7 +66,7 @@ export async function validateKey(apiKey: string): Promise<string | null> {
  *  picks from their real current lineup, including newer models like
  *  Gemini 3 / "Nano Banana" with whatever id Google actually assigned. */
 export async function listModels(apiKey: string): Promise<{ id: string; label: string }[]> {
-  const res = await fetch(`${API_BASE}/models?key=${encodeURIComponent(apiKey)}&pageSize=1000`, {
+  const res = await fetch(modelsUrl(apiKey, 1000), {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },
   });

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -93,6 +93,57 @@ test.describe('Multi-provider AI', () => {
     expect(fcPart.thoughtSignature).toBe('SIG_ABC');
   });
 
+  test('Gemini validateKey tolerates a 503 and pings the models endpoint, not generateContent', async ({ page }) => {
+    // Regression: validateKey used a generateContent ping on a hard-coded
+    // model. When that model is overloaded Google answers 503 UNAVAILABLE
+    // ("high demand") and a valid key looked rejected. Validation now hits
+    // the lightweight models-list endpoint and treats 5xx as a transient
+    // hiccup (non-blocking), so a busy backend never blocks a good key.
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel');
+    const out = await page.evaluate(async () => {
+      const gemini = await import('/src/ai/gemini.ts');
+      const calls: string[] = [];
+      const origFetch = window.fetch;
+      // @ts-expect-error test stub
+      window.fetch = async (input: unknown) => {
+        calls.push(String(input));
+        const body = JSON.stringify({ error: { code: 503, status: 'UNAVAILABLE', message: 'high demand' } });
+        return new Response(body, { status: 503 });
+      };
+      try {
+        const result = await gemini.validateKey('AIza-test-key');
+        return { result, calls };
+      } finally {
+        window.fetch = origFetch;
+      }
+    });
+    expect(out.result).toBeNull();
+    expect(out.calls).toHaveLength(1);
+    expect(out.calls[0]).toContain('/models');
+    expect(out.calls[0]).not.toContain('generateContent');
+  });
+
+  test('Gemini validateKey reports a clearly invalid key', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel');
+    const result = await page.evaluate(async () => {
+      const gemini = await import('/src/ai/gemini.ts');
+      const origFetch = window.fetch;
+      // @ts-expect-error test stub
+      window.fetch = async () => {
+        const body = JSON.stringify({ error: { code: 400, status: 'INVALID_ARGUMENT', message: 'API key not valid. Please pass a valid API key.' } });
+        return new Response(body, { status: 400 });
+      };
+      try {
+        return await gemini.validateKey('bogus');
+      } finally {
+        window.fetch = origFetch;
+      }
+    });
+    expect(result).toBe('Invalid API key.');
+  });
+
   test('Gemini routes thought parts to the thinking channel', async ({ page }) => {
     // Gemini 3 thinking models emit reasoning as `thought:true` text parts.
     // They must land in result.thinking (the collapsible box), NOT in the


### PR DESCRIPTION
## Summary

Adding a Gemini API key could fail with a `503 ... "This model is currently experiencing high demand ... UNAVAILABLE"` error during validation — even when the key was perfectly valid.

**Root cause:** `validateKey` in `src/ai/gemini.ts` made a real `generateContent` ping against a hard-coded model (`gemini-2.5-flash-lite`). That couples key validation to one model's availability, so when the model is overloaded Google returns `503 UNAVAILABLE` and the surfaced status string blocks the user from saving an otherwise-good key.

Changing the model id (the reported workaround idea) would only move the problem — any single generation model can be overloaded, and hard-coded ids also go stale (the `listModels` comment in this same file already warns about exactly that). Instead:

- **Validate against the lightweight `GET /models` metadata endpoint** rather than a generation call. It checks only that the key is accepted — no per-model availability, no generation quota consumed, and no hard-coded model id to rot. This is the same endpoint the settings modal already uses to list models.
- **Treat `429` / `5xx` as a transient hiccup** (non-blocking): the key is almost certainly fine, so Google being busy never blocks saving it. Persistent `400/401/403` key problems are still surfaced (friendly "Invalid API key." when the body matches an auth pattern, otherwise the raw status).
- Extracted a small `modelsUrl(apiKey, pageSize)` helper shared by `validateKey` and `listModels` (matches the existing `streamUrl`/`generateUrl` style).

Scope is intentionally limited to Gemini, which is what was reported. Anthropic/OpenAI validation is untouched.

## Test plan

- [x] `npm run build` — passes (tsc + vite)
- [x] `npm run test:e2e` (ai-providers + smoke) — 37 passed
- [x] New e2e: `validateKey` returns `null` on a `503` and hits `/models`, not `generateContent`
- [x] New e2e: a clear `400 "API key not valid"` still returns `"Invalid API key."`

https://claude.ai/code/session_01KFpz5J5ZpsoJk99QgNHYjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFpz5J5ZpsoJk99QgNHYjR)_