### PR TITLE
fix: adapt camera clip planes to model size so large models stay visible

### DIFF
--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -293,6 +293,15 @@ export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boole
       center.y - maxDim * 1.2,
       center.z + maxDim * 1.2,
     );
+    // Adapt the clip planes to the model size. With a fixed far plane a large
+    // model (e.g. scaled to ~890mm) auto-frames the camera far enough away that
+    // the geometry falls beyond the frustum and disappears; a fixed near plane
+    // would z-fight on tiny models. Scale both with the model's largest dim.
+    if (maxDim > 0) {
+      camera.near = Math.max(0.05, maxDim * 0.005);
+      camera.far = Math.max(1000, maxDim * 50);
+      camera.updateProjectionMatrix();
+    }
     controls.update();
 
     // Update clip plane position if clipping


### PR DESCRIPTION
## Summary

Standalone hotfix branched off latest `main`, isolating just the viewport camera fix from PR #217 so it can be reviewed/merged on its own.

The viewport camera had a fixed far-clip plane of `1000`. Once a model is scaled up enough (e.g. ~890mm), the auto-frame distance pushes the camera farther than 1000 units from the target — so the model falls **outside the camera frustum** and the viewport renders empty. (Triggered while testing `scaleModel` to fit a 256mm bed; the resulting scaled object simply disappeared.)

This change adapts `camera.near` / `camera.far` to the model's bounding-box size each time `updateMesh()` re-frames the scene:

```ts
camera.near = Math.max(0.05, maxDim * 0.005);
camera.far  = Math.max(1000, maxDim * 50);
camera.updateProjectionMatrix();
```

Floors preserve current behavior for normal-sized models; the `*50` ceiling gives generous headroom for very large geometry.

## Test plan
- [x] `npm run build` — clean
- [x] Scaling a 20mm model to ~890mm keeps it visible (previously vanished)
- [x] Full e2e suite — no regressions attributable to this change

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADFC9Fz9UM7KxAaqiVtkzn)_