### PR TITLE
Release: staging → production

### DIFF
--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -98,9 +98,11 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
   standard: {
     vision: { views: true, resolution: 'medium', angles: 'auto' },
     // Paint off by default — color regions lock the editor and are easy
-    // for the model to mis-target. Users who want AI-driven painting
-    // can flip the Paint pill on, or pick the Full preset.
-    scope: { runCode: true, saveVersions: true, paintFaces: false, sessionNotes: true },
+    // for the model to mis-target. Notes off by default — the chat
+    // transcript already records the reasoning, so each addSessionNote
+    // call is a redundant tool round-trip. Users who want either can
+    // flip the pill on, or pick the Full preset.
+    scope: { runCode: true, saveVersions: true, paintFaces: false, sessionNotes: false },
     autoRetry: 1,
     maxIterations: 'high',
     maxSpend: 'medium',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1956,6 +1956,7 @@ async function main() {
     },
     onImportFile: async (file) => { await handleImportFile(file); },
     onImportInboxEntry: handleReimportInboxEntry,
+    onToggleAi: () => { void toggleAiPanelFromToolbar(); },
     onLanguageSwitch: async (lang: 'manifold-js' | 'scad') => {
       if (lang === getActiveLanguage()) return;
       // If current session has work, ask before switching

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -27,6 +27,8 @@ export interface ToolbarCallbacks {
   onImportInboxEntry: (entry: ImportInboxEntry) => void | Promise<void>;
   onLanguageSwitch: (lang: 'manifold-js' | 'scad') => void;
   onGoHome: () => void;
+  /** Toggle the AI chat drawer — drives the prominent "Use AI" button in the toolbar. */
+  onToggleAi: () => void;
 }
 
 /** Update the unseen-error badge count on the diagnostics rail button.
@@ -49,25 +51,34 @@ export type AiToolbarMode = 'disconnected' | 'cloud' | 'local';
  *  connected; Local = a local WebGPU model is configured; Disconnected =
  *  neither, so clicking opens the connect flow. */
 export function setAiToolbarState(mode: AiToolbarMode | boolean): void {
-  // The AI control now lives in the activity rail (id `btn-ai`) as a labeled
-  // item with a small connection-status dot. Update the dot colour + title.
-  const dot = document.getElementById('ai-status-dot');
-  const btn = document.getElementById('btn-ai');
-  if (!dot || !btn) return;
+  // Two entry points share the same status: the activity-rail item (id
+  // `btn-ai`, label "AI") and the prominent toolbar button (id
+  // `btn-ai-toolbar`, label "Use AI"). Each has its own status-dot span; we
+  // sync title + dot colour on both so they always agree.
+  const railDot = document.getElementById('ai-status-dot');
+  const railBtn = document.getElementById('btn-ai');
+  const toolbarDot = document.getElementById('ai-toolbar-status-dot');
+  const toolbarBtn = document.getElementById('btn-ai-toolbar');
   // Tolerate the legacy boolean caller signature so an old import doesn't
   // crash at runtime.
   const actual: AiToolbarMode = typeof mode === 'boolean' ? (mode ? 'cloud' : 'disconnected') : mode;
   const base = 'w-1.5 h-1.5 rounded-full shrink-0 ';
+  let dotClass: string;
+  let title: string;
   if (actual === 'cloud') {
-    dot.className = base + 'bg-blue-400';
-    btn.title = 'AI chat — hosted Claude connected. Click to open.';
+    dotClass = base + 'bg-blue-400';
+    title = 'AI chat — hosted Claude connected. Click to open.';
   } else if (actual === 'local') {
-    dot.className = base + 'bg-emerald-400';
-    btn.title = 'AI chat — local WebGPU model. Click to open.';
+    dotClass = base + 'bg-emerald-400';
+    title = 'AI chat — local WebGPU model. Click to open.';
   } else {
-    dot.className = base + 'bg-zinc-500';
-    btn.title = 'AI chat — not connected. Click to connect an API key or local model.';
+    dotClass = base + 'bg-zinc-500';
+    title = 'AI chat — not connected. Click to connect an API key or local model.';
   }
+  if (railDot) railDot.className = dotClass;
+  if (railBtn) railBtn.title = title;
+  if (toolbarDot) toolbarDot.className = dotClass;
+  if (toolbarBtn) toolbarBtn.title = title;
 }
 
 /** File extensions accepted by the Import button and drag-and-drop. */
@@ -199,6 +210,29 @@ export function createToolbar(
   const spacer = document.createElement('div');
   spacer.className = 'flex-1';
   toolbar.appendChild(spacer);
+
+  // Use AI — primary entry point to the chat drawer. The activity rail also
+  // has a "✦ AI" item, but on mobile it lives in a horizontally-scrollable
+  // strip and is easy to miss; this toolbar button is always visible and
+  // styled with an indigo accent so it catches the eye while still fitting
+  // the zinc toolbar palette. Id is `btn-ai-toolbar` to avoid colliding with
+  // the rail's existing `#btn-ai` (which tests and the tour both reference).
+  const aiToolbarBtn = document.createElement('button');
+  aiToolbarBtn.id = 'btn-ai-toolbar';
+  const aiBase = 'flex items-center gap-1.5 px-3 py-1.5 md:px-2.5 md:py-1 rounded text-xs font-semibold transition-colors border ml-2';
+  const aiIdle = `${aiBase} bg-indigo-500/15 border-indigo-500/40 text-indigo-200 [@media(hover:hover)]:hover:bg-indigo-500/25 [@media(hover:hover)]:hover:text-indigo-100`;
+  const aiOpen = `${aiBase} bg-indigo-500/30 border-indigo-500/70 text-indigo-50 [@media(hover:hover)]:hover:bg-indigo-500/35`;
+  aiToolbarBtn.className = aiIdle;
+  aiToolbarBtn.title = 'AI chat — not connected. Click to connect an API key or local model.';
+  aiToolbarBtn.setAttribute('aria-label', 'Open AI chat panel');
+  aiToolbarBtn.innerHTML = '<span id="ai-toolbar-status-dot" class="w-1.5 h-1.5 rounded-full shrink-0 bg-zinc-500"></span><span class="text-sm leading-none" aria-hidden="true">✦</span><span>Use AI</span>';
+  aiToolbarBtn.addEventListener('click', callbacks.onToggleAi);
+  window.addEventListener('ai-panel-toggled', (e) => {
+    const open = !!(e as CustomEvent).detail?.open;
+    aiToolbarBtn.className = open ? aiOpen : aiIdle;
+    aiToolbarBtn.setAttribute('aria-pressed', String(open));
+  });
+  toolbar.appendChild(aiToolbarBtn);
 
   // Catalog — navigates to /catalog where premade sessions are browsed.
   // (Catalog moved to the activity rail's utility group \u2014 see createLayout.)
@@ -504,8 +538,6 @@ export function createToolbar(
   });
 
   toolbar.appendChild(exportWrapper);
-
-  // (The AI chat toggle lives in the activity rail — see createLayout.)
 
   // Dark mode toggle — text button, on by default, off when clicked
   const themeBtn = document.createElement('button');

--- a/tests/generate-scad-catalog-entries.spec.ts
+++ b/tests/generate-scad-catalog-entries.spec.ts
@@ -70,9 +70,12 @@ test.describe.serial('generate SCAD catalog entries', () => {
   });
 
   // SCAD WASM (~10MB) + BOSL2 import + threaded-rod / gear-tooth math can
-  // easily push a single compile past the default 30s timeout. Give each
-  // generation a generous 180s.
-  test.setTimeout(180_000);
+  // easily push a single compile past the default 30s timeout. The engine
+  // itself allots 180s for a SCAD execute (see EXECUTE_TIMEOUT_MS), and the
+  // test does goto + waitForEngine + setActiveLanguage + thumbnail/export on
+  // top of that, so give the test a comfortable margin above the engine
+  // ceiling rather than racing it.
+  test.setTimeout(300_000);
 
   for (const entry of newEntries) {
     test(`build ${entry.catalogFile}`, async ({ page }) => {
@@ -85,26 +88,22 @@ test.describe.serial('generate SCAD catalog entries', () => {
       await page.goto('/editor');
       await waitForEngine(page);
 
-      // Switch to SCAD via the language toggle. SCAD WASM is heavy so this
-      // first switch can take ~10s on a fresh page. Confirm any dialog that
-      // pops up about discarding state.
-      page.on('dialog', d => d.accept());
-      await page.locator('#lang-toggle button:has-text("SCAD")').click();
-      // Re-wait for partwright after the engine swap, then give SCAD a moment
-      // to spin up before issuing the first compile.
-      await page.waitForFunction(
-        () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
-        { timeout: 30_000 },
-      );
-      await page.waitForTimeout(2_000);
-
+      // Switch to SCAD via the partwright API rather than the UI toggle so the
+      // active language flip and the SCAD-WASM init are deterministically
+      // awaited before runAndSave fires. The toolbar click hands off to an
+      // async handler that isn't awaited by Playwright; on a slow CI runner
+      // the wait that followed wasn't long enough for activeLanguage to land
+      // on 'scad', and runAndSave then executed under the manifold-js 60s
+      // timeout ceiling against a BOSL2 compile that needs ~50s on its own.
       const payload = await page.evaluate(async ({ code, name }) => {
         const pw = (window as unknown as { partwright: {
-          createSession: (n: string, lang?: string) => Promise<unknown>;
+          setActiveLanguage: (lang: 'manifold-js' | 'scad') => Promise<void>;
+          createSession: (n: string) => Promise<unknown>;
           runAndSave: (c: string, label?: string, a?: unknown) => Promise<unknown>;
           exportSessionData: (id?: string, opts?: { includeThumbnails?: boolean }) => Promise<{ data?: unknown; error?: string }>;
         } }).partwright;
-        await pw.createSession(name, 'scad');
+        await pw.setActiveLanguage('scad');
+        await pw.createSession(name);
         // Don't enforce maxComponents — some SCAD models in this batch are
         // intentionally multi-part (hex bolt + nut + washer is 3 pieces laid
         // out side-by-side, the gear pair has 2 free gears on a plate, etc.).


### PR DESCRIPTION
## Summary

Promote the current known-good `staging` (commit `6e9ae3b`) to `production`. Staging has passed the post-merge gate (build + unit + e2e) for all included changes.

## Included changes

- **feat: add prominent "Use AI" button to top toolbar** (#260) — surfaces the chat drawer entry point on mobile where the activity rail was easy to miss.
- **feat: disable AI session notes by default in standard preset** (#261) — drops a redundant per-turn tool round-trip; existing users keep their saved toggle values.
- **fix: drop SCAD catalog test's UI-click language race** (#262) — switches the test to `partwright.setActiveLanguage` and lifts the per-test timeout, removing a flaky staging-gate failure.

## Test plan

- [x] Staging gate green on `6e9ae3b` (build + unit + e2e)
- [ ] Validate `staging.mainifold.pages.dev` before merging
- [ ] After merge, confirm `www.partwrightstudio.com` deploys cleanly


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9eFQFsbH3eaCxfqkKJ9Zw)_