### PR TITLE
feat: voxel rounded-edge surfacing + cylinder/mirror/translate/hollow ops

### DIFF
--- a/public/ai/voxel.md
+++ b/public/ai/voxel.md
@@ -58,7 +58,11 @@ are **integers** in the range −1024…1023 on each axis. 1 voxel = 1 world uni
 | `v.get(x, y, z)` → `0xRRGGBB \| null` | Color of a voxel, or null if empty. |
 | `v.fillBox([x0,y0,z0], [x1,y1,z1], color)` | Fill an inclusive box (corners in any order). |
 | `v.sphere([cx,cy,cz], radius, color)` | Fill a solid sphere. |
+| `v.cylinder([cx,cy,cz], radius, height, color, axis?)` | Fill a solid cylinder; base centered on the point, extends `height` along `axis` (`'x'`/`'y'`/`'z'`, default `'z'`). |
 | `v.line([x0,y0,z0], [x1,y1,z1], color)` | Draw a 1-voxel-thick line (3D Bresenham). |
+| `v.translate([dx,dy,dz])` | Shift every voxel by an integer offset. |
+| `v.mirror('x' \| 'y' \| 'z')` | Add a mirrored copy across that axis's 0-plane (great for symmetric models). |
+| `v.hollow(thickness?)` | Remove interior voxels, leaving a shell of the given wall thickness (default 1). |
 | `v.size` | Number of occupied voxels. |
 | `v.bounds()` → `{min,max} \| null` | Inclusive extents, or null when empty. |
 | `v.forEach((x,y,z,color) => …)` | Iterate occupied voxels. |
@@ -86,6 +90,39 @@ rendered model is colored with no extra step, and GLB / 3MF / OBJ exports carry
 those colors out. (The face-region **paint tools** are mesh-triangle based and
 designed around the solid engines — painting *on top of* a voxel model is a
 planned follow-up; for now, set color per voxel in code.)
+
+## Rounded edges (smooth surfacing)
+
+By default a grid meshes as hard cubes. Call `.smooth()` before returning it to
+round the edges and corners instead — useful for organic shapes, soft props, or
+just softening the blocky look:
+
+```js
+const { voxels } = api;
+return voxels()
+  .sphere([0, 0, 0], 6, '#e7b')
+  .smooth();              // rounded edges
+```
+
+`.smooth(opts)` accepts an iteration count or `{ iterations, detail }`:
+
+- **`iterations`** (1–8, default 2) — more passes = rounder. It's a Taubin
+  λ/μ smoothing of the mesh, so the model rounds without collapsing/shrinking.
+- **`detail`** (1–4, default 1) — supersamples the grid ×`detail` before
+  smoothing, giving finer, more controlled rounding on coarse/small models (at
+  more triangles). The result is scaled back to the original world size.
+
+```js
+return voxels().fillBox([-4,-4,0],[4,4,8], '#6cf').smooth({ iterations: 4, detail: 2 });
+```
+
+Smoothing only moves vertices — topology is unchanged — so per-voxel colors are
+preserved and the result stays a watertight manifold (exports/paint still work).
+Call `.blocky()` to switch back to hard faces (the default).
+
+> For a fully organic surface from an implicit field, manifold-js's
+> `Manifold.levelSet` or the `api.sdf` engine are better suited; `.smooth()` is
+> the lightweight "round my voxels" option that stays inside the voxel workflow.
 
 ## Image import
 

--- a/public/ai/voxel.md
+++ b/public/ai/voxel.md
@@ -61,7 +61,7 @@ are **integers** in the range −1024…1023 on each axis. 1 voxel = 1 world uni
 | `v.cylinder([cx,cy,cz], radius, height, color, axis?)` | Fill a solid cylinder; base centered on the point, extends `height` along `axis` (`'x'`/`'y'`/`'z'`, default `'z'`). |
 | `v.line([x0,y0,z0], [x1,y1,z1], color)` | Draw a 1-voxel-thick line (3D Bresenham). |
 | `v.translate([dx,dy,dz])` | Shift every voxel by an integer offset. |
-| `v.mirror('x' \| 'y' \| 'z')` | Add a mirrored copy across that axis's 0-plane (great for symmetric models). |
+| `v.mirror('x' \| 'y' \| 'z')` | Add a mirrored copy across that axis's 0-plane (great for symmetric models; the mirrored copy wins where it overlaps an existing voxel). |
 | `v.hollow(thickness?)` | Remove interior voxels, leaving a shell of the given wall thickness (default 1). |
 | `v.size` | Number of occupied voxels. |
 | `v.bounds()` → `{min,max} \| null` | Inclusive extents, or null when empty. |
