### PR TITLE
fix: swap engine language when navigating versions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5367,7 +5367,21 @@ async function main() {
       if (typeof check === 'object' && check !== null && 'error' in check) return check;
       const version = await navigateVersion(direction);
       if (version) {
+        // Each version remembers the language it was authored in (since schema
+        // 1.8). Swap the engine before re-running so a JS version stepped into
+        // while another engine is active doesn't run under the wrong sandbox —
+        // e.g. a manifold-js version under the voxel/replicad engine, whose
+        // `api` has no `params` (and voxel no `Manifold`), which surfaced as
+        // "api.params is not a function" / "reading 'cube' of undefined".
+        // Mirrors loadVersion()'s language handling.
+        const versionLang = effectiveVersionLanguage(version, getState().session);
+        if (versionLang !== getActiveLanguage()) {
+          await switchLanguage(versionLang);
+        }
         setValue(version.code);
+        // Restore this version's Customizer overrides before the re-run so it
+        // renders with the values it was saved at (matches loadVersion).
+        currentParamValues = { ...(version.paramValues ?? {}) };
         await runCodeSync(version.code);
         rehydrateColorRegions(version.geometryData);
         applyVersionAnnotations(version);

--- a/tests/version-nav-language.spec.ts
+++ b/tests/version-nav-language.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from 'playwright/test';
+
+// Regression: stepping through versions of a mixed-language session must swap
+// the engine to each version's authored language before re-running its code.
+//
+// The bug: the console `navigateVersion()` API re-ran the target version's
+// code in whatever engine happened to be active, instead of switching to the
+// version's own language first (the way `loadVersion()` already does). When a
+// manifold-js version was re-run under the voxel/replicad engine — whose
+// sandbox `api` has no `params` (and voxel has no `Manifold`) — the user saw:
+//   - "api.params is not a function"
+//   - "Cannot read properties of undefined (reading 'cube')"
+// This surfaced on resume, when the agent stepped back through history.
+
+const JS_CUBE = `
+const { Manifold } = api;
+return Manifold.cube([10, 10, 10], true);
+`;
+
+const JS_PARAMS = `
+const { Manifold } = api;
+api.params({ size: { type: 'number', default: 10 } });
+return Manifold.cube([api.size, api.size, api.size], true);
+`;
+
+const VOXEL_CODE = `
+const v = api.voxels();
+v.fillBox([0, 0, 0], [4, 4, 4], '#88aaff');
+return v;
+`;
+
+async function waitReady(page: import('playwright/test').Page) {
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    undefined,
+    { timeout: 30_000 },
+  );
+}
+
+function readGeometryError(page: import('playwright/test').Page) {
+  return page.evaluate(() => {
+    const txt = document.getElementById('geometry-data')?.textContent || '{}';
+    try { return (JSON.parse(txt) as { status?: string; error?: string }); } catch { return {}; }
+  });
+}
+
+test.describe('cross-language version navigation', () => {
+  test('navigateVersion swaps the engine to the target version language', async ({ page }) => {
+    await page.goto('/editor');
+    await waitReady(page);
+
+    // Build a session with two manifold-js versions and a trailing voxel
+    // version, leaving the voxel engine active.
+    await page.evaluate(async ({ cube, params, voxel }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('mixed');
+      await pw.setActiveLanguage('manifold-js');
+      await pw.runAndSave(cube, 'js-cube');     // v1
+      await pw.runAndSave(params, 'js-params');  // v2
+      await pw.setActiveLanguage('voxel');
+      await pw.runAndSave(voxel, 'voxel');       // v3 (active engine now = voxel)
+    }, { cube: JS_CUBE, params: JS_PARAMS, voxel: VOXEL_CODE });
+
+    // Step back to v2 (manifold-js, uses api.params).
+    const r2 = await page.evaluate(() => (window as any).partwright.navigateVersion('prev'));
+    expect(r2).toBeTruthy();
+    const afterV2 = await readGeometryError(page);
+    expect(afterV2.status).not.toBe('error');
+    expect(afterV2.error ?? '').not.toMatch(/params is not a function|reading 'cube'/);
+    expect(await page.evaluate(() => (window as any).partwright.getActiveLanguage())).toBe('manifold-js');
+
+    // Step back to v1 (manifold-js, uses Manifold.cube).
+    const r1 = await page.evaluate(() => (window as any).partwright.navigateVersion('prev'));
+    expect(r1).toBeTruthy();
+    const afterV1 = await readGeometryError(page);
+    expect(afterV1.status).not.toBe('error');
+    expect(afterV1.error ?? '').not.toMatch(/params is not a function|reading 'cube'/);
+
+    // Step forward back to the voxel version — engine must swap back too.
+    await page.evaluate(() => (window as any).partwright.navigateVersion('next'));
+    await page.evaluate(() => (window as any).partwright.navigateVersion('next'));
+    const afterVoxel = await readGeometryError(page);
+    expect(afterVoxel.status).not.toBe('error');
+    expect(await page.evaluate(() => (window as any).partwright.getActiveLanguage())).toBe('voxel');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the two errors a user hit after modeling across multiple languages in one session and reopening it:

- `Cannot read properties of undefined (reading 'cube')`
- `api.params is not a function`

**Root cause:** the console `navigateVersion()` API (`window.partwright.navigateVersion`) re-ran the target version's code in whatever engine happened to be *active*, instead of first switching the engine to the version's own authored language — unlike its sibling `loadVersion()`, which already does this. When a resume/review flow stepped back through a mixed-language session, a `manifold-js` version got re-run under the `voxel`/`replicad` engine. Those sandboxes expose a different `api` (no `params`; voxel also has no `Manifold`), so the JS code threw exactly those two errors.

The UI session-bar arrows were unaffected — they route through `loadVersionIntoEditor`, which swaps the engine. Only the programmatic `navigateVersion` API (used by the AI agent to step through history, e.g. on resume) was missing the swap.

**Fix:** mirror `loadVersion()` in `navigateVersion` — resolve the version's effective language (`effectiveVersionLanguage`), `switchLanguage` before re-running, and restore the version's saved Customizer overrides so it renders with its saved params.

## Test plan

- Added `tests/version-nav-language.spec.ts`: builds a session with two `manifold-js` versions and a trailing `voxel` version (leaving the voxel engine active), then steps backward to each JS version and forward back to the voxel version, asserting no execution error and that the active language tracks each version. Fails before the fix, passes after.
- `npm run build` ✓ (type-check)
- `npm run test:unit` ✓ (374 passed)
- `npx playwright test version-nav-language versions-tab` ✓ (5 passed)

https://claude.ai/code/session_014pBuhVoBSFmcykTtNfWcnp

---
_Generated by [Claude Code](https://claude.ai/code/session_014pBuhVoBSFmcykTtNfWcnp)_