### PR TITLE
fix: correct OpenAI/Gemini parity gaps and cross-provider review

### DIFF
--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -289,15 +289,15 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
         }, streamCallbacks, signal);
       } else {
         if (!toggles.localModel) throw new Error('No local model is selected. Open AI settings → Local model.');
-        // Local provider doesn't accept AbortSignal yet — the user's Stop
-        // click takes effect at the next iteration / tool boundary.
+        // Stop interrupts the in-flight local generation via the signal (WebLLM
+        // interruptGenerate), not just at the next iteration / tool boundary.
         result = await streamLocalTurn({
           modelId: toggles.localModel,
           systemPrompt,
           systemSuffix: toggleSuffix(toggles),
           history: workingHistory,
           tools,
-        }, streamCallbacks);
+        }, streamCallbacks, signal);
       }
     } catch (err) {
       // Surface the error to the caller; runTurn returns normally and the

--- a/src/ai/local.ts
+++ b/src/ai/local.ts
@@ -474,11 +474,20 @@ export interface LocalRequestSpec {
  *      with an UnsupportedModelIdError. We inject tool descriptions into
  *      the system prompt and ask the model to emit `<tool_call>{...}</tool_call>`
  *      blocks, then parse them out post-stream. */
-export async function streamLocalTurn(spec: LocalRequestSpec, callbacks: StreamCallbacks = {}): Promise<StreamResult> {
+export async function streamLocalTurn(spec: LocalRequestSpec, callbacks: StreamCallbacks = {}, signal?: AbortSignal): Promise<StreamResult> {
   if (!loaded || loaded.modelId !== spec.modelId) {
     throw new Error(`Local model ${spec.modelId} is not loaded. Open AI settings → Local model to download it first.`);
   }
   const { engine, info } = loaded;
+  // Already aborted before we even start — don't kick off a generation we'd
+  // immediately throw away.
+  if (signal?.aborted) {
+    return {
+      text: '', toolCalls: [], stopReason: 'aborted',
+      usage: { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+      truncated: false,
+    };
+  }
   // Default is intentionally modest — local models share their context
   // with the whole conversation, and the 70B is capped at 4K. Reserving
   // 768 for output leaves room for the system prompt + tool docs +
@@ -504,6 +513,11 @@ export async function streamLocalTurn(spec: LocalRequestSpec, callbacks: StreamC
   }
 
   const stream = await engine.chat.completions.create(baseReq);
+
+  // Stop WebLLM generation promptly on a Stop click, even if no further chunk
+  // arrives to trip the per-chunk signal check inside the loop below.
+  const onAbort = () => { try { engine.interruptGenerate(); } catch { /* noop */ } };
+  if (signal) signal.addEventListener('abort', onAbort, { once: true });
 
   let rawText = '';
   let stopReason = 'unknown';
@@ -533,6 +547,7 @@ export async function streamLocalTurn(spec: LocalRequestSpec, callbacks: StreamC
   const MAX_OPEN_LEN = Math.max(TOOL_CALL_OPEN.length, THINK_OPEN.length);
 
   try { for await (const chunk of stream as AsyncIterable<any>) {
+    if (signal?.aborted) { stopReason = 'aborted'; break; }
     const choice = chunk?.choices?.[0];
     if (choice?.delta?.content) {
       const delta = choice.delta.content as string;
@@ -608,6 +623,8 @@ export async function streamLocalTurn(spec: LocalRequestSpec, callbacks: StreamC
     // as a normal end-of-turn by resetting stopReason to 'stop'.
     if (err?.name !== 'ToolCallOutputParseError') throw err;
     stopReason = 'stop';
+  } finally {
+    if (signal) signal.removeEventListener('abort', onAbort);
   }
 
   // Final flush: anything still unemitted outside a suppressed block goes
@@ -654,7 +671,10 @@ export async function streamLocalTurn(spec: LocalRequestSpec, callbacks: StreamC
   // Normalize finish_reason to match Anthropic vocabulary ("tool_use" /
   // "end_turn") so chatLoop's branching reads the same.
   let normStop = stopReason;
-  if (toolCalls.length > 0 && !truncatedMidToolCall) normStop = 'tool_use';
+  // An aborted turn wins over everything else: chatLoop persists the partial
+  // text and skips tool execution when stopReason is 'aborted'.
+  if (signal?.aborted || stopReason === 'aborted') normStop = 'aborted';
+  else if (toolCalls.length > 0 && !truncatedMidToolCall) normStop = 'tool_use';
   else if (truncatedMidToolCall || truncatedMaxTokens) normStop = 'max_tokens';
   else if (stopReason === 'stop') normStop = 'end_turn';
 

--- a/src/ai/review.ts
+++ b/src/ai/review.ts
@@ -109,7 +109,10 @@ export async function runReview(
         systemSuffix: '',
         apiMessages: buildApiMessages([ephemeral]),
         tools: [],
-        maxTokens: 1024,
+        // No maxTokens override: use each provider's reasoning-aware default
+        // (Anthropic 8192, OpenAI 8192, Gemini 32768). A hardcoded 1024 here
+        // let a thinking/reasoning reviewer model (Gemini Pro, OpenAI o-series)
+        // spend the whole ceiling on hidden reasoning and return an empty review.
       });
       text = r.text;
       usage = r.usage;
@@ -123,7 +126,8 @@ export async function runReview(
         systemSuffix: '',
         history: [ephemeral],
         tools: [],
-        maxTokens: 1024,
+        // See the Anthropic branch: use the provider default so an o-series /
+        // gpt-5 reviewer has headroom for hidden reasoning + the answer.
       });
       text = r.text;
       usage = r.usage;
@@ -137,19 +141,21 @@ export async function runReview(
         systemSuffix: '',
         history: [ephemeral],
         tools: [],
-        maxTokens: 1024,
+        // See the Anthropic branch: Gemini's 32768 default is what keeps a
+        // Pro/2.5 thinking reviewer from spending the ceiling on reasoning.
       });
       text = r.text;
       usage = r.usage;
     } else {
-      // local
+      // local — keep an explicit ceiling (local's default is only 768, which
+      // can truncate a multi-sentence review), but give the answer headroom.
       const r = await streamLocalTurn({
         modelId: req.model,
         systemPrompt: REVIEW_SYSTEM,
         systemSuffix: '',
         history: [ephemeral],
         tools: [],
-        maxTokens: 1024,
+        maxTokens: 2048,
       });
       text = r.text;
       usage = r.usage;

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -62,9 +62,10 @@ const state: PanelState = {
 };
 
 /** Cached length of `public/ai.md` + PREAMBLE, in characters, populated
- *  once on init. Used when the active provider is Anthropic. Default is
- *  a rough match for the current slimmed ai.md so the context meter is
- *  sensible before the fetch lands. */
+ *  once on init. Used for every hosted provider (Anthropic/OpenAI/Gemini),
+ *  which all receive the full ai.md system prompt. Default is a rough match
+ *  for the current ai.md so the context meter is sensible before the fetch
+ *  lands. */
 let cachedAiMdLength = 55_000;
 
 /** Effective system-prompt length in characters for the active provider /
@@ -75,7 +76,11 @@ function effectiveSystemPromptChars(): number {
   const s = loadSettings();
   const override = s.systemPromptOverrides?.[s.toggles.provider] ?? null;
   if (override !== null) return override.length;
-  if (s.toggles.provider === 'anthropic') return cachedAiMdLength;
+  // Every hosted provider gets the full ai.md prompt (see chatLoop's
+  // system-prompt branch); only 'local' gets the slim variant. Counting the
+  // local length for OpenAI/Gemini under-reported ~12K tokens of prompt and
+  // made the context meter / auto-compaction fire far too late.
+  if (s.toggles.provider !== 'local') return cachedAiMdLength;
   if (s.toggles.localModel) {
     try {
       const info = resolveLocalModel(s.toggles.localModel);

--- a/src/ui/aiSystemPromptModal.ts
+++ b/src/ui/aiSystemPromptModal.ts
@@ -15,7 +15,7 @@
 // override to localStorage so it sticks across reloads. Picking a built-in
 // tier replaces the textarea contents and clears the override on save.
 
-import { loadSettings, saveSettings, setSystemPromptOverride } from '../ai/settings';
+import { loadSettings, saveSettings, setSystemPromptOverride, providerLabel } from '../ai/settings';
 import { buildLocalSystemPrompt, buildMediumLocalSystemPrompt, buildSystemPrompt, loadAiMd } from '../ai/systemPrompt';
 import { resolveLocalModel } from '../ai/local';
 import type { Provider } from '../ai/types';
@@ -50,7 +50,7 @@ export async function showSystemPromptModal(provider: Provider, cb: SystemPrompt
   header.className = 'px-5 py-3 border-b border-zinc-700 flex items-center justify-between shrink-0';
   const title = document.createElement('h2');
   title.className = 'text-sm font-semibold text-zinc-100';
-  title.textContent = `System prompt — ${provider === 'local' ? 'Local (WebGPU)' : 'Anthropic (cloud)'}`;
+  title.textContent = `System prompt — ${provider === 'local' ? 'Local (WebGPU)' : `${providerLabel(provider)} (cloud)`}`;
   header.appendChild(title);
   const closeBtn = document.createElement('button');
   closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
@@ -75,7 +75,8 @@ export async function showSystemPromptModal(provider: Provider, cb: SystemPrompt
   // for this model)" next to the tier picker. Anthropic defaults to full;
   // local defaults to whichever tier the active model declares.
   let providerDefaultTier: Tier;
-  if (provider === 'anthropic') {
+  if (provider !== 'local') {
+    // Every hosted provider (Anthropic/OpenAI/Gemini) is sent the Full ai.md.
     providerDefaultTier = 'full';
   } else if (settings.toggles.localModel) {
     providerDefaultTier = resolveLocalModel(settings.toggles.localModel).promptTier;
@@ -123,7 +124,10 @@ export async function showSystemPromptModal(provider: Provider, cb: SystemPrompt
           : 'The Full tier (~' + Math.round(fullPromptTokens / 1000) + 'K tokens) is too large for this model — pick Slim or Medium, or enable sliding-window mode in AI settings.'}`;
     intro.innerHTML = `This is the wrapper prompt sent to every local-model turn. Pick a built-in tier or edit your own. ${ctxLine}`;
   } else {
-    intro.innerHTML = 'This is the wrapper prompt sent to every Anthropic turn. The Full tier is the default (it\'s prompt-cached, so you pay for it once per cache window). The Slim and Medium tiers are useful when you want to fit more conversation into context, paired with <code>readDoc</code> to pull subdoc detail on demand.';
+    const cacheNote = provider === 'anthropic'
+      ? ' (it\'s prompt-cached, so you pay for it once per cache window)'
+      : '';
+    intro.innerHTML = `This is the wrapper prompt sent to every ${providerLabel(provider)} turn. The Full tier is the default${cacheNote}. The Slim and Medium tiers are useful when you want to fit more conversation into context, paired with <code>readDoc</code> to pull subdoc detail on demand.`;
   }
   body.appendChild(intro);
 


### PR DESCRIPTION
## Summary

Four AI defects from the staging review, grouped because they all stem from features that were built Anthropic-first and not fully generalized to the other providers:

1. **Context meter & auto-compaction under-counted for OpenAI/Gemini.** `effectiveSystemPromptChars()` (aiPanel.ts) returned the full ai.md length only for `anthropic`; OpenAI/Gemini fell through to the ~700-token *local* prompt length — but `chatLoop` sends every hosted provider the full ai.md (~12.5K tokens). So the context % bar read near-empty and auto-compaction fired far too late on two of three cloud providers. Now keyed on `provider !== 'local'`, matching chatLoop's own system-prompt branch.
2. **Cross-provider review returned empty for thinking/reasoning reviewers.** `review.ts` hardcoded `maxTokens: 1024` for all four branches. A Gemini 2.5/3 Pro or OpenAI o-series *reviewer* (the obvious "second opinion" pick) spends most/all of that on hidden reasoning and returns no answer text → persisted as "(empty review)". The normal chat path defends against this with each provider's reasoning-aware default; review now does too (drops the override so Anthropic 8192 / OpenAI 8192 / Gemini 32768 apply; local keeps an explicit 2048 since its default of 768 can truncate a multi-sentence review). `maxTokens` is a ceiling, not a target, so cost stays bounded by the short review the system prompt asks for.
3. **Local (WebLLM) Stop was a no-op mid-generation.** `streamLocalTurn` ignored the abort signal, so Stop only took effect at the next iteration/tool boundary. It now accepts the signal, calls `interruptGenerate()` on abort (and pre-checks before starting), and returns `stopReason: 'aborted'` so chatLoop persists the partial text and skips tool execution like the hosted providers.
4. **System-prompt modal mislabeled OpenAI/Gemini.** The title hardcoded "Anthropic (cloud)", the intro copy was Anthropic-specific, and `providerDefaultTier` treated only `anthropic` as full-tier — so OpenAI/Gemini were shown as defaulting to the *slim* tier (and "Reset to provider default" / override-clearing behaved wrong) even though they receive the full prompt. Now uses `providerLabel(provider)` and treats every hosted provider as full-tier.

### Deferred (not in this PR)
The review modal opens the hand-rolled local-model modal stacked on top of itself (one Escape collapses both). The clean fix interacts subtly with the non-shell local modal's overlay/Escape handling and needs browser verification to avoid a worse regression, so I left it out of this PR — happy to do it as a focused follow-up.

## Test plan

Automated (run locally):
- [x] `npm run build` (tsc + vite) — clean
- [x] `npx playwright test tests/ai-providers.spec.ts tests/smoke.spec.ts` — 37/37 (covers the panel, review modal open, diagnostics, per-provider connect modal, capability suffix)

Manual integration (these need real API keys / a local model — can't run offline):
- [ ] Connect OpenAI or Gemini, send a few turns → the context % meter climbs realistically (not stuck near 0), and auto-compaction triggers at a sensible point.
- [ ] 👁 Review with a **Gemini 2.5/3 Pro** reviewer and again with an **OpenAI o-series** reviewer → you get actual review text, not "(empty review)".
- [ ] Load a local (WebGPU) model, start a long generation, hit **Stop** → generation halts promptly and the partial answer is preserved (previously kept going until the next boundary).
- [ ] Open the system-prompt editor (prompt chip / AI settings) while the active provider is OpenAI, then Gemini → the title reads "OpenAI (cloud)" / "Google Gemini (cloud)", the intro names the right provider, and the **Full** tier shows "(default)".

https://claude.ai/code/session_01PbDgWKhV2zatS932QyomPB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbDgWKhV2zatS932QyomPB)_