### PR TITLE
fix: close export and geometry robustness gaps

### DIFF
--- a/src/export/gltf.ts
+++ b/src/export/gltf.ts
@@ -32,6 +32,27 @@ function shouldExcludeFromExport(obj: THREE.Object3D): boolean {
   return false;
 }
 
+/** Throws if any mesh that will be exported carries a non-finite (NaN/Infinity)
+ *  vertex coordinate. GLB builds from the live Three.js scene rather than a
+ *  MeshData, so it can't reuse assertFiniteMesh — but it needs the same guard so
+ *  every export path (menu button AND window.partwright.exportGLB/exportGLBData)
+ *  fails loudly instead of writing garbage floats. Run after excluded objects
+ *  are hidden so only the geometry GLTFExporter will actually serialize is
+ *  checked (the exporter skips invisible objects by default). */
+function assertFiniteExportableScene(scene: THREE.Object3D): void {
+  scene.traverse(obj => {
+    if (!obj.visible || !(obj instanceof THREE.Mesh) || shouldExcludeFromExport(obj)) return;
+    const pos = (obj.geometry as THREE.BufferGeometry).attributes?.position;
+    if (!pos) return;
+    const arr = pos.array;
+    for (let i = 0; i < arr.length; i++) {
+      if (!Number.isFinite(arr[i])) {
+        throw new Error(`Cannot export: mesh "${obj.name || 'model'}" has a non-finite (NaN/Infinity) coordinate. Check the geometry before exporting.`);
+      }
+    }
+  });
+}
+
 /** Build the GLB blob for the current scene without triggering a download. */
 export async function buildGLB(customName?: string): Promise<BuiltExport> {
   const scene = getScene();
@@ -46,6 +67,7 @@ export async function buildGLB(customName?: string): Promise<BuiltExport> {
   });
 
   try {
+    assertFiniteExportableScene(scene);
     const result = await exporter.parseAsync(scene, { binary: true });
     const mimeType = 'model/gltf-binary';
     const blob = new Blob([result as ArrayBuffer], { type: mimeType });

--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -253,7 +253,18 @@ export async function validateCodeAsync(source: string, lang?: Language): Promis
     await workerReady;
     const callId = `val-${++callIdCounter}`;
     return new Promise<ValidateResult>((resolve, reject) => {
-      pendingValidations.set(callId, { resolve, reject });
+      // A hung validate never posts a result back. Mirror executeCodeAsync's
+      // timeout so a stuck OpenSCAD parse restarts the worker (which rejects all
+      // pending validations) instead of leaving the promise unsettled forever.
+      const timer = setTimeout(() => {
+        if (pendingValidations.has(callId)) {
+          restartEngineWorker(`OpenSCAD validation timed out after ${EXECUTE_TIMEOUT_MS / 1000}s`);
+        }
+      }, EXECUTE_TIMEOUT_MS);
+      pendingValidations.set(callId, {
+        resolve: (r) => { clearTimeout(timer); resolve(r); },
+        reject:  (e) => { clearTimeout(timer); reject(e); },
+      });
       engineWorker!.postMessage({ type: 'validate', callId, code: source, lang: l });
     });
   }

--- a/src/import/parsers/stl.ts
+++ b/src/import/parsers/stl.ts
@@ -67,6 +67,9 @@ function parseBinarySTL(bytes: Uint8Array, weldTolerance: number): MeshData | nu
       const x = view.getFloat32(offset, true); offset += 4;
       const y = view.getFloat32(offset, true); offset += 4;
       const z = view.getFloat32(offset, true); offset += 4;
