### PR TITLE
fix: don't yank AI transcript back to bottom while user scrolls up

### DIFF
--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -143,6 +143,22 @@ let forwardBtnRef: HTMLButtonElement | null = null;
 let drawerEl: HTMLElement | null = null;
 let transcriptEl: HTMLElement | null = null;
 let inputEl: HTMLTextAreaElement | null = null;
+
+/** "Stuck to bottom" detection for the transcript. The auto-scroll on every
+ *  streamed delta used to fight the user when they scrolled up to read earlier
+ *  content. The fix is to measure pinned-ness *before* mutating content (since
+ *  appending text grows scrollHeight and would otherwise un-pin a user who was
+ *  at the bottom), then only re-pin to bottom if they were already there. The
+ *  threshold gives leeway for sub-pixel rounding and inertial scrolling. */
+const STICKY_BOTTOM_THRESHOLD_PX = 24;
+function isTranscriptPinnedToBottom(): boolean {
+  if (!transcriptEl) return true;
+  return transcriptEl.scrollHeight - transcriptEl.scrollTop - transcriptEl.clientHeight <= STICKY_BOTTOM_THRESHOLD_PX;
+}
+function pinTranscriptToBottom(): void {
+  if (!transcriptEl) return;
+  transcriptEl.scrollTop = transcriptEl.scrollHeight;
+}
 let pendingImagesEl: HTMLElement | null = null;
 let toggleStripEl: HTMLElement | null = null;
 let costMeterEl: HTMLElement | null = null;
@@ -251,6 +267,9 @@ export async function setActiveSession(sessionId: string | null): Promise<void> 
   await loadHistoryForCurrentSession();
   await applySessionAiPreference();
   renderTranscript();
+  // Session switch is an explicit user action — land at the bottom regardless
+  // of where they were scrolled in the previous session's transcript.
+  pinTranscriptToBottom();
   renderCostMeter();
 }
 
