### PR TITLE
fix: save after painting silently no-ops on a stalled thumbnail capture

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -363,16 +363,39 @@ function updateGeometryData(executionTimeMs?: number, sourceCode?: string) {
   geometryDataEl.textContent = JSON.stringify(data, null, 2);
 }
 
+/** How long to wait for `canvas.toBlob` before giving up on the thumbnail.
+ *  `toBlob` can stall indefinitely when encoding a 2D canvas that a WebGL render
+ *  was composited into (observed after painting subdivides + colors the mesh) —
+ *  the GPU readback never settles the callback. A thumbnail is non-essential, so
+ *  we cap the wait and let the save proceed without it rather than hang forever
+ *  (which silently blocked saving a painted version). */
+const THUMBNAIL_TIMEOUT_MS = 4000;
+
 function captureThumbnail(mesh: MeshData | null = currentMeshData): Promise<Blob | null> {
   if (!mesh) return Promise.resolve(null);
+  let canvas: HTMLCanvasElement;
   try {
-    const canvas = renderCompositeCanvas(applyTriColorsIfVisible(mesh));
-    return new Promise(resolve => {
-      canvas.toBlob(b => resolve(b), 'image/png');
-    });
+    canvas = renderCompositeCanvas(applyTriColorsIfVisible(mesh));
   } catch {
     return Promise.resolve(null);
   }
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = (b: Blob | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(b);
+    };
+    // Bound the wait: if toBlob never calls back, resolve null so the caller
+    // (save / snapshot) still completes.
+    const timer = setTimeout(() => finish(null), THUMBNAIL_TIMEOUT_MS);
+    try {
+      canvas.toBlob(b => finish(b), 'image/png');
+    } catch {
+      finish(null);
+    }
+  });
 }
 
 // Capture a thumbnail + geometry-data for an arbitrary `mesh` without touching

--- a/src/ui/sessionBar.ts
+++ b/src/ui/sessionBar.ts
@@ -13,6 +13,7 @@ import {
 } from '../storage/sessionManager';
 import { onChange as onColorRegionsChange } from '../color/regions';
 import { onChange as onAnnotationStrokesChange } from '../annotations/annotations';
+import { showToast } from './toast';
 
 export interface SessionBarCallbacks {
   onSaveVersion: () => Promise<{ code: string; geometryData: Record<string, unknown> | null; thumbnail: Blob | null }>;
@@ -186,6 +187,10 @@ function render(state: SessionState) {
         undefined,
         force ? { force: true } : undefined,
       );
+    } catch (err) {
+      // A failed save must not be silent \u2014 surface it so the user knows their
+      // painted/edited state wasn't captured (rather than assume it saved).
+      showToast(`Couldn't save version: ${err instanceof Error ? err.message : String(err)}`, { variant: 'warn' });
     } finally {
       saving = false;
       saveBtn.disabled = false;

--- a/tests/save-after-paint.spec.ts
+++ b/tests/save-after-paint.spec.ts
@@ -1,0 +1,44 @@
+// Regression: clicking "Save" after painting must create a new version.
+//
+// The session-bar Save button calls onSaveVersion(), which awaits
+// captureThumbnail(). On a painted (subdivided + colored) mesh, the composite
+// canvas's toBlob() can stall indefinitely — with no timeout and no catch, the
+// save silently never happened (no new version, no error). captureThumbnail now
+// caps the toBlob wait and resolves null on timeout so the save still commits.
+
+import { test, expect } from 'playwright/test';
+
+test('clicking Save after painting creates a new version', async ({ page }) => {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+  const before = await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.createSession('save-after-paint');
+    await pw.runAndSave(`const { Manifold } = api; return Manifold.cube([10, 10, 10], true);`, 'v1');
+    return (await pw.listVersions()).length;
+  });
+
+  // Paint a region (same regions store the UI face-pick feeds).
+  const painted = await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    pw.paintStroke({ points: [[0, 0, 5]], radius: 3, resolution: 64, color: [1, 0, 0] });
+    return pw.listRegions().length;
+  });
+  expect(painted).toBe(1);
+
+  // Click the real Save button.
+  await page.locator('#btn-save-version').dispatchEvent('click');
+
+  // A new version must appear. (If the thumbnail toBlob stalls, captureThumbnail
+  // falls back to null after its timeout and the save still commits — so allow
+  // generously more than that timeout here.)
+  await expect
+    .poll(async () => page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (await (window as any).partwright.listVersions()).length;
+    }), { timeout: 12000 })
+    .toBe(before + 1);
+});


### PR DESCRIPTION
## Summary

Reported: after painting a cube, clicking **Save** created no new version and showed no error.

**Root cause.** The session-bar Save handler awaits `onSaveVersion()`, which awaits `captureThumbnail()`. On a painted mesh (subdivided + vertex-colored), `captureThumbnail` renders a 4-up composite into a 2D canvas (a WebGL render `drawImage`'d into it) and calls `canvas.toBlob(...)`. That `toBlob` callback can **stall indefinitely** for the composited canvas (the GPU readback never settles) — a plain 2D-canvas `toBlob` in the same state works fine, so it's specific to the WebGL-composited canvas. With **no timeout** on the `toBlob` promise and **no `catch`** in the Save handler, the `await` hung forever: no version saved, no error surfaced. (`runAndSave` was unaffected because it re-runs the code first and thumbnails the *base* mesh; the UI Save thumbnails the current *refined* mesh.)

## Fix

- **`captureThumbnail` (`src/main.ts`)** — cap the `toBlob` wait (`THUMBNAIL_TIMEOUT_MS = 4000`) and resolve `null` on timeout. A thumbnail is optional; committing the user's painted/edited version is not. This repairs *every* save path that captures a thumbnail — session-bar Save, `mod`+`S` / command palette, and the simplify snapshot. In the common case `toBlob` returns in well under the cap, so thumbnails are unaffected; the cap only trips on the pathological stall.
- **Session-bar Save handler (`src/ui/sessionBar.ts`)** — wrap the save in `try/catch` and surface a warn toast on failure, so a future failure is visible instead of silent.

## Test plan

- [x] New regression test `tests/save-after-paint.spec.ts`: run a cube, paint, click the real `#btn-save-version`, assert a new version is created.
- [x] `npm run build` clean.
- [x] Regression: `versions-tab`, `paint-controls-extended`, `paint-batch-and-lifecycle` green; `save-after-paint` green.
- [x] Branch cut from latest `origin/staging`.

### Pre-existing failures (NOT caused by this change — confirmed red on pristine `origin/staging` in this sandbox)

- `simplify` › *"Save as version preserves an unsaved edited original as its own version"*.
- `paint-smooth-brush` › *"a smooth stroke survives save + reload"* — its assumption that re-running code resets the mesh to base no longer holds: `pw.run()` now keeps color regions and re-resolves/re-refines them (so `baseTri` stays the refined count, not 12). That's a separate `run()`/region-persistence behavior change on `staging`, worth its own look — happy to investigate separately.

https://claude.ai/code/session_017QcgmoypYepU3oA3mYEZKE

---
_Generated by [Claude Code](https://claude.ai/code/session_017QcgmoypYepU3oA3mYEZKE)_