### PR TITLE
feat: add getShareLink API and recommend share links over gallery URL

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -288,8 +288,9 @@ await partwright.listVersions()          // -> [{id, index, label, timestamp, st
 await partwright.loadVersion({index} | {id})  // Load version into editor -> {id, index, label, code, geometryData, labelsAvailable, labelCount} or {error}
 await partwright.forkVersion({index} | {id}, transformFn, label?, assertions?, carryColors=true) // Load + modify + validate + save atomically; carries parent colors -> {..., codeDiff, colors}
 await partwright.copyColorsFromVersion({index} | {id}) // Re-apply a prior version's colors onto the current mesh -> {source, carried, dropped}
-partwright.getGalleryUrl()               // -> URL for gallery view (human review)
-partwright.getSessionUrl()               // -> URL for this session
+await partwright.getShareLink()          // -> {url, encodedBytes} read-only share link (or {error}); the link to hand the user when done
+partwright.getGalleryUrl()               // -> URL for gallery view (local browser only)
+partwright.getSessionUrl()               // -> URL for this session (local browser only)
 await partwright.listSessions()          // -> [{id, name, updated}]
 await partwright.openSession(id)         // Open existing session
 await partwright.clearAllSessions()      // Delete all sessions & versions
@@ -1035,7 +1036,8 @@ Read the notes and version history before making changes. The notes tell you:
 3. Modify code, test with `modifyAndTest(patchFn)` or `runIsolated(code)` -- no side effects
 4. When satisfied, save: `runAndSave(modifiedCode, "v2 - improvements", assertions)` -- check the diff
 5. Use `query({sliceAt: [...], decompose: true})` for follow-up inspection without re-running
