### PR TITLE
Add About modal with build/version info for deploy tracing

### DIFF
--- a/src/buildInfo.ts
+++ b/src/buildInfo.ts
@@ -1,0 +1,67 @@
+// Build/version metadata, injected at compile time by the `__BUILD_INFO__`
+// define in vite.config.ts (from Cloudflare's CF_PAGES_* env vars, or local
+// git as a fallback). Surfaced in the in-app About dialog so you can confirm
+// exactly which branch/commit a given deploy is running — handy for Cloudflare
+// branch & PR preview deploys, which otherwise look identical.
+
+export interface BuildInfo {
+  /** Full commit SHA, or 'unknown' if it couldn't be resolved at build time. */
+  commit: string;
+  /** Branch name, or 'unknown'. */
+  branch: string;
+  /** ISO 8601 build timestamp, or 'unknown'. */
+  buildTime: string;
+  /** GitHub "owner/name" slug used to build commit / branch / PR links. */
+  repo: string;
+  /** True when the build included uncommitted local changes (dev builds only). */
+  dirty: boolean;
+}
+
+// Replaced wholesale by vite's `define`. The typeof guard keeps this module
+// importable under the vitest unit tier, where the define isn't applied.
+declare const __BUILD_INFO__: BuildInfo | undefined;
+
+const FALLBACK: BuildInfo = {
+  commit: 'unknown',
+  branch: 'unknown',
+  buildTime: 'unknown',
+  repo: 'kemper/mainifold',
+  dirty: false,
+};
+
+export const buildInfo: BuildInfo =
+  typeof __BUILD_INFO__ !== 'undefined' && __BUILD_INFO__ ? __BUILD_INFO__ : FALLBACK;
+
+const SHA_RE = /^[0-9a-f]{7,40}$/i;
+const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
+
+/** Abbreviated 7-char commit, or the raw value if it isn't a SHA. */
+export function shortCommit(commit: string): string {
+  return SHA_RE.test(commit) ? commit.slice(0, 7) : commit;
+}
+
+function repoBase(repo: string): string | null {
+  return REPO_RE.test(repo) ? `https://github.com/${repo}` : null;
+}
+
+/** GitHub URL for the exact commit, or null if commit / repo are unusable. */
+export function commitUrl(info: BuildInfo): string | null {
+  const base = repoBase(info.repo);
+  return base && SHA_RE.test(info.commit) ? `${base}/commit/${info.commit}` : null;
+}
+
+/** GitHub URL for the branch tree, or null if branch / repo are unusable. */
+export function branchUrl(info: BuildInfo): string | null {
+  const base = repoBase(info.repo);
+  return base && info.branch && info.branch !== 'unknown'
+    ? `${base}/tree/${encodeURIComponent(info.branch)}`
+    : null;
+}
+
+/** GitHub search URL listing PRs whose head is this branch, or null. */
+export function pullRequestsUrl(info: BuildInfo): string | null {
+  const base = repoBase(info.repo);
+  return base && info.branch && info.branch !== 'unknown'
+    ? `${base}/pulls?q=${encodeURIComponent(`is:pr head:${info.branch}`)}`
+    : null;
+}

--- a/src/buildInfo.ts
+++ b/src/buildInfo.ts
@@ -50,11 +50,18 @@ export function commitUrl(info: BuildInfo): string | null {
   return base && SHA_RE.test(info.commit) ? `${base}/commit/${info.commit}` : null;
 }
 
+// Encode each path segment but keep slashes literal — GitHub's /tree/<branch>
+// route 404s on a percent-encoded slash (%2F), and branch names here are
+// routinely slash-namespaced (e.g. "claude/foo").
+function encodeBranchPath(branch: string): string {
+  return branch.split('/').map(encodeURIComponent).join('/');
+}
+
 /** GitHub URL for the branch tree, or null if branch / repo are unusable. */
 export function branchUrl(info: BuildInfo): string | null {
   const base = repoBase(info.repo);
   return base && info.branch && info.branch !== 'unknown'
-    ? `${base}/tree/${encodeURIComponent(info.branch)}`
+    ? `${base}/tree/${encodeBranchPath(info.branch)}`
     : null;
 }
 

