### PR TITLE
fix: render paintStroke regions correctly on version load

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6413,10 +6413,23 @@ async function main() {
       // saved version re-runs the code first, which rebuilds the map.
       currentLabelMap = result.labelMap ?? null;
 
-      // Apply any existing color regions to the mesh
-      const displayMesh = hasColorRegions() ? applyTriColorsIfVisible(result.mesh) : result.mesh;
-      updateMesh(displayMesh);
-      updatePaintMesh(result.mesh); // always pass uncolored mesh for adjacency
+      // Apply any existing color regions to the mesh. Smooth-brush regions
+      // (`brushStroke`) subdivide the mesh: their triangle indices point into
+      // the REFINED tessellation, not this freshly-run coarse base. Re-running
+      // the code (e.g. the debounced auto-run that fires ~300ms after a saved
+      // version loads) resets currentMeshData to the coarse base, so naively
+      // coloring `result.mesh` would stamp those refined-mesh indices onto
+      // coarse triangles — the "shattered shards" load bug. Rebuild the refined
+      // geometry and re-resolve every region against it, exactly as the
+      // visibility-toggle path does via reconcilePaintedGeometry.
+      if (hasColorRegions() && strokeDescriptors().length > 0) {
+        rebuildPaintedGeometry();
+        lastStrokeList = strokeDescriptors();
+      } else {
+        const displayMesh = hasColorRegions() ? applyTriColorsIfVisible(result.mesh) : result.mesh;
+        updateMesh(displayMesh);
+        updatePaintMesh(result.mesh); // always pass uncolored mesh for adjacency
+      }
 
       updateGeometryData(elapsed, src);
       syncClipSliderBounds();


### PR DESCRIPTION
## Summary

Opening a saved model painted with the smooth brush (`paintStroke`) flashed the correct render, then degraded to coarse "shattered shard" color regions — until the user toggled a region's visibility, which snapped it back to correct. This fixes the on-load render so it's correct immediately, no toggle required.

## Root cause

`paintStroke` **subdivides** the mesh; its region triangle indices point into the *refined* tessellation. On load, `loadVersionIntoEditor` rehydrates the regions correctly (refines + re-resolves), but `setValue(code)` also schedules the **debounced ~300 ms auto-run**. That auto-run reset `currentMeshData` to the freshly-run **coarse base** and the run-completion path then did:

```ts
const displayMesh = hasColorRegions() ? applyTriColorsIfVisible(result.mesh) : result.mesh;
```

i.e. it stamped the regions' refined-mesh indices onto the coarse triangles → the shards. The visibility-toggle path looked correct because `setRegionVisibility → reconcilePaintedGeometry → rebuildPaintedGeometry` re-subdivides the base under all strokes and re-resolves every region; the run path never did that.

## Fix (`src/main.ts`, +17/−4)

In the run-completion block, when stroke (`brushStroke`) regions exist, run the same `rebuildPaintedGeometry()` the toggle path uses (and sync `lastStrokeList`) instead of coloring the coarse mesh with stale indices. Non-stroke regions keep the original lightweight path.

## Verification

- Reproduced the bug (mesh flips from 192,468 refined tris → 1,518 coarse tris ~100 ms after load; spots become shards), confirmed it's gone after the fix — on-load render shows clean dots with **no** toggle.
- `npm run build` passes (no TS errors).
- `npm run test:e2e`: 156 passed; 5 failures (keyboard-shortcuts, paint-camera wheel-zoom, simplify timeout) are pre-existing — verified identical on clean `origin/staging`, none touch the region/render path.

## Test plan
- [x] Load a paintStroke-painted model → painted regions render correctly on load without toggling
- [x] Visibility toggle still works
- [x] `npm run build` green
- [x] e2e suite: no new failures

https://claude.ai/code/session_01BjC3bmhM1dQzSbVcybs4aT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjC3bmhM1dQzSbVcybs4aT)_