### PR TITLE
test: fix flaky AI-chat e2e tests that race the editor bootstrap

### DIFF
--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'playwright/test';
-import { openAiPanel } from './helpers/aiPanel';
+import { openAiPanel, waitForChatSessionId } from './helpers/aiPanel';
 
 // Regression coverage for the multi-provider extension to the in-app
 // chat. The base in-browser AI surface (Anthropic + Local) has its own
@@ -198,11 +198,12 @@ test.describe('Multi-provider AI', () => {
     await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch {} });
     await page.waitForSelector('#ai-panel', { state: 'attached' });
     // Bare /editor auto-restores a session (id in the URL, stable across
-    // reload), so the chat pins to that bucket — seed there, not global.
-    await page.evaluate(async () => {
+    // reload), so the chat pins to that bucket — seed there, not global. The
+    // session is created after WASM init, so wait for it before seeding or the
+    // message lands in the global bucket and the reload restore never shows it.
+    const sid = await waitForChatSessionId(page);
+    await page.evaluate(async ({ sid }) => {
       const db = await import('/src/ai/db.ts');
-      const sm = await import('/src/storage/sessionManager.ts');
-      const sid = sm.getState().session?.id ?? db.GLOBAL_CHAT_BUCKET;
       await db.putMessages([{
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         id: 'm-think-1', sessionId: sid, role: 'assistant',
@@ -213,7 +214,7 @@ test.describe('Multi-provider AI', () => {
         createdAt: Date.now(), seq: 1,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any]);
-    });
+    }, { sid });
     await page.reload();
     await page.waitForSelector('#ai-panel', { state: 'attached' });
     await openAiPanel(page);

--- a/tests/ai-tool-result-images.spec.ts
+++ b/tests/ai-tool-result-images.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'playwright/test';
-import { openAiPanel } from './helpers/aiPanel';
+import { openAiPanel, waitForChatSessionId, waitForEditorReady } from './helpers/aiPanel';
 
 // Coverage for surfacing tool-returned renderings (renderView / renderViews
 // snapshots) in the chat transcript. Two halves:
@@ -18,7 +18,7 @@ const TINY_PNG =
 test.describe('Tool-result renderings in the chat transcript', () => {
   test('chatLoop surfaces the renderViews image to the panel as the turn runs', async ({ page }) => {
     await page.goto('/editor');
-    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    await waitForEditorReady(page);
 
     const captured = await page.evaluate(async ({ tinyPng }) => {
       const cl = await import('/src/ai/chatLoop.ts');
@@ -147,12 +147,14 @@ test.describe('Tool-result renderings in the chat transcript', () => {
   test('a persisted tool_result image renders inline in the transcript', async ({ page }) => {
     await page.goto('/editor');
     await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ } });
-    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    await waitForEditorReady(page);
+    // Seed under the bootstrapped session bucket (stable across the reload
+    // below). The session is created after WASM init, so wait for it first or
+    // the messages land in the global bucket and the reload restore drops them.
+    const sid = await waitForChatSessionId(page);
 
-    await page.evaluate(async ({ tinyPng }) => {
+    await page.evaluate(async ({ tinyPng, sid }) => {
       const db = await import('/src/ai/db.ts');
-      const sm = await import('/src/storage/sessionManager.ts');
-      const sid = sm.getState().session?.id ?? db.GLOBAL_CHAT_BUCKET;
       await db.putMessages([
         {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -175,7 +177,7 @@ test.describe('Tool-result renderings in the chat transcript', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any,
       ]);
-    }, { tinyPng: TINY_PNG });
+    }, { tinyPng: TINY_PNG, sid });
 
     await page.reload();
     await openAiPanel(page);

--- a/tests/chat-export.spec.ts
+++ b/tests/chat-export.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type Page } from 'playwright/test';
 import { readFileSync } from 'fs';
-import { openAiPanel } from './helpers/aiPanel';
+import { openAiPanel, waitForEditorReady } from './helpers/aiPanel';
 
 // Network-free coverage for the chat export feature:
 //   - the standalone "⬇ Chat" button in the AI panel header (Markdown), and
@@ -47,7 +47,7 @@ test.beforeEach(async ({ page }) => {
 test.describe('Chat export', () => {
   test('Export button on an empty chat warns and downloads nothing', async ({ page }) => {
     await page.goto('/editor');
-    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    await waitForEditorReady(page);
     await openAiPanel(page);
     const panel = page.locator('#ai-panel');
 
@@ -61,12 +61,12 @@ test.describe('Chat export', () => {
 
   test('Export button downloads a Markdown transcript of the conversation', async ({ page }) => {
     await page.goto('/editor');
-    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    await waitForEditorReady(page);
     const id = await createSession(page, 'Export Test');
     await seedChat(page, id);
 
     await page.goto(`/editor?session=${id}`);
-    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    await waitForEditorReady(page);
     await openAiPanel(page);
     const panel = page.locator('#ai-panel');
     await expect(panel).toContainText('Design a widget bracket');
@@ -86,7 +86,7 @@ test.describe('Chat export', () => {
 
   test('session export embeds chat and import restores it under the new session', async ({ page }) => {
     await page.goto('/editor');
-    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    await waitForEditorReady(page);
     const id = await createSession(page, 'Roundtrip');
     await seedChat(page, id);
 
@@ -163,7 +163,7 @@ async function seedSplit(page: Page, fromId: string, toId: string): Promise<void
 test.describe('Chat history recovery', () => {
   test('mergeChatHistory reunites a conversation split across two sessions', async ({ page }) => {
     await page.goto('/editor');
-    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    await waitForEditorReady(page);
     const a = await createSession(page, 'First half');
     const b = await createSession(page, 'Second half');
     await seedSplit(page, a, b);

--- a/tests/helpers/aiPanel.ts
+++ b/tests/helpers/aiPanel.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from 'playwright/test';
+import { waitFor } from './waitFor';
 
 /** Ensure the AI panel is open.
  *
@@ -17,4 +18,40 @@ export async function openAiPanel(page: Page): Promise<void> {
     }
     await expect(panel).toBeVisible({ timeout: 500 });
   }).toPass({ timeout: 10_000 });
+}
+
+/** Wait until the editor is fully booted and *past* the one-time COI service-
+ *  worker reload.
+ *
+ *  `coi-serviceworker.js` reloads the page once on a fresh context to turn on
+ *  cross-origin isolation. A `page.evaluate` issued before that reload lands is
+ *  torn down by the navigation ("Execution context was destroyed"). The "Ready"
+ *  status only appears after WASM init, which needs cross-origin isolation, so
+ *  it is a reliable signal that the reload is behind us — wait for it before any
+ *  early `page.evaluate` / `createSession` / seed step. */
+export async function waitForEditorReady(page: Page): Promise<void> {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+}
+
+/** Wait for the editor bootstrap to create/restore the active session and return
+ *  its id.
+ *
+ *  On a bare `/editor` load the session is created only *after* WASM init
+ *  (`syncEditorFromURL` → `createSession`), which is long after `#ai-panel`
+ *  attaches. Tests that seed chat messages keyed to the session bucket must wait
+ *  for this first — otherwise, under load, `getState().session?.id` is still
+ *  undefined and the seed lands in `GLOBAL_CHAT_BUCKET`, which the post-reload
+ *  session restore never reads back, so the seeded turn never renders.
+ *
+ *  Each poll is one `page.evaluate`; if a COI reload tears the context down
+ *  mid-poll, `waitFor` swallows the throw and retries on the fresh page. */
+export async function waitForChatSessionId(page: Page): Promise<string> {
+  return waitFor(
+    () =>
+      page.evaluate(async () => {
+        const sm = await import('/src/storage/sessionManager.ts');
+        return sm.getState().session?.id ?? null;
+      }),
+    { timeout: 15_000, message: 'the editor session to initialize' },
+  );
 }

--- a/tests/helpers/waitFor.ts
+++ b/tests/helpers/waitFor.ts
@@ -1,0 +1,45 @@
+export interface WaitForOptions {
+  /** Total time to keep retrying before throwing. Default 5000ms. */
+  timeout?: number;
+  /** Delay between attempts. Default 50ms. */
+  interval?: number;
+  /** Names the awaited condition in the timeout error, e.g. "the session id". */
+  message?: string;
+}
+
+/** Poll `probe` until it returns a truthy value, then return that value.
+ *
+ *  This is the project's standard alternative to `page.waitForTimeout(ms)` for
+ *  *condition* waits: never sleep a fixed guess hoping something is ready — poll
+ *  for the thing itself, so a test is as fast as it can be and only as slow as
+ *  it must be. A throw from `probe` is treated as "not ready yet" and retried,
+ *  so it tolerates probes that read state which doesn't exist yet (including a
+ *  `page.evaluate` whose context is torn down by a navigation mid-poll).
+ *
+ *  Playwright's `expect.poll(fn).toBe(x)` and `expect(fn).toPass()` already
+ *  cover the retry-an-assertion case and should be preferred when you only need
+ *  to *assert*. Reach for `waitFor` when you need the resolved value back — e.g.
+ *  an id minted during app bootstrap — which the built-ins discard. */
+export async function waitFor<T>(
+  probe: () => T | Promise<T>,
+  options: WaitForOptions = {},
+): Promise<NonNullable<T>> {
+  const { timeout = 5000, interval = 50, message } = options;
+  const deadline = Date.now() + timeout;
+  let last = 'never returned a truthy value';
+  for (;;) {
+    try {
+      const value = await probe();
+      if (value) return value as NonNullable<T>;
+      last = `returned ${JSON.stringify(value) ?? String(value)}`;
+    } catch (err) {
+      last = err instanceof Error ? err.message : String(err);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `waitFor: timed out after ${timeout}ms waiting for ${message ?? 'condition'} (last: ${last})`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}

--- a/tests/session-modal.spec.ts
+++ b/tests/session-modal.spec.ts
@@ -14,8 +14,14 @@ type PW = {
 };
 
 function waitForApi(page: Page) {
+  // Require crossOriginIsolated too: it only flips true on the page *after* the
+  // one-time COI service-worker reload (coi-serviceworker.js), so this gates the
+  // following createSession / IndexedDB-seed evaluates until the reload that
+  // would otherwise destroy their execution context is behind us.
   return page.waitForFunction(
-    () => !!(window as unknown as { partwright?: { createSession?: unknown } }).partwright?.createSession,
+    () =>
+      (window as unknown as { crossOriginIsolated: boolean }).crossOriginIsolated === true &&
+      !!(window as unknown as { partwright?: { createSession?: unknown } }).partwright?.createSession,
   );
 }
 


### PR DESCRIPTION
## Summary

CI shard 1 of the e2e suite was flaky (green locally, red under CI load). The reported failure was `ai-providers.spec.ts:193 › thinking block renders as a collapsible box`, but investigation surfaced **two distinct editor-bootstrap timing races**, both from interacting before the app reached a stable state:

- **Wrong chat bucket** — `ai-providers` "thinking block…" (the observed CI failure) and the sibling `ai-tool-result-images` "persisted tool_result image…" seeded chat messages keyed to `getState().session?.id ?? GLOBAL_CHAT_BUCKET`, but only waited for `#ai-panel` to *attach*. On a bare `/editor` the session is created only *after* WASM init, so under load `session?.id` was still undefined → the seed landed in the global bucket → the post-reload session restore never showed it.
- **Destroyed execution context** — `chat-export` "Export…" / "session export…" ran a `page.evaluate` that `coi-serviceworker.js`'s one-time cross-origin-isolation reload tore down (`Execution context was destroyed, most likely because of a navigation`). Reproduced locally 1-in-3.

### Changes (test-only — no `src/` changes)
- Add `tests/helpers/waitFor.ts`: a generic, **value-returning** retry helper (`waitFor(probe, opts)`, default 5s, configurable). Playwright's `expect.poll`/`toPass` already retry *assertions*, but neither returns a value — the gap these waits needed.
- Add `waitForChatSessionId` (built on `waitFor`) and `waitForEditorReady` (waits for the `Ready` status, which only appears after the COI reload) to `tests/helpers/aiPanel.ts`.
- Route the flaky tests through them instead of bare `#ai-panel`-attached waits; harden `session-modal`'s `waitForApi` to also require `crossOriginIsolated`.

## Test plan
- [x] `npm run build` (tsc) — clean
- [x] `npm run test:unit` — 8/8 pass
- [x] Affected files run 4× each (fresh context per repeat = a fresh shot at the COI-reload race): **136 passed, 0 failed, 0 flaky**. `chat-export` (previously ~1-in-3 flaky locally) passed all 16 of its executions; `ai-providers:193` passed all 4.
- [x] Re-synced with latest `origin/main` (clean merge, no overlap with changed files)

https://claude.ai/code/session_01NUUaedPVQyjTPhPGCvgmPh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUUaedPVQyjTPhPGCvgmPh)_