--- a/src/ui/aboutModal.ts
+++ b/src/ui/aboutModal.ts
@@ -1,0 +1,168 @@
+// About dialog — shows which build this page is running so a Cloudflare branch
+// or PR preview deploy can be traced back to an exact commit. Opened from the
+// toolbar ⓘ button.
+
+import { createModalShell } from './modalShell';
+import { partwrightMarkSvg } from './brand';
+import {
+  buildInfo,
+  shortCommit,
+  commitUrl,
+  branchUrl,
+  pullRequestsUrl,
+} from '../buildInfo';
+
+function detectEnvironment(): { label: string; cls: string } {
+  const host = window.location.hostname;
+  if (host === 'www.partwrightstudio.com' || host === 'partwrightstudio.com') {
+    return { label: 'Production', cls: 'text-emerald-400' };
+  }
+  if (host.endsWith('.pages.dev')) return { label: 'Preview (Cloudflare)', cls: 'text-amber-400' };
+  if (host === 'localhost' || host === '127.0.0.1') return { label: 'Local dev', cls: 'text-zinc-300' };
+  return { label: host, cls: 'text-zinc-300' };
+}
+
+function formatBuildTime(iso: string): { text: string; title: string } {
+  if (!iso || iso === 'unknown') return { text: 'unknown', title: '' };
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return { text: iso, title: iso };
+  return { text: d.toLocaleString(), title: iso };
+}
+
+function buildInfoText(): string {
+  return [
+    'Partwright build',
+    `branch:  ${buildInfo.branch}`,
+    `commit:  ${buildInfo.commit}${buildInfo.dirty ? ' (uncommitted changes)' : ''}`,
+    `built:   ${buildInfo.buildTime}`,
+    `repo:    ${buildInfo.repo}`,
+    `url:     ${window.location.href}`,
+  ].join('\n');
+}
+
+function externalLink(text: string, href: string): HTMLAnchorElement {
+  const a = document.createElement('a');
+  a.href = href;
+  a.target = '_blank';
+  a.rel = 'noopener noreferrer';
+  a.className = 'text-blue-400 hover:text-blue-300 transition-colors break-all';
+  a.textContent = text;
+  return a;
+}
+
+function plainValue(text: string): HTMLElement {
+  const s = document.createElement('span');
+  s.className = 'text-zinc-200 break-all';
+  s.textContent = text;
+  return s;
+}
+
+function addRow(parent: HTMLElement, label: string, value: HTMLElement): void {
+  const row = document.createElement('div');
+  row.className = 'flex items-baseline justify-between gap-4 py-1.5';
+  const l = document.createElement('span');
+  l.className = 'text-xs text-zinc-500 shrink-0';
+  l.textContent = label;
+  value.classList.add('text-right', 'text-sm', 'min-w-0');
+  row.appendChild(l);
+  row.appendChild(value);
+  parent.appendChild(row);
+}
+
+export function showAboutModal(): void {
+  const shell = createModalShell({ title: 'About Partwright' });
+
+  // Brand header
+  const brand = document.createElement('div');
+  brand.className = 'flex items-center gap-3';
+  const mark = document.createElement('div');
+  mark.innerHTML = partwrightMarkSvg(28);
+  brand.appendChild(mark);
+  const nameCol = document.createElement('div');
+  nameCol.className = 'flex flex-col';
+  const name = document.createElement('span');
+  name.className = 'text-sm font-semibold text-zinc-100';
+  name.textContent = 'Partwright';
+  const tagline = document.createElement('span');
+  tagline.className = 'text-xs text-zinc-500';
+  tagline.textContent = 'AI-driven parametric CAD';
+  nameCol.append(name, tagline);
+  brand.appendChild(nameCol);
+  shell.body.appendChild(brand);
+
+  const intro = document.createElement('p');
+  intro.className = 'text-xs text-zinc-400 leading-relaxed';
+  intro.textContent =
+    'Which build this page is running. Use it to confirm a Cloudflare branch or PR preview is serving the commit you expect.';
+  shell.body.appendChild(intro);
+
+  // Detail card
+  const card = document.createElement('div');
+  card.className = 'rounded-lg border border-zinc-700 bg-zinc-900/40 px-3 divide-y divide-zinc-800';
+
+  const env = detectEnvironment();
+  const envEl = document.createElement('span');
+  envEl.className = `font-medium ${env.cls}`;
+  envEl.textContent = env.label;
+  addRow(card, 'Environment', envEl);
+
+  const bUrl = branchUrl(buildInfo);
+  const branchEl = bUrl ? externalLink(buildInfo.branch, bUrl) : plainValue(buildInfo.branch);
+  branchEl.classList.add('font-mono');
+  addRow(card, 'Branch', branchEl);
+
+  const commitWrap = document.createElement('span');
+  commitWrap.className = 'inline-flex items-center gap-2 justify-end flex-wrap';
+  const cUrl = commitUrl(buildInfo);
+  const sha = shortCommit(buildInfo.commit);
+  const shaEl = cUrl ? externalLink(sha, cUrl) : plainValue(sha);
+  shaEl.id = 'about-commit';
+  shaEl.classList.add('font-mono');
+  commitWrap.appendChild(shaEl);
+  if (buildInfo.dirty) {
+    const badge = document.createElement('span');
+    badge.className =
+      'text-[9px] uppercase tracking-wide text-amber-400 border border-amber-400/30 rounded px-1 py-px';
+    badge.textContent = 'uncommitted';
+    commitWrap.appendChild(badge);
+  }
+  addRow(card, 'Commit', commitWrap);
+
+  const bt = formatBuildTime(buildInfo.buildTime);
+  const builtEl = plainValue(bt.text);
+  if (bt.title) builtEl.title = bt.title;
+  addRow(card, 'Built', builtEl);
+
+  shell.body.appendChild(card);
+
+  // Extra action link — branch deploys have no PR number, so offer a search
+  // that lists PRs opened from this branch.
+  const prUrl = pullRequestsUrl(buildInfo);
+  if (prUrl) {
+    const links = document.createElement('div');
+    links.className = 'flex flex-wrap gap-x-4 gap-y-1 text-sm';
+    links.appendChild(externalLink('Find the pull request ↗', prUrl));
+    shell.body.appendChild(links);
+  }
+
+  // Footer
+  const copyBtn = document.createElement('button');
+  copyBtn.className = 'px-3 py-1.5 rounded text-xs font-medium bg-zinc-700 hover:bg-zinc-600 text-zinc-100';
+  copyBtn.textContent = 'Copy build info';
+  copyBtn.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(buildInfoText());
+      copyBtn.textContent = 'Copied!';
+    } catch {
+      copyBtn.textContent = 'Copy failed';
+    }
+    setTimeout(() => { copyBtn.textContent = 'Copy build info'; }, 1600);
+  });
+  shell.footer.appendChild(copyBtn);
+
+  const doneBtn = document.createElement('button');
+  doneBtn.className = 'px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white';
+  doneBtn.textContent = 'Done';
+  doneBtn.addEventListener('click', () => shell.close());
+  shell.footer.appendChild(doneBtn);
+}

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -1,6 +1,7 @@
 import { resetTour, startTour } from './tour';
 import { partwrightMarkSvg } from './brand';
 import { showQualitySettingsModal } from './qualitySettingsModal';
