### PR TITLE
fix: repair two staging test regressions (chat-only import, simplify Apply)

### DIFF
--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -1382,14 +1382,19 @@ export async function importSession(
   if (warning && onWarning) onWarning(warning);
 
   // Validate before creating anything: a file with no `versions` array would
-  // throw partway through (data.versions.reduce/for-of) and strand an empty
-  // orphan session. `parts`/`chat` are already guarded with Array.isArray, so
-  // mirror that here for `versions` and fail with a clear message instead.
+  // otherwise throw partway through (data.versions.reduce/for-of) and strand an
+  // empty orphan session. The `Array.isArray` default below prevents that throw;
+  // we still reject a file that carries *nothing* importable. A chat- or
+  // notes-only export (a session used before any geometry was saved) is
+  // legitimate and must still round-trip, so only fail when versions, chat, and
+  // notes are all empty.
   if (!data.session || typeof data.session !== 'object') {
     throw new Error('Invalid session file: missing "session" data.');
   }
   const versions = Array.isArray(data.versions) ? data.versions : [];
-  if (versions.length === 0) {
+  const hasChat = Array.isArray(data.chat) && data.chat.length > 0;
+  const hasNotes = Array.isArray(data.notes) && data.notes.length > 0;
+  if (versions.length === 0 && !hasChat && !hasNotes) {
     throw new Error('Invalid session file: no versions found.');
   }
 

--- a/tests/simplify.spec.ts
+++ b/tests/simplify.spec.ts
@@ -157,6 +157,7 @@ test.describe('Simplify tool', () => {
 
     const target = Math.max(50, Math.round(base / 4));
     await page.locator('#simplify-input').fill(String(target));
+    await page.locator('#simplify-apply').dispatchEvent('click');
     await page.waitForFunction(
       (b) => {
         const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;


### PR DESCRIPTION
## Summary

Two e2e tests were failing on `staging`. Both are fixed here — one is a real behavior regression, the other a stale test.

- **`chat-export` › *session export embeds chat and import restores it under the new session*** — the IndexedDB-durability hardening (#226) added an `importSession` guard that threw `Invalid session file: no versions found.` for any export with zero versions. But a session legitimately holds chat (or notes) before any geometry is saved, and the `Array.isArray(data.versions)` default already prevents the crash the guard was meant to stop. The guard now only rejects when versions **and** chat **and** notes are all empty, so a chat-only export round-trips again while a genuinely empty/malformed file is still refused.

- **`simplify` › *Save as version preserves an unsaved edited original as its own version*** — gating simplify behind an Apply button (#206) updated two simplify specs to click `#simplify-apply` but missed this one, which still waited for the live model to shrink from setting the target alone and timed out. Added the missing Apply click, matching its sibling tests.

## Test plan

- [x] `npm run build` (clean)
- [x] `npx playwright test tests/chat-export.spec.ts tests/simplify.spec.ts` → 8/8 pass
- [x] `npm run test:e2e` (full suite) → **173 passed** (was 171 passed / 2 failed)
- [x] Independent review pass over the diff — both fixes confirmed correct, no defects/dropped functionality/security issues
- [x] Cloudflare Pages deploy preview: success

## Note (out of scope)

The review surfaced a **pre-existing** limitation unrelated to these test failures: `deleteIfEmpty()` counts only versions + notes as "content," not chat, so a purely *chat-only* imported session would be garbage-collected on navigating away. This fix makes such files importable (which is what the test checks); durably retaining chat-only sessions across navigation would be a separate `deleteIfEmpty` change.

https://claude.ai/code/session_01FqJsLJeCP1muHJAhc3zc2S