### PR TITLE
feat: extend Customizer to voxel + BREP engines and add exact numeric entry

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -70,7 +70,7 @@ Reach for the right tool the first time. If the table sends you to a subdoc, fet
 |---|---|---|---|
 | Cube / sphere / cylinder | `Manifold.cube/sphere/cylinder(...)` | `cube()`, `sphere()`, `cylinder()` | `BREP.box([w,d,h])`, `BREP.sphere(r)`, `BREP.cylinder(r, h)` |
 | Boolean union / difference / intersection | `.add(o)`, `.subtract(o)`, `.intersect(o)` | `union(){...}`, `difference(){...}`, `intersection(){...}` | `.fuse(o)` / `.cut(o)` / `.intersect(o)`, or `BREP.fuseAll([a,b,c])` / `BREP.cutAll([body,…holes])` / `BREP.intersectAll([…])` for N-way |
-| Expose tweakable knobs (make it customizable) | `api.params({...})` at the top → live Parameters panel; `partwright.getParams()`/`setParams({...})` to drive | (manifold-js only) | (manifold-js only) |
+| Expose tweakable knobs (make it customizable) | `api.params({...})` at the top → live Parameters panel; `partwright.getParams()`/`setParams({...})` to drive | (not in SCAD yet) | `api.params({...})` — same as manifold-js (also works in voxel sessions) |
 | 2D shape extruded to 3D | `cs.extrude(h, nDiv?, twist?, scaleTop?)` | `linear_extrude(h, twist=, slices=, scale=) polygon(...)` | (use manifold-js + BREP for one piece) |
 | Surface of revolution (vase, lens, bottle) | `cs.revolve(n?, degrees?)` | `rotate_extrude(angle=) polygon(...)` | (use manifold-js) |
 | Smooth curve from a few points | `Curves.bezier(controls)` -> `/ai/curves.md` | `bezier_curve()` (BOSL2) -> `/ai/bosl2.md` | (use manifold-js Curves) |
