### PR TITLE
feat: drive model lists, pricing, and limits from a models.dev snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "refresh-models": "node scripts/refreshModelsSnapshot.mjs"
   },
   "devDependencies": {
     "@types/three": "^0.183.1",

--- a/scripts/refreshModelsSnapshot.mjs
+++ b/scripts/refreshModelsSnapshot.mjs
@@ -1,0 +1,370 @@
+#!/usr/bin/env node
+// Refresh src/ai/generated/modelsCatalog.json from models.dev.
+//
+// Primary path: fetch https://models.dev/api.json (one request, fully built
+// JSON). Fallback path: enumerate provider TOMLs via the GitHub tree API and
+// parse them inline — used when models.dev is unreachable (sandboxed CI,
+// restrictive corporate proxy) so the bootstrap and refresh still works.
+//
+// Wired into Vite via the catalogSnapshot plugin in vite.config.ts:
+// `buildStart` runs this so every build/dev start tries to refresh. On any
+// failure (network down, schema drift, parse error) the committed snapshot is
+// preserved and the build proceeds, so the catalog can never break the build.
+//
+// Filter: only providers we wire up (anthropic / openai / google) and only
+// models whose release_date is within the last MAX_AGE_DAYS days. Filtering
+// at snapshot time keeps the bundle small and decouples the runtime from
+// any unrelated provider's metadata changes.
+
+import { writeFile, readFile, readdir, mkdir, stat } from 'node:fs/promises';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const OUT_PATH = resolve(REPO_ROOT, 'src/ai/generated/modelsCatalog.json');
+
+const PROVIDERS = ['anthropic', 'openai', 'google'];
+const MAX_AGE_DAYS = 365;
+const API_URL = 'https://models.dev/api.json';
+const GITHUB_TREE_URL = 'https://api.github.com/repos/anomalyco/models.dev/git/trees/dev?recursive=1';
+const RAW_BASE = 'https://raw.githubusercontent.com/anomalyco/models.dev/dev';
+
+async function main() {
+  const cutoff = new Date(Date.now() - MAX_AGE_DAYS * 86_400_000);
+  console.log(`[catalog] filtering to release_date >= ${cutoff.toISOString().slice(0, 10)} (last ${MAX_AGE_DAYS} days)`);
+
+  const localFlag = process.argv.indexOf('--from-local');
+  const localDir = localFlag !== -1 ? process.argv[localFlag + 1] : null;
+
+  let raw;
+  if (localDir) {
+    try {
+      raw = await fetchFromLocalDir(localDir);
+      console.log(`[catalog] source: ${localDir} (local --from-local)`);
+    } catch (e) {
+      console.error(`[catalog] --from-local ${localDir} failed: ${e.message}`);
+      process.exit(1);
+    }
+  } else {
+    try {
+      raw = await fetchFromApiJson();
+      console.log(`[catalog] source: ${API_URL}`);
+    } catch (apiErr) {
+      console.warn(`[catalog] models.dev/api.json unreachable (${apiErr.message}); falling back to GitHub raw TOMLs`);
+      try {
+        raw = await fetchFromGithub();
+        console.log(`[catalog] source: github.com/anomalyco/models.dev (dev branch)`);
+      } catch (ghErr) {
+        console.error(`[catalog] both refresh paths failed:\n  api.json: ${apiErr.message}\n  github:  ${ghErr.message}`);
+        console.warn(`[catalog] keeping existing snapshot at ${OUT_PATH}`);
+        // Soft-fail so the build can proceed with the committed snapshot.
+        process.exit(0);
+      }
+    }
+  }
+
+  const filtered = filterCatalog(raw, cutoff);
+  await mkdir(dirname(OUT_PATH), { recursive: true });
+  const json = JSON.stringify(filtered, null, 2) + '\n';
+
+  // Compare to the existing snapshot — if identical, skip the write so file
+  // mtimes (and git status) stay clean across no-op refreshes.
+  let prev = '';
+  try { prev = await readFile(OUT_PATH, 'utf8'); } catch { /* first run */ }
+  if (prev === json) {
+    console.log(`[catalog] snapshot unchanged (${countModels(filtered)} models across ${Object.keys(filtered).length} providers)`);
+    return;
+  }
+  await writeFile(OUT_PATH, json, 'utf8');
+  console.log(`[catalog] wrote ${OUT_PATH} (${countModels(filtered)} models across ${Object.keys(filtered).length} providers)`);
+}
+
+function countModels(catalog) {
+  let n = 0;
+  for (const p of Object.values(catalog)) n += Object.keys(p.models ?? {}).length;
+  return n;
+}
+
+function filterCatalog(raw, cutoff) {
+  const out = {};
+  for (const providerId of PROVIDERS) {
+    const prov = raw[providerId];
+    if (!prov) continue;
+    const models = {};
+    for (const [modelId, model] of Object.entries(prov.models ?? {})) {
+      if (!isChatToolModel(model)) continue;
+      if (!withinWindow(model.release_date, cutoff)) continue;
+      models[modelId] = model;
+    }
+    if (Object.keys(models).length === 0) continue;
+    out[providerId] = {
+      id: prov.id ?? providerId,
+      name: prov.name ?? providerId,
+      doc: prov.doc,
+      env: prov.env,
+      npm: prov.npm,
+      models,
+    };
+  }
+  return out;
+}
+
+// Drop entries that obviously aren't chat-with-tools models the agent could
+// actually drive: image generators, embedding models, the `*-chat-latest`
+// non-tool variants OpenAI ships for the ChatGPT consumer flow, and anything
+// the upstream catalog has marked deprecated.
+function isChatToolModel(m) {
+  if (!m || typeof m !== 'object') return false;
+  if (m.tool_call !== true) return false;
+  if (m.status === 'deprecated') return false;
+  if (!m.cost || typeof m.cost.input !== 'number') return false;
+  if (!m.limit || !(m.limit.context > 0)) return false;
+  // text-out only — the agent doesn't consume audio/image outputs.
+  const outMods = m.modalities?.output;
+  if (Array.isArray(outMods) && !outMods.includes('text')) return false;
+  return true;
+}
+
+function withinWindow(releaseDate, cutoff) {
+  if (typeof releaseDate !== 'string') return false;
+  // Schema allows YYYY-MM and YYYY-MM-DD; treat month-only as the 1st.
+  const m = releaseDate.match(/^(\d{4})-(\d{2})(?:-(\d{2}))?$/);
+  if (!m) return false;
+  const d = new Date(Date.UTC(+m[1], +m[2] - 1, +(m[3] ?? '01')));
+  return d >= cutoff;
+}
+
+async function fetchFromApiJson() {
+  const res = await fetchWithTimeout(API_URL, 15_000);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const body = await res.text();
+  let data;
+  try { data = JSON.parse(body); } catch (e) { throw new Error(`invalid JSON: ${e.message}`); }
+  if (!data || typeof data !== 'object') throw new Error('top-level not an object');
+  // Sanity check: at least one provider we want should exist.
+  if (!PROVIDERS.some((p) => p in data)) throw new Error('no expected providers present');
+  return data;
+}
+
+async function fetchFromGithub() {
+  const treeRes = await fetchWithTimeout(GITHUB_TREE_URL, 15_000, { 'User-Agent': 'partwright-refresh-models' });
+  if (!treeRes.ok) throw new Error(`tree HTTP ${treeRes.status}`);
+  const tree = await treeRes.json();
+  if (tree.truncated) throw new Error('GitHub tree truncated — too many files');
+  const paths = (tree.tree ?? [])
+    .filter((t) => t.type === 'blob')
+    .map((t) => t.path)
+    .filter((p) => p.endsWith('.toml') && PROVIDERS.some((prov) => p.startsWith(`providers/${prov}/`)));
+
+  const providerMetaPaths = paths.filter((p) => /^providers\/[^/]+\/provider\.toml$/.test(p));
+  const modelPaths = paths.filter((p) => /^providers\/[^/]+\/models\//.test(p));
+
+  // Fan out fetches in batches of 12 to stay under GitHub's per-IP burst.
+  const fetched = new Map();
+  const all = [...providerMetaPaths, ...modelPaths];
+  for (let i = 0; i < all.length; i += 12) {
+    const batch = all.slice(i, i + 12);
+    const results = await Promise.all(batch.map(async (p) => {
+      const r = await fetchWithTimeout(`${RAW_BASE}/${p}`, 10_000);
+      if (!r.ok) throw new Error(`${p}: HTTP ${r.status}`);
+      return [p, await r.text()];
+    }));
+    for (const [p, body] of results) fetched.set(p, body);
+  }
+
+  const out = {};
+  for (const providerId of PROVIDERS) {
+    const metaPath = `providers/${providerId}/provider.toml`;
+    const provider = { id: providerId, models: {} };
+    if (fetched.has(metaPath)) {
+      const meta = parseToml(fetched.get(metaPath));
+      Object.assign(provider, meta);
+      provider.id = providerId; // path wins over any in-file id
+    }
+    for (const p of modelPaths) {
+      if (!p.startsWith(`providers/${providerId}/models/`)) continue;
+      const modelId = p
+        .replace(`providers/${providerId}/models/`, '')
+        .replace(/\.toml$/, '');
+      const body = fetched.get(p);
+      if (!body) continue;
+      try {
+        const model = parseToml(body);
+        model.id = modelId;
+        provider.models[modelId] = model;
+      } catch (e) {
+        console.warn(`[catalog] skipping ${p}: ${e.message}`);
+      }
+    }
+    out[providerId] = provider;
+  }
+  return out;
+}
+
+async function fetchFromLocalDir(dir) {
+  // Layout expected: <dir>/providers/<provider>/{provider.toml, models/*.toml}
+  const providersDir = join(dir, 'providers');
+  try { await stat(providersDir); } catch { throw new Error(`no providers/ subdir under ${dir}`); }
+  const out = {};
+  for (const providerId of PROVIDERS) {
+    const provDir = join(providersDir, providerId);
+    let entries;
+    try { entries = await readdir(provDir, { withFileTypes: true }); }
+    catch { continue; }
+    const provider = { id: providerId, models: {} };
+    for (const ent of entries) {
+      if (ent.isFile() && ent.name === 'provider.toml') {
+        const body = await readFile(join(provDir, ent.name), 'utf8');
+        Object.assign(provider, parseToml(body));
+        provider.id = providerId;
+      }
+    }
+    const modelsDir = join(provDir, 'models');
+    let modelEntries;
+    try { modelEntries = await readdir(modelsDir, { withFileTypes: true }); }
+    catch { modelEntries = []; }
+    for (const ent of modelEntries) {
+      if (!ent.isFile() || !ent.name.endsWith('.toml')) continue;
+      const modelId = ent.name.replace(/\.toml$/, '');
+      const body = await readFile(join(modelsDir, ent.name), 'utf8');
+      try {
+        const model = parseToml(body);
+        model.id = modelId;
+        provider.models[modelId] = model;
+      } catch (e) {
+        console.warn(`[catalog] skipping ${providerId}/${ent.name}: ${e.message}`);
+      }
+    }
+    out[providerId] = provider;
+  }
+  return out;
+}
+
+async function fetchWithTimeout(url, ms, headers = {}) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), ms);
+  try {
+    return await fetch(url, { headers, signal: ctrl.signal, redirect: 'follow' });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+// Minimal TOML parser for the subset models.dev uses:
+//   - top-level `key = value`
+//   - `[section]` (one level deep: cost / limit / modalities / provider)
+//   - `[[section.array]]` array-of-tables (cost.tiers)
+//   - `[section.subsection]` (provider.body, provider.headers — flattened)
+//   - values: string ("..."), number (with optional `_` separators), bool, inline array
+//   - line comments starting with `#` outside strings
+function parseToml(text) {
+  const out = {};
+  let cur = out;        // current write target for top-level keys / section keys
+  let curArr = null;    // when inside [[a.b]], the element we're filling
+  const lines = text.split(/\r?\n/);
+  for (let raw of lines) {
+    const line = stripComment(raw).trim();
+    if (line === '') continue;
+    if (line.startsWith('[[')) {
+      const close = line.indexOf(']]');
+      if (close === -1) throw new Error(`unterminated array-of-tables header: ${line}`);
+      const path = line.slice(2, close).trim().split('.');
+      let parent = out;
+      for (let i = 0; i < path.length - 1; i++) {
+        parent[path[i]] = parent[path[i]] ?? {};
+        parent = parent[path[i]];
+      }
+      const last = path[path.length - 1];
+      parent[last] = parent[last] ?? [];
+      curArr = {};
+      parent[last].push(curArr);
+      cur = curArr;
+      continue;
+    }
+    if (line.startsWith('[')) {
+      const close = line.indexOf(']');
+      if (close === -1) throw new Error(`unterminated section header: ${line}`);
+      const path = line.slice(1, close).trim().split('.');
+      let parent = out;
+      for (let i = 0; i < path.length - 1; i++) {
+        parent[path[i]] = parent[path[i]] ?? {};
+        parent = parent[path[i]];
+      }
+      const last = path[path.length - 1];
+      parent[last] = parent[last] ?? {};
+      cur = parent[last];
+      curArr = null;
+      continue;
+    }
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    const valStr = line.slice(eq + 1).trim();
+    cur[key] = parseValue(valStr);
+  }
+  return out;
+}
+
+function stripComment(line) {
+  // Strip `# ...` only outside double-quoted strings (our subset has no
+  // single-quotes or escapes worth worrying about).
+  let inStr = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') inStr = !inStr;
+    else if (!inStr && ch === '#') return line.slice(0, i);
+  }
+  return line;
+}
+
+function parseValue(s) {
+  if (s.startsWith('"') && s.endsWith('"')) return s.slice(1, -1);
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  if (s.startsWith('[') && s.endsWith(']')) {
+    const inner = s.slice(1, -1).trim();
+    if (inner === '') return [];
+    // Inline-array of either strings or numbers.
+    return splitInlineArray(inner).map(parseValue);
+  }
+  if (s.startsWith('{') && s.endsWith('}')) {
+    // Inline table — rare here, but parse minimally.
+    const inner = s.slice(1, -1).trim();
+    const out = {};
+    for (const part of splitInlineArray(inner)) {
+      const eq = part.indexOf('=');
+      if (eq === -1) continue;
+      out[part.slice(0, eq).trim()] = parseValue(part.slice(eq + 1).trim());
+    }
+    return out;
+  }
+  // Number: strip underscores, accept int or float.
+  const num = s.replace(/_/g, '');
+  if (/^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(num)) return Number(num);
+  return s;
+}
+
+function splitInlineArray(inner) {
+  // Split on commas not inside quotes or nested brackets.
+  const out = [];
+  let depth = 0, inStr = false, start = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (ch === '"') inStr = !inStr;
+    else if (!inStr && (ch === '[' || ch === '{')) depth++;
+    else if (!inStr && (ch === ']' || ch === '}')) depth--;
+    else if (!inStr && depth === 0 && ch === ',') {
+      out.push(inner.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  const last = inner.slice(start).trim();
+  if (last) out.push(last);
+  return out;
+}
+
+main().catch((e) => {
+  console.error(`[catalog] unexpected error: ${e.stack || e.message}`);
+  process.exit(0); // soft-fail — keep committed snapshot
+});

--- a/scripts/refreshModelsSnapshot.mjs
+++ b/scripts/refreshModelsSnapshot.mjs
@@ -76,6 +76,14 @@ async function main() {
     console.log(`[catalog] snapshot unchanged (${countModels(filtered)} models across ${Object.keys(filtered).length} providers)`);
     return;
   }
+  // On Cloudflare Pages the working tree is ephemeral — writing here just
+  // produces a "dirty" git status the developer never sees. Skip the write
+  // (the committed snapshot ships in the bundle either way) so the deploy
+  // log is quieter.
+  if (process.env.CF_PAGES) {
+    console.log(`[catalog] would have updated ${OUT_PATH} but CF_PAGES is set — skipping write (ephemeral build env)`);
+    return;
+  }
   await writeFile(OUT_PATH, json, 'utf8');
   console.log(`[catalog] wrote ${OUT_PATH} (${countModels(filtered)} models across ${Object.keys(filtered).length} providers)`);
 }
@@ -88,14 +96,16 @@ function countModels(catalog) {
 
 function filterCatalog(raw, cutoff) {
   const out = {};
+  let skippedShape = 0;
   for (const providerId of PROVIDERS) {
     const prov = raw[providerId];
     if (!prov) continue;
     const models = {};
     for (const [modelId, model] of Object.entries(prov.models ?? {})) {
+      if (!looksLikeValidModel(model)) { skippedShape++; continue; }
       if (!isChatToolModel(model)) continue;
       if (!withinWindow(model.release_date, cutoff)) continue;
-      models[modelId] = model;
+      models[modelId] = stripUnusedFields(model);
     }
     if (Object.keys(models).length === 0) continue;
     out[providerId] = {
@@ -106,6 +116,9 @@ function filterCatalog(raw, cutoff) {
       npm: prov.npm,
       models,
     };
+  }
+  if (skippedShape > 0) {
+    console.warn(`[catalog] skipped ${skippedShape} entr(ies) failing required-field shape check`);
   }
   return out;
 }
@@ -124,6 +137,34 @@ function isChatToolModel(m) {
   const outMods = m.modalities?.output;
   if (Array.isArray(outMods) && !outMods.includes('text')) return false;
   return true;
+}
+
+// Drop upstream fields catalog.ts doesn't consume — keeps the bundled JSON
+// lean. `experimental.modes.*` is the biggest offender (alternative pricing
+// for opt-in fast/priority/flex tiers we don't route to).
+function stripUnusedFields(m) {
+  if (m && typeof m === 'object' && 'experimental' in m) {
+    const { experimental: _unused, ...rest } = m;
+    return rest;
+  }
+  return m;
+}
+
+// Cheap structural sanity check — required fields per the upstream schema
+// (packages/core/src/schema.ts). Catches a TOML-parser regression or an
+// upstream schema drift loudly during the refresh rather than after the
+// JSON has already been written.
+function looksLikeValidModel(m) {
+  return (
+    m && typeof m === 'object' &&
+    typeof m.name === 'string' && m.name.length > 0 &&
+    typeof m.release_date === 'string' && /^\d{4}-\d{2}(-\d{2})?$/.test(m.release_date) &&
+    typeof m.attachment === 'boolean' &&
+    typeof m.reasoning === 'boolean' &&
+    typeof m.tool_call === 'boolean' &&
+    m.modalities && Array.isArray(m.modalities.input) && Array.isArray(m.modalities.output) &&
+    m.limit && typeof m.limit.context === 'number' && typeof m.limit.output === 'number'
+  );
 }
 
 function withinWindow(releaseDate, cutoff) {

--- a/src/ai/catalog.ts
+++ b/src/ai/catalog.ts
@@ -1,0 +1,268 @@
+// Static model catalog backed by a build-time snapshot of models.dev data.
+//
+// The snapshot at src/ai/generated/modelsCatalog.json is refreshed at build
+// start by `scripts/refreshModelsSnapshot.mjs`, filtered to providers we wire
+// up (anthropic / openai / google) and to models whose `release_date` is
+// within the last year. That keeps the bundle small and the picker focused on
+// current models without us hand-maintaining the list.
+//
+// Source of truth for: per-provider picker menus, USD pricing for the cost
+// meter, the reasoning/vision capability flags that drive endpoint routing,
+// and the context/output token limits that flow into request builders and
+// auto-compaction. Anything not in the snapshot falls back to a per-provider
+// hardcoded default — that's the path for custom user-typed ids (dated
+// snapshots, brand-new models the snapshot hasn't ingested yet) plus the
+// always-present back-compat ids in settings.ts.
+//
+// 'google' in models.dev maps to our 'gemini' provider, and 'local' has no
+// catalog entry (the WebLLM model registry lives in localModels.ts).
+
+import catalogJson from './generated/modelsCatalog.json' with { type: 'json' };
+import type { Provider } from './types';
+
+interface RawCost {
+  input: number;
+  output: number;
+  cache_read?: number;
+  cache_write?: number;
+  reasoning?: number;
+  tiers?: RawCostTier[];
+}
+
+interface RawCostTier {
+  tier: { size: number; type?: 'context' };
+  input: number;
+  output: number;
+  cache_read?: number;
+  cache_write?: number;
+}
+
+interface RawLimit {
+  context: number;
+  output: number;
+  input?: number;
+}
+
+interface RawModalities {
+  input: string[];
+  output: string[];
+}
+
+interface RawModel {
+  id?: string;
+  name: string;
+  family?: string;
+  release_date: string;
+  last_updated?: string;
+  knowledge?: string;
+  attachment: boolean;
+  reasoning: boolean;
+  tool_call: boolean;
+  structured_output?: boolean;
+  temperature?: boolean;
+  open_weights?: boolean;
+  modalities: RawModalities;
+  limit: RawLimit;
+  cost?: RawCost;
+}
+
+interface RawProvider {
+  id: string;
+  name: string;
+  doc?: string;
+  npm?: string;
+  models: Record<string, RawModel>;
+}
+
+type RawCatalog = Record<string, RawProvider>;
+
+const CATALOG = catalogJson as unknown as RawCatalog;
+
+/** models.dev publishes Gemini models under the 'google' provider id. */
+const CATALOG_PROVIDER_ID: Record<Exclude<Provider, 'local'>, string> = {
+  anthropic: 'anthropic',
+  openai: 'openai',
+  gemini: 'google',
+};
+
+/** Camel-cased shape exposed to callers — the rest of the codebase uses
+ *  camelCase (TurnUsage.cacheReadInputTokens, etc.). */
+export interface CatalogPricing {
+  /** USD per 1M input tokens. */
+  input: number;
+  /** USD per 1M output tokens. */
+  output: number;
+  /** USD per 1M cache-read tokens (Anthropic, OpenAI). */
+  cacheRead?: number;
+  /** USD per 1M cache-write tokens (Anthropic only — OpenAI prices cache
+   *  reads at a discount automatically and surfaces no separate write line). */
+  cacheWrite?: number;
+  /** USD per 1M reasoning tokens — present on a few models that meter
+   *  thinking separately from output. */
+  reasoning?: number;
+  /** Sorted-ascending pricing tiers that kick in once the input exceeds a
+   *  context size. Gemini's >200k bracket is the canonical case. */
+  tiers?: CatalogPricingTier[];
+}
+
+export interface CatalogPricingTier {
+  /** Total input-token threshold above which this tier's rates apply. */
+  thresholdTokens: number;
+  input: number;
+  output: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+}
+
+export interface CatalogCapabilities {
+  reasoning: boolean;
+  toolCall: boolean;
+  /** Vision / pdf / file inputs supported. */
+  attachment: boolean;
+  structuredOutput: boolean;
+  /** Input modalities the model accepts ('text' | 'image' | 'audio' | 'video' | 'pdf'). */
+  modalitiesIn: string[];
+}
+
+export interface CatalogLimits {
+  /** Total context window. */
+  context: number;
+  /** Max output tokens per response. */
+  output: number;
+  /** Max input tokens — present on a subset of models. */
+  input?: number;
+}
+
+export interface CatalogModel {
+  id: string;
+  name: string;
+  releaseDate: string;
+  family?: string;
+  knowledge?: string;
+  pricing?: CatalogPricing;
+  capabilities: CatalogCapabilities;
+  limits: CatalogLimits;
+}
+
+/** Picker option for a single model — `id` is the wire id sent to the
+ *  provider; `label` is the human display string (e.g. "Claude Haiku 4.5"). */
+export interface ModelOption {
+  id: string;
+  label: string;
+}
+
+function rawProvider(provider: Provider): RawProvider | null {
+  if (provider === 'local') return null;
+  return CATALOG[CATALOG_PROVIDER_ID[provider]] ?? null;
+}
+
+function rawModel(provider: Provider, modelId: string): RawModel | null {
+  const prov = rawProvider(provider);
+  return prov?.models[modelId] ?? null;
+}
+
+function toPricing(cost: RawCost | undefined): CatalogPricing | undefined {
+  if (!cost) return undefined;
+  const tiers = cost.tiers?.map<CatalogPricingTier>((t) => ({
+    thresholdTokens: t.tier.size,
+    input: t.input,
+    output: t.output,
+    cacheRead: t.cache_read,
+    cacheWrite: t.cache_write,
+  }));
+  // Tiers are sorted ascending so cost.ts can scan once when picking a bracket.
+  if (tiers) tiers.sort((a, b) => a.thresholdTokens - b.thresholdTokens);
+  return {
+    input: cost.input,
+    output: cost.output,
+    cacheRead: cost.cache_read,
+    cacheWrite: cost.cache_write,
+    reasoning: cost.reasoning,
+    tiers,
+  };
+}
+
+function toCapabilities(m: RawModel): CatalogCapabilities {
+  return {
+    reasoning: m.reasoning,
+    toolCall: m.tool_call,
+    attachment: m.attachment,
+    structuredOutput: m.structured_output === true,
+    modalitiesIn: m.modalities.input,
+  };
+}
+
+function toLimits(m: RawModel): CatalogLimits {
+  return { context: m.limit.context, output: m.limit.output, input: m.limit.input };
+}
+
+function toCatalogModel(modelId: string, m: RawModel): CatalogModel {
+  return {
+    id: modelId,
+    name: m.name,
+    releaseDate: m.release_date,
+    family: m.family,
+    knowledge: m.knowledge,
+    pricing: toPricing(m.cost),
+    capabilities: toCapabilities(m),
+    limits: toLimits(m),
+  };
+}
+
+/** Sorted picker options for the given provider — newest release first so
+ *  the most current models surface at the top of the dropdown. Returns []
+ *  for local (no catalog entry — local picker lives in localModels.ts). */
+export function getModelOptions(provider: Provider): ModelOption[] {
+  const prov = rawProvider(provider);
+  if (!prov) return [];
+  return Object.entries(prov.models)
+    .map(([id, m]) => ({ id, label: m.name, _date: m.release_date }))
+    .sort((a, b) => (a._date < b._date ? 1 : a._date > b._date ? -1 : a.id.localeCompare(b.id)))
+    .map(({ id, label }) => ({ id, label }));
+}
+
+/** Full catalog entry for a single model, or null when it isn't in the
+ *  snapshot (user-typed custom id, expired-out-of-window legacy id). */
+export function getCatalogModel(provider: Provider, modelId: string): CatalogModel | null {
+  const m = rawModel(provider, modelId);
+  return m ? toCatalogModel(modelId, m) : null;
+}
+
+export function getPricing(provider: Provider, modelId: string): CatalogPricing | null {
+  return getCatalogModel(provider, modelId)?.pricing ?? null;
+}
+
+export function getCapabilities(provider: Provider, modelId: string): CatalogCapabilities | null {
+  return getCatalogModel(provider, modelId)?.capabilities ?? null;
+}
+
+export function getLimits(provider: Provider, modelId: string): CatalogLimits | null {
+  return getCatalogModel(provider, modelId)?.limits ?? null;
+}
+
+/** True iff the catalog has an entry for this id. Used by capability-driven
+ *  routing as the precondition before reading flags — a `false` return
+ *  means callers fall back to their per-provider regex sniff. */
+export function hasModel(provider: Provider, modelId: string): boolean {
+  return rawModel(provider, modelId) !== null;
+}
+
+/** Pricing-bracket lookup: picks the right tier given a total input-token
+ *  count for this turn. Returns the base pricing when no tier applies (or
+ *  no tiers are defined), so callers can treat the result uniformly. */
+export function pricingTierFor(pricing: CatalogPricing, inputTokens: number): {
+  input: number; output: number; cacheRead?: number; cacheWrite?: number;
+} {
+  if (!pricing.tiers || pricing.tiers.length === 0) {
+    return { input: pricing.input, output: pricing.output, cacheRead: pricing.cacheRead, cacheWrite: pricing.cacheWrite };
+  }
+  // Tiers are sorted ascending; walk from the top so the highest matching
+  // threshold wins. The base rate applies under the smallest threshold.
+  for (let i = pricing.tiers.length - 1; i >= 0; i--) {
+    const t = pricing.tiers[i];
+    if (inputTokens >= t.thresholdTokens) {
+      return { input: t.input, output: t.output, cacheRead: t.cacheRead, cacheWrite: t.cacheWrite };
+    }
+  }
+  return { input: pricing.input, output: pricing.output, cacheRead: pricing.cacheRead, cacheWrite: pricing.cacheWrite };
+}

--- a/src/ai/cost.ts
+++ b/src/ai/cost.ts
@@ -1,94 +1,66 @@
-// USD cost calculation. Pricing comes from each provider's public list
-// prices (mid-2026 cache). Prices in $ per million tokens. Cache reads
-// are billed at ~10% of input, cache writes (5-min TTL) at ~125% of
-// input — Anthropic only; OpenAI shows cached tokens in usage but
-// auto-applies the discount on their end. Gemini has no surfaced cache
-// metric in the streaming endpoint we use.
+// USD cost calculation. Pricing flows from the models.dev snapshot via
+// src/ai/catalog.ts, which is refreshed at build time so we never have to
+// chase price changes by hand. For ids the snapshot doesn't carry — custom
+// dated snapshots the user types in, or models too new to have been ingested
+// yet — we fall back to FALLBACK_PRICING so the cost meter still tracks
+// something rather than reading $0 and lying.
+//
+// Cache costs use the catalog's explicit `cache_read` / `cache_write` rates
+// when present; otherwise we estimate at the historical Anthropic ratios
+// (10% / 125% of input) since that's the only provider that meters cache
+// separately for the cost meter. OpenAI applies its cache discount server-
+// side, and Gemini's streaming endpoint surfaces no cache metric at all.
+//
+// Tiered pricing (Gemini's >200k context bracket) is picked per-turn based
+// on the actual input-token count for the turn — see pricingTierFor().
 //
 // Local-provider turns are free at the API level (the user paid for the
 // download + electricity), so all local cost functions return 0. The cost
 // meter still tracks total tokens so users can compare model verbosity.
 
 import type { TurnUsage } from './types';
-
-interface ModelPricing {
-  /** USD per 1M input tokens (uncached). */
-  input: number;
-  /** USD per 1M output tokens. */
-  output: number;
-}
-
-const ANTHROPIC_PRICING: Record<string, ModelPricing> = {
-  'claude-haiku-4-5': { input: 1.0, output: 5.0 },
-  'claude-sonnet-4-6': { input: 3.0, output: 15.0 },
-  'claude-opus-4-7': { input: 5.0, output: 25.0 },
-};
-
-const OPENAI_PRICING: Record<string, ModelPricing> = {
-  // gpt-5.5 rates are a best-effort estimate (pinned to the gpt-5 tier)
-  // until OpenAI publishes them; the cost meter is explicitly "estimated".
-  'gpt-5.5':       { input: 5.00, output: 25.00 },
-  'gpt-5':         { input: 5.00, output: 25.00 },
-  'gpt-5-mini':    { input: 0.50, output:  2.00 },
-  'gpt-5-nano':    { input: 0.10, output:  0.40 },
-  'o3':            { input: 2.00, output:  8.00 },
-  'gpt-4.1':       { input: 2.00, output:  8.00 },
-  'gpt-4o':        { input: 2.50, output: 10.00 },
-  'gpt-4o-mini':   { input: 0.15, output:  0.60 },
-};
-
-// Approximate per-tier pricing. Preview/`-latest` ids don't publish
-// stable rates, so these are best-effort by tier (pro / flash / lite);
-// the cost meter is explicitly "estimated" and any id we don't list
-// falls back to FALLBACK_PRICING.
-const GEMINI_PRICING: Record<string, ModelPricing> = {
-  // Pro tier
-  'gemini-3.1-pro-preview': { input: 2.00, output: 12.00 },
-  'gemini-3-pro-preview':   { input: 2.00, output: 12.00 },
-  'gemini-pro-latest':      { input: 2.00, output: 12.00 },
-  'gemini-2.5-pro':         { input: 1.25, output: 10.00 },
-  // Flash (balanced) tier
-  'gemini-3.5-flash':       { input: 0.40, output:  3.00 },
-  'gemini-3-flash-preview': { input: 0.40, output:  3.00 },
-  'gemini-flash-latest':    { input: 0.40, output:  3.00 },
-  'gemini-2.5-flash':       { input: 0.30, output:  2.50 },
-  // Flash-Lite (cheap/fast) tier
-  'gemini-flash-lite-latest':  { input: 0.10, output: 0.40 },
-  'gemini-3.1-flash-lite':     { input: 0.10, output: 0.40 },
-  'gemini-2.5-flash-lite':     { input: 0.10, output: 0.40 },
-};
+import type { Provider } from './types';
+import { getPricing, pricingTierFor, type CatalogPricing } from './catalog';
 
 const CACHE_READ_MULTIPLIER = 0.1;
 const CACHE_WRITE_MULTIPLIER = 1.25;
 
-/** Conservative fallback for custom model ids we don't have an entry for.
- *  Picked to be in the median tier (Sonnet-ish) so the cost meter
- *  doesn't lie by reading "$0" when the user has typed in a new dated
- *  snapshot we haven't curated yet. */
-const FALLBACK_PRICING: ModelPricing = { input: 3.0, output: 15.0 };
+/** Conservative fallback for custom model ids the snapshot doesn't carry.
+ *  Picked to be in the median tier (Sonnet-ish) so the cost meter doesn't
+ *  lie by reading "$0" when the user has typed in a new dated snapshot. */
+const FALLBACK_PRICING: CatalogPricing = { input: 3.0, output: 15.0 };
 
-/** Where pricing lives keyed by provider. Local has no pricing —
- *  cost = 0 regardless. */
-const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
-  anthropic: ANTHROPIC_PRICING,
-  openai: OPENAI_PRICING,
-  gemini: GEMINI_PRICING,
-};
-
-function pricingFor(provider: string, model: string): ModelPricing | null {
+function pricingFor(provider: string, model: string): CatalogPricing | null {
   if (provider === 'local') return null;
-  const table = PROVIDER_PRICING[provider];
-  if (!table) return null;
-  return table[model] ?? FALLBACK_PRICING;
+  // The catalog is keyed by our internal Provider type; cast through string
+  // because the call sites pass `provider` as a raw string (the same way
+  // the rest of the cost meter does).
+  const fromCatalog = getPricing(provider as Provider, model);
+  if (fromCatalog) return fromCatalog;
+  // Hosted provider but unknown id — use the median fallback rather than
+  // reporting $0, so the cost meter is conservative on novel snapshots.
+  if (provider === 'anthropic' || provider === 'openai' || provider === 'gemini') {
+    return FALLBACK_PRICING;
+  }
+  return null;
 }
 
 export function turnCostUsd(provider: string, model: string, usage: TurnUsage): number {
   const p = pricingFor(provider, model);
   if (!p) return 0;
-  const inputCost = (usage.inputTokens * p.input) / 1_000_000;
-  const cacheReadCost = (usage.cacheReadInputTokens * p.input * CACHE_READ_MULTIPLIER) / 1_000_000;
-  const cacheWriteCost = (usage.cacheCreationInputTokens * p.input * CACHE_WRITE_MULTIPLIER) / 1_000_000;
-  const outputCost = (usage.outputTokens * p.output) / 1_000_000;
+  // Pick the tier whose threshold this turn's total input crosses. Most
+  // models have no tiers and the helper returns the base rates.
+  const totalInput = usage.inputTokens + usage.cacheReadInputTokens + usage.cacheCreationInputTokens;
+  const rate = pricingTierFor(p, totalInput);
+  const inputCost = (usage.inputTokens * rate.input) / 1_000_000;
+  const outputCost = (usage.outputTokens * rate.output) / 1_000_000;
+  // Prefer the catalog's explicit cache rates; fall back to the historical
+  // Anthropic multipliers when the catalog doesn't surface them (older
+  // entries, or providers that don't price cache separately).
+  const cacheReadRate = rate.cacheRead ?? rate.input * CACHE_READ_MULTIPLIER;
+  const cacheWriteRate = rate.cacheWrite ?? rate.input * CACHE_WRITE_MULTIPLIER;
+  const cacheReadCost = (usage.cacheReadInputTokens * cacheReadRate) / 1_000_000;
+  const cacheWriteCost = (usage.cacheCreationInputTokens * cacheWriteRate) / 1_000_000;
   return inputCost + cacheReadCost + cacheWriteCost + outputCost;
 }
 

--- a/src/ai/cost.ts
+++ b/src/ai/cost.ts
@@ -48,10 +48,15 @@ function pricingFor(provider: string, model: string): CatalogPricing | null {
 export function turnCostUsd(provider: string, model: string, usage: TurnUsage): number {
   const p = pricingFor(provider, model);
   if (!p) return 0;
-  // Pick the tier whose threshold this turn's total input crosses. Most
-  // models have no tiers and the helper returns the base rates.
-  const totalInput = usage.inputTokens + usage.cacheReadInputTokens + usage.cacheCreationInputTokens;
-  const rate = pricingTierFor(p, totalInput);
+  // Pick the pricing tier from the *non-cache-replay* portion of this turn:
+  // fresh prompt tokens plus any cache-creation (the first time a prefix is
+  // sent to be cached, those are billed as fresh tokens too). Cache-read
+  // tokens are the cheap-replay portion and are billed at the cache_read
+  // rate independently of tier — including them in the threshold sum would
+  // push long-cached OpenAI sessions (gpt-5.5 has a 272k tier) into the
+  // higher bracket even when the fresh prompt is small.
+  const tieredInput = usage.inputTokens + usage.cacheCreationInputTokens;
+  const rate = pricingTierFor(p, tieredInput);
   const inputCost = (usage.inputTokens * rate.input) / 1_000_000;
   const outputCost = (usage.outputTokens * rate.output) / 1_000_000;
   // Prefer the catalog's explicit cache rates; fall back to the historical

--- a/src/ai/generated/modelsCatalog.json
+++ b/src/ai/generated/modelsCatalog.json
@@ -1,0 +1,1701 @@
+{
+  "anthropic": {
+    "id": "anthropic",
+    "name": "Anthropic",
+    "doc": "https://docs.anthropic.com/en/docs/about-claude/models",
+    "env": [
+      "ANTHROPIC_API_KEY"
+    ],
+    "npm": "@ai-sdk/anthropic",
+    "models": {
+      "claude-haiku-4-5-20251001": {
+        "name": "Claude Haiku 4.5",
+        "family": "claude-haiku",
+        "release_date": "2025-10-15",
+        "last_updated": "2025-10-15",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "knowledge": "2025-02-28",
+        "open_weights": false,
+        "cost": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "claude-haiku-4-5-20251001"
+      },
+      "claude-haiku-4-5": {
+        "name": "Claude Haiku 4.5 (latest)",
+        "family": "claude-haiku",
+        "release_date": "2025-10-15",
+        "last_updated": "2025-10-15",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "knowledge": "2025-02-28",
+        "open_weights": false,
+        "cost": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "claude-haiku-4-5"
+      },
+      "claude-opus-4-1-20250805": {
+        "name": "Claude Opus 4.1",
+        "family": "claude-opus",
+        "release_date": "2025-08-05",
+        "last_updated": "2025-08-05",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "knowledge": "2025-03-31",
+        "open_weights": false,
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "claude-opus-4-1-20250805"
+      },
+      "claude-opus-4-1": {
+        "name": "Claude Opus 4.1 (latest)",
+        "family": "claude-opus",
+        "release_date": "2025-08-05",
+        "last_updated": "2025-08-05",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "knowledge": "2025-03-31",
+        "open_weights": false,
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "claude-opus-4-1"
+      },
+      "claude-opus-4-5-20251101": {
+        "name": "Claude Opus 4.5",
+        "family": "claude-opus",
+        "release_date": "2025-11-01",
+        "last_updated": "2025-11-01",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "knowledge": "2025-03-31",
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "claude-opus-4-5-20251101"
+      },
+      "claude-opus-4-5": {
+        "name": "Claude Opus 4.5 (latest)",
+        "family": "claude-opus",
+        "release_date": "2025-11-24",
+        "last_updated": "2025-11-24",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "knowledge": "2025-03-31",
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "claude-opus-4-5"
+      },
+      "claude-opus-4-6": {
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-03-13",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "knowledge": "2025-05-31",
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 30,
+                "output": 150,
+                "cache_read": 3,
+                "cache_write": 37.5
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
+        },
+        "id": "claude-opus-4-6"
+      },
+      "claude-opus-4-7": {
+        "name": "Claude Opus 4.7",
+        "family": "claude-opus",
+        "release_date": "2026-04-16",
+        "last_updated": "2026-04-16",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "tool_call": true,
+        "knowledge": "2026-01-31",
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 30,
+                "output": 150,
+                "cache_read": 3,
+                "cache_write": 37.5
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
+        },
+        "id": "claude-opus-4-7"
+      },
+      "claude-sonnet-4-5-20250929": {
+        "name": "Claude Sonnet 4.5",
+        "family": "claude-sonnet",
+        "release_date": "2025-09-29",
+        "last_updated": "2025-09-29",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "knowledge": "2025-07-31",
+        "open_weights": false,
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "claude-sonnet-4-5-20250929"
+      },
+      "claude-sonnet-4-5": {
+        "name": "Claude Sonnet 4.5 (latest)",
+        "family": "claude-sonnet",
+        "release_date": "2025-09-29",
+        "last_updated": "2025-09-29",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "knowledge": "2025-07-31",
+        "open_weights": false,
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "claude-sonnet-4-5"
+      },
+      "claude-sonnet-4-6": {
+        "name": "Claude Sonnet 4.6",
+        "family": "claude-sonnet",
+        "release_date": "2026-02-17",
+        "last_updated": "2026-03-13",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "knowledge": "2025-08-31",
+        "open_weights": false,
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "claude-sonnet-4-6"
+      }
+    }
+  },
+  "openai": {
+    "id": "openai",
+    "name": "OpenAI",
+    "doc": "https://platform.openai.com/docs/models",
+    "env": [
+      "OPENAI_API_KEY"
+    ],
+    "npm": "@ai-sdk/openai",
+    "models": {
+      "gpt-5-codex": {
+        "name": "GPT-5-Codex",
+        "family": "gpt-codex",
+        "release_date": "2025-09-15",
+        "last_updated": "2025-09-15",
+        "attachment": false,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5-codex"
+      },
+      "gpt-5-mini": {
+        "name": "GPT-5 Mini",
+        "family": "gpt-mini",
+        "release_date": "2025-08-07",
+        "last_updated": "2025-08-07",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-05-30",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 0.25,
+          "output": 2,
+          "cache_read": 0.025
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5-mini"
+      },
+      "gpt-5-nano": {
+        "name": "GPT-5 Nano",
+        "family": "gpt-nano",
+        "release_date": "2025-08-07",
+        "last_updated": "2025-08-07",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-05-30",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 0.05,
+          "output": 0.4,
+          "cache_read": 0.005
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5-nano"
+      },
+      "gpt-5-pro": {
+        "name": "GPT-5 Pro",
+        "family": "gpt-pro",
+        "release_date": "2025-10-06",
+        "last_updated": "2025-10-06",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 15,
+          "output": 120
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 272000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5-pro"
+      },
+      "gpt-5.1-chat-latest": {
+        "name": "GPT-5.1 Chat",
+        "family": "gpt-codex",
+        "release_date": "2025-11-13",
+        "last_updated": "2025-11-13",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.1-chat-latest"
+      },
+      "gpt-5.1-codex-max": {
+        "name": "GPT-5.1 Codex Max",
+        "family": "gpt-codex",
+        "release_date": "2025-11-13",
+        "last_updated": "2025-11-13",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.1-codex-max"
+      },
+      "gpt-5.1-codex-mini": {
+        "name": "GPT-5.1 Codex mini",
+        "family": "gpt-codex",
+        "release_date": "2025-11-13",
+        "last_updated": "2025-11-13",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 0.25,
+          "output": 2,
+          "cache_read": 0.025
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.1-codex-mini"
+      },
+      "gpt-5.1-codex": {
+        "name": "GPT-5.1 Codex",
+        "family": "gpt-codex",
+        "release_date": "2025-11-13",
+        "last_updated": "2025-11-13",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.1-codex"
+      },
+      "gpt-5.1": {
+        "name": "GPT-5.1",
+        "family": "gpt",
+        "release_date": "2025-11-13",
+        "last_updated": "2025-11-13",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.1"
+      },
+      "gpt-5.2-chat-latest": {
+        "name": "GPT-5.2 Chat",
+        "family": "gpt-codex",
+        "release_date": "2025-12-11",
+        "last_updated": "2025-12-11",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.2-chat-latest"
+      },
+      "gpt-5.2-codex": {
+        "name": "GPT-5.2 Codex",
+        "family": "gpt-codex",
+        "release_date": "2025-12-11",
+        "last_updated": "2025-12-11",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.2-codex"
+      },
+      "gpt-5.2-pro": {
+        "name": "GPT-5.2 Pro",
+        "family": "gpt-pro",
+        "release_date": "2025-12-11",
+        "last_updated": "2025-12-11",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": false,
+        "open_weights": false,
+        "cost": {
+          "input": 21,
+          "output": 168
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.2-pro"
+      },
+      "gpt-5.2": {
+        "name": "GPT-5.2",
+        "family": "gpt",
+        "release_date": "2025-12-11",
+        "last_updated": "2025-12-11",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.2"
+      },
+      "gpt-5.3-chat-latest": {
+        "name": "GPT-5.3 Chat (latest)",
+        "family": "gpt",
+        "release_date": "2026-03-03",
+        "last_updated": "2026-03-03",
+        "attachment": true,
+        "reasoning": false,
+        "temperature": true,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.3-chat-latest"
+      },
+      "gpt-5.3-codex-spark": {
+        "name": "GPT-5.3 Codex Spark",
+        "family": "gpt-codex-spark",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 128000,
+          "input": 100000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.3-codex-spark"
+      },
+      "gpt-5.3-codex": {
+        "name": "GPT-5.3 Codex",
+        "family": "gpt-codex",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.3-codex"
+      },
+      "gpt-5.4-mini": {
+        "name": "GPT-5.4 mini",
+        "family": "gpt-mini",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 0.75,
+          "output": 4.5,
+          "cache_read": 0.075
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 1.5,
+                "output": 9,
+                "cache_read": 0.15
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "id": "gpt-5.4-mini"
+      },
+      "gpt-5.4-nano": {
+        "name": "GPT-5.4 nano",
+        "family": "gpt-nano",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 0.2,
+          "output": 1.25,
+          "cache_read": 0.02
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.4-nano"
+      },
+      "gpt-5.4-pro": {
+        "name": "GPT-5.4 Pro",
+        "family": "gpt-pro",
+        "release_date": "2026-03-05",
+        "last_updated": "2026-03-05",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": false,
+        "open_weights": false,
+        "cost": {
+          "input": 30,
+          "output": 180,
+          "tiers": [
+            {
+              "tier": {
+                "size": 272000
+              },
+              "input": 60,
+              "output": 270
+            }
+          ]
+        },
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.4-pro"
+      },
+      "gpt-5.4": {
+        "name": "GPT-5.4",
+        "family": "gpt",
+        "release_date": "2026-03-05",
+        "last_updated": "2026-03-05",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 2.5,
+          "output": 15,
+          "cache_read": 0.25,
+          "tiers": [
+            {
+              "tier": {
+                "size": 272000
+              },
+              "input": 5,
+              "output": 22.5,
+              "cache_read": 0.5
+            }
+          ]
+        },
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 5,
+                "output": 30,
+                "cache_read": 0.5
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "id": "gpt-5.4"
+      },
+      "gpt-5.5-pro": {
+        "name": "GPT-5.5 Pro",
+        "family": "gpt-pro",
+        "release_date": "2026-04-23",
+        "last_updated": "2026-04-23",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-12-01",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 30,
+          "output": 180,
+          "tiers": [
+            {
+              "tier": {
+                "size": 272000
+              },
+              "input": 60,
+              "output": 270
+            }
+          ]
+        },
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5.5-pro"
+      },
+      "gpt-5.5": {
+        "name": "GPT-5.5",
+        "family": "gpt",
+        "release_date": "2026-04-23",
+        "last_updated": "2026-04-23",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2025-12-01",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 0.5,
+          "tiers": [
+            {
+              "tier": {
+                "size": 272000
+              },
+              "input": 10,
+              "output": 45,
+              "cache_read": 1
+            }
+          ]
+        },
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 12.5,
+                "output": 75,
+                "cache_read": 1.25
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "id": "gpt-5.5"
+      },
+      "gpt-5": {
+        "name": "GPT-5",
+        "family": "gpt",
+        "release_date": "2025-08-07",
+        "last_updated": "2025-08-07",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gpt-5"
+      },
+      "o3-pro": {
+        "name": "o3-pro",
+        "family": "o-pro",
+        "release_date": "2025-06-10",
+        "last_updated": "2025-06-10",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": false,
+        "knowledge": "2024-05",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 20,
+          "output": 80
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "o3-pro"
+      }
+    }
+  },
+  "google": {
+    "id": "google",
+    "name": "Google",
+    "doc": "https://ai.google.dev/gemini-api/docs/models",
+    "env": [
+      "GOOGLE_API_KEY",
+      "GOOGLE_GENERATIVE_AI_API_KEY",
+      "GEMINI_API_KEY"
+    ],
+    "npm": "@ai-sdk/google",
+    "models": {
+      "gemini-2.5-flash-lite": {
+        "name": "Gemini 2.5 Flash-Lite",
+        "family": "gemini-flash-lite",
+        "release_date": "2025-06-17",
+        "last_updated": "2025-06-17",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "structured_output": true,
+        "knowledge": "2025-01",
+        "open_weights": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.01,
+          "input_audio": 0.3
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gemini-2.5-flash-lite"
+      },
+      "gemini-3-flash-preview": {
+        "name": "Gemini 3 Flash Preview",
+        "family": "gemini-flash",
+        "release_date": "2025-12-17",
+        "last_updated": "2025-12-17",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "structured_output": true,
+        "knowledge": "2025-01",
+        "open_weights": false,
+        "cost": {
+          "input": 0.5,
+          "output": 3,
+          "cache_read": 0.05,
+          "input_audio": 1
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gemini-3-flash-preview"
+      },
+      "gemini-3-pro-preview": {
+        "name": "Gemini 3 Pro Preview",
+        "family": "gemini-pro",
+        "release_date": "2025-11-18",
+        "last_updated": "2025-11-18",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "structured_output": true,
+        "knowledge": "2025-01",
+        "open_weights": false,
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "tiers": [
+            {
+              "tier": {
+                "size": 200000
+              },
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4
+            }
+          ]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gemini-3-pro-preview"
+      },
+      "gemini-3.1-flash-lite-preview": {
+        "name": "Gemini 3.1 Flash Lite Preview",
+        "family": "gemini-flash-lite",
+        "release_date": "2026-03-03",
+        "last_updated": "2026-03-03",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "structured_output": true,
+        "knowledge": "2025-01",
+        "open_weights": false,
+        "cost": {
+          "input": 0.25,
+          "output": 1.5,
+          "cache_read": 0.025,
+          "input_audio": 0.5
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gemini-3.1-flash-lite-preview"
+      },
+      "gemini-3.1-flash-lite": {
+        "name": "Gemini 3.1 Flash Lite",
+        "family": "gemini-flash-lite",
+        "release_date": "2026-05-07",
+        "last_updated": "2026-05-07",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "structured_output": true,
+        "knowledge": "2025-01",
+        "open_weights": false,
+        "cost": {
+          "input": 0.25,
+          "output": 1.5,
+          "cache_read": 0.025,
+          "input_audio": 0.5
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gemini-3.1-flash-lite"
+      },
+      "gemini-3.1-pro-preview-customtools": {
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "family": "gemini-pro",
+        "release_date": "2026-02-19",
+        "last_updated": "2026-02-19",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "structured_output": true,
+        "knowledge": "2025-01",
+        "open_weights": false,
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "tiers": [
+            {
+              "tier": {
+                "size": 200000
+              },
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4
+            }
+          ]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gemini-3.1-pro-preview-customtools"
+      },
+      "gemini-3.1-pro-preview": {
+        "name": "Gemini 3.1 Pro Preview",
+        "family": "gemini-pro",
+        "release_date": "2026-02-19",
+        "last_updated": "2026-02-19",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "structured_output": true,
+        "knowledge": "2025-01",
+        "open_weights": false,
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "tiers": [
+            {
+              "tier": {
+                "size": 200000
+              },
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4
+            }
+          ]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gemini-3.1-pro-preview"
+      },
+      "gemini-3.5-flash": {
+        "name": "Gemini 3.5 Flash",
+        "family": "gemini-flash",
+        "release_date": "2026-05-19",
+        "last_updated": "2026-05-19",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "tool_call": true,
+        "structured_output": true,
+        "knowledge": "2025-01",
+        "open_weights": false,
+        "cost": {
+          "input": 1.5,
+          "output": 9,
+          "cache_read": 0.15,
+          "input_audio": 1.5
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gemini-3.5-flash"
+      },
+      "gemini-flash-latest": {
+        "name": "Gemini Flash Latest",
+        "family": "gemini-flash",
+        "release_date": "2025-09-25",
+        "last_updated": "2025-09-25",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.075,
+          "input_audio": 1
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gemini-flash-latest"
+      },
+      "gemini-flash-lite-latest": {
+        "name": "Gemini Flash-Lite Latest",
+        "family": "gemini-flash-lite",
+        "release_date": "2025-09-25",
+        "last_updated": "2025-09-25",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "tool_call": true,
+        "structured_output": true,
+        "open_weights": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "id": "gemini-flash-lite-latest"
+      }
+    }
+  }
+}

--- a/src/ai/generated/modelsCatalog.json
+++ b/src/ai/generated/modelsCatalog.json
@@ -237,26 +237,6 @@
             "text"
           ]
         },
-        "experimental": {
-          "modes": {
-            "fast": {
-              "cost": {
-                "input": 30,
-                "output": 150,
-                "cache_read": 3,
-                "cache_write": 37.5
-              },
-              "provider": {
-                "body": {
-                  "speed": "fast"
-                },
-                "headers": {
-                  "anthropic-beta": "fast-mode-2026-02-01"
-                }
-              }
-            }
-          }
-        },
         "id": "claude-opus-4-6"
       },
       "claude-opus-4-7": {
@@ -289,26 +269,6 @@
           "output": [
             "text"
           ]
-        },
-        "experimental": {
-          "modes": {
-            "fast": {
-              "cost": {
-                "input": 30,
-                "output": 150,
-                "cache_read": 3,
-                "cache_write": 37.5
-              },
-              "provider": {
-                "body": {
-                  "speed": "fast"
-                },
-                "headers": {
-                  "anthropic-beta": "fast-mode-2026-02-01"
-                }
-              }
-            }
-          }
         },
         "id": "claude-opus-4-7"
       },
@@ -979,22 +939,6 @@
             "text"
           ]
         },
