### PR TITLE
chore: align dev-server CSP with production allowlist

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -129,7 +129,13 @@ export default defineConfig({
     headers: {
       'Cross-Origin-Opener-Policy': 'same-origin',
       'Cross-Origin-Embedder-Policy': 'require-corp',
-      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' https:; worker-src 'self' blob:; font-src 'self'",
+      // Mirror the production CSP (public/_headers) so an accidental new
+      // external call surfaces here in dev instead of slipping through to
+      // production. The ONLY intentional delta is in connect-src: dev also
+      // allows the localhost WebSocket that Vite uses for HMR/live-reload,
+      // which production has no equivalent of. Keep the host allowlist below
+      // in sync with public/_headers.
+      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' ws://localhost:* ws://127.0.0.1:* https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://huggingface.co https://*.huggingface.co https://*.xethub.hf.co https://raw.githubusercontent.com; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'",
     },
     fs: {
       // Relax strict fs access for WASM files in node_modules


### PR DESCRIPTION
## Summary

The Vite **dev server** was sending a looser `Content-Security-Policy` than production. Its `connect-src` was `'self' https:` (any HTTPS host allowed), while production (`public/_headers`) uses an explicit allowlist. The practical downside: an accidental new external network call would pass silently in dev and only surface after deploying behind the stricter prod policy.

This change makes the dev-server CSP **mirror the production CSP** so such calls are caught during development:
- `connect-src` now lists the same explicit hosts as `public/_headers` (Anthropic / OpenAI / Gemini APIs + HuggingFace + `raw.githubusercontent.com` for the opt-in local-model feature).
- Adds the same `object-src 'none'; base-uri 'self'; form-action 'self'` hardening directives prod already had.

**One intentional delta:** `connect-src` in dev additionally allows `ws://localhost:* ws://127.0.0.1:*` — the WebSocket Vite uses for HMR / live-reload, which production has no equivalent of. A verbatim copy of the prod CSP would have broken hot reload; this keeps it working while still tightening the host allowlist.

Only the dev server is affected. Production headers (`public/_headers`) and the build output are unchanged.

## Test plan

- [x] `npm run build` — passes (tsc type-check + vite build)
- [x] `npm run test:unit` — 95/95 pass
- [x] **Manual, headless Chromium against `npm run dev`:**
  - HMR WebSocket connects (`[vite] connected.`) ✅
  - WASM engine reaches **Ready** under the stricter CSP ✅
  - `crossOriginIsolated === true` (COOP/COEP intact) ✅
  - **0 CSP violations** ✅
- [ ] CI: build + unit + 3 e2e shards green

## Notes

This came out of a review of the app's external-dependency surface: the core app (manifold + OpenSCAD WASM, Three.js, CodeMirror, BOSL2, fonts) is already fully self-contained and version-pinned via the lockfile + `npm ci`. This PR just closes the dev/prod CSP gap so the dev server reflects the same network constraints as production.

https://claude.ai/code/session_01V4MdASHiqTorNKVNzPtXe7

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4MdASHiqTorNKVNzPtXe7)_