### PR TITLE
feat: hide code pane by default when AI drawer is open

### DIFF
--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -17,6 +17,12 @@ export interface AiSettings {
    *  the AI surface is discoverable; persists the user's choice thereafter, so
    *  once they close it it stays closed on reload. */
   drawerOpen: boolean;
+  /** Whether the code editor pane is collapsed. `null` means "no explicit
+   *  preference yet" — layout.ts then defaults it to match `drawerOpen` so a
+   *  first-time visitor with the AI panel up doesn't see two competing surfaces
+   *  in the editor. Once the user clicks "Hide code" / "Show code" the choice
+   *  is persisted and respected on every subsequent load. */
+  editorCollapsed: boolean | null;
   /** Default for new sessions before the user has touched the toggle bar. */
   autoCompactMode: 'off' | 'conservative' | 'standard' | 'aggressive';
   /** User-overridden system prompts. `null` means "use the built-in default
@@ -132,6 +138,7 @@ const DEFAULT_SETTINGS: AiSettings = {
   preset: 'standard',
   toggles: DEFAULT_TOGGLES,
   drawerOpen: true,
+  editorCollapsed: null,
   autoCompactMode: 'off',
   systemPromptOverrides: { anthropic: null, local: null, openai: null, gemini: null },
   customLocalModels: [],
@@ -392,6 +399,7 @@ interface LegacyAiSettings {
   preset?: Preset;
   autoCompactMode?: AiSettings['autoCompactMode'];
   drawerOpen?: boolean;
+  editorCollapsed?: boolean | null;
   toggles?: Partial<ChatToggles> & { model?: ModelId };
   systemPromptOverrides?: Partial<AiSettings['systemPromptOverrides']>;
   customLocalModels?: CustomLocalModel[];
@@ -443,6 +451,7 @@ function mergeWithDefaults(partial: LegacyAiSettings): AiSettings {
     preset: partial.preset ?? DEFAULT_SETTINGS.preset,
     autoCompactMode: partial.autoCompactMode ?? DEFAULT_SETTINGS.autoCompactMode,
     drawerOpen: partial.drawerOpen ?? DEFAULT_SETTINGS.drawerOpen,
+    editorCollapsed: typeof partial.editorCollapsed === 'boolean' ? partial.editorCollapsed : null,
     toggles: {
       vision: { ...DEFAULT_SETTINGS.toggles.vision, ...(tgls.vision ?? {}) },
       scope: { ...DEFAULT_SETTINGS.toggles.scope, ...(tgls.scope ?? {}) },

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,6 +1,7 @@
 import { getMobilePane, onMobilePaneChange, setMobilePane } from './mobilePane';
 import { showQualitySettingsModal } from './qualitySettingsModal';
 import { showAboutModal } from './aboutModal';
+import { loadSettings, saveSettings } from '../ai/settings';
 
 export type TabName = 'interactive' | 'gallery' | 'versions' | 'images' | 'diff' | 'notes' | 'data';
 
@@ -353,7 +354,12 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   // Tracks the most recently activated tab so breakpoint or mobile-pane
   // changes can recompose visibility without re-running tab DOM toggling.
   let _currentTab: TabName = 'interactive';
-  let editorCollapsed = false;
+  // Default the code pane closed when the AI drawer is opening too — two big
+  // surfaces fighting for the same screen on a first visit pushes the viewport
+  // into a sliver. The user's explicit Hide/Show choice (persisted below)
+  // takes precedence on every subsequent load.
+  const aiSettings = loadSettings();
+  let editorCollapsed = aiSettings.editorCollapsed ?? aiSettings.drawerOpen;
   const mqDesktop = window.matchMedia('(min-width: 768px)');
 
   // Composes desktop/mobile pane visibility from the active tab and (on mobile)
@@ -387,10 +393,29 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
     window.dispatchEvent(new Event('resize'));
   }
 
+  function rememberEditorCollapsed(collapsed: boolean): void {
+    saveSettings({ ...loadSettings(), editorCollapsed: collapsed });
+  }
+
   collapseEditorBtn.addEventListener('click', () => {
     if (editorCollapsed) expandEditor(); else collapseEditor();
+    rememberEditorCollapsed(editorCollapsed);
   });
-  expandEditorBtn.addEventListener('click', expandEditor);
+  expandEditorBtn.addEventListener('click', () => {
+    expandEditor();
+    rememberEditorCollapsed(false);
+  });
+
+  // Apply the resolved initial collapsed state to the DOM before the first
+  // syncPaneVisibility() runs below — otherwise the "if (!editorCollapsed)…
+  // width = 40%" branch would expand it on the first paint and clobber the
+  // resolved default.
+  if (editorCollapsed) {
+    editorGroup.style.width = '0';
+    editorGroup.style.overflow = 'hidden';
+    expandEditorBtn.classList.remove('hidden');
+    splitter.classList.add('hidden');
+  }
 
   // === Parts rail collapse ===
   // Mirrors the editor collapse: hide the rail to reclaim width, leaving a small

--- a/tests/editor-autocomplete.spec.ts
+++ b/tests/editor-autocomplete.spec.ts
@@ -7,6 +7,11 @@ import { test, expect } from 'playwright/test';
 async function openEditor(page: import('playwright/test').Page) {
   await page.addInitScript(() => {
     try { localStorage.setItem('partwright-tour-completed', new Date().toISOString()); } catch { /* ignore */ }
