### PR TITLE
feat: organize the catalog into category sections with characteristic badges

### DIFF
--- a/src/ui/catalog.ts
+++ b/src/ui/catalog.ts
@@ -46,7 +46,7 @@ interface LoadedEntry {
 /** The catalog is sectioned so each tile's reason for being here is obvious.
  *  Categories are mutually exclusive and assigned in {@link categorize}; the
  *  array order is the on-page section order. */
-type CategoryId = 'customizable' | 'manifold' | 'sdf' | 'scad' | 'brep';
+type CategoryId = 'customizable' | 'manifold' | 'sdf' | 'voxel' | 'scad' | 'brep';
 
 interface CategoryDef {
   id: CategoryId;
@@ -57,7 +57,8 @@ interface CategoryDef {
 const CATEGORIES: CategoryDef[] = [
   { id: 'customizable', title: 'Customizable', blurb: 'Tweak these live with sliders and toggles — open the 🎛 Customize panel in the editor, no code changes needed.' },
   { id: 'manifold', title: 'JavaScript Models', blurb: 'Built with the default manifold-3d mesh API — the everyday JS modeling path.' },
-  { id: 'sdf', title: 'Implicit Surfaces (SDF)', blurb: 'Signed-distance-field models via levelSet — gyroids, lattices, and organic blends.' },
+  { id: 'sdf', title: 'Implicit Surfaces (SDF)', blurb: 'Signed-distance-field models via the Sdf builder — gyroids, lattices, and organic blends.' },
+  { id: 'voxel', title: 'Voxel Models', blurb: 'Built by painting and baking a voxel grid.' },
   { id: 'scad', title: 'OpenSCAD', blurb: 'Authored in OpenSCAD with the BOSL2 library — gears, threads, and machined parts.' },
   { id: 'brep', title: 'Solid CAD (BREP)', blurb: 'Exact OpenCASCADE solids (replicad) with true fillets and STEP export.' },
 ];
@@ -70,6 +71,7 @@ function categorize(entry: LoadedEntry): CategoryId {
   const lang = entry.payload?.session.language ?? entry.manifest.language ?? 'manifold-js';
   if (lang === 'scad') return 'scad';
   if (lang === 'replicad') return 'brep';
+  if (lang === 'voxel') return 'voxel';
   if (entry.isSDF) return 'sdf';
   return 'manifold';
 }
@@ -80,7 +82,13 @@ function categorize(entry: LoadedEntry): CategoryId {
 function deriveCharacteristics(entry: CatalogManifestEntry, payload: ExportedSession | null): { hasParams: boolean; isSDF: boolean } {
   const code = (payload?.versions ?? []).map(v => v.code ?? '').join('\n');
   const hasParams = /\bapi\.params\s*\(/.test(code);
-  const isSDF = /\blevelSet\s*\(/.test(code) || /^sdf[-_]/i.test(entry.id);
+  // SDF catalog entries reach the surface builder through the `sdf` api
+  // namespace — either `api.sdf.…` or, more often, destructured as
+  // `const { sdf, Manifold } = api`. Detect both, plus the raw manifold
+  // `levelSet`, and fall back to the `sdf-` id prefix so a thumbnail-only or
+  // differently-authored entry still classifies.
+  const usesSdfApi = /\bapi\.sdf\b/.test(code) || /[{,]\s*sdf\s*[,}]/.test(code);
+  const isSDF = usesSdfApi || /\blevelSet\s*\(/.test(code) || /^sdf[-_]/i.test(entry.id);
   return { hasParams, isSDF };
 }
 

--- a/src/ui/catalog.ts
+++ b/src/ui/catalog.ts
@@ -35,7 +35,53 @@ interface LoadedEntry {
   payload: ExportedSession | null;
   /** Pulled from the latest version's embedded thumbnail, or null. */
   thumbnailUrl: string | null;
+  /** Declares `api.params({...})` in any version's code — drives the
+   *  "Customizable" category + the parametric tile badge. */
+  hasParams: boolean;
+  /** Uses an implicit/signed-distance surface (`levelSet`, or an `sdf-` id). */
+  isSDF: boolean;
   error: string | null;
+}
+
+/** The catalog is sectioned so each tile's reason for being here is obvious.
+ *  Categories are mutually exclusive and assigned in {@link categorize}; the
+ *  array order is the on-page section order. */
+type CategoryId = 'customizable' | 'manifold' | 'sdf' | 'scad' | 'brep';
+
+interface CategoryDef {
+  id: CategoryId;
+  title: string;
+  blurb: string;
+}
+
+const CATEGORIES: CategoryDef[] = [
+  { id: 'customizable', title: 'Customizable', blurb: 'Tweak these live with sliders and toggles — open the 🎛 Customize panel in the editor, no code changes needed.' },
+  { id: 'manifold', title: 'JavaScript Models', blurb: 'Built with the default manifold-3d mesh API — the everyday JS modeling path.' },
+  { id: 'sdf', title: 'Implicit Surfaces (SDF)', blurb: 'Signed-distance-field models via levelSet — gyroids, lattices, and organic blends.' },
+  { id: 'scad', title: 'OpenSCAD', blurb: 'Authored in OpenSCAD with the BOSL2 library — gears, threads, and machined parts.' },
+  { id: 'brep', title: 'Solid CAD (BREP)', blurb: 'Exact OpenCASCADE solids (replicad) with true fillets and STEP export.' },
+];
+
+/** Assign one category per entry. Parametric models lead (it's the trait users
+ *  most want to find); otherwise we split by engine, with SDF pulled out of the
+ *  manifold-js bucket as its own showcase. */
+function categorize(entry: LoadedEntry): CategoryId {
+  if (entry.hasParams) return 'customizable';
+  const lang = entry.payload?.session.language ?? entry.manifest.language ?? 'manifold-js';
+  if (lang === 'scad') return 'scad';
+  if (lang === 'replicad') return 'brep';
+  if (entry.isSDF) return 'sdf';
+  return 'manifold';
+}
+
+/** Inspect a payload's code for the characteristics that drive categorization
+ *  and tile badges. Reads across all versions so a trait declared on any
+ *  version still counts. */
+function deriveCharacteristics(entry: CatalogManifestEntry, payload: ExportedSession | null): { hasParams: boolean; isSDF: boolean } {
+  const code = (payload?.versions ?? []).map(v => v.code ?? '').join('\n');
+  const hasParams = /\bapi\.params\s*\(/.test(code);
+  const isSDF = /\blevelSet\s*\(/.test(code) || /^sdf[-_]/i.test(entry.id);
+  return { hasParams, isSDF };
 }
 
 export async function createCatalogPage(
@@ -81,7 +127,7 @@ export async function createCatalogPage(
 
   const intro = document.createElement('p');
   intro.className = 'w-full max-w-5xl px-6 -mt-4 mb-6 text-sm text-zinc-400 leading-relaxed';
-  intro.textContent = 'Curated premade models. Click a tile to import it as a fresh session you can edit.';
+  intro.textContent = 'Curated premade models, grouped by what makes each one tick — parametric, JavaScript, implicit-surface (SDF), OpenSCAD, and solid-CAD (BREP). Click a tile to import it as a fresh session you can edit.';
   page.appendChild(intro);
 
   // Body: grid (loading / empty / error states handled below).
@@ -131,25 +177,65 @@ export async function createCatalogPage(
         const versions = payload.versions ?? [];
         const latest = versions.length > 0 ? versions[versions.length - 1] : null;
         const thumbnailUrl = latest?.thumbnail ?? null;
-        return { manifest: entry, payload, thumbnailUrl, error: null };
+        const { hasParams, isSDF } = deriveCharacteristics(entry, payload);
+        return { manifest: entry, payload, thumbnailUrl, hasParams, isSDF, error: null };
       } catch (e) {
-        return { manifest: entry, payload: null, thumbnailUrl: null, error: (e as Error).message };
+        return { manifest: entry, payload: null, thumbnailUrl: null, hasParams: false, isSDF: false, error: (e as Error).message };
       }
     }),
   );
 
   status.remove();
 
-  const grid = document.createElement('div');
-  grid.className = 'grid gap-4';
-  grid.style.gridTemplateColumns = 'repeat(auto-fill, minmax(220px, 1fr))';
-  body.appendChild(grid);
-
+  // Bucket entries into their category, then render the non-empty sections in
+  // CATEGORIES order. Entry order within a section follows the manifest.
+  const buckets = new Map<CategoryId, LoadedEntry[]>();
   for (const entry of loaded) {
-    grid.appendChild(renderTile(entry, callbacks));
+    const cat = categorize(entry);
+    const arr = buckets.get(cat);
+    if (arr) arr.push(entry);
+    else buckets.set(cat, [entry]);
+  }
+
+  for (const def of CATEGORIES) {
+    const entries = buckets.get(def.id);
+    if (!entries || entries.length === 0) continue;
+    body.appendChild(renderCategorySection(def, entries, callbacks));
   }
 
   return page;
+}
+
+/** Render one titled, blurbed category section with its own tile grid. */
+function renderCategorySection(def: CategoryDef, entries: LoadedEntry[], callbacks: CatalogCallbacks): HTMLElement {
+  const section = document.createElement('section');
+  section.className = 'mb-10';
+  section.dataset.category = def.id;
+
+  const titleRow = document.createElement('div');
+  titleRow.className = 'flex items-baseline gap-2';
+  const h2 = document.createElement('h2');
+  h2.className = 'text-lg font-semibold text-zinc-100';
+  h2.textContent = def.title;
+  const count = document.createElement('span');
+  count.className = 'text-xs text-zinc-500 tabular-nums';
+  count.textContent = String(entries.length);
+  titleRow.appendChild(h2);
+  titleRow.appendChild(count);
+  section.appendChild(titleRow);
+
+  const blurb = document.createElement('p');
+  blurb.className = 'text-xs text-zinc-400 mt-0.5 mb-3 leading-relaxed';
+  blurb.textContent = def.blurb;
+  section.appendChild(blurb);
+
+  const grid = document.createElement('div');
+  grid.className = 'grid gap-4';
+  grid.style.gridTemplateColumns = 'repeat(auto-fill, minmax(220px, 1fr))';
+  for (const entry of entries) grid.appendChild(renderTile(entry, callbacks));
+  section.appendChild(grid);
+
+  return section;
 }
 
 function renderTile(loaded: LoadedEntry, callbacks: CatalogCallbacks): HTMLElement {
@@ -198,6 +284,16 @@ function renderTile(loaded: LoadedEntry, callbacks: CatalogCallbacks): HTMLEleme
   langBadge.className = `font-semibold border rounded px-1 ${badge.classes}`;
   langBadge.textContent = badge.label;
   meta.appendChild(langBadge);
+
+  // Parametric chip — the headline "special characteristic": this model exposes
+  // tweakable knobs. Reinforces the Customizable section at a per-tile glance.
+  if (loaded.hasParams) {
+    const paramBadge = document.createElement('span');
+    paramBadge.className = 'font-semibold border rounded px-1 text-violet-300 border-violet-400/30';
+    paramBadge.textContent = '🎛 Parametric';
+    paramBadge.title = 'Exposes adjustable parameters — tweak it in the Customize panel';
+    meta.appendChild(paramBadge);
+  }
 
   if (loaded.error) {
     const errBadge = document.createElement('span');

--- a/tests/catalog.spec.ts
+++ b/tests/catalog.spec.ts
@@ -1,0 +1,66 @@
+// The /catalog page groups its curated entries into category sections
+// (Customizable, JavaScript, SDF, OpenSCAD, BREP) so a visitor can tell at a
+// glance why each model is there, and tags parametric tiles with a badge.
+// This drives the real page against the static manifest + payloads in
+// public/catalog/ (no engine/WASM needed — the page only fetches JSON).
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function gotoCatalog(page: Page) {
+  await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  await page.goto('/catalog');
+  await page.waitForSelector('#catalog-page section[data-category]', { timeout: 20_000 });
+}
+
+test.describe('Catalog categories', () => {
+  test('renders category sections in order, each with a count and blurb', async ({ page }) => {
+    await gotoCatalog(page);
+
+    const sections = page.locator('#catalog-page section[data-category]');
+    // Sections only render when non-empty; the shipped catalog populates all
+    // five, in this canonical order.
+    await expect(sections).toHaveCount(5);
+
+    const ids = await sections.evaluateAll((els) => els.map((e) => (e as HTMLElement).dataset.category));
+    expect(ids).toEqual(['customizable', 'manifold', 'sdf', 'scad', 'brep']);
+
+    // Every section has a heading, a numeric count, a descriptive blurb, and at
+    // least one tile.
+    const count = await sections.count();
+    for (let i = 0; i < count; i++) {
+      const sec = sections.nth(i);
+      await expect(sec.locator('h2')).toBeVisible();
+      await expect(sec.locator('h2 + span')).toHaveText(/^\d+$/);
+      await expect(sec.locator('p')).not.toBeEmpty();
+      expect(await sec.locator('div.grid > button').count()).toBeGreaterThan(0);
+    }
+  });
+
+  test('the Customizable section holds the parametric models and tags them', async ({ page }) => {
+    await gotoCatalog(page);
+
+    const customizable = page.locator('#catalog-page section[data-category="customizable"]');
+    const tiles = customizable.locator('div.grid > button');
+    const tileCount = await tiles.count();
+    expect(tileCount).toBeGreaterThan(0);
+
+    // Every tile in the Customizable section carries the parametric badge…
+    await expect(customizable.locator('span:has-text("Parametric")')).toHaveCount(tileCount);
+
+    // …and the parametric badge appears ONLY inside the Customizable section
+    // (parametric is the trait that defines membership).
+    const totalBadges = await page.locator('#catalog-page span:has-text("Parametric")').count();
+    expect(totalBadges).toBe(tileCount);
+
+    // A known parametric entry lives here, not in a language bucket.
+    await expect(customizable).toContainText('Layer Cake');
+  });
+
+  test('clicking a tile imports the session and opens the editor', async ({ page }) => {
+    await gotoCatalog(page);
+    const firstTile = page.locator('#catalog-page section[data-category] div.grid > button').first();
+    await expect(firstTile).toBeEnabled();
+    await firstTile.click();
+    await expect(page).toHaveURL(/\/editor/, { timeout: 20_000 });
+  });
+});


### PR DESCRIPTION
## Summary

The `/catalog` page was one undifferentiated grid, so it wasn't clear why any given model was included. This groups entries into titled, described **category sections** so each tile's reason for being there is obvious — and tags parametric models with a badge.

### Categories (section order)
1. **Customizable** — models that expose `api.params({...})`. The trait users most want to find, so it leads.
2. **JavaScript Models** — the default manifold-3d mesh API.
3. **Implicit Surfaces (SDF)** — models that use the `sdf` builder namespace.
4. **Voxel Models** — voxel-grid models (inert until such an entry ships).
5. **OpenSCAD** — `scad`-language parts.
6. **Solid CAD (BREP)** — `replicad`/OpenCASCADE solids.

Each section has a heading, an item count, and a one-line blurb explaining what it is. Empty sections are skipped.

### How categories are assigned
Categories are **derived from each loaded payload** rather than hand-tagged in the manifest, so they stay correct automatically as the catalog grows:
- **Parametric** — code contains `api.params(`.
- **SDF** — code reaches the surface builder via the `sdf` api namespace (`api.sdf` or destructured `const { sdf } = api`), or uses raw `levelSet`, with the `sdf-` id prefix as a fallback. (Initial implementation only matched a literal `levelSet`, which no catalog entry uses — fixed so all 12 SDF entries classify by code.)
- **Language** — `scad` / `replicad` / `voxel` from the session payload.

Assignment is mutually exclusive: parametric wins first, then engine/language, with SDF pulled out of the manifold-js bucket. For the shipped catalog: Customizable 10, JavaScript 29, SDF 12, OpenSCAD 9, BREP 13.

### Tile badges
Tiles now carry a **🎛 Parametric** chip (alongside the existing language badge) so the headline "special characteristic" reads at a glance.

## Test plan
- `npm run build` ✓ (type-check clean)
- `npm run test:unit` ✓ (374 passed)
- `npx playwright test tests/catalog.spec.ts` ✓ (3 passed — section order/counts/blurbs, parametric-section membership + badge exclusivity, tile→editor import)
- Verified SDF detection: all 12 SDF entries match by code with zero false positives across the shipped catalog.
- Manual: rendered `/catalog`, confirmed sections, blurbs, counts, and the violet Parametric badges on every Customizable tile.

## Review follow-ups folded in
An automated review pass flagged two latent gaps (neither broke the shipped catalog); both are addressed in this branch:
- SDF code-detection was effectively dead (relied on `levelSet`, which no entry uses) → now detects the real `sdf` api usage.
- `voxel` language was unmapped → now has its own category.

🤖 https://claude.ai/code/session_011MSXKpt9dp2ZG1T4VaPkTw