### PR TITLE
feat: authenticate Gemini via x-goog-api-key header (launch readiness)

### DIFF
--- a/src/ai/gemini.ts
+++ b/src/ai/gemini.ts
@@ -15,16 +15,16 @@ import { readSseStream } from './sse';
 
 const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 
-function streamUrl(model: string, apiKey: string): string {
-  return `${API_BASE}/models/${encodeURIComponent(model)}:streamGenerateContent?alt=sse&key=${encodeURIComponent(apiKey)}`;
+function streamUrl(model: string): string {
+  return `${API_BASE}/models/${encodeURIComponent(model)}:streamGenerateContent?alt=sse`;
 }
 
-function generateUrl(model: string, apiKey: string): string {
-  return `${API_BASE}/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+function generateUrl(model: string): string {
+  return `${API_BASE}/models/${encodeURIComponent(model)}:generateContent`;
 }
 
-function modelsUrl(apiKey: string, pageSize: number): string {
-  return `${API_BASE}/models?key=${encodeURIComponent(apiKey)}&pageSize=${pageSize}`;
+function modelsUrl(pageSize: number): string {
+  return `${API_BASE}/models?pageSize=${pageSize}`;
 }
 
 export function resetClient(): void {
@@ -39,9 +39,9 @@ export async function validateKey(apiKey: string): Promise<string | null> {
   // key itself — no per-model availability, no generation quota, and no
   // hard-coded model id to go stale (the same trap listModels warns about).
   try {
-    const res = await fetch(modelsUrl(apiKey, 1), {
+    const res = await fetch(modelsUrl(1), {
       method: 'GET',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
     });
     if (res.ok) return null;
     // 429/5xx are transient service hiccups (overload, maintenance) — the key
@@ -66,9 +66,9 @@ export async function validateKey(apiKey: string): Promise<string | null> {
  *  picks from their real current lineup, including newer models like
  *  Gemini 3 / "Nano Banana" with whatever id Google actually assigned. */
 export async function listModels(apiKey: string): Promise<{ id: string; label: string }[]> {
-  const res = await fetch(modelsUrl(apiKey, 1000), {
+  const res = await fetch(modelsUrl(1000), {
     method: 'GET',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
   });
   if (!res.ok) {
     const err = await res.text().catch(() => '');
@@ -219,9 +219,9 @@ export async function streamTurn(
 
   let res: Response;
   try {
-    res = await fetch(streamUrl(spec.model, spec.apiKey), {
+    res = await fetch(streamUrl(spec.model), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'x-goog-api-key': spec.apiKey },
       body: JSON.stringify(body),
       signal,
     });
@@ -495,9 +495,9 @@ export async function summarize(
   user: string,
   maxTokens = 4096,
 ): Promise<{ text: string; usage: TurnUsage }> {
-  const res = await fetch(generateUrl(model, apiKey), {
+  const res = await fetch(generateUrl(model), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
     body: JSON.stringify({
       contents: [{ role: 'user', parts: [{ text: user }] }],
       generationConfig: { maxOutputTokens: maxTokens },

--- a/src/ui/aiKeyModal.tsx
+++ b/src/ui/aiKeyModal.tsx
@@ -34,10 +34,6 @@ interface ProviderUi {
   consoleUrl: string;
   consoleLabel: string;
   placeholder: string;
-  /** Optional extra note rendered under the intro. Used for Gemini, whose
-   *  wire protocol puts the key in the request URL (unlike the header-based
-   *  Anthropic/OpenAI), which is worth calling out. */
-  note?: string;
   validate: (key: string) => Promise<string | null>;
   reset: () => void;
 }
@@ -69,7 +65,6 @@ const PROVIDER_UI: Record<HostedProvider, ProviderUi> = {
     consoleUrl: 'https://aistudio.google.com/app/apikey',
     consoleLabel: 'Get a key at aistudio.google.com →',
     placeholder: 'AIza...',
-    note: 'Gemini’s API sends the key as a URL query parameter (not an auth header), so it can appear in browser history and proxy logs. Use a key scoped to this project and rotate it if you have concerns.',
     validate: validateGeminiKey,
     reset: resetGeminiClient,
   },
@@ -161,9 +156,6 @@ function KeyFormBody(props: {
   return (
     <>
       <p class="text-zinc-300 leading-snug">{ui.intro}</p>
-      {ui.note && (
-        <p class="rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 leading-snug">{ui.note}</p>
-      )}
       <a
         href={ui.consoleUrl}
         target="_blank"

--- a/tests/import-safety.spec.ts
+++ b/tests/import-safety.spec.ts
@@ -1,5 +1,4 @@
-// E2E for the import-preview code-execution warning and the Gemini
-// key-in-URL note. No external network.
+// E2E for the import-preview code-execution warning. No external network.
 
 import { test, expect, type Page } from 'playwright/test';
 
@@ -52,24 +51,5 @@ test.describe('Import safety note', () => {
     // Cancel — nothing is imported.
     await dialog.getByRole('button', { name: 'Cancel' }).click();
     await expect(dialog).toBeHidden();
-  });
-});
-
-test.describe('Gemini key note', () => {
-  test('the Gemini connect modal explains the key travels in the URL', async ({ page }) => {
-    await openEditor(page);
-
-    // Open the Gemini key modal directly via the exported helper (avoids
-    // depending on the toolbar→provider navigation).
-    await page.evaluate(async () => {
-      const mod = await import('/src/ui/aiKeyModal.tsx');
-      (mod as { showAiKeyModal: (cb: { onConnected: () => void; provider?: string }) => void })
-        .showAiKeyModal({ onConnected: () => {}, provider: 'gemini' });
-    });
-
-    const dialog = page.locator('[role="dialog"]');
-    await expect(dialog).toBeVisible({ timeout: 6000 });
-    await expect(dialog).toContainText('Connect Google Gemini');
-    await expect(dialog).toContainText('key as a URL query parameter');
   });
 });


### PR DESCRIPTION
Part of the **launch readiness** series.

Switches the Gemini provider from sending the API key as a `?key=` URL query parameter to the `x-goog-api-key` HTTP header across all four fetch sites (`validateKey`, `listModels`, `streamTurn`, `summarize`), and removes the now-inaccurate "key travels in the URL" caution note from the Gemini connect modal (added in #279), the now-unused `note` mechanism, and its e2e assertion.

**Why:** URL-embedded keys can surface in browser history and proxy/CDN logs; an auth header doesn't.

⚠️ **Needs live verification before merge.** Must be confirmed with a real cross-origin request to `generativelanguage.googleapis.com` from a browser — if Google's CORS doesn't allow the `x-goog-api-key` header on the preflight, Gemini calls would break entirely. CI has no external network, so build/unit pass but can't exercise the live call. If it fails live: revert to `?key=` and keep the note.

- Rebased onto `main` after #279 merged — now a clean single-commit diff.
- `npm run build` ✅ · `npm run test:unit` ✅ · verified `gemini.ts` has 0 `key=` URL params and 4 `x-goog-api-key` headers.

https://claude.ai/code/session_01CnFPgrhZRBBrV4sYsGtxXj