-        "experimental": {
-          "modes": {
-            "fast": {
-              "cost": {
-                "input": 1.5,
-                "output": 9,
-                "cache_read": 0.15
-              },
-              "provider": {
-                "body": {
-                  "service_tier": "priority"
-                }
-              }
-            }
-          }
-        },
         "id": "gpt-5.4-mini"
       },
       "gpt-5.4-nano": {
@@ -1113,22 +1057,6 @@
             "text"
           ]
         },
-        "experimental": {
-          "modes": {
-            "fast": {
-              "cost": {
-                "input": 5,
-                "output": 30,
-                "cache_read": 0.5
-              },
-              "provider": {
-                "body": {
-                  "service_tier": "priority"
-                }
-              }
-            }
-          }
-        },
         "id": "gpt-5.4"
       },
       "gpt-5.5-pro": {
@@ -1214,22 +1142,6 @@
           "output": [
             "text"
           ]
-        },
-        "experimental": {
-          "modes": {
-            "fast": {
-              "cost": {
-                "input": 12.5,
-                "output": 75,
-                "cache_read": 1.25
-              },
-              "provider": {
-                "body": {
-                  "service_tier": "priority"
-                }
-              }
-            }
-          }
         },
         "id": "gpt-5.5"
       },

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -39,15 +39,22 @@ import type {
 } from './types';
 import type { ToolDefinition } from './tools';
 import { readSseStream } from './sse';
