### PR TITLE
feat: make the paint menu a scrollable bottom sheet on mobile

### DIFF
--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -115,7 +115,13 @@ export function initPaintUI(controlsContainer: HTMLElement): void {
   }
 
   pickerPanel = createPickerPanel();
-  controlsContainer.appendChild(pickerPanel);
+  // Anchor the panel to the positioned viewport pane (the toolbar's parent)
+  // rather than the small top-right toolbar box, so the mobile bottom-sheet
+  // layout measures against the full viewport. The viewport pane owns the
+  // wheel-forwarder, so wheel-to-zoom still passes through the panel whenever it
+  // isn't actively scrolling.
+  const overlayHost = controlsContainer.parentElement ?? controlsContainer;
+  overlayHost.appendChild(pickerPanel);
 
   onRegionsChange(() => {
     updateBadge();
@@ -171,15 +177,44 @@ function updateBadge(): void {
 function createPickerPanel(): HTMLElement {
   const panel = document.createElement('div');
   panel.id = 'paint-picker-panel';
-  panel.className = 'hidden absolute top-10 right-2 z-20 bg-zinc-800/95 backdrop-blur border border-zinc-600/60 rounded-lg p-2.5 shadow-xl';
-  panel.style.minWidth = '200px';
-  panel.style.maxWidth = '240px';
+  // Responsive shell. On mobile it's a bottom sheet docked to the viewport's
+  // bottom edge, so the model stays visible above it and it never covers the top
+  // toolbar (including the Paint toggle). On desktop it's a compact floating
+  // panel pinned top-right. Either way it's a flex column with a sticky header
+  // and footer around one scrollable middle, so the action row stays reachable
+  // no matter how long the region list grows.
+  panel.className = [
+    'hidden z-20 flex flex-col overflow-hidden bg-zinc-800/95 backdrop-blur border border-zinc-600/60 shadow-xl',
+    'absolute inset-x-2 bottom-2 top-auto max-h-[55%] rounded-xl',
+    'md:inset-x-auto md:bottom-auto md:left-auto md:right-2 md:top-12 md:w-60 md:max-h-[calc(100%-3.5rem)] md:rounded-lg',
+  ].join(' ');
+
+  // === Header (sticky): title + close affordance ===
+  const header = document.createElement('div');
+  header.className = 'shrink-0 flex items-center justify-between gap-2 px-2.5 py-2 border-b border-zinc-700/70';
+  const headerTitle = document.createElement('div');
+  headerTitle.className = 'text-[11px] text-zinc-300 font-medium';
+  headerTitle.textContent = '\uD83C\uDFA8 Paint';
+  header.appendChild(headerTitle);
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'shrink-0 -mr-1 w-7 h-7 flex items-center justify-center rounded text-base leading-none text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700/60 transition-colors';
+  closeBtn.title = 'Close paint menu';
+  closeBtn.setAttribute('aria-label', 'Close paint menu');
+  closeBtn.textContent = '\u2715';
+  closeBtn.addEventListener('click', () => { togglePaintMode(); });
+  header.appendChild(closeBtn);
+  panel.appendChild(header);
+
+  // === Scrollable content ===
+  const content = document.createElement('div');
+  content.className = 'flex-1 min-h-0 overflow-y-auto px-2.5 py-2.5';
+  panel.appendChild(content);
 
   // === Tool selector ===
   const toolTitle = document.createElement('div');
   toolTitle.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1.5 font-medium';
   toolTitle.textContent = 'Tool';
-  panel.appendChild(toolTitle);
+  content.appendChild(toolTitle);
 
   const toolRow = document.createElement('div');
   toolRow.className = 'grid grid-cols-2 gap-1 mb-2.5';
@@ -187,13 +222,13 @@ function createPickerPanel(): HTMLElement {
   toolRow.appendChild(createToolButton('brush', '\u{1F58C}\uFE0F Brush', 'Paint individual triangles (drag to paint)'));
   toolRow.appendChild(createToolButton('slab', '\u{1F9F1} Slab', 'Paint all faces inside an axis-aligned range'));
   toolRow.appendChild(createToolButton('box', '\u25C6 Shape', 'Paint everything inside a positionable, rotatable, scalable 3D shape (box, sphere, cylinder, or cone)'));
-  panel.appendChild(toolRow);
+  content.appendChild(toolRow);
 
   // === Color picker ===
   const title = document.createElement('div');
   title.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1.5 font-medium';
   title.textContent = 'Color';
-  panel.appendChild(title);
+  content.appendChild(title);
 
   const grid = document.createElement('div');
   grid.className = 'grid grid-cols-4 gap-1.5 mb-2';
@@ -211,7 +246,7 @@ function createPickerPanel(): HTMLElement {
   }
   const first = grid.children[0] as HTMLElement;
   if (first) first.classList.add('border-white/80', 'ring-1', 'ring-white/30');
-  panel.appendChild(grid);
+  content.appendChild(grid);
 
   const customRow = document.createElement('div');
   customRow.className = 'flex items-center gap-1.5';
@@ -238,41 +273,44 @@ function createPickerPanel(): HTMLElement {
 
   customRow.appendChild(colorInput);
   customRow.appendChild(customLabel);
-  panel.appendChild(customRow);
+  content.appendChild(customRow);
 
   // === Bucket tool controls (tolerance slider + number input) ===
   bucketControls = createBucketControls();
-  panel.appendChild(bucketControls);
+  content.appendChild(bucketControls);
 
   // === Brush tool controls (radius slider + number input) ===
   brushControls = createBrushControls();
-  panel.appendChild(brushControls);
+  content.appendChild(brushControls);
 
   // === Slab tool controls ===
   slabControls = createSlabControls();
-  panel.appendChild(slabControls);
+  content.appendChild(slabControls);
 
   // === Box tool controls ===
   boxControls = createBoxControls();
-  panel.appendChild(boxControls);
+  content.appendChild(boxControls);
 
   // === Region list ===
+  // Flows inside the single scroll area; the sticky footer keeps the actions
+  // reachable, so it no longer needs its own capped inner scrollbar.
   const regionList = document.createElement('div');
   regionList.id = 'paint-region-list';
-  regionList.className = 'mt-2 border-t border-zinc-700 pt-2 max-h-32 overflow-y-auto';
-  panel.appendChild(regionList);
+  regionList.className = 'mt-2 border-t border-zinc-700 pt-2';
+  content.appendChild(regionList);
 
   onRegionsChange(() => updateRegionList(regionList));
 
-  // === Action row ===
-  const actions = document.createElement('div');
-  actions.className = 'flex items-center gap-1.5 mt-2 pt-2 border-t border-zinc-700 flex-wrap';
+  // === Footer (sticky): region actions stay reachable no matter how far the
+  // scrollable content above is scrolled ===
+  const footer = document.createElement('div');
+  footer.className = 'shrink-0 flex items-center gap-1.5 px-2.5 py-2 border-t border-zinc-700 bg-zinc-800/95 flex-wrap';
 
   visibilityBtn = document.createElement('button');
   visibilityBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors';
   visibilityBtn.title = 'Toggle all paint region visibility in viewport (exports keep colors regardless)';
   visibilityBtn.addEventListener('click', () => { setPaintVisible(!isPaintVisible()); });
-  actions.appendChild(visibilityBtn);
+  footer.appendChild(visibilityBtn);
 
   undoBtn = document.createElement('button');
   undoBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors opacity-40 cursor-not-allowed';
@@ -280,7 +318,7 @@ function createPickerPanel(): HTMLElement {
   undoBtn.title = 'Remove the most recent paint region';
   undoBtn.disabled = true;
   undoBtn.addEventListener('click', () => { removeLastRegion(); });
-  actions.appendChild(undoBtn);
+  footer.appendChild(undoBtn);
 
   redoBtn = document.createElement('button');
   redoBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors opacity-40 cursor-not-allowed';
@@ -288,7 +326,7 @@ function createPickerPanel(): HTMLElement {
   redoBtn.title = 'Restore the most recently undone paint region';
   redoBtn.disabled = true;
   redoBtn.addEventListener('click', () => { redoLastRegion(); });
-  actions.appendChild(redoBtn);
+  footer.appendChild(redoBtn);
 
   undoClearBtn = document.createElement('button');
   undoClearBtn.className = 'px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-300 hover:bg-zinc-600/60 transition-colors opacity-40 cursor-not-allowed';
@@ -296,16 +334,16 @@ function createPickerPanel(): HTMLElement {
   undoClearBtn.title = 'Restore all regions removed by the last Clear (only available until the next paint)';
   undoClearBtn.disabled = true;
   undoClearBtn.addEventListener('click', () => { undoClear(); });
-  actions.appendChild(undoClearBtn);
+  footer.appendChild(undoClearBtn);
 
   const clearBtn = document.createElement('button');
   clearBtn.className = 'px-2 py-1 rounded text-[10px] bg-red-700/60 text-red-200 hover:bg-red-600/60 transition-colors';
   clearBtn.textContent = 'Clear';
   clearBtn.title = 'Remove all paint regions';
   clearBtn.addEventListener('click', () => { clearRegions(); });
-  actions.appendChild(clearBtn);
+  footer.appendChild(clearBtn);
 
-  panel.appendChild(actions);
+  panel.appendChild(footer);
 
   return panel;
 }


### PR DESCRIPTION
## Summary

Fixes three problems with the Paint menu (`src/color/paintUI.ts`), all stemming from the panel being a fixed-width, top-right overlay with **no height bound**:

- **Bottom unreachable as history grows** — the panel had no `max-height`/scroll. Once the region list filled its inner `max-h-32` cap on top of the tool controls, the action row (Hide all / Undo / Redo / Undo clear / Clear) overflowed below the viewport with no way to scroll to it. Reported on desktop, and worse on mobile.
- **Covers the model & the Paint toggle on mobile** — anchored `top-10 right-2`, the panel sat on top of the wrapping toolbar (including the very Paint button used to dismiss it) and ate into the model view.
- **Overlaps toolbar buttons at narrow widths** — the right-anchored fixed-width overlay collided with the wrapping toolbar.

### What changed

Restructured the panel into a **flex column**: a sticky **header** (title + ✕ close), one **scrollable middle**, and a sticky **footer** holding the action row — so the actions stay reachable no matter how long the region list grows. Made it **responsive**:

- **Mobile** (`< md`): a **bottom sheet** docked to the viewport's bottom edge (`inset-x-2 bottom-2`, capped at `max-h-[55%]`). The model stays visible above it, the top toolbar is never covered, and the in-sheet ✕ gives a reliable way to close even if the Paint toggle is off-screen.
- **Desktop** (`md+`): a compact floating panel (`right-2 top-12 w-60`), height-capped to the viewport (`max-h-[calc(100%-3.5rem)]`) so the footer is always on-screen.

The region list dropped its own inner scrollbar (the single content scroll + sticky footer replace it). The panel is re-parented from the small top-right toolbar box to the positioned **viewport pane** so the bottom-sheet layout measures against the full viewport; the pane still owns the wheel-forwarder, so wheel-to-zoom passes through the panel unchanged (only consumed when the content is actually scrolling).

No data/schema changes; selectors (`#paint-picker-panel`, `#paint-region-list`, button text/titles, `data-action` attrs) are preserved.

## Test plan

- [x] `npm run build` (tsc type-check) — clean
- [x] `npm run test:unit` — 8/8 pass
- [x] Paint e2e specs — 25/25 pass (`paint-camera-passthrough`, `paint-controls-extended`, `keyboard-shortcuts`, `save-after-paint`, `paint-batch-and-lifecycle`), incl. the wheel-over-panel-zooms passthrough test
- [x] Browser verification at 1280×720 and 390×740 with 30 painted regions: footer (Clear) stays inside the viewport, content scrolls, mobile sheet docks to the bottom spanning full width and leaves the top ~60% for the model, ✕ closes the menu
- [x] Full `npm run test:e2e` — 167/167 pass
- [x] Multi-agent diff review — no defects found
- [ ] Cloudflare Pages preview deploy green (verified via CI on this PR)

https://claude.ai/code/session_01NXSPKyPQriRtwy4Jg8uQbj