-6. Repeat. Gallery URL is in `#geometry-data` or the `runAndSave` return value.
+6. Repeat.
+7. When done, hand the user a **share link**: `const { url } = await partwright.getShareLink()`. This is a self-contained, read-only URL that encodes the whole design — anyone can open it anywhere and fork it into their own copy. Prefer it over `getSessionUrl()`/`getGalleryUrl()`, which only resolve against *your* browser's local storage and won't open for the user.
 
 ## Visual verification
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8440,7 +8440,8 @@ async function main() {
         'changePart':      { signature: 'await changePart(id) -- Switch active part (loads its latest version)', docs: '/ai.md#console-api--windowpartwright' },
         'renamePart':      { signature: 'await renamePart(id, name) -- Rename a part', docs: '/ai.md#console-api--windowpartwright' },
         'deletePart':      { signature: 'await deletePart(id) -- Delete a part and its versions', docs: '/ai.md#console-api--windowpartwright' },
-        'getGalleryUrl':   { signature: 'getGalleryUrl() -- URL for gallery view (human review)', docs: '/ai.md#console-api--windowpartwright' },
+        'getShareLink':    { signature: 'await getShareLink() -- Read-only share link for the current version -> {url, encodedBytes} or {error}; the link to hand the user when done', docs: '/ai.md#console-api--windowpartwright' },
+        'getGalleryUrl':   { signature: 'getGalleryUrl() -- URL for gallery view (local browser only)', docs: '/ai.md#console-api--windowpartwright' },
         // Notes
         'addSessionNote':  { signature: 'await addSessionNote(text) -- Add note with [PREFIX] tag', docs: '/ai.md#session-notes----tracking-design-context' },
         'listSessionNotes': { signature: 'await listSessionNotes() -- List all session notes', docs: '/ai.md#session-notes----tracking-design-context' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -2568,32 +2568,36 @@ async function main() {
   // with a toast rather than minting a link that silently won't open.
   const MAX_SHARE_ENCODED_CHARS = 1_500_000;
 
-  /** Encode the current committed version into a `#share=…` link and open the
-   *  copy modal. Saves the current buffer first (exportSession reads the SAVED
-   *  version), feature-detects CompressionStream, and trims the thumbnail if the
-   *  link is too large before giving up. */
-  const actionShareLink = async (): Promise<void> => {
+  /** Encode the current committed version into a self-contained `#share=…`
+   *  read-only link. Saves the current buffer first (exportSession reads the
+   *  SAVED version), feature-detects CompressionStream, and trims the thumbnail
+   *  if the link is too large before giving up. Returns `{ url, encodedBytes }`
+   *  on success or `{ error }` with a user-facing message. Pure builder: it does
+   *  no UI — callers decide whether to open the modal (toolbar) or just return
+   *  the string (the partwright API).
+   *
+   *  `notify` optionally surfaces the "multi-part designs share one part" toast;
+   *  the API path passes a no-op so it never pops UI out from under an agent. */
+  const buildShareLink = async (
+    notify: (msg: string) => void = () => {},
+  ): Promise<{ url: string; encodedBytes: number } | { error: string }> => {
     if (typeof CompressionStream === 'undefined') {
-      showToast('Sharing needs a newer browser', { variant: 'warn' });
-      return;
+      return { error: 'Sharing needs a newer browser' };
     }
     if (!getState().session || !engineOk) {
-      showToast('Open or create a design before sharing.', { variant: 'warn' });
-      return;
+      return { error: 'Open or create a design before sharing.' };
     }
     // exportSession reads the SAVED version from IndexedDB, so commit the current
     // buffer first — both to give a fresh /editor (currentVersion: null) a
     // version to export and to capture any unsaved edits the user is sharing.
     const saved = await saveCurrentVersion();
     if ('error' in saved) {
-      showToast(saved.error, { variant: 'warn' });
-      return;
+      return { error: saved.error };
     }
     const state = getState();
     const versionIndex = state.currentVersion?.index;
     if (versionIndex === undefined) {
-      showToast('No saved version to share yet.', { variant: 'warn' });
-      return;
+      return { error: 'No saved version to share yet.' };
     }
 
     const sessionId = state.session!.id;
@@ -2606,8 +2610,7 @@ async function main() {
       includeNotes: false,
     });
     if (!exported) {
-      showToast('Could not prepare this design for sharing.', { variant: 'warn' });
-      return;
+      return { error: 'Could not prepare this design for sharing.' };
     }
     if (state.parts.length > 1) {
       // A share link carries one version of one part. Tell the user so a
@@ -2615,7 +2618,7 @@ async function main() {
       // after the current part.
       const partName = state.currentPart?.name;
       if (partName) exported.session = { ...exported.session, name: partName };
-      showToast(`Sharing only "${partName ?? 'the current part'}" — multi-part designs share one part per link.`, { variant: 'neutral' });
+      notify(`Sharing only "${partName ?? 'the current part'}" — multi-part designs share one part per link.`);
     }
 
     try {
@@ -2631,19 +2634,27 @@ async function main() {
         encoded = await encodeShare(slimmed);
       }
       if (encoded.length > MAX_SHARE_ENCODED_CHARS) {
-        showToast('Design too large to share via link', { variant: 'warn' });
-        return;
+        return { error: 'Design too large to share via link' };
       }
-      const url = `${location.origin}/editor#share=${encoded}`;
-      openShareModal(url, encoded.length);
+      return { url: `${location.origin}/editor#share=${encoded}`, encodedBytes: encoded.length };
     } catch (e) {
       if (e instanceof ShareUnsupportedError) {
-        showToast('Sharing needs a newer browser', { variant: 'warn' });
-      } else {
-        showToast('Could not create a share link.', { variant: 'warn' });
-        errorLog.capture({ level: 'error', source: 'app', message: `share encode failed: ${e instanceof Error ? e.message : String(e)}` });
+        return { error: 'Sharing needs a newer browser' };
       }
+      errorLog.capture({ level: 'error', source: 'app', message: `share encode failed: ${e instanceof Error ? e.message : String(e)}` });
+      return { error: 'Could not create a share link.' };
     }
+  };
+
+  /** Build the share link and open the copy modal. Thin toolbar wrapper around
+   *  {@link buildShareLink}; surfaces every error path as a toast. */
+  const actionShareLink = async (): Promise<void> => {
+    const result = await buildShareLink((msg) => showToast(msg, { variant: 'neutral' }));
+    if ('error' in result) {
+      showToast(result.error, { variant: 'warn' });
+      return;
+    }
+    openShareModal(result.url, result.encodedBytes);
   };
 
   /** True when the share action can run: an active session on a ready engine. */
@@ -5699,6 +5710,23 @@ async function main() {
     /** Get URL for the gallery view of the current session */
     getGalleryUrl() {
       return getGalleryUrl();
+    },
+
+    /** Mint a self-contained, read-only share link for the current version.
+     *
+     *  This is the link to hand back to the user when you're done — unlike
+     *  `getSessionUrl()`/`getGalleryUrl()` (which only resolve on this browser,
+     *  against this browser's IndexedDB), a share link encodes the whole design
+     *  into the URL hash, so anyone can open it anywhere and fork it into their
+     *  own editable copy. Nothing is uploaded to a server.
+     *
+     *  Commits the current buffer first (so unsaved edits are captured), then
+     *  encodes the current part's current version. Multi-part sessions share one
+     *  part per link. Returns `{ url, encodedBytes }` on success or `{ error }`
+     *  (e.g. no session open, browser lacks CompressionStream, or the design is
+     *  too large to fit in a URL). */
+    async getShareLink() {
+      return buildShareLink();
     },
 
     /** Get current session state */

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -267,8 +267,8 @@ export function createHelpPage(
           '2. Build a standard 2x4 Lego brick (approximately 31.8mm x 15.8mm x 11.4mm with studs on top and hollow underside with tubes)\n' +
           '3. Save each major step as a version (e.g. v1 - base block, v2 - add studs, v3 - hollow underside with tubes)\n' +
           '4. Use assertions to verify each version is a valid manifold with maxComponents: 1\n' +
-          '5. Give me the gallery URL when done so I can review the versions</code></pre>' +
-          'The agent should read <code class="text-emerald-400 bg-zinc-800 px-1 rounded">ai.md</code>, create a named session, iterate through versions, and hand back a gallery link for review.';
+          '5. Give me a share link (partwright.getShareLink()) when done so I can open the design</code></pre>' +
+          'The agent should read <code class="text-emerald-400 bg-zinc-800 px-1 rounded">ai.md</code>, create a named session, iterate through versions, and hand back a read-only share link for review.';
       })(),
     },
     {

--- a/src/ui/landing.ts
+++ b/src/ui/landing.ts
@@ -361,7 +361,7 @@ Then navigate to ${origin}/editor and use the window.partwright console API to:
 2. Build a standard 2x4 Lego brick (approximately 31.8mm x 15.8mm x 11.4mm with studs on top and hollow underside with tubes)
 3. Save each major step as a version (e.g. v1 - base block, v2 - add studs, v3 - hollow underside with tubes)
 4. Use assertions to verify each version is a valid manifold with maxComponents: 1
-5. Give me the gallery URL when done so I can review the versions`;
+5. Give me a share link (partwright.getShareLink()) when done so I can open the design`;
 
 function buildAgentSection(): HTMLElement {
   const section = document.createElement('section');

--- a/tests/share-link.spec.ts
+++ b/tests/share-link.spec.ts
@@ -135,6 +135,26 @@ test.describe('share links', () => {
     await expect(page.getByText('Link copied')).toBeVisible();
   });
 
+  test('T1b partwright.getShareLink() returns a self-contained hash URL', async ({ page }) => {
+    // The console/AI API surface for sharing — what an agent hands back to the
+    // user when done. It commits the current buffer, then encodes the design.
+    await openEditor(page);
+
+    const result = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: {
+        getShareLink(): Promise<{ url: string; encodedBytes: number } | { error: string }>;
+      } }).partwright;
+      return pw.getShareLink();
+    });
+
+    expect('error' in result).toBe(false);
+    if ('url' in result) {
+      const origin = new URL(page.url()).origin;
+      expect(result.url.startsWith(`${origin}/editor#share=`)).toBe(true);
+      expect(result.encodedBytes).toBeGreaterThan(0);
+    }
+  });
+
   test('T2 Opening a share link shows a cold, read-only preview (no execution)', async ({ page }) => {
     await openEditor(page);
 


### PR DESCRIPTION
## Summary

The landing-page and Help agent prompts told agents to hand back the **gallery URL** when done. But the gallery view has been folded into Versions, and a gallery/session URL only resolves against the *agent's own* browser IndexedDB — it won't open for the user on a different machine. This swaps that guidance for a **read-only share link**, which encodes the whole design into the URL hash so anyone can open and fork it (nothing is uploaded).

To give agents a way to mint that link, this adds a `partwright.getShareLink()` console/AI API:

- Extracts a pure `buildShareLink()` helper out of the toolbar's existing `actionShareLink` (the share modal logic). It returns `{ url, encodedBytes }` or `{ error }` and does **no UI**, so callers decide whether to open the modal (toolbar) or just return the string (the API). `actionShareLink` is now a thin wrapper that surfaces errors as toasts.
- Exposes `partwright.getShareLink()` next to `getSessionUrl()`/`getGalleryUrl()`. It commits the current buffer first, then encodes the current part's current version (multi-part sessions share one part per link).

Prompt + docs updates:
- `src/ui/landing.ts` — the "Built for AI agents" sample prompt now asks for a share link.
- `src/ui/help.ts` — the "Try it with an external AI agent" sample prompt + surrounding copy updated to match.
- `public/ai.md` — documents `getShareLink()` in the API list, notes that `getGalleryUrl()`/`getSessionUrl()` are local-browser-only, and adds a closing step to the iteration pattern recommending the share link as the deliverable.

## Test plan

- `npm run build` — green (type-check passes).
- `npm run test:unit` — 374 passing.
- Added e2e **T1b** in `tests/share-link.spec.ts`: asserts `partwright.getShareLink()` returns a `${origin}/editor#share=…` URL with `encodedBytes > 0`.
- Existing share-link e2e (T1–T4) still covers the toolbar modal path, which now flows through the extracted helper.

https://claude.ai/code/session_01A7Rws7SFXoTrL13egrDBQL

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7Rws7SFXoTrL13egrDBQL)_