### PR TITLE
feat: show a geometry preview next to each part in the parts rail

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -378,9 +378,9 @@ function captureThumbnail(mesh: MeshData | null = currentMeshData): Promise<Blob
   let canvas: HTMLCanvasElement;
   try {
     canvas = renderSingleViewCanvas(applyTriColorsIfVisible(mesh), {
-      elevation: STANDARD_VIEWS.front.elevation,
-      azimuth: STANDARD_VIEWS.front.azimuth,
-      ortho: STANDARD_VIEWS.front.ortho,
+      elevation: STANDARD_VIEWS.iso.elevation,
+      azimuth: STANDARD_VIEWS.iso.azimuth,
+      ortho: STANDARD_VIEWS.iso.ortho,
     });
   } catch {
     return Promise.resolve(null);

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEng
 import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
 import { initViewport, updateMesh, setOnMeshUpdate, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange } from './renderer/viewport';
-import { renderCompositeCanvas, renderSingleView, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode } from './renderer/multiview';
+import { renderCompositeCanvas, renderSingleView, renderSingleViewCanvas, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode } from './renderer/multiview';
 import { generateId } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, getAutoFormat, setAutoFormat, editorContentDiffersFrom } from './editor/codeEditor';
@@ -377,7 +377,11 @@ function captureThumbnail(mesh: MeshData | null = currentMeshData): Promise<Blob
   if (!mesh) return Promise.resolve(null);
   let canvas: HTMLCanvasElement;
   try {
-    canvas = renderCompositeCanvas(applyTriColorsIfVisible(mesh));
+    canvas = renderSingleViewCanvas(applyTriColorsIfVisible(mesh), {
+      elevation: STANDARD_VIEWS.front.elevation,
+      azimuth: STANDARD_VIEWS.front.azimuth,
+      ortho: STANDARD_VIEWS.front.ortho,
+    });
   } catch {
     return Promise.resolve(null);
   }

