### PR TITLE
feat: open catalog items directly from landing tiles

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3125,6 +3125,7 @@ async function main() {
         onOpenHelp: () => showHelp(),
         onOpenCatalog: () => { void showCatalogPage(); },
         onOpenSession: openSessionFromLanding,
+        onLoadCatalogEntry: handleCatalogEntryLoad,
       });
     }
     return landingEl;

--- a/src/ui/landing.ts
+++ b/src/ui/landing.ts
@@ -15,6 +15,7 @@ import { languageBadge } from './languageBadge';
 import { showUninstallModal } from './uninstallModal';
 import { getTheme, onThemeChange, toggleTheme } from './theme';
 import type { ExportedSession } from '../storage/sessionManager';
+import type { CatalogManifestEntry } from './catalog';
 
 export interface LandingCallbacks {
   onOpenEditor: () => void;
@@ -23,14 +24,6 @@ export interface LandingCallbacks {
   onOpenSession: (sessionId: string) => void;
   /** Load a single catalog entry straight into the editor as a fresh session. */
   onLoadCatalogEntry: (entry: CatalogManifestEntry, payload: ExportedSession) => void | Promise<void>;
-}
-
-interface CatalogManifestEntry {
-  id: string;
-  name: string;
-  file: string;
-  language?: 'manifold-js' | 'scad' | 'replicad' | 'voxel';
-  description?: string;
 }
 
 interface FeaturedCatalogEntry {

--- a/src/ui/landing.ts
+++ b/src/ui/landing.ts
@@ -21,6 +21,8 @@ export interface LandingCallbacks {
   onOpenHelp: () => void;
   onOpenCatalog: () => void;
   onOpenSession: (sessionId: string) => void;
+  /** Load a single catalog entry straight into the editor as a fresh session. */
+  onLoadCatalogEntry: (entry: CatalogManifestEntry, payload: ExportedSession) => void | Promise<void>;
 }
 
 interface CatalogManifestEntry {
@@ -224,7 +226,7 @@ async function buildFeaturedCatalog(callbacks: LandingCallbacks): Promise<HTMLEl
   section.className = 'w-full max-w-5xl px-6 py-12 border-t border-zinc-800';
 
   const header = document.createElement('div');
-  header.className = 'flex items-baseline justify-between mb-6';
+  header.className = 'flex items-center justify-between mb-6';
 
   const heading = document.createElement('h2');
   heading.id = 'catalog-heading';
@@ -233,7 +235,7 @@ async function buildFeaturedCatalog(callbacks: LandingCallbacks): Promise<HTMLEl
   header.appendChild(heading);
 
   const browseAll = document.createElement('button');
-  browseAll.className = 'text-xs text-blue-400 hover:text-blue-300 transition-colors';
+  browseAll.className = 'shrink-0 inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-sm font-medium border border-blue-500/60 text-blue-300 hover:bg-blue-500/10 hover:border-blue-400 transition-colors';
   browseAll.textContent = 'Browse the full catalog →';
   browseAll.addEventListener('click', callbacks.onOpenCatalog);
   header.appendChild(browseAll);
@@ -255,9 +257,27 @@ async function buildFeaturedCatalog(callbacks: LandingCallbacks): Promise<HTMLEl
   }
 
   for (const entry of entries) {
-    grid.appendChild(buildCatalogTile(entry, callbacks.onOpenCatalog));
+    grid.appendChild(buildCatalogTile(entry, () => { void loadFeaturedCatalogEntry(entry.manifest, callbacks); }));
   }
   return section;
+}
+
+/**
+ * Fetch a featured catalog entry's session payload and hand it to the editor.
+ * Mirrors the catalog page's load path so clicking a landing tile opens the
+ * item directly instead of routing through the full catalog.
+ */
+async function loadFeaturedCatalogEntry(manifest: CatalogManifestEntry, callbacks: LandingCallbacks): Promise<void> {
+  try {
+    const res = await fetch(`/catalog/${manifest.file}`, { cache: 'no-cache' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const payload = await res.json() as ExportedSession;
+    await callbacks.onLoadCatalogEntry(manifest, payload);
+  } catch {
+    // If the entry can't be loaded directly, fall back to the full catalog
+    // page so the user still has a path to the content.
+    callbacks.onOpenCatalog();
+  }
 }
 
 async function loadFeaturedCatalogEntries(): Promise<FeaturedCatalogEntry[]> {


### PR DESCRIPTION
## Summary

Reworks how the "What you can build" featured catalog tiles on the landing page behave:

- **Tiles now open the item directly in the editor.** Clicking a featured catalog tile fetches that entry's session payload and hands it to the shared catalog-load path (`handleCatalogEntryLoad`), importing it as a fresh session — exactly like clicking a tile on the full `/catalog` page. Previously every tile just navigated to `/catalog`. If the payload fetch fails, it falls back to opening the full catalog so there's still a path to the content.
- **The "Browse the full catalog" link is more prominent.** Promoted from a tiny `text-xs` link to a bordered pill button (`px-3 py-1.5`, blue border, hover fill), and the header switches to `items-center` alignment to sit cleanly next to it. This keeps the full catalog discoverable now that the tiles no longer lead there.

### How it works

- Adds an `onLoadCatalogEntry(entry, payload)` callback to `LandingCallbacks`, wired in `main.ts` to the existing `handleCatalogEntryLoad` — the same handler the `/catalog` page already uses, so history/back-button handling and session import are unchanged.
- A new `loadFeaturedCatalogEntry()` helper in `landing.ts` does the per-tile fetch + dispatch.

## Test plan

- [x] `npm run build` — passes, no type errors
- [x] `npm run test:unit` — 374 passing
- [ ] e2e shards (fire on ready-for-review)
- [ ] Manual: landing → click a featured tile → lands in editor with that catalog item loaded as a new session; browser back returns to the landing page
- [ ] Manual: "Browse the full catalog" button is visibly prominent and still opens `/catalog`

https://claude.ai/code/session_01YXsLpKbMP9zMXD6bRmzVKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXsLpKbMP9zMXD6bRmzVKJ)_