### PR TITLE
feat: multi-select parts in the rail for bulk delete

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -148,6 +148,7 @@ import {
   changePart,
   renamePart,
   deletePart,
+  deleteParts,
   reorderParts,
   getState,
   getSessionUrl,
@@ -1452,6 +1453,15 @@ async function main() {
       const wasCurrent = getState().currentPart?.id === partId;
       const result = await deletePart(partId);
       if (result && wasCurrent) {
+        await loadPartIntoEditor(getState().currentVersion);
+      }
+    },
+    onDeleteParts: async (partIds: string[]) => {
+      if (isReadOnlyViewer()) return;
+      const result = await deleteParts(partIds);
+      // Only reload the editor when the active part was among those removed
+      // (deleteParts reports this via newCurrent).
+      if (result && result.newCurrent) {
         await loadPartIntoEditor(getState().currentVersion);
       }
     },

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -594,24 +594,38 @@ export async function updatePartOrders(updates: { id: string; order: number }[])
 }
 
 export async function deletePart(id: string): Promise<void> {
+  await deleteParts([id]);
+}
+
+/**
+ * Delete several parts (and cascade-delete their versions) atomically in a
+ * single transaction, so a multi-select bulk delete either fully commits or
+ * fully rolls back. No-op for an empty list.
+ */
+export async function deleteParts(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
   const db = await openDB();
   const txn = db.transaction(['parts', 'versions'], 'readwrite');
-  txn.objectStore('parts').delete(id);
-  // Cascade-delete the part's versions.
+  const partStore = txn.objectStore('parts');
   const vIdx = txn.objectStore('versions').index('partId');
-  const vReq = vIdx.openCursor(IDBKeyRange.only(id));
-  await new Promise<void>((resolve, reject) => {
-    vReq.onsuccess = () => {
-      const cursor = vReq.result;
-      if (cursor) {
-        cursor.delete();
-        cursor.continue();
-      } else {
-        resolve();
-      }
-    };
-    vReq.onerror = () => reject(vReq.error);
-  });
+  for (const id of ids) {
+    partStore.delete(id);
+    // Cascade-delete the part's versions. Awaiting each cursor keeps the shared
+    // transaction alive (its requests resolve in the IDB callbacks above).
+    await new Promise<void>((resolve, reject) => {
+      const vReq = vIdx.openCursor(IDBKeyRange.only(id));
+      vReq.onsuccess = () => {
+        const cursor = vReq.result;
+        if (cursor) {
+          cursor.delete();
+          cursor.continue();
+        } else {
+          resolve();
+        }
+      };
+      vReq.onerror = () => reject(vReq.error);
+    });
+  }
   await txComplete(txn);
 }
 

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -22,6 +22,7 @@ import {
   updatePart as dbUpdatePart,
   updatePartOrders as dbUpdatePartOrders,
   deletePart as dbDeletePart,
+  deleteParts as dbDeleteParts,
   addNote as dbAddNote,
   listNotes as dbListNotes,
   deleteNote as dbDeleteNote,
@@ -675,6 +676,55 @@ export async function deletePart(partId: string): Promise<DeletePartResult | nul
   updateURL();
   notify();
   return { deleted: target, newCurrent: null };
+}
+
+export interface DeletePartsResult {
+  /** Ids actually removed (input ids that matched a current part). */
+  deletedIds: string[];
+  /** The part that became active after deletion (only set when the active part
+   *  was among those deleted). */
+  newCurrent: Part | null;
+}
+
+/**
+ * Delete several parts and all their versions in one atomic transaction. Mirrors
+ * the single-part rule: a session must keep at least one part, so the call is
+ * refused (returns null) if the selection covers every remaining part. When the
+ * active part is among those deleted, the nearest survivor above it in display
+ * order — else the first remaining — becomes active. Returns null if nothing
+ * matched or the delete was refused.
+ */
+export async function deleteParts(partIds: string[]): Promise<DeletePartsResult | null> {
+  if (!currentState.session) return null;
+  const parts = currentState.parts;
+  const idSet = new Set(partIds);
+  const targets = parts.filter(p => idSet.has(p.id));
+  if (targets.length === 0) return null;
+  if (targets.length >= parts.length) return null; // keep at least one part
+
+  const deletedSet = new Set(targets.map(p => p.id));
+  await dbDeleteParts(targets.map(p => p.id));
+
+  const remaining = parts.filter(p => !deletedSet.has(p.id));
+  const currentId = currentState.currentPart?.id;
+  const currentDeleted = currentId != null && deletedSet.has(currentId);
+
+  if (currentDeleted) {
+    const pos = parts.findIndex(p => p.id === currentId);
+    let next = remaining[0];
+    for (let i = pos - 1; i >= 0; i--) {
+      if (!deletedSet.has(parts[i].id)) { next = parts[i]; break; }
+    }
+    currentState = { ...currentState, parts: remaining };
+    await changePart(next.id);
+    return { deletedIds: [...deletedSet], newCurrent: next };
+  }
+
+  currentState = { ...currentState, parts: remaining };
+  broadcastPartChange();
+  updateURL();
+  notify();
+  return { deletedIds: [...deletedSet], newCurrent: null };
 }
 
 /**

--- a/src/ui/partList.ts
+++ b/src/ui/partList.ts
@@ -1,7 +1,7 @@
 // Parts rail — an IDE-style list of the active session's parts. Supports
-// create, select, inline rename, delete, and pointer-based drag-to-reorder.
-// Renders into the rail container created by layout.ts and re-renders on every
-// session-state change.
+// create, select, inline rename, delete, multi-select bulk delete, and
+// pointer-based drag-to-reorder. Renders into the rail container created by
+// layout.ts and re-renders on every session-state change.
 
 import { getState, onStateChange, type SessionState, type Part } from '../storage/sessionManager';
 
@@ -12,6 +12,8 @@ export interface PartListCallbacks {
   onCreatePart: () => void | Promise<void>;
   onRenamePart: (id: string, name: string) => void | Promise<void>;
   onDeletePart: (id: string) => void | Promise<void>;
+  /** Delete several parts at once (multi-select bulk delete). */
+  onDeleteParts: (ids: string[]) => void | Promise<void>;
   /** Persist a new part order (array of part ids, first = top). */
   onReorderParts: (orderedIds: string[]) => void | Promise<void>;
   /** Collapse the rail (handled by layout). */
