### PR TITLE
fix: harden IndexedDB durability and stop orphaning session data

### DIFF
--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -419,7 +419,8 @@ export async function createSession(name?: string, language?: 'manifold-js' | 's
     ...(language && language !== 'manifold-js' ? { language } : {}),
   };
   const store = await tx('sessions', 'readwrite');
-  await reqToPromise(store.put(session));
+  store.put(session);
+  await txComplete(store.transaction);
   return session;
 }
 
@@ -505,9 +506,11 @@ export async function updateSession(id: string, updates: Partial<Pick<Session, '
 
 export async function deleteSession(id: string): Promise<void> {
   const db = await openDB();
-  const txn = db.transaction(['sessions', 'versions', 'notes', 'parts'], 'readwrite');
+  const txn = db.transaction(['sessions', 'versions', 'notes', 'parts', 'aiChats'], 'readwrite');
   txn.objectStore('sessions').delete(id);
-  // Delete all versions, notes, and parts belonging to this session.
+  // Delete all versions, notes, parts, and AI chat messages belonging to this
+  // session. Chats are keyed by id but indexed by sessionId, so they're swept
+  // here too — otherwise the transcript is orphaned in IndexedDB forever.
   const deleteByIndex = (storeName: string) => {
     const idx = txn.objectStore(storeName).index('sessionId');
     const req = idx.openCursor(IDBKeyRange.only(id));
@@ -528,6 +531,7 @@ export async function deleteSession(id: string): Promise<void> {
     deleteByIndex('versions'),
     deleteByIndex('notes'),
     deleteByIndex('parts'),
+    deleteByIndex('aiChats'),
   ]);
   // Wait for the entire transaction to commit
   await txComplete(txn);
@@ -545,7 +549,8 @@ export async function createPart(sessionId: string, name: string, order: number)
     updated: Date.now(),
   };
   const store = await tx('parts', 'readwrite');
-  await reqToPromise(store.put(part));
+  store.put(part);
+  await txComplete(store.transaction);
   return part;
 }
 
@@ -565,6 +570,26 @@ export async function updatePart(id: string, updates: Partial<Pick<Part, 'name' 
     Object.assign(part, updates);
     store.put(part);
   };
+  await txComplete(store.transaction);
+}
+
+/** Apply a batch of part-order updates in a single transaction so a reorder is
+ *  atomic — an interruption can't leave parts with duplicate/partial `order`
+ *  values the way N separate transactions could. */
+export async function updatePartOrders(updates: { id: string; order: number }[]): Promise<void> {
+  if (updates.length === 0) return;
+  const store = await tx('parts', 'readwrite');
+  const now = Date.now();
+  for (const { id, order } of updates) {
+    const getReq = store.get(id);
+    getReq.onsuccess = () => {
+      const part = getReq.result as Part | null;
+      if (!part) return;
+      part.order = order;
+      part.updated = now;
+      store.put(part);
+    };
+  }
   await txComplete(store.transaction);
 }
 
@@ -753,7 +778,8 @@ export async function addNote(sessionId: string, text: string): Promise<SessionN
     timestamp: Date.now(),
   };
   const store = await tx('notes', 'readwrite');
-  await reqToPromise(store.put(note));
+  store.put(note);
+  await txComplete(store.transaction);
   await updateSession(sessionId, { updated: Date.now() });
   return note;
 }
