### PR TITLE
feat: add client-side shareable session links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Built on [manifold-3d](https://github.com/elalish/manifold) (fast WASM boolean e
 - **Cross-sections** — Slice geometry at any Z height, inspect the 2D profile as SVG.
 - **Color regions** — Paint coplanar face regions with the in-app paint mode or the `paintRegion` console API; colors flow through GLB and 3MF exports for multi-material slicing.
 - **Export** — GLB, STL, OBJ, and 3MF download. GLB and 3MF carry per-region colors when present.
+- **Share links** — Turn the current version into a public link that encodes the whole design in the URL hash (gzipped, client-side — nothing is uploaded to any server). Opening a link shows a read-only preview (thumbnail + code + stats); the shared code never runs until the viewer chooses to fork it into their own local session.
 
 ## Quick start
 

--- a/src/color/editorLock.ts
+++ b/src/color/editorLock.ts
@@ -82,25 +82,35 @@ function hideLockOverlay(): void {
   }
 }
 
-function disableRun(): void {
-  if (runButton) {
-    (runButton as HTMLButtonElement).disabled = true;
-    runButton.classList.add('opacity-40', 'pointer-events-none');
+/** Disable the manual Run + auto-run buttons. Exported so other read-only
+ *  modes (e.g. shared-link preview in main.ts) reuse the same disable approach
+ *  rather than re-grabbing `#btn-run`/`#btn-auto-run` in a third place. The
+ *  ids are re-queried each call so a caller that runs before initEditorLock —
+ *  or after the buttons are recreated — still works. */
+export function disableRun(): void {
+  const run = runButton ?? document.getElementById('btn-run');
+  const auto = autoRunButton ?? document.getElementById('btn-auto-run');
+  if (run) {
+    (run as HTMLButtonElement).disabled = true;
+    run.classList.add('opacity-40', 'pointer-events-none');
   }
-  if (autoRunButton) {
-    (autoRunButton as HTMLButtonElement).disabled = true;
-    autoRunButton.classList.add('opacity-40', 'pointer-events-none');
+  if (auto) {
+    (auto as HTMLButtonElement).disabled = true;
+    auto.classList.add('opacity-40', 'pointer-events-none');
   }
 }
 
-function enableRun(): void {
-  if (runButton) {
-    (runButton as HTMLButtonElement).disabled = false;
-    runButton.classList.remove('opacity-40', 'pointer-events-none');
+/** Re-enable the Run + auto-run buttons disabled by {@link disableRun}. */
+export function enableRun(): void {
+  const run = runButton ?? document.getElementById('btn-run');
+  const auto = autoRunButton ?? document.getElementById('btn-auto-run');
+  if (run) {
+    (run as HTMLButtonElement).disabled = false;
+    run.classList.remove('opacity-40', 'pointer-events-none');
   }
-  if (autoRunButton) {
-    (autoRunButton as HTMLButtonElement).disabled = false;
-    autoRunButton.classList.remove('opacity-40', 'pointer-events-none');
+  if (auto) {
+    (auto as HTMLButtonElement).disabled = false;
+    auto.classList.remove('opacity-40', 'pointer-events-none');
   }
 }
 

--- a/src/editor/editorAccess.ts
+++ b/src/editor/editorAccess.ts
@@ -1,8 +1,11 @@
 // Composes the editor's single read-only flag from multiple independent
-// reasons. The color-region lock (editorLock.ts) and multi-tab viewer mode
-// (viewerMode.ts) each want the editor read-only for their own reason; routing
-// both through here means neither stomps the other — the editor is read-only if
-// ANY reason is active, regardless of the order the two modules run in.
+// reasons. The color-region lock (editorLock.ts), multi-tab viewer mode
+// (viewerMode.ts), and the shared-link preview (main.ts, reason 'shared') each
+// want the editor read-only for their own reason; routing them all through here
+// means none stomps another — the editor is read-only if ANY reason is active,
+// regardless of the order the modules run in.
+//
+// Known reasons: 'colorLock', 'viewer', 'shared'.
 
 import { setReadOnly } from './codeEditor';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -299,12 +299,18 @@ let geometryDataEl: HTMLElement;
 // When the editor is showing a decoded share link (`/editor#share=…`), it is a
 // strictly READ-ONLY preview of UNTRUSTED code: nothing the sharer wrote may
 // execute until the viewer explicitly Forks. This module-scoped flag is the
-// chokepoint guard — `runCode`/`runCodeSync` (and therefore the console
-// `partwright.run()`/`runAndSave()`, which route through them) and
-// `saveCurrentVersion` all refuse while it's set. It's separate from the
-// CodeMirror read-only flag (which only blocks typing) and from the multi-tab
-// viewer flag.
+// chokepoint guard — every code-execution entry point bails while it's set:
+// `runCode`/`runCodeSync` (and the console `partwright.run()`/`runAndSave()`
+// that route through them), `executeIsolated` (which backs the AI-exposed
+// `runIsolated`/`runAndAssert`/`runDecompose`, modify/test, and forkVersion),
+// and `setReferenceGeometry`, plus `saveCurrentVersion` and the export actions.
+// It's separate from the CodeMirror read-only flag (which only blocks typing)
+// and from the multi-tab viewer flag.
 let _sharedPreview = false;
+
+/** Error string returned by the execution chokepoints while a read-only shared
+ *  preview is on screen — the sharer's untrusted code must not run until Fork. */
+const SHARED_PREVIEW_REFUSAL = 'Read-only shared preview — fork this design first to run code.';
 
 /** True while the editor is showing a decoded share link (read-only preview).
  *  Execution + save chokepoints bail when this returns true. */
@@ -2032,6 +2038,7 @@ async function main() {
   // Mesh export actions, shared by the toolbar and the command palette so the
   // guards + success/error toasts stay in one place.
   const actionExportGLB = async () => {
+    if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
     try {
       if (currentMeshData) assertFiniteMesh(currentMeshData);
       const filename = await exportGLB();
@@ -2041,16 +2048,19 @@ async function main() {
     }
   };
   const actionExportSTL = () => {
+    if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
     if (!currentMeshData) return;
     try { showToast(`Exported ${exportSTL(currentMeshData)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : 'STL export failed', { variant: 'warn' }); }
   };
   const actionExportOBJ = () => {
+    if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
     if (!currentMeshData) return;
     try { showToast(`Exported ${exportOBJ(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : 'OBJ export failed', { variant: 'warn' }); }
   };
   const actionExport3MF = () => {
+    if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
     if (!currentMeshData) return;
     try { showToast(`Exported ${export3MF(hasColorRegions() ? applyTriColors(currentMeshData) : currentMeshData)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
@@ -2102,8 +2112,13 @@ async function main() {
       showToast('Could not prepare this design for sharing.', { variant: 'warn' });
       return;
     }
-    if (state.parts.length > 1 && state.currentPart?.name) {
-      exported.session = { ...exported.session, name: state.currentPart.name };
+    if (state.parts.length > 1) {
+      // A share link carries one version of one part. Tell the user so a
+      // multi-part assembly isn't silently reduced, and name the shared session
+      // after the current part.
+      const partName = state.currentPart?.name;
+      if (partName) exported.session = { ...exported.session, name: partName };
+      showToast(`Sharing only "${partName ?? 'the current part'}" — multi-part designs share one part per link.`, { variant: 'neutral' });
     }
 
     try {
@@ -2135,7 +2150,7 @@ async function main() {
   };
 
   /** True when the share action can run: an active session on a ready engine. */
-  const canShare = (): boolean => !!getState().session && engineOk && !isSharedPreview();
+  const canShare = (): boolean => !!getState().session && engineOk && !isSharedPreview() && typeof CompressionStream !== 'undefined';
 
   // Create toolbar
   createToolbar(editorUI, {
@@ -2752,15 +2767,16 @@ async function main() {
     setControlNeutralized('btn-save-version', true);
     setControlNeutralized('lang-toggle', true);
 
-    if (!sharedBannerEl) {
-      sharedBannerEl = renderSharedBanner(() => { void onFork(); });
-      const editorPane = editorContainer.parentElement;
-      if (editorPane) editorPane.insertBefore(sharedBannerEl, editorContainer);
-    }
-    if (!sharedOverlayEl) {
-      sharedOverlayEl = renderSharedOverlay({ thumbnail, onFork: () => { void onFork(); } });
-      viewportPane.appendChild(sharedOverlayEl);
-    }
+    // Rebuild the banner + overlay fresh on every entry so re-previewing a
+    // DIFFERENT share link (pasted over an active preview) shows the new
+    // thumbnail rather than a stale one carried over from the previous link.
+    if (sharedBannerEl) { sharedBannerEl.remove(); sharedBannerEl = null; }
+    if (sharedOverlayEl) { sharedOverlayEl.remove(); sharedOverlayEl = null; }
+    sharedBannerEl = renderSharedBanner(() => { void onFork(); });
+    const editorPane = editorContainer.parentElement;
+    if (editorPane) editorPane.insertBefore(sharedBannerEl, editorContainer);
+    sharedOverlayEl = renderSharedOverlay({ thumbnail, onFork: () => { void onFork(); } });
+    viewportPane.appendChild(sharedOverlayEl);
   }
 
   /** Leave shared-preview mode: re-enable every control and remove the banner +
@@ -2775,6 +2791,9 @@ async function main() {
     setControlNeutralized('lang-toggle', false);
     if (sharedBannerEl) { sharedBannerEl.remove(); sharedBannerEl = null; }
     if (sharedOverlayEl) { sharedOverlayEl.remove(); sharedOverlayEl = null; }
+    // Re-derive the Run button state from the (reason-counted) editor lock, so we
+    // never leave Run enabled if a color lock happens to be active.
+    syncLockState();
   }
 
   /** Strip the `#share=` hash from the URL without touching the back stack or
@@ -2808,7 +2827,10 @@ async function main() {
       if (!branded) throw new Error('not a Partwright payload');
       payload = validateSharePayloadShape(branded);
     } catch (e) {
-      errorLog.capture({ level: 'warn', source: 'app', message: `invalid share link: ${e instanceof Error ? e.message : String(e)}` });
+      // A malformed/hostile share link is an expected degrade path, not an app
+      // error — log to the console only (keep it out of the user-facing
+      // diagnostic log) and fall back to a normal editable editor.
+      console.debug('Partwright: ignoring invalid share link —', e instanceof Error ? e.message : String(e));
       stripShareHash();
       exitSharedMode();
       // Fall through to a normal, editable empty editor.
@@ -3497,6 +3519,25 @@ async function main() {
   // during initial load don't hit a Temporal Dead Zone error.)
 
   async function executeIsolated(code: string, lang?: Language) {
+    // Hard refusal in a read-only shared preview. executeIsolated is the single
+    // funnel for every isolated run — runIsolated / runAndAssert / runDecompose
+    // (all AI-exposed tools), modify/test, and forkVersion — so guarding it here
+    // stops the sharer's untrusted code from reaching the `new Function` sandbox
+    // (and thus fetch / indexedDB) via any of them. Fork clears the flag before
+    // importing, so the consented run is unaffected.
+    if (isSharedPreview()) {
+      return {
+        geometryData: {
+          status: 'error' as const,
+          error: SHARED_PREVIEW_REFUSAL,
+          diagnostics: [] as SourceDiagnostic[],
+          executionTimeMs: 0,
+          codeHash: simpleHash(code),
+        },
+        meshData: null as MeshData | null,
+        manifold: null as unknown,
+      };
+    }
     const t0 = performance.now();
     const result = await executeCodeAsync(code, lang);
     const elapsed = Math.round(performance.now() - t0);
@@ -5619,6 +5660,9 @@ async function main() {
       });
       if (typeof check === 'object' && check !== null && 'error' in check) {
         return { success: false, error: check.error };
+      }
+      if (isSharedPreview()) {
+        return { success: false, error: SHARED_PREVIEW_REFUSAL };
       }
       const result = executeCode(code, 'manifold-js');
       if (result.error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,11 @@ import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as ge
 import { buildStrokeMesh, buildRefinedMesh, brushRefineRegion, strokeFootprintTriangles, deriveSampleNormals, buildGeodesicField, tangentBasis, childrenByParent, type BrushStroke, type BrushShape, type RefineRegion } from './color/subdivide';
 import { refineInWorker, SubdivisionAbortError, terminateSubdivisionWorker } from './color/subdivisionClient';
 import { startProgress, endProgress, __setProgressModalDelayForTests } from './ui/progressModal';
-import { initEditorLock, syncLockState, setUnlockHandlers } from './color/editorLock';
+import { initEditorLock, syncLockState, setUnlockHandlers, disableRun, enableRun } from './color/editorLock';
+import { setReadOnlyReason } from './editor/editorAccess';
+import { asLanguage } from './storage/languageFallback';
+import { encodeShare, decodeShare, validateSharePayloadShape, ShareUnsupportedError } from './share/shareLink';
+import { openShareModal, renderSharedBanner, renderSharedOverlay } from './share/shareUI';
 import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, resolveSeed, findNearestTriangle, type AdjacencyGraph } from './color/adjacency';
 import { findSlabTriangles, slabRefineRegion, smoothEdgeForResolution } from './color/slabPaint';
 import { findBoxTriangles, findShapeTriangles, shapeRefineRegion } from './color/boxPaint';
@@ -289,6 +293,38 @@ let currentLostLabels: string[] | null = null;
 
 // #geometry-data element — always-updated machine-readable state
 let geometryDataEl: HTMLElement;
+
+// === Shared-link preview mode ===
+//
+// When the editor is showing a decoded share link (`/editor#share=…`), it is a
+// strictly READ-ONLY preview of UNTRUSTED code: nothing the sharer wrote may
+// execute until the viewer explicitly Forks. This module-scoped flag is the
+// chokepoint guard — `runCode`/`runCodeSync` (and therefore the console
+// `partwright.run()`/`runAndSave()`, which route through them) and
+// `saveCurrentVersion` all refuse while it's set. It's separate from the
+// CodeMirror read-only flag (which only blocks typing) and from the multi-tab
+// viewer flag.
+let _sharedPreview = false;
+
+/** True while the editor is showing a decoded share link (read-only preview).
+ *  Execution + save chokepoints bail when this returns true. */
+function isSharedPreview(): boolean {
+  return _sharedPreview;
+}
+
+/** The encoded value of the current `#share=` hash, or null when the hash isn't
+ *  a share link. Used to detect share links and to guard hashchange re-entrancy. */
+function getShareHashValue(): string | null {
+  const hash = window.location.hash;
+  if (!hash.startsWith('#share=')) return null;
+  const value = hash.slice('#share='.length);
+  return value.length > 0 ? value : null;
+}
+
+/** True when the URL hash carries a share link. */
+function hasShareHash(): boolean {
+  return getShareHashValue() !== null;
+}
 
 /** Paint selector containment test. `centroid` is the historical default
  *  (a triangle is in the selection when its centroid lies inside the
@@ -1255,6 +1291,9 @@ async function saveCurrentVersion(label?: string): Promise<
   | { id: string; index: number; label: string }
   | { skipped: true; reason: string }
 > {
+  if (isSharedPreview()) {
+    return { error: 'This is a read-only shared preview. Fork it first to make edits you can save.' };
+  }
   if (!getState().session) {
     return { error: 'No active session. Call createSession() or openSession(id) first.' };
   }
@@ -1338,8 +1377,10 @@ function shouldShowLanding(): boolean {
   const path = window.location.pathname;
   const params = new URLSearchParams(window.location.search);
   // Landing if at root path AND no query params that indicate a specific view
+  // AND no share-link hash (a bare `/#share=…` must open the shared preview, not
+  // the landing page).
   const isRootPath = path === '/' || path === '';
-  return isRootPath && !params.has('view') && !params.has('session') && !params.has('gallery') && !params.has('versions') && !params.has('images') && !params.has('diff') && !params.has('notes') && !params.has('data');
+  return isRootPath && !hasShareHash() && !params.has('view') && !params.has('session') && !params.has('gallery') && !params.has('versions') && !params.has('images') && !params.has('diff') && !params.has('notes') && !params.has('data');
 }
 
 function shouldShowHelp(): boolean {
@@ -2015,6 +2056,87 @@ async function main() {
     catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
   };
 
+  // Hard cap on the encoded share string. Browsers and chat apps choke on very
+  // long URLs; past this we drop the thumbnail once and, if still too big, abort
+  // with a toast rather than minting a link that silently won't open.
+  const MAX_SHARE_ENCODED_CHARS = 1_500_000;
+
+  /** Encode the current committed version into a `#share=…` link and open the
+   *  copy modal. Saves the current buffer first (exportSession reads the SAVED
+   *  version), feature-detects CompressionStream, and trims the thumbnail if the
+   *  link is too large before giving up. */
+  const actionShareLink = async (): Promise<void> => {
+    if (typeof CompressionStream === 'undefined') {
+      showToast('Sharing needs a newer browser', { variant: 'warn' });
+      return;
+    }
+    if (!getState().session || !engineOk) {
+      showToast('Open or create a design before sharing.', { variant: 'warn' });
+      return;
+    }
+    // exportSession reads the SAVED version from IndexedDB, so commit the current
+    // buffer first — both to give a fresh /editor (currentVersion: null) a
+    // version to export and to capture any unsaved edits the user is sharing.
+    const saved = await saveCurrentVersion();
+    if ('error' in saved) {
+      showToast(saved.error, { variant: 'warn' });
+      return;
+    }
+    const state = getState();
+    const versionIndex = state.currentVersion?.index;
+    if (versionIndex === undefined) {
+      showToast('No saved version to share yet.', { variant: 'warn' });
+      return;
+    }
+
+    const sessionId = state.session!.id;
+    // Single-version, lean payload: no chat, no notes. Name the shared session
+    // after the current part when the session is multi-part so the preview reads
+    // sensibly (the share covers only the current part's current version).
+    const exported = await exportSession(sessionId, {
+      versionIndices: [versionIndex],
+      includeChat: false,
+      includeNotes: false,
+    });
+    if (!exported) {
+      showToast('Could not prepare this design for sharing.', { variant: 'warn' });
+      return;
+    }
+    if (state.parts.length > 1 && state.currentPart?.name) {
+      exported.session = { ...exported.session, name: state.currentPart.name };
+    }
+
+    try {
+      let encoded = await encodeShare(exported);
+      // If the link is too long, drop the (heavy) thumbnail and try once more.
+      if (encoded.length > MAX_SHARE_ENCODED_CHARS && exported.versions[0]?.thumbnail) {
+        const slimmed = {
+          ...exported,
+          versions: exported.versions.map((v, i) =>
+            i === 0 ? (() => { const { thumbnail: _t, ...rest } = v; return rest; })() : v,
+          ),
+        };
+        encoded = await encodeShare(slimmed);
+      }
+      if (encoded.length > MAX_SHARE_ENCODED_CHARS) {
+        showToast('Design too large to share via link', { variant: 'warn' });
+        return;
+      }
+      const url = `${location.origin}/editor#share=${encoded}`;
+      openShareModal(url, encoded.length);
+    } catch (e) {
+      if (e instanceof ShareUnsupportedError) {
+        showToast('Sharing needs a newer browser', { variant: 'warn' });
+      } else {
+        showToast('Could not create a share link.', { variant: 'warn' });
+        errorLog.capture({ level: 'error', source: 'app', message: `share encode failed: ${e instanceof Error ? e.message : String(e)}` });
+      }
+    }
+  };
+
+  /** True when the share action can run: an active session on a ready engine. */
+  const canShare = (): boolean => !!getState().session && engineOk && !isSharedPreview();
+
   // Create toolbar
   createToolbar(editorUI, {
     onGoHome: () => {
@@ -2068,6 +2190,7 @@ async function main() {
       const ok = await exportSessionJSON(undefined, opts);
       if (!ok) alert('No active session to export. Save a version first.');
     },
+    onShareLink: () => { void actionShareLink(); },
     onExportRawCode: () => {
       exportRawCode(getValue(), getActiveLanguage());
     },
@@ -2272,6 +2395,7 @@ async function main() {
     { id: 'export-stl', title: 'Export STL', hint: 'Export', keywords: 'download print', run: actionExportSTL, enabled: () => currentMeshData !== null },
     { id: 'export-obj', title: 'Export OBJ', hint: 'Export', keywords: 'download wavefront', run: actionExportOBJ, enabled: () => currentMeshData !== null },
     { id: 'export-3mf', title: 'Export 3MF', hint: 'Export', keywords: 'download print color', run: actionExport3MF, enabled: () => currentMeshData !== null },
+    { id: 'share-link', title: 'Share design (copy link)', hint: 'Share', keywords: 'url public link copy fork readonly', run: () => { void actionShareLink(); }, enabled: canShare },
     { id: 'toggle-ai', title: 'Toggle AI panel', hint: 'View', keywords: 'chat assistant drawer', run: () => toggleAiPanel() },
     { id: 'toggle-diagnostics', title: 'Toggle diagnostic log', hint: 'View', keywords: 'errors warnings console', run: () => toggleDiagnosticsPanel() },
     { id: 'open-catalog', title: 'Open catalog', hint: 'Navigate', keywords: 'examples premade browse', run: () => { void showCatalogPage(); } },
@@ -2598,6 +2722,149 @@ async function main() {
     updateDocumentTitle({ page: 'editor' });
   }
 
+  // === Shared-link preview mode (read-only) ===
+
+  // DOM owned by shared-preview mode, removed on exit so nothing leaks.
+  let sharedBannerEl: HTMLElement | null = null;
+  let sharedOverlayEl: HTMLElement | null = null;
+
+  /** Toggle a control's disabled state + dimmed/non-interactive styling. Used to
+   *  neutralize Paint, Save, and the language toggle in shared preview without
+   *  re-implementing each control's own logic. */
+  function setControlNeutralized(id: string, off: boolean): void {
+    const el = document.getElementById(id);
+    if (!el) return;
+    if ('disabled' in el) (el as HTMLButtonElement).disabled = off;
+    el.classList.toggle('opacity-40', off);
+    el.classList.toggle('pointer-events-none', off);
+  }
+
+  /** Enter read-only shared-preview mode: refuse execution + save (via the
+   *  module flag), hold the editor read-only, and neutralize Run / Paint / Save /
+   *  language toggle. Mounts the banner above the editor and the overlay (with
+   *  the decoded thumbnail + Fork CTA) over the viewport. */
+  function enterSharedMode(thumbnail: string | undefined): void {
+    _sharedPreview = true;
+    setReadOnlyReason('shared', true);
+    disableRun();
+    if (isPaintOpen()) closePaintMenu();
+    setControlNeutralized('paint-toggle', true);
+    setControlNeutralized('btn-save-version', true);
+    setControlNeutralized('lang-toggle', true);
+
+    if (!sharedBannerEl) {
+      sharedBannerEl = renderSharedBanner(() => { void onFork(); });
+      const editorPane = editorContainer.parentElement;
+      if (editorPane) editorPane.insertBefore(sharedBannerEl, editorContainer);
+    }
+    if (!sharedOverlayEl) {
+      sharedOverlayEl = renderSharedOverlay({ thumbnail, onFork: () => { void onFork(); } });
+      viewportPane.appendChild(sharedOverlayEl);
+    }
+  }
+
+  /** Leave shared-preview mode: re-enable every control and remove the banner +
+   *  overlay. Disposes nothing on the GPU here — the cold preview never built a
+   *  Three.js mesh — but tears down the overlay's <img> via .remove(). */
+  function exitSharedMode(): void {
+    _sharedPreview = false;
+    setReadOnlyReason('shared', false);
+    enableRun();
+    setControlNeutralized('paint-toggle', false);
+    setControlNeutralized('btn-save-version', false);
+    setControlNeutralized('lang-toggle', false);
+    if (sharedBannerEl) { sharedBannerEl.remove(); sharedBannerEl = null; }
+    if (sharedOverlayEl) { sharedOverlayEl.remove(); sharedOverlayEl = null; }
+  }
+
+  /** Strip the `#share=` hash from the URL without touching the back stack or
+   *  re-firing routing. Modeled on the ?takeover=1 strip — keeps path + search,
+   *  drops only the hash, so refresh / Back never re-decodes the link. */
+  function stripShareHash(): void {
+    window.history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+
+  /** Open a `#share=…` link as a read-only preview. Decodes + validates the
+   *  UNTRUSTED payload, strips the hash, and renders code/stats/thumbnail
+   *  WITHOUT touching IndexedDB or running anything. On any failure it degrades
+   *  to a normal editable empty editor (no uncaught error, no scary toast). */
+  async function enterSharedFromHash(): Promise<void> {
+    const hashValue = getShareHashValue();
+    if (hashValue === null) return;
+
+    transitionToEditor();
+    switchTab('interactive', { history: 'none' });
+    updateDocumentTitle({ page: 'editor' });
+    await ensureEditorReady();
+    if (!engineOk) return;
+
+    // Decode + validate. ANY failure → graceful fallback to a blank editor.
+    let payload: ExportedSession;
+    try {
+      const parsed = await decodeShare(hashValue);
+      // App-level brand/schema check first, then the structural/security shape
+      // validator (which also drops an unsafe thumbnail).
+      const branded = validateSessionPayload(parsed);
+      if (!branded) throw new Error('not a Partwright payload');
+      payload = validateSharePayloadShape(branded);
+    } catch (e) {
+      errorLog.capture({ level: 'warn', source: 'app', message: `invalid share link: ${e instanceof Error ? e.message : String(e)}` });
+      stripShareHash();
+      exitSharedMode();
+      // Fall through to a normal, editable empty editor.
+      if (!getState().session) await createSession();
+      setStatus(statusBar, 'ready', 'Ready');
+      runCode(defaultCode);
+      return;
+    }
+
+    // Valid: strip the hash immediately so refresh / Back can't re-fire it.
+    stripShareHash();
+
+    const version = payload.versions[0];
+    const lang = asLanguage(version.language ?? payload.session.language) ?? 'manifold-js';
+
+    // Apply the version's language with the BARE alias (engine + editor only —
+    // never switchLanguageWithDrafts, which would createSession() + runCode()).
+    if (lang !== getActiveLanguage()) await switchLanguage(lang);
+
+    // Read-only preview, no IndexedDB writes, no execution.
+    enterSharedMode(version.thumbnail);
+    setValue(version.code); // setValue does not auto-run
+    // Populate the live stats panel straight from the embedded geometryData —
+    // we deliberately do NOT run the code.
+    const stats = version.geometryData;
+    geometryDataEl.textContent = stats
+      ? JSON.stringify(stats, null, 2)
+      : JSON.stringify({ status: 'shared-preview' });
+    setStatus(statusBar, 'ready', 'Shared preview (read-only)');
+
+    // Stash the validated payload for the Fork handler (the consented import).
+    pendingSharedPayload = payload;
+  }
+
+  // The decoded share payload awaiting an explicit Fork (the first consented
+  // execution). Held only while a shared preview is on screen.
+  let pendingSharedPayload: ExportedSession | null = null;
+
+  /** Fork the previewed share into a real local session. Reuses the
+   *  catalog-load ORDER (push /editor → transition → ensureReady →
+   *  importSessionPayload, which runs the code) — this is the consented first
+   *  execution. Then leaves shared mode. */
+  async function onFork(): Promise<void> {
+    const payload = pendingSharedPayload;
+    if (!payload) return;
+    // Leave shared mode FIRST so the import's runCode() isn't refused by the
+    // execution guard.
+    exitSharedMode();
+    pendingSharedPayload = null;
+    updateAppHistory('/editor', 'push');
+    transitionToEditor();
+    await ensureEditorReady();
+    await importSessionPayload(payload);
+    updateDocumentTitle({ page: 'editor' });
+  }
+
   async function syncEditorFromURL() {
     transitionToEditor();
     const tab = getTabFromURL();
@@ -2658,7 +2925,12 @@ async function main() {
     if (shouldShowLanding() || shouldShowHelp() || shouldShowCatalog() || shouldShow404()) {
       void setAiActiveSession(null);
     }
-    if (shouldShowLanding()) {
+    // A share-link hash takes precedence over the normal editor sync on this
+    // path too (e.g. a popstate that lands back on a `#share=` URL), so we never
+    // createSession()+default-code over a shared preview.
+    if (hasShareHash()) {
+      await enterSharedFromHash();
+    } else if (shouldShowLanding()) {
       await showLandingPage();
     } else if (shouldShowHelp()) {
       showHelp({ history: 'none' });
@@ -2673,6 +2945,19 @@ async function main() {
 
   window.addEventListener('popstate', () => {
     void syncRouteFromURL();
+  });
+
+  // Pasting a share URL into an already-open editor changes only the hash, which
+  // fires `hashchange` (NOT popstate). Decode it into a read-only preview.
+  // Re-entrancy guard: skip if we're already previewing this exact hash (entering
+  // shared mode itself strips the hash, so this won't loop on our own change).
+  let lastSharedHash: string | null = null;
+  window.addEventListener('hashchange', () => {
+    const value = getShareHashValue();
+    if (value === null) return;
+    if (_sharedPreview && value === lastSharedHash) return;
+    lastSharedHash = value;
+    void enterSharedFromHash();
   });
 
   // Expose showHelp for toolbar
@@ -2968,15 +3253,25 @@ async function main() {
   editorReady = true;
   editorReadyResolve();
 
-  // Start guided tour on first visit (after editor fully renders)
-  if (!showLanding && !showHelpPage && !showCatalog && !show404) {
+  // Start guided tour on first visit (after editor fully renders) — but not over
+  // a shared preview, which is a read-only landing surface for an external link.
+  if (!showLanding && !showHelpPage && !showCatalog && !show404 && !hasShareHash()) {
     maybeStartTour();
     maybeShowShortcutsHint();
   }
 
-  // If not on landing/help/catalog/404, load session or default code now
+  // A `#share=…` link opens the read-only preview INSTEAD of the normal editor
+  // load. enterSharedFromHash must run before syncEditorFromURL so the latter
+  // never createSession()s + runs default code on this path; it strips the hash
+  // and degrades to a normal editable editor if the link is invalid. (The
+  // editor + engine are ready here, so its internal ensureEditorReady resolves
+  // immediately — no deadlock from awaiting it earlier in main().)
   if (!showLanding && !showHelpPage && !showCatalog && !show404 && engineOk) {
-    await syncEditorFromURL();
+    if (hasShareHash()) {
+      await enterSharedFromHash();
+    } else {
+      await syncEditorFromURL();
+    }
   }
 
   // Keep this tab's session state in sync with peer tabs that mutate the same
@@ -7935,6 +8230,8 @@ async function main() {
   }
 
   function runCode(code?: string, opts: { surfaceErrors?: boolean } = {}) {
+    // Never execute the sharer's untrusted code in a read-only preview. Fork first.
+    if (isSharedPreview()) return;
     const src = code ?? getValue();
     setStatus(statusBar, 'running', 'Running...');
     clearEditorDiagnostics();
@@ -7950,6 +8247,11 @@ async function main() {
   }
 
   async function runCodeSync(src: string, opts: { surfaceErrors?: boolean } = {}): Promise<boolean> {
+    // Hard refusal in shared-preview mode: this is the single execution
+    // chokepoint that the console API (partwright.run / runAndSave) also routes
+    // through, so guarding it here keeps the sharer's untrusted code from ever
+    // reaching `new Function('api', code)` until the viewer forks.
+    if (isSharedPreview()) return false;
     // Manual runs (Run button, version load, partwright.run) surface errors
     // immediately; auto-runs defer to the idle/blur triggers so the editor
     // doesn't flicker an error on every keystroke.

--- a/src/share/shareLink.ts
+++ b/src/share/shareLink.ts
@@ -100,7 +100,10 @@ export function isSafeImageDataUrl(s: unknown): s is string {
   if (s.length > MAX_IMAGE_DATA_URL_CHARS) return false;
   // Anchored: scheme + raster mime + base64 marker + a pure base64 body to end.
   // No whitespace or `<`/`>`/`"` can appear because the body class excludes them.
-  return /^data:image\/(?:png|jpe?g|webp|gif);base64,[A-Za-z0-9+/]+={0,2}$/i.test(s);
+  // `(?![\s\S])` (true end-of-string) rather than `$`, which without the `m`
+  // flag would also match just before a trailing newline — so "…AAAA\n" is
+  // rejected, keeping the validator exactly as strict as its doc comment.
+  return /^data:image\/(?:png|jpe?g|webp|gif);base64,[A-Za-z0-9+/]+={0,2}(?![\s\S])/i.test(s);
 }
 
 // === trim ===

--- a/src/share/shareLink.ts
+++ b/src/share/shareLink.ts
@@ -1,0 +1,284 @@
+// Pure, DOM-free, dependency-free codec for client-side shareable session links.
+//
+// A share link encodes ONE committed design version into the URL hash
+// (`/editor#share=<base64url>`) so the design never reaches a server. The
+// payload is a single-version {@link ExportedSession} (the same type file
+// import/export already use) gzipped via the native `CompressionStream` and
+// base64url-encoded. Decoding reverses it. Both directions cap the decompressed
+// size so a hostile link can't OOM the tab (zip-bomb defense).
+//
+// This module is the security-critical half of the feature: the viewer decodes
+// UNTRUSTED input, so every validator here is hardened and the module stays
+// import-free for isolated vitest coverage (mirrors src/ai/patch.ts).
+//
+// See `.plans/share-links.md` for the design and the documented PHASE 2
+// (durable short-link backend / live-spin-without-fork) follow-ups.
+
+import type { ExportedSession } from '../storage/sessionManager';
+
+/** Hard cap on the gunzipped payload size. Decoding aborts the moment the
+ *  running total of decompressed bytes exceeds this, before buffering the rest,
+ *  so a small gzip that expands to gigabytes can't exhaust memory. */
+export const MAX_DECOMPRESSED_BYTES = 8_000_000;
+
+/** Per-string sanity caps applied by {@link validateSharePayloadShape}. A
+ *  shared link is untrusted, so reject absurd field sizes outright rather than
+ *  letting them flow into the editor / DOM. */
+const MAX_CODE_CHARS = 512 * 1024;
+const MAX_LABEL_CHARS = 256;
+const MAX_NAME_CHARS = 256;
+
+/** Cap on a thumbnail data URL we'll accept as "safe". A few hundred KB covers
+ *  a generous PNG/JPEG/WebP preview; anything larger is dropped. */
+const MAX_IMAGE_DATA_URL_CHARS = 1_500_000;
+
+/** Thrown for any decode/validation failure on untrusted share input. Callers
+ *  treat every instance as "this shared link is invalid or corrupted" and fall
+ *  back to a normal editable editor. */
+export class ShareDecodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ShareDecodeError';
+  }
+}
+
+/** Thrown by {@link encodeShare} when the browser lacks `CompressionStream`.
+ *  Distinct from {@link ShareDecodeError} so the share-action path can surface a
+ *  "needs a newer browser" message instead of "corrupted". */
+export class ShareUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ShareUnsupportedError';
+  }
+}
+
+// === base64url ===
+
+/** Encode bytes as URL-safe base64 (`-_` alphabet, no `=` padding). */
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  let bin = '';
+  const CHUNK = 0x8000; // avoid the arg-count limit on String.fromCharCode.apply
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Decode URL-safe base64 back into bytes. Rejects input containing the
+ *  standard-base64 characters (`+`, `/`, `=`) — those never appear in our
+ *  URL-safe output, so their presence means the string was tampered with or is
+ *  the wrong encoding. */
+export function base64UrlToBytes(s: string): Uint8Array {
+  if (typeof s !== 'string') throw new ShareDecodeError('share: input is not a string');
+  if (/[+/=]/.test(s)) throw new ShareDecodeError('share: input contains non-url-safe base64 characters');
+  // Restore the standard alphabet + padding for atob.
+  let b64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = b64.length % 4;
+  if (pad === 2) b64 += '==';
+  else if (pad === 3) b64 += '=';
+  else if (pad === 1) throw new ShareDecodeError('share: invalid base64url length');
+  let bin: string;
+  try {
+    bin = atob(b64);
+  } catch {
+    throw new ShareDecodeError('share: not valid base64');
+  }
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+// === thumbnail safety ===
+
+/** Anchored, case-insensitive allow-list for a thumbnail data URL: only raster
+ *  PNG/JPEG/WebP/GIF base64 payloads. Rejects svg/text/html/javascript schemes,
+ *  https URLs, whitespace, embedded characters (e.g. `,<script>`), and anything
+ *  over the length cap. Used both before assigning `img.src` in the viewer and
+ *  to drop an unsafe thumbnail from an imported payload. */
+export function isSafeImageDataUrl(s: unknown): s is string {
+  if (typeof s !== 'string') return false;
+  if (s.length > MAX_IMAGE_DATA_URL_CHARS) return false;
+  // Anchored: scheme + raster mime + base64 marker + a pure base64 body to end.
+  // No whitespace or `<`/`>`/`"` can appear because the body class excludes them.
+  return /^data:image\/(?:png|jpe?g|webp|gif);base64,[A-Za-z0-9+/]+={0,2}$/i.test(s);
+}
+
+// === trim ===
+
+/** Drop the heavy, share-irrelevant parts of an exported session: the
+ *  base64-encoded imported-mesh buffers (STL geometry) on each version, and any
+ *  bulky mesh array smuggled inside `geometryData` (e.g. raw vertex/triangle
+ *  arrays) — while KEEPING the stats (volume/surfaceArea/boundingBox/
+ *  componentCount/isManifold) and `colorRegions` that the preview needs. Does
+ *  not mutate the input. */
+export function trimForShare(exported: ExportedSession): ExportedSession {
+  const versions = Array.isArray(exported.versions) ? exported.versions : [];
+  return {
+    ...exported,
+    versions: versions.map(v => {
+      const { importedMeshes: _drop, geometryData, ...rest } = v;
+      return { ...rest, geometryData: trimGeometryData(geometryData) };
+    }),
+  };
+}
+
+/** Strip heavy mesh arrays from a geometryData blob while keeping the scalar
+ *  stats and `colorRegions`. The renderer never reads raw mesh arrays out of
+ *  geometryData (they live on the Version's `importedMeshes`), so dropping them
+ *  here is lossless for the preview. */
+function trimGeometryData(
+  geometryData: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+  if (!geometryData || typeof geometryData !== 'object') return geometryData ?? null;
+  const HEAVY_KEYS = ['mesh', 'vertProperties', 'triVerts', 'vertices', 'triangles', 'faces', 'normals'];
+  let touched = false;
+  const out: Record<string, unknown> = {};
+  for (const [k, val] of Object.entries(geometryData)) {
+    if (HEAVY_KEYS.includes(k) && (ArrayBuffer.isView(val) || Array.isArray(val))) {
+      touched = true;
+      continue;
+    }
+    out[k] = val;
+  }
+  return touched ? out : geometryData;
+}
+
+// === encode / decode ===
+
+/** Read a ReadableStream of Uint8Array chunks fully into a single Uint8Array,
+ *  aborting (and throwing {@link ShareDecodeError}) the moment the running byte
+ *  total exceeds {@link MAX_DECOMPRESSED_BYTES}. The early bail is what makes
+ *  decode safe against a zip bomb — we never buffer the full output first. */
+async function readAllBounded(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > MAX_DECOMPRESSED_BYTES) {
+        await reader.cancel();
+        throw new ShareDecodeError('share: decompressed payload exceeds size cap');
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return out;
+}
+
+/** Trim → JSON → gzip → base64url. Throws {@link ShareUnsupportedError} when the
+ *  browser has no `CompressionStream` so the caller can disable the feature
+ *  gracefully rather than crash. */
+export async function encodeShare(exported: ExportedSession): Promise<string> {
+  if (typeof CompressionStream === 'undefined') {
+    throw new ShareUnsupportedError('share: CompressionStream is not available in this browser');
+  }
+  const trimmed = trimForShare(exported);
+  const json = JSON.stringify(trimmed);
+  const input = new TextEncoder().encode(json);
+  const cs = new CompressionStream('gzip');
+  const writer = cs.writable.getWriter();
+  // See decodeShare: keep writer-side promises from floating as unhandled
+  // rejections if the stream is torn down early.
+  writer.write(input).catch(() => {});
+  writer.close().catch(() => {});
+  const gzipped = await readAllBounded(cs.readable);
+  return bytesToBase64Url(gzipped);
+}
+
+/** base64url → gunzip (bounded, chunk-by-chunk) → TextDecoder → JSON.parse.
+ *  Throws {@link ShareDecodeError} on any failure. The distinct "exceeds size
+ *  cap" message (from {@link readAllBounded}) lets callers/tests tell a zip bomb
+ *  apart from plain non-gzip/JSON garbage. Returns the parsed value as `unknown`
+ *  — run it through {@link validateSharePayloadShape} (and the app's
+ *  brand/schema validator) before trusting it. */
+export async function decodeShare(encoded: string): Promise<unknown> {
+  if (typeof DecompressionStream === 'undefined') {
+    throw new ShareDecodeError('share: DecompressionStream is not available in this browser');
+  }
+  const bytes = base64UrlToBytes(encoded);
+  const ds = new DecompressionStream('gzip');
+  const writer = ds.writable.getWriter();
+  // Swallow writer-side rejections: when the input isn't valid gzip the writable
+  // half rejects too, and an unhandled rejection would crash the test runner /
+  // surface a console error. The real failure is read off the readable side
+  // below (readAllBounded), so the canonical error message comes from there.
+  writer.write(bytes).catch(() => {});
+  writer.close().catch(() => {});
+  let raw: Uint8Array;
+  try {
+    raw = await readAllBounded(ds.readable);
+  } catch (e) {
+    // Preserve a deliberate "exceeds size cap" ShareDecodeError; remap any other
+    // failure (e.g. malformed gzip stream) to the generic decode error.
+    if (e instanceof ShareDecodeError) throw e;
+    throw new ShareDecodeError('share: not valid gzip data');
+  }
+  let json: string;
+  try {
+    json = new TextDecoder().decode(raw);
+  } catch {
+    throw new ShareDecodeError('share: payload is not valid UTF-8');
+  }
+  try {
+    return JSON.parse(json);
+  } catch {
+    throw new ShareDecodeError('share: payload is not valid JSON');
+  }
+}
+
+// === structural + security validation ===
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return !!x && typeof x === 'object' && !Array.isArray(x);
+}
+
+function assertStringCap(value: unknown, max: number, what: string): void {
+  if (value === undefined || value === null) return;
+  if (typeof value !== 'string') throw new ShareDecodeError(`share: ${what} must be a string`);
+  if (value.length > max) throw new ShareDecodeError(`share: ${what} exceeds the size cap`);
+}
+
+/** Structural + security validator for a decoded share payload. Asserts the
+ *  object has a `session` object and a non-empty `versions` array, enforces
+ *  per-string caps (code / label / session name), and drops an unsafe
+ *  `versions[0].thumbnail` (keeping the rest of the payload). Throws
+ *  {@link ShareDecodeError} on any structural violation. Does NOT check the
+ *  `partwright`/`mainifold` brand or schema version — that's validated
+ *  separately by the app's `validateSessionPayload`. Returns the same object
+ *  (possibly with an unsafe thumbnail removed) typed as {@link ExportedSession}. */
+export function validateSharePayloadShape(raw: unknown): ExportedSession {
+  if (!isObject(raw)) throw new ShareDecodeError('share: payload is not an object');
+  if (!isObject(raw.session)) throw new ShareDecodeError('share: payload is missing "session"');
+  if (!Array.isArray(raw.versions) || raw.versions.length === 0) {
+    throw new ShareDecodeError('share: payload has no versions');
+  }
+
+  assertStringCap(raw.session.name, MAX_NAME_CHARS, 'session.name');
+
+  for (const v of raw.versions) {
+    if (!isObject(v)) throw new ShareDecodeError('share: version entry is not an object');
+    assertStringCap(v.code, MAX_CODE_CHARS, 'version code');
+    assertStringCap(v.label, MAX_LABEL_CHARS, 'version label');
+  }
+
+  // Drop an unsafe leading thumbnail rather than rejecting the whole payload —
+  // the rest of the design is still safe to preview, just without the image.
+  const first = raw.versions[0] as Record<string, unknown>;
+  if ('thumbnail' in first && !isSafeImageDataUrl(first.thumbnail)) {
+    delete first.thumbnail;
+  }
+
+  return raw as unknown as ExportedSession;
+}

--- a/src/share/shareUI.ts
+++ b/src/share/shareUI.ts
@@ -1,0 +1,193 @@
+// DOM widgets for the shareable-link feature: the "copy this link" modal, the
+// read-only preview banner, and the viewport overlay. These take callbacks and
+// hold NO main.ts / session state — main.ts owns insertion and removal so the
+// resource lifecycle (listeners, the thumbnail <img>) stays in one place.
+//
+// Security: every shared string is rendered via textContent and the thumbnail
+// is assigned to img.src ONLY after isSafeImageDataUrl passes — never innerHTML,
+// style, or background-image. See src/share/shareLink.ts.
+
+import { showToast } from '../ui/toast';
+import { isSafeImageDataUrl } from './shareLink';
+
+/** Above this many encoded bytes, the share modal shows an amber warning that
+ *  the link is large (some chat apps / browsers truncate very long URLs). */
+const LARGE_SHARE_BYTES = 500_000;
+
+/** Open the "copy your share link" modal. `url` is the full
+ *  `${origin}/editor#share=…` link; `encodedBytes` is the encoded payload length
+ *  (drives the size readout + large-link warning). Mirrors the editorLock modal
+ *  structure and its single leak-free `close()` teardown. */
+export function openShareModal(url: string, encodedBytes: number): void {
+  const backdrop = document.createElement('div');
+  backdrop.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm';
+
+  const modal = document.createElement('div');
+  modal.className = 'bg-zinc-800 border border-zinc-600 rounded-xl shadow-2xl p-6 max-w-md w-full mx-4';
+
+  const title = document.createElement('h2');
+  title.className = 'text-base font-semibold text-zinc-100 mb-2';
+  title.textContent = 'Share a read-only link';
+
+  const explanation = document.createElement('p');
+  explanation.className = 'text-sm text-zinc-400 mb-4 leading-relaxed';
+  explanation.textContent =
+    'This link encodes the current version entirely inside the URL — nothing is uploaded to any server. Anyone who opens it sees a read-only preview and can fork it into their own local copy.';
+
+  // Single teardown for every dismissal path (Copy stays open; Close, backdrop,
+  // Escape all run this) so the keydown listener is always removed.
+  const close = () => {
+    backdrop.remove();
+    document.removeEventListener('keydown', onKey);
+  };
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') close();
+  };
+
+  // URL field + Copy button row.
+  const row = document.createElement('div');
+  row.className = 'flex items-stretch gap-2 mb-3';
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.readOnly = true;
+  input.value = url; // value, never innerHTML
+  input.className =
+    'flex-1 min-w-0 px-3 py-2 rounded bg-zinc-900 border border-zinc-600 text-xs text-zinc-200 font-mono';
+  input.addEventListener('focus', () => input.select());
+
+  const copyBtn = document.createElement('button');
+  copyBtn.type = 'button';
+  // ≥44px tall touch target for mobile.
+  copyBtn.className =
+    'shrink-0 min-h-[44px] px-4 rounded bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors';
+  copyBtn.textContent = 'Copy';
+  copyBtn.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      showToast('Link copied', { variant: 'success' });
+    } catch {
+      // Clipboard can be blocked (permissions, insecure context). Fall back to
+      // selecting the field so the user can copy manually.
+      input.focus();
+      input.select();
+      showToast('Press Ctrl/Cmd+C to copy', { variant: 'warn' });
+    }
+  });
+
+  row.append(input, copyBtn);
+
+  // Size readout.
+  const sizeKb = Math.max(1, Math.round(encodedBytes / 1024));
+  const sizeRow = document.createElement('p');
+  sizeRow.className = 'text-xs text-zinc-500 mb-1';
+  sizeRow.textContent = `Link size: ~${sizeKb} KB`;
+
+  modal.append(title, explanation, row, sizeRow);
+
+  // Large-link warning (amber), only when the encoded payload is big.
+  if (encodedBytes > LARGE_SHARE_BYTES) {
+    const warn = document.createElement('p');
+    warn.className = 'mt-2 px-3 py-2 rounded bg-amber-900/40 border border-amber-500/40 text-xs text-amber-200 leading-relaxed';
+    warn.textContent =
+      '⚠️ This link is large. Some chat apps and browsers truncate very long URLs — if the preview fails to open, send the exported .partwright.json file instead.';
+    modal.appendChild(warn);
+  }
+
+  // Provenance / trust note.
+  const trust = document.createElement('p');
+  trust.className = 'mt-3 text-[11px] text-zinc-500 leading-relaxed';
+  trust.textContent =
+    'Only open share links from people you trust. Shared code never runs until you choose to fork it.';
+  modal.appendChild(trust);
+
+  const btnRow = document.createElement('div');
+  btnRow.className = 'flex justify-end mt-4';
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'px-4 py-2 rounded text-sm text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 transition-colors';
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', () => close());
+  btnRow.appendChild(closeBtn);
+  modal.appendChild(btnRow);
+
+  backdrop.appendChild(modal);
+  backdrop.addEventListener('click', (e) => {
+    if (e.target === backdrop) close();
+  });
+  document.addEventListener('keydown', onKey);
+  document.body.appendChild(backdrop);
+
+  // Pre-select the URL so a keyboard copy works immediately.
+  input.focus();
+  input.select();
+}
+
+/** Read-only banner shown above the editor while previewing a shared link.
+ *  Returns the element; main.ts owns insertion/removal. */
+export function renderSharedBanner(onFork: () => void): HTMLElement {
+  const banner = document.createElement('div');
+  banner.id = 'shared-preview-banner';
+  banner.className =
+    'flex items-center justify-between px-3 py-1.5 bg-blue-900/50 border-b border-blue-500/40 text-xs text-blue-100 shrink-0';
+
+  const msg = document.createElement('span');
+  msg.textContent = 'Read-only shared preview. Fork it to edit and run.';
+
+  const forkBtn = document.createElement('button');
+  forkBtn.type = 'button';
+  forkBtn.className =
+    'px-2 py-0.5 rounded text-xs bg-blue-500/20 hover:bg-blue-500/40 text-blue-50 border border-blue-500/40 transition-colors';
+  forkBtn.textContent = 'Fork to edit';
+  forkBtn.addEventListener('click', onFork);
+
+  banner.append(msg, forkBtn);
+  return banner;
+}
+
+/** Full-viewport overlay for the shared preview: shows the decoded thumbnail (if
+ *  safe) and a prominent "Fork to edit & run" CTA. Modeled on viewerMode's
+ *  overlay; it both displays the preview image and blocks viewport interaction
+ *  (the geometry pipeline stays cold until Fork). Returns the element; main.ts
+ *  owns insertion/removal so the <img> is torn down explicitly. */
+export function renderSharedOverlay(opts: { thumbnail?: string; onFork: () => void }): HTMLElement {
+  const overlay = document.createElement('div');
+  overlay.id = 'shared-preview-overlay';
+  // Cover the viewport pane only (main.ts mounts it into the viewport),
+  // pointer-events on so it intercepts orbit/click on the cold scene.
+  overlay.className =
+    'absolute inset-0 z-40 flex flex-col items-center justify-center gap-4 bg-zinc-900/80 backdrop-blur-[1px] p-6 text-center';
+
+  const card = document.createElement('div');
+  card.className = 'flex flex-col items-center gap-4 max-w-sm w-full';
+
+  if (isSafeImageDataUrl(opts.thumbnail)) {
+    const img = document.createElement('img');
+    img.alt = 'Shared design preview';
+    img.className = 'max-h-64 w-auto rounded-lg border border-zinc-600 bg-zinc-800 object-contain';
+    // Assign ONLY to src, ONLY after the safety check above.
+    img.src = opts.thumbnail;
+    card.appendChild(img);
+  } else {
+    const placeholder = document.createElement('div');
+    placeholder.className = 'text-sm text-zinc-400';
+    placeholder.textContent = 'No preview image — fork to render this design.';
+    card.appendChild(placeholder);
+  }
+
+  const cta = document.createElement('button');
+  cta.type = 'button';
+  cta.className =
+    'min-h-[44px] px-5 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold shadow-lg transition-colors';
+  cta.textContent = 'Fork to edit & run';
+  cta.addEventListener('click', opts.onFork);
+  card.appendChild(cta);
+
+  const hint = document.createElement('p');
+  hint.className = 'text-[11px] text-zinc-400 leading-relaxed';
+  hint.textContent = 'This is a read-only preview. The shared code does not run until you fork it.';
+  card.appendChild(hint);
+
+  overlay.appendChild(card);
+  return overlay;
+}

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -25,6 +25,9 @@ export interface ToolbarCallbacks {
    *  decide visibility. */
   onExportSTEP: () => void;
   onExportSessionJSON: () => void;
+  /** "Share link…" — encode the current version into a read-only,
+   *  hash-encoded share URL and open the copy modal. */
+  onShareLink: () => void;
   onExportRawCode: () => void;
   onImportFile: (file: File) => void | Promise<void>;
   /** Re-import a blob already held in the inbox (e.g. recent-imports re-click). */
@@ -490,8 +493,18 @@ export function createToolbar(
     callbacks.onExportRawCode();
   });
 
+  const shareOpt = createDescribedItem(
+    'Share link…',
+    'Create a public read-only link to this version. Anyone can preview and fork it — nothing is uploaded.',
+  );
+  shareOpt.addEventListener('click', () => {
+    dropdown.classList.add('hidden');
+    callbacks.onShareLink();
+  });
+
   dropdown.appendChild(sessionOpt);
   dropdown.appendChild(codeOpt);
+  dropdown.appendChild(shareOpt);
 
   // Section: Recent Exports — reuse-anything-you-just-downloaded list. Hidden when empty.
   const recentDivider = createDivider();

--- a/tests/share-link.spec.ts
+++ b/tests/share-link.spec.ts
@@ -80,6 +80,30 @@ async function sessionCount(page: Page): Promise<number> {
   });
 }
 
+/** Wipe the IndexedDB `sessions` store to establish a clean baseline. The bare
+ *  /editor load auto-creates a disposable empty session; clearing it lets a
+ *  preview's non-mutation be asserted as an exact 0 (independent of the
+ *  pre-existing empty-session GC). */
+async function clearSessions(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const db: IDBDatabase = await new Promise((res, rej) => {
+      const r = indexedDB.open('partwright');
+      r.onsuccess = () => res(r.result);
+      r.onerror = () => rej(r.error);
+    });
+    try {
+      await new Promise<void>((res, rej) => {
+        const txn = db.transaction('sessions', 'readwrite');
+        txn.objectStore('sessions').clear();
+        txn.oncomplete = () => res();
+        txn.onerror = () => rej(txn.error);
+      });
+    } finally {
+      db.close();
+    }
+  });
+}
+
 /** Read the parsed #geometry-data JSON. */
 async function geometryData(page: Page): Promise<Record<string, unknown>> {
   return page.evaluate(() => {
@@ -121,7 +145,9 @@ test.describe('share links', () => {
     const sharedCode = 'const { Manifold } = api;\nreturn Manifold.cube([5,5,5], true);';
     const url = await buildShareUrl(page, { code: sharedCode, volume: SENTINEL_VOL, thumbnail: TINY_PNG });
 
-    const before = await sessionCount(page);
+    // Clear the disposable default session created by the initial /editor load so
+    // the preview's non-mutation is unambiguous: it must add NO session of its own.
+    await clearSessions(page);
 
     await page.goto(url);
     await page.waitForSelector('#shared-preview-banner', { timeout: 20000 });
@@ -151,12 +177,52 @@ test.describe('share links', () => {
     // Hash stripped to exactly /editor (no #, no ?session=).
     expect(page.url()).toBe(`${new URL(url).origin}/editor`);
 
-    // No IndexedDB writes.
-    expect(await sessionCount(page)).toBe(before);
+    // Non-mutating: no active session in the URL and no session row created.
+    expect(new URL(page.url()).searchParams.has('session')).toBe(false);
+    expect(await sessionCount(page)).toBe(0);
 
     // Back must not resurrect a #share= URL.
     await page.goBack().catch(() => {});
     expect(page.url()).not.toContain('#share=');
+  });
+
+  test('T2b Console execution APIs (runIsolated / runAndAssert) refuse in a preview', async ({ page }) => {
+    // runIsolated / runAndAssert back the AI-exposed tools and bypass the Run
+    // button, so they must honor the no-execution invariant too — otherwise a
+    // prompt-injected agent could run the sharer's code (reaching fetch /
+    // indexedDB, where API keys live) without an explicit Fork.
+    await openEditor(page);
+    const SENTINEL_VOL = 4242;
+    const url = await buildShareUrl(page, {
+      code: 'const { Manifold } = api;\nreturn Manifold.cube([5,5,5], true);',
+      volume: SENTINEL_VOL,
+      thumbnail: TINY_PNG,
+    });
+
+    await page.goto(url);
+    await page.waitForSelector('#shared-preview-banner', { timeout: 20000 });
+
+    const out = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: {
+        runIsolated(code: string): Promise<{ geometryData: { status?: string; error?: string } }>;
+        runAndAssert(code: string, a: unknown): Promise<{ passed: boolean; failures?: string[] }>;
+      } }).partwright;
+      const evil = 'const { Manifold } = api; return Manifold.cube([9,9,9], true);';
+      // Use a VALID assertion shape (minVolume), so the call passes argument
+      // validation and actually reaches the execution guard rather than failing
+      // shape-validation first.
+      return { isolated: await pw.runIsolated(evil), asserted: await pw.runAndAssert(evil, { minVolume: 0 }) };
+    });
+
+    // runIsolated is refused with an error result …
+    expect(out.isolated.geometryData.status).toBe('error');
+    expect(String(out.isolated.geometryData.error)).toMatch(/shared preview/i);
+    // … and runAndAssert fails with the same refusal.
+    expect(out.asserted.passed).toBe(false);
+    expect(String(out.asserted.failures?.[0])).toMatch(/shared preview/i);
+
+    // The geometry pipeline stayed cold: the embedded sentinel is unchanged.
+    expect((await geometryData(page)).volume).toBe(SENTINEL_VOL);
   });
 
   test('T3 Fork makes the design hot, editable, and persisted', async ({ page }) => {

--- a/tests/share-link.spec.ts
+++ b/tests/share-link.spec.ts
@@ -1,0 +1,292 @@
+// E2E for client-side shareable session links. Runs offline (no network):
+// the share URL encodes the design into the hash, the viewer decodes it, and
+// nothing is uploaded.
+//
+// Security is the heart of T2: opening a share link must NOT execute the
+// sharer's code. Since user code runs in a Worker (not the page), the
+// observable "did it run?" signal is the geometry pipeline output in
+// #geometry-data. We embed stats with a SENTINEL volume that differs from what
+// the code would compute, so a cold preview shows the embedded number and a
+// post-fork run shows the computed one.
+
+import { test, expect, type Page } from 'playwright/test';
+
+// 1x1 transparent PNG — a valid raster data URL that passes isSafeImageDataUrl
+// and yields naturalWidth > 0 once decoded.
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+/** Pre-dismiss the first-run tour so its backdrop/keys don't interfere, then
+ *  open the editor and wait for the engine. Mirrors command-palette.spec.ts. */
+async function openEditor(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', new Date().toISOString()); } catch { /* ignore */ }
+    // Keep the code pane visible: the app collapses it when the AI drawer
+    // auto-opens, which would hide .cm-content and break editor interactions.
+    try { localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({ editorCollapsed: false })); } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 20000 });
+}
+
+/** Build a `#share=` URL for arbitrary code/stats/thumbnail by importing the
+ *  pure codec in the page and encoding a single-version ExportedSession. Lets a
+ *  viewer test embed a sentinel without going through the Share UI. */
+async function buildShareUrl(
+  page: Page,
+  opts: { code: string; language?: string; volume?: number; thumbnail?: string | null },
+): Promise<string> {
+  return page.evaluate(async (o) => {
+    const mod = await import('/src/share/shareLink.ts');
+    const exported = {
+      partwright: '1.8',
+      session: { name: 'Shared test', created: 1000, updated: 2000, language: o.language ?? 'manifold-js' },
+      parts: [{ name: 'Part 1', order: 0 }],
+      versions: [
+        {
+          index: 1,
+          code: o.code,
+          label: 'v1',
+          geometryData: { status: 'ok', volume: o.volume ?? 1331, surfaceArea: 100, isManifold: true, componentCount: 1 },
+          timestamp: 1500,
+          ...(o.language ? { language: o.language } : {}),
+          ...(o.thumbnail ? { thumbnail: o.thumbnail } : {}),
+        },
+      ],
+    };
+    const encoded = await mod.encodeShare(exported as never);
+    return `${location.origin}/editor#share=${encoded}`;
+  }, opts);
+}
+
+/** Count rows in the IndexedDB `sessions` store (0 in a fresh context). */
+async function sessionCount(page: Page): Promise<number> {
+  return page.evaluate(async () => {
+    const db: IDBDatabase = await new Promise((res, rej) => {
+      const r = indexedDB.open('partwright');
+      r.onsuccess = () => res(r.result);
+      r.onerror = () => rej(r.error);
+    });
+    try {
+      const count: number = await new Promise((res, rej) => {
+        const req = db.transaction('sessions', 'readonly').objectStore('sessions').count();
+        req.onsuccess = () => res(req.result);
+        req.onerror = () => rej(req.error);
+      });
+      return count;
+    } finally {
+      db.close();
+    }
+  });
+}
+
+/** Read the parsed #geometry-data JSON. */
+async function geometryData(page: Page): Promise<Record<string, unknown>> {
+  return page.evaluate(() => {
+    try { return JSON.parse(document.getElementById('geometry-data')?.textContent || '{}'); } catch { return {}; }
+  });
+}
+
+test.describe('share links', () => {
+  test('T1 Share action opens a modal with a copyable hash URL', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await openEditor(page);
+
+    // Run the default so there's geometry, then share via the command palette.
+    await page.keyboard.press('ControlOrMeta+k');
+    const palette = page.locator('input[aria-label="Search commands"]');
+    await palette.fill('Share design');
+    await expect(page.locator('[role="option"]').filter({ hasText: 'Share design' })).toBeVisible();
+    await page.keyboard.press('Enter');
+
+    // The modal's read-only input holds the full share URL.
+    const urlInput = page.locator('input[readonly]').first();
+    await expect(urlInput).toBeVisible({ timeout: 10000 });
+    const origin = new URL(page.url()).origin;
+    const value = await urlInput.inputValue();
+    expect(value.startsWith(`${origin}/editor#share=`)).toBe(true);
+
+    // Copy → success toast (clipboard readback is best-effort only).
+    await page.getByRole('button', { name: 'Copy', exact: true }).click();
+    await expect(page.getByText('Link copied')).toBeVisible();
+  });
+
+  test('T2 Opening a share link shows a cold, read-only preview (no execution)', async ({ page }) => {
+    await openEditor(page);
+
+    // Embed code that computes volume 125 but stats that claim volume 4242.
+    // A cold preview must surface 4242 (the embedded number); a real run would
+    // overwrite it with 125.
+    const SENTINEL_VOL = 4242;
+    const sharedCode = 'const { Manifold } = api;\nreturn Manifold.cube([5,5,5], true);';
+    const url = await buildShareUrl(page, { code: sharedCode, volume: SENTINEL_VOL, thumbnail: TINY_PNG });
+
+    const before = await sessionCount(page);
+
+    await page.goto(url);
+    await page.waitForSelector('#shared-preview-banner', { timeout: 20000 });
+
+    // Banner + Fork CTA visible.
+    await expect(page.locator('#shared-preview-banner')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Fork to edit & run' })).toBeVisible();
+
+    // Editor read-only: Run disabled AND typing leaves the doc unchanged.
+    await expect(page.locator('#btn-run')).toBeDisabled();
+    const codeBefore = await page.evaluate(() => (window as { partwright?: { getCode(): string } }).partwright?.getCode?.() ?? '');
+    // Editor auto-format may respace the array literal; compare whitespace-insensitively.
+    expect(codeBefore.replace(/\s+/g, '')).toContain('Manifold.cube([5,5,5],true)');
+    await page.locator('.cm-content').click();
+    await page.keyboard.type('// injected', { delay: 10 });
+    const codeAfter = await page.evaluate(() => (window as { partwright?: { getCode(): string } }).partwright?.getCode?.() ?? '');
+    expect(codeAfter).toBe(codeBefore);
+
+    // Thumbnail rendered via a CSP-safe data URL (naturalWidth proves decode).
+    const img = page.locator('#shared-preview-overlay img');
+    await expect(img).toBeVisible();
+    expect(await img.evaluate((el: HTMLImageElement) => el.naturalWidth)).toBeGreaterThan(0);
+
+    // Pipeline stayed COLD: the embedded sentinel volume is what's shown.
+    expect((await geometryData(page)).volume).toBe(SENTINEL_VOL);
+
+    // Hash stripped to exactly /editor (no #, no ?session=).
+    expect(page.url()).toBe(`${new URL(url).origin}/editor`);
+
+    // No IndexedDB writes.
+    expect(await sessionCount(page)).toBe(before);
+
+    // Back must not resurrect a #share= URL.
+    await page.goBack().catch(() => {});
+    expect(page.url()).not.toContain('#share=');
+  });
+
+  test('T3 Fork makes the design hot, editable, and persisted', async ({ page }) => {
+    await openEditor(page);
+
+    const SENTINEL_VOL = 4242;
+    const sharedCode = 'const { Manifold } = api;\nreturn Manifold.cube([5,5,5], true);';
+    const url = await buildShareUrl(page, { code: sharedCode, volume: SENTINEL_VOL, thumbnail: TINY_PNG });
+
+    await page.goto(url);
+    await page.waitForSelector('#shared-preview-banner', { timeout: 20000 });
+    const before = await sessionCount(page);
+
+    await page.getByRole('button', { name: 'Fork to edit & run' }).click();
+
+    // Banner gone, Run enabled, URL carries ?session=, editor editable.
+    await expect(page.locator('#shared-preview-banner')).toHaveCount(0);
+    await expect(page.locator('#shared-preview-overlay')).toHaveCount(0);
+    await expect(page.locator('#btn-run')).toBeEnabled();
+    await expect.poll(() => new URL(page.url()).searchParams.has('session')).toBe(true);
+
+    // Forked code matches the shared code (whitespace-insensitive: the editor
+    // may reformat the array literal).
+    const forkedCode = await page.evaluate(() => (window as { partwright?: { getCode(): string } }).partwright?.getCode?.() ?? '');
+    expect(forkedCode.replace(/\s+/g, '')).toContain('Manifold.cube([5,5,5],true)');
+
+    // Sentinel NOW fired: a real run computed volume 125, replacing the 4242
+    // the preview displayed.
+    await expect.poll(async () => (await geometryData(page)).volume, { timeout: 15000 }).toBe(125);
+
+    // A session row was created.
+    expect(await sessionCount(page)).toBe(before + 1);
+
+    // Editing works.
+    await page.locator('.cm-content').click();
+    await page.keyboard.type('\n// edited after fork', { delay: 10 });
+    const edited = await page.evaluate(() => (window as { partwright?: { getCode(): string } }).partwright?.getCode?.() ?? '');
+    expect(edited).toContain('edited after fork');
+
+    // Persists across reload.
+    await page.reload();
+    await page.waitForSelector('text=Ready', { timeout: 20000 });
+    expect(await sessionCount(page)).toBe(before + 1);
+  });
+
+  test('T4 Invalid share links fall back to a normal editable editor', async ({ page }) => {
+    // Case A: pure garbage hash.
+    await openEditor(page);
+    await page.goto('/editor#share=garbage');
+    await page.waitForSelector('text=Ready', { timeout: 20000 });
+    await expect(page.locator('#shared-preview-banner')).toHaveCount(0);
+    await expect(page.locator('#btn-run')).toBeEnabled();
+    expect(page.url()).not.toContain('#share=');
+
+    // Case B: valid gzip+JSON that FAILS the brand/shape validation (no
+    // partwright brand). Still a normal editable editor, no crash, no toast.
+    const badUrl = await page.evaluate(async () => {
+      const mod = await import('/src/share/shareLink.ts');
+      // Encode an object that decodes fine but isn't a Partwright session.
+      const notASession = { hello: 'world', versions: [] };
+      const encoded = await mod.encodeShare(notASession as never);
+      return `${location.origin}/editor#share=${encoded}`;
+    });
+    await page.goto(badUrl);
+    await page.waitForSelector('text=Ready', { timeout: 20000 });
+    await expect(page.locator('#shared-preview-banner')).toHaveCount(0);
+    await expect(page.locator('#btn-run')).toBeEnabled();
+    expect(page.url()).not.toContain('#share=');
+    // No error toast surfaced.
+    await expect(page.getByText('invalid or corrupted')).toHaveCount(0);
+  });
+
+  test('T5 SCAD share previews without running and forks into SCAD', async ({ page }) => {
+    await openEditor(page);
+
+    const scadCode = 'cube([10, 10, 10], center = true);';
+    const url = await buildShareUrl(page, { code: scadCode, language: 'scad', volume: 1000, thumbnail: TINY_PNG });
+
+    await page.goto(url);
+    await page.waitForSelector('#shared-preview-banner', { timeout: 20000 });
+
+    // Preview shows the code + thumbnail, no engine run (sentinel volume intact).
+    const previewCode = await page.evaluate(() => (window as { partwright?: { getCode(): string } }).partwright?.getCode?.() ?? '');
+    expect(previewCode.replace(/\s+/g, '')).toContain('cube([10,10,10]');
+    expect((await geometryData(page)).volume).toBe(1000);
+    await expect(page.locator('#shared-preview-overlay img')).toBeVisible();
+
+    // Fork → engine switches to SCAD and runs.
+    await page.getByRole('button', { name: 'Fork to edit & run' }).click();
+    await expect(page.locator('#shared-preview-banner')).toHaveCount(0);
+    await expect.poll(() => new URL(page.url()).searchParams.has('session')).toBe(true);
+    // SCAD engine computes a real volume (1000 for a 10³ cube) — proves a run.
+    await expect.poll(async () => (await geometryData(page)).status, { timeout: 30000 }).toBe('ok');
+  });
+
+  test('T6 Share modal is usable at 375px', async ({ page, context }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await openEditor(page);
+
+    await page.keyboard.press('ControlOrMeta+k');
+    const palette = page.locator('input[aria-label="Search commands"]');
+    await palette.fill('Share design');
+    await page.keyboard.press('Enter');
+
+    const urlInput = page.locator('input[readonly]').first();
+    await expect(urlInput).toBeVisible({ timeout: 10000 });
+    const box = await urlInput.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeLessThanOrEqual(375);
+
+    // Copy button is a ≥44px touch target.
+    const copyBox = await page.getByRole('button', { name: 'Copy', exact: true }).boundingBox();
+    expect(copyBox).not.toBeNull();
+    expect(copyBox!.height).toBeGreaterThanOrEqual(44);
+  });
+
+  test('Offline: the viewer reaches a loaded preview with no cross-origin network', async ({ page }) => {
+    await openEditor(page);
+    const url = await buildShareUrl(page, { code: 'const { Manifold } = api;\nreturn Manifold.cube([3,3,3], true);', volume: 27, thumbnail: TINY_PNG });
+
+    const origin = new URL(url).origin;
+    await page.route('**/*', (route) => {
+      const reqOrigin = new URL(route.request().url()).origin;
+      return reqOrigin === origin ? route.continue() : route.abort();
+    });
+
+    await page.goto(url);
+    await page.waitForSelector('#shared-preview-banner', { timeout: 20000 });
+    await expect(page.getByRole('button', { name: 'Fork to edit & run' })).toBeVisible();
+    expect((await geometryData(page)).volume).toBe(27);
+  });
+});

--- a/tests/unit/shareLink.test.ts
+++ b/tests/unit/shareLink.test.ts
@@ -109,6 +109,9 @@ describe('isSafeImageDataUrl', () => {
     expect(isSafeImageDataUrl('data:image/png;base64,iVBOR\nw0KGgo=')).toBe(false);
     expect(isSafeImageDataUrl('data:image/png;base64,iVBOR,<script>alert(1)</script>')).toBe(false);
     expect(isSafeImageDataUrl('data:image/png;base64,abc"def')).toBe(false);
+    // Trailing newline must be rejected — a bare `$` (no `m` flag) would match
+    // the position just before it and let "…=\n" through.
+    expect(isSafeImageDataUrl('data:image/png;base64,iVBORw0KGgo=\n')).toBe(false);
   });
 
   test('rejects an oversized data URL', () => {

--- a/tests/unit/shareLink.test.ts
+++ b/tests/unit/shareLink.test.ts
@@ -1,0 +1,278 @@
+// Unit tests for the client-side share-link codec (src/share/shareLink.ts).
+// Pure logic, no browser/DOM — encode/decode lean on the native (Compression|
+// Decompression)Stream + TextEncoder/atob/btoa, all available in Node 18+.
+//
+// encode/decode are ASYNC: await them, and use `await expect(...).rejects` for
+// failure cases (a sync `.toThrow` would silently pass on a rejected promise).
+
+import { describe, test, expect } from 'vitest';
+import {
+  bytesToBase64Url,
+  base64UrlToBytes,
+  isSafeImageDataUrl,
+  trimForShare,
+  encodeShare,
+  decodeShare,
+  validateSharePayloadShape,
+  ShareDecodeError,
+  MAX_DECOMPRESSED_BYTES,
+} from '../../src/share/shareLink';
+import type { ExportedSession } from '../../src/storage/sessionManager';
+
+// Fail loud if the runtime lacks the streams API — these tests can't run
+// without it, and a silent skip would hide a regression.
+expect(typeof DecompressionStream).toBe('function');
+expect(typeof CompressionStream).toBe('function');
+
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
+
+function makeExported(overrides: Partial<ExportedSession['versions'][0]> = {}, top: Partial<ExportedSession> = {}): ExportedSession {
+  return {
+    partwright: '1.8',
+    session: { name: 'Test design', created: 1000, updated: 2000 },
+    parts: [{ name: 'Part 1', order: 0 }],
+    versions: [
+      {
+        index: 1,
+        code: 'const { Manifold } = api;\nreturn Manifold.cube([5,5,5], true);',
+        label: 'v1',
+        geometryData: { status: 'ok', volume: 125, surfaceArea: 150, isManifold: true, componentCount: 1 },
+        timestamp: 1500,
+        ...overrides,
+      },
+    ],
+    ...top,
+  };
+}
+
+describe('bytesToBase64Url / base64UrlToBytes', () => {
+  test('round-trips arbitrary bytes', () => {
+    const bytes = new Uint8Array([0, 1, 2, 250, 251, 255, 100, 42]);
+    const s = bytesToBase64Url(bytes);
+    expect(Array.from(base64UrlToBytes(s))).toEqual(Array.from(bytes));
+  });
+
+  test('round-trips a 1-byte tail (length % 3 === 1)', () => {
+    const bytes = new Uint8Array([7]); // base64 would normally pad with "=="
+    const s = bytesToBase64Url(bytes);
+    expect(s).not.toMatch(/[+/=]/);
+    expect(Array.from(base64UrlToBytes(s))).toEqual([7]);
+  });
+
+  test('round-trips a 2-byte tail (length % 3 === 2)', () => {
+    const bytes = new Uint8Array([7, 200]); // base64 would normally pad with "="
+    const s = bytesToBase64Url(bytes);
+    expect(s).not.toMatch(/[+/=]/);
+    expect(Array.from(base64UrlToBytes(s))).toEqual([7, 200]);
+  });
+
+  test('output never contains +, /, or =', () => {
+    // 0xFB,0xFF would produce "+/" in standard base64.
+    const bytes = new Uint8Array([0xfb, 0xff, 0xbf, 0xff]);
+    const s = bytesToBase64Url(bytes);
+    expect(s).not.toMatch(/[+/=]/);
+  });
+
+  test('base64UrlToBytes rejects standard-base64 characters', () => {
+    expect(() => base64UrlToBytes('ab+c')).toThrow(ShareDecodeError);
+    expect(() => base64UrlToBytes('ab/c')).toThrow(ShareDecodeError);
+    expect(() => base64UrlToBytes('abc=')).toThrow(ShareDecodeError);
+  });
+});
+
+describe('isSafeImageDataUrl', () => {
+  test('accepts png / jpeg / webp / gif raster data URLs', () => {
+    expect(isSafeImageDataUrl(TINY_PNG)).toBe(true);
+    expect(isSafeImageDataUrl('data:image/jpeg;base64,/9j/4AAQSkZJRg==')).toBe(true);
+    expect(isSafeImageDataUrl('data:image/webp;base64,UklGRhoAAABXRUJQ')).toBe(true);
+    expect(isSafeImageDataUrl('data:image/gif;base64,R0lGODlhAQABAAAAACw=')).toBe(true);
+  });
+
+  test('is case-insensitive on the scheme and mime', () => {
+    expect(isSafeImageDataUrl('DATA:IMAGE/PNG;BASE64,iVBORw0KGgo=')).toBe(true);
+    expect(isSafeImageDataUrl('Data:Image/Png;Base64,iVBORw0KGgo=')).toBe(true);
+  });
+
+  test('rejects svg / text-html / javascript / https / non-string', () => {
+    expect(isSafeImageDataUrl('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=')).toBe(false);
+    expect(isSafeImageDataUrl('data:text/html;base64,PHNjcmlwdD4=')).toBe(false);
+    expect(isSafeImageDataUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeImageDataUrl('https://evil.example/x.png')).toBe(false);
+    expect(isSafeImageDataUrl(undefined)).toBe(false);
+    expect(isSafeImageDataUrl(null)).toBe(false);
+    expect(isSafeImageDataUrl(12345)).toBe(false);
+  });
+
+  test('rejects whitespace and embedded characters', () => {
+    expect(isSafeImageDataUrl('data:image/png;base64, iVBORw0KGgo=')).toBe(false);
+    expect(isSafeImageDataUrl('data:image/png;base64,iVBOR\nw0KGgo=')).toBe(false);
+    expect(isSafeImageDataUrl('data:image/png;base64,iVBOR,<script>alert(1)</script>')).toBe(false);
+    expect(isSafeImageDataUrl('data:image/png;base64,abc"def')).toBe(false);
+  });
+
+  test('rejects an oversized data URL', () => {
+    const huge = 'data:image/png;base64,' + 'A'.repeat(2_000_000);
+    expect(isSafeImageDataUrl(huge)).toBe(false);
+  });
+});
+
+describe('trimForShare', () => {
+  test('strips importedMeshes but keeps stats + colorRegions + thumbnail', () => {
+    const exported = makeExported({
+      thumbnail: TINY_PNG,
+      colorRegions: [{ kind: 'coplanar', seedPoint: [0, 0, 0], color: '#ff0000' } as never],
+      importedMeshes: [{ id: 'm1', filename: 'x.stl', format: 'stl', numVert: 3, numTri: 1, numProp: 3, vertProperties: 'AAA', triVerts: 'AAA' }],
+    });
+    const trimmed = trimForShare(exported);
+    expect(trimmed.versions[0].importedMeshes).toBeUndefined();
+    expect(trimmed.versions[0].thumbnail).toBe(TINY_PNG);
+    expect(trimmed.versions[0].colorRegions).toBeDefined();
+    expect(trimmed.versions[0].geometryData).toMatchObject({ volume: 125, isManifold: true });
+  });
+
+  test('drops a heavy mesh array inside geometryData but keeps scalar stats', () => {
+    const exported = makeExported({
+      geometryData: { status: 'ok', volume: 10, vertProperties: new Float32Array(1000), triVerts: [1, 2, 3, 4, 5, 6] },
+    });
+    const trimmed = trimForShare(exported);
+    const geo = trimmed.versions[0].geometryData as Record<string, unknown>;
+    expect(geo.vertProperties).toBeUndefined();
+    expect(geo.triVerts).toBeUndefined();
+    expect(geo.volume).toBe(10);
+  });
+
+  test('does not mutate the input', () => {
+    const exported = makeExported({ importedMeshes: [{ id: 'm1', filename: 'x.stl', format: 'stl', numVert: 0, numTri: 0, numProp: 3, vertProperties: '', triVerts: '' }] });
+    trimForShare(exported);
+    expect(exported.versions[0].importedMeshes).toBeDefined();
+  });
+});
+
+describe('encodeShare / decodeShare round-trip', () => {
+  test('round-trips a plain payload', async () => {
+    const x = makeExported();
+    const decoded = await decodeShare(await encodeShare(x));
+    expect(validateSharePayloadShape(decoded)).toEqual(trimForShare(x));
+  });
+
+  test('round-trips with colorRegions', async () => {
+    const x = makeExported({ colorRegions: [{ kind: 'coplanar', seedPoint: [1, 2, 3], color: '#00ff00' } as never] });
+    const decoded = await decodeShare(await encodeShare(x));
+    expect(validateSharePayloadShape(decoded)).toEqual(trimForShare(x));
+  });
+
+  test('round-trips with annotations', async () => {
+    const x = makeExported({ annotations: [{ kind: 'stroke', id: 'a1', points: [[0, 0, 0]], color: '#fff', width: 2 } as never] });
+    const decoded = await decodeShare(await encodeShare(x));
+    expect(validateSharePayloadShape(decoded)).toEqual(trimForShare(x));
+  });
+
+  test('round-trips with a thumbnail', async () => {
+    const x = makeExported({ thumbnail: TINY_PNG });
+    const decoded = await decodeShare(await encodeShare(x));
+    const validated = validateSharePayloadShape(decoded);
+    expect(validated.versions[0].thumbnail).toBe(TINY_PNG);
+    expect(validated).toEqual(trimForShare(x));
+  });
+
+  test('strips importedMeshes through the round-trip (trim runs in encode)', async () => {
+    const x = makeExported({ importedMeshes: [{ id: 'm', filename: 'f.stl', format: 'stl', numVert: 1, numTri: 1, numProp: 3, vertProperties: 'QQ', triVerts: 'QQ' }] });
+    const decoded = await decodeShare(await encodeShare(x)) as ExportedSession;
+    expect(decoded.versions[0].importedMeshes).toBeUndefined();
+  });
+
+  test('decodeShare rejects garbage base64url (not gzip) with the generic error', async () => {
+    // Valid base64url characters but not a gzip stream.
+    await expect(decodeShare('bm90Z3ppcGRhdGE')).rejects.toThrow(ShareDecodeError);
+    await expect(decodeShare('bm90Z3ppcGRhdGE')).rejects.toThrow(/not valid gzip/);
+  });
+
+  test('decodeShare rejects non-url-safe input', async () => {
+    await expect(decodeShare('++not+url+safe++')).rejects.toThrow(ShareDecodeError);
+  });
+});
+
+describe('decodeShare zip-bomb defense', () => {
+  test('rejects a payload that decompresses past the cap with the DISTINCT cap error, and rejects fast', async () => {
+    // Build a real gzip of a multi-MB zero-filled buffer (compresses tiny,
+    // expands well over MAX_DECOMPRESSED_BYTES).
+    const zeros = new Uint8Array(MAX_DECOMPRESSED_BYTES + 2_000_000); // ~10 MB of zeros
+    const gz = new Uint8Array(
+      await new Response(new Blob([zeros]).stream().pipeThrough(new CompressionStream('gzip'))).arrayBuffer(),
+    );
+    const encoded = bytesToBase64Url(gz);
+    // Encoded gzip of zeros is small, proving the bomb shape.
+    expect(encoded.length).toBeLessThan(200_000);
+
+    const start = Date.now();
+    await expect(decodeShare(encoded)).rejects.toThrow(/exceeds.*size cap/i);
+    // Bounded: the bail happens chunk-by-chunk, not after buffering ~10 MB.
+    expect(Date.now() - start).toBeLessThan(5000);
+  });
+
+  test('the cap error message is distinct from the not-gzip error message', async () => {
+    let capMsg = '';
+    let garbageMsg = '';
+    const zeros = new Uint8Array(MAX_DECOMPRESSED_BYTES + 2_000_000);
+    const gz = new Uint8Array(
+      await new Response(new Blob([zeros]).stream().pipeThrough(new CompressionStream('gzip'))).arrayBuffer(),
+    );
+    try { await decodeShare(bytesToBase64Url(gz)); } catch (e) { capMsg = (e as Error).message; }
+    try { await decodeShare('bm90Z3ppcGRhdGE'); } catch (e) { garbageMsg = (e as Error).message; }
+    expect(capMsg).not.toBe(garbageMsg);
+    expect(capMsg).toMatch(/exceeds/i);
+    expect(garbageMsg).toMatch(/gzip/i);
+  });
+});
+
+describe('validateSharePayloadShape (sync)', () => {
+  test('accepts a well-formed payload', () => {
+    expect(() => validateSharePayloadShape(makeExported())).not.toThrow();
+  });
+
+  test('throws on a non-object', () => {
+    expect(() => validateSharePayloadShape(null)).toThrow(ShareDecodeError);
+    expect(() => validateSharePayloadShape('a string')).toThrow(ShareDecodeError);
+    expect(() => validateSharePayloadShape(42)).toThrow(ShareDecodeError);
+    expect(() => validateSharePayloadShape([])).toThrow(ShareDecodeError);
+  });
+
+  test('throws when session is missing', () => {
+    expect(() => validateSharePayloadShape({ partwright: '1.8', versions: [{ index: 1, code: 'x', label: 'v', geometryData: null, timestamp: 0 }] })).toThrow(/missing "session"/);
+  });
+
+  test('throws on an empty or missing versions array', () => {
+    expect(() => validateSharePayloadShape({ partwright: '1.8', session: { name: 'x', created: 0, updated: 0 }, versions: [] })).toThrow(/no versions/);
+    expect(() => validateSharePayloadShape({ partwright: '1.8', session: { name: 'x', created: 0, updated: 0 } })).toThrow(/no versions/);
+  });
+
+  test('throws on oversized code', () => {
+    const big = makeExported({ code: 'x'.repeat(600 * 1024) });
+    expect(() => validateSharePayloadShape(big)).toThrow(/code exceeds/);
+  });
+
+  test('throws on oversized label', () => {
+    const big = makeExported({ label: 'L'.repeat(300) });
+    expect(() => validateSharePayloadShape(big)).toThrow(/label exceeds/);
+  });
+
+  test('throws on oversized session name', () => {
+    const big = makeExported({}, { session: { name: 'N'.repeat(300), created: 0, updated: 0 } });
+    expect(() => validateSharePayloadShape(big)).toThrow(/name exceeds/);
+  });
+
+  test('drops an unsafe thumbnail but keeps the rest of the payload', () => {
+    const payload = makeExported({ thumbnail: 'data:text/html;base64,PHNjcmlwdD4=' });
+    const validated = validateSharePayloadShape(payload);
+    expect(validated.versions[0].thumbnail).toBeUndefined();
+    expect(validated.versions[0].code).toBe(payload.versions[0].code);
+    expect(validated.session.name).toBe('Test design');
+  });
+
+  test('keeps a safe thumbnail', () => {
+    const payload = makeExported({ thumbnail: TINY_PNG });
+    const validated = validateSharePayloadShape(payload);
+    expect(validated.versions[0].thumbnail).toBe(TINY_PNG);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **shareable public session links** — a user generates a link that encodes one design version, and anyone who opens it gets a **read-only preview** they can **fork** into their own local session. Closes the create → *share* → feedback → iterate loop that was previously dead-ended at "create" (everything lived in one browser's IndexedDB).

**Fully client-side, no backend.** The design is encoded into the URL **hash** (`/editor#share=<base64url>`), so the data never reaches a server — not even Cloudflare (the hash isn't sent in requests). Pipeline: a single-version `ExportedSession` → gzip via the native `CompressionStream` (no new dependency) → base64url. This respects the "static site, no backend" architecture and is fully testable offline.

### Security model (the load-bearing part)
The code sandbox is `new Function('api', code)` — **not** a security boundary; it can reach `fetch`/`indexedDB`, and IndexedDB holds the user's AI API keys. So **opening a shared link never executes the sharer's code**:
- The preview shows the embedded **thumbnail + read-only code + stats** (read from the payload's `geometryData`) and renders **nothing** through the engine.
- A module-scoped `isSharedPreview()` flag hard-refuses at **every** execution entry point — `runCode`/`runCodeSync` (and the console `partwright.run()`/`runAndSave()` that route through them), `executeIsolated` (which backs the AI-exposed `runIsolated`/`runAndAssert`/`runDecompose`, modify-test, and `forkVersion`), `setReferenceGeometry`, plus `saveCurrentVersion` and the GLB/STL/OBJ/3MF export actions. Run/Paint/Save/language-toggle are disabled and a viewport overlay blocks interaction.
- The **first execution only happens after an explicit Fork**, which imports the payload into a real local session via the existing `importSessionPayload` path (the consented run).
- Untrusted input is hardened: structural + size validation, a **streaming zip-bomb guard** (decode aborts mid-stream past a decompressed-byte cap), a thumbnail allow-list (`isSafeImageDataUrl` — raster MIME only, assigned solely to `img.src`), and all shared strings rendered via `textContent`. Any malformed/oversized/invalid link degrades silently to a normal editable editor.

### How it works
- **Share** (export menu "Share link…" + command palette): saves the current version first (so the *committed* version is shared), encodes it, copies the link, and opens a modal with the URL, a size readout, and a large-link warning. Feature-detects `CompressionStream`, drops the thumbnail once if the link is too large, and warns when a multi-part design is reduced to one part.
- **Open a link**: `/editor#share=…` boots a read-only preview (hash stripped immediately via `replaceState`, so refresh/Back never re-fire it), with a banner + "Fork to edit & run". Detected on initial load, `popstate`, and `hashchange` (pasting into an open tab).
- **Fork**: creates a local session (back button returns to the page before the link).

### Reuse, not reinvention
The payload *is* a single-version `ExportedSession` (no parallel type) built with `exportSession({ versionIndices })`, trimming only the heavy `importedMeshes`; Fork reuses `importSessionPayload` + the `handleCatalogEntryLoad` history ordering; read-only reuses `setReadOnlyReason('shared')` and the generalized `disableRun`/`enableRun`; colors/annotations rehydrate for free through the existing import path.

## Files
- `src/share/shareLink.ts` (new) — pure, dependency-free codec/validators (base64url, `isSafeImageDataUrl`, `trimForShare`, `encodeShare`/`decodeShare` with streaming zip-bomb guard, `validateSharePayloadShape`). Unit-tested in isolation.
- `src/share/shareUI.ts` (new) — share modal + read-only banner + viewport overlay (textContent-only, leak-free teardown).
- `src/main.ts` — `isSharedPreview()` flag + chokepoint guards on every execution/export path; `actionShareLink`; `enterSharedFromHash`; `onFork`; boot/popstate/`hashchange` dispatch; `!hasShareHash()` in `shouldShowLanding`; toolbar + command-palette wiring.
- `src/ui/toolbar.ts`, `src/color/editorLock.ts` (export `disableRun`/`enableRun`), `src/editor/editorAccess.ts` (document `'shared'` reason), `README.md`.
- `tests/unit/shareLink.test.ts` (new) + `tests/share-link.spec.ts` (new).

## Test plan
- `npm run build`: green (tsc + vite). `npm run test:unit`: **173 passed** (31 new share-codec tests). Both re-verified after merging the latest `origin/main`.
- `tests/share-link.spec.ts`: **8/8 passing locally**, all offline. Covers: Share → modal/copy; **non-execution** (`T2`: sentinel stays cold, editor read-only, thumbnail decodes, hash stripped, no session row, Back doesn't resurrect `#share=`); **console-API refusal** (`T2b`: `runIsolated`/`runAndAssert` refuse in a preview); Fork → runs, persists across reload; malformed link → graceful fallback; scad share; mobile 375px; offline route-abort guard.

## Post-implementation review (folded in)
A plan-stage 5-critic pass plus a security/correctness/completeness review of the diff drove these hardening fixes (commit `def2a50`):
- **[security]** Closed an execution gap — `executeIsolated`/`setReferenceGeometry` (and thus the AI-exposed `runIsolated`/`runAndAssert`) bypassed the run guard; now gated, with a regression test (`T2b`).
- **[correctness]** Export actions gated so a preview over an open session can't leak the prior mesh; preview overlay rebuilt on re-entry (no stale thumbnail); defensive run-lock re-sync on exit.
- **[polish]** `isSafeImageDataUrl` trailing-newline rejection; `CompressionStream` feature-detect in `canShare`; multi-part share warning; invalid links logged to `console.debug` rather than the user-facing diagnostic log.

## Phase 2 (documented, not built — see `.plans/share-links.md`)
- A Cloudflare Worker + R2/KV **short-link backend** (`/s/<id>`) for durable, short URLs and large designs (the hash approach produces long links that some messaging apps truncate — surfaced via the modal's size warning).
- Live spinnable preview *without* forking would need an embedded mesh (too big for a URL) or a hardened null-origin sandbox.

https://claude.ai/code/session_01AntzLqXnvhQBu1yDHZZuax