@@ -26,6 +28,11 @@ let dragging = false;
 // Set when a state change arrives mid-drag (suppressed); flushed on drag end so
 // the rail never shows stale parts after an async update lands during a drag.
 let pendingRender = false;
+// Ids of parts checked for a bulk action. Pruned on every render so it never
+// references a part that was deleted or belongs to another session.
+const selected = new Set<string>();
+// Anchor row id for shift-click range selection.
+let lastClickedId: string | null = null;
 
 export function createPartList(container: HTMLElement, callbacks: PartListCallbacks): void {
   railEl = container;
@@ -39,6 +46,17 @@ export function createPartList(container: HTMLElement, callbacks: PartListCallba
 
 function render(state: SessionState): void {
   if (!railEl) return;
+
+  // Drop any selection that no longer maps to a live part (deleted, or the
+  // session was switched/closed) so the action bar can't act on stale ids.
+  if (state.session) {
+    const live = new Set(state.parts.map(p => p.id));
+    for (const id of [...selected]) if (!live.has(id)) selected.delete(id);
+    if (lastClickedId && !live.has(lastClickedId)) lastClickedId = null;
+  } else {
+    clearSelection();
+  }
+
   railEl.innerHTML = '';
 
   // Header: title + collapse + add.
@@ -80,9 +98,15 @@ function render(state: SessionState): void {
   for (const part of state.parts) {
     list.appendChild(buildRow(part, part.id === state.currentPart?.id, state.parts.length, list));
   }
+
+  // Bulk-action footer — only present while one or more parts are checked.
+  if (selected.size > 0) {
+    railEl.appendChild(buildActionBar(state));
+  }
 }
 
 function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLElement): HTMLElement {
+  const isSelected = selected.has(part.id);
   const row = document.createElement('div');
   row.dataset.partId = part.id;
   row.setAttribute('role', 'button');
@@ -91,8 +115,38 @@ function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLE
     'group flex items-center gap-1 px-1.5 py-2.5 mx-1 rounded cursor-pointer select-none',
     isCurrent
       ? 'bg-blue-500/15 text-zinc-100 border-l-2 border-blue-500'
-      : 'text-zinc-400 [@media(hover:hover)]:hover:bg-zinc-700/40 border-l-2 border-transparent',
+      : isSelected
+        ? 'bg-blue-500/10 text-zinc-200 border-l-2 border-blue-500/40'
+        : 'text-zinc-400 [@media(hover:hover)]:hover:bg-zinc-700/40 border-l-2 border-transparent',
   ].join(' ');
+
+  // Selection checkbox (multi-select bulk delete). Only offered when more than
+  // one part exists — a session must always keep at least one. Subtle until
+  // hover on pointer devices, but always shown on touch and whenever a
+  // selection is already in progress (so it can't silently hide checked rows).
+  if (partCount > 1) {
+    const anySelected = selected.size > 0;
+    const cbWrap = document.createElement('span');
+    cbWrap.className = 'shrink-0 flex items-center justify-center px-1 py-1 cursor-pointer';
+    if (!anySelected) {
+      cbWrap.className += ' [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 focus-within:opacity-100';
+    }
+    const cbx = document.createElement('input');
+    cbx.type = 'checkbox';
+    cbx.checked = isSelected;
+    cbx.className = 'w-3.5 h-3.5 accent-blue-500 cursor-pointer';
+    cbx.setAttribute('aria-label', `Select part ${part.name}`);
+    const onToggle = (e: Event) => {
+      e.stopPropagation();
+      toggleSelection(part.id, (e as MouseEvent).shiftKey);
+    };
+    cbx.addEventListener('click', onToggle);
+    cbWrap.addEventListener('click', (e) => {
+      if (e.target !== cbx) onToggle(e); // let padding around the box toggle too
+    });
+    cbWrap.appendChild(cbx);
+    row.appendChild(cbWrap);
+  }
 
   // Drag handle (pointer-based reorder — works for mouse, touch, and pen).
   // Always visible (not hover-gated) so it's discoverable on touch.
@@ -137,6 +191,80 @@ function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLE
   }
 
   return row;
+}
+
+// === Multi-select bulk actions ===
+
+/** Toggle one part's checkbox, or — with shift held — select the inclusive
+ *  range between the last-clicked anchor and this row, then re-render. */
+function toggleSelection(id: string, shift: boolean): void {
+  const parts = getState().parts;
+  const a = lastClickedId ? parts.findIndex(p => p.id === lastClickedId) : -1;
+  const b = parts.findIndex(p => p.id === id);
+  if (shift && a >= 0 && b >= 0 && a !== b) {
+    const [lo, hi] = a < b ? [a, b] : [b, a];
+    for (let i = lo; i <= hi; i++) selected.add(parts[i].id);
+  } else if (selected.has(id)) {
+    selected.delete(id);
+  } else {
+    selected.add(id);
+  }
+  lastClickedId = id;
+  render(getState());
+}
+
+function clearSelection(): void {
+  selected.clear();
+  lastClickedId = null;
+}
+
+/** Footer bar shown while parts are checked: count, clear, and bulk delete. */
+function buildActionBar(state: SessionState): HTMLElement {
+  const bar = document.createElement('div');
+  bar.id = 'parts-bulk-actions';
+  bar.className = 'shrink-0 flex items-center gap-1.5 px-2 py-1.5 border-t border-zinc-700/70 bg-zinc-800/70';
+
+  const count = document.createElement('span');
+  count.className = 'flex-1 min-w-0 truncate text-[11px] text-zinc-300';
+  count.textContent = `${selected.size} selected`;
+  bar.appendChild(count);
+
+  const clearBtn = document.createElement('button');
+  clearBtn.className = 'shrink-0 px-2 h-7 rounded text-[11px] text-zinc-300 hover:text-zinc-100 hover:bg-zinc-700 transition-colors';
+  clearBtn.textContent = 'Clear';
+  clearBtn.title = 'Clear selection';
+  clearBtn.addEventListener('click', () => { clearSelection(); render(getState()); });
+  bar.appendChild(clearBtn);
+
+  // A session must always keep at least one part, so a select-all delete is
+  // refused (mirrors the single-row delete, which hides when only one remains).
+  const wouldEmptySession = selected.size >= state.parts.length;
+  const delBtn = document.createElement('button');
+  delBtn.id = 'btn-delete-parts';
+  delBtn.className = 'shrink-0 px-2 h-7 rounded text-[11px] font-medium text-white transition-colors '
+    + (wouldEmptySession ? 'bg-red-600/40 opacity-60 cursor-default' : 'bg-red-600/80 hover:bg-red-600');
+  delBtn.textContent = `Delete ${selected.size}`;
+  if (wouldEmptySession) {
+    delBtn.disabled = true;
+    delBtn.title = 'At least one part must remain — deselect one to delete.';
+  } else {
+    delBtn.title = 'Delete the selected parts and all their versions';
+  }
+  delBtn.addEventListener('click', () => {
+    if (delBtn.disabled) return;
+    const ids = [...selected];
+    if (ids.length === 0) return;
+    const msg = ids.length === 1
+      ? 'Delete this part and all of its versions? This cannot be undone.'
+      : `Delete ${ids.length} parts and all of their versions? This cannot be undone.`;
+    if (!confirm(msg)) return;
+    clearSelection();
+    render(getState()); // hide the bar immediately; the delete re-renders on commit
+    void cb.onDeleteParts(ids);
+  });
+  bar.appendChild(delBtn);
+
+  return bar;
 }
 
 function beginRename(name: HTMLElement, part: Part): void {

--- a/tests/parts.spec.ts
+++ b/tests/parts.spec.ts
@@ -200,4 +200,70 @@ test.describe('Multi-part sessions', () => {
     expect(regionCount).toBe(0);
     await expect(page.locator('#editor-lock-overlay')).toHaveCount(0);
   });
+
+  test('multi-select bulk-deletes parts from the rail', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    await page.evaluate(async ({ code }) => {
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      await pw.createSession('bulk');
+      await pw.runAndSave(code, 'a1');     // Part 1
+      await pw.createPart('Beta');
+      await pw.createPart('Gamma');        // becomes the current part
+    }, { code: cube(10, 'A1') });
+
+    const list = page.locator('#parts-list');
+    await expect(list.locator('[data-part-id]')).toHaveCount(3);
+    // No bulk-action bar until at least one part is checked.
+    await expect(page.locator('#parts-bulk-actions')).toHaveCount(0);
+
+    const checkbox = (name: string) =>
+      list.locator('[data-part-id]', { hasText: name }).locator('input[type="checkbox"]');
+    await checkbox('Beta').click();
+    await checkbox('Gamma').click();
+
+    // The footer reports the count and offers a matching delete.
+    const bar = page.locator('#parts-bulk-actions');
+    await expect(bar).toBeVisible();
+    await expect(bar).toContainText('2 selected');
+    const delBtn = page.locator('#btn-delete-parts');
+    await expect(delBtn).toHaveText('Delete 2');
+    await expect(delBtn).toBeEnabled();
+
+    // Confirm and delete; the current part (Gamma) was selected, so the active
+    // part must fall back to a survivor and the editor title follows.
+    page.once('dialog', d => d.accept());
+    await delBtn.click();
+
+    await expect
+      .poll(() => page.evaluate(() =>
+        (window as unknown as { partwright: PartsAPI }).partwright.listParts().map(p => p.name)))
+      .toEqual(['Part 1']);
+    await expect(page.locator('#parts-bulk-actions')).toHaveCount(0);
+    await expect(page.locator('#editor-title')).toHaveText('Part 1');
+  });
+
+  test('bulk delete refuses to remove every part', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    await page.evaluate(async ({ code }) => {
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      await pw.createSession('guard');
+      await pw.runAndSave(code, 'a1');
+      await pw.createPart('Beta');
+    }, { code: cube(10, 'A1') });
+
+    const list = page.locator('#parts-list');
+    await expect(list.locator('[data-part-id]')).toHaveCount(2);
+
+    // Selecting every part disables delete — a session must keep one.
+    for (const row of await list.locator('[data-part-id]').all()) {
+      await row.locator('input[type="checkbox"]').click();
+    }
+    const delBtn = page.locator('#btn-delete-parts');
+    await expect(delBtn).toHaveText('Delete 2');
+    await expect(delBtn).toBeDisabled();
+  });
 });


