### PR TITLE
test: fix undo-hijack test focusing a hidden bucket input

### DIFF
--- a/tests/keyboard-shortcuts.spec.ts
+++ b/tests/keyboard-shortcuts.spec.ts
@@ -82,6 +82,10 @@ test.describe('keyboard shortcuts', () => {
     await page.locator('#paint-toggle').dispatchEvent('click');
     await page.waitForSelector('#paint-picker-panel:not(.hidden)');
 
+    // Bucket is no longer the default tool, so its angle input starts hidden —
+    // reveal it first (a display:none input can't take focus).
+    await page.locator('#paint-picker-panel button:has-text("Bucket")').dispatchEvent('click');
+
     // Focus a numeric input inside the paint panel, then press undo. The handler
     // must defer to the field's native editing and leave paint regions intact.
     const angleInput = page.locator('#paint-picker-panel input[type="number"][title*="Bend angle"]');


### PR DESCRIPTION
## Summary

Fixes the pre-existing failure in `keyboard-shortcuts.spec.ts:72` ("undo is not hijacked while a text input is focused").

The test focuses the bucket tool's "Bend angle" number input, then presses undo, expecting the handler to defer to the field's native editing (leaving the 2 paint regions intact). But the default paint tool is now **brush**, so the bucket controls — including that angle input — start hidden (`display:none`). Focusing a hidden input is a no-op, so `activeElement` was never the field; the undo fired and removed a region, leaving 1 instead of 2.

The fix reveals the bucket controls (by clicking the **Bucket** tool button) before focusing its angle input, so the input is actually focusable. `"Bucket"` is unique among the tool buttons, so the selector is unambiguous.

## Test plan

- [x] `npx playwright test keyboard-shortcuts` — all 3 pass (was 2/3)
- [x] Test-only change; no app code touched

https://claude.ai/code/session_0194hFPFiCkSzGBCoP5pbyHh

---
_Generated by [Claude Code](https://claude.ai/code/session_0194hFPFiCkSzGBCoP5pbyHh)_