### PR TITLE
fix: forward agent Worker AI-call diagnostics to the AI Call Log

### DIFF
--- a/src/ai/agentWorker.ts
+++ b/src/ai/agentWorker.ts
@@ -12,12 +12,26 @@
 // Protocol — Worker → Main:
 //   { type: 'tool_call',  callId, name, input }
 //   { type: 'callback',   name: string, args: unknown[] }
+//   { type: 'diagnostic', event: DiagnosticEvent }
 //   { type: 'turn_done',  history: ChatMessage[] }
 //   { type: 'error',      message: string }
 
 import { runTurn, type RunTurnInput, type RunTurnCallbacks } from './chatLoop';
+import { setEventForwarder } from './diagnostics';
 import type { ChatBlock } from './types';
 import type { ToolExecResult } from './tools';
+
+// The chat loop records each provider API call via diagnostics.recordEvent.
+// Inside this Worker those land in the Worker's own module-instance ring
+// buffer, which the AI Call Log modal (main thread) never reads — so for
+// hosted providers the log looked empty save for the main-thread validateKey
+// ping. Forward every event to the main thread, where agentWorkerClient
+// ingests it into the buffer the modal actually shows. Registered once at
+// module load; DiagnosticEvent is a plain object, so it structured-clones
+// across the postMessage boundary.
+setEventForwarder((event) => {
+  self.postMessage({ type: 'diagnostic', event });
+});
 
 /** Serialisable subset of RunTurnInput sent from the main thread.
  *  signal, onDrainQueuedBlocks and executeToolFn are managed by the Worker

--- a/src/ai/agentWorkerClient.ts
+++ b/src/ai/agentWorkerClient.ts
@@ -10,6 +10,7 @@
 //  • Expose pushQueuedBlocks() so aiPanel can relay mid-turn queued input.
 
 import { executeTool } from './tools';
+import { ingestEvent, type DiagnosticEvent } from './diagnostics';
 import type { RunTurnInput, RunTurnCallbacks } from './chatLoop';
 import type { ChatBlock, ChatMessage, PersistedToolResult } from './types';
 import type { AgentWorkerInput } from './agentWorker';
@@ -59,6 +60,14 @@ async function handleMessage(event: MessageEvent): Promise<void> {
     };
     const result = await executeTool(name, input);
     getWorker().postMessage({ type: 'tool_result', callId, result });
+    return;
+  }
+
+  // ── diagnostic: an AI-call event the chat loop recorded inside the Worker.
+  //    Ingest it into the main-thread ring buffer so the AI Call Log modal
+  //    (which only reads this thread's buffer) shows the streamTurn calls. ──
+  if (msg.type === 'diagnostic') {
+    ingestEvent(msg.event as DiagnosticEvent);
     return;
   }
 

--- a/src/ai/diagnostics.ts
+++ b/src/ai/diagnostics.ts
@@ -52,10 +52,26 @@ const MAX_EVENTS = 50;
 const events: DiagnosticEvent[] = [];
 const listeners = new Set<() => void>();
 let counter = 0;
+let forwarder: ((evt: DiagnosticEvent) => void) | null = null;
 
 function nextId(): string {
   counter += 1;
   return `diag-${Date.now().toString(36)}-${counter.toString(36)}`;
+}
+
+/** Register a sink that receives each event INSTEAD of storing it in this
+ *  context's ring buffer (pass `null` to clear).
+ *
+ *  The AI chat loop runs inside the agent Worker for every hosted provider
+ *  (anthropic/openai/gemini — see aiPanel's runTurn router), so the
+ *  `streamTurn` events it records would otherwise land in the Worker's own
+ *  module-instance buffer — which the AI Call Log modal, living on the main
+ *  thread, never reads. The Worker sets a forwarder that ships each event to
+ *  the main thread via postMessage; the main thread (no forwarder) stores them
+ *  as usual. Without this, only main-thread calls (validateKey, review,
+ *  compaction) ever showed up in the log. */
+export function setEventForwarder(fn: ((evt: DiagnosticEvent) => void) | null): void {
+  forwarder = fn;
 }
 
 /** Push an event. Caller fills everything except `id` and `timestamp`. */
@@ -65,6 +81,26 @@ export function recordEvent(evt: Omit<DiagnosticEvent, 'id' | 'timestamp'>): voi
     timestamp: Date.now(),
     ...evt,
   };
