### PR TITLE
feat: run the local model engine in a dedicated Web Worker

### DIFF
--- a/src/ai/local.ts
+++ b/src/ai/local.ts
@@ -148,6 +148,45 @@ function customModelToInfo(custom: CustomLocalModel): LocalModelInfo {
 let loaded: LoadedEngine | null = null;
 let loadInFlight: Promise<LoadedEngine> | null = null;
 
+// The actual MLCEngine lives in a dedicated Web Worker (localEngineWorker.ts);
+// `engineProxy` is the main-thread `WebWorkerMLCEngine` handle that forwards
+// reload / chat.completions / interrupt / unload to it and exposes the exact
+// same interface as a same-thread MLCEngine. We keep both as singletons for
+// the session: the worker holds the WASM runtime + GPU device, so reusing it
+// across model switches (reload swaps the weights in place) is far cheaper
+// than spawning a fresh worker each time. `loaded` still tracks which model is
+// currently resident; `engineProxy` outlives an unload so the next load is
+// fast.
+let engineWorker: Worker | null = null;
+// Typed loosely (like LoadedEngine.engine) so this module doesn't drag the
+// ~6 MB WebLLM SDK types into every chunk that imports our `types`.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let engineProxy: any = null;
+
+/** Lazily create the model worker + its main-thread proxy, then refresh the
+ *  per-load bits (app config for custom models, progress callback) so the
+ *  current caller sees download progress. Reused across loads. */
+function getEngineProxy(
+  webllm: typeof import('@mlc-ai/web-llm'),
+  appConfig: import('@mlc-ai/web-llm').AppConfig,
+  onProgress: (report: { progress: number; text: string }) => void,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any {
+  if (!engineWorker) {
+    engineWorker = new Worker(new URL('./localEngineWorker.ts', import.meta.url), { type: 'module' });
+  }
+  if (!engineProxy) {
+    engineProxy = new webllm.WebWorkerMLCEngine(engineWorker, { appConfig, initProgressCallback: onProgress });
+  } else {
+    // setAppConfig posts to the worker; postMessage ordering guarantees it
+    // lands before the reload below. setInitProgressCallback only updates the
+    // proxy-side closure, so progress for this load reaches the right caller.
+    engineProxy.setAppConfig(appConfig);
+    engineProxy.setInitProgressCallback(onProgress);
+  }
+  return engineProxy;
+}
+
 export interface ProgressUpdate {
   /** 0..1, or NaN if WebLLM doesn't know yet. */
   progress: number;
@@ -325,15 +364,14 @@ export async function ensureModelLoaded(modelId: string, opts: LoadOptions = {})
       ...buildCustomModelEntries(webllm),
     ];
 
-    const engine = new webllm.MLCEngine({
-      // Default cache backend is "cache" (Cache API). Safari caps that at
-      // ~1 GB; OPFS is uncapped after the storage permission prompt, so we
-      // prefer it when available. WebLLM falls back if the browser lacks
-      // OPFS.
-      appConfig,
-      initProgressCallback: (report: { progress: number; text: string }) => {
-        opts.onProgress?.({ progress: report.progress, text: report.text });
-      },
+    // The engine runs in localEngineWorker.ts; this proxy forwards to it.
+    // Default cache backend is "cache" (Cache API). Safari caps that at ~1 GB;
+    // OPFS is uncapped after the storage permission prompt, so WebLLM prefers
+    // it when available and falls back if the browser lacks OPFS. The cache is
+    // origin-wide, so weights downloaded by the worker are still visible to
+    // the main-thread cache helpers (getCachedModels / deleteCachedModel).
+    const engine = getEngineProxy(webllm, appConfig, (report: { progress: number; text: string }) => {
+      opts.onProgress?.({ progress: report.progress, text: report.text });
     });
 
     // Compute the context override. Priority: user-set global override,

--- a/src/ai/localEngineWorker.ts
+++ b/src/ai/localEngineWorker.ts
@@ -1,0 +1,18 @@
+// Dedicated Web Worker that owns the WebLLM MLCEngine.
+//
+// The main thread drives it through a `WebWorkerMLCEngine` proxy built in
+// local.ts (`getEngineProxy`). Keeping the engine here moves the heavy work —
+// model download, GPU weight upload, and per-token generation — off the main
+// thread so the UI stays responsive during local inference.
+//
+// WebLLM ships this handler for exactly this purpose: it instantiates its own
+// MLCEngine and answers the proxy's reload / chat.completions / interrupt /
+// unload messages, forwarding init-progress reports back over postMessage.
+
+import { WebWorkerMLCEngineHandler } from '@mlc-ai/web-llm';
+
+const handler = new WebWorkerMLCEngineHandler();
+
+self.onmessage = (event: MessageEvent): void => {
+  handler.onmessage(event);
+};


### PR DESCRIPTION
## Summary

Moves the local (WebLLM) model engine off the main thread into a **dedicated Web Worker**, so model download, GPU weight upload, and per-token generation no longer run on the UI thread.

- New `src/ai/localEngineWorker.ts` — a worker hosting WebLLM's `WebWorkerMLCEngineHandler`, which owns the real `MLCEngine`.
- `src/ai/local.ts` — `ensureModelLoaded` now builds a `WebWorkerMLCEngine` **proxy** over that worker instead of constructing a same-thread `MLCEngine`.

This is the worker-based design discussed as the "ideal" alternative to the main-thread fix in #219.

## Relationship to #219

#219 ("run local chat turns on the main thread") is **already merged into `staging`** and fixed the actual bug (local turns ran in the agent Worker, which couldn't see the engine loaded on the main thread). This PR is an **enhancement on top of that**, not a replacement:

- The local→main-thread chat-loop dispatch from #219 stays. The loop still *orchestrates* on the main thread (tool calls hit `window.partwright` directly — no proxy round-trip), but the engine it talks to now *lives in a worker*.
- Net effect: orchestration on the main thread (cheap, mostly awaiting), heavy inference in the worker (the win).

## Why this design (vs. moving the whole loop into the agent Worker)

The engine has two distinct client contexts: the chat loop, and the main-thread UI (download modal, `isModelLoaded` badges, Stop button) + compaction + cross-provider review. WebLLM's `WebWorkerMLCEngine` proxy exposes the **identical interface** as `MLCEngine`, so localizing the worker boundary at the engine keeps every existing caller working untouched:

- `streamLocalTurn`, `summarizeLocal`, `interruptLocal`, `unloadActiveLocalModel` — unchanged (they call the proxy).
- `isModelLoaded` / `loadedModelId` stay **synchronous** on the main thread (the resident-model flag is tracked main-side).
- `getCachedModels` / `getStorageUsage` / `deleteCachedModel` stay on the main thread — the model cache (Cache API / OPFS) is origin-wide, so weights the worker downloads are visible to these helpers.
- The proxy + worker are session singletons reused across model switches (`reload` swaps weights in place — no re-spawn).

## Tradeoffs / notes

- **Browser support:** requires WebGPU **inside a worker** (Chrome/Edge, Safari 26+) — the same set the app already gates local models on. If a browser supported main-thread WebGPU but not worker WebGPU, `reload()` would reject and surface "Failed to load"; I can add a main-thread fallback if you want broader coverage (happy to do it as a follow-up).
- **Bundle:** the WebLLM SDK (~6 MB, ~2 MB gz) is now also bundled into the worker chunk, so first-ever local use downloads it twice (main-thread proxy/cache utils + worker engine). It's cached after that and dwarfed by the multi-GB model weights, but it's a real one-time cost. Eliminating it would mean routing *all* webllm usage (cache checks, appConfig) through the worker too — a much larger refactor I deliberately scoped out.

## Test plan

- [x] `npm run build` — passes; emits the `localEngineWorker` chunk and the main bundle is unchanged in size.
- [x] `npm run test:e2e` — **167/167 passed**, no app-wide regression (the local inference path itself isn't covered — see below).
- [x] Cloudflare Pages deploy — green.
- [ ] Manual (requires WebGPU + a real model — **cannot run in CI/sandbox**): pick a local model, download it (progress should report from the worker), send a chat message → streams a reply; Stop mid-generation halts it; switch models → reloads; reload the page → loads from cache.

> **Testing limitation (please validate locally before merging):** the local provider can't be exercised end-to-end in CI/sandbox — WebLLM needs a real WebGPU adapter and a multi-GB weights download (no network), and there's no seam to fake the engine. This change alters the engine's *execution model*, so it's verified by `npm run build`, the full e2e suite (app-wide regression), and checking the implementation against the installed WebLLM source (`WebWorkerMLCEngine`/`WebWorkerMLCEngineHandler` message protocol) — but the actual in-worker inference path is unverified by automation. I'd recommend a quick manual smoke on Chrome before merging.

https://claude.ai/code/session_016zNaWuu3ZCeqiX2A5Ne4vH