+    // Force the code pane visible: the app now defaults it collapsed when the
+    // AI drawer auto-opens, which would hide .cm-content and break these tests.
+    try {
+      localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({ editorCollapsed: false }));
+    } catch { /* ignore */ }
   });
   await page.goto('/editor');
   await page.waitForSelector('text=Ready', { timeout: 15000 });

--- a/tests/editor-live-errors.spec.ts
+++ b/tests/editor-live-errors.spec.ts
@@ -8,6 +8,11 @@ import { test, expect } from 'playwright/test';
 async function openEditor(page: import('playwright/test').Page) {
   await page.addInitScript(() => {
     try { localStorage.setItem('partwright-tour-completed', new Date().toISOString()); } catch { /* ignore */ }
+    // Force the code pane visible: the app now defaults it collapsed when the
+    // AI drawer auto-opens, which would hide .cm-content and break these tests.
+    try {
+      localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({ editorCollapsed: false }));
+    } catch { /* ignore */ }
   });
   await page.goto('/editor');
   await page.waitForSelector('text=Ready', { timeout: 15000 });

--- a/tests/parts.spec.ts
+++ b/tests/parts.spec.ts
@@ -37,8 +37,16 @@ const cubeAt = (s: number, x: number, marker: string) =>
 
 test.describe('Multi-part sessions', () => {
   // Suppress the first-visit guided tour so its backdrop doesn't intercept clicks.
+  // Also force the code pane visible: the app now defaults it collapsed when
+  // the AI drawer auto-opens, which would zero out the editor pane and hide
+  // #editor-title and #editor-lock-overlay that these tests assert on.
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+    await page.addInitScript(() => {
+      localStorage.setItem('partwright-tour-completed', '1');
+      try {
+        localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({ editorCollapsed: false }));
+      } catch { /* ignore */ }
+    });
   });
 
   test('parts carry independent code and version history', async ({ page }) => {

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -88,6 +88,30 @@ test.describe('AI chat panel', () => {
     await expect(page.getByRole('heading', { name: 'AI Settings' })).toHaveCount(0);
   });
 
+  test('code pane defaults hidden when the AI drawer is open, and respects an explicit Show code', async ({ page }) => {
+    // First visit: drawer opens by default, so the code pane should NOT
+    // compete with it for screen real estate. The "▶ Show code" expand
+    // button only shows when the editor group is collapsed.
+    await page.goto('/editor');
+    await page.waitForSelector('#btn-ai');
+    await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
+    await expect(page.locator('#ai-panel')).toBeVisible();
+    const expandBtn = page.locator('button:has-text("▶ Show code")');
+    await expect(expandBtn).toBeVisible();
+
+    // User opts in to the code pane; that choice must survive a reload even
+    // though the AI drawer is still open.
+    await expandBtn.click();
+    await expect(expandBtn).toBeHidden();
+    await expect(page.locator('.cm-content')).toBeVisible();
+
+    await page.reload();
+    await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
+    await expect(page.locator('#ai-panel')).toBeVisible();
+    await expect(page.locator('button:has-text("▶ Show code")')).toBeHidden();
+    await expect(page.locator('.cm-content')).toBeVisible();
+  });
+
   test('drawer close state persists across reload', async ({ page }) => {
     // The drawer opens by default, but the user's choice is remembered: once
     // they close it, the stored drawerOpen=false keeps it closed on reload.


### PR DESCRIPTION
## Summary

- A first-time visit to `/editor` auto-opens the AI drawer **and** showed the code pane, so two big surfaces split the editor and pushed the viewport into a sliver. With the drawer up by default the code pane shouldn't compete with it.
- New `AiSettings.editorCollapsed: boolean | null` (nullable so we can distinguish "no preference yet" from "user said no"). When `null`, layout defaults the code pane collapsed iff the AI drawer is open.
- Clicking **Hide code** / **Show code** now persists the choice. Returning users who explicitly want code visible see it on every load — even with the AI drawer open. Closing the AI drawer also restores the code pane the next time around (the `null` default falls through to `drawerOpen=false → editor visible`).

## Test plan

- [x] `npm run build`
- [x] `npm run test:unit`
- [ ] `npm run test:e2e` — running on the draft
- [ ] New smoke test `code pane defaults hidden when the AI drawer is open, and respects an explicit Show code` covers the init default and the persisted opt-in across reload
- [ ] Updated `editor-autocomplete`, `editor-live-errors`, and `parts` specs to seed `editorCollapsed: false` so editor-focused tests aren't affected by the new default
- [ ] Manual: fresh visit shows only the AI drawer + viewport with a "▶ Show code" expand chip; click → editor returns; reload → editor stays

---
_Generated by [Claude Code](https://claude.ai/code/session_012AxjQBsRHRGkoKptvhuLgC)_