@@ -119,6 +119,12 @@ return voxels().fillBox([-4,-4,0],[4,4,8], '#6cf').smooth({ iterations: 4, detai
 Smoothing only moves vertices — topology is unchanged — so per-voxel colors are
 preserved and the result stays a watertight manifold (exports/paint still work).
 Call `.blocky()` to switch back to hard faces (the default).
+
+**Smoothing wants features at least 2 voxels thick.** A `λ` pass pulls each
+vertex toward its neighbours, so smoothing a 1-voxel-thick wall or a
+`hollow(1)` shell can draw opposite faces together and self-intersect (the mesh
+is still a valid manifold and won't error, but it can look pinched). Thicken the
+feature (`hollow(2)`, ≥2-voxel walls) or use fewer `iterations` if you see it.
 
 > For a fully organic surface from an implicit field, manifold-js's
 > `Manifold.levelSet` or the `api.sdf` engine are better suited; `.smooth()` is

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -307,7 +307,7 @@ export function toggleSuffix(toggles: ChatToggles): string {
         : lang === 'replicad'
           ? ' Note: BREP sessions return a BREP shape (api.BREP.box/cylinder/sphere.fillet/.chamfer/.fuse/.cut/.intersect), not a Manifold. See /ai/replicad.md for the full BREP API and STEP-export workflow. Mesh-only ops (api.Manifold.warp / .levelSet) are not exposed in BREP sessions — switch to manifold-js if you need them.'
           : lang === 'voxel'
-            ? ' Note: voxel sessions build a colored cube grid — `const v = api.voxels(); v.fillBox([x0,y0,z0],[x1,y1,z1],color); v.set(x,y,z,color); return v;`. No Manifold, no booleans, no return-a-Manifold; colors are per-voxel (hex or [r,g,b]). See /ai/voxel.md.'
+            ? ' Note: voxel sessions build a colored cube grid — `const v = api.voxels(); v.fillBox([x0,y0,z0],[x1,y1,z1],color); v.set(x,y,z,color); return v;`. No Manifold, no booleans, no return-a-Manifold; colors are per-voxel (hex or [r,g,b]). Also: v.cylinder/sphere/line/mirror/translate/hollow, and v.smooth() for rounded edges. See /ai/voxel.md.'
             : ' Tip: you can also reach for api.BREP.* inside a manifold-js session for one-off exact fillets/chamfers (then api.BREP.toManifold(shape, api.Manifold) to drop back into the mesh world) — no language switch needed unless STEP export is the goal.'
     }`,
     `Model: ${model}`,

--- a/src/geometry/engines/voxel.ts
+++ b/src/geometry/engines/voxel.ts
@@ -1,7 +1,7 @@
 import type { Engine, MeshResult, ValidateResult } from './types';
 import { javaScriptSyntaxDiagnostics, runtimeDiagnostic } from '../sourceDiagnostics';
 import { VoxelGrid, decodeGrid, normalizeColor } from '../voxel/grid';
-import { gridToMeshData } from '../voxel/mesher';
+import { meshGrid } from '../voxel/mesher';
 
 // The `voxel` engine: user code builds a sparse VoxelGrid and returns it; we
 // mesh the exposed faces into welded `MeshData` (with per-voxel colors) that
@@ -79,7 +79,7 @@ export const voxelEngine: Engine = {
     }
 
     try {
-      const mesh = gridToMeshData(grid);
+      const mesh = meshGrid(grid);
       return { mesh, manifold: null, error: null };
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);

--- a/src/geometry/voxel/grid.ts
+++ b/src/geometry/voxel/grid.ts
@@ -7,7 +7,7 @@
 // unit-tested directly in the vitest tier and imported into the geometry
 // Worker without pulling in browser globals.
 
-import { assertNumber, assertNumberTuple, ValidationError } from '../../validation/apiValidation';
+import { assertNumber, assertNumberTuple, assertObject, assertEnum, assertNoUnknownKeys, ValidationError } from '../../validation/apiValidation';
 
 export type Vec3 = [number, number, number];
 /** A color the sandbox API accepts: `[r,g,b]` 0–255, `'#rgb'`/`'#rrggbb'`, or a
@@ -31,6 +31,12 @@ function assertCoord(v: number, name: string): number {
 function packKey(x: number, y: number, z: number): number {
   // Each component is shifted into [0, 2047] before packing.
   return ((x + HALF) * DIM + (y + HALF)) * DIM + (z + HALF);
+}
+
+function inRange(x: number, y: number, z: number): boolean {
+  return x >= COORD_MIN && x <= COORD_MAX
+    && y >= COORD_MIN && y <= COORD_MAX
+    && z >= COORD_MIN && z <= COORD_MAX;
 }
 
 /** Normalize any accepted color form to a 24-bit `0xRRGGBB` integer. */
@@ -63,12 +69,19 @@ export function colorComponents(rgb: number): Vec3 {
 
 export interface GridBounds { min: Vec3; max: Vec3 }
 
+/** How a grid is turned into a mesh. `blocks` = hard cube faces (default);
+ *  `smooth` = Taubin-rounded edges (optionally over a `detail`× supersampled
+ *  grid for finer rounding). Carried on the grid so the mesher/engine can read
+ *  it off the returned value. */
+export interface Surfacing { mode: 'blocks' | 'smooth'; iterations: number; detail: number }
+
 /** A mutable sparse voxel grid. Builder methods chain (`return this`). */
 export class VoxelGrid {
   /** @internal Brand so the engine can recognize a returned grid even across
    *  bundle boundaries where `instanceof` alone might be fragile. */
   readonly __isVoxelGrid = true as const;
   private cells = new Map<number, number>();
+  private _surfacing: Surfacing = { mode: 'blocks', iterations: 2, detail: 1 };
 
   /** Number of occupied voxels. */
   get size(): number { return this.cells.size; }
@@ -179,6 +192,150 @@ export class VoxelGrid {
       if (z < min[2]) min[2] = z; if (z > max[2]) max[2] = z;
     });
     return { min, max };
+  }
+
+  /** Fill a solid cylinder of `radius` and `height` (in voxels) whose base
+   *  face is centered on `base`, extending in +`axis`. */
+  cylinder(base: Vec3, radius: number, height: number, color: ColorInput, axis: 'x' | 'y' | 'z' = 'z'): this {
+    const b = assertNumberTuple(base, 3, 'cylinder(base)');
+    const r = assertNumber(radius, 'cylinder(radius)', { min: 0 })!;
+    const h = assertNumber(height, 'cylinder(height)', { integer: true, min: 1 })!;
+    const ax = assertEnum(axis, ['x', 'y', 'z'] as const, 'cylinder(axis)');
+    const rgb = normalizeColor(color, 'cylinder(color)');
+    const bx = Math.round(b[0]), by = Math.round(b[1]), bz = Math.round(b[2]);
+    const ri = Math.ceil(r), r2 = r * r;
+    for (let l = 0; l < h; l++) {
+      for (let du = -ri; du <= ri; du++) {
+        for (let dv = -ri; dv <= ri; dv++) {
+          if (du * du + dv * dv > r2) continue;
+          let x: number, y: number, z: number;
+          if (ax === 'z') { x = bx + du; y = by + dv; z = bz + l; }
+          else if (ax === 'y') { x = bx + du; y = by + l; z = bz + dv; }
+          else { x = bx + l; y = by + du; z = bz + dv; }
+          if (inRange(x, y, z)) this.cells.set(packKey(x, y, z), rgb);
+        }
+      }
+    }
+    return this;
+  }
+
+  /** Translate every voxel by an integer offset (rounded). */
+  translate(delta: Vec3): this {
+    const d = assertNumberTuple(delta, 3, 'translate(delta)');
+    const dx = Math.round(d[0]), dy = Math.round(d[1]), dz = Math.round(d[2]);
+    const moved = new Map<number, number>();
+    this.forEach((x, y, z, c) => {
+      const nx = x + dx, ny = y + dy, nz = z + dz;
+      if (inRange(nx, ny, nz)) moved.set(packKey(nx, ny, nz), c);
+    });
+    this.cells = moved;
+    return this;
+  }
+
+  /** Add a mirrored copy of every voxel across the given axis's 0-plane (cell
+   *  `n` maps to cell `-1-n`, so the geometry mirrors exactly about 0). */
+  mirror(axis: 'x' | 'y' | 'z'): this {
+    const ax = assertEnum(axis, ['x', 'y', 'z'] as const, 'mirror(axis)');
+    const additions: [number, number, number, number][] = [];
+    this.forEach((x, y, z, c) => {
+      let nx = x, ny = y, nz = z;
+      if (ax === 'x') nx = -1 - x; else if (ax === 'y') ny = -1 - y; else nz = -1 - z;
+      if (inRange(nx, ny, nz)) additions.push([nx, ny, nz, c]);
+    });
+    for (const [x, y, z, c] of additions) this.cells.set(packKey(x, y, z), c);
+    return this;
+  }
+
+  /** Hollow the solid into a shell of the given wall `thickness` (in voxels),
+   *  removing voxels deeper than `thickness` from the surface. */
+  hollow(thickness = 1): this {
+    const t = assertNumber(thickness, 'hollow(thickness)', { integer: true, min: 1 })!;
+    // BFS the depth of each occupied voxel from the surface (a voxel with any
+    // empty face-neighbour is depth 1); remove anything deeper than `t`.
+    const dist = new Map<number, number>();
+    const queue: number[] = []; // flattened (x,y,z) triples
+    this.forEach((x, y, z) => {
+      if (!this.has(x + 1, y, z) || !this.has(x - 1, y, z)
+        || !this.has(x, y + 1, z) || !this.has(x, y - 1, z)
+        || !this.has(x, y, z + 1) || !this.has(x, y, z - 1)) {
+        dist.set(packKey(x, y, z), 1);
+        queue.push(x, y, z);
+      }
+    });
+    for (let head = 0; head < queue.length; head += 3) {
+      const x = queue[head], y = queue[head + 1], z = queue[head + 2];
+      const d = dist.get(packKey(x, y, z))!;
+      const nbrs: Vec3[] = [[x + 1, y, z], [x - 1, y, z], [x, y + 1, z], [x, y - 1, z], [x, y, z + 1], [x, y, z - 1]];
+      for (const [nx, ny, nz] of nbrs) {
+        if (!this.has(nx, ny, nz)) continue;
+        const nk = packKey(nx, ny, nz);
+        if (dist.has(nk)) continue;
+        dist.set(nk, d + 1);
+        queue.push(nx, ny, nz);
+      }
+    }
+    const toRemove: number[] = [];
+    this.forEach((x, y, z) => {
+      const d = dist.get(packKey(x, y, z));
+      if (d === undefined || d > t) toRemove.push(packKey(x, y, z));
+    });
+    for (const k of toRemove) this.cells.delete(k);
+    return this;
+  }
+
+  // ---- Surfacing (how the grid is meshed) -------------------------------
+
+  /** Select rounded-edge surfacing. Accepts an iteration count or
+   *  `{ iterations, detail }`; more iterations = rounder, higher detail
+   *  (supersample factor) = finer rounding on coarse models. Chainable. */
+  smooth(opts: number | { iterations?: number; detail?: number } = {}): this {
+    let iterations = 2, detail = 1;
+    if (typeof opts === 'number') {
+      iterations = assertNumber(opts, 'smooth(iterations)', { integer: true, min: 1, max: 8 })!;
+    } else {
+      const o = assertObject(opts, 'smooth(opts)')!;
+      assertNoUnknownKeys(o, ['iterations', 'detail'], 'smooth(opts)');
+      if (o.iterations !== undefined) iterations = assertNumber(o.iterations, 'smooth.iterations', { integer: true, min: 1, max: 8 })!;
+      if (o.detail !== undefined) detail = assertNumber(o.detail, 'smooth.detail', { integer: true, min: 1, max: 4 })!;
+    }
+    this._surfacing = { mode: 'smooth', iterations, detail };
+    return this;
+  }
+
+  /** Reset to hard-faced (blocky) surfacing — the default. Chainable. */
+  blocky(): this {
+    this._surfacing = { mode: 'blocks', iterations: 2, detail: 1 };
+    return this;
+  }
+
+  /** The grid's current surfacing settings (a copy). */
+  surfacing(): Surfacing { return { ...this._surfacing }; }
+
+  /** Return a NEW grid with every voxel expanded into a `factor`³ block — used
+   *  by smooth surfacing to give the smoother more vertices to work with. The
+   *  result uses default (blocky) surfacing; the caller scales the mesh back
+   *  down. Throws if the expansion would exceed the coordinate range. */
+  supersample(factor: number): VoxelGrid {
+    const f = assertNumber(factor, 'supersample(factor)', { integer: true, min: 1, max: 8 })!;
+    const out = new VoxelGrid();
+    const b = this.bounds();
+    if (!b || f === 1) {
+      this.forEach((x, y, z, c) => out.cells.set(packKey(x, y, z), c));
+      return out;
+    }
+    const lo = Math.min(b.min[0], b.min[1], b.min[2]) * f;
+    const hi = Math.max(b.max[0], b.max[1], b.max[2]) * f + (f - 1);
+    if (lo < COORD_MIN || hi > COORD_MAX) {
+      throw new ValidationError(`supersample(${f}): the model is too large to supersample by ${f}× (coordinates would exceed ±${HALF}). Use a smaller detail factor.`);
+    }
+    this.forEach((x, y, z, c) => {
+      const bx = x * f, by = y * f, bz = z * f;
+      for (let i = 0; i < f; i++)
+        for (let j = 0; j < f; j++)
+          for (let k = 0; k < f; k++)
+            out.cells.set(packKey(bx + i, by + j, bz + k), c);
+    });
+    return out;
   }
 
   /** @internal Raw cell map — for the mesher's fast neighbor queries. */

--- a/src/geometry/voxel/mesher.ts
+++ b/src/geometry/voxel/mesher.ts
@@ -17,6 +17,7 @@
 
 import type { MeshData } from '../types';
 import { VoxelGrid, colorComponents } from './grid';
+import { taubinSmooth, scaleMeshPositions } from './smooth';
 
 // The 6 face directions: neighbor offset + the 4 corner offsets (relative to
 // the voxel's min corner) in CCW order viewed from outside, so each face's
@@ -93,4 +94,19 @@ export function gridToMeshData(grid: VoxelGrid): MeshData {
     numProp: 3,
     triColors: triColorArr,
   };
+}
+
+/** Mesh a grid according to its surfacing setting. `blocks` (default) returns
+ *  the hard-faced mesh; `smooth` rounds the edges by Taubin-smoothing the
+ *  block mesh (optionally over a supersampled grid, then scaled back to the
+ *  original world size). Topology is unchanged by smoothing, so per-voxel
+ *  colors and manifoldness carry through. This is what the engine calls. */
+export function meshGrid(grid: VoxelGrid): MeshData {
+  const surf = grid.surfacing();
+  if (surf.mode !== 'smooth') return gridToMeshData(grid);
+  const dense = surf.detail > 1 ? grid.supersample(surf.detail) : grid;
+  let mesh = gridToMeshData(dense);
+  mesh = taubinSmooth(mesh, surf.iterations);
+  if (surf.detail > 1) scaleMeshPositions(mesh, 1 / surf.detail);
+  return mesh;
 }

--- a/src/geometry/voxel/smooth.ts
+++ b/src/geometry/voxel/smooth.ts
@@ -1,0 +1,91 @@
+// Taubin (λ|μ) mesh smoothing — the "rounded edges" surfacing for voxel models.
+//
+// Plain Laplacian smoothing rounds a blocky mesh but shrinks it (every pass
+// pulls vertices toward their neighbours' centroid). Taubin alternates a
+// positive λ pass with a slightly larger negative μ pass, which relaxes the
+// surface while pushing back against shrinkage — so corners and edges round
+// off but the model keeps its size.
+//
+// This runs on the welded block mesh produced by the face-culling mesher, so:
+//   - topology is unchanged (same triVerts) → per-triangle `triColors` stay
+//     valid and the result is still a watertight manifold for ofMesh;
+//   - only vertex positions move, toward a rounded form.
+//
+// Pure logic (no DOM/WASM): unit-tested in the vitest tier.
+
+import type { MeshData } from '../types';
+
+// Standard Taubin coefficients: a smoothing λ and an anti-shrink μ with
+// |μ| > λ. These values are the widely-used defaults (pass-band ~0.1).
+const LAMBDA = 0.5;
+const MU = -0.53;
+
+/** Build, for each vertex, the set of vertices it shares an edge with. */
+function buildAdjacency(triVerts: Uint32Array, numVert: number): number[][] {
+  const adj: Set<number>[] = Array.from({ length: numVert }, () => new Set<number>());
+  for (let t = 0; t < triVerts.length; t += 3) {
+    const a = triVerts[t], b = triVerts[t + 1], c = triVerts[t + 2];
+    adj[a].add(b); adj[a].add(c);
+    adj[b].add(a); adj[b].add(c);
+    adj[c].add(a); adj[c].add(b);
+  }
+  return adj.map(s => [...s]);
+}
+
+/** One Laplacian relaxation pass: move each vertex a `factor` of the way
+ *  toward the centroid of its edge-neighbours. Reads from `src`, writes `dst`
+ *  (both length numVert*3). */
+function relaxPass(src: Float32Array, dst: Float32Array, adj: number[][], factor: number): void {
+  for (let v = 0; v < adj.length; v++) {
+    const nbrs = adj[v];
+    const i = v * 3;
+    if (nbrs.length === 0) { // isolated vertex (shouldn't happen on a closed mesh)
+      dst[i] = src[i]; dst[i + 1] = src[i + 1]; dst[i + 2] = src[i + 2];
+      continue;
+    }
+    let cx = 0, cy = 0, cz = 0;
+    for (const n of nbrs) { cx += src[n * 3]; cy += src[n * 3 + 1]; cz += src[n * 3 + 2]; }
+    const inv = 1 / nbrs.length;
+    cx *= inv; cy *= inv; cz *= inv;
+    dst[i] = src[i] + factor * (cx - src[i]);
+    dst[i + 1] = src[i + 1] + factor * (cy - src[i + 1]);
+    dst[i + 2] = src[i + 2] + factor * (cz - src[i + 2]);
+  }
+}
+
+/** Taubin-smooth a mesh's vertex positions. `iterations` is the number of
+ *  λ/μ pass pairs (more = rounder). Returns a NEW MeshData sharing the input's
+ *  triangle and color arrays (topology is untouched). Assumes `numProp === 3`
+ *  (voxel meshes are position-only), which all callers satisfy. */
+export function taubinSmooth(mesh: MeshData, iterations = 2): MeshData {
+  const n = Math.max(0, Math.floor(iterations));
+  if (n === 0 || mesh.numVert === 0) return mesh;
+
+  const adj = buildAdjacency(mesh.triVerts, mesh.numVert);
+  let pos = Float32Array.from(mesh.vertProperties);
+  let scratch = new Float32Array(pos.length);
+
+  for (let i = 0; i < n; i++) {
+    relaxPass(pos, scratch, adj, LAMBDA);
+    [pos, scratch] = [scratch, pos];
+    relaxPass(pos, scratch, adj, MU);
+    [pos, scratch] = [scratch, pos];
+  }
+
+  return {
+    vertProperties: pos,
+    triVerts: mesh.triVerts,
+    numVert: mesh.numVert,
+    numTri: mesh.numTri,
+    numProp: mesh.numProp,
+    triColors: mesh.triColors,
+  };
+}
+
+/** Scale every vertex position by `s` in place and return the mesh. Used to
+ *  bring a supersampled mesh back to the original grid's world size. */
+export function scaleMeshPositions(mesh: MeshData, s: number): MeshData {
+  const p = mesh.vertProperties;
+  for (let i = 0; i < p.length; i++) p[i] *= s;
+  return mesh;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3194,6 +3194,7 @@ async function main() {
     "v.fillBox([-5, -5, 0], [4, 4, 0], '#6b8cff');   // a 10x10 base slab\n" +
     "v.fillBox([-1, -1, 1], [1, 1, 6], '#ff8c42');   // a tower\n" +
     "v.set(0, 0, 7, '#ff3b30');                       // a red cap\n" +
+    '// Tip: return v.smooth() for rounded edges (see /ai/voxel.md).\n' +
     'return v;\n';
   // BREP / replicad — quick showcase of the headline features:
   //   - selective fillet (the inDirection-based workaround for box edges,

--- a/tests/unit/voxel.test.ts
+++ b/tests/unit/voxel.test.ts
@@ -7,7 +7,8 @@ import {
   decodeGrid,
   COORD_MAX,
 } from '../../src/geometry/voxel/grid';
-import { gridToMeshData } from '../../src/geometry/voxel/mesher';
+import { gridToMeshData, meshGrid } from '../../src/geometry/voxel/mesher';
+import { taubinSmooth } from '../../src/geometry/voxel/smooth';
 import {
   imageDataToVoxelGrid,
   generateVoxelImportCode,
@@ -226,5 +227,136 @@ describe('imageDataToVoxelGrid', () => {
     const restored = decodeGrid(JSON.parse(m![1]));
     expect(restored.size).toBe(grid.size);
     expect(restored.get(-1, 0, 1)).toBe(0xff0000);
+  });
+});
+
+describe('VoxelGrid ops', () => {
+  it('cylinder fills a disc-extruded solid along the chosen axis', () => {
+    const v = new VoxelGrid();
+    v.cylinder([0, 0, 0], 3, 5, '#ffffff'); // Z by default, height 5
+    expect(v.has(0, 0, 0)).toBe(true);
+    expect(v.has(0, 0, 4)).toBe(true);    // height 5 → z 0..4
+    expect(v.has(0, 0, 5)).toBe(false);
+    expect(v.has(3, 0, 2)).toBe(true);    // 3² ≤ 9 (on the rim)
+    expect(v.has(3, 3, 2)).toBe(false);   // 18 > 9 (corner, outside)
+    const b = v.bounds()!;
+    expect([b.min[2], b.max[2]]).toEqual([0, 4]);
+
+    const vx = new VoxelGrid();
+    vx.cylinder([0, 0, 0], 2, 4, '#fff', 'x');
+    expect(vx.has(3, 0, 0)).toBe(true);   // extends along +X
+    expect(vx.has(0, 2, 0)).toBe(true);   // radius on the YZ disc
+  });
+
+  it('translate shifts every voxel and keeps colors', () => {
+    const v = new VoxelGrid();
+    v.set(0, 0, 0, '#ffffff').set(1, 0, 0, '#ff0000');
+    v.translate([5, 2, -1]);
+    expect(v.has(5, 2, -1)).toBe(true);
+    expect(v.has(6, 2, -1)).toBe(true);
+    expect(v.has(0, 0, 0)).toBe(false);
+    expect(v.size).toBe(2);
+    expect(v.get(5, 2, -1)).toBe(0xffffff);
+  });
+
+  it('mirror adds a reflected copy across the axis 0-plane', () => {
+    const v = new VoxelGrid();
+    v.set(2, 0, 0, '#abcdef');
+    v.mirror('x');
+    expect(v.has(2, 0, 0)).toBe(true);
+    expect(v.has(-3, 0, 0)).toBe(true); // cell 2 -> cell -1-2
+    expect(v.get(-3, 0, 0)).toBe(0xabcdef);
+    expect(v.size).toBe(2);
+  });
+
+  it('hollow removes interior voxels, leaving a shell', () => {
+    const v = new VoxelGrid();
+    v.fillBox([0, 0, 0], [2, 2, 2], '#ffffff'); // solid 3×3×3 = 27
+    expect(v.size).toBe(27);
+    v.hollow(1);
+    expect(v.has(1, 1, 1)).toBe(false); // the one interior voxel is gone
+    expect(v.has(0, 0, 0)).toBe(true);  // shell kept
+    expect(v.size).toBe(26);
+  });
+
+  it('supersample expands each voxel into a factor³ block', () => {
+    const v = new VoxelGrid();
+    v.set(0, 0, 0, '#aabbcc');
+    const big = v.supersample(2);
+    expect(big.size).toBe(8);
+    expect(big.get(0, 0, 0)).toBe(0xaabbcc);
+    expect(big.get(1, 1, 1)).toBe(0xaabbcc);
+    expect(v.size).toBe(1); // original untouched
+  });
+
+  it('supersample throws when the result would exceed the coordinate range', () => {
+    const v = new VoxelGrid();
+    v.set(1000, 0, 0, '#fff'); // 1000*8 ≫ 1023
+    expect(() => v.supersample(8)).toThrow();
+  });
+
+  it('surfacing defaults to blocks and smooth() toggles it', () => {
+    const v = new VoxelGrid();
+    expect(v.surfacing().mode).toBe('blocks');
+    v.smooth();
+    expect(v.surfacing()).toMatchObject({ mode: 'smooth', iterations: 2, detail: 1 });
+    v.smooth(4);
+    expect(v.surfacing().iterations).toBe(4);
+    v.smooth({ iterations: 3, detail: 2 });
+    expect(v.surfacing()).toMatchObject({ mode: 'smooth', iterations: 3, detail: 2 });
+    v.blocky();
+    expect(v.surfacing().mode).toBe('blocks');
+    expect(() => v.smooth({ detail: 9 })).toThrow();
+  });
+});
+
+describe('voxel surfacing (Taubin smoothing)', () => {
+  it('taubinSmooth moves vertices but preserves topology + colors', () => {
+    const v = new VoxelGrid();
+    v.fillBox([0, 0, 0], [3, 3, 3], '#3399ff');
+    const block = gridToMeshData(v);
+    const smoothed = taubinSmooth(block, 2);
+    expect(smoothed.numVert).toBe(block.numVert);
+    expect(smoothed.numTri).toBe(block.numTri);
+    expect(smoothed.triColors).toBe(block.triColors); // colors carried (same ref)
+    expect(Array.from(smoothed.vertProperties).every(Number.isFinite)).toBe(true);
+    let moved = false;
+    for (let i = 0; i < block.vertProperties.length; i++) {
+      if (Math.abs(block.vertProperties[i] - smoothed.vertProperties[i]) > 1e-6) { moved = true; break; }
+    }
+    expect(moved).toBe(true);
+  });
+
+  it('taubinSmooth with 0 iterations is a no-op', () => {
+    const v = new VoxelGrid();
+    v.set(0, 0, 0, '#fff');
+    const m = gridToMeshData(v);
+    expect(taubinSmooth(m, 0)).toBe(m);
+  });
+
+  it('meshGrid applies smooth surfacing (detail 1 keeps topology, detail>1 densifies)', () => {
+    const v = new VoxelGrid();
+    v.fillBox([0, 0, 0], [3, 3, 3], '#3399ff').smooth();
+    const m = meshGrid(v);
+    expect(m.numTri).toBe(192); // detail 1 → same topology as the block mesh
+    const block = gridToMeshData(new VoxelGrid().fillBox([0, 0, 0], [3, 3, 3], '#3399ff'));
+    let moved = false;
+    for (let i = 0; i < block.vertProperties.length; i++) {
+      if (Math.abs(block.vertProperties[i] - m.vertProperties[i]) > 1e-6) { moved = true; break; }
+    }
+    expect(moved).toBe(true);
+
+    const v2 = new VoxelGrid();
+    v2.fillBox([0, 0, 0], [3, 3, 3], '#3399ff').smooth({ iterations: 2, detail: 2 });
+    const m2 = meshGrid(v2);
+    expect(m2.numTri).toBeGreaterThan(192); // supersampled → denser mesh
+    expect(Array.from(m2.vertProperties).every(Number.isFinite)).toBe(true);
+    // Scaled back to the original world size — the block spans ~0..4 units,
+    // NOT the 0..8 of the 2× supersampled grid. (Taubin's anti-shrink pass can
+    // nudge corner vertices slightly past 4, so allow a small margin.)
+    let maxX = -Infinity;
+    for (let i = 0; i < m2.vertProperties.length; i += 3) maxX = Math.max(maxX, m2.vertProperties[i]);
+    expect(maxX).toBeGreaterThan(3);
+    expect(maxX).toBeLessThan(5);
   });
 });

--- a/tests/voxel-engine.spec.ts
+++ b/tests/voxel-engine.spec.ts
@@ -98,4 +98,46 @@ test.describe('voxel engine', () => {
     expect(result.lang).toBe('voxel');
     expect(result.geo.isManifold).toBe(true);
   });
+
+  test('smooth surfacing rounds the mesh while staying a manifold', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.setActiveLanguage('voxel');
+      const block = await pw.run(`
+        const { voxels } = api;
+        return voxels().fillBox([0,0,0],[5,5,5], '#3399ff');
+      `);
+      const smooth = await pw.run(`
+        const { voxels } = api;
+        return voxels().fillBox([0,0,0],[5,5,5], '#3399ff').smooth();
+      `);
+      return { block, smooth };
+    });
+    expect(result.block.error).toBeFalsy();
+    expect(result.smooth.error).toBeFalsy();
+    // The real-WASM proof: ofMesh accepts the smoothed mesh too.
+    expect(result.smooth.isManifold).toBe(true);
+    expect(result.smooth.componentCount).toBe(1);
+    // detail 1 only moves vertices, so the triangle count matches the block mesh.
+    expect(result.smooth.triangleCount).toBe(result.block.triangleCount);
+    // Still a valid, positive-volume solid (Taubin's anti-shrink pass keeps the
+    // size roughly stable rather than collapsing it).
+    expect(result.smooth.volume).toBeGreaterThan(0);
+  });
+
+  test('smooth with higher detail densifies and stays manifold', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.setActiveLanguage('voxel');
+      return await pw.run(`
+        const { voxels } = api;
+        return voxels().cylinder([0,0,0], 4, 12, '#ff8c42').smooth({ iterations: 2, detail: 2 });
+      `);
+    });
+    expect(result.error).toBeFalsy();
+    expect(result.isManifold).toBe(true);
+    expect(result.triangleCount).toBeGreaterThan(0);
+  });
 });

--- a/tests/voxel-engine.spec.ts
+++ b/tests/voxel-engine.spec.ts
@@ -140,4 +140,21 @@ test.describe('voxel engine', () => {
     expect(result.isManifold).toBe(true);
     expect(result.triangleCount).toBeGreaterThan(0);
   });
+
+  test('hollow + smooth (thin shell) still produces a valid manifold', async ({ page }) => {
+    // Smoothing preserves topology, so even a 1-voxel-thick shell stays a
+    // topological manifold (it can self-intersect geometrically — documented —
+    // but it must not error or crash the run).
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.setActiveLanguage('voxel');
+      return await pw.run(`
+        const { voxels } = api;
+        return voxels().fillBox([0,0,0],[7,7,7],'#88aaff').hollow(1).smooth();
+      `);
+    });
+    expect(result.error).toBeFalsy();
+    expect(result.isManifold).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to the voxel engine (#280): adds **rounded-edge surfacing** plus several new grid-building ops.

> **Stacked on #280.** This branch is built on top of the base voxel engine, so until #280 merges this PR's diff includes #280's commits. Once you merge #280 into `main`, the diff narrows to just the changes below. (Both branches are re-synced with the latest `main`, which now includes the SDF engine from #272.)

### Rounded edges (the headline)

```js
const { voxels } = api;
return voxels().sphere([0,0,0], 6, '#e7b').smooth();   // rounded instead of blocky
```

- **`v.smooth(opts?)`** selects a smooth surfacing mode — **Taubin (λ/μ) smoothing** of the block mesh, which rounds edges/corners *without* the volume collapse of plain Laplacian smoothing. Accepts an iteration count or `{ iterations, detail }`:
  - `iterations` (1–8, default 2) — more = rounder.
  - `detail` (1–4, default 1) — supersamples the grid ×detail for finer rounding on coarse models, then scales the mesh back to the original world size.
- **`v.blocky()`** returns to hard faces (the default).
- Smoothing **only moves vertices** (topology unchanged), so **per-voxel colors are preserved** and the result stays a **watertight manifold** — `Manifold.ofMesh` accepts it (proven in the e2e tier).

### New grid ops

- `v.cylinder(base, radius, height, color, axis?)` — filled cylinder along x/y/z.
- `v.translate([dx,dy,dz])` — shift all voxels.
- `v.mirror('x'|'y'|'z')` — add a reflected copy across the axis 0-plane (symmetric models).
- `v.hollow(thickness?)` — BFS-depth shell; removes interior voxels.
- `v.supersample(factor)` — expand each voxel into a factor³ block (used by smooth surfacing; throws cleanly if it would exceed the coordinate range).

### Files

- New: `src/geometry/voxel/smooth.ts` (Taubin + position scale, pure logic).
- `src/geometry/voxel/grid.ts` — surfacing state + `smooth`/`blocky`/`surfacing` + the new ops.
- `src/geometry/voxel/mesher.ts` — `meshGrid()` dispatches blocks-vs-smooth; engine calls it.
- `public/ai/voxel.md` — surfacing section + new ops; `main.ts` starter tip; `ai/systemPrompt.ts` note.
- Tests: `tests/unit/voxel.test.ts` (Taubin / meshGrid / every op), `tests/voxel-engine.spec.ts` (smoothed mesh stays manifold, incl. thin-shell `hollow(1).smooth()`).

### Review pass (folded in)

An automated review hand-traced the Taubin math (correct, non-mutating, finite), the supersample range check (sound under mixed-sign coords), and the `mirror`/`hollow`/`cylinder` + `_painted`/manifold lifecycle — no bugs. The one non-blocking risk it raised — smoothing a 1-voxel-thick shell could pull opposite faces together — I verified stays a valid manifold (topology is preserved; it can self-intersect *geometrically*, a visual matter, not an error), added a `hollow(1).smooth()` regression test, and documented the ≥2-voxel-thick guidance.

### Design note

`.smooth()` is the lightweight "round my voxels" option that stays inside the voxel workflow. For a fully organic implicit surface, manifold-js's `Manifold.levelSet` or the `api.sdf` engine are better suited — noted in the docs so users pick the right tool.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm run test:unit` — **285 pass** (Taubin topology/color preservation, no-op at 0 iters, meshGrid surfacing, cylinder/translate/mirror/hollow/supersample, surfacing validation).
- [x] `npm run test:e2e` — **full suite 254 passed** locally (incl. `tests/voxel-engine.spec.ts`: smooth surfacing, higher-detail, and thin-shell `hollow(1).smooth()` all confirming `Manifold.ofMesh` accepts the rounded mesh).
- [x] CI `build-unit` green; Cloudflare Pages preview deploys cleanly.
- [x] Re-synced with latest `origin/main` (clean merge; includes #272's SDF engine).

https://claude.ai/code/session_01V1686pagVqsQ7hXi7vMByK