### PR TITLE
fix: register runAndExplain as an AI chat tool

### DIFF
--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -701,6 +701,17 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'runAndExplain',
+    description: 'Run code in isolation and decompose the result into its boolean-distinct components — the diagnostic to reach for when getGeometryData reports componentCount > 1 and you need to know WHICH pieces failed to union. Does NOT save a version or touch the editor/viewport. Returns {stats, components, hints?, containmentWarnings?}: `components` is the per-piece breakdown ({index, volume, surfaceArea, centroid, boundingBox}, or null when the result is a single component), `hints` names the main body vs. tiny floaters and which face/axis a floater sits on with a concrete .translate() overlap suggestion, and `containmentWarnings` flags pieces fully hidden inside another (geometrically invisible). Turns a failed union into an actionable fix instead of guessing coordinates.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        code: { type: 'string', description: 'Code to run in the active language. Must return a Manifold (manifold-js) or evaluate to one (SCAD).' },
+      },
+      required: ['code'],
+    },
+  },
+  {
     name: 'query',
     description: 'Multi-query the current geometry in one call. Pass any combination of sliceAt (cross-section areas at given Z heights), decompose (component breakdown), boundingBox. Returns only the keys you asked for. Cheaper than separate calls.',
     input_schema: {
@@ -939,6 +950,7 @@ const ALWAYS_AVAILABLE = new Set([
   'paintExplain',
   'forkVersion',
   'runAndAssert',
+  'runAndExplain',
   'query',
   'modifyAndTest',
   'probeRay',
@@ -1340,6 +1352,8 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.copyColorsFromVersion({ index: input.index });
     case 'runAndAssert':
       return api.runAndAssert(input.code, input.assertions);
+    case 'runAndExplain':
+      return api.runAndExplain(input.code as string);
     case 'query':
       return api.query(input);
     case 'modifyAndTest': {

--- a/tests/ai-runandexplain-tool.spec.ts
+++ b/tests/ai-runandexplain-tool.spec.ts
@@ -1,0 +1,80 @@
+// Regression: the in-app chat agent is told to "use runAndExplain(code) to
+// identify which pieces are floating" — public/ai.md documents it in the
+// "Isolated execution" block right next to its registered siblings runIsolated,
+// runAndAssert and modifyAndTest, and window.partwright.runAndExplain exists —
+// but the tool was never registered as a chat tool. The call fell through
+// dispatch()'s default branch and came back as "Unknown tool: runAndExplain",
+// leaving the agent with no way to debug disconnected components. This covers
+// that the tool is now listed (always-available, like its isolated-execution
+// siblings) and that it dispatches to the console API end to end.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+test.describe('runAndExplain chat tool', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('is always listed (even with runCode paused) and dispatches to the console API', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const result = await page.evaluate(async () => {
+      const tools = await import('/src/ai/tools.ts');
+      const baseToggles = {
+        vision: { views: true, resolution: 'medium', angles: 'auto' },
+        scope: { runCode: true, saveVersions: true, paintFaces: true, sessionNotes: true },
+        autoRetry: 0,
+        maxIterations: 'medium',
+        maxSpend: 'high',
+        thinking: 'off',
+        provider: 'anthropic',
+        anthropicModel: 'claude-haiku-4-5',
+        localModel: null,
+        openaiModel: 'gpt-5-mini',
+        geminiModel: 'gemini-flash-latest',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const listFor = (t: any) => tools.buildToolList(t).map((d) => d.name);
+      const listedDefault = listFor(baseToggles).includes('runAndExplain');
+      // Still listed when the runCode scope is paused — it runs in isolation
+      // (no editor/viewport mutation) just like its always-on siblings
+      // runAndAssert and modifyAndTest.
+      const listedWithRunOff = listFor({ ...baseToggles, scope: { ...baseToggles.scope, runCode: false } }).includes('runAndExplain');
+
+      // End-to-end dispatch: a big cube unioned with a tiny far-away cube
+      // produces two boolean-distinct components, so runAndExplain returns a
+      // component breakdown and floater hints.
+      const code = 'const { Manifold } = api; return Manifold.union([Manifold.cube([20, 20, 20], true), Manifold.cube([2, 2, 2], true).translate([50, 0, 0])]);';
+      const exec = await tools.executeTool('runAndExplain', { code });
+      return { listedDefault, listedWithRunOff, exec };
+    });
+
+    // Always available — present with full scope and with runCode paused.
+    expect(result.listedDefault).toBe(true);
+    expect(result.listedWithRunOff).toBe(true);
+
+    // The call dispatched to window.partwright instead of throwing the old
+    // "Unknown tool" error, and returned the component breakdown + hints.
+    expect(result.exec.isError).toBe(false);
+    expect(result.exec.content).not.toContain('Unknown tool');
+    const parsed = JSON.parse(result.exec.content) as {
+      stats?: { componentCount?: number };
+      components?: Array<{ index: number; volume: number }> | null;
+      hints?: string[];
+    };
+    expect(parsed.stats?.componentCount).toBe(2);
+    expect(Array.isArray(parsed.components)).toBe(true);
+    expect(parsed.components!.length).toBe(2);
+    expect(Array.isArray(parsed.hints)).toBe(true);
+    expect(parsed.hints!.join(' ')).toContain('disconnected');
+  });
+});


### PR DESCRIPTION
## Summary

- The in-app AI chat agent could call `runAndExplain(code)` and get back `Unknown tool: runAndExplain`. The method is documented in `public/ai.md` (the agent's system prompt) in the **Isolated execution** block right next to its registered siblings `runIsolated`, `runAndAssert`, and `modifyAndTest`, and `window.partwright.runAndExplain` has always existed — but the tool was never added to the chat tool registry in `src/ai/tools.ts`. The call fell through `dispatch()`'s `default` branch and threw, leaving the agent with no way to debug disconnected components (`componentCount > 1`).
- Registered the tool: added its schema to `ALL_TOOLS`, marked it `ALWAYS_AVAILABLE` (it runs in isolation with no side effects, exactly like `runAndAssert` and `modifyAndTest`), and added a `dispatch()` case forwarding to `api.runAndExplain(code)`.
- This is the same bug class — and the same fix shape — as the earlier `listRegions` fix (`tests/ai-listregions-tool.spec.ts`).

## Root cause

`runAndExplain` was documented as agent-callable and implemented on `window.partwright`, but missing from all three places a chat tool must be registered in `src/ai/tools.ts`: the `ALL_TOOLS` schema array, a gating set, and the `dispatch()` switch. A `tool_use` for it therefore hit `throw new Error(\`Unknown tool: ${name}\`)`.

## Test plan

- [x] `npm run build` — passes (no TypeScript errors)
- [x] New regression test `tests/ai-runandexplain-tool.spec.ts` — asserts the tool is listed (even with `runCode` scope paused, like its isolated-execution siblings) and dispatches end-to-end (two disconnected cubes → `componentCount: 2`, component breakdown + floater hints, no "Unknown tool")
- [x] Sibling `tests/ai-listregions-tool.spec.ts` still passes
- [x] Full `npm run test:e2e` — 171 passed; the 2 failures (`paint-smooth-brush`, `simplify`) are pre-existing environmental/WASM issues that reproduce in isolation and are unrelated to AI tool dispatch (this change adds no geometry code)

https://claude.ai/code/session_01DwpkxCZ7hKR2X98GDjWg6j

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwpkxCZ7hKR2X98GDjWg6j)_