@@ -1372,6 +1391,9 @@ function formatDuration(ms: number): string {
 
 function renderTranscript(): void {
   if (!transcriptEl) return;
+  // Measure before replaceChildren — clearing children clamps scrollTop, so
+  // any post-clear check would mis-report the user's intent.
+  const pinned = isTranscriptPinnedToBottom();
   transcriptEl.replaceChildren();
   const hasHistory = state.history.length > 0;
   const hasQueue = state.queuedBlocks.length > 0;
@@ -1395,7 +1417,7 @@ function renderTranscript(): void {
   if (hasQueue) {
     transcriptEl.appendChild(renderQueuedPreview());
   }
-  transcriptEl.scrollTop = transcriptEl.scrollHeight;
+  if (pinned) pinTranscriptToBottom();
 }
 
 function renderQueuedPreview(): HTMLElement {
@@ -2209,6 +2231,10 @@ async function sendMessage(): Promise<void> {
   state.rewindStack = [];
   progressState.retryCount = 0;
   stalledByWatchdog = false;
+  // Hitting send is an explicit "follow the new turn" gesture — re-pin to
+  // bottom so the user's own bubble and the streamed reply are visible even
+  // if they had been scrolled up reading earlier history.
+  pinTranscriptToBottom();
   await runTurnWithStallRetry(apiKey, settings.toggles, blocks);
 }
 
@@ -2343,11 +2369,13 @@ async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatTo
       },
       onAssistantText: delta => {
         if (liveTextEl) {
+          const pinned = isTranscriptPinnedToBottom();
           liveTextEl.textContent = (liveTextEl.textContent ?? '') + delta;
-          if (transcriptEl) transcriptEl.scrollTop = transcriptEl.scrollHeight;
+          if (pinned) pinTranscriptToBottom();
         }
       },
       onAssistantThinking: delta => {
+        const pinned = isTranscriptPinnedToBottom();
         if (!liveThinkingEl) {
           const wrapEl = (liveTextEl?.parentElement
             ?? transcriptEl?.querySelector(`[data-message-id="${activeAssistantId}"]`)) as HTMLElement | null;
@@ -2360,9 +2388,12 @@ async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatTo
         const body = liveThinkingEl.querySelector('[data-thinking-body]') as HTMLElement | null;
         if (body) {
           body.textContent = (body.textContent ?? '') + delta;
+          // The thinking box's inner <pre> (max-h-32) is its own scroll
+          // container — keep it pinned so the latest reasoning tokens stay
+          // visible inside the bubble itself.
           body.scrollTop = body.scrollHeight;
         }
-        if (transcriptEl) transcriptEl.scrollTop = transcriptEl.scrollHeight;
+        if (pinned) pinTranscriptToBottom();
       },
       onProgress: info => {
         // The next step has begun — fold the live thinking preview into its

--- a/tests/chat-export.spec.ts
+++ b/tests/chat-export.spec.ts
@@ -106,7 +106,7 @@ test.describe('Chat export', () => {
         chat?: { id?: string; sessionId?: string; blocks: { type: string; text?: string }[] }[];
       };
     }, id);
-    expect(exported.partwright).toBe('1.7');
+    expect(exported.partwright).toBe('1.8');
     expect(exported.chat?.length).toBe(3);
     expect(exported.chat?.[0].blocks[0].text).toBe('Design a widget bracket');
     expect(exported.chat?.[0].id).toBeUndefined();


### PR DESCRIPTION
## Summary

The AI panel auto-scrolled to the bottom on every streamed text or thinking delta, which fought the user when they scrolled up to re-read earlier conversation — every new token snapped them back down.

Switched to a **sticky-bottom** behavior: measure pinned-ness (within 24 px of the bottom) *before* mutating content, and only re-pin if the user was already there. Once they scroll back down to the bottom, the next delta naturally re-engages the pin — so the panel "locks back in place" exactly as requested.

- New helpers `isTranscriptPinnedToBottom()` / `pinTranscriptToBottom()` in `src/ui/aiPanel.ts`.
- Three auto-scroll sites converted: `renderTranscript()`, `onAssistantText`, `onAssistantThinking`.
- The thinking bubble's inner `<pre>` (its own `max-h-32` scroll container) still auto-pins so the latest reasoning tokens stay visible inside the bubble.
- Measurement happens *before* `replaceChildren` / `textContent` mutation, because appending text grows `scrollHeight` and would otherwise un-pin a user who was at the bottom.
- Explicit user actions still force-scroll to bottom so the user always sees their own message land: `sendMessage()` and `setActiveSession()`.

### Incidental: fix a stale e2e assertion

`tests/chat-export.spec.ts:109` expected `partwright === '1.7'` but `SCHEMA_VERSION` was bumped to `'1.8'` in commit `286d6f9 feat: per-version modeling language`. The test was failing on `main` already; bumped the assertion so the staging gate runs clean after this merges.

## Test plan

- [x] `npm run build` — green
- [x] `npm run test:unit` — 95/95 passing
- [x] `npm run test:e2e` — 230/230 passing locally (after the stale-assertion fix)
- [x] Automated review pass over the diff — clean
- [x] PR-checks CI (build + unit) — green on f7e28de
- [x] Cloudflare Pages preview — green at https://claude-upbeat-tesla-cz05y.mainifold.pages.dev
- [ ] Manual: open AI panel, send a long-running prompt, scroll up mid-stream — transcript stays put
- [ ] Manual: scroll back to bottom mid-stream — next delta re-pins
- [ ] Manual: scroll up, hit Send — new user bubble + streamed reply visible (force-scroll override)
- [ ] Manual: scroll up, switch sessions — new session opens at bottom (force-scroll override)
- [ ] Manual: thinking bubble streams while user is scrolled up — transcript stays put, inner thinking `<pre>` still auto-scrolls
