### PR TITLE
docs: adopt draft-PR-first AI workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,20 +19,24 @@ Hosted on **Cloudflare Pages** with production custom domain `www.partwrightstud
 - **`staging`** branch → Cloudflare Pages preview deploy
 - **`main`** branch → production deploy (protected, requires PR review)
 
-**All work should be merged to `staging` first.** Do not push directly to `main`. The workflow is:
+**All work should be merged to `staging` first.** Do not push directly to `main`. Feature work follows a **draft-PR-first** flow: open the PR as a draft the moment the implementation looks good, run the slow verification *on the draft*, and only then mark it ready for review. The full sequence:
 
 1. **Start from the latest `staging`.** Before writing any code, run `git fetch origin staging` and base your feature branch on `origin/staging`. Do this at the *start* of the task, not just before the final push.
-2. Before your final push or PR, sync with the latest staging: `git fetch origin staging`, then merge `origin/staging` into your branch (or rebase onto it if the branch hasn't been pushed yet), resolve any conflicts, and re-run `npm run build` + `npm run test:e2e`
-3. Merge to `staging` — auto-deploys for verification
-4. Once validated on staging, open a PR from `staging` → `main` for production release
+2. **Implement** until the change looks good and working by your own lightweight checks (render/stat verification, a quick read-through of the diff). Don't run the slow e2e suite yet — that comes after the draft is up.
+3. **Pre-flight, then push a draft PR.** Re-sync with the latest staging (`git fetch origin staging`, then merge `origin/staging` into your branch, or rebase onto it if the branch hasn't been pushed yet, resolving conflicts), run the fast `npm run build` to catch type errors, push the branch, and open the PR into `staging` **as a draft** (`create_pull_request` with `draft: true`). Keep the pre-flight light — `npm run build` only, *not* `npm run test:e2e`. See [Pull Requests](#pull-requests--open-a-draft-when-the-work-looks-good-mark-ready-once-verified).
+4. **Verify on the draft.** Now run the slow checks — `npm run test:e2e` plus any deeper or manual verification the change warrants — and follow CI. Fix any failures on the same branch and re-run until clean. See [After Opening a PR](#after-opening-a-pr).
+5. **Mark ready for review** once the review pass is clean and e2e/CI/deploy are all green (`update_pull_request` with `draft: false`). The task is not done until the PR is out of draft.
+6. After the feature PR merges to `staging`, it auto-deploys for verification. Once validated on staging, open a PR from `staging` → `main` for production release.
 
-> **Always start from — and re-sync against — the latest `origin/staging`.** Branches cut from a stale staging produce noisy diffs and merge conflicts, and can quietly clobber recently merged work. Re-fetch and merge/rebase `origin/staging` right before your final push, and again before opening any PR.
+> **Always start from — and re-sync against — the latest `origin/staging`.** Branches cut from a stale staging produce noisy diffs and merge conflicts, and can quietly clobber recently merged work. Re-fetch and merge/rebase `origin/staging` right before pushing the draft, and again before marking the PR ready or opening any `staging` → `main` PR.
 
-### Pull Requests — always open one when a task is complete
+### Pull Requests — open a draft when the work looks good, mark ready once verified
 
-When you finish an agent task, **create a pull request into `staging` as the final step.** This is a standing instruction that overrides any default "don't open a PR unless explicitly asked" behavior: treat task completion as the authorization to open the PR. Don't pause to ask whether to create one, and don't report a task as done without it.
+When an implementation looks good and working, **open a draft pull request into `staging`** — don't wait until you've run the slow verification. This is a standing instruction that overrides any default "don't open a PR unless explicitly asked" behavior: treat "the implementation looks done" as the authorization to open the draft. Don't pause to ask whether to create one, and don't report a task as done without it.
 
-Skip the PR only when the user explicitly scoped you away from it — a request to "just commit" or "push to the branch" is *not* a request for a PR — or for a pure throwaway experiment. If you genuinely can't tell whether the work is a complete, reviewable unit, ask. Follow the [commit & PR conventions](#commit--pr-conventions) below for the title, prefix, and labels, and [After Opening a PR](#after-opening-a-pr) for the review pass and CI follow-up once it's up.
+Open it as a **draft** (`create_pull_request` with `draft: true`) after a fast pre-flight only — re-sync `origin/staging` and run `npm run build`. **Defer the slow `npm run test:e2e` and any deeper verification until after the draft is up** (see [After Opening a PR](#after-opening-a-pr)); the draft PR is what *kicks off* that verification phase, not the finish line. The task is done only once the PR is flipped to **ready for review** (`update_pull_request` with `draft: false`), which you do yourself after the review pass is clean and e2e/CI/deploy are green.
+
+Skip the PR only when the user explicitly scoped you away from it — a request to "just commit" or "push to the branch" is *not* a request for a PR — or for a pure throwaway experiment. If you genuinely can't tell whether the work is a complete, reviewable unit, ask. Follow the [commit & PR conventions](#commit--pr-conventions) below for the title, prefix, and labels.
 
 - **Build command:** `npm run build`
 - **Output directory:** `dist/`
@@ -317,9 +321,11 @@ Anything unlabeled lands in "Other Changes." That's fine for occasional internal
 
 ### After Opening a PR
 
-Opening the PR (see [the standing instruction](#pull-requests--always-open-one-when-a-task-is-complete) in Deployment) isn't the finish line. Once it's up, do the following (the first two can run in parallel):
+Opening the **draft** PR (see [the standing instruction](#pull-requests--open-a-draft-when-the-work-looks-good-mark-ready-once-verified) above) isn't the finish line — it's the start of the verification phase. The PR stays in **draft** through everything below; you flip it to ready only at the very end (step 5). Steps 1–4 can overlap.
 
-**1. Kick off an automated review pass.** Right after pushing the initial PR, launch a review subagent (the Agent tool) over your branch diff against `origin/staging` and the code it touches. Have it hunt specifically for problems your change may have introduced:
+**1. Run the slow verification you skipped pre-flight.** Now run `npm run test:e2e` (and any deeper or manual verification the change warrants — e.g. exercising the affected UI in a browser per the [Smoke Test](#smoke-test--verifying-the-app-works)). This is the work you deliberately deferred to keep the path-to-draft fast. Fix failures on the same branch and re-run until clean.
+
+**2. Kick off an automated review pass.** Right after pushing the draft, launch a review subagent (the Agent tool) over your branch diff against `origin/staging` and the code it touches. Have it hunt specifically for problems your change may have introduced:
 
 - **Defects** — logic errors, unhandled cases, broken or orphaned call sites in the new code.
 - **Functionality dropped in a merge** — features or code paths silently lost while resolving conflicts or re-syncing with `origin/staging`. Diff against what was there before, not just your own edits.
@@ -328,7 +334,7 @@ Opening the PR (see [the standing instruction](#pull-requests--always-open-one-w
 
 Surface the results on the PR (a review comment, or fold clear fixes straight into the branch). If the pass turns up something ambiguous or large, raise it with the user rather than silently reworking.
 
-**2. Follow CI and auto-fix what you can.** Watch the PR's checks — the `npm run build` / `npm run test:e2e` workflow and the Cloudflare Pages deployment — and **auto-fix build or deployment failures when you can** by pushing a fix straight to the PR branch:
+**3. Follow CI and auto-fix what you can.** Watch the PR's checks — the `npm run build` / `npm run test:e2e` workflow and the Cloudflare Pages deployment — and **auto-fix build or deployment failures when you can** by pushing a fix straight to the PR branch:
 
 1. Reproduce the failure locally first (`npm run build`, `npm run test:e2e`) so you're fixing the real cause, not guessing from the log.
 2. Re-sync with the latest `origin/staging` if the branch has drifted (see the Deployment workflow), then commit and push the fix to the same PR branch.
@@ -336,7 +342,9 @@ Surface the results on the PR (a review comment, or fold clear fixes straight in
 
 Only push fixes you're confident in — failures clearly caused by your own changes. If a failure is ambiguous, unrelated to your changes, or would require a large refactor or a risky/destructive change to resolve, stop and ask the user instead of pushing speculative fixes.
 
-**3. Keep the PR description in sync with the branch.** Any time you push new work to an open PR — review fixes, CI fixes, or follow-up commits that go beyond the PR's original scope — re-check the PR description and update it to cover the *totality* of the work now on the branch, not just what existed when the PR was first opened. Fold the new changes into the Summary, refresh the Test plan, and bring the title, prefix, and labels back in line with the [commit & PR conventions](#commit--pr-conventions) if the scope has grown. The description and the branch diff should never tell different stories — don't let the description silently drift behind the work.
+**4. Keep the PR description in sync with the branch.** Any time you push new work to an open PR — review fixes, CI fixes, or follow-up commits that go beyond the PR's original scope — re-check the PR description and update it to cover the *totality* of the work now on the branch, not just what existed when the PR was first opened. Fold the new changes into the Summary, refresh the Test plan, and bring the title, prefix, and labels back in line with the [commit & PR conventions](#commit--pr-conventions) if the scope has grown. The description and the branch diff should never tell different stories — don't let the description silently drift behind the work.
+
+**5. Mark the PR ready for review.** Once the automated review pass is clean, `npm run test:e2e` is green, and CI/Cloudflare deploy are green, flip the PR out of draft with `update_pull_request` (`draft: false`) and apply the [release-note labels](#commit--pr-conventions). This is the final step — the task is not done until the draft is marked ready. If verification surfaced something ambiguous or large, leave the PR in draft and raise it with the user instead of un-drafting.
 
 ## Common Errors
 


### PR DESCRIPTION
## Summary

Restructures the AI agent workflow in `CLAUDE.md` (the single source of truth — `AGENTS.md` and `GEMINI.md` are symlinks to it) so the slow end-to-end suite no longer blocks the path to a PR. The new flow is **draft-PR-first**:

1. **Implement** until it looks good by lightweight checks (render/stat verification, diff read-through).
2. **Pre-flight + push a draft PR** — re-sync `origin/staging`, run the fast `npm run build` only (no e2e), open the PR into `staging` with `draft: true`.
3. **Verify on the draft** — run `npm run test:e2e` plus any deeper/manual verification, kick off the review subagent, follow CI, keep the description in sync.
4. **Mark ready for review** — flip the PR out of draft (`update_pull_request` with `draft: false`) only once the review pass is clean and e2e/CI/Cloudflare deploy are green.

### Changes (all in `CLAUDE.md`)

- **Deployment workflow** — reordered into a 6-step draft-first sequence; the slow `npm run test:e2e` moves out of the pre-PR step and into post-draft verification, leaving `npm run build` as the only pre-flight gate.
- **"Pull Requests" section** — reframed: open a **draft** at the "implementation looks good" milestone; the task is done only when the PR is marked ready for review.
- **"After Opening a PR" section** — now the post-draft *verification phase*; added a step 1 for running the deferred slow checks and a step 5 for un-drafting once green. Existing review-subagent / CI-follow-up / description-sync items renumbered.
- Internal anchor cross-references updated to match the renamed "Pull Requests" heading; no stale links remain.

## Test plan

- [x] No stale `#pull-requests--always-open-...` anchor references remain; new anchor links resolve within the doc.
- [x] `AGENTS.md` / `GEMINI.md` symlinks still resolve to `CLAUDE.md`.
- [ ] Docs-only change — no code touched, so `npm run test:e2e` exercises nothing relevant to this diff (it tests app behavior, not markdown).

> Opened as a draft to dogfood the new flow. Since this is a markdown-only change, the slow e2e step has nothing to exercise, so it'll be marked ready for review after the link/anchor self-review above.

https://claude.ai/code/session_01APRSHZA3aPkJ4DD7mYoKD7

---
_Generated by [Claude Code](https://claude.ai/code/session_01APRSHZA3aPkJ4DD7mYoKD7)_