### PR TITLE
feat: list api.label features in the paint panel with hover-to-highlight

### DIFF
--- a/src/color/labels.ts
+++ b/src/color/labels.ts
@@ -7,6 +7,12 @@ export interface LabelInfo {
   name: string;
   triangleCount: number;
   triangles: Set<number>;
+  /** Largest triangle id in the set, so hover-preview consumers can cheaply
+   *  bounds-check against the currently-displayed paint mesh. Labels are
+   *  built against the run's *base* mesh; if smooth paint refinement later
+   *  inflates that mesh, indexing base ids into the refined mesh produces
+   *  wrong-region highlights. -1 when the set is empty. */
+  maxTriId: number;
 }
 
 let labels: LabelInfo[] = [];
@@ -15,7 +21,11 @@ const listeners: (() => void)[] = [];
 export function setPaintLabels(map: Map<string, Set<number>> | null): void {
   labels = map
     ? [...map.entries()]
-        .map(([name, triangles]) => ({ name, triangleCount: triangles.size, triangles }))
+        .map(([name, triangles]) => {
+          let maxTriId = -1;
+          for (const t of triangles) if (t > maxTriId) maxTriId = t;
+          return { name, triangleCount: triangles.size, triangles, maxTriId };
+        })
         .sort((a, b) => a.name.localeCompare(b.name))
     : [];
   for (const fn of listeners) fn();

--- a/src/color/labels.ts
+++ b/src/color/labels.ts
@@ -1,0 +1,30 @@
+// Per-run snapshot of named labels (assigned via `api.label(shape, name)` in
+// user code) and the triangle sets they cover. Mirrors `currentLabelMap` in
+// main.ts so the paint UI can render a labels list without reaching across
+// modules. Refreshed after every successful run; cleared otherwise.
+
+export interface LabelInfo {
+  name: string;
+  triangleCount: number;
+  triangles: Set<number>;
+}
+
+let labels: LabelInfo[] = [];
+const listeners: (() => void)[] = [];
+
+export function setPaintLabels(map: Map<string, Set<number>> | null): void {
+  labels = map
+    ? [...map.entries()]
+        .map(([name, triangles]) => ({ name, triangleCount: triangles.size, triangles }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+    : [];
+  for (const fn of listeners) fn();
+}
+
+export function getPaintLabels(): LabelInfo[] {
+  return labels;
+}
+
+export function onPaintLabelsChange(cb: () => void): void {
+  listeners.push(cb);
+}

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -6,6 +6,7 @@ import {
   deactivate,
   isActive,
   setColor,
+  getColor,
   setTool,
   getTool,
   setBucketTolerance,
@@ -56,7 +57,9 @@ import {
   clearRegions,
   removeRegion,
   setRegionVisibility,
+  addRegion,
 } from './regions';
+import { getPaintLabels, onPaintLabelsChange, type LabelInfo } from './labels';
 import { forceDeactivate as forceDeactivateAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as forceDeactivateAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as forceDeactivateAnnotateSelect } from '../annotations/selectMode';
@@ -300,6 +303,20 @@ function createPickerPanel(): HTMLElement {
   // === Box tool controls ===
   boxControls = createBoxControls();
   content.appendChild(boxControls);
+
+  // === Labels list ===
+  // Surfaces the named features `api.label(shape, name)` registered in the
+  // current run. Hovering a row highlights the label's triangles on the model
+  // (same translucent overlay the regions list uses); clicking paints them
+  // with the active color via a byLabel descriptor — identical to what
+  // `partwright.paintByLabel` produces from a script.
+  const labelList = document.createElement('div');
+  labelList.id = 'paint-label-list';
+  labelList.className = 'mt-2 border-t border-zinc-700 pt-2';
+  content.appendChild(labelList);
+  updateLabelList(labelList);
+  onPaintLabelsChange(() => updateLabelList(labelList));
+  onRegionsChange(() => updateLabelList(labelList));
 
   // === Region list ===
   // Flows inside the single scroll area; the sticky footer keeps the actions
@@ -1198,6 +1215,114 @@ function updateActiveSwatch(grid: HTMLElement, activeSwatch: HTMLElement): void 
     (child as HTMLElement).classList.remove('border-white/80', 'ring-1', 'ring-white/30');
   }
   activeSwatch.classList.add('border-white/80', 'ring-1', 'ring-white/30');
+}
+
+function updateLabelList(container: HTMLElement): void {
+  const labels = getPaintLabels();
+  container.innerHTML = '';
+
+  const header = document.createElement('div');
+  header.className = 'flex items-center justify-between mb-1';
+  const headerLabel = document.createElement('div');
+  headerLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider font-medium';
+  headerLabel.textContent = 'Labels';
+  header.appendChild(headerLabel);
+  if (labels.length > 0) {
+    const count = document.createElement('span');
+    count.className = 'text-[10px] text-zinc-600 tabular-nums';
+    count.textContent = String(labels.length);
+    header.appendChild(count);
+  }
+  container.appendChild(header);
+
+  if (labels.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'text-[10px] text-zinc-500 leading-snug';
+    empty.innerHTML = 'No labels in this run. Wrap features with <code class="px-1 py-0.5 rounded bg-zinc-900/60 text-zinc-300 text-[10px]">api.label(shape, "name")</code> in your code to get clickable labelled regions here.';
+    container.appendChild(empty);
+    return;
+  }
+
+  // Which labels are already painted, so the row can show a "painted" hint
+  // instead of pretending nothing's there. A label may be painted multiple
+  // times (e.g. a different color over the same area); we only need to know
+  // that *something* paints it.
+  const paintedLabels = new Set<string>();
+  for (const r of getRegions()) {
+    if (r.descriptor.kind === 'byLabel') paintedLabels.add(r.descriptor.label);
+  }
+
+  for (const label of labels) {
+    container.appendChild(createLabelRow(label, paintedLabels.has(label.name)));
+  }
+}
+
+function createLabelRow(label: LabelInfo, alreadyPainted: boolean): HTMLElement {
+  const row = document.createElement('div');
+  row.className = 'flex items-center gap-1.5 py-0.5 group rounded px-1 -mx-1 hover:bg-zinc-700/40 transition-colors cursor-pointer';
+  row.dataset.labelName = label.name;
+  row.title = alreadyPainted
+    ? `Paint label "${label.name}" again with the current color`
+    : `Paint label "${label.name}" with the current color`;
+
+  // Hover-to-highlight: render a 40%-opacity overlay over the label's triangles
+  // in the current paint color. The user can preview which region a click will
+  // paint before committing. Teardown on mouseleave so nothing sticks if the
+  // user moves away without clicking.
+  let releaseHover: (() => void) | null = null;
+  row.addEventListener('mouseenter', () => {
+    if (label.triangles.size === 0) return;
+    releaseHover = previewTriangles(label.triangles, getColor());
+  });
+  row.addEventListener('mouseleave', () => {
+    if (releaseHover) { releaseHover(); releaseHover = null; }
+  });
+
+  row.addEventListener('click', () => {
+    if (label.triangles.size === 0) return;
+    if (releaseHover) { releaseHover(); releaseHover = null; }
+    // Clone the triangle set so later region edits don't mutate the label
+    // snapshot. byLabel descriptor matches what partwright.paintByLabel emits,
+    // so re-hydration on session reload goes through the same resolve path.
+    addRegion(
+      label.name,
+      [...getColor()] as [number, number, number],
+      'paintbrush',
+      { kind: 'byLabel', label: label.name },
+      new Set(label.triangles),
+    );
+  });
+
+  const dot = document.createElement('span');
+  dot.className = 'w-3 h-3 rounded-sm shrink-0 border border-zinc-600/60';
+  if (alreadyPainted) {
+    // Show the most recently-applied color for this label so the user can
+    // distinguish "blue eye" from "red eye" at a glance.
+    const last = [...getRegions()].reverse().find(r => r.descriptor.kind === 'byLabel' && r.descriptor.label === label.name);
+    if (last) dot.style.backgroundColor = rgbToCSS(last.color);
+  }
+
+  const nameEl = document.createElement('span');
+  nameEl.className = 'text-[11px] truncate flex-1 text-zinc-300';
+  nameEl.textContent = label.name;
+
+  const count = document.createElement('span');
+  count.className = 'text-[10px] text-zinc-600 tabular-nums';
+  count.textContent = `${label.triangleCount}△`;
+
+  row.appendChild(dot);
+  row.appendChild(nameEl);
+  row.appendChild(count);
+
+  if (alreadyPainted) {
+    const badge = document.createElement('span');
+    badge.className = 'shrink-0 text-[10px] text-emerald-400 leading-none';
+    badge.textContent = '✓';
+    badge.title = 'Already painted (click to paint again with the current color)';
+    row.appendChild(badge);
+  }
+
+  return row;
 }
 
 function updateRegionList(container: HTMLElement): void {

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -38,6 +38,7 @@ import {
   setSlabAxis,
   getSlabAxis,
   previewTriangles,
+  getCurrentMesh as getPaintMesh,
   type PaintTool,
   type BrushShape,
 } from './paintMode';
@@ -1217,8 +1218,23 @@ function updateActiveSwatch(grid: HTMLElement, activeSwatch: HTMLElement): void 
   activeSwatch.classList.add('border-white/80', 'ring-1', 'ring-white/30');
 }
 
+// Active hover-release closure for the labels list. Releasing it inside
+// `updateLabelList` before `innerHTML = ''` matters: if a fresh run fires
+// `setPaintLabels` while the user's pointer is over a row, the row DOM is
+// destroyed before its `mouseleave` handler can run, and the THREE highlight
+// mesh would otherwise stay parented to the viewport until the next preview.
+let activeLabelHoverRelease: (() => void) | null = null;
+
+function releaseLabelHover(): void {
+  if (activeLabelHoverRelease) {
+    activeLabelHoverRelease();
+    activeLabelHoverRelease = null;
+  }
+}
+
 function updateLabelList(container: HTMLElement): void {
   const labels = getPaintLabels();
+  releaseLabelHover();
   container.innerHTML = '';
 
   const header = document.createElement('div');
@@ -1265,25 +1281,30 @@ function createLabelRow(label: LabelInfo, alreadyPainted: boolean): HTMLElement 
     ? `Paint label "${label.name}" again with the current color`
     : `Paint label "${label.name}" with the current color`;
 
-  // Hover-to-highlight: render a 40%-opacity overlay over the label's triangles
-  // in the current paint color. The user can preview which region a click will
-  // paint before committing. Teardown on mouseleave so nothing sticks if the
-  // user moves away without clicking.
-  let releaseHover: (() => void) | null = null;
+  // Hover-to-highlight: render a 40%-opacity overlay over the label's
+  // triangles in the current paint color so the user can preview which
+  // region a click will paint. Skip the preview entirely when the active
+  // paint mesh has been refined past the label's index range — labels are
+  // built against the run's base mesh, and `paintByLabel`'s commit path
+  // remaps to refined ids via `parentToChildren`, but `previewTriangles`
+  // doesn't, so indexing raw base ids into a refined mesh would highlight
+  // the wrong triangles. Bounds-check via the pre-computed `maxTriId`.
   row.addEventListener('mouseenter', () => {
     if (label.triangles.size === 0) return;
-    releaseHover = previewTriangles(label.triangles, getColor());
+    const mesh = getPaintMesh();
+    if (!mesh || label.maxTriId >= mesh.numTri) return;
+    releaseLabelHover();
+    activeLabelHoverRelease = previewTriangles(label.triangles, getColor());
   });
-  row.addEventListener('mouseleave', () => {
-    if (releaseHover) { releaseHover(); releaseHover = null; }
-  });
+  row.addEventListener('mouseleave', releaseLabelHover);
 
   row.addEventListener('click', () => {
     if (label.triangles.size === 0) return;
-    if (releaseHover) { releaseHover(); releaseHover = null; }
+    releaseLabelHover();
     // Clone the triangle set so later region edits don't mutate the label
     // snapshot. byLabel descriptor matches what partwright.paintByLabel emits,
-    // so re-hydration on session reload goes through the same resolve path.
+    // so re-hydration on session reload goes through the same resolve path
+    // — including refined-mesh remapping via `parentToChildren`.
     addRegion(
       label.name,
       [...getColor()] as [number, number, number],

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,6 +120,7 @@ import { setColor as setAnnotateColor, setWidth as setAnnotateWidth, getWidth as
 import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontSize as getAnnotateFontSize } from './annotations/textMode';
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
 import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, setRegionTriangles, buildTriColors, createEmptyTriColors, overlayPainted, type SerializedColorRegion, type RegionDescriptor } from './color/regions';
+import { setPaintLabels } from './color/labels';
 import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as getPaintBucketTolerance, setBrushRadius as setPaintBrushRadius, getBrushRadius as getPaintBrushRadius, setBrushSmooth as setPaintBrushSmooth, isBrushSmooth as isPaintBrushSmooth, setBrushSmoothDivisor as setPaintBrushSmoothDivisor, getBrushSmoothDivisor as getPaintBrushSmoothDivisor, setBrushSurface as setPaintBrushSurface, getBrushSurface as getPaintBrushSurface, setBrushPaintDepth as setPaintBrushDepth, getBrushPaintDepth as getPaintBrushDepth, SMOOTH_DIVISOR_MIN, SMOOTH_DIVISOR_MAX } from './color/paintMode';
 import { buildStrokeMesh, buildRefinedMesh, brushRefineRegion, strokeFootprintTriangles, deriveSampleNormals, buildGeodesicField, tangentBasis, childrenByParent, type BrushStroke, type BrushShape, type RefineRegion } from './color/subdivide';
 import { refineInWorker, SubdivisionAbortError, terminateSubdivisionWorker } from './color/subdivisionClient';
@@ -7650,6 +7651,7 @@ async function main() {
       // region descriptors look up their triangles here; rehydrating a
       // saved version re-runs the code first, which rebuilds the map.
       currentLabelMap = result.labelMap ?? null;
+      setPaintLabels(currentLabelMap);
 
       // Apply any existing color regions to the mesh. Refining regions —
       // smooth brush strokes AND smooth slab/box regions — subdivide the mesh:

--- a/tests/paint-labels-panel.spec.ts
+++ b/tests/paint-labels-panel.spec.ts
@@ -1,0 +1,94 @@
+// Verifies the labels list in the paint panel:
+//   1. After running code that calls api.label(...), the labels section in the
+//      open paint panel lists each label with its triangle count.
+//   2. Clicking a label row paints it — the resulting region uses a byLabel
+//      descriptor and the same triangle set the AI's paintByLabel produces,
+//      so re-hydration goes through the same code path.
+//   3. Unlabeled code surfaces the empty-state hint instead of a blank section.
+//
+// Uses `dispatchEvent('click')` to dodge the first-paint onboarding backdrop.
+
+import { test, expect } from 'playwright/test';
+
+async function openEditorWithCode(page: import('playwright/test').Page, code: string) {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  await page.evaluate(async (src) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.run(src);
+  }, code);
+}
+
+test.describe('paint labels panel', () => {
+  test('lists labels from the current run and paints on click', async ({ page }) => {
+    // Eye sticks out of the head by ~2 units so it has visible surface
+    // triangles after boolean union — `paintByLabel` returns 0 triangles if
+    // the labelled feature is fully buried.
+    await openEditorWithCode(page, `
+      const { Manifold } = api;
+      const head = api.label(Manifold.sphere(20, 32), 'head');
+      const eye = api.label(Manifold.sphere(5, 16).translate([-8, 14, 5]), 'eye');
+      return head.add(eye);
+    `);
+
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    const labelList = page.locator('#paint-label-list');
+    await expect(labelList).toBeVisible();
+    // Header + row for each label
+    await expect(labelList.locator('text=Labels')).toBeVisible();
+    const rows = labelList.locator('[data-label-name]');
+    await expect(rows).toHaveCount(2);
+    await expect(labelList.locator('[data-label-name="head"]')).toBeVisible();
+    await expect(labelList.locator('[data-label-name="eye"]')).toBeVisible();
+
+    // Click the eye label — should create a byLabel region with the eye's
+    // triangle set. The triangle count must match what listLabels reports
+    // for that name (the snapshot is the source of truth for both).
+    const expectedTris = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const labels: { name: string; triangleCount: number }[] = pw.listLabels().labels;
+      return labels.find(l => l.name === 'eye')?.triangleCount ?? 0;
+    });
+    expect(expectedTris).toBeGreaterThan(0);
+
+    await labelList.locator('[data-label-name="eye"]').dispatchEvent('click');
+
+    // Wait for the new region to land in #paint-region-list (one row).
+    const regionRows = page.locator('#paint-region-list [data-region-id]');
+    await expect(regionRows).toHaveCount(1);
+    // Region name matches the label.
+    await expect(regionRows.first()).toContainText('eye');
+
+    // The new region is named after the label and covers the same triangle set
+    // (so it matches what `partwright.paintByLabel('eye', ...)` would produce).
+    const region = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const regions = pw.listRegions() as { name: string; triangles: number }[];
+      return regions[0];
+    });
+    expect(region.name).toBe('eye');
+    expect(region.triangles).toBe(expectedTris);
+
+    // The label row now shows the ✓ already-painted hint.
+    await expect(labelList.locator('[data-label-name="eye"]')).toContainText('✓');
+  });
+
+  test('empty state hints at api.label when no labels in the run', async ({ page }) => {
+    await openEditorWithCode(page, `return api.Manifold.cube([10, 10, 10], true);`);
+
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    const labelList = page.locator('#paint-label-list');
+    await expect(labelList).toBeVisible();
+    await expect(labelList).toContainText('No labels in this run');
+    await expect(labelList).toContainText('api.label');
+    // No row elements when empty.
+    await expect(labelList.locator('[data-label-name]')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **Labels** section to the paint picker that lists every name registered via `api.label(shape, name)` in the current run, along with the triangle count for each.
- **Hover** a label row → translucent overlay tints the matching triangles on the model with the active paint color (reuses the existing `previewTriangles` helper the regions list already uses for hover-to-locate).
- **Click** a label row → paints those triangles with the active color as a `byLabel` region — identical to what `partwright.paintByLabel` produces from a script, so the resulting region survives session save/reload through the same re-hydration path.
- Already-painted labels show a green ✓ plus a swatch of the last color applied, so the user can tell at a glance which features they've covered.
- Empty runs (no `api.label` calls) surface a hint that points at `api.label(shape, "name")` rather than a blank section.

Source of truth is a tiny new `src/color/labels.ts` store; `main.ts` pushes the current label map to it right after `currentLabelMap` is refreshed on each successful run.

### Review follow-ups (commit 2)

- **Highlight teardown on list re-render.** `updateLabelList` clears the row DOM via `innerHTML = ''`. If a fresh run fires `setPaintLabels` while the pointer is over a row, the row's `mouseleave` never gets to run, so the THREE highlight mesh would have stayed parented to the viewport. Now tracked in a module-scoped release closure that `updateLabelList` tears down before clearing.
- **Refined-mesh bounds check.** Labels are built against the run's *base* mesh; smooth paint refinement inflates that mesh later. The click path remaps base ids via `parentToChildren` inside the byLabel resolver, but `previewTriangles` does not — so hovering would have highlighted wrong triangles on a refined mesh. Each label now pre-computes `maxTriId` at `setPaintLabels` time, and the hover handler skips the preview when it exceeds the active paint mesh's `numTri`. Click stays correct (the descriptor path already remaps).

## Test plan

- [x] `npm run build` — clean.
- [x] `npm run test:unit` — 95/95 pass.
- [x] `npx playwright test paint-` — all paint e2e (64 tests, then 41 on the second pass) pass, including the new `paint-labels-panel.spec.ts`:
  - lists labels with triangle counts from a multi-label run
  - clicking a row creates a region named after the label with the matching triangle count
  - row shows ✓ after painting
  - empty-state hint appears when the run has no labels
- [x] Manual: in the dev server, loaded a head-with-eyes-and-mouth labelled model, opened the paint panel, hovered each label (overlay appears on the right region), and clicked through to paint them.