--- a/src/renderer/multiview.ts
+++ b/src/renderer/multiview.ts
@@ -369,13 +369,13 @@ export function buildViewCamera(meshData: MeshData, options: {
   return camera;
 }
 
-export function renderSingleView(meshData: MeshData, options: {
+export function renderSingleViewCanvas(meshData: MeshData, options: {
   elevation?: number;
   azimuth?: number;
   ortho?: boolean;
   size?: number;
   wireframe?: boolean;
-} = {}): string {
+} = {}): HTMLCanvasElement {
   const viewSize = options.size ?? 500;
 
   const geometry = meshDataToGeometry(meshData);
@@ -400,7 +400,18 @@ export function renderSingleView(meshData: MeshData, options: {
   }
   disposeScene(scene);
   geometry.dispose();
-  return canvas.toDataURL('image/png');
+  return canvas;
+}
+
+/** Render a single named angle to a PNG data URL. */
+export function renderSingleView(meshData: MeshData, options: {
+  elevation?: number;
+  azimuth?: number;
+  ortho?: boolean;
+  size?: number;
+  wireframe?: boolean;
+} = {}): string {
+  return renderSingleViewCanvas(meshData, options).toDataURL('image/png');
 }
 
 /** Render a cross-section at a given Z height as an SVG string */

--- a/src/ui/partList.ts
+++ b/src/ui/partList.ts
@@ -3,7 +3,8 @@
 // Renders into the rail container created by layout.ts and re-renders on every
 // session-state change.
 
-import { getState, onStateChange, type SessionState, type Part } from '../storage/sessionManager';
+import { getState, onStateChange, type SessionState, type Part, type Version } from '../storage/sessionManager';
+import { getLatestVersion } from '../storage/db';
 
 export interface PartListCallbacks {
   /** Switch the active part (loads its latest version into the editor). */
@@ -26,6 +27,11 @@ let dragging = false;
 // Set when a state change arrives mid-drag (suppressed); flushed on drag end so
 // the rail never shows stale parts after an async update lands during a drag.
 let pendingRender = false;
+// partId -> the object URL of its latest thumbnail and the version it came from.
+// Lets re-renders reuse an already-built preview (no flicker, no extra DB read)
+// and rebuild the URL only when the underlying version actually changes. The URL
+// is owned here: revoked when replaced (applyThumb) or pruned (pruneThumbCache).
+const thumbCache = new Map<string, { versionId: string; url: string }>();
 
 export function createPartList(container: HTMLElement, callbacks: PartListCallbacks): void {
   railEl = container;
@@ -70,6 +76,7 @@ function render(state: SessionState): void {
   railEl.appendChild(list);
 
   if (!state.session) {
+    pruneThumbCache(new Set());
     const empty = document.createElement('div');
     empty.className = 'px-3 py-2 text-[11px] text-zinc-600 italic';
     empty.textContent = 'No session';
@@ -77,12 +84,21 @@ function render(state: SessionState): void {
     return;
   }
 
+  pruneThumbCache(new Set(state.parts.map((p) => p.id)));
   for (const part of state.parts) {
-    list.appendChild(buildRow(part, part.id === state.currentPart?.id, state.parts.length, list));
+    list.appendChild(
+      buildRow(
+        part,
+        part.id === state.currentPart?.id,
+        state.parts.length,
+        list,
+        state.currentVersion,
+      ),
+    );
   }
 }
 
-function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLElement): HTMLElement {
+function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLElement, currentVersion: Version | null): HTMLElement {
   const row = document.createElement('div');
   row.dataset.partId = part.id;
   row.setAttribute('role', 'button');
@@ -103,6 +119,9 @@ function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLE
   grip.setAttribute('aria-label', 'Drag to reorder');
   attachDragHandlers(grip, row, list);
   row.appendChild(grip);
+
+  // Small geometry preview of the part, next to its name.
+  row.appendChild(buildThumb(part, isCurrent, currentVersion));
 
   const name = document.createElement('span');
   name.className = 'flex-1 min-w-0 truncate text-xs';
@@ -137,6 +156,75 @@ function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLE
   }
 
   return row;
+}
+
+/** A small fixed-size preview slot for a part's latest geometry. */
+function buildThumb(part: Part, isCurrent: boolean, currentVersion: Version | null): HTMLElement {
+  const box = document.createElement('span');
+  box.dataset.thumb = '';
+  box.className = 'shrink-0 w-6 h-6 rounded bg-zinc-900 overflow-hidden flex items-center justify-center';
+
+  // Show whatever we already have cached straight away so an unrelated re-render
+  // (part switch, rename, reorder) doesn't flash the preview off and back on.
+  const cached = thumbCache.get(part.id);
+  if (cached) box.appendChild(makeThumbImg(cached.url));
+
+  if (isCurrent) {
+    // The current part's latest version is already in memory and stays fresh as
+    // the user saves — no DB read needed.
+    applyThumb(part.id, currentVersion, box);
+  } else if (!cached) {
+    // A non-current part's thumbnail can't change until it becomes current, so
+    // fetch it once and rely on the cache from then on.
+    void getLatestVersion(part.id).then((v) => applyThumb(part.id, v, box));
+  }
+  return box;
+}
+
+/** Point the preview box at `version`'s thumbnail, (re)building the object URL
+ *  only when the version changed since we last cached one for this part. */
+function applyThumb(partId: string, version: Version | null, box: HTMLElement): void {
+  if (!version || !version.thumbnail) return; // no saved geometry yet
+  const cached = thumbCache.get(partId);
+  if (cached && cached.versionId === version.id) {
+    paintThumb(partId, cached.url, box); // already cached — just ensure it's shown
+    return;
+  }
+  if (cached) URL.revokeObjectURL(cached.url);
+  const url = URL.createObjectURL(version.thumbnail);
+  thumbCache.set(partId, { versionId: version.id, url });
+  paintThumb(partId, url, box);
+}
+
+/** Draw `url` into the part's preview slot. Prefers the row that's currently in
+ *  the DOM (looked up by part id) so an async paint can't land on a stale box
+ *  left behind by an intervening re-render; falls back to `box` when the row
+ *  isn't mounted yet (the synchronous current-part path). */
+function paintThumb(partId: string, url: string, box: HTMLElement): void {
+  const live = railEl?.querySelector<HTMLElement>(`[data-part-id="${CSS.escape(partId)}"] [data-thumb]`);
+  const target = live ?? box;
+  const existing = target.querySelector('img');
+  if (existing && existing.src === url) return; // already showing this image
+  target.textContent = '';
+  target.appendChild(makeThumbImg(url));
+}
+
+function makeThumbImg(url: string): HTMLImageElement {
+  const img = document.createElement('img');
+  img.src = url;
+  img.alt = '';
+  img.className = 'w-full h-full object-contain';
+  return img;
+}
+
+/** Drop (and revoke) cached preview URLs for parts that no longer exist. */
+function pruneThumbCache(validIds: Set<string>): void {
+  for (const [partId, entry] of thumbCache) {
+    if (!validIds.has(partId)) {
+      URL.revokeObjectURL(entry.url);
+      thumbCache.delete(partId);
+    }
+  }
 }
 
 function beginRename(name: HTMLElement, part: Part): void {

--- a/tests/parts.spec.ts
+++ b/tests/parts.spec.ts
@@ -139,6 +139,30 @@ test.describe('Multi-part sessions', () => {
       .toBe(3);
   });
 
+  test('each part row shows a geometry preview thumbnail', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    await page.evaluate(async ({ codeA1, codeB1 }) => {
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      await pw.createSession('previews');
+      await pw.runAndSave(codeA1, 'a1');   // Part 1 gets a saved version (+thumbnail)
+      await pw.createPart('Lid');
+      await pw.runAndSave(codeB1, 'b1');   // Lid (now current) gets its own
+    }, { codeA1: cube(10, 'A1'), codeB1: cube(6, 'LID') });
+
+    const list = page.locator('#parts-list');
+    await expect(list.locator('[data-part-id]')).toHaveCount(2);
+
+    // Both rows render an <img> preview in their thumbnail slot: the current part
+    // (Lid) is painted synchronously from in-memory state, the other (Part 1) via
+    // the cached async fetch. toHaveCount auto-waits for the async paint to land.
+    const thumbs = list.locator('[data-part-id] [data-thumb] img');
+    await expect(thumbs).toHaveCount(2);
+    const srcs = await thumbs.evaluateAll((imgs) => imgs.map((i) => (i as HTMLImageElement).src));
+    for (const src of srcs) expect(src).toMatch(/^blob:/);
+  });
+
   test('parts can be drag-reordered in the rail', async ({ page }) => {
     await page.goto('/editor');
     await waitForEngine(page);


### PR DESCRIPTION
## Summary
- Each row in the Parts rail (`src/ui/partList.ts`) now shows a small (24×24) thumbnail of the part's latest geometry beside its name.
- The **current** part's preview is sourced synchronously from in-memory `state.currentVersion`, so it stays fresh on every save with no extra IndexedDB read. **Other** parts are fetched once via `getLatestVersion(partId)` and cached. Object URLs are owned by a module-level cache: reused across re-renders (no flicker on part switch / rename / reorder), revoked when a part's latest version changes, and pruned + revoked when a part is removed or the session closes. Async paints target the live row by `data-part-id` so a mid-fetch re-render can't leave a stale/empty slot.
- **Saved thumbnails are now a single isometric "hero" view** (upper-front-right, `STANDARD_VIEWS.iso`) instead of the 2×2 isometric composite — it reads as a 3D solid and is cleaner at thumbnail size. `renderSingleView` gained a `renderSingleViewCanvas` helper (mirroring `renderCompositeCanvas`), and `captureThumbnail` uses it. This applies everywhere version thumbnails appear (parts rail, Gallery, landing-page session tiles, session switcher). Existing saved thumbnails are untouched and refresh on the next save — no migration.
- Merged latest `main` (multi-select bulk-delete in the rail); both features coexist.

## Test plan
- [x] `npm run build` (tsc type-check) — clean
- [x] `npm run test:unit` — passing
- [x] `npm run test:e2e -- tests/parts.spec.ts` — all 8 passing (preview + bulk-delete), incl. a new test asserting every part row renders a `blob:` `<img>` preview (sync current-part path + async cached path)
- [x] Visual check: previews render as single isometric 3D views (box / sphere / cylinder), no iso grid and no flat elevation
- [x] Confirmed thumbnail-related e2e tests don't assert composite shape (`runIsolated`/`renderViews` paths are unchanged)
- [ ] Full `npm run test:e2e` suite (final run on the branch)

> Note: the full suite has one pre-existing failure unrelated to this change — `tests/paint-camera-passthrough.spec.ts` ("wheel over the clip-controls toolbar zooms the camera"), which fails identically on `origin/main`.

🤖 Generated with [Claude Code](https://claude.ai/code)