+      // Reject non-finite coords here rather than letting a NaN/Infinity vertex
+      // flow downstream and fail export later with a misleading "geometry" error.
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return null;
       const key = `${quantize(x)},${quantize(y)},${quantize(z)}`;
       let idx = vertIndex.get(key);
       if (idx === undefined) {
@@ -120,6 +123,9 @@ function parseAsciiSTL(bytes: Uint8Array, weldTolerance: number): MeshData | nul
       const x = parseFloat(m[1]);
       const y = parseFloat(m[2]);
       const z = parseFloat(m[3]);
+      // Guard against overflow tokens like "1e999" (→ Infinity) producing a
+      // non-finite mesh; fail the parse cleanly instead.
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return null;
       const key = `${quantize(x)},${quantize(y)},${quantize(z)}`;
       let idx = vertIndex.get(key);
       if (idx === undefined) {

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -60,7 +60,11 @@ let clippingEnabled = false;
 let clipZ = 0;
 let modelBounds: { min: number; max: number } = { min: 0, max: 10 };
 
-// Back-face cap material — shows the cut face in a different color
+// Back-face cap material — shows the cut face in a different color. Used as a
+// TEMPLATE only: each cap mesh gets its own clone (capMaterial.clone()) so that
+// updateMesh's disposal loop, which disposes every child mesh's material, frees
+// the per-cap clone and never this shared singleton (disposing it would leave
+// the next cap rendering with a dead material).
 const capMaterial = new THREE.MeshPhongMaterial({
   color: 0xff6b6b,
   shininess: 20,
@@ -261,7 +265,7 @@ export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boole
   // Back-face cap mesh (shows cut face when clipping)
   if (clippingEnabled) {
     const capGeometry = geometry.clone();
-    const capMesh = new THREE.Mesh(capGeometry, capMaterial);
+    const capMesh = new THREE.Mesh(capGeometry, capMaterial.clone());
     capMesh.name = 'clip-cap';
     meshGroup.add(capMesh);
   }
@@ -332,7 +336,7 @@ export function setClipping(enabled: boolean): void {
       const solidChild = meshGroup.children[0];
       if (solidChild instanceof THREE.Mesh) {
         const capGeometry = solidChild.geometry.clone();
-        const capMesh = new THREE.Mesh(capGeometry, capMaterial);
+        const capMesh = new THREE.Mesh(capGeometry, capMaterial.clone());
         capMesh.name = 'clip-cap';
         meshGroup.add(capMesh);
       }


### PR DESCRIPTION
## Summary

Four robustness defects from the staging review, grouped because they all sit in the geometry → export/import pipeline:

1. **GLB export wasn't fully guarded against non-finite coords.** `buildSTL`/`buildOBJ`/`build3MF` call `assertFiniteMesh` *internally*, so every caller (including `window.partwright.exportSTL/exportOBJ/export3MF`) is covered. GLB builds from the live Three.js scene instead of a `MeshData`, and its only finite-guard lived at the export-menu call site (`main.ts`) — so the AI-facing `window.partwright.exportGLB()` and `exportGLBData()` paths exported unguarded, silently writing garbage floats for a NaN/Infinity model. `buildGLB` now runs a scene-based finite check (same error message), so all GLB paths fail loudly. (The existing menu-call-site guard is now redundant but harmless and left untouched to keep this PR off `main.ts`.)
2. **`updateMesh` disposed the shared singleton `capMaterial`.** The clip-cap mesh reused the module-level `capMaterial`; `updateMesh`'s clear loop disposes every child mesh's material, so after the first re-run with clipping on, the shared material was disposed and the next cap rendered with a dead material. Each cap now gets its own `capMaterial.clone()`, so disposal frees the clone and the template survives.
3. **`validateCodeAsync` (OpenSCAD) had no timeout.** Unlike `executeCodeAsync`, a hung SCAD validate set a pending promise with no timer and was never covered by `restartEngineWorker`, so it could hang forever. It now uses the same timeout → worker-restart path (the restart already rejects pending validations).
4. **STL import produced NaN meshes.** Binary `getFloat32` can decode NaN/Infinity from arbitrary bytes, and the ASCII parser's number charset accepts overflow tokens like `1e999` (→ `Infinity` via `parseFloat`). Both parsers now reject non-finite coords up front (returning `null`, consistent with the existing parse-failure contract) instead of yielding a NaN mesh that fails *export* later with a misleading "check the geometry" error.

No format/schema changes — exported GLB/3MF and imported STL remain compatible.

## Test plan

Automated (run locally):
- [x] `npm run build` (tsc + vite) — clean
- [x] `npx playwright test tests/stl-import.spec.ts` — 2/2
- [x] `npx playwright test tests/paint-render-color.spec.ts tests/smoke.spec.ts` — 14/14 (viewport renders)
- [x] `npx playwright test tests/quality-scad.spec.ts` — pass
- [x] `npx playwright test tests/simplify.spec.ts` — 4/5; the 1 failure (`simplify.spec.ts:133`) **also fails on clean `origin/staging`**, so it is pre-existing (timing-sensitive in the sandbox), not a regression from this PR.

Manual integration:
- [ ] Enable the cross-section/clip slider on a model, then re-run the code (or edit + re-run) several times with clipping still on → the red cut-face cap should keep rendering correctly every time (previously went black/broken after the first re-run).
- [ ] Toggle clipping off/on repeatedly → cap still correct, no visual artifacts.
- [ ] Drive `window.partwright.exportGLBData()` (or `exportGLB()`) from the console on a normal model → GLB downloads fine.
- [ ] Import a normal binary and ASCII STL → both load. (Optional) hand-craft an ASCII STL with a `1e999` coordinate → import fails cleanly rather than rendering a broken/NaN mesh.
- [ ] In SCAD mode, type valid + invalid SCAD → validation still surfaces errors normally (timeout only triggers on a genuinely hung parse).

https://claude.ai/code/session_01PbDgWKhV2zatS932QyomPB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbDgWKhV2zatS932QyomPB)_