### PR TITLE
test: fix slow-CI auto-connect modal race in openAiPanel helper

### DIFF
--- a/tests/helpers/aiPanel.ts
+++ b/tests/helpers/aiPanel.ts
@@ -8,16 +8,39 @@ import { waitFor } from './waitFor';
  *  is idempotent: it only clicks when the panel is hidden, and retries so it
  *  tolerates the brief window during editor init where `state.open` is already
  *  true but the drawer hasn't been un-hidden yet (a click then would race the
- *  init and toggle it shut). */
+ *  init and toggle it shut).
+ *
+ *  Opening the panel from the rail *while disconnected* also kicks off the
+ *  connect flow, which auto-opens the AI Settings modal one tick later (after an
+ *  async connection check). Left open, that modal races — and clobbers — the
+ *  next modal a caller opens, since `createModalShell` permits only one modal at
+ *  a time. So whenever we actually had to click to open the panel, wait for that
+ *  connect modal to settle and dismiss it. Callers that genuinely want a modal
+ *  open it explicitly after this resolves. On a fast machine the default-open
+ *  wins the race and no click happens, so this path is skipped entirely. */
 export async function openAiPanel(page: Page): Promise<void> {
   await page.waitForSelector('#ai-panel', { state: 'attached' });
   const panel = page.locator('#ai-panel');
+  let clicked = false;
   await expect(async () => {
     if (!(await panel.isVisible())) {
       await page.locator('#btn-ai').dispatchEvent('click');
+      clicked = true;
     }
     await expect(panel).toBeVisible({ timeout: 500 });
   }).toPass({ timeout: 10_000 });
+
+  if (clicked) {
+    const settingsHeading = page.getByRole('heading', { name: 'AI Settings' });
+    const appeared = await settingsHeading
+      .waitFor({ state: 'visible', timeout: 2_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (appeared) {
+      await page.keyboard.press('Escape');
+      await expect(settingsHeading).toBeHidden();
+    }
+  }
 }
 
 /** Wait until the editor is fully booted and *past* the one-time COI service-


### PR DESCRIPTION
## Summary

The e2e staging gate went red on `main` even though the full suite passes locally. Root cause is a timing race in the shared test helper `openAiPanel` (`tests/helpers/aiPanel.ts`):

- When `openAiPanel` has to click `#btn-ai` to open a **closed** panel **while disconnected**, the connect flow auto-opens the **AI Settings** modal one tick later (after an async connection check). The helper returned as soon as the panel was visible and left that modal open.
- The late modal then raced and **clobbered** the next modal the calling test opened (Review, AI Call Log, settings cog…), because `createModalShell` permits only one modal at a time.
- On a fast machine the default-open-on-load wins the race (no click → no auto-modal), so it's green locally; on a **slow CI runner** the click fires first and the failure becomes deterministic — exactly the local-green / CI-red split we saw.

This is the cross-cutting follow-on to the auto-connect-modal feature (#232): the original `openPanelDismissingAutoSettings` guard was later consolidated into the generic `openAiPanel`, which silently dropped the dismissal.

**Fix:** `openAiPanel` now waits for and dismisses that connect modal whenever it actually clicked to open the panel. The fast path (panel already open by default) is untouched, so there's no added cost on the common case.

## Test plan

- [x] Reproduced locally by simulating a slow runner via CDP CPU throttling + a closed-panel seed: the Review-modal flow failed **5/5** before the fix and passes **6/6** after.
- [x] `npm run build` (tsc + vite) — green
- [x] `npm run test:unit` — green (18/18)
- [x] `npm run test:e2e` — full suite green (**181 passed, 0 flaky**, incl. the new render-edge-mode specs from #248)
- [x] PR-checks CI + Cloudflare Pages preview — both green

> Note: CI installs Playwright's pinned **Chrome 145**; this sandbox only has **Chrome 141** and the 145 download is network-blocked here, so the race was verified on Chrome 141 under CPU throttling. The failure is machine-speed-dependent, not browser-version-specific, so this reproduction is faithful to the CI cause.

https://claude.ai/code/session_01K3ANcS8QAMFXYUXgjovTDi