### PR TITLE
fix: never auto-open AI drawer on the landing page

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4032,6 +4032,9 @@ async function main() {
           await syncRouteFromURL();
         },
         mountInto: appRow,
+        // Never auto-open the drawer when the app boots on the landing page —
+        // the remembered open state only applies once the user is in the editor.
+        suppressAutoOpen: shouldShowLanding(),
       });
       const cur = getState();
       await setAiActiveSession(cur.session?.id ?? null);

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -191,6 +191,11 @@ export interface AiPanelOptions {
    *  changes (landing ↔ editor) — the landing-page chat flow depends on that.
    *  Falls back to <body> if omitted. */
   mountInto?: HTMLElement;
+  /** Suppress the remembered-open auto-expand for this load. main.ts passes
+   *  this when the app boots on the landing page so the drawer never
+   *  auto-opens there, even if `drawerOpen` is set from a prior editor
+   *  session. The user can still open it manually. */
+  suppressAutoOpen?: boolean;
 }
 
 /** Mount the drawer once on app start. Idempotent. */
@@ -205,7 +210,10 @@ export async function initAiPanel(opts: AiPanelOptions = {}): Promise<void> {
 
   const settings = loadSettings();
   panelWidth = settings.aiPanelWidth;
-  state.open = settings.drawerOpen;
+  // Honor the remembered open state, but never auto-open on the landing page
+  // (main.ts sets suppressAutoOpen there) — the drawer shouldn't pop open
+  // before the user has even entered the editor.
+  state.open = settings.drawerOpen && !opts.suppressAutoOpen;
 
   buildDrawer();
   // The panel docks as a column on desktop but becomes a full-screen overlay
@@ -237,7 +245,13 @@ export async function initAiPanel(opts: AiPanelOptions = {}): Promise<void> {
   // On a default-open load, show the panel without grabbing keyboard focus —
   // the user hasn't asked to type in it yet.
   if (state.open) showDrawer(false);
-  else hideDrawer();
+  else if (opts.suppressAutoOpen) {
+    // Landing-page boot: keep the drawer visually hidden (its default state)
+    // but DON'T persist drawerOpen:false — that would wipe the user's
+    // remembered preference, so the panel wouldn't auto-open in the editor
+    // later. The drawer element already starts with the `hidden` class.
+    state.open = false;
+  } else hideDrawer();
 }
 
 /** Called by main.ts whenever the active session changes (open / close).

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -240,25 +240,23 @@ test.describe('AI chat panel', () => {
     }
   });
 
-  test('drawer + send from landing page navigates to editor', async ({ page }) => {
-    // Ensure the drawer is open on /editor first so it persists open, then go
-    // back to the landing page. The drawer docks into the app-level row
-    // (outside the per-page subtrees), so it stays mounted and visible there.
+  test('drawer never auto-opens on a fresh landing-page load', async ({ page }) => {
+    // Open the drawer in the editor so the remembered drawerOpen=true setting
+    // is persisted, then do a FULL reload of the landing page. The drawer must
+    // NOT auto-open there — the remembered open state only applies once the
+    // user is in the editor. (The panel still docks into the app-level row, so
+    // it stays mounted/attached — it's just hidden.)
     await page.goto('/editor');
     await openAiPanel(page);
     await page.goto('/');
     await page.waitForSelector('#ai-panel', { state: 'attached' });
-    await expect(page.locator('#ai-panel')).toBeVisible();
+    await expect(page.locator('#ai-panel')).toBeHidden();
 
-    // Sending a message from the landing page should navigate to /editor.
-    // No key is set so the key modal appears first — that path is fine,
-    // we just want to confirm we don't silently model on /.
-    await page.locator('#ai-panel textarea').fill('build a cube');
-    await page.locator('#ai-panel button:has-text("Send")').dispatchEvent('click');
-    const onEditor = page.waitForURL(/\/editor/, { timeout: 5000 }).then(() => 'editor');
-    const onModal = page.waitForSelector('input[type="password"]', { timeout: 5000 }).then(() => 'modal');
-    const which = await Promise.race([onEditor, onModal]);
-    expect(['editor', 'modal']).toContain(which);
+    // And the remembered preference is untouched: opening the editor again
+    // auto-opens the drawer as before.
+    await page.goto('/editor');
+    await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
+    await expect(page.locator('#ai-panel')).toBeVisible();
   });
 
   test('Send stays as Send when a turn is in flight; Stop is the separate red button', async ({ page }) => {


### PR DESCRIPTION
## Summary

The AI side drawer auto-expanded on the **landing page** whenever the remembered `drawerOpen` setting was `true` — popping open before the user had even entered the editor. `initAiPanel` (`src/ui/aiPanel.ts`) unconditionally honored `settings.drawerOpen` on mount, so any user who'd previously left the drawer open in the editor would see it spring open on `/`.

### Fix
- Added a `suppressAutoOpen` option to `initAiPanel`. When set, the drawer stays in its default-hidden state on boot regardless of `drawerOpen`.
- `main.ts` passes `suppressAutoOpen: shouldShowLanding()` so the drawer never auto-opens when the app boots on the landing page.
- The suppressed path deliberately does **not** persist `drawerOpen: false` — the user's remembered preference is left untouched, so the panel still auto-opens as before once they're in the editor. (The landing page has no manual open affordance, so the AI pane is now simply absent there — confirmed as the intended behavior.)

### Test
- Replaced the old `drawer + send from landing page navigates to editor` smoke test (which relied on the now-removed landing auto-open) with `drawer never auto-opens on a fresh landing-page load`: it opens the drawer in the editor, full-reloads `/`, asserts the drawer is hidden there, then re-opens the editor and asserts it auto-opens again (proving the persisted preference is untouched).

## Test plan
- `npm run build` — green (type-check + Vite build)
- `npm run test:unit` — 374 passing
- `npx playwright test smoke.spec.ts` (drawer tests) — green locally, incl. the new landing-load assertion
- Manual: load `/` with `drawerOpen` previously set → drawer stays closed; open editor → drawer auto-opens as before.

https://claude.ai/code/session_01CzYMuXuDmPbn7xWyG12f8G