@@ -399,6 +399,8 @@ Standard JavaScript globals (`Math`, `Array`, `Object`, `JSON`, `Date`, `console
 ### Customizer parameters (`api.params`)
 
 Declare the model's tweakable dimensions/options at the top via `api.params(schema)`. It returns an object of resolved values; a **Parameters panel** appears in the viewport so the user (or you) can adjust them with sliders/toggles/dropdowns and the model re-runs live — Tinkercad-style customization without leaving code. This is the preferred way to make a model reusable: expose the few dimensions someone would actually want to change.
+
+`api.params` works the same in **manifold-js, voxel, and BREP (replicad) sessions** — all three are JS sandboxes that share one implementation (SCAD is the exception and has no `api.params` yet). For `number`/`int` params the panel pairs a slider with an editable number field, so you can type an exact value (and exceed the slider's range when the spec declares no `max`).
 
 ```js
 const { Manifold } = api;

--- a/public/ai/replicad.md
+++ b/public/ai/replicad.md
@@ -155,6 +155,11 @@ What BREP **doesn't** do:
 
 ## The shape API
 
+> **Customizer:** `api.params({...})` is available in BREP-language sessions too,
+> identical to manifold-js — declare tweakable dimensions at the top (e.g.
+> `const p = api.params({ r: { type: 'number', default: 10, min: 2, max: 40 } });`)
+> and the live Parameters panel drives them. See the Customizer section in `/ai.md`.
+
 ```js
 const { BREP } = api;
 

--- a/public/ai/voxel.md
+++ b/public/ai/voxel.md
@@ -45,6 +45,18 @@ v.set(0, 0, 7, '#ff3b30');                       // a single red cap voxel
 return v;
 ```
 
+`api.params({...})` works here too, exactly as in manifold-js — declare tweakable
+knobs (grid size, colors, counts) at the top and the live Parameters panel drives
+them. See the Customizer section in `/ai.md`. Example:
+
+```js
+const { voxels } = api;
+const p = api.params({ size: { type: 'int', default: 6, min: 2, max: 20 }, tint: { type: 'color', default: '#6b8cff' } });
+const v = voxels();
+v.fillBox([0, 0, 0], [p.size - 1, p.size - 1, p.size - 1], p.tint);
+return v;
+```
+
 ### Grid builder methods
 
 All methods mutate the grid in place and return it (so they chain). Coordinates

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -50,9 +50,9 @@ export function voxelCount(): number { return run?.grid.size ?? 0; }
 /** Activate voxel paint on the given code. Runs the code locally to obtain the
  *  grid + provenance, attaches a click handler, and pushes the meshed grid
  *  through `onMeshUpdate`. Returns null on success or an error string. */
-export function activate(code: string, callbacks: VoxelPaintCallbacks): string | null {
+export function activate(code: string, callbacks: VoxelPaintCallbacks, paramOverrides?: Record<string, unknown>): string | null {
   if (active) deactivate();
-  const r = runVoxelForPaint(code);
+  const r = runVoxelForPaint(code, paramOverrides);
   if (!r.ok) return r.error;
   // Smooth surfacing moves vertices off the voxel grid, so a clicked
   // triangle's coords no longer map cleanly to a single source voxel. Refuse

--- a/src/geometry/engineWorker.ts
+++ b/src/geometry/engineWorker.ts
@@ -109,7 +109,7 @@ self.onmessage = async (event: MessageEvent) => {
       let result;
       if (effectiveLang === 'voxel') {
         // Pure-JS voxel meshing — no WASM, no lazy init, synchronous.
-        result = voxelEngine.run(code as string);
+        result = voxelEngine.run(code as string, params ?? undefined);
       } else if (effectiveLang === 'scad') {
         // Ensure the OpenSCAD engine is loaded (lazy init).
         if (!openscadEngine.isReady()) await openscadEngine.init();
@@ -118,7 +118,7 @@ self.onmessage = async (event: MessageEvent) => {
         // Full replicad-language session — lazy-init OCCT then evaluate as
         // BREP. Tessellation happens inside the engine before returning.
         if (!replicadEngine.isReady()) await replicadEngine.init();
-        result = await runReplicadAsync(code as string);
+        result = await runReplicadAsync(code as string, params ?? undefined);
       } else {
         if (!manifoldReady) {
           self.postMessage({

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -2,7 +2,7 @@ import type { Engine, MeshResult, ValidateResult } from './types';
 import { javaScriptSyntaxDiagnostics, runtimeDiagnostic } from '../sourceDiagnostics';
 import { createCurvesNamespace } from '../curves';
 import { createMeshOpsNamespace } from '../meshOps';
-import { normalizeParamSchema, resolveParamValues, mergeParamSchemas, protectParamValues, type ParamSpec } from '../params';
+import { createParamCapture } from '../params';
 import { getDefaultCircularSegments } from '../qualitySettings';
 import { getActiveImports } from '../../import/importedMesh';
 import { createSdfNamespace, SdfNode } from '../sdf';
@@ -230,26 +230,17 @@ export const manifoldJsEngine: Engine = {
 
     // Customizer parameters. `api.params(schema)` declares the model's tweakable
     // knobs and returns their resolved values (the Customizer's overrides for
-    // this run, falling back to each declared default). We record every call's
-    // normalized schema so the caller can surface it to the Parameters panel; a
-    // malformed *schema* throws a clear `api.params: …` error (author bug),
-    // while bad *override values* degrade to defaults inside resolveParamValues.
-    const overrides = paramOverrides ?? {};
-    const capturedSchemas: ParamSpec[][] = [];
-    const params = (schema: unknown): Record<string, number | boolean | string> => {
-      const normalized = normalizeParamSchema(schema);
-      capturedSchemas.push(normalized);
-      // Guard the returned object so a typo'd read (p.widht) throws instead of
-      // silently injecting `undefined`/NaN into the geometry.
-      return protectParamValues(resolveParamValues(normalized, overrides));
-    };
-    const collectParamsSchema = (): ParamSpec[] | undefined =>
-      capturedSchemas.length > 0 ? mergeParamSchemas(capturedSchemas) : undefined;
+    // this run, falling back to each declared default). The shared capture
+    // records every call's normalized schema so we can surface it to the
+    // Parameters panel via `paramCapture.collectSchema()` below — the same
+    // helper the voxel and replicad JS engines use, so all three behave
+    // identically.
+    const paramCapture = createParamCapture(paramOverrides);
 
     const api = {
       Manifold,
       CrossSection,
-      params,
+      params: paramCapture.params,
       Curves: curvesNamespace,
       BREP,
       meshOps: meshOpsNamespace,
@@ -396,7 +387,7 @@ export const manifoldJsEngine: Engine = {
         error: null,
         labelMap,
         labelColors: labelColors.size > 0 ? labelColors : undefined,
-        paramsSchema: collectParamsSchema(),
+        paramsSchema: paramCapture.collectSchema(),
         renderOnly,
       };
     } catch (e: unknown) {
@@ -423,7 +414,7 @@ export const manifoldJsEngine: Engine = {
         manifold: null,
         error: msg,
         diagnostics: isSyntaxError ? javaScriptSyntaxDiagnostics(jsCode, msg, e) : runtimeDiagnostic(msg, hint, 'JavaScript'),
-        paramsSchema: collectParamsSchema(),
+        paramsSchema: paramCapture.collectSchema(),
       };
     } finally {
       // Stop tracking, then free every intermediate the run created. The value

--- a/src/geometry/engines/replicad.ts
+++ b/src/geometry/engines/replicad.ts
@@ -190,11 +190,14 @@ export async function runReplicadAsync(jsCode: string, paramOverrides?: Record<s
     // allocated along the way (e.g. `BREP.box(...).fillet(...)` chains whose
     // final step threw).
     disposeBrepAllocationsExcept(consumeBrepAllocations(), null);
+    // Schema rides on the error return too (matching manifold-js) so a model
+    // that declared params before failing keeps its Customizer panel live.
     return {
       mesh: null,
       manifold: null,
       error: userScriptError?.error ?? 'BREP code did not produce a shape.',
       diagnostics: userScriptError?.diagnostics,
+      paramsSchema: paramCapture.collectSchema(),
     };
   }
 
@@ -281,6 +284,7 @@ export async function runReplicadAsync(jsCode: string, paramOverrides?: Record<s
       manifold: null,
       error: `BREP tessellation failed: ${msg}`,
       diagnostics: runtimeDiagnostic(msg, undefined, 'JavaScript'),
+      paramsSchema: paramCapture.collectSchema(),
     };
   }
 }

--- a/src/geometry/engines/replicad.ts
+++ b/src/geometry/engines/replicad.ts
@@ -3,6 +3,7 @@ import { javaScriptSyntaxDiagnostics, runtimeDiagnostic } from '../sourceDiagnos
 import { ensureBrepLoaded, getBrepNamespace, consumeBrepAllocations, disposeBrepAllocationsExcept, extractLabelMap, getPendingBrepImports, type BrepShape } from '../brepRuntime';
 import { getManifoldModule, manifoldJsEngine } from './manifoldJs';
 import { getActiveImports } from '../../import/importedMesh';
+import { createParamCapture } from '../params';
 
 // === replicad engine — Phase A of the BREP integration ===
 //
@@ -90,7 +91,7 @@ export const replicadEngine: Engine = {
  *  through `Manifold.ofMesh()` so downstream Partwright features (slice,
  *  stats, paint persistence) keep working, and stash the live BrepShape in
  *  `lastShape` so STEP export can find it. */
-export async function runReplicadAsync(jsCode: string): Promise<MeshResult> {
+export async function runReplicadAsync(jsCode: string, paramOverrides?: Record<string, unknown>): Promise<MeshResult> {
   if (!manifoldModule || !getBrepNamespace()) {
     const error = 'BREP/replicad engine not initialised.';
     return { mesh: null, manifold: null, error };
@@ -143,12 +144,18 @@ export async function runReplicadAsync(jsCode: string): Promise<MeshResult> {
     triVerts: m.triVerts,
   }));
 
+  // Customizer parameters, shared with the manifold-js and voxel engines: a
+  // BREP-session model can declare `api.params({...})` to surface the same live
+  // slider/toggle panel and accept the Customizer's tweaked overrides.
+  const paramCapture = createParamCapture(paramOverrides);
+
   const api = {
     BREP,
     Manifold,
     CrossSection: manifoldModule.CrossSection,
     imports: brepImports,
     meshImports,
+    params: paramCapture.params,
   };
 
   // Same per-run BREP allocation drain pattern as the manifold-js engine —
@@ -248,6 +255,7 @@ export async function runReplicadAsync(jsCode: string): Promise<MeshResult> {
         manifold,
         error: null,
         labelMap,
+        paramsSchema: paramCapture.collectSchema(),
       };
     }
     // Non-manifold tessellation — render the raw triangles.
@@ -262,6 +270,7 @@ export async function runReplicadAsync(jsCode: string): Promise<MeshResult> {
       manifold: null,
       error: null,
       labelMap,
+      paramsSchema: paramCapture.collectSchema(),
     };
   } catch (e: unknown) {
     // Tessellation failure — free the shape so we don't leak it.

--- a/src/geometry/engines/voxel.ts
+++ b/src/geometry/engines/voxel.ts
@@ -2,6 +2,7 @@ import type { Engine, MeshResult, ValidateResult } from './types';
 import { javaScriptSyntaxDiagnostics, runtimeDiagnostic } from '../sourceDiagnostics';
 import { VoxelGrid, decodeGrid, normalizeColor } from '../voxel/grid';
 import { meshGrid, gridToMeshWithProvenance, type VoxelMesh } from '../voxel/mesher';
+import { createParamCapture, type ParamCapture } from '../params';
 
 // The `voxel` engine: user code builds a sparse VoxelGrid and returns it; we
 // mesh the exposed faces into welded `MeshData` (with per-voxel colors) that
@@ -18,11 +19,15 @@ interface VoxelsHandle {
   color(c: Parameters<typeof normalizeColor>[0]): number;
 }
 
-function createVoxelApi() {
+function createVoxelApi(params?: ParamCapture['params']) {
   const voxels = (() => new VoxelGrid()) as VoxelsHandle;
   voxels.decode = (data: string) => decodeGrid(data);
   voxels.color = (c) => normalizeColor(c);
-  return { voxels, VoxelGrid };
+  // `api.params({...})` is exposed identically across all JS-sandbox engines
+  // (manifold-js, voxel, replicad) so a Customizer-driven voxel model gets the
+  // same live slider/toggle panel. Omitted only on paths that don't capture a
+  // schema (none currently — both run paths pass it).
+  return { voxels, VoxelGrid, ...(params ? { params } : {}) };
 }
 
 function isVoxelGrid(v: unknown): v is VoxelGrid {
@@ -38,8 +43,9 @@ export const voxelEngine: Engine = {
 
   isReady() { return true; },
 
-  run(jsCode: string): MeshResult {
-    const api = createVoxelApi();
+  run(jsCode: string, paramOverrides?: Record<string, unknown>): MeshResult {
+    const capture = createParamCapture(paramOverrides);
+    const api = createVoxelApi(capture.params);
     let result: unknown;
     try {
       const fn = new Function('api', `"use strict";\n${jsCode}`);
@@ -80,7 +86,7 @@ export const voxelEngine: Engine = {
 
     try {
       const mesh = meshGrid(grid);
-      return { mesh, manifold: null, error: null };
+      return { mesh, manifold: null, error: null, paramsSchema: capture.collectSchema() };
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       return { mesh: null, manifold: null, error: msg, diagnostics: runtimeDiagnostic(msg, undefined, 'JavaScript') };
@@ -114,8 +120,8 @@ export interface VoxelPaintRun extends VoxelMesh { grid: VoxelGrid }
  *  Returns null and a message on error. Smooth surfacing is honored for
  *  rendering only — paint operates on the un-supersampled, block-meshed grid
  *  so triangle indices map cleanly to user-authored voxels. */
-export function runVoxelForPaint(jsCode: string): { ok: true; data: VoxelPaintRun } | { ok: false; error: string } {
-  const api = createVoxelApi();
+export function runVoxelForPaint(jsCode: string, paramOverrides?: Record<string, unknown>): { ok: true; data: VoxelPaintRun } | { ok: false; error: string } {
+  const api = createVoxelApi(createParamCapture(paramOverrides).params);
   let result: unknown;
   try {
     const fn = new Function('api', `"use strict";\n${jsCode}`);

--- a/src/geometry/engines/voxel.ts
+++ b/src/geometry/engines/voxel.ts
@@ -53,6 +53,10 @@ export const voxelEngine: Engine = {
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       const isSyntaxError = e instanceof SyntaxError;
+      // The schema rides on error returns too (matching manifold-js) so a
+      // model that declared params before throwing keeps its Customizer panel
+      // live for correction. `collectSchema()` returns whatever was captured
+      // before the throw — possibly undefined, which is the right answer.
       return {
         mesh: null,
         manifold: null,
@@ -60,6 +64,7 @@ export const voxelEngine: Engine = {
         diagnostics: isSyntaxError
           ? javaScriptSyntaxDiagnostics(jsCode, msg, e)
           : runtimeDiagnostic(msg, undefined, 'JavaScript'),
+        paramsSchema: capture.collectSchema(),
       };
     }
 
@@ -70,6 +75,7 @@ export const voxelEngine: Engine = {
         manifold: null,
         error,
         diagnostics: runtimeDiagnostic(error, 'Add a final `return` that returns the grid from api.voxels().', 'JavaScript'),
+        paramsSchema: capture.collectSchema(),
       };
     }
 
@@ -81,6 +87,7 @@ export const voxelEngine: Engine = {
         manifold: null,
         error,
         diagnostics: runtimeDiagnostic(error, 'Occupy at least one voxel before returning the grid.', 'JavaScript'),
+        paramsSchema: capture.collectSchema(),
       };
     }
 
@@ -89,7 +96,7 @@ export const voxelEngine: Engine = {
       return { mesh, manifold: null, error: null, paramsSchema: capture.collectSchema() };
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      return { mesh: null, manifold: null, error: msg, diagnostics: runtimeDiagnostic(msg, undefined, 'JavaScript') };
+      return { mesh: null, manifold: null, error: msg, diagnostics: runtimeDiagnostic(msg, undefined, 'JavaScript'), paramsSchema: capture.collectSchema() };
     }
   },
 

--- a/src/geometry/params.ts
+++ b/src/geometry/params.ts
@@ -276,3 +276,36 @@ export function pruneParamValues(schema: ParamSpec[], overrides?: Record<string,
   }
   return out;
 }
+
+/** A per-run Customizer capture shared by the JS-sandbox engines (manifold-js,
+ *  voxel, replicad). Each engine builds one with the user's overrides, hands
+ *  {@link ParamCapture.params} to the sandbox as `api.params`, then reads
+ *  {@link ParamCapture.collectSchema} afterward to report the declared schema
+ *  back to the Customizer panel. Lives here — the dependency-free param layer —
+ *  so all three engines share exactly one implementation rather than each
+ *  re-deriving the capture/merge/guard logic. */
+export interface ParamCapture {
+  /** The `api.params(schema)` function exposed to model code: validates +
+   *  normalizes the schema (throwing a clear `api.params: …` error on an author
+   *  bug), records it for {@link collectSchema}, and returns the resolved values
+   *  (override-or-default) guarded so a typo'd read throws instead of `NaN`. */
+  params: (schema: unknown) => ParamValues;
+  /** Merge of every schema captured this run (last definition wins, first-seen
+   *  order preserved), or `undefined` if the model declared none. */
+  collectSchema: () => ParamSpec[] | undefined;
+}
+
+export function createParamCapture(overrides?: Record<string, unknown>): ParamCapture {
+  const ov = overrides ?? {};
+  const captured: ParamSpec[][] = [];
+  return {
+    params(schema: unknown): ParamValues {
+      const normalized = normalizeParamSchema(schema);
+      captured.push(normalized);
+      return protectParamValues(resolveParamValues(normalized, ov));
+    },
+    collectSchema(): ParamSpec[] | undefined {
+      return captured.length > 0 ? mergeParamSchemas(captured) : undefined;
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3824,7 +3824,7 @@ async function main() {
       const err = voxelPaint.activate(code, {
         onMeshUpdate: (mesh) => { updateMesh(mesh, { skipAutoFrame: true }); },
         onLockChange: (locked) => { setReadOnlyReason('voxelPaint', locked); },
-      });
+      }, currentParamValues);
       if (err) alert(`Voxel paint: ${err}`);
       syncVoxelPaintUI();
     },
@@ -8068,7 +8068,7 @@ async function main() {
       const err = voxelPaint.activate(code, {
         onMeshUpdate: (mesh) => { updateMesh(mesh, { skipAutoFrame: true }); },
         onLockChange: (locked) => { setReadOnlyReason('voxelPaint', locked); },
-      });
+      }, currentParamValues);
       if (err) return { error: `activateVoxelPaint: ${err}` };
       syncVoxelPaintUI();
       return { voxelCount: voxelPaint.voxelCount() };

--- a/src/ui/paramsPanel.ts
+++ b/src/ui/paramsPanel.ts
@@ -181,33 +181,68 @@ function buildWidget(spec: ParamSpec, onChange: (key: string, value: ParamValue)
   let setValue: (v: ParamValue) => void;
 
   if (spec.type === 'number' || spec.type === 'int') {
-    // Numeric readout sits next to the label; a range slider drives it. We fire
-    // onChange on 'change' (pointer release) to avoid a re-run per slider tick,
-    // but update the readout live on 'input'.
-    const readout = document.createElement('span');
-    readout.className = 'text-[11px] font-mono tabular-nums text-zinc-200';
-    labelRow.appendChild(readout);
+    // Numeric editor sits next to the label: an *editable* number field paired
+    // with a range slider. The slider gives quick coarse control; the field
+    // lets you type an exact value (e.g. 47.5) — and, when the spec sets no
+    // `max`, type a value beyond the slider's synthesized range (params.ts only
+    // clamps to limits the author actually declared). We fire onChange on
+    // 'change' (slider pointer-release / field blur-or-Enter), not per slider
+    // tick, but keep the field in sync live on slider 'input'.
+    const isInt = spec.type === 'int';
+    const min = spec.min ?? 0;
+    const max = spec.max ?? (typeof spec.default === 'number' ? Math.max(spec.default * 2, spec.default + 10) : 100);
+    const step = spec.step ?? (isInt ? 1 : (max - min) / 100 || 1);
+
+    const numInput = document.createElement('input');
+    numInput.type = 'number';
+    // Narrow, mono, right-aligned — reads like the old readout but is editable.
+    numInput.className = 'w-16 text-[11px] font-mono tabular-nums text-right text-zinc-200 bg-zinc-800 border border-zinc-600 rounded px-1 py-0.5 focus:border-blue-400 focus:outline-none';
+    // Only constrain the field by limits the author declared, so an undeclared
+    // bound doesn't silently clamp a typed value (the slider keeps its own
+    // synthesized range for the thumb).
+    if (spec.min !== undefined) numInput.min = String(spec.min);
+    if (spec.max !== undefined) numInput.max = String(spec.max);
+    numInput.step = String(step);
+    labelRow.appendChild(numInput);
     row.appendChild(labelRow);
 
     const slider = document.createElement('input');
     slider.type = 'range';
     slider.className = 'w-full accent-blue-400 cursor-pointer';
-    const min = spec.min ?? 0;
-    const max = spec.max ?? (typeof spec.default === 'number' ? Math.max(spec.default * 2, spec.default + 10) : 100);
     slider.min = String(min);
     slider.max = String(max);
-    slider.step = String(spec.step ?? (spec.type === 'int' ? 1 : (max - min) / 100 || 1));
-    slider.addEventListener('input', () => { readout.textContent = slider.value; });
+    slider.step = String(step);
+    slider.addEventListener('input', () => { numInput.value = slider.value; });
     slider.addEventListener('change', () => {
-      const n = spec.type === 'int' ? Math.round(Number(slider.value)) : Number(slider.value);
+      const n = isInt ? Math.round(Number(slider.value)) : Number(slider.value);
+      numInput.value = String(n);
       onChange(spec.key, n);
     });
     row.appendChild(slider);
 
+    const commitField = () => {
+      const raw = Number(numInput.value);
+      if (numInput.value.trim() === '' || !Number.isFinite(raw)) {
+        // Empty / unparseable — revert the field to the slider's value, no run.
+        numInput.value = slider.value;
+        return;
+      }
+      const n = isInt ? Math.round(raw) : raw;
+      // Reflect the typed value on the slider thumb (the browser clamps it into
+      // the slider's range; the field keeps the true value). The post-run
+      // sync via setValue will reconcile both to params.ts's coerced result.
+      slider.value = String(n);
+      if (isInt) numInput.value = String(n);
+      onChange(spec.key, n);
+    };
+    numInput.addEventListener('change', commitField);
+    // Enter commits without leaving the field (change already fires on blur).
+    numInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); numInput.blur(); } });
+
     setValue = (v) => {
       const n = typeof v === 'number' ? v : Number(v);
       slider.value = String(n);
-      readout.textContent = String(n);
+      numInput.value = String(n);
     };
   } else if (spec.type === 'boolean') {
     const wrap = document.createElement('div');

--- a/tests/customizer.spec.ts
+++ b/tests/customizer.spec.ts
@@ -75,8 +75,10 @@ test.describe('Customizer parameters', () => {
     expect(after.x).toBeCloseTo(20, 1);
 
     await expect(page.locator('#params-panel')).toBeVisible();
-    // One widget row per declared parameter.
+    // One widget row per declared parameter. Number params pair the slider with
+    // an editable number field (the exact-entry feature).
     await expect(page.locator('#params-panel input[type="range"]')).toHaveCount(2); // width + height
+    await expect(page.locator('#params-panel input[type="number"]')).toHaveCount(2); // width + height fields
     await expect(page.locator('#params-panel input[type="checkbox"]')).toHaveCount(1); // hollow
     await expect(page.locator('#params-panel select')).toHaveCount(1); // style
 
@@ -98,6 +100,57 @@ test.describe('Customizer parameters', () => {
       slider.dispatchEvent(new Event('change', { bubbles: true }));
     });
     await expect.poll(() => currentXDim(page)).toBeCloseTo(100, 0);
+  });
+
+  test('typing an exact value into a number field re-runs the model', async ({ page }) => {
+    await page.evaluate((code) => (window as unknown as { partwright: PW }).partwright.run(code), PARAM_MODEL);
+    await expect(page.locator('#params-panel')).toBeVisible();
+
+    // Type 47 into the Width number field (first number input) and commit with
+    // a 'change' event — the model re-runs to the exact typed dimension, which a
+    // slider's discrete steps may not land on as directly.
+    await page.evaluate(() => {
+      const panel = document.getElementById('params-panel')!;
+      const field = panel.querySelector('input[type="number"]') as HTMLInputElement; // first = width
+      field.value = '47';
+      field.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await expect.poll(() => currentXDim(page)).toBeCloseTo(47, 0);
+
+    // The paired slider tracked the typed value too.
+    const sliderVal = await page.evaluate(() => {
+      const panel = document.getElementById('params-panel')!;
+      return (panel.querySelector('input[type="range"]') as HTMLInputElement).value;
+    });
+    expect(Number(sliderVal)).toBeCloseTo(47, 0);
+  });
+
+  test('parameters work in a voxel session (engine-agnostic)', async ({ page }) => {
+    const VOXEL_PARAM_MODEL = `
+const p = api.params({ size: { type: 'int', default: 4, min: 1, max: 20, label: 'Size' } });
+const v = api.voxels();
+v.fillBox([0, 0, 0], [p.size - 1, p.size - 1, p.size - 1], '#88aaff');
+return v;`;
+
+    const out = await page.evaluate(async (code) => {
+      const api = (window as unknown as { partwright: PW & { setActiveLanguage: (l: string) => Promise<void> } }).partwright;
+      await api.createSession('voxel-customizer');
+      await api.setActiveLanguage('voxel');
+      const geo = await api.run(code);
+      const wide = await api.setParams({ size: 12 });
+      return {
+        schema: api.getParams().schema.map(s => s.key),
+        defaultX: (geo.boundingBox as { dimensions?: number[] }).dimensions?.[0] ?? -1,
+        wideX: (wide.geometry as { boundingBox: { dimensions: number[] } }).boundingBox.dimensions[0],
+      };
+    }, VOXEL_PARAM_MODEL);
+
+    // Schema captured + panel shown for a voxel model, and setParams re-runs it.
+    expect(out.schema).toEqual(['size']);
+    expect(out.defaultX).toBeCloseTo(4, 0);
+    expect(out.wideX).toBeCloseTo(12, 0);
+    await expect(page.locator('#params-panel')).toBeVisible();
+    await expect(page.locator('#customize-toggle')).toContainText('Customize (1)');
   });
 
   test('Customize toolbar pill toggles the panel, and close → reopen always works', async ({ page }) => {

--- a/tests/unit/params.test.ts
+++ b/tests/unit/params.test.ts
@@ -7,6 +7,7 @@ import {
   pruneParamValues,
   protectParamValues,
   normalizeHexColor,
+  createParamCapture,
   type ParamSpec,
 } from '../../src/geometry/params';
 
@@ -151,5 +152,49 @@ describe('normalizeHexColor', () => {
     expect(normalizeHexColor('#abc')).toBe('#aabbcc');
     expect(normalizeHexColor('red')).toBeNull();
     expect(normalizeHexColor(123)).toBeNull();
+  });
+});
+
+// The shared capture used by every JS-sandbox engine (manifold-js, voxel,
+// replicad) so they expose `api.params` identically. The per-engine wiring is
+// covered in the e2e tier (worker round-trip); this locks the pure logic.
+describe('createParamCapture', () => {
+  it('captures the declared schema and resolves override-or-default values', () => {
+    const capture = createParamCapture({ width: 80, bogus: 1 });
+    const resolved = capture.params({
+      width: { type: 'number', default: 20, min: 10, max: 100 },
+      height: { type: 'number', default: 30, min: 5, max: 80 },
+    });
+    // Override applied to width; height falls back to its default; unknown
+    // override keys are ignored.
+    expect(resolved.width).toBe(80);
+    expect(resolved.height).toBe(30);
+    expect(capture.collectSchema()?.map(s => s.key)).toEqual(['width', 'height']);
+  });
+
+  it('guards the returned values against typo reads', () => {
+    const capture = createParamCapture();
+    const p = capture.params({ width: { type: 'number', default: 20 } });
+    expect(p.width).toBe(20);
+    expect(() => (p as Record<string, unknown>).widht).toThrow(/no parameter "widht"/);
+  });
+
+  it('clamps an out-of-range override to the declared limits', () => {
+    const capture = createParamCapture({ width: 999 });
+    const p = capture.params({ width: { type: 'number', default: 20, min: 10, max: 100 } });
+    expect(p.width).toBe(100);
+  });
+
+  it('merges schemas across multiple api.params calls (last def wins, order kept)', () => {
+    const capture = createParamCapture();
+    capture.params({ a: { type: 'int', default: 1 } });
+    capture.params({ b: { type: 'boolean', default: true }, a: { type: 'int', default: 5 } });
+    const schema = capture.collectSchema()!;
+    expect(schema.map(s => s.key)).toEqual(['a', 'b']);
+    expect(schema.find(s => s.key === 'a')?.default).toBe(5);
+  });
+
+  it('reports undefined schema when the model declares no params', () => {
+    expect(createParamCapture().collectSchema()).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Two improvements to the Customizer (`api.params`) feature:

### 1. Engine-agnostic parameters (was manifold-js only)
The capture/merge/typo-guard logic is extracted into a shared `createParamCapture()` in the dependency-free param layer (`src/geometry/params.ts`) and wired into the two other **JS-sandbox** engines:

- **Voxel** — `voxel.run` / `runVoxelForPaint` accept `paramOverrides`, expose `api.params`, and report the declared schema, so a voxel model now gets the same live Parameters panel. Overrides also thread through the voxel-paint path so a customized voxel model paints correctly.
- **BREP / replicad** — BREP-language sessions expose `api.params` and report the schema on both the manifold and raw-mesh return paths.
- `engineWorker` now passes the run's `params` through to voxel and replicad (the run loop already fed `currentParamValues` to every engine — the non-manifold-js engines simply ignored them, so no main-thread plumbing changed beyond voxel paint).
- The schema also rides on voxel/replicad **error** returns (matching manifold-js), so a parametric model that errors keeps its Customizer panel live for correction.

manifold-js was refactored to use the same shared helper (no behavior change).

**Scope note:** SCAD is the one non-JS engine; OpenSCAD's native customizer annotations are a separate parsing/source-rewriting mechanism, so SCAD parity is left as a clean follow-up.

### 2. Exact numeric entry
`number`/`int` widgets now pair the slider with an **editable number field**. You can type an exact value (e.g. `47.5`), and exceed the slider's synthesized range when the spec declares no `max` (`params.ts` only clamps to author-declared limits). The field and slider stay in sync both ways.

## Test plan

- `npm run build` — clean (no TS errors).
- `npm run test:unit` — 379 pass, including 5 new `createParamCapture` cases (override-or-default, typo guard, clamping, multi-call merge, empty schema).
- `npx playwright test customizer.spec.ts` — 6 pass, including 2 new tests:
  - typing an exact value into a number field re-runs the model and syncs the slider;
  - parameters work in a **voxel session** (schema captured, panel shown, `setParams` re-runs).
- `npx playwright test version-nav-language.spec.ts` — still green (cross-language nav unaffected).
- Docs updated: `ai.md` capability table + Customizer section, `voxel.md`, `replicad.md`.

## Review

An automated review pass over the diff found no blockers; its one should-fix (error-path schema parity for voxel/replicad) is addressed in this branch.

https://claude.ai/code/session_01TsavoEF6pNJAzjowjYa2EX