### PR TITLE
fix: keep Ready status indicator visible when code pane is collapsed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ After any changes that touch routing, Vite config, index.html, or initialization
 
 1. **Landing page**: Navigate to `http://localhost:5173/` — should show the hero section ("Partwright", "AI-driven parametric CAD in your browser"), CTA buttons, and a Recent Sessions grid (or empty state).
 2. **Open Editor**: Click "Open Editor" on the landing page — URL should change to `/editor`, status should show "Ready" (green), the code editor should appear on the left with a default example, and a 3D model should render in the viewport on the right.
-3. **WASM engine loads**: The status indicator (between editor header and tabs) should say "Ready" in green, NOT "Loading WASM..." or "WASM failed". If it shows "WASM failed", check:
+3. **WASM engine loads**: The status indicator (small pill in the top-left of the viewport) should say "Ready" in green, NOT "Loading WASM..." or "WASM failed". If it shows "WASM failed", check:
    - `coi-serviceworker.js` loads without 404 (check Network tab)
    - `manifold.wasm` loads without 403 (check Network tab) — if 403, check `server.fs.strict` in vite.config.ts
    - COEP/COOP headers are present on responses (check Response Headers)

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -95,9 +95,12 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
 
   const statusBar = document.createElement('span');
   statusBar.id = 'status-indicator';
-  statusBar.className = 'text-xs text-emerald-400 font-mono shrink-0';
+  // Lives on rightPane (appended below) as an always-visible overlay so engine
+  // status stays on screen even when the code pane is collapsed — otherwise
+  // tests and users lose the Ready/Loading signal whenever the AI drawer hides
+  // the editor header.
+  statusBar.className = 'absolute top-2 left-2 z-20 text-xs text-emerald-400 font-mono bg-zinc-900/70 px-2 py-0.5 rounded border border-zinc-700 pointer-events-none';
   statusBar.textContent = 'Ready';
-  editorHeader.appendChild(statusBar);
 
   const collapseEditorBtn = document.createElement('button');
   collapseEditorBtn.className = 'shrink-0 px-2 py-0.5 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700 text-xs leading-none border border-transparent hover:border-zinc-600';
@@ -159,6 +162,7 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   // === Right (or bottom on mobile): viewport + tab panes ===
   const rightPane = document.createElement('div');
   rightPane.className = 'flex-1 flex flex-col min-w-0 min-h-0 relative';
+  rightPane.appendChild(statusBar);
 
   const tabInteractive = createRailItem('Interactive', '3D View', '\ud83e\uddca', true);
   tabInteractive.title = 'Live 3D viewport \u2014 orbit, zoom, and inspect';


### PR DESCRIPTION
## Summary

Fixes the e2e regression that landed with #263 ("hide code pane by default when AI drawer is open"). After that change, fresh `/editor` loads default `editorCollapsed: true` (because `aiSettings.drawerOpen: true` is the default — see `src/ai/settings.ts:140-141`), and the `editorGroup` is collapsed to `width: 0; overflow: hidden`. The `#status-indicator` lived inside `editorHeader` (a child of `editorPane` inside `editorGroup`), so it disappeared along with the rest of the code pane.

That breaks two things:
- **UX:** users without the code pane visible lose any signal about engine state (loading WASM, ready, running, error).
- **E2E suite:** 37 test files do `await page.goto('/editor'); await page.waitForSelector('text=Ready', …)` as the canonical "wait for engine ready" step. `waitForSelector` defaults to `state: 'visible'`, and the element is now hidden by an ancestor with `width: 0; overflow: hidden`. Every one of those tests fails on a fresh browser context.

Confirmed in the wild on the in-flight CI for #265 (which only touches CI yaml + markdown, so its e2e shouldn't be affected by anything in the PR): all 3 shards failed at `tests/render-color-readability.spec.ts:70` with the message `locator resolved to hidden <span ...>Ready</span>`. The `staging` branch is also stuck at `6e9ae3b` (PR #262) while `main` is at `3526846` (#263), meaning the staging-gate after #263 already failed on the same regression.

## Fix

Move the status indicator out of `editorHeader` and onto `rightPane` as an absolutely-positioned overlay (top-left, small dark pill). `rightPane` is always present (it hosts every tab — interactive viewport, gallery, versions, etc.) and never collapses, so the indicator stays visible whether the code pane is shown or hidden, and across all tabs. `pointer-events-none` so it can't intercept clicks on viewport controls underneath.

CLAUDE.md's smoke-test note (#3 under "Smoke Test — Verifying the App Works") updated to describe the new location.

## Test plan

- [x] `npm run build` clean.
- [x] `npm run test:unit` — 86/86 pass.
- [x] Local Playwright run of representative affected specs all pass: `tests/render-color-readability.spec.ts` (3/3), `tests/paint-coverage.spec.ts` (2/2), `tests/multi-tab-lock.spec.ts` (1/1).
- [ ] CI build + unit goes green.
- [ ] After flipping to ready: all 3 e2e shards green (this is the real verification — the fix should restore the whole suite).

https://claude.ai/code/session_01MRoHgoCjLzuUoS6PKGGikx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRoHgoCjLzuUoS6PKGGikx)_