### PR TITLE
feat: inline AI key entry and local model picker into Settings

### DIFF
--- a/src/ui/aiKeyModal.ts
+++ b/src/ui/aiKeyModal.ts
@@ -31,7 +31,9 @@ interface ProviderUi {
   reset: () => void;
 }
 
-const PROVIDER_UI: Record<Exclude<Provider, 'local'>, ProviderUi> = {
+export type HostedProvider = Exclude<Provider, 'local'>;
+
+const PROVIDER_UI: Record<HostedProvider, ProviderUi> = {
   anthropic: {
     title: 'Connect Anthropic API',
     intro: 'Partwright AI uses your Anthropic API key. The key is stored only in this browser — not on any Partwright server.',
@@ -61,9 +63,74 @@ const PROVIDER_UI: Record<Exclude<Provider, 'local'>, ProviderUi> = {
   },
 };
 
+/** Display-only metadata for a hosted provider's key entry (title, console
+ *  link, input placeholder). Exposed so the inline key form in the AI
+ *  Settings modal can render the same copy without launching this modal. */
+export function providerKeyMeta(provider: HostedProvider): {
+  title: string;
+  intro: string;
+  consoleUrl: string;
+  consoleLabel: string;
+  placeholder: string;
+} {
+  const ui = PROVIDER_UI[provider];
+  return {
+    title: ui.title,
+    intro: ui.intro,
+    consoleUrl: ui.consoleUrl,
+    consoleLabel: ui.consoleLabel,
+    placeholder: ui.placeholder,
+  };
+}
+
+/** Validate a pasted key, then persist it and promote its provider to
+ *  active. Returns an error message on failure, or `null` on success.
+ *  Shared by the standalone key modal and the inline key form in AI
+ *  Settings so the validate → store → set-active sequence lives in one
+ *  place. */
+export async function validateAndStoreKey(provider: HostedProvider, rawKey: string): Promise<string | null> {
+  const ui = PROVIDER_UI[provider];
+  const key = rawKey.trim();
+  if (key.length < 10) return 'That key looks too short.';
+
+  const t0 = performance.now();
+  const error = await ui.validate(key);
+  recordEvent({
+    provider,
+    model: '(validate)',
+    kind: 'validateKey',
+    durationMs: Math.round(performance.now() - t0),
+    status: error ? 'error' : 'ok',
+    errorMessage: error ?? undefined,
+    requestSummary: '1-token ping',
+  });
+  if (error) return error;
+
+  const existing = await getKey(provider);
+  await putKey({
+    provider,
+    apiKey: key,
+    createdAt: existing?.createdAt ?? Date.now(),
+    lastUsed: Date.now(),
+    totalInputTokens: existing?.totalInputTokens ?? 0,
+    totalOutputTokens: existing?.totalOutputTokens ?? 0,
+    totalCostUsd: existing?.totalCostUsd ?? 0,
+  });
+  ui.reset();
+  // Promote the just-connected provider to active so the key "just works"
+  // without an extra dropdown trip. Per-provider model selections are
+  // preserved by setProvider.
+  const cur = loadSettings();
+  if (cur.toggles.provider !== provider) {
+    saveSettings(setProvider(cur, provider));
+  }
+  return null;
+}
+
 export async function showAiKeyModal(cb: AiKeyModalCallbacks): Promise<void> {
-  const providerId: Provider = cb.provider ?? 'anthropic';
-  if (providerId === 'local') return; // local uses no key
+  const requested: Provider = cb.provider ?? 'anthropic';
+  if (requested === 'local') return; // local uses no key
+  const providerId: HostedProvider = requested;
   const ui = PROVIDER_UI[providerId];
   const shell = createModalShell({ title: ui.title });
 
@@ -139,8 +206,7 @@ export async function showAiKeyModal(cb: AiKeyModalCallbacks): Promise<void> {
   setTimeout(() => input.focus(), 0);
 
   async function attemptConnect() {
-    const key = input.value.trim();
-    if (key.length < 10) {
+    if (input.value.trim().length < 10) {
       showError('That key looks too short.');
       return;
     }
@@ -150,42 +216,13 @@ export async function showAiKeyModal(cb: AiKeyModalCallbacks): Promise<void> {
     status.textContent = 'Sending a 1-token test request to verify the key...';
     errorBox.classList.add('hidden');
 
-    const t0 = performance.now();
-    const error = await ui.validate(key);
-    recordEvent({
-      provider: providerId,
-      model: '(validate)',
-      kind: 'validateKey',
-      durationMs: Math.round(performance.now() - t0),
-      status: error ? 'error' : 'ok',
-      errorMessage: error ?? undefined,
-      requestSummary: '1-token ping',
-    });
+    const error = await validateAndStoreKey(providerId, input.value);
     if (error) {
       showError(error);
       connectBtn.disabled = false;
       connectBtn.textContent = 'Connect';
       status.classList.add('hidden');
       return;
-    }
-
-    const existing = await getKey(providerId);
-    await putKey({
-      provider: providerId,
-      apiKey: key,
-      createdAt: existing?.createdAt ?? Date.now(),
-      lastUsed: Date.now(),
-      totalInputTokens: existing?.totalInputTokens ?? 0,
-      totalOutputTokens: existing?.totalOutputTokens ?? 0,
-      totalCostUsd: existing?.totalCostUsd ?? 0,
-    });
-    ui.reset();
-    // Promote the just-connected provider to active so the key "just
-    // works" without an extra dropdown trip. Per-provider model
-    // selections are preserved by setProvider.
-    const cur = loadSettings();
-    if (cur.toggles.provider !== providerId) {
-      saveSettings(setProvider(cur, providerId));
     }
     shell.close();
     cb.onConnected();

--- a/src/ui/aiLocalModal.ts
+++ b/src/ui/aiLocalModal.ts
@@ -56,6 +56,15 @@ export interface AiLocalModalCallbacks {
   onChange: () => void;
 }
 
+export interface LocalPickerOptions {
+  /** When true the picker is rendered inside the AI Settings modal rather
+   *  than its own pop-up. The settings host supplies its own "About"
+   *  framing and a dedicated "Local context" controls section, so the
+   *  embedded picker drops the standalone context-window note to avoid
+   *  saying the same thing twice. */
+  embedded?: boolean;
+}
+
 export async function showAiLocalModal(cb: AiLocalModalCallbacks): Promise<void> {
   closeModal();
 
@@ -88,7 +97,7 @@ export async function showAiLocalModal(cb: AiLocalModalCallbacks): Promise<void>
   modalEl = overlay;
 
   // Re-render reactively when state changes (cache scan, download progress).
-  await rerender(body, cb);
+  await renderLocalPicker(body, cb);
 
   escHandler = (e: KeyboardEvent) => {
     if (e.key === 'Escape') closeModal();
@@ -96,7 +105,17 @@ export async function showAiLocalModal(cb: AiLocalModalCallbacks): Promise<void>
   document.addEventListener('keydown', escHandler);
 }
 
-async function rerender(body: HTMLElement, cb: AiLocalModalCallbacks): Promise<void> {
+/** Fill `body` with the full local-model picker UI: crash warning, WebGPU /
+ *  storage banners, the grouped model cards, the custom-model form, and the
+ *  trust panel. Re-entrant — every state change (cache scan, download
+ *  finish, model removal) calls this again on the same container. Exported
+ *  so the AI Settings "Local" tab can embed it inline instead of opening a
+ *  separate modal. */
+export async function renderLocalPicker(
+  body: HTMLElement,
+  cb: AiLocalModalCallbacks,
+  opts: LocalPickerOptions = {},
+): Promise<void> {
   body.replaceChildren();
   body.appendChild(buildCrashRiskWarning());
   body.appendChild(buildIntro());
@@ -154,7 +173,7 @@ async function rerender(body: HTMLElement, cb: AiLocalModalCallbacks): Promise<v
     const list = document.createElement('div');
     list.className = 'flex flex-col gap-2 mb-1';
     for (const model of models) {
-      list.appendChild(renderModelCard(model, settings.toggles.localModel, body, cb));
+      list.appendChild(renderModelCard(model, settings.toggles.localModel, body, cb, opts));
     }
     body.appendChild(list);
   }
@@ -167,13 +186,13 @@ async function rerender(body: HTMLElement, cb: AiLocalModalCallbacks): Promise<v
     const list = document.createElement('div');
     list.className = 'flex flex-col gap-2 mb-1';
     for (const c of settings.customLocalModels) {
-      list.appendChild(renderCustomModelCard(c, settings.toggles.localModel, body, cb));
+      list.appendChild(renderCustomModelCard(c, settings.toggles.localModel, body, cb, opts));
     }
     body.appendChild(list);
   }
 
-  body.appendChild(buildCustomModelForm(body, cb));
-  body.appendChild(buildContextNote());
+  body.appendChild(buildCustomModelForm(body, cb, opts));
+  if (!opts.embedded) body.appendChild(buildContextNote());
   body.appendChild(buildTrustPanel());
 }
 
@@ -199,6 +218,7 @@ function renderCustomModelCard(
   activeId: string | null,
   parentBody: HTMLElement,
   cb: AiLocalModalCallbacks,
+  opts: LocalPickerOptions,
 ): HTMLElement {
   const isActive = custom.id === activeId;
   const isCached = cachedSet.has(custom.id);
@@ -274,7 +294,7 @@ function renderCustomModelCard(
   } else {
     primary.className = 'px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white';
     primary.textContent = isCached ? 'Use this model' : 'Download & use';
-    primary.addEventListener('click', () => { void selectCustomModel(custom.id, parentBody, cb); });
+    primary.addEventListener('click', () => { void selectCustomModel(custom.id, parentBody, cb, opts); });
   }
   actions.appendChild(primary);
 
@@ -286,7 +306,7 @@ function renderCustomModelCard(
     if (!confirm(`Remove "${custom.label || custom.id}" from your custom model list?`)) return;
     saveSettings(removeCustomLocalModel(loadSettings(), custom.id));
     cb.onChange();
-    await rerender(parentBody, cb);
+    await renderLocalPicker(parentBody, cb, opts);
   });
   actions.appendChild(remove);
 
@@ -295,18 +315,18 @@ function renderCustomModelCard(
   return card;
 }
 
-async function selectCustomModel(modelId: string, parentBody: HTMLElement, cb: AiLocalModalCallbacks): Promise<void> {
+async function selectCustomModel(modelId: string, parentBody: HTMLElement, cb: AiLocalModalCallbacks, opts: LocalPickerOptions): Promise<void> {
   // Reuse the standard download flow; ensureModelLoaded reads the custom
   // entries from settings on every call so a freshly-added model is
   // visible to WebLLM.
-  await selectModel(modelId, parentBody, cb);
+  await selectModel(modelId, parentBody, cb, opts);
 }
 
 /** Form at the bottom of the modal where the user pastes a Hugging Face
  *  URL (or `org/repo`) and optionally a compiled-WASM URL. Validation is
  *  loose — we just save what they typed and let the engine surface a
  *  network error if the URLs are wrong. */
-function buildCustomModelForm(parentBody: HTMLElement, cb: AiLocalModalCallbacks): HTMLElement {
+function buildCustomModelForm(parentBody: HTMLElement, cb: AiLocalModalCallbacks, opts: LocalPickerOptions): HTMLElement {
   const wrap = document.createElement('div');
   wrap.className = 'mt-3 rounded border border-zinc-700 bg-zinc-900/40 p-3 flex flex-col gap-2';
 
@@ -407,7 +427,7 @@ function buildCustomModelForm(parentBody: HTMLElement, cb: AiLocalModalCallbacks
       return;
     }
     cb.onChange();
-    void rerender(parentBody, cb);
+    void renderLocalPicker(parentBody, cb, opts);
   });
   actions.appendChild(addBtn);
   wrap.appendChild(actions);
@@ -629,6 +649,7 @@ function renderModelCard(
   activeId: string | null,
   parentBody: HTMLElement,
   cb: AiLocalModalCallbacks,
+  opts: LocalPickerOptions,
 ): HTMLElement {
   const isActive = model.id === activeId;
   const isCached = cachedSet.has(model.id);
@@ -754,12 +775,12 @@ function renderModelCard(
   } else if (isCached) {
     primary.className = 'px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50';
     primary.textContent = 'Use this model';
-    primary.addEventListener('click', () => { void selectModel(model.id, parentBody, cb); });
+    primary.addEventListener('click', () => { void selectModel(model.id, parentBody, cb, opts); });
   } else {
     primary.className = 'px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed';
     primary.textContent = `Download ${model.downloadGB.toFixed(1)} GB`;
     if (webGpuStatus.state === 'bad') primary.disabled = true;
-    primary.addEventListener('click', () => { void selectModel(model.id, parentBody, cb); });
+    primary.addEventListener('click', () => { void selectModel(model.id, parentBody, cb, opts); });
   }
   actions.appendChild(primary);
 
@@ -779,7 +800,7 @@ function renderModelCard(
       }
       await deleteCachedModel(model.id);
       cb.onChange();
-      await rerender(parentBody, cb);
+      await renderLocalPicker(parentBody, cb, opts);
     });
     actions.appendChild(remove);
   }
@@ -790,7 +811,7 @@ function renderModelCard(
   return card;
 }
 
-async function selectModel(modelId: string, parentBody: HTMLElement, cb: AiLocalModalCallbacks): Promise<void> {
+async function selectModel(modelId: string, parentBody: HTMLElement, cb: AiLocalModalCallbacks, opts: LocalPickerOptions): Promise<void> {
   // Disable everything in the modal while we download / load.
   const oldBody = parentBody.cloneNode(false) as HTMLElement;
   parentBody.replaceWith(oldBody);
@@ -843,14 +864,14 @@ async function selectModel(modelId: string, parentBody: HTMLElement, cb: AiLocal
     cb.onChange();
 
     // Re-render the model list so the just-loaded model shows as Active.
-    await rerender(oldBody, cb);
+    await renderLocalPicker(oldBody, cb, opts);
   } catch (err) {
     status.textContent = `Failed to load: ${err instanceof Error ? err.message : String(err)}`;
     bar.style.background = '#dc2626';
     const back = document.createElement('button');
     back.className = 'self-start mt-2 px-3 py-1.5 rounded text-xs text-zinc-200 bg-zinc-700 hover:bg-zinc-600';
     back.textContent = 'Back';
-    back.addEventListener('click', () => { void rerender(oldBody, cb); });
+    back.addEventListener('click', () => { void renderLocalPicker(oldBody, cb, opts); });
     progressWrap.appendChild(back);
   }
 }

--- a/src/ui/aiSettingsModal.ts
+++ b/src/ui/aiSettingsModal.ts
@@ -8,8 +8,8 @@ import { resetClient, listModels as listAnthropicModels } from '../ai/anthropic'
 import { resetClient as resetOpenaiClient, listModels as listOpenaiModels } from '../ai/openai';
 import { resetClient as resetGeminiClient, listModels as listGeminiModels } from '../ai/gemini';
 import { formatUsd } from '../ai/cost';
-import { showAiKeyModal } from './aiKeyModal';
-import { showAiLocalModal } from './aiLocalModal';
+import { providerKeyMeta, validateAndStoreKey, type HostedProvider } from './aiKeyModal';
+import { renderLocalPicker } from './aiLocalModal';
 import { showSystemPromptModal } from './aiSystemPromptModal';
 import { createModalShell } from './modalShell';
 import {
@@ -27,7 +27,7 @@ import {
   OPENAI_MODEL_OPTIONS,
   GEMINI_MODEL_OPTIONS,
 } from '../ai/settings';
-import { effectiveContextCeiling, resolveLocalModel, isModelLoaded, unloadActiveLocalModel } from '../ai/local';
+import { effectiveContextCeiling, resolveLocalModel, unloadActiveLocalModel } from '../ai/local';
 import { getCachedCeiling } from '../ai/modelMetadata';
 import type { AnthropicModelId, Provider } from '../ai/types';
 
@@ -41,26 +41,36 @@ export interface AiSettingsOptions {
 }
 
 export async function showAiSettingsModal(cb: AiSettingsCallbacks, opts: AiSettingsOptions = {}): Promise<void> {
-  const shell = createModalShell({ title: 'AI Settings', scrollable: true });
+  // Wider than the default 'md' so the inlined local-model cards (left
+  // metadata + right action column) and the per-provider key form have
+  // room to breathe. The shell is scrollable, so tall tabs (Local) scroll.
+  const shell = createModalShell({ title: 'AI Settings', scrollable: true, maxWidth: 'lg' });
   shell.body.classList.remove('gap-3');
   shell.body.classList.add('gap-4');
 
   let viewedTab: Provider = opts.initialTab ?? loadSettings().toggles.provider;
+  const switchTab = (tab: Provider): void => {
+    viewedTab = tab;
+    void rerender();
+  };
 
   const rerender = async (): Promise<void> => {
     shell.body.replaceChildren();
     shell.footer.replaceChildren();
-    const tabBar = buildTabBar(viewedTab, tab => {
-      viewedTab = tab;
-      void rerender();
-    });
+    const tabBar = buildTabBar(viewedTab, switchTab);
     shell.body.appendChild(tabBar);
     const tabContent = document.createElement('div');
     tabContent.className = 'flex flex-col gap-4';
     shell.body.appendChild(tabContent);
-    await renderTabContent(viewedTab, tabContent, shell.footer, shell.close, cb, () => { void rerender(); });
+    await renderTabContent(viewedTab, tabContent, shell.close, cb, () => { void rerender(); }, switchTab);
     shell.body.appendChild(makeDivider());
     shell.body.appendChild(buildAutoCompactSection(cb, () => { void rerender(); }));
+
+    const done = document.createElement('button');
+    done.className = 'px-3 py-1.5 rounded text-xs font-medium bg-zinc-700 hover:bg-zinc-600 text-zinc-100';
+    done.textContent = 'Done';
+    done.addEventListener('click', shell.close);
+    shell.footer.appendChild(done);
   };
 
   await rerender();
@@ -110,33 +120,43 @@ function buildTabBar(viewedTab: Provider, onSwitch: (tab: Provider) => void): HT
 async function renderTabContent(
   viewedTab: Provider,
   container: HTMLElement,
-  footer: HTMLElement,
   close: () => void,
   cb: AiSettingsCallbacks,
   rerender: () => void,
+  switchTab: (tab: Provider) => void,
 ): Promise<void> {
-  container.appendChild(await buildEnableRow(viewedTab, cb, rerender));
+  // The Enable row reflects whether the viewed provider is active. Picking a
+  // local model (inline below) flips that without a full tab rebuild, so the
+  // row lives in its own host we can refresh on its own.
+  const enableRowHost = document.createElement('div');
+  enableRowHost.appendChild(await buildEnableRow(viewedTab, cb, rerender));
+  container.appendChild(enableRowHost);
+  const refreshEnableRow = async (): Promise<void> => {
+    enableRowHost.replaceChildren(await buildEnableRow(viewedTab, cb, rerender));
+  };
 
-  if (viewedTab === 'anthropic') {
-    container.appendChild(buildAnthropicIntro());
+  if (viewedTab === 'anthropic' || viewedTab === 'openai' || viewedTab === 'gemini') {
+    const hosted = viewedTab;
+    container.appendChild(buildHostedIntro(hosted));
     container.appendChild(makeDivider());
-    await buildAnthropicKeySection(close, footer, container, cb);
+    container.appendChild(await buildKeySection(hosted, cb, rerender, switchTab));
     container.appendChild(makeDivider());
-    container.appendChild(buildAnthropicModelSection(cb));
+    container.appendChild(hosted === 'anthropic'
+      ? buildAnthropicModelSection(cb)
+      : buildHostedModelSection(hosted, cb));
     container.appendChild(makeDivider());
-    container.appendChild(buildSystemPromptSection('anthropic', close, cb));
-  } else if (viewedTab === 'openai' || viewedTab === 'gemini') {
-    container.appendChild(buildHostedIntro(viewedTab));
-    container.appendChild(makeDivider());
-    await buildHostedKeySection(viewedTab, close, footer, container, cb);
-    container.appendChild(makeDivider());
-    container.appendChild(buildHostedModelSection(viewedTab, cb));
-    container.appendChild(makeDivider());
-    container.appendChild(buildSystemPromptSection(viewedTab, close, cb));
+    container.appendChild(buildSystemPromptSection(hosted, close, cb));
   } else {
-    container.appendChild(buildLocalIntro());
-    container.appendChild(makeDivider());
-    container.appendChild(buildLocalSection(close, cb));
+    // Inline the full local-model picker (formerly a separate pop-up).
+    // Activating a model here also flips the Enable row above to "active".
+    const picker = document.createElement('div');
+    picker.className = 'flex flex-col gap-3';
+    container.appendChild(picker);
+    void renderLocalPicker(
+      picker,
+      { onChange: () => { cb.onChange(); void refreshEnableRow(); } },
+      { embedded: true },
+    );
     container.appendChild(makeDivider());
     container.appendChild(buildLocalContextSection(cb));
     container.appendChild(makeDivider());
@@ -207,7 +227,9 @@ async function buildEnableRow(viewedTab: Provider, cb: AiSettingsCallbacks, rere
   return wrap;
 }
 
-function buildAnthropicIntro(): HTMLElement {
+/** "About" blurb for a hosted (cloud) provider. Covers all three so the
+ *  Anthropic / OpenAI / Gemini tabs share one builder. */
+function buildHostedIntro(provider: HostedProvider): HTMLElement {
   const wrap = document.createElement('div');
   wrap.className = 'flex flex-col gap-2';
   const head = document.createElement('div');
@@ -216,21 +238,11 @@ function buildAnthropicIntro(): HTMLElement {
   wrap.appendChild(head);
   const body = document.createElement('p');
   body.className = 'text-[11px] text-zinc-300 leading-snug';
-  body.innerHTML = 'Sends chat turns to <strong>Anthropic\'s hosted Claude</strong> models. Higher quality, vision support, and full <code>ai.md</code> system prompt — but each turn costs a few cents charged to your Anthropic account. The API key is stored only in this browser and never sent to a Partwright server.';
-  wrap.appendChild(body);
-  return wrap;
-}
-
-function buildLocalIntro(): HTMLElement {
-  const wrap = document.createElement('div');
-  wrap.className = 'flex flex-col gap-2';
-  const head = document.createElement('div');
-  head.className = 'text-xs text-zinc-400';
-  head.textContent = 'About';
-  wrap.appendChild(head);
-  const body = document.createElement('p');
-  body.className = 'text-[11px] text-zinc-300 leading-snug';
-  body.innerHTML = 'Runs a <strong>WebLLM model entirely in this browser</strong> on your GPU. No API key, no per-turn cost, no network traffic after the one-time weight download — but quality is noticeably lower than Claude, and you\'ll need a few GB of GPU memory. Best on Chrome / Edge / Safari 26+ on a recent discrete GPU.';
+  body.innerHTML = provider === 'anthropic'
+    ? 'Sends chat turns to <strong>Anthropic\'s hosted Claude</strong> models. Higher quality, vision support, and full <code>ai.md</code> system prompt — but each turn costs a few cents charged to your Anthropic account. The API key is stored only in this browser and never sent to a Partwright server.'
+    : provider === 'openai'
+      ? 'Sends chat turns to <strong>OpenAI\'s hosted GPT / o-series</strong> models. Vision support and the full <code>ai.md</code> system prompt; each turn is billed to your OpenAI account. The API key is stored only in this browser and never sent to a Partwright server.'
+      : 'Sends chat turns to <strong>Google\'s hosted Gemini</strong> models. Vision support and the full <code>ai.md</code> system prompt; each turn is billed to your Google AI account. The API key is stored only in this browser and never sent to a Partwright server.';
   wrap.appendChild(body);
   return wrap;
 }
@@ -343,42 +355,18 @@ function buildAnthropicModelSection(cb: AiSettingsCallbacks): HTMLElement {
   return wrap;
 }
 
-// === OpenAI / Gemini tabs ===
-// These two hosted providers share one set of builders (they differ only
-// in copy, model list, and which setter/resetClient to call). Anthropic
-// keeps its own bespoke builders above because its key section predates
-// this and the smoke test anchors on its exact "Connect Anthropic API"
-// string.
+// === OpenAI / Gemini model picker ===
+// These two cloud providers share the bespoke model-picker builder below
+// (custom-id input + loader). Anthropic uses buildAnthropicModelSection.
+// Key entry + status is unified across all three in buildKeySection.
 
-type HostedProvider = 'openai' | 'gemini';
-
-function hostedConsoleUrl(provider: HostedProvider): { url: string; label: string } {
-  return provider === 'openai'
-    ? { url: 'https://platform.openai.com/api-keys', label: 'platform.openai.com' }
-    : { url: 'https://aistudio.google.com/app/apikey', label: 'aistudio.google.com' };
-}
-
-function buildHostedIntro(provider: HostedProvider): HTMLElement {
-  const wrap = document.createElement('div');
-  wrap.className = 'flex flex-col gap-2';
-  const head = document.createElement('div');
-  head.className = 'text-xs text-zinc-400';
-  head.textContent = 'About';
-  wrap.appendChild(head);
-  const body = document.createElement('p');
-  body.className = 'text-[11px] text-zinc-300 leading-snug';
-  body.innerHTML = provider === 'openai'
-    ? 'Sends chat turns to <strong>OpenAI\'s hosted GPT / o-series</strong> models. Vision support and the full <code>ai.md</code> system prompt; each turn is billed to your OpenAI account. The API key is stored only in this browser and never sent to a Partwright server.'
-    : 'Sends chat turns to <strong>Google\'s hosted Gemini</strong> models. Vision support and the full <code>ai.md</code> system prompt; each turn is billed to your Google AI account. The API key is stored only in this browser and never sent to a Partwright server.';
-  wrap.appendChild(body);
-  return wrap;
-}
+type CloudPairProvider = 'openai' | 'gemini';
 
 /** Default-model picker for a hosted provider. Mirrors
  *  buildAnthropicModelSection but reads/writes the provider's own model
  *  field and includes a custom-id input for dated snapshots / brand-new
  *  releases not in the curated list. */
-function buildHostedModelSection(provider: HostedProvider, cb: AiSettingsCallbacks): HTMLElement {
+function buildHostedModelSection(provider: CloudPairProvider, cb: AiSettingsCallbacks): HTMLElement {
   // Starts from the curated list; for Gemini the user can replace it with
   // their key's real lineup via the "Load models from your key" button.
   let optionList = provider === 'openai' ? OPENAI_MODEL_OPTIONS : GEMINI_MODEL_OPTIONS;
@@ -469,20 +457,32 @@ function buildHostedModelSection(provider: HostedProvider, cb: AiSettingsCallbac
   return wrap;
 }
 
-/** Key status + connect/replace/disconnect for a hosted provider. Mirrors
- *  buildAnthropicKeySection; actions live in the modal footer like the
- *  Anthropic tab. */
-async function buildHostedKeySection(
-  provider: HostedProvider,
-  close: () => void,
-  footer: HTMLElement,
-  body: HTMLElement,
-  cb: AiSettingsCallbacks,
-): Promise<void> {
-  const label = providerLabel(provider);
-  const reset = provider === 'openai' ? resetOpenaiClient : resetGeminiClient;
-  const console = hostedConsoleUrl(provider);
+function resetClientFor(provider: HostedProvider): void {
+  if (provider === 'anthropic') resetClient();
+  else if (provider === 'openai') resetOpenaiClient();
+  else resetGeminiClient();
+}
 
+/** The submit/label text on a hosted provider's connect button. Anchored
+ *  by the e2e tests, so keep the exact strings:
+ *  Anthropic → "Connect Anthropic API", OpenAI → "Connect OpenAI",
+ *  Gemini → "Connect Google Gemini". */
+function connectButtonLabel(provider: HostedProvider): string {
+  return provider === 'anthropic' ? 'Connect Anthropic API' : `Connect ${providerLabel(provider)}`;
+}
+
+/** Unified key section for any hosted provider. When no key is stored it
+ *  renders the inline entry form (input + validate); once connected it
+ *  shows lifetime usage stats and an inline "Remove key" link. This
+ *  replaces the old pattern of a "Connect…" button that closed Settings
+ *  and popped a separate key modal. */
+async function buildKeySection(
+  provider: HostedProvider,
+  cb: AiSettingsCallbacks,
+  rerender: () => void,
+  switchTab: (tab: Provider) => void,
+): Promise<HTMLElement> {
+  const label = providerLabel(provider);
   const wrap = document.createElement('div');
   wrap.className = 'flex flex-col gap-2';
   const head = document.createElement('div');
@@ -492,30 +492,8 @@ async function buildHostedKeySection(
 
   const key = await getKey(provider);
   if (!key) {
-    const empty = document.createElement('p');
-    empty.className = 'text-[11px] text-zinc-400';
-    empty.textContent = `No ${label} key connected.`;
-    wrap.appendChild(empty);
-    const linkRow = document.createElement('p');
-    linkRow.className = 'text-[11px]';
-    const a = document.createElement('a');
-    a.href = console.url;
-    a.target = '_blank';
-    a.rel = 'noopener noreferrer';
-    a.className = 'text-blue-400 hover:text-blue-300 underline';
-    a.textContent = `Get a key at ${console.label} →`;
-    linkRow.appendChild(a);
-    wrap.appendChild(linkRow);
-    const connectBtn = document.createElement('button');
-    connectBtn.className = 'self-start px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white';
-    connectBtn.textContent = `Connect ${label}`;
-    connectBtn.addEventListener('click', () => {
-      close();
-      void showAiKeyModal({ provider, onConnected: cb.onChange });
-    });
-    wrap.appendChild(connectBtn);
-    body.appendChild(wrap);
-    return;
+    wrap.appendChild(buildKeyEntryForm(provider, cb, rerender, switchTab));
+    return wrap;
   }
 
   const last4 = key.apiKey.slice(-4);
@@ -541,72 +519,123 @@ async function buildHostedKeySection(
 
   const note = document.createElement('p');
   note.className = 'text-[11px] text-zinc-500 leading-snug';
-  note.textContent = 'Estimated spend uses public list prices and may differ slightly from your provider invoice.';
+  note.textContent = `Estimated spend uses public list prices and may differ slightly from your ${provider === 'anthropic' ? 'Anthropic' : 'provider'} invoice.`;
   wrap.appendChild(note);
-  body.appendChild(wrap);
 
-  const replaceBtn = document.createElement('button');
-  replaceBtn.className = 'px-3 py-1.5 rounded text-xs text-zinc-200 bg-zinc-700 hover:bg-zinc-600';
-  replaceBtn.textContent = 'Replace key';
-  replaceBtn.addEventListener('click', () => {
-    close();
-    void showAiKeyModal({ provider, onConnected: cb.onChange });
-  });
-  footer.appendChild(replaceBtn);
-
-  const disconnectBtn = document.createElement('button');
-  disconnectBtn.className = 'px-3 py-1.5 rounded text-xs text-red-300 bg-red-900/40 hover:bg-red-800/60';
-  disconnectBtn.textContent = 'Disconnect';
-  disconnectBtn.addEventListener('click', async () => {
-    if (!confirm(`Disconnect ${label}? Your chat history is kept; only the key is removed.`)) return;
+  const remove = document.createElement('button');
+  remove.className = 'self-start text-[11px] text-red-300 hover:text-red-200 underline';
+  remove.textContent = `Remove ${label} key`;
+  remove.title = 'Delete this key from the browser. Your chat history is kept; you can paste a new key any time.';
+  remove.addEventListener('click', async () => {
+    if (!confirm(`Remove your ${label} key? Your chat history is kept; only the key is removed.`)) return;
     await deleteKey(provider);
-    reset();
-    close();
+    resetClientFor(provider);
     cb.onChange();
+    // Re-render the tab so the inline entry form reappears.
+    rerender();
   });
-  footer.appendChild(disconnectBtn);
+  wrap.appendChild(remove);
+  return wrap;
+}
+
+/** Inline API-key entry form rendered directly inside a provider tab. On a
+ *  successful validate it stores the key, promotes the provider to active,
+ *  and re-renders the tab (flipping to the usage-stats view) — no separate
+ *  pop-up modal. */
+function buildKeyEntryForm(
+  provider: HostedProvider,
+  cb: AiSettingsCallbacks,
+  rerender: () => void,
+  switchTab: (tab: Provider) => void,
+): HTMLElement {
+  const meta = providerKeyMeta(provider);
+  const wrap = document.createElement('div');
+  wrap.className = 'flex flex-col gap-2';
+
+  const link = document.createElement('a');
+  link.href = meta.consoleUrl;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  link.className = 'text-blue-400 hover:text-blue-300 underline text-[11px]';
+  link.textContent = meta.consoleLabel;
+  wrap.appendChild(link);
+
+  const tip = document.createElement('div');
+  tip.className = 'rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-[11px] text-amber-200 leading-snug';
+  tip.innerHTML = '<strong>Recommended:</strong> use a workspace-scoped key with a monthly spend cap. Anyone who can run code in this page (extensions, devtools) can read the key.';
+  wrap.appendChild(tip);
+
+  const input = document.createElement('input');
+  input.type = 'password';
+  input.placeholder = meta.placeholder;
+  input.className = 'w-full px-3 py-2 rounded bg-zinc-900 border border-zinc-600 text-zinc-100 text-sm font-mono placeholder:text-zinc-600 focus:outline-none focus:border-blue-500';
+  input.spellcheck = false;
+  input.autocomplete = 'off';
+  wrap.appendChild(input);
+
+  const errorBox = document.createElement('div');
+  errorBox.className = 'text-[11px] text-red-400 hidden';
+  wrap.appendChild(errorBox);
+
+  const status = document.createElement('div');
+  status.className = 'text-[11px] text-zinc-500 hidden';
+  wrap.appendChild(status);
+
+  const connectBtn = document.createElement('button');
+  connectBtn.className = 'self-start px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed';
+  connectBtn.textContent = connectButtonLabel(provider);
+  wrap.appendChild(connectBtn);
+
+  // Local-model escape hatch — switches to the Local tab (no pop-up).
+  const altRow = document.createElement('div');
+  altRow.className = 'text-[11px] text-zinc-400 leading-snug';
+  altRow.appendChild(document.createTextNode('Don’t want an API key? '));
+  const localLink = document.createElement('button');
+  localLink.className = 'underline text-emerald-300 hover:text-emerald-200';
+  localLink.textContent = 'Run a local model in your browser';
+  localLink.addEventListener('click', () => switchTab('local'));
+  altRow.appendChild(localLink);
+  altRow.appendChild(document.createTextNode(' — free, runs on your GPU.'));
+  wrap.appendChild(altRow);
+
+  const showError = (msg: string) => {
+    errorBox.textContent = msg;
+    errorBox.classList.remove('hidden');
+  };
+
+  async function attempt(): Promise<void> {
+    if (input.value.trim().length < 10) {
+      showError('That key looks too short.');
+      return;
+    }
+    connectBtn.disabled = true;
+    connectBtn.textContent = 'Validating…';
+    status.classList.remove('hidden');
+    status.textContent = 'Sending a 1-token test request to verify the key…';
+    errorBox.classList.add('hidden');
+
+    const error = await validateAndStoreKey(provider, input.value);
+    if (error) {
+      showError(error);
+      connectBtn.disabled = false;
+      connectBtn.textContent = connectButtonLabel(provider);
+      status.classList.add('hidden');
+      return;
+    }
+    cb.onChange();
+    rerender();
+  }
+
+  connectBtn.addEventListener('click', () => { void attempt(); });
+  input.addEventListener('keydown', e => {
+    if (e.key === 'Enter') { e.preventDefault(); void attempt(); }
+  });
+  return wrap;
 }
 
 function formatK(n: number): string {
   if (n >= 1024 && n % 1024 === 0) return `${n / 1024}K`;
   return n.toLocaleString();
-}
-
-function buildLocalSection(close: () => void, cb: AiSettingsCallbacks): HTMLElement {
-  const wrap = document.createElement('div');
-  wrap.className = 'flex flex-col gap-2';
-  const head = document.createElement('div');
-  head.className = 'flex items-center justify-between';
-  const h = document.createElement('div');
-  h.className = 'text-xs text-zinc-400';
-  h.textContent = 'Local model';
-  head.appendChild(h);
-  const pick = document.createElement('button');
-  pick.className = 'px-3 py-1 rounded text-xs text-zinc-200 bg-zinc-700 hover:bg-zinc-600';
-  pick.textContent = 'Choose model…';
-  pick.addEventListener('click', () => {
-    close();
-    void showAiLocalModal({ onChange: cb.onChange });
-  });
-  head.appendChild(pick);
-  wrap.appendChild(head);
-
-  const settings = loadSettings();
-  const status = document.createElement('div');
-  status.className = 'text-[11px] text-zinc-400 leading-snug';
-  if (settings.toggles.localModel) {
-    try {
-      const info = resolveLocalModel(settings.toggles.localModel);
-      const resident = isModelLoaded(info.id);
-      status.textContent = `${info.label} · ${(info.vramMB / 1024).toFixed(1)} GB VRAM · ${resident ? 'in GPU memory' : 'not yet loaded'}`;
-    } catch {
-      status.textContent = 'Previously selected model is no longer available. Pick another.';
-    }
-  } else {
-    status.textContent = 'No local model picked yet. Click “Choose model…” to download one.';
-  }
-  wrap.appendChild(status);
-  return wrap;
 }
 
 /** "Local context" section — controls the trade-off between conversation
@@ -810,82 +839,4 @@ function buildSystemPromptSection(provider: Provider, close: () => void, cb: AiS
   });
   wrap.appendChild(editBtn);
   return wrap;
-}
-
-/** Anthropic key + lifetime usage panel. Renders the empty-state connect
- *  button inline, and (when a key exists) puts Replace / Disconnect into
- *  the modal footer. */
-async function buildAnthropicKeySection(close: () => void, footer: HTMLElement, body: HTMLElement, cb: AiSettingsCallbacks): Promise<void> {
-  const wrap = document.createElement('div');
-  wrap.className = 'flex flex-col gap-2';
-  const head = document.createElement('div');
-  head.className = 'text-xs text-zinc-400';
-  head.textContent = 'Anthropic key';
-  wrap.appendChild(head);
-
-  const key = await getKey('anthropic');
-  if (!key) {
-    const empty = document.createElement('p');
-    empty.className = 'text-[11px] text-zinc-400';
-    empty.textContent = 'No Anthropic key connected.';
-    wrap.appendChild(empty);
-    const connectBtn = document.createElement('button');
-    connectBtn.className = 'self-start px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white';
-    connectBtn.textContent = 'Connect Anthropic API';
-    connectBtn.addEventListener('click', () => {
-      close();
-      void showAiKeyModal({ onConnected: cb.onChange });
-    });
-    wrap.appendChild(connectBtn);
-    body.appendChild(wrap);
-    return;
-  }
-
-  const last4 = key.apiKey.slice(-4);
-  const row = (label: string, value: string) => {
-    const r = document.createElement('div');
-    r.className = 'flex justify-between gap-3 text-xs';
-    const l = document.createElement('span');
-    l.className = 'text-zinc-400';
-    l.textContent = label;
-    const v = document.createElement('span');
-    v.className = 'text-zinc-100 font-mono';
-    v.textContent = value;
-    r.appendChild(l);
-    r.appendChild(v);
-    return r;
-  };
-  wrap.appendChild(row('Key', `…${last4}`));
-  wrap.appendChild(row('Connected', new Date(key.createdAt).toLocaleString()));
-  wrap.appendChild(row('Last used', new Date(key.lastUsed).toLocaleString()));
-  wrap.appendChild(row('Input tokens', key.totalInputTokens.toLocaleString()));
-  wrap.appendChild(row('Output tokens', key.totalOutputTokens.toLocaleString()));
-  wrap.appendChild(row('Spent (estimated)', formatUsd(key.totalCostUsd)));
-
-  const note = document.createElement('p');
-  note.className = 'text-[11px] text-zinc-500 leading-snug';
-  note.textContent = 'Estimated spend uses public list prices and may differ slightly from your Anthropic invoice.';
-  wrap.appendChild(note);
-  body.appendChild(wrap);
-
-  const replaceBtn = document.createElement('button');
-  replaceBtn.className = 'px-3 py-1.5 rounded text-xs text-zinc-200 bg-zinc-700 hover:bg-zinc-600';
-  replaceBtn.textContent = 'Replace key';
-  replaceBtn.addEventListener('click', () => {
-    close();
-    void showAiKeyModal({ onConnected: cb.onChange });
-  });
-  footer.appendChild(replaceBtn);
-
-  const disconnectBtn = document.createElement('button');
-  disconnectBtn.className = 'px-3 py-1.5 rounded text-xs text-red-300 bg-red-900/40 hover:bg-red-800/60';
-  disconnectBtn.textContent = 'Disconnect';
-  disconnectBtn.addEventListener('click', async () => {
-    if (!confirm('Disconnect Anthropic? Your chat history is kept; only the key is removed.')) return;
-    await deleteKey('anthropic');
-    resetClient();
-    close();
-    cb.onChange();
-  });
-  footer.appendChild(disconnectBtn);
 }

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -761,7 +761,7 @@ test.describe('Multi-provider AI', () => {
     await expect(modal.locator('text=stop: end_turn')).toBeVisible();
   });
 
-  test('connect modal renders correctly per provider', async ({ page }) => {
+  test('inline key form renders correctly per provider', async ({ page }) => {
     await page.goto('/editor');
     await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch {} });
     await page.reload();
@@ -769,12 +769,12 @@ test.describe('Multi-provider AI', () => {
     await page.locator('#btn-ai').dispatchEvent('click');
     await page.locator('#ai-panel button[title^="AI settings"]').dispatchEvent('click');
     await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
-    // Tabbed modal — view the OpenAI tab first, then its Connect button.
+    // Tabbed modal — the OpenAI tab shows its key form inline (no second
+    // pop-up): placeholder input, console link, and Connect button together.
     await page.locator('button:has-text("OpenAI (cloud)")').dispatchEvent('click');
-    await page.locator('button:has-text("Connect OpenAI")').dispatchEvent('click');
-    await expect(page.getByRole('heading', { name: 'Connect OpenAI' })).toBeVisible();
     await expect(page.locator('input[placeholder*="sk-proj"]')).toBeVisible();
     await expect(page.locator('a[href*="platform.openai.com"]')).toBeVisible();
+    await expect(page.locator('button:has-text("Connect OpenAI")')).toBeVisible();
   });
 });
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -104,24 +104,24 @@ test.describe('AI chat panel', () => {
     await expect(panel.locator('button', { hasText: /^Send$/ })).toBeVisible();
   });
 
-  test('key modal opens and closes', async ({ page }) => {
+  test('inline key entry shows in settings and dismisses cleanly', async ({ page }) => {
     await page.goto('/editor');
     await page.waitForSelector('#btn-ai');
     // Let editor init (and session auto-restore) settle before clicking, so a
     // late ?session= navigation doesn't tear down the modal mid-test.
     await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
     await page.click('#btn-ai');
-    // The panel CTA now opens the generic AI Settings modal; the per-provider
-    // key modal is one click deeper (Anthropic tab → Connect Anthropic API).
+    // The panel CTA opens the AI Settings modal. The per-provider key form is
+    // now inline in the tab (no separate pop-up): the Anthropic tab is shown
+    // by default and exposes the password field + Connect button right away.
     // dispatchEvent — same flex-child viewport quirk as the toggle pills.
     await page.locator('#ai-panel button:has-text("Connect an AI agent")').dispatchEvent('click');
     await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
-    await page.locator('button:has-text("Connect Anthropic API")').click();
     await expect(page.locator('input[type="password"]')).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Connect Anthropic API' })).toBeVisible();
+    await expect(page.locator('button:has-text("Connect Anthropic API")')).toBeVisible();
 
-    // Cancel returns to the panel, no key persisted
-    await page.locator('.bg-zinc-800.rounded-xl button:text-is("Cancel")').click();
+    // Done closes the modal; no key was persisted.
+    await page.locator('.bg-zinc-800.rounded-xl button:text-is("Done")').click();
     await expect(page.locator('input[type="password"]')).toHaveCount(0);
     await expect(page.locator('#btn-ai')).toContainText(/Connect AI/);
   });


### PR DESCRIPTION
## Summary

Collapses the per-provider **API-key entry** and **local-model selection** flows directly into the AI Settings tabs, instead of closing Settings and launching separate pop-up sub-modals.

- **Hosted tabs (Anthropic / OpenAI / Gemini):** when no key is stored, the tab now shows the API-key input form **inline** (console "get a key" link, security tip, validate button, and a "Run a local model" link that switches tabs in place). Once a key is connected, the tab shows lifetime usage stats plus an inline **"Remove key"** link — matching the requested "input if not entered, otherwise stats + a link to remove the key."
- **Local tab:** embeds the **full** model picker inline — crash-risk warning, WebGPU / storage banners, grouped model cards, custom-model form, and trust panel. The Settings shell is scrollable and widened to `lg` so all of the messaging fits and scrolls.
- **No duplicated logic:** extracted `validateAndStoreKey` + `providerKeyMeta` into `aiKeyModal`, and an exported `renderLocalPicker(container, cb, { embedded })` into `aiLocalModal`. The standalone key/local modals remain for the panel's in-flow prompts (send-with-no-key, model picker) and the cross-provider review modal.
- The Enable row refreshes on its own when a local model is activated inline, so it flips to "active" without a jarring full-tab rebuild.

## Test plan

- [x] `npm run build` — clean (tsc + vite)
- [x] `npm run test:e2e` — 170 passed; 2 unrelated failures (`paint-smooth-brush`, `simplify`) reproduce identically on a clean `origin/staging` (WASM mesh nondeterminism in the sandbox), so they pre-date this change
- [x] `ai-providers.spec.ts` (24) and `smoke.spec.ts` (13) green; updated the two specs that asserted the old pop-up behavior to assert the inline form instead
- [x] Visually verified in-browser: Anthropic tab inline form, OpenAI tab with planted key (stats + "Remove key"), and the tall scrolling Local tab

https://claude.ai/code/session_018gk9HLub9nbAozv3vHs9Ve

---
_Generated by [Claude Code](https://claude.ai/code/session_018gk9HLub9nbAozv3vHs9Ve)_