### PR TITLE
fix: drop SCAD catalog test's UI-click language race

### DIFF
--- a/tests/generate-scad-catalog-entries.spec.ts
+++ b/tests/generate-scad-catalog-entries.spec.ts
@@ -70,9 +70,12 @@ test.describe.serial('generate SCAD catalog entries', () => {
   });
 
   // SCAD WASM (~10MB) + BOSL2 import + threaded-rod / gear-tooth math can
-  // easily push a single compile past the default 30s timeout. Give each
-  // generation a generous 180s.
-  test.setTimeout(180_000);
+  // easily push a single compile past the default 30s timeout. The engine
+  // itself allots 180s for a SCAD execute (see EXECUTE_TIMEOUT_MS), and the
+  // test does goto + waitForEngine + setActiveLanguage + thumbnail/export on
+  // top of that, so give the test a comfortable margin above the engine
+  // ceiling rather than racing it.
+  test.setTimeout(300_000);
 
   for (const entry of newEntries) {
     test(`build ${entry.catalogFile}`, async ({ page }) => {
@@ -85,26 +88,22 @@ test.describe.serial('generate SCAD catalog entries', () => {
       await page.goto('/editor');
       await waitForEngine(page);
 
-      // Switch to SCAD via the language toggle. SCAD WASM is heavy so this
-      // first switch can take ~10s on a fresh page. Confirm any dialog that
-      // pops up about discarding state.
-      page.on('dialog', d => d.accept());
-      await page.locator('#lang-toggle button:has-text("SCAD")').click();
-      // Re-wait for partwright after the engine swap, then give SCAD a moment
-      // to spin up before issuing the first compile.
-      await page.waitForFunction(
-        () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
-        { timeout: 30_000 },
-      );
-      await page.waitForTimeout(2_000);
-
+      // Switch to SCAD via the partwright API rather than the UI toggle so the
+      // active language flip and the SCAD-WASM init are deterministically
+      // awaited before runAndSave fires. The toolbar click hands off to an
+      // async handler that isn't awaited by Playwright; on a slow CI runner
+      // the wait that followed wasn't long enough for activeLanguage to land
+      // on 'scad', and runAndSave then executed under the manifold-js 60s
+      // timeout ceiling against a BOSL2 compile that needs ~50s on its own.
       const payload = await page.evaluate(async ({ code, name }) => {
         const pw = (window as unknown as { partwright: {
-          createSession: (n: string, lang?: string) => Promise<unknown>;
+          setActiveLanguage: (lang: 'manifold-js' | 'scad') => Promise<void>;
+          createSession: (n: string) => Promise<unknown>;
           runAndSave: (c: string, label?: string, a?: unknown) => Promise<unknown>;
           exportSessionData: (id?: string, opts?: { includeThumbnails?: boolean }) => Promise<{ data?: unknown; error?: string }>;
         } }).partwright;
-        await pw.createSession(name, 'scad');
+        await pw.setActiveLanguage('scad');
+        await pw.createSession(name);
         // Don't enforce maxComponents — some SCAD models in this batch are
         // intentionally multi-part (hex bolt + nut + washer is 3 pieces laid
         // out side-by-side, the gear pair has 2 free gears on a plate, etc.).


### PR DESCRIPTION
## Summary

- `tests/generate-scad-catalog-entries.spec.ts` was clicking the toolbar's SCAD button and then waiting 2s before calling `runAndSave`. That handler runs `onLanguageSwitch` asynchronously and Playwright doesn't await it, so on slow CI runners `activeLanguage` hadn't landed on `'scad'` by the time `runAndSave` → `executeCodeAsync` ran. The call used the 60s manifold-js timeout ceiling, and the BOSL2 hex-bolt + nut compile (high-50s on CI) tipped over it — surfacing as `Geometry evaluation timed out after 60s` in the staging-gate run.
- Drive the language switch through `pw.setActiveLanguage('scad')` instead. It awaits `switchLanguage('scad')`, which sets `activeLanguage` synchronously and then blocks on `ensureEngineReady('scad')`, so there's no race by the time `createSession` + `runAndSave` run.
- Lift the per-test timeout from 180s → 300s so the test has comfortable margin above the engine's own 180s SCAD ceiling (goto + waitForEngine + thumbnail/export add wall-clock on top).

## Test plan

- [x] `npm run build`
- [x] `npm run test:unit`
- [x] `npx playwright test tests/generate-scad-catalog-entries.spec.ts` — all 5 tests pass serially (~2.6m)
- [ ] CI green on the draft (PR-checks + Cloudflare preview)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YJDtQDSFaaqp7CBUf2THeF)_