+  if (forwarder) {
+    // Forward-only context (the agent Worker): hand the fully-formed event to
+    // the sink and skip local storage. This buffer is never displayed here,
+    // and the main thread stores + console-mirrors the event on receipt —
+    // doing both would double-log it in devtools.
+    try { forwarder(full); }
+    catch { /* a broken forwarder must never break the caller's turn */ }
+    return;
+  }
+  ingestEvent(full);
+}
+
+/** Insert a fully-formed event (id + timestamp already assigned) into this
+ *  context's ring buffer, mirror it to the console, and notify listeners.
+ *
+ *  Called by recordEvent on the storing context, and directly by the main
+ *  thread when it receives an event forwarded from the agent Worker — the
+ *  origin thread's id/timestamp are preserved so the modal shows the call's
+ *  real time, not when the main thread happened to receive it. */
+export function ingestEvent(full: DiagnosticEvent): void {
   events.unshift(full);
   if (events.length > MAX_EVENTS) events.length = MAX_EVENTS;
   // Mirror to devtools so a user who reports "diagnostics shows nothing"

--- a/tests/ai-call-log.spec.ts
+++ b/tests/ai-call-log.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from 'playwright/test';
+import { openAiPanel, waitForEditorReady } from './helpers/aiPanel';
+
+// Regression: the AI Call Log (🩺) only showed the main-thread validateKey
+// ping — never the chat turns. For hosted providers the chat loop runs inside
+// the agent Worker, so its streamTurn diagnostics events landed in the
+// Worker's own ring buffer, which the modal (main thread) never reads. The fix
+// forwards Worker-recorded events to the main thread.
+//
+// This drives a real Anthropic turn through the Worker. There's no network in
+// CI, so the provider request fails — but that failure is itself a streamTurn
+// event recorded *inside the Worker* (chatLoop's catch path). Before the fix
+// the log stayed empty; after it, the forwarded error row shows up. We assert
+// the row appears, not that the request succeeded (per the no-network rule).
+
+test.beforeEach(async ({ page }) => {
+  // Suppress the first-run guided tour — its backdrop intercepts clicks.
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+  });
+});
+
+/** Plant a hosted-provider key straight into IndexedDB. The real connect flow
+ *  hits api.anthropic.com (blocked in CI), so tests seed the key directly —
+ *  the same trick the provider specs use. */
+async function plantAnthropicKey(page: import('playwright/test').Page): Promise<void> {
+  await page.evaluate(async () => {
+    await new Promise<void>((resolve, reject) => {
+      const open = indexedDB.open('partwright');
+      open.onsuccess = () => {
+        const db = open.result;
+        const txn = db.transaction('aiKeys', 'readwrite');
+        txn.objectStore('aiKeys').put({
+          provider: 'anthropic',
+          apiKey: 'sk-ant-test-planted-key-0000000000',
+          createdAt: Date.now(),
+          lastUsed: Date.now(),
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
+          totalCostUsd: 0,
+        });
+        txn.oncomplete = () => { db.close(); resolve(); };
+        txn.onerror = () => reject(txn.error);
+      };
+      open.onerror = () => reject(open.error);
+    });
+  });
+}
+
+test.describe('AI Call Log', () => {
+  test('records streamTurn events from the agent Worker (hosted providers)', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+
+    // Connect Anthropic (the default provider) by seeding the key, then reload
+    // so the panel boots in its connected state with the key resident.
+    await plantAnthropicKey(page);
+    await page.reload();
+    await waitForEditorReady(page);
+
+    await openAiPanel(page);
+    // A stray AI Settings modal (auto-opened when the panel is toggled while
+    // disconnected) would swallow our clicks — dismiss it if present.
+    const settingsHeading = page.getByRole('heading', { name: 'AI Settings' });
+    if (await settingsHeading.isVisible().catch(() => false)) {
+      await page.keyboard.press('Escape');
+      await expect(settingsHeading).toBeHidden();
+    }
+
+    // Fire a turn. provider=anthropic → runs in the agent Worker. With no
+    // network the provider call fails, and the chat loop records that failure
+    // as a streamTurn event *inside the Worker*.
+    const input = page.locator('#ai-panel textarea');
+    await input.fill('make a 10mm cube');
+    await input.press('Enter');
+
+    // Open the AI Call Log. The modal subscribes to the buffer, so it
+    // live-updates as the forwarded event lands.
+    await page.locator('#ai-panel button[title^="AI Call Log"]').dispatchEvent('click');
+    const modal = page.locator('.bg-zinc-800.rounded-xl').filter({ hasText: 'AI Call Log' });
+    await expect(modal).toBeVisible();
+
+    // The streamTurn row is the proof the Worker-side event reached the main
+    // thread's buffer. Before the fix this never appeared. Generous timeout:
+    // the turn has to reach the provider transport and fail first.
+    await expect(modal.getByText('streamTurn', { exact: false }).first()).toBeVisible({ timeout: 25_000 });
+  });
+});