+import { showAboutModal } from './aboutModal';
 import { getTheme, onThemeChange, toggleTheme } from './theme';
 import { downloadBlob } from '../export/download';
 import {
@@ -569,6 +570,17 @@ export function createToolbar(
 
   diagBtn.addEventListener('click', callbacks.onToggleDiagnostics);
   toolbar.appendChild(diagBtn);
+
+  // About button — build/version info (commit, branch, links) for verifying
+  // which Cloudflare branch/PR deploy you're testing.
+  const aboutBtn = document.createElement('button');
+  aboutBtn.id = 'btn-about';
+  aboutBtn.className = 'flex items-center justify-center w-10 h-10 md:w-6 md:h-6 rounded-full text-zinc-500 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700 transition-colors text-sm md:text-xs ml-1';
+  aboutBtn.title = 'About — build & version info';
+  aboutBtn.setAttribute('aria-label', 'About this build');
+  aboutBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>';
+  aboutBtn.addEventListener('click', () => { showAboutModal(); });
+  toolbar.appendChild(aboutBtn);
 
   // Help button
   const helpBtn = document.createElement('button');

--- a/tests/about-modal.spec.ts
+++ b/tests/about-modal.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from 'playwright/test';
+
+// Verifies the toolbar ⓘ "About" button opens a dialog that reports the build
+// the page is running (environment / branch / commit / build time), so a
+// Cloudflare branch or PR preview can be traced to a commit.
+
+test.beforeEach(async ({ page }) => {
+  // Suppress the first-run guided tour — its backdrop intercepts clicks.
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+  });
+});
+
+test.describe('About / build info', () => {
+  test('toolbar button opens the About modal with build metadata', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#btn-about');
+
+    await page.locator('#btn-about').click();
+    await expect(page.getByRole('heading', { name: 'About Partwright' })).toBeVisible();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toContainText('Environment');
+    await expect(modal).toContainText('Branch');
+    await expect(modal).toContainText('Commit');
+    await expect(modal).toContainText('Built');
+
+    // The commit value renders something (a short SHA from git, or 'unknown').
+    const commit = page.locator('#about-commit');
+    await expect(commit).toBeVisible();
+    await expect(commit).not.toHaveText('');
+
+    // The copy-to-clipboard affordance is present.
+    await expect(modal.getByRole('button', { name: /Copy/ })).toBeVisible();
+  });
+
+  test('Done closes the modal', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#btn-about');
+
+    await page.locator('#btn-about').click();
+    await expect(page.getByRole('heading', { name: 'About Partwright' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Done' }).click();
+    await expect(page.getByRole('heading', { name: 'About Partwright' })).toHaveCount(0);
+  });
+});

--- a/tests/unit/buildInfo.test.ts
+++ b/tests/unit/buildInfo.test.ts
@@ -1,0 +1,66 @@
+// Unit tests for the pure GitHub-link builders behind the About dialog. These
+// take an explicit BuildInfo so they exercise no build-time `define` and stay
+// in the dependency-free vitest unit tier.
+
+import { describe, test, expect } from 'vitest';
+import {
+  shortCommit,
+  commitUrl,
+  branchUrl,
+  pullRequestsUrl,
+  type BuildInfo,
+} from '../../src/buildInfo';
+
+const base: BuildInfo = {
+  commit: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+  branch: 'main',
+  buildTime: '2026-05-24T00:00:00.000Z',
+  repo: 'kemper/mainifold',
+  dirty: false,
+};
+
+describe('shortCommit', () => {
+  test('abbreviates a full SHA to 7 chars', () => {
+    expect(shortCommit(base.commit)).toBe('a1b2c3d');
+  });
+
+  test('passes non-SHA values (e.g. "unknown") through unchanged', () => {
+    expect(shortCommit('unknown')).toBe('unknown');
+  });
+});
+
+describe('commitUrl', () => {
+  test('links to the commit on GitHub', () => {
+    expect(commitUrl(base)).toBe(`https://github.com/kemper/mainifold/commit/${base.commit}`);
+  });
+
+  test('returns null when the commit is unknown', () => {
+    expect(commitUrl({ ...base, commit: 'unknown' })).toBeNull();
+  });
+
+  test('returns null for a malformed repo slug', () => {
+    expect(commitUrl({ ...base, repo: 'not a repo' })).toBeNull();
+  });
+});
+
+describe('branchUrl', () => {
+  test('links to the branch tree, URL-encoding slashes', () => {
+    expect(branchUrl({ ...base, branch: 'claude/laughing-davinci' }))
+      .toBe('https://github.com/kemper/mainifold/tree/claude%2Flaughing-davinci');
+  });
+
+  test('returns null when the branch is unknown', () => {
+    expect(branchUrl({ ...base, branch: 'unknown' })).toBeNull();
+  });
+});
+
+describe('pullRequestsUrl', () => {
+  test('builds a PR search scoped to the branch head', () => {
+    expect(pullRequestsUrl({ ...base, branch: 'feature/x' }))
+      .toBe(`https://github.com/kemper/mainifold/pulls?q=${encodeURIComponent('is:pr head:feature/x')}`);
+  });
+
+  test('returns null when the branch is unknown', () => {
+    expect(pullRequestsUrl({ ...base, branch: 'unknown' })).toBeNull();
+  });
+});

--- a/tests/unit/buildInfo.test.ts
+++ b/tests/unit/buildInfo.test.ts
@@ -44,9 +44,16 @@ describe('commitUrl', () => {
 });
 
 describe('branchUrl', () => {
-  test('links to the branch tree, URL-encoding slashes', () => {
+  test('links to the branch tree, keeping namespace slashes literal', () => {
+    // GitHub's /tree/<branch> 404s on a percent-encoded slash, so slashes in
+    // slash-namespaced branch names must stay raw.
     expect(branchUrl({ ...base, branch: 'claude/laughing-davinci' }))
-      .toBe('https://github.com/kemper/mainifold/tree/claude%2Flaughing-davinci');
+      .toBe('https://github.com/kemper/mainifold/tree/claude/laughing-davinci');
+  });
+
+  test('encodes unsafe characters per segment but preserves slashes', () => {
+    expect(branchUrl({ ...base, branch: 'feature/a b' }))
+      .toBe('https://github.com/kemper/mainifold/tree/feature/a%20b');
   });
 
   test('returns null when the branch is unknown', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, type Plugin, type Connect } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
+import { execSync } from 'node:child_process';
 
 // Set charset=utf-8 on .md and .txt files served from public/ during dev.
 // Prevents em-dashes and other UTF-8 chars from rendering as mojibake.
@@ -51,8 +52,43 @@ function absoluteUrls(): Plugin {
   };
 }
 
+// Build/version metadata surfaced by the in-app About dialog so a given deploy
+// can be traced back to an exact commit/branch — handy for Cloudflare branch &
+// PR preview deploys, which otherwise look identical. Cloudflare sets CF_PAGES_*
+// at build time; we fall back to local git so `npm run dev` and laptop builds
+// show real values too.
+function parseGitHubRepo(remoteUrl: string): string {
+  const m = remoteUrl.match(/github\.com[:/]+([\w.-]+\/[\w.-]+?)(?:\.git)?$/i);
+  return m ? m[1] : '';
+}
+
+function resolveBuildInfo() {
+  const git = (cmd: string): string => {
+    try {
+      return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    } catch {
+      return '';
+    }
+  };
+  const onCloudflare = !!process.env.CF_PAGES;
+  const commit = process.env.CF_PAGES_COMMIT_SHA || git('git rev-parse HEAD') || 'unknown';
+  const branch = process.env.CF_PAGES_BRANCH || git('git rev-parse --abbrev-ref HEAD') || 'unknown';
+  const repo =
+    process.env.GITHUB_REPOSITORY ||
+    parseGitHubRepo(git('git config --get remote.origin.url')) ||
+    'kemper/mainifold';
+  // "dirty" only means something for a local working tree; a fresh CI / CF
+  // clone is always clean, so skip the (possibly slow) status call there.
+  const dirty = !onCloudflare && git('git status --porcelain') !== '';
+  return { commit, branch, buildTime: new Date().toISOString(), repo, dirty };
+}
+
 export default defineConfig({
   base: '/',
+  // Replaced verbatim wherever `__BUILD_INFO__` appears (see src/buildInfo.ts).
+  define: {
+    __BUILD_INFO__: JSON.stringify(resolveBuildInfo()),
+  },
   plugins: [tailwindcss(), absoluteUrls(), markdownCharset()],
   worker: {
     // ES module Workers support code-splitting and are required when


### PR DESCRIPTION
## Summary

Adds an in-app About dialog that displays build metadata (environment, branch, commit, build time) so Cloudflare branch and PR preview deploys can be traced back to an exact commit. The dialog is opened from a new ⓘ button in the toolbar.

## Changes

- **`src/buildInfo.ts`** (new): Core module that resolves build metadata at compile time from Cloudflare Pages environment variables (`CF_PAGES_*`) or local git as a fallback. Exports helper functions to generate GitHub links (commit, branch, PR search) and format the short commit SHA.

- **`src/ui/aboutModal.ts`** (new): Modal UI that displays build info in a styled card with environment detection, branch/commit links, build timestamp, and a "Copy build info" button. Includes helper functions for environment detection, time formatting, and DOM construction.

- **`vite.config.ts`**: Added `resolveBuildInfo()` function to gather metadata at build time and inject it via Vite's `define` option. Parses git remote URL to extract the GitHub repo slug, falls back to `kemper/mainifold` if unavailable. Detects "dirty" working tree only for local builds (skips on Cloudflare to avoid slow `git status` calls).

- **`src/ui/toolbar.ts`**: Added About button (`#btn-about`) to the toolbar that triggers `showAboutModal()` on click.

- **`tests/unit/buildInfo.test.ts`** (new): Unit tests for the pure GitHub link builders (`shortCommit`, `commitUrl`, `branchUrl`, `pullRequestsUrl`), exercising edge cases like unknown commits/branches and malformed repo slugs.

- **`tests/about-modal.spec.ts`** (new): Playwright e2e tests verifying the About button opens the modal, displays all required fields, and the Done button closes it.

## Implementation Details

- Build metadata is injected at compile time via Vite's `define` option, replacing `__BUILD_INFO__` throughout the codebase. A fallback object is used if the define is not applied (e.g., in vitest unit tests).
- Environment detection uses `window.location.hostname` to distinguish production, Cloudflare preview, and local dev, each with a distinct color indicator.
- GitHub links are only generated if the repo slug and commit/branch values are valid; otherwise plain text is shown.
- The "Copy build info" button uses the Clipboard API with a transient success/failure message.
- The modal reuses the existing `createModalShell` utility for consistent styling and behavior.

https://claude.ai/code/session_01Khme7Gnr49E815QeWGVKF2