@@ -767,7 +793,8 @@ export async function listNotes(sessionId: string): Promise<SessionNote[]> {
 
 export async function deleteNote(id: string): Promise<void> {
   const store = await tx('notes', 'readwrite');
-  await reqToPromise(store.delete(id));
+  store.delete(id);
+  await txComplete(store.transaction);
 }
 
 export async function updateNote(id: string, text: string): Promise<void> {
@@ -787,10 +814,14 @@ export async function updateNote(id: string, text: string): Promise<void> {
 
 export async function clearAllData(): Promise<void> {
   const db = await openDB();
-  const txn = db.transaction(['sessions', 'versions', 'notes', 'parts'], 'readwrite');
+  const txn = db.transaction(['sessions', 'versions', 'notes', 'parts', 'aiChats'], 'readwrite');
   txn.objectStore('sessions').clear();
   txn.objectStore('versions').clear();
   txn.objectStore('notes').clear();
   txn.objectStore('parts').clear();
+  // Session-scoped AI transcripts go too; saved API keys (aiKeys) and the
+  // global recent-image cache (aiAttachments) are not session data and are
+  // left for the Uninstall modal's per-category wipe.
+  txn.objectStore('aiChats').clear();
   await txComplete(txn);
 }

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -20,6 +20,7 @@ import {
   createPart as dbCreatePart,
   listParts as dbListParts,
   updatePart as dbUpdatePart,
+  updatePartOrders as dbUpdatePartOrders,
   deletePart as dbDeletePart,
   addNote as dbAddNote,
   listNotes as dbListNotes,
@@ -522,6 +523,10 @@ export async function setSessionLanguage(id: string, language: 'manifold-js' | '
  *  live-mirroring the active model across windows (which would fight the user). */
 export async function setSessionAiPreference(provider: string, model: string | null): Promise<void> {
   if (!currentState.session || !model) return;
+  // A read-only viewer must not mutate the shared session row, or it would
+  // clobber the leader's remembered provider/model (last reopen would win
+  // whatever the viewer last picked).
+  if (isViewerTab()) return;
   const cur = currentState.session.aiPreference;
   if (cur && cur.provider === provider && cur.model === model) return;
   const id = currentState.session.id;
@@ -689,7 +694,7 @@ export async function reorderParts(orderedIds: string[]): Promise<void> {
   for (const p of currentState.parts) if (byId.has(p.id)) ordered.push(p);
 
   const next = ordered.map((p, i) => ({ ...p, order: i }));
-  for (const p of next) await dbUpdatePart(p.id, { order: p.order });
+  await dbUpdatePartOrders(next.map(p => ({ id: p.id, order: p.order })));
 
   currentState = {
     ...currentState,
@@ -1376,6 +1381,18 @@ export async function importSession(
   const warning = getSchemaCompatibilityWarning(data);
   if (warning && onWarning) onWarning(warning);
 
+  // Validate before creating anything: a file with no `versions` array would
+  // throw partway through (data.versions.reduce/for-of) and strand an empty
+  // orphan session. `parts`/`chat` are already guarded with Array.isArray, so
+  // mirror that here for `versions` and fail with a clear message instead.
+  if (!data.session || typeof data.session !== 'object') {
+    throw new Error('Invalid session file: missing "session" data.');
+  }
+  const versions = Array.isArray(data.versions) ? data.versions : [];
+  if (versions.length === 0) {
+    throw new Error('Invalid session file: no versions found.');
+  }
+
   const session = await dbCreateSession(data.session.name, data.session.language);
 
   // Restore images if present in the exported data. Handle two legacy shapes:
@@ -1392,7 +1409,7 @@ export async function importSession(
   // Determine the index of the latest exported version. Schema 1.2 stored
   // annotations at the top level; for back-compat we attach them to whichever
   // version was most recent at export time (assumed to be the highest index).
-  const latestExportedIndex = data.versions.reduce((m, v) => Math.max(m, v.index), -Infinity);
+  const latestExportedIndex = versions.reduce((m, v) => Math.max(m, v.index), -Infinity);
 
   // Reconstruct parts. Schema 1.7+ ships an explicit `parts` array; older files
   // have none, so all their versions collapse into a single default part.
@@ -1411,7 +1428,7 @@ export async function importSession(
   // Group versions by owning part, then save each group ordered by original
   // index so the per-part indices we assign preserve the source sequence.
   const versionsByPart = new Map<string, ExportedSession['versions']>();
-  for (const v of data.versions) {
+  for (const v of versions) {
     const partId = orderToPartId.get(v.part ?? 0) ?? firstPartId;
     const arr = versionsByPart.get(partId) ?? [];
     arr.push(v);


### PR DESCRIPTION
## Summary

Five storage/persistence defects found in the staging review, grouped because they all touch IndexedDB durability and session data integrity:

1. **Transactions returning before commit** — `createSession`, `createPart`, `addNote`, and `deleteNote` awaited only the request promise, not `txn.oncomplete`. Per the project rule (CLAUDE.md → *IndexedDB Transactions*) the transaction can still fail to commit after the request resolves, so a caller could treat an uncommitted write as persisted. These now `await txComplete(...)`, matching the sibling `update*` functions that were already fixed.
2. **Orphaned AI chat transcripts** — `deleteSession` and `clearAllData` only swept `sessions/versions/notes/parts`, leaving every `aiChats` row behind (keyed by `id`, indexed by `sessionId`). So "Delete session" and the session list's "Clear All" left transcripts permanently unreachable in IndexedDB. Both now also sweep `aiChats`. Credentials (`aiKeys`) and the global recent-image cache (`aiAttachments`) are intentionally left to the Uninstall modal's per-category wipe, since they're not session-scoped data.
3. **Non-atomic part reorder** — `reorderParts` issued one transaction per part (`for … await dbUpdatePart`); an interruption mid-loop could leave parts with duplicate/partial `order` values. Replaced with a single-transaction `updatePartOrders` batch (mirrors `migratePartsData`).
4. **Malformed-import orphan** — `importSession` called `data.versions.reduce(...)` / `for…of` with no guard, so a `.partwright` file missing `versions` threw *after* a session row was already created, stranding an empty orphan session. Now validated up front (matching the existing `Array.isArray` guards on `parts`/`chat`) and fails with a clear message before creating anything.
5. **Read-only viewer clobbering AI preference** — `setSessionAiPreference` had no viewer guard (unlike the save paths), so a read-only viewer tab switching its model overwrote the leader's remembered provider/model in the shared session row. Now bails for `isViewerTab()`.

No schema version bump; all changes are read/write-path hardening and remain backwards-compatible with existing IndexedDB data and exported files.

## Test plan

Automated (run locally, all green):
- [x] `npm run build` (tsc + vite) — clean
- [x] `npx playwright test tests/parts.spec.ts` — 5/5 (covers create part, persistence across reload, **drag-reorder** → new `updatePartOrders`)
- [x] `npx playwright test tests/session-modal.spec.ts tests/smoke.spec.ts` — 15/15 (covers `createSession`)

Manual integration:
- [ ] Create a session, paint/run a few versions, add notes → reload → confirm everything persists (durable commit).
- [ ] Have an AI chat in a session, then delete that session from the session list → reopen DevTools → Application → IndexedDB → `partwright` → `aiChats`: confirm no rows remain for that `sessionId`.
- [ ] Session list → "Clear All" → confirm `aiChats` is empty afterward (and that `aiKeys` API keys survive).
- [ ] Multi-part session → drag-reorder parts repeatedly → reload → order is stable and unique.
- [ ] Import a deliberately malformed `.partwright` file (delete the `versions` key) → expect a clear "no versions found" error and **no** new empty session left behind in the session list.
- [ ] Open the same session in two tabs (one becomes read-only viewer) → in the viewer, switch the AI model → close both → reopen the session → confirm it restored the **leader's** model, not the viewer's pick.

https://claude.ai/code/session_01PbDgWKhV2zatS932QyomPB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbDgWKhV2zatS932QyomPB)_