### PR DESCRIPTION
## Summary

Adds multi-select to the **Parts rail** so you can act on several parts at once — the first action being bulk delete.

- **Selection checkboxes** on each part row (shown when a session has more than one part). Subtle until hover on pointer devices, always visible on touch and whenever a selection is in progress. **Shift-click** selects an inclusive range.
- **Bulk-action footer** appears while parts are checked: shows `N selected`, a **Clear** button, and a **Delete N** button.
- **Atomic delete** — `deleteParts()` removes the parts and cascade-deletes their versions in a single IndexedDB transaction (all-or-nothing).
- **Invariant preserved** — a session always keeps at least one part, so a select-all delete is refused (the Delete button disables with an explanatory tooltip), mirroring the existing single-row delete rule.
- If the **active part** is among those deleted, the nearest survivor above it (else the first remaining) becomes active and the editor reloads — same behavior as single-part delete.

The existing per-row single delete (`✕`) and drag-to-reorder are unchanged.

## Implementation

- `src/storage/db.ts` — new `deleteParts(ids)` batch transaction; single `deletePart` now delegates to it. The batch loop `await`s each version-cascade cursor; resolving from the IDB `onsuccess` callback keeps the shared transaction alive across iterations, and it ends with the required `await txComplete(txn)`.
- `src/storage/sessionManager.ts` — new `deleteParts(partIds)` + `DeletePartsResult`, modeled on the single-part path (current-part reassignment, keep-at-least-one guard). The user-facing `deletePart` / `window.partwright.deletePart` / AI `deletePart` tool are untouched.
- `src/ui/partList.ts` — checkboxes, shift-range selection state, the footer action bar, and selection pruning on every render. Part names are inserted via `textContent` / `setAttribute` only (no `innerHTML`).
- `src/main.ts` — wires the new `onDeleteParts` callback (read-only viewers are blocked, like the other structural edits).
- `tests/parts.spec.ts` — e2e: bulk-delete two parts (incl. the active one, exercising the cross-`await` IndexedDB path) and the select-all refusal guard.

## Verification

- [x] `npm run build` (type-check) — green
- [x] `npm run test:unit` — green
- [x] `npm run test:e2e` — **169 passed** (full suite, incl. 2 new parts tests)
- [x] CI "checks" (build + unit) and Cloudflare Pages preview — green
- [x] Independent diff review — no blockers / should-fix; confirmed no event double-toggle, no row-click leak-through, correct current-part reassignment, valid IndexedDB transaction lifetime, no XSS via part names, and unchanged single-delete back-compat.

Manual check: select 2+ parts → footer shows count → Delete removes them; deleting the active part reloads the editor onto a survivor; selecting all disables Delete; Clear deselects; shift-click selects a range.

https://claude.ai/code/session_01LFUu29LbC1UTjpYc9hsvNn