--- a/tests/unit/diagnostics.test.ts
+++ b/tests/unit/diagnostics.test.ts
@@ -1,0 +1,144 @@
+// Regression tests for the AI Call Log's cross-thread plumbing.
+//
+// The bug: the chat loop runs inside the agent Worker for every hosted
+// provider (anthropic/openai/gemini), so the `streamTurn` events it recorded
+// landed in the Worker's *own* module-instance ring buffer. The AI Call Log
+// modal reads the main thread's buffer, so those events never showed up —
+// only the main-thread validateKey ping did. The fix routes Worker events
+// through a forwarder (setEventForwarder) → postMessage → ingestEvent on the
+// main thread. These tests pin that forward/store/ingest contract; the
+// Worker↔main wiring itself is exercised end-to-end in the e2e suite.
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+  recordEvent,
+  ingestEvent,
+  setEventForwarder,
+  listEvents,
+  clearEvents,
+  onEventsChange,
+  type DiagnosticEvent,
+} from '../../src/ai/diagnostics';
+
+// The ring buffer + forwarder are module-level singletons. Reset both around
+// every test so one case can't leak state into the next.
+beforeEach(() => {
+  setEventForwarder(null);
+  clearEvents();
+});
+afterEach(() => {
+  setEventForwarder(null);
+  clearEvents();
+});
+
+describe('diagnostics event forwarding', () => {
+  test('with no forwarder (main thread) events store locally', () => {
+    recordEvent({
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      kind: 'streamTurn',
+      durationMs: 12,
+      status: 'ok',
+      stopReason: 'end_turn',
+      outputTokens: 7,
+    });
+
+    const events = listEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('streamTurn');
+    expect(events[0].id).toBeTruthy();
+    expect(typeof events[0].timestamp).toBe('number');
+  });
+
+  test('with a forwarder (agent Worker) events forward INSTEAD of storing', () => {
+    const forwarded: DiagnosticEvent[] = [];
+    setEventForwarder((evt) => forwarded.push(evt));
+
+    recordEvent({
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      kind: 'streamTurn',
+      durationMs: 12,
+      status: 'error',
+      errorMessage: 'network down',
+    });
+
+    // The Worker's own buffer stays empty — it is never displayed there.
+    expect(listEvents()).toHaveLength(0);
+    // The sink received a fully-formed event (id + timestamp already filled)
+    // ready to ship across the postMessage boundary.
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0].id).toBeTruthy();
+    expect(typeof forwarded[0].timestamp).toBe('number');
+    expect(forwarded[0].kind).toBe('streamTurn');
+    expect(forwarded[0].errorMessage).toBe('network down');
+  });
+
+  test('ingestEvent stores a forwarded event verbatim and never re-forwards', () => {
+    // A forwarder is registered, but ingestEvent must NOT route through it —
+    // otherwise the main thread (which both ingests and could forward) would
+    // loop. ingestEvent always stores.
+    const forwarded: DiagnosticEvent[] = [];
+    setEventForwarder((evt) => forwarded.push(evt));
+
+    const evt: DiagnosticEvent = {
+      id: 'diag-fromworker-1',
+      timestamp: 1_700_000_000_000,
+      provider: 'openai',
+      model: 'gpt-5',
+      kind: 'streamTurn',
+      durationMs: 42,
+      status: 'ok',
+      stopReason: 'tool_use',
+      toolCallCount: 2,
+    };
+    ingestEvent(evt);
+
+    const events = listEvents();
+    expect(events).toHaveLength(1);
+    // id + timestamp are preserved from the origin thread (not regenerated).
+    expect(events[0]).toEqual(evt);
+    expect(forwarded).toHaveLength(0);
+  });
+
+  test('Worker→main round trip: forwarded events land in the main-thread buffer', () => {
+    // Phase 1 — pretend we are the Worker: a forwarder captures the wire.
+    const wire: DiagnosticEvent[] = [];
+    setEventForwarder((evt) => wire.push(evt));
+    recordEvent({ provider: 'gemini', model: 'gemini-3-pro', kind: 'streamTurn', durationMs: 5, status: 'ok', stopReason: 'tool_use', toolCallCount: 1 });
+    recordEvent({ provider: 'gemini', model: 'gemini-3-pro', kind: 'streamTurn', durationMs: 9, status: 'ok', stopReason: 'end_turn', outputTokens: 30 });
+    expect(listEvents()).toHaveLength(0); // nothing stored Worker-side
+
+    // Phase 2 — pretend we are the main thread (no forwarder) receiving the
+    // posted events in order.
+    setEventForwarder(null);
+    for (const e of wire) ingestEvent(e);
+
+    const events = listEvents(); // newest first
+    expect(events).toHaveLength(2);
+    expect(events[0].stopReason).toBe('end_turn');
+    expect(events[1].stopReason).toBe('tool_use');
+    expect(events[1].toolCallCount).toBe(1);
+  });
+
+  test('listeners fire on ingest so an open modal live-updates', () => {
+    let notifications = 0;
+    const off = onEventsChange(() => { notifications += 1; });
+    try {
+      ingestEvent({
+        id: 'diag-x', timestamp: Date.now(), provider: 'anthropic', model: 'm',
+        kind: 'streamTurn', durationMs: 1, status: 'ok',
+      });
+      expect(notifications).toBe(1);
+    } finally {
+      off();
+    }
+  });
+
+  test('a throwing forwarder never breaks the recording caller', () => {
+    setEventForwarder(() => { throw new Error('postMessage failed'); });
+    expect(() => recordEvent({
+      provider: 'anthropic', model: 'm', kind: 'streamTurn', durationMs: 1, status: 'ok',
+    })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

The **AI Call Log** (🩺) only showed the initial `validateKey` ping (recorded when you paste a key) — the actual chat turns never appeared, even after the AI finished. This was the reported symptom for an Anthropic chat.

**Root cause:** for every hosted provider (anthropic/openai/gemini) the chat loop runs **inside the agent Worker** (`aiPanel.ts`'s `runTurn` router → `agentWorkerClient`). The loop records each provider call via `diagnostics.recordEvent`, but `diagnostics.ts` is a per-thread module, so those `streamTurn` events landed in the **Worker's own** in-memory ring buffer. The AI Call Log modal reads the **main thread's** buffer, so it only ever saw the main-thread-recorded calls: `validateKey` (key modal), `review`, and `compaction`. The Worker's chat turns were invisible. (The `local` provider runs on the main thread, so it was unaffected.)

**Fix:** route Worker-recorded events to the main thread.

- `diagnostics.ts` gains `setEventForwarder(sink | null)` and an `ingestEvent(fullEvent)` storage primitive (split out of `recordEvent`). When a forwarder is registered, `recordEvent` forwards the fully-formed event and skips local storage; otherwise it stores as before. `ingestEvent` never re-forwards, so there's no loop.
- `agentWorker.ts` registers a forwarder once at module load that `postMessage`s each event (`{ type: 'diagnostic', event }`).
- `agentWorkerClient.ts` ingests those into the main-thread buffer, preserving the origin thread's `id`/`timestamp` so the log shows the call's real time.

The Worker forwards-only (no local store, no double console-mirror); the main thread keeps recording its own calls and additionally ingests the forwarded ones. No schema or persisted-data changes — the ring buffer is in-memory only.

## Test plan

- **Unit** (`tests/unit/diagnostics.test.ts`, pure-logic tier): pins the forward/store/ingest contract — no-forwarder stores locally; a registered forwarder forwards instead of storing; `ingestEvent` stores verbatim and never re-forwards; a Worker→main round trip lands events in the main buffer newest-first; listeners fire on ingest (open-modal live-update); a throwing forwarder can't break the caller's turn.
- **E2E** (`tests/ai-call-log.spec.ts`): seeds an Anthropic key, fires a real turn through the agent Worker, and asserts a `streamTurn` row reaches the AI Call Log modal. With no network in CI the provider request fails — but that failure is itself a Worker-recorded `streamTurn` event, so it exercises the exact forwarding path. Verified it **fails before the fix** (no row appears) and **passes after**, including against the newly Preact-ported diagnostics modal.
- `npm run build` (type-check) and `npm run test:unit` (142 passing) both green locally after rebasing onto the latest `main`.

https://claude.ai/code/session_01Bkv1FqUxQnnHSHdu7GQqLq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bkv1FqUxQnnHSHdu7GQqLq)_