### PR TITLE
feat: disable AI session notes by default

### DIFF
--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -98,9 +98,11 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
   standard: {
     vision: { views: true, resolution: 'medium', angles: 'auto' },
     // Paint off by default — color regions lock the editor and are easy
-    // for the model to mis-target. Users who want AI-driven painting
-    // can flip the Paint pill on, or pick the Full preset.
-    scope: { runCode: true, saveVersions: true, paintFaces: false, sessionNotes: true },
+    // for the model to mis-target. Notes off by default — the chat
+    // transcript already records the reasoning, so each addSessionNote
+    // call is a redundant tool round-trip. Users who want either can
+    // flip the pill on, or pick the Full preset.
+    scope: { runCode: true, saveVersions: true, paintFaces: false, sessionNotes: false },
     autoRetry: 1,
     maxIterations: 'high',
     maxSpend: 'medium',


### PR DESCRIPTION
## Summary
- Flip `sessionNotes` off in the **standard** preset (the default for new users). The minimal preset was already off; the full preset stays on for users who want everything.
- The chat transcript already records the model's reasoning, so every `addSessionNote` call is a redundant tool round-trip — disabling by default saves spend without hiding any information.
- Users who still want AI-logged notes can flip the 📝 Notes pill on, or pick the Full preset.
- Existing users keep their stored toggle values (via `mergeWithDefaults` in `src/ai/settings.ts`); only fresh sessions / a "reset to Standard" pick up the new default.

## Test plan
- [x] `npm run build` (type-check + Vite build)
- [x] `npm run test:unit` (86/86)
- [x] `npm run test:e2e` (229/229)
- [x] Automated review pass over the diff — no blockers
