### PR TITLE
fix: paint regressions — re-run shatter, runaway subdivision, leaks

### DIFF
--- a/src/color/editorLock.ts
+++ b/src/color/editorLock.ts
@@ -149,6 +149,17 @@ function showUnlockModal(): void {
   optionsContainer.appendChild(opt1.wrapper);
   optionsContainer.appendChild(opt2.wrapper);
 
+  // Single teardown for every dismissal path (Cancel, backdrop click, Escape,
+  // confirm) so the document keydown listener is always removed — closing via
+  // anything other than Escape used to leak one listener per open/close cycle.
+  const close = () => {
+    backdrop.remove();
+    document.removeEventListener('keydown', onKey);
+  };
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') close();
+  };
+
   // Buttons
   const btnRow = document.createElement('div');
   btnRow.className = 'flex justify-end gap-2';
@@ -156,7 +167,7 @@ function showUnlockModal(): void {
   const cancelBtn = document.createElement('button');
   cancelBtn.className = 'px-4 py-2 rounded text-sm text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 transition-colors';
   cancelBtn.textContent = 'Cancel';
-  cancelBtn.addEventListener('click', () => backdrop.remove());
+  cancelBtn.addEventListener('click', () => close());
 
   const confirmBtn = document.createElement('button');
   confirmBtn.className = 'px-4 py-2 rounded text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors';
@@ -165,7 +176,7 @@ function showUnlockModal(): void {
     const preserveRadio = opt1.wrapper.querySelector('input') as HTMLInputElement;
     const preserve = preserveRadio.checked;
 
-    backdrop.remove();
+    close();
 
     if (preserve && onUnlockFork) {
       const colorData = serializeRegions();
@@ -190,13 +201,9 @@ function showUnlockModal(): void {
 
   // Close on backdrop click
   backdrop.addEventListener('click', (e) => {
-    if (e.target === backdrop) backdrop.remove();
+    if (e.target === backdrop) close();
   });
 
-  // Close on Escape
-  const onKey = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') { backdrop.remove(); document.removeEventListener('keydown', onKey); }
-  };
   document.addEventListener('keydown', onKey);
 
   document.body.appendChild(backdrop);

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -47,6 +47,11 @@ type ChangeListener = () => void;
 
 let regions: ColorRegion[] = [];
 let nextOrder = 1;
+// Monotonic, session-unique region id source. Deliberately never reset (not
+// even on clearRegions) so an id can't collide with a region still held in an
+// undo snapshot. Ids are runtime-only — the rehydrate path assigns fresh ones
+// via addRegion rather than restoring the serialized id.
+let nextRegionId = 1;
 let visible = true;
 const listeners: ChangeListener[] = [];
 const visibilityListeners: ChangeListener[] = [];
@@ -157,7 +162,7 @@ export function addRegion(
   triangles: Set<number>,
   visible: boolean = true,
 ): ColorRegion {
-  const id = Date.now() + Math.floor(Math.random() * 1000);
+  const id = nextRegionId++;
   const region: ColorRegion = {
     id,
     name,

--- a/src/color/subdivide.ts
+++ b/src/color/subdivide.ts
@@ -62,6 +62,15 @@ export interface RefineRegion {
  *  warning and a live triangle count instead of silently degrading quality. */
 const MAX_PASSES = 16;
 
+/** Absolute safety ceiling on the refined triangle count. Normal painting stays
+ *  far below this (the UI surfaces a high-complexity warning around 1M). It is
+ *  NOT a quality cap on legitimate multi-stroke growth — it's an OOM guard so a
+ *  single pathological region (e.g. a brush stroke handed a tiny absolute
+ *  `maxEdge`) can't subdivide until the tab runs out of memory. When a pass
+ *  would cross it, we stop refining and accept a coarser-than-requested edge
+ *  rather than freeze. */
+const MAX_REFINED_TRIANGLES = 5_000_000;
+
 /** True when `p` is within the brush footprint of any of the stroke's samples,
  *  using the shape's distance metric (circle = Euclidean, square = Chebyshev,
  *  diamond = L1). */
@@ -298,6 +307,9 @@ export function buildRefinedMesh(
     for (let pass = 0; pass < MAX_PASSES; pass++) {
       const selected = selectByClassify(mesh, region);
       if (selected.size === 0) break;
+      // Each selected triangle becomes 4 (+3 net). Stop before crossing the
+      // safety ceiling so a tiny maxEdge can't OOM the tab.
+      if (mesh.numTri + selected.size * 3 > MAX_REFINED_TRIANGLES) break;
       const { mesh: nm, childToParent } = subdivideSelected(mesh, selected);
       mesh = nm;
       comp = composeMaps(comp, childToParent);

--- a/src/main.ts
+++ b/src/main.ts
@@ -5039,7 +5039,11 @@ async function main() {
       const shp: BrushShape = (shape === 'square' || shape === 'diamond') ? shape : 'circle';
       // maxEdge (absolute) overrides; otherwise radius / resolution, default 256.
       const res = Math.max(SMOOTH_DIVISOR_MIN, Math.min(SMOOTH_DIVISOR_MAX, resolution ?? 256));
-      const target = maxEdge !== undefined ? maxEdge : radius / res;
+      // Floor an explicit maxEdge at the same finest edge the resolution path
+      // can request (radius / SMOOTH_DIVISOR_MAX). A tinier value just drives
+      // runaway subdivision for no visible benefit (the safety ceiling in
+      // buildRefinedMesh would cut it off anyway).
+      const target = maxEdge !== undefined ? Math.max(maxEdge, radius / SMOOTH_DIVISOR_MAX) : radius / res;
       const region = addRegion(
         typeof name === 'string' && name ? name : `Region ${getRegions().length + 1}`,
         [color[0], color[1], color[2]],
@@ -6559,16 +6563,17 @@ async function main() {
       // saved version re-runs the code first, which rebuilds the map.
       currentLabelMap = result.labelMap ?? null;
 
-      // Apply any existing color regions to the mesh. Smooth-brush regions
-      // (`brushStroke`) subdivide the mesh: their triangle indices point into
-      // the REFINED tessellation, not this freshly-run coarse base. Re-running
-      // the code (e.g. the debounced auto-run that fires ~300ms after a saved
-      // version loads) resets currentMeshData to the coarse base, so naively
-      // coloring `result.mesh` would stamp those refined-mesh indices onto
-      // coarse triangles — the "shattered shards" load bug. Rebuild the refined
-      // geometry and re-resolve every region against it, exactly as the
+      // Apply any existing color regions to the mesh. Refining regions —
+      // smooth brush strokes AND smooth slab/box regions — subdivide the mesh:
+      // their triangle indices point into the REFINED tessellation, not this
+      // freshly-run coarse base. Re-running the code (e.g. the debounced
+      // auto-run that fires ~300ms after a saved version loads) resets
+      // currentMeshData to the coarse base, so naively coloring `result.mesh`
+      // would stamp those refined-mesh indices onto coarse triangles — the
+      // "shattered shards" bug. Gate on hasRefineDescriptors() (not just brush
+      // strokes) so slab/box smooth regions rebuild too, exactly as the
       // visibility-toggle path does via reconcilePaintedGeometry.
-      if (hasColorRegions() && strokeDescriptors().length > 0) {
+      if (hasColorRegions() && hasRefineDescriptors()) {
         rebuildPaintedGeometry();
         lastStrokeList = strokeDescriptors();
       } else {

--- a/tests/paint-smooth-brush.spec.ts
+++ b/tests/paint-smooth-brush.spec.ts
@@ -306,8 +306,11 @@ test.describe('smooth paintbrush', () => {
       const paintedColored = pw.listRegions()[0].triangles;
 
       const sv = await pw.runAndSave(pw.getCode(), 'smooth-v');
-      // Re-run the bare code so the refined mesh is gone, then reload the version:
-      // loadVersion re-runs the code and replays the stroke descriptor.
+      // Re-run the same code. A refining region that persists across the re-run
+      // deterministically rebuilds the refined mesh — it does NOT reset to the
+      // coarse base, otherwise the region's refined-mesh triangle indices would
+      // be stamped onto coarse triangles ("shattered shards"). loadVersion then
+      // independently reconstructs the same refined mesh from the descriptor.
       await pw.run(`const { Manifold } = api; return Manifold.cube([20, 20, 4], true);`);
       const baseTri = pw.getMesh().numTri;
       await pw.loadVersion({ index: sv.version.index });
@@ -321,8 +324,8 @@ test.describe('smooth paintbrush', () => {
       };
     });
 
-    expect(out.baseTri).toBe(12);                         // bare cube, no refinement
     expect(out.paintedTri).toBeGreaterThan(12);
+    expect(out.baseTri).toBe(out.paintedTri);             // re-run rebuilds the refined mesh deterministically
     expect(out.reloadedTri).toBe(out.paintedTri);         // refined mesh reconstructed deterministically
     expect(out.reloadedColored).toBe(out.paintedColored); // same painted triangle set
     expect(out.reloadedRegions).toBe(1);
@@ -411,6 +414,9 @@ test.describe('smooth slab & shape painting', () => {
       const liveColored = pw.listRegions().find((r: { id: number }) => r.id === region.id).triangles;
 
       const sv = await pw.runAndSave(pw.getCode(), 'slab-v');
+      // Re-run the same code: the persisting smooth-slab region rebuilds the
+      // refined mesh deterministically (matching the brush path) rather than
+      // leaving the coarse base with stale refined indices.
       await pw.run(`const { Manifold } = api; return Manifold.cube([30, 30, 30], true);`);
       const baseTri = pw.getMesh().numTri;
       await pw.loadVersion({ index: sv.version.index });
@@ -418,8 +424,8 @@ test.describe('smooth slab & shape painting', () => {
       return { liveTri, liveColored, baseTri, reloadTri: pw.getMesh().numTri, reloadColored: reloaded?.triangles ?? -1 };
     });
 
-    expect(out.baseTri).toBe(12);                    // bare cube, no refinement
     expect(out.liveTri).toBeGreaterThan(12);         // smoothing subdivided
+    expect(out.baseTri).toBe(out.liveTri);           // re-run rebuilds the refined mesh deterministically
     expect(out.reloadTri).toBe(out.liveTri);         // refined mesh reconstructed deterministically
     expect(out.reloadColored).toBe(out.liveColored); // same painted set
   });


### PR DESCRIPTION
## Summary

Four paint/color defects from the staging review:

1. **Smooth slab/box regions "shattered" after a plain re-run.** The re-run handler (`main.ts`) gated the refined-mesh rebuild on `strokeDescriptors().length > 0`, which only counts **brush strokes**. A smooth `slab`/`box` region also subdivides the mesh and holds *refined-mesh* triangle indices, so on a plain `pw.run()`/`runAndSave()` (e.g. the debounced auto-run after a colored version loads) it fell through to the coarse-mesh path and stamped those refined indices onto coarse triangles — visual corruption. The gate now keys on `hasRefineDescriptors()`, making slab/box consistent with the brush path (which already rebuilt). Live, re-run, and reload now all reconstruct the same refined mesh deterministically.
2. **Runaway subdivision.** `paintStroke`'s `maxEdge` was validated only `> 0`; a tiny absolute value drives near-unbounded 1→4 subdivision (the `radius/resolution` path is already bounded by the clamped resolution). Two guards: `buildRefinedMesh` now stops before crossing an absolute triangle ceiling (5M — an OOM safety net, far above the ~1M high-complexity warning, protecting brush/slab/box alike), and `paintStroke` floors an explicit `maxEdge` at `radius / SMOOTH_DIVISOR_MAX` (the finest the resolution path can request).
3. **editorLock unlock-modal listener leak.** The `document` `keydown` (Escape) handler was removed only on the Escape path; closing via Cancel, backdrop click, or Confirm leaked one listener per open/close cycle. All paths now route through a single `close()`.
4. **Region id collision.** Region ids came from `Date.now() + random(1000)`, which can collide for two regions created in the same millisecond. Replaced with a monotonic, session-unique counter (never reset, so it can't collide with a region held in an undo snapshot; ids are runtime-only — the rehydrate path already assigns fresh ones).

### Test changes
`tests/paint-smooth-brush.spec.ts` had two determinism tests asserting `baseTri === 12` after a bare re-run — encoding the old "re-run resets to coarse" model. Correct color rendering of a *refining* region requires the refined mesh, so that assertion is wrong; they now assert the deterministic rebuild (`baseTri === paintedTri/liveTri`). Note: the **brush** version of this test was *already failing on `origin/staging`* for exactly this reason (the brush path already rebuilt) — this PR brings the test in line with the real, now-consistent behavior.

## Test plan

Automated (run locally, all green):
- [x] `npm run build` (tsc + vite) — clean
- [x] `npx playwright test tests/paint-smooth-brush.spec.ts` — 18/18 (incl. the two updated determinism tests + `paintStroke` maxEdge/resolution)
- [x] `npx playwright test tests/save-after-paint.spec.ts tests/fork-color-carry.spec.ts tests/paint-batch-and-lifecycle.spec.ts tests/paint-coverage.spec.ts` — 16/16

Manual integration:
- [ ] Paint a **smooth slab** (or oriented box) on a model, save a version, then trigger a re-run (edit + run, or reload the version so the auto-run fires) → colors render correctly on the smooth boundary, no "shattered shards".
- [ ] Repeat with a **smooth brush** stroke → still correct.
- [ ] `window.partwright.paintStroke({ points:[[...]], radius:5, maxEdge: 0.0001, color:[1,0,0] })` → completes without freezing/OOM (subdivision is bounded), colors fine.
- [ ] Paint a face → "Unlock to edit" → dismiss the modal via Cancel, backdrop click, Escape, and Confirm in turn → no Escape-handler buildup (paint several times; Escape still closes exactly one modal).

https://claude.ai/code/session_01PbDgWKhV2zatS932QyomPB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbDgWKhV2zatS932QyomPB)_