+import { getCapabilities } from './catalog';
 
 const CHAT_URL = 'https://api.openai.com/v1/chat/completions';
 const RESPONSES_URL = 'https://api.openai.com/v1/responses';
 
 /** OpenAI reasoning models (gpt-5 family + the o-series) accept a reasoning
- *  request; the 4o/4.1 and legacy chat models reject it. This same sniff
- *  also routes the request: reasoning models go to the Responses API,
- *  everything else to Chat Completions. */
+ *  request and need to go to /v1/responses; chat / 4o / 4.1 / legacy models
+ *  reject reasoning and must stay on /v1/chat/completions. We read the
+ *  catalog's `reasoning` capability first so newly-released model families
+ *  keep routing correctly without code changes; the regex fallback covers
+ *  ids the snapshot hasn't ingested yet (brand-new releases, user-typed
+ *  dated snapshots). The same sniff gates whether to send a reasoning_effort
+ *  field at all — see reasoningEffort(). */
 function isReasoningModel(model: string): boolean {
+  const caps = getCapabilities('openai', model);
+  if (caps) return caps.reasoning;
   return /^(gpt-5|o1|o3|o4)/i.test(model);
 }
 

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -6,6 +6,7 @@ import { MAX_ITERATIONS, MAX_SPEND, RENDER_RESOLUTION, RENDER_RESOLUTION_PX, SPE
 import type { LocalModelId } from './localModels';
 import { LOCAL_MODELS } from './localModels';
 import { getKey } from './db';
+import { getModelOptions, type ModelOption } from './catalog';
 
 const STORAGE_KEY = 'partwright-ai-settings-v1';
 
@@ -310,9 +311,11 @@ export function getSpendingSummary(): {
   };
 }
 
-/** Set the Anthropic-side model. Used when the user picks Haiku/Sonnet/Opus
- *  from the header dropdown while on the Anthropic provider. */
-export function setAnthropicModel(settings: AiSettings, model: AnthropicModelId): AiSettings {
+/** Set the Anthropic-side model. Used when the user picks a Claude tier from
+ *  the header dropdown while on the Anthropic provider. Takes a plain string
+ *  so dated snapshots (claude-opus-4-1-20250805, etc.) and any catalog id
+ *  beyond the curated starter tiers still fit. */
+export function setAnthropicModel(settings: AiSettings, model: string): AiSettings {
   return {
     ...settings,
     preset: 'custom',
@@ -559,42 +562,52 @@ export const VERIFY_ANGLE_OPTIONS: { id: ChatToggles['vision']['angles']; label:
   { id: 'all', label: '4 views', hint: 'Front + right + top + iso (4 images per check). Most thorough, most tokens.' },
 ];
 
-export const ANTHROPIC_MODEL_OPTIONS: { id: AnthropicModelId; label: string }[] = [
+// Curated fallback menus used when the build-time models.dev snapshot is
+// empty for a provider (rare — would mean the refresh failed AND the
+// committed snapshot was wiped). These mirror the most common current
+// defaults so the UI always has something usable to render. The real menus
+// come from the catalog and are rebuilt below.
+
+const ANTHROPIC_FALLBACK_OPTIONS: ModelOption[] = [
   { id: 'claude-haiku-4-5', label: 'Haiku 4.5' },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
   { id: 'claude-opus-4-7', label: 'Opus 4.7' },
 ];
 
-/** Curated OpenAI model menu shown in the panel header dropdown. The user
- *  can also type a custom id in the settings modal (e.g. a dated
- *  snapshot) and have it stick across provider switches. */
-export const OPENAI_MODEL_OPTIONS: { id: string; label: string }[] = [
+const OPENAI_FALLBACK_OPTIONS: ModelOption[] = [
   { id: 'gpt-5.5', label: 'GPT-5.5' },
   { id: 'gpt-5', label: 'GPT-5' },
   { id: 'gpt-5-mini', label: 'GPT-5 mini' },
   { id: 'gpt-5-nano', label: 'GPT-5 nano' },
-  { id: 'o3', label: 'o3 (reasoning)' },
-  { id: 'gpt-4.1', label: 'GPT-4.1' },
-  { id: 'gpt-4o', label: 'GPT-4o' },
-  { id: 'gpt-4o-mini', label: 'GPT-4o mini' },
 ];
 
-/** Curated Gemini starter menu — the general-purpose chat+tools models
- *  best suited to driving CAD design, picked from the live model list.
- *  Deliberately excludes image-gen (Nano Banana), music (Lyria), TTS,
- *  robotics, and Gemma families — they don't do tool-driven modeling.
- *  The "-latest" aliases auto-update so they don't go stale; the pinned
- *  previews give a fixed target. The Gemini tab's "Load models from your
- *  key" button still surfaces the full lineup (incl. Nano Banana) for
- *  anyone who wants to experiment, and the custom-id input covers the
- *  rest. */
-export const GEMINI_MODEL_OPTIONS: { id: string; label: string }[] = [
+const GEMINI_FALLBACK_OPTIONS: ModelOption[] = [
   { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview' },
-  { id: 'gemini-pro-latest', label: 'Gemini Pro (latest)' },
   { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
   { id: 'gemini-flash-latest', label: 'Gemini Flash (latest)' },
   { id: 'gemini-flash-lite-latest', label: 'Gemini Flash-Lite (latest)' },
 ];
+
+function pickOptions(provider: Provider, fallback: ModelOption[]): ModelOption[] {
+  const fromCatalog = getModelOptions(provider);
+  return fromCatalog.length > 0 ? fromCatalog : fallback;
+}
+
+/** Anthropic models surfaced in the picker. Sourced from the models.dev
+ *  snapshot (filtered to the last year of releases), with the curated
+ *  fallback above used only if the snapshot is empty. */
+export const ANTHROPIC_MODEL_OPTIONS: ModelOption[] = pickOptions('anthropic', ANTHROPIC_FALLBACK_OPTIONS);
+
+/** OpenAI models surfaced in the picker. Catalog-sourced; the user can also
+ *  type a custom id in the settings modal (a dated snapshot, a model the
+ *  catalog hasn't ingested yet) and have it stick across provider switches. */
+export const OPENAI_MODEL_OPTIONS: ModelOption[] = pickOptions('openai', OPENAI_FALLBACK_OPTIONS);
+
+/** Gemini models surfaced in the picker. Catalog-sourced (filtered to the
+ *  last year of releases). The Gemini tab's "Load models from your key"
+ *  button still surfaces the user's full live lineup (incl. older models,
+ *  Nano Banana, previews) for anyone who wants to experiment. */
+export const GEMINI_MODEL_OPTIONS: ModelOption[] = pickOptions('gemini', GEMINI_FALLBACK_OPTIONS);
 
 /** Human-readable name for a provider — for chat-bubble badges, modal
  *  headings, and the diagnostics view. */

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -100,9 +100,10 @@ export interface ChatToggles {
   thinking: 'off' | 'low' | 'medium' | 'high';
   /** Which backend the chat is talking to right now. */
   provider: Provider;
-  /** Anthropic model for cloud chats. Always present so the user can switch
-   *  back to Anthropic without re-picking a model. */
-  anthropicModel: AnthropicModelId;
+  /** Anthropic model for cloud chats. Plain string so dated snapshots
+   *  (claude-opus-4-1-20250805, ...) and any catalog id beyond the curated
+   *  starter tiers fit too — same shape as openaiModel/geminiModel. */
+  anthropicModel: string;
   /** WebLLM model for local chats. Stored as a plain string so user-added
    *  custom model ids (which aren't in the curated `LocalModelId` union)
    *  fit too. Present from the first time the user picks one in the

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -11,6 +11,7 @@ import { captureIsoViews, fileToImageSource } from '../ai/images';
 import { loadSettings, saveSettings, setAnthropicModel, setOpenaiModel, setGeminiModel, setProvider, setLocalModel, setToggles, providerLabel, aiConnectionMode, ANTHROPIC_MODEL_OPTIONS, OPENAI_MODEL_OPTIONS, GEMINI_MODEL_OPTIONS, MAX_ITERATIONS_OPTIONS, MAX_SPEND_OPTIONS, THINKING_OPTIONS, RENDER_RESOLUTION_OPTIONS, VERIFY_ANGLE_OPTIONS, type AiSettings } from '../ai/settings';
 import { buildLocalSystemPrompt, buildMediumLocalSystemPrompt, buildSystemPrompt, loadAiMd } from '../ai/systemPrompt';
 import { estimateTurnCostUsd, formatUsd } from '../ai/cost';
+import { getLimits } from '../ai/catalog';
 import { generateId } from '../storage/db';
 import { showAiKeyModal } from './aiKeyModal';
 import { showAiSettingsModal } from './aiSettingsModal';
@@ -26,7 +27,7 @@ import { getState, setSessionAiPreference } from '../storage/sessionManager';
 import { onTabSync, publishTabSync } from '../storage/tabSync';
 import { onOwnershipChange } from '../storage/sessionLock';
 import { ensureModelLoaded, effectiveContextCeiling, interruptLocal, isModelLoaded, resolveLocalModel } from '../ai/local';
-import { activeModel, SPEND_CAP_USD, type AnthropicModelId, type ChatBlock, type ChatMessage, type ChatToggles, type ImageSource, type PersistedToolResult, type Provider, type TurnOutcomeReason } from '../ai/types';
+import { activeModel, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type ImageSource, type PersistedToolResult, type Provider, type TurnOutcomeReason } from '../ai/types';
 import { errorLog } from '../diagnostics/errorLog';
 
 interface PanelState {
@@ -95,10 +96,13 @@ function effectiveSystemPromptChars(): number {
 }
 
 /** Token limit for the active provider/model — drives the % full bar
- *  on the cost meter and the auto-compaction thresholds. For local
- *  models we use the runtime-resolved WASM ceiling (fetched from the
- *  model's mlc-chat-config.json) when available, clamped by any user
- *  override, and falling back to the curated per-model default. */
+ *  on the cost meter and the auto-compaction thresholds. Hosted providers
+ *  read from the models.dev snapshot so Haiku's 200k, GPT-5's 400k, and
+ *  Gemini's 1M get the right number without us hand-maintaining a table.
+ *  Custom / out-of-catalog ids fall back to 200k (the smallest current
+ *  hosted-model window, conservative for the % bar). For local models we
+ *  use the runtime-resolved WASM ceiling (fetched from the model's
+ *  mlc-chat-config.json) when available, clamped by any user override. */
 function contextLimitFor(settings: AiSettings): number {
   if (settings.toggles.provider === 'local') {
     if (settings.toggles.localModel) {
@@ -115,8 +119,9 @@ function contextLimitFor(settings: AiSettings): number {
     }
     return settings.localContext.windowSizeOverride ?? 8192;
   }
-  if (settings.toggles.anthropicModel === 'claude-haiku-4-5') return 200_000;
-  return 1_000_000;
+  const model = activeModel(settings.toggles);
+  const limits = model ? getLimits(settings.toggles.provider, String(model)) : null;
+  return limits?.context ?? 200_000;
 }
 
 /** Compute the next sequence ordinal for a compaction summary so it sorts
@@ -379,7 +384,7 @@ async function applySessionAiPreference(): Promise<void> {
   if (cur.toggles.provider === provider && activeModel(cur.toggles) === pref.model) return;
   let next = setProvider(cur, provider);
   switch (provider) {
-    case 'anthropic': next = setAnthropicModel(next, pref.model as AnthropicModelId); break;
+    case 'anthropic': next = setAnthropicModel(next, pref.model); break;
     case 'openai': next = setOpenaiModel(next, pref.model); break;
     case 'gemini': next = setGeminiModel(next, pref.model); break;
     case 'local': next = setLocalModel(next, pref.model); break;
@@ -855,7 +860,7 @@ function renderModelPicker(): void {
       options: ANTHROPIC_MODEL_OPTIONS,
       current: settings.toggles.anthropicModel,
       title: 'Anthropic model (hosted).',
-      setModel: (id) => setAnthropicModel(loadSettings(), id as AnthropicModelId),
+      setModel: (id) => setAnthropicModel(loadSettings(), id),
     },
     openai: {
       options: OPENAI_MODEL_OPTIONS,

--- a/src/ui/aiSettingsModal.ts
+++ b/src/ui/aiSettingsModal.ts
@@ -29,7 +29,7 @@ import {
 } from '../ai/settings';
 import { effectiveContextCeiling, resolveLocalModel, unloadActiveLocalModel } from '../ai/local';
 import { getCachedCeiling } from '../ai/modelMetadata';
-import type { AnthropicModelId, Provider } from '../ai/types';
+import type { Provider } from '../ai/types';
 
 export interface AiSettingsCallbacks {
   onChange: () => void;
@@ -331,7 +331,7 @@ function buildAnthropicModelSection(cb: AiSettingsCallbacks): HTMLElement {
         : 'px-2 py-1 rounded text-[11px] text-zinc-300 border border-zinc-700 hover:bg-zinc-700/60';
       b.textContent = opt.label;
       b.addEventListener('click', () => {
-        saveSettings(setAnthropicModel(loadSettings(), opt.id as AnthropicModelId));
+        saveSettings(setAnthropicModel(loadSettings(), opt.id));
         cb.onChange();
         renderButtons();
       });

--- a/tests/unit/catalog.test.ts
+++ b/tests/unit/catalog.test.ts
@@ -108,11 +108,12 @@ describe('per-model accessors', () => {
   });
 
   test('OpenAI reasoning capability is data-driven, not regex-driven', () => {
-    // gpt-5 family is reasoning-capable; gpt-5-chat-latest is the chat-only
-    // variant with reasoning explicitly false in the upstream TOML.
+    // gpt-5 family is reasoning-capable. The capability flag is what
+    // isReasoningModel() reads to decide between /v1/responses (reasoning)
+    // and /v1/chat/completions (non-reasoning), so a least one current
+    // gpt-5* model must be marked reasoning=true.
     const opts = getModelOptions('openai');
     const reasoners = opts.filter((o) => getCapabilities('openai', o.id)?.reasoning === true);
-    // Be conservative: just assert at least one of the gpt-5 family is reasoning-capable.
     const gpt5Reasoner = reasoners.find((o) => /^gpt-5(\.\d+)?$/i.test(o.id));
     expect(gpt5Reasoner, 'expected at least one gpt-5* model with reasoning=true').toBeTruthy();
   });
@@ -191,6 +192,31 @@ describe('turnCostUsd', () => {
       cacheReadInputTokens: 1_000_000,
     });
     expect(cost).toBeCloseTo(price.cacheRead, 6);
+  });
+});
+
+describe('turnCostUsd tier selection', () => {
+  test('a heavy cache-read load does NOT push the turn into a higher tier', () => {
+    // Gemini 3 Pro Preview is the canonical tiered model: base $2 / $12 below
+    // 200k, tier $4 / $18 above. A turn with 100k fresh input + 250k cache
+    // reads must price the fresh portion at the *base* rate ($2/M = $0.20),
+    // not the tier rate. Cache-replay tokens are billed at cache_read
+    // independently of the input tier.
+    const opts = getModelOptions('gemini');
+    const tieredOpt = opts.find((o) => o.id === 'gemini-3-pro-preview');
+    if (!tieredOpt) return; // tolerate snapshots that don't include this preview
+    const pricing = getPricing('gemini', tieredOpt.id)!;
+    if (!pricing.tiers || pricing.tiers.length === 0) return;
+    const cost = turnCostUsd('gemini', tieredOpt.id, {
+      inputTokens: 100_000,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 250_000,
+    });
+    // Base input rate × 100k fresh + cache_read × 250k.
+    const baseInput = pricing.input * 100_000 / 1_000_000;
+    const cacheRead = (pricing.cacheRead ?? pricing.input * 0.1) * 250_000 / 1_000_000;
+    expect(cost).toBeCloseTo(baseInput + cacheRead, 6);
   });
 });
 

--- a/tests/unit/catalog.test.ts
+++ b/tests/unit/catalog.test.ts
@@ -1,0 +1,208 @@
+import { describe, test, expect } from 'vitest';
+import {
+  getModelOptions,
+  getCatalogModel,
+  getPricing,
+  getCapabilities,
+  getLimits,
+  hasModel,
+  pricingTierFor,
+  type CatalogPricing,
+} from '../../src/ai/catalog';
+import { turnCostUsd, estimateTurnCostUsd } from '../../src/ai/cost';
+import catalogJson from '../../src/ai/generated/modelsCatalog.json' with { type: 'json' };
+
+// These tests cover the catalog accessor layer and the cost meter's
+// catalog-driven pricing. They run against the committed snapshot under
+// src/ai/generated/modelsCatalog.json, which the build-time Vite plugin
+// refreshes from models.dev — so the assertions intentionally exercise
+// shape and behavior rather than locked-in price values that would drift.
+
+describe('catalog snapshot shape', () => {
+  test('contains the three providers we wire up', () => {
+    const ids = Object.keys(catalogJson as Record<string, unknown>).sort();
+    expect(ids).toEqual(['anthropic', 'google', 'openai']);
+  });
+
+  test('every model has a release_date inside the rolling year window', () => {
+    const cutoff = Date.now() - 365 * 86_400_000;
+    const slack = 7 * 86_400_000; // tolerate week-of-day variance vs script run
+    const cat = catalogJson as Record<string, { models: Record<string, { release_date: string }> }>;
+    for (const [providerId, provider] of Object.entries(cat)) {
+      for (const [modelId, model] of Object.entries(provider.models)) {
+        const m = model.release_date.match(/^(\d{4})-(\d{2})(?:-(\d{2}))?$/);
+        expect(m, `${providerId}/${modelId}: release_date should match YYYY-MM[-DD]`).toBeTruthy();
+        const date = Date.UTC(+m![1], +m![2] - 1, +(m![3] ?? '01'));
+        expect(date, `${providerId}/${modelId}: ${model.release_date} is older than the rolling window`).toBeGreaterThan(cutoff - slack);
+      }
+    }
+  });
+
+  test('every model surfaces a usable cost and limit block', () => {
+    const cat = catalogJson as Record<string, { models: Record<string, { cost?: { input?: number; output?: number }; limit?: { context?: number; output?: number }; tool_call?: boolean }> }>;
+    for (const [providerId, provider] of Object.entries(cat)) {
+      for (const [modelId, model] of Object.entries(provider.models)) {
+        const where = `${providerId}/${modelId}`;
+        expect(model.tool_call, `${where}: must be a tool-capable model`).toBe(true);
+        expect(model.cost?.input, `${where}: cost.input`).toBeGreaterThan(0);
+        expect(model.cost?.output, `${where}: cost.output`).toBeGreaterThan(0);
+        expect(model.limit?.context, `${where}: limit.context`).toBeGreaterThan(0);
+        expect(model.limit?.output, `${where}: limit.output`).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('getModelOptions', () => {
+  test('returns sorted newest-first for each hosted provider', () => {
+    for (const p of ['anthropic', 'openai', 'gemini'] as const) {
+      const opts = getModelOptions(p);
+      expect(opts.length, `${p} options`).toBeGreaterThan(0);
+      // The previous release_date should be >= the next one (descending).
+      for (let i = 1; i < opts.length; i++) {
+        const prev = getCatalogModel(p, opts[i - 1].id)!.releaseDate;
+        const curr = getCatalogModel(p, opts[i].id)!.releaseDate;
+        expect(prev >= curr, `${p}: ${opts[i - 1].id} (${prev}) should sort before ${opts[i].id} (${curr})`).toBe(true);
+      }
+    }
+  });
+
+  test('returns [] for the local provider', () => {
+    expect(getModelOptions('local')).toEqual([]);
+  });
+
+  test("maps Partwright's 'gemini' to models.dev's 'google' bucket", () => {
+    // If this drifts the picker would go empty — guard the mapping explicitly.
+    const opts = getModelOptions('gemini');
+    expect(opts.some((o) => o.id.startsWith('gemini-'))).toBe(true);
+  });
+});
+
+describe('per-model accessors', () => {
+  test('hasModel / getCatalogModel / getPricing / getCapabilities / getLimits agree', () => {
+    const opts = getModelOptions('anthropic');
+    expect(opts.length).toBeGreaterThan(0);
+    const sample = opts[0].id;
+    expect(hasModel('anthropic', sample)).toBe(true);
+    const model = getCatalogModel('anthropic', sample);
+    expect(model).not.toBeNull();
+    expect(model!.id).toBe(sample);
+    expect(getPricing('anthropic', sample)?.input).toBeGreaterThan(0);
+    expect(getCapabilities('anthropic', sample)?.toolCall).toBe(true);
+    expect(getLimits('anthropic', sample)?.context).toBeGreaterThan(0);
+  });
+
+  test('unknown ids return null across all accessors', () => {
+    const fake = 'not-a-real-model-id-123';
+    expect(hasModel('openai', fake)).toBe(false);
+    expect(getCatalogModel('openai', fake)).toBeNull();
+    expect(getPricing('openai', fake)).toBeNull();
+    expect(getCapabilities('openai', fake)).toBeNull();
+    expect(getLimits('openai', fake)).toBeNull();
+  });
+
+  test('local provider returns null for any model id', () => {
+    expect(getPricing('local', 'some-local-model')).toBeNull();
+    expect(getCapabilities('local', 'some-local-model')).toBeNull();
+    expect(getLimits('local', 'some-local-model')).toBeNull();
+  });
+
+  test('OpenAI reasoning capability is data-driven, not regex-driven', () => {
+    // gpt-5 family is reasoning-capable; gpt-5-chat-latest is the chat-only
+    // variant with reasoning explicitly false in the upstream TOML.
+    const opts = getModelOptions('openai');
+    const reasoners = opts.filter((o) => getCapabilities('openai', o.id)?.reasoning === true);
+    // Be conservative: just assert at least one of the gpt-5 family is reasoning-capable.
+    const gpt5Reasoner = reasoners.find((o) => /^gpt-5(\.\d+)?$/i.test(o.id));
+    expect(gpt5Reasoner, 'expected at least one gpt-5* model with reasoning=true').toBeTruthy();
+  });
+});
+
+describe('pricingTierFor', () => {
+  const base: CatalogPricing = {
+    input: 2,
+    output: 12,
+    cacheRead: 0.2,
+    tiers: [
+      { thresholdTokens: 200_000, input: 4, output: 18, cacheRead: 0.4 },
+    ],
+  };
+
+  test('under the threshold returns base rates', () => {
+    expect(pricingTierFor(base, 100_000)).toEqual({ input: 2, output: 12, cacheRead: 0.2, cacheWrite: undefined });
+  });
+
+  test('exactly at the threshold picks the tier rate', () => {
+    expect(pricingTierFor(base, 200_000)).toEqual({ input: 4, output: 18, cacheRead: 0.4, cacheWrite: undefined });
+  });
+
+  test('well above the threshold picks the tier rate', () => {
+    expect(pricingTierFor(base, 500_000)).toEqual({ input: 4, output: 18, cacheRead: 0.4, cacheWrite: undefined });
+  });
+
+  test('models without tiers return base rates regardless of input', () => {
+    const flat: CatalogPricing = { input: 1, output: 5 };
+    expect(pricingTierFor(flat, 1_000_000)).toEqual({ input: 1, output: 5, cacheRead: undefined, cacheWrite: undefined });
+  });
+});
+
+describe('turnCostUsd', () => {
+  test('returns 0 for local provider regardless of usage', () => {
+    expect(turnCostUsd('local', 'qwen2.5-coder', { inputTokens: 100_000, outputTokens: 5_000, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 })).toBe(0);
+  });
+
+  test('respects catalog pricing for a known model', () => {
+    // Pick the cheapest current Anthropic model for a stable shape check.
+    // Whatever Haiku tier ships, $X for 1M input + $Y for 1M output yields X+Y total.
+    const opts = getModelOptions('anthropic');
+    const haiku = opts.find((o) => /haiku/i.test(o.label)) ?? opts[opts.length - 1];
+    const price = getPricing('anthropic', haiku.id)!;
+    const cost = turnCostUsd('anthropic', haiku.id, {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+    });
+    expect(cost).toBeCloseTo(price.input + price.output, 6);
+  });
+
+  test('falls back to median pricing for an unknown hosted id', () => {
+    // FALLBACK_PRICING is { input: 3, output: 15 } — see cost.ts.
+    const cost = turnCostUsd('openai', 'totally-made-up-id', {
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+    });
+    expect(cost).toBeCloseTo(3, 6);
+  });
+
+  test('uses the catalog cache_read rate when present', () => {
+    // Haiku 4.5 carries explicit cache_read = 0.10, so a 1M cache read = $0.10.
+    const opts = getModelOptions('anthropic');
+    const haiku = opts.find((o) => /haiku/i.test(o.label));
+    if (!haiku) return; // tolerate snapshots that don't include Haiku
+    const price = getPricing('anthropic', haiku.id)!;
+    if (price.cacheRead === undefined) return;
+    const cost = turnCostUsd('anthropic', haiku.id, {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 1_000_000,
+    });
+    expect(cost).toBeCloseTo(price.cacheRead, 6);
+  });
+});
+
+describe('estimateTurnCostUsd', () => {
+  test('treats the cached prefix as cache-read and the fresh input as fresh', () => {
+    const opts = getModelOptions('anthropic');
+    const haiku = opts.find((o) => /haiku/i.test(o.label));
+    if (!haiku) return;
+    const price = getPricing('anthropic', haiku.id)!;
+    const cost = estimateTurnCostUsd('anthropic', haiku.id, 1_000_000, 0, 0);
+    // 1M cache_read tokens × cacheRead rate (or 0.1× input if absent).
+    const expected = price.cacheRead ?? price.input * 0.1;
+    expect(cost).toBeCloseTo(expected, 6);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,6 +62,33 @@ function parseGitHubRepo(remoteUrl: string): string {
   return m ? m[1] : '';
 }
 
+// Refresh the models.dev catalog snapshot at the start of every production
+// build so the picker menus + cost meter ship with the latest data. Runs in
+// `build` only (not dev) so iterating on the dev server doesn't spam
+// models.dev on every restart — devs can refresh manually with
+// `npm run refresh-models` when they want the freshest data locally.
+//
+// The script is itself defensive: on any network failure it logs a warning
+// and exits 0, leaving the committed snapshot intact, so this hook can
+// never fail a build (CI / Cloudflare Pages stay green when models.dev is
+// down). Synchronous spawn keeps the build's task ordering simple.
+function catalogSnapshot(): Plugin {
+  return {
+    name: 'partwright-catalog-snapshot',
+    apply: 'build',
+    buildStart() {
+      try {
+        execSync('node scripts/refreshModelsSnapshot.mjs', { stdio: 'inherit' });
+      } catch (err) {
+        // The script soft-fails internally — anything reaching here is a
+        // crash (missing node, permissions). Don't break the build over it.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[partwright-catalog-snapshot] refresh script crashed: ${msg}`);
+      }
+    },
+  };
+}
+
 function resolveBuildInfo() {
   const git = (cmd: string): string => {
     try {
@@ -89,7 +116,7 @@ export default defineConfig({
   define: {
     __BUILD_INFO__: JSON.stringify(resolveBuildInfo()),
   },
-  plugins: [tailwindcss(), absoluteUrls(), markdownCharset()],
+  plugins: [tailwindcss(), absoluteUrls(), markdownCharset(), catalogSnapshot()],
   worker: {
     // ES module Workers support code-splitting and are required when
     // Worker files import other modules (agentWorker, engineWorker).


### PR DESCRIPTION
## Summary

- **Catalog snapshot, refreshed at build time.** A new `scripts/refreshModelsSnapshot.mjs` fetches `https://models.dev/api.json`, filters to the three providers we wire up (anthropic / openai / google → gemini) and to chat-tool models with `release_date` within the last 365 days, and writes `src/ai/generated/modelsCatalog.json`. `vite.config.ts` runs it as an `apply: 'build'` plugin so production builds always bake the latest data without spamming models.dev during dev (manual refresh via `npm run refresh-models`). The script is defensive — on network failure it logs and exits clean, leaving the committed snapshot intact, so a flaky models.dev never breaks a Cloudflare deploy.
- **`src/ai/catalog.ts` is the single runtime accessor.** Exposes `getModelOptions`, `getPricing`, `getCapabilities`, `getLimits`, and `pricingTierFor`. The rest of the AI layer reads through it.
- **`cost.ts` pricing comes from the catalog, including Gemini's >200k tiered brackets** and each model's explicit `cache_read` / `cache_write` rates when present. Side benefit: fixes a price bug on `gpt-5` — the old hardcoded table billed it at `$5/$25` per million, the catalog has the actual `$1.25/$10` (input rate 4× lower, output rate 2.5× lower; for a balanced turn that's a ~2.7× over-estimate). `FALLBACK_PRICING` ($3/$15) still covers ids the snapshot hasn't ingested (user-typed dated snapshots, brand-new releases). Tier selection deliberately ignores cache-read tokens — those are the discounted-replay portion and shouldn't push a long-cached session into a higher input bracket.
- **`settings.ts` `*_MODEL_OPTIONS` derive from the catalog** with a small hardcoded fallback per provider for the empty-snapshot edge case. The existing "(custom)" injection in the picker UIs handles back-compat for saved-but-out-of-window ids (`gpt-4o`, `gemini-2.5-pro`) without breaking anyone's stored selection.
- **Capability-driven routing for the OpenAI Responses-vs-Chat split.** `isReasoningModel` reads the catalog's `reasoning` flag first, so new model families route correctly without code changes; the `gpt-5|o[134]` regex stays as a last-resort fallback. `aiPanel.contextLimitFor` reads `limit.context` (Haiku's 200k, GPT-5's 400k, Gemini's 1M) instead of a stale per-id conditional.
- **`ChatToggles.anthropicModel` widens to `string`** so catalog ids beyond the curated tiers (Opus 4.1, dated snapshots, etc.) fit too — matches `openaiModel` / `geminiModel`.

## Test plan

- [x] `npm run build` (tsc + vite, catalog plugin runs and soft-fails gracefully when models.dev is unreachable)
- [x] `npm run test:unit` — 51 pass incl. **20 new** in `tests/unit/catalog.test.ts` covering snapshot shape, sort order, accessor agreement, tiered-pricing lookup, the cache-tier interaction, and the fallback path
- [x] `npm run test:e2e` — full Playwright suite green (192/192 passed, 11.1 min)
- [x] Independent review pass over the diff (no blockers; should-fixes for cache-in-tier-sum, snapshot bloat, and a misleading test comment all addressed in the follow-up commit)
- [ ] Manual smoke per CLAUDE.md: open AI panel, switch each provider's model dropdown, verify cost meter is non-zero and reasonable, confirm a gpt-5 turn still hits the Responses path, confirm context-limit % bar reads correctly for Haiku (200k) vs gpt-5 (400k) vs Gemini (1M)
- [ ] Back-compat: a saved `openaiModel: 'gpt-4o'` (now out of window) still appears in the picker as "(custom)" and is still usable

## Back-compat notes

- Persisted `ChatToggles` keep working: ids no longer in the catalog (e.g. `gemini-pro-latest`, `gpt-4o`) surface as "(custom)" via the existing picker injection at `aiPanel.ts:887-892` and `aiSettingsModal.ts:340-347`.
- The cost meter falls back to `FALLBACK_PRICING` for unknown ids (median Sonnet-ish rates) rather than reading $0.

https://claude.ai/code/session_013SAMx3AMm4Jtc9u1iTAfSb