### PR TITLE
feat: geometry export units, safety confirmations + attribution (launch readiness)

### DIFF
--- a/src/export/gltf.ts
+++ b/src/export/gltf.ts
@@ -53,6 +53,15 @@ function assertFiniteExportableScene(scene: THREE.Object3D): void {
   });
 }
 
+// NOTE on attribution: the other export formats (3MF metadata, STL header,
+// OBJ/MTL comment) carry a "Partwright" attribution string. GLB intentionally
+// does not. The glTF spec puts producer info in `asset.generator`, but
+// three.js's GLTFExporter hard-codes that field and offers no public option to
+// set it; the only alternative (stuffing it into `scene.userData` → `extras`)
+// serializes inconsistently across three versions and risks emitting a
+// malformed GLB. Since a broken export is far worse than a missing credit, we
+// leave GLB attribution out rather than fight the exporter.
+
 /** Build the GLB blob for the current scene without triggering a download. */
 export async function buildGLB(customName?: string): Promise<BuiltExport> {
   const scene = getScene();

--- a/src/export/obj.ts
+++ b/src/export/obj.ts
@@ -23,7 +23,7 @@ export function buildOBJ(meshData: MeshData, customName?: string): BuiltExport {
   const hasColors = triColors != null && hasAnyPainted(triColors, validTris);
 
   const baseName = getExportFilename('obj', customName).replace(/\.obj$/, '');
-  const lines: string[] = [`# ${title}`];
+  const lines: string[] = ['# Partwright — https://www.partwrightstudio.com', `# ${title}`];
 
   const numUniqueVerts = uniquePositions.length / 3;
   const fv = (origVert: number) => remap[origVert] + 1;
@@ -53,7 +53,7 @@ export function buildOBJ(meshData: MeshData, customName?: string): BuiltExport {
     }
 
     // Generate MTL file with Kd diffuse colors
-    const mtlLines: string[] = [`# ${title} — Materials`];
+    const mtlLines: string[] = ['# Partwright — https://www.partwrightstudio.com', `# ${title} — Materials`];
     for (const hex of colorGroups.keys()) {
       const r = parseInt(hex.slice(1, 3), 16) / 255;
       const g = parseInt(hex.slice(3, 5), 16) / 255;

--- a/src/export/stl.ts
+++ b/src/export/stl.ts
@@ -15,13 +15,23 @@ export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
   const buffer = new ArrayBuffer(bufferSize);
   const view = new DataView(buffer);
 
-  // Header (80 bytes) — include session name if available. The header must be
-  // plain ASCII: setUint8 truncates each code unit to one byte, so a multi-byte
-  // char (e.g. the em-dash getExportTitle puts between "name — label") would
-  // otherwise write garbage. Normalize dashes and drop other non-ASCII.
-  const header = getExportTitle()
+  // Header (80 bytes) — include session name if available, plus a Partwright
+  // attribution suffix when it fits. The header must be plain ASCII: setUint8
+  // truncates each code unit to one byte, so a multi-byte char (e.g. the
+  // em-dash getExportTitle puts between "name — label") would otherwise write
+  // garbage. Normalize dashes and drop other non-ASCII.
+  //
+  // CRITICAL: the header is fixed at 80 bytes and byte 80 holds the triangle
+  // count — the header must NEVER exceed 80 bytes or the count is corrupted.
+  // The attribution is only appended when the title + suffix still fits; the
+  // loop below caps at 80 as a final backstop regardless.
+  const title = getExportTitle()
     .replace(/[‒-―]/g, '-')
     .replace(/[^\x20-\x7E]/g, '?');
+  const ATTRIBUTION = 'Partwright partwrightstudio.com';
+  const header = (title.length + 3 + ATTRIBUTION.length <= 80)
+    ? `${title} - ${ATTRIBUTION}`
+    : title;
   for (let i = 0; i < Math.min(header.length, 80); i++) {
     view.setUint8(i, header.charCodeAt(i));
   }

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -76,7 +76,9 @@ ${colors}
   const modelXml = `<?xml version="1.0" encoding="UTF-8"?>
 <model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"${nsAttr}>
   <metadata name="Title">${title}</metadata>
-  <metadata name="Application">Partwright</metadata>
+  <metadata name="Application">Partwright (https://www.partwrightstudio.com)</metadata>
+  <metadata name="Designer">Partwright</metadata>
+  <metadata name="LicenseTerms">Created with Partwright — https://www.partwrightstudio.com</metadata>
   <resources>${colorgroupXml}
     <object id="1" type="model"${hasColors ? ' pid="2" pindex="0"' : ''}>
       <mesh>

--- a/src/geometry/units.ts
+++ b/src/geometry/units.ts
@@ -2,10 +2,33 @@
 
 export type UnitSystem = 'mm' | 'cm' | 'in' | 'unitless';
 
-let currentUnit: UnitSystem = 'unitless';
+const STORAGE_KEY = 'partwright-units';
+const VALID_UNITS: readonly UnitSystem[] = ['mm', 'cm', 'in', 'unitless'];
+
+// Default MUST stay 'unitless' for back-compat (it drives export filenames and
+// the 3MF unit attribute). Persisted across sessions in localStorage so a
+// chosen unit sticks, but a fresh browser still starts unitless.
+function readPersistedUnit(): UnitSystem {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && (VALID_UNITS as readonly string[]).includes(stored)) {
+      return stored as UnitSystem;
+    }
+  } catch {
+    // localStorage unavailable (private mode / SSR) — fall through to default.
+  }
+  return 'unitless';
+}
+
+let currentUnit: UnitSystem = readPersistedUnit();
 
 export function setUnits(unit: UnitSystem): void {
   currentUnit = unit;
+  try {
+    localStorage.setItem(STORAGE_KEY, unit);
+  } catch {
+    // Persisting is best-effort; the in-memory value still updates.
+  }
 }
 
 export function getUnits(): UnitSystem {

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,7 @@ import { createLandingPage } from './ui/landing';
 import { createHelpPage } from './ui/help';
 import { createLegalPage } from './ui/legal';
 import { showExportOptionsDialog } from './ui/exportOptionsDialog';
+import { showExportConfirm, hasExportWarning, type ExportWarningInfo } from './ui/exportConfirmModal';
 import { createCatalogPage, type CatalogManifestEntry } from './ui/catalog';
 import { createWhatsNewPage } from './ui/whatsNew';
 import { createNotFoundPage } from './ui/notFound';
@@ -2620,8 +2621,42 @@ async function main() {
 
   // Mesh export actions, shared by the toolbar and the command palette so the
   // guards + success/error toasts stay in one place.
+  //
+  // These UI actions gate on the pre-export safety modal (unitless / non-
+  // manifold / multi-component) — but the underlying window.partwright.export*
+  // console API stays unguarded so AI agents and e2e can drive it
+  // programmatically without a blocking modal.
+
+  /** Build the warning descriptor for the current geometry from the published
+   *  stats blob (which carries bbox dimensions, isManifold, componentCount even
+   *  for render-only imports where currentManifold is null). */
+  function exportWarningInfo(format: string): ExportWarningInfo {
+    const gd = getGeometryDataObj();
+    const bbox = gd?.boundingBox as { dimensions?: unknown } | null | undefined;
+    const rawDims = bbox?.dimensions;
+    const dimensions = Array.isArray(rawDims) && rawDims.length === 3 && rawDims.every(n => typeof n === 'number')
+      ? (rawDims as [number, number, number])
+      : null;
+    return {
+      unitless: _getUnits() === 'unitless',
+      dimensions,
+      isManifold: gd?.isManifold !== false, // treat unknown as manifold (no false alarm)
+      componentCount: typeof gd?.componentCount === 'number' ? gd.componentCount : 1,
+      format,
+    };
+  }
+
+  /** Returns true if the export should proceed: no warning, or the user
+   *  confirmed it. Only used by the UI export actions below. */
+  async function confirmExportOrProceed(format: string): Promise<boolean> {
+    const info = exportWarningInfo(format);
+    if (!hasExportWarning(info)) return true;
+    return showExportConfirm(info);
+  }
+
   const actionExportGLB = async () => {
     if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
+    if (!(await confirmExportOrProceed('GLB'))) return;
     try {
       if (currentMeshData) assertFiniteMesh(currentMeshData);
       const filename = await exportGLB();
@@ -2630,21 +2665,24 @@ async function main() {
       showToast(e instanceof Error ? e.message : 'GLB export failed', { variant: 'warn' });
     }
   };
-  const actionExportSTL = () => {
+  const actionExportSTL = async () => {
     if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
     if (!currentMeshData) return;
+    if (!(await confirmExportOrProceed('STL'))) return;
     try { showToast(`Exported ${exportSTL(currentMeshData)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : 'STL export failed', { variant: 'warn' }); }
   };
-  const actionExportOBJ = () => {
+  const actionExportOBJ = async () => {
     if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
     if (!currentMeshData) return;
+    if (!(await confirmExportOrProceed('OBJ'))) return;
     try { showToast(`Exported ${exportOBJ((hasColorRegions() || hasModelColorRegions()) ? applyTriColors(currentMeshData) : currentMeshData)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : 'OBJ export failed', { variant: 'warn' }); }
   };
-  const actionExport3MF = () => {
+  const actionExport3MF = async () => {
     if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
     if (!currentMeshData) return;
+    if (!(await confirmExportOrProceed('3MF'))) return;
     try { showToast(`Exported ${export3MF((hasColorRegions() || hasModelColorRegions()) ? applyTriColors(currentMeshData) : currentMeshData)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
   };

--- a/src/ui/exportConfirmModal.ts
+++ b/src/ui/exportConfirmModal.ts
@@ -1,0 +1,101 @@
+// Pre-export safety confirmation. Shown ONLY from the UI export path (toolbar /
+// command palette) — never from the window.partwright.export* console API,
+// which AI agents and e2e drive programmatically and must not be blocked.
+//
+// Surfaces up to two warnings in a single modal:
+//   1. Unitless geometry — most slicers assume millimeters, so the printed
+//      part will be the wrong size if the model was authored at another scale.
+//   2. Printability — the geometry is non-manifold (not watertight) and/or
+//      has multiple disconnected components, which many slicers choke on.
+//
+// If neither applies, the caller skips the modal entirely and exports directly.
+
+import { createModalShell } from './modalShell';
+import { BUTTON_PRIMARY, BUTTON_CANCEL } from './styleConstants';
+import { formatDimension } from '../geometry/units';
+
+export interface ExportWarningInfo {
+  /** True when the active unit system is 'unitless'. */
+  unitless: boolean;
+  /** Bounding-box dimensions [x, y, z], or null when unknown. */
+  dimensions: [number, number, number] | null;
+  /** False when the geometry is non-manifold (not watertight). */
+  isManifold: boolean;
+  /** Number of disconnected components (1 = single solid). */
+  componentCount: number;
+  /** Format label shown in the confirm button, e.g. 'STL'. */
+  format: string;
+}
+
+/** Whether any warning is worth interrupting the export for. */
+export function hasExportWarning(info: ExportWarningInfo): boolean {
+  return info.unitless || !info.isManifold || info.componentCount > 1;
+}
+
+/**
+ * Show the export-confirmation modal. Resolves true if the user proceeds,
+ * false if they cancel/dismiss. Callers should check `hasExportWarning` first
+ * and only call this when there's something to warn about.
+ */
+export function showExportConfirm(info: ExportWarningInfo): Promise<boolean> {
+  return new Promise((resolve) => {
+    let result = false;
+    const shell = createModalShell({
+      title: `Export ${info.format}?`,
+      onClose: () => {
+        document.removeEventListener('keydown', onEnter);
+        resolve(result);
+      },
+    });
+
+    if (info.unitless) {
+      const block = document.createElement('div');
+      block.className = 'rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 leading-snug';
+      const dims = info.dimensions;
+      const dimText = dims
+        ? `${formatDimension(dims[0])} × ${formatDimension(dims[1])} × ${formatDimension(dims[2])}`
+        : null;
+      block.innerHTML =
+        '<strong>No units set.</strong> Most slicers assume <strong>millimeters</strong>. ' +
+        'If you modeled at another scale, the printed part will be the wrong size. ' +
+        (dimText ? `This model\'s bounding box is <span class="font-mono">${dimText}</span>. ` : '') +
+        'Set units in the Export menu to silence this check.';
+      shell.body.appendChild(block);
+    }
+
+    if (!info.isManifold || info.componentCount > 1) {
+      const block = document.createElement('div');
+      block.className = 'rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 leading-snug';
+      const lines: string[] = [];
+      if (!info.isManifold) {
+        lines.push('the geometry is <strong>not manifold</strong> (not watertight)');
+      }
+      if (info.componentCount > 1) {
+        lines.push(`it has <strong>${info.componentCount} disconnected components</strong>`);
+      }
+      block.innerHTML =
+        '<strong>Printability warning:</strong> ' + lines.join(' and ') +
+        '. Many slicers may fail or produce a bad print. Consider fixing the model before exporting.';
+      shell.body.appendChild(block);
+    }
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = BUTTON_CANCEL;
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => { result = false; shell.close(); });
+    shell.footer.appendChild(cancelBtn);
+
+    const exportBtn = document.createElement('button');
+    exportBtn.className = BUTTON_PRIMARY;
+    exportBtn.textContent = `Export anyway`;
+    exportBtn.addEventListener('click', () => { result = true; shell.close(); });
+    shell.footer.appendChild(exportBtn);
+
+    function onEnter(e: KeyboardEvent) {
+      if (e.key === 'Enter') { e.preventDefault(); result = true; shell.close(); }
+    }
+    document.addEventListener('keydown', onEnter);
+
+    exportBtn.focus();
+  });
+}

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -1,6 +1,7 @@
 import { partwrightMarkSvg } from './brand';
 import { getTheme, onThemeChange, toggleTheme } from './theme';
 import { downloadBlob } from '../export/download';
+import { getUnits, setUnits, type UnitSystem } from '../geometry/units';
 import {
   listExports,
   clearExports,
@@ -480,6 +481,45 @@ export function createToolbar(
   // Section: 3D model formats
   dropdown.appendChild(createSectionHeader('3D model'));
 
+  // Units selector — declares what the model's numbers mean (metadata only,
+  // no coordinate transform). Drives export filenames + the 3MF unit
+  // attribute, and the unitless-export confirmation. Default stays 'unitless'.
+  const unitsRow = document.createElement('div');
+  unitsRow.className = 'flex items-center justify-between gap-2 px-3 py-1.5';
+  const unitsLabel = document.createElement('label');
+  unitsLabel.className = 'text-xs text-zinc-400';
+  unitsLabel.textContent = 'Units';
+  unitsLabel.htmlFor = 'export-units-select';
+  const unitsSelect = document.createElement('select');
+  unitsSelect.id = 'export-units-select';
+  unitsSelect.className = 'text-xs bg-zinc-900 border border-zinc-600 rounded px-2 py-1 text-zinc-200 focus:outline-none focus:border-blue-500';
+  unitsSelect.title = 'Declares what the model dimensions mean. Affects export metadata only — never scales geometry.';
+  const UNIT_LABELS: Record<UnitSystem, string> = {
+    mm: 'Millimeters (mm)',
+    cm: 'Centimeters (cm)',
+    in: 'Inches (in)',
+    unitless: 'Unitless',
+  };
+  for (const u of ['mm', 'cm', 'in', 'unitless'] as const) {
+    const opt = document.createElement('option');
+    opt.value = u;
+    opt.textContent = UNIT_LABELS[u];
+    unitsSelect.appendChild(opt);
+  }
+  // Reflect the persisted value, and refresh on each menu open (below) in case
+  // the console API changed it.
+  unitsSelect.value = getUnits();
+  unitsSelect.addEventListener('change', () => {
+    setUnits(unitsSelect.value as UnitSystem);
+  });
+  // Stop clicks on the select from bubbling to the document click-outside
+  // handler that closes the dropdown.
+  unitsRow.addEventListener('click', (e) => e.stopPropagation());
+  unitsRow.appendChild(unitsLabel);
+  unitsRow.appendChild(unitsSelect);
+  dropdown.appendChild(unitsRow);
+  dropdown.appendChild(createDivider());
+
   const threemfOpt = createDescribedItem(
     '3MF',
     'Geometry + color. Native format for Bambu Studio multi-color prints.',
@@ -664,6 +704,8 @@ export function createToolbar(
     // keeps the menu logic local; a language switch closes the menu first anyway.
     stepOpt.classList.toggle('hidden', _currentLang !== 'replicad');
     voxOpt.classList.toggle('hidden', _currentLang !== 'voxel');
+    // Reflect the current unit (the console API can change it out-of-band).
+    unitsSelect.value = getUnits();
     dropdown.classList.toggle('hidden');
   });
 

--- a/tests/export-safety.spec.ts
+++ b/tests/export-safety.spec.ts
@@ -1,0 +1,97 @@
+// E2E coverage for the pre-export safety confirmation (unitless + printability)
+// and the export-units selector. Runs with no external network — all geometry
+// is produced locally via the window.partwright console API.
+//
+// IMPORTANT: the confirmation gates ONLY the toolbar/UI export path. The
+// console API (window.partwright.exportSTL etc.) is intentionally unguarded;
+// these tests therefore drive the UI buttons, not the API.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+type PW = {
+  createSession: (n?: string) => Promise<unknown>;
+  run: (code: string) => Promise<unknown>;
+  setUnits: (u: string) => void;
+};
+
+async function runManifold(page: Page, code: string) {
+  await page.evaluate(async (c) => {
+    const pw = (window as unknown as { partwright: PW }).partwright;
+    await pw.createSession('export-safety');
+    await pw.run(c);
+  }, code);
+}
+
+const CUBE = 'const { Manifold } = api; return Manifold.cube([10, 10, 10], true);';
+// Two non-overlapping cubes → 2 disconnected components (printability warning).
+const TWO_COMPONENTS =
+  'const { Manifold } = api; return Manifold.cube([5,5,5], true).add(Manifold.cube([5,5,5], true).translate([40,0,0]));';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('partwright-tour-completed', '1');
+      // Ensure a clean unit baseline regardless of any persisted value.
+      localStorage.removeItem('partwright-units');
+    } catch { /* ignore */ }
+  });
+});
+
+test.describe('Export safety confirmation', () => {
+  test('unitless STL export shows a confirm modal with bounding-box dims', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    await runManifold(page, CUBE);
+
+    await page.locator('#btn-export').click();
+    await page.locator('#export-dropdown').getByText('STL', { exact: true }).click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('No units set');
+    // 10×10×10 cube → bounding box dims show up.
+    await expect(dialog).toContainText('10.00 × 10.00 × 10.00');
+
+    // Cancelling aborts — no toast, modal closes.
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test('non-manifold / multi-component geometry shows a printability warning', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    await runManifold(page, TWO_COMPONENTS);
+
+    await page.locator('#btn-export').click();
+    await page.locator('#export-dropdown').getByText('STL', { exact: true }).click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Printability warning');
+    await expect(dialog).toContainText('disconnected components');
+  });
+
+  test('setting a unit suppresses the unitless modal', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    await runManifold(page, CUBE);
+
+    // Pick millimeters via the export-menu selector.
+    await page.locator('#btn-export').click();
+    await page.locator('#export-units-select').selectOption('mm');
+    await page.locator('#export-dropdown').getByText('STL', { exact: true }).click();
+
+    // A watertight single-component cube in mm has no warning → exports
+    // directly, surfacing the success toast and no dialog.
+    await expect(page.locator('[role="dialog"]')).toHaveCount(0);
+    await expect(page.getByRole('status')).toContainText('Exported', { timeout: 5_000 });
+  });
+});

--- a/tests/export-safety.spec.ts
+++ b/tests/export-safety.spec.ts
@@ -92,6 +92,10 @@ test.describe('Export safety confirmation', () => {
     // A watertight single-component cube in mm has no warning → exports
     // directly, surfacing the success toast and no dialog.
     await expect(page.locator('[role="dialog"]')).toHaveCount(0);
-    await expect(page.getByRole('status')).toContainText('Exported', { timeout: 5_000 });
+    // Target the toast specifically — the status pill (<span role="status">
+    // "Ready") also matches role=status, so getByRole would be ambiguous.
+    await expect(
+      page.locator('div[role="status"]').filter({ hasText: /Exported/ }),
+    ).toBeVisible({ timeout: 5_000 });
   });
 });

--- a/tests/feedback-a11y.spec.ts
+++ b/tests/feedback-a11y.spec.ts
@@ -18,6 +18,9 @@ test.describe('feedback + a11y', () => {
   test('exporting surfaces a success toast', async ({ page }) => {
     await openEditor(page);
     await page.click('#btn-export');
+    // Pick a real unit first so the unitless safety-confirmation modal doesn't
+    // intercept the export — this test asserts the success-toast live region.
+    await page.locator('#export-units-select').selectOption('mm');
     await page.locator('#export-dropdown').getByText('STL', { exact: true }).click();
     await expect(
       page.locator('div[role="status"]').filter({ hasText: /Exported .*\.stl/ }),

--- a/tests/unit/export.test.ts
+++ b/tests/unit/export.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { buildSTL } from '../../src/export/stl';
+import { build3MF } from '../../src/export/threemf';
+import { buildOBJ } from '../../src/export/obj';
+import type { MeshData } from '../../src/geometry/types';
+
+// A trivial single-triangle mesh — enough to exercise the export writers.
+function tri(): MeshData {
+  return {
+    numProp: 3,
+    numVert: 3,
+    numTri: 1,
+    vertProperties: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    triVerts: new Uint32Array([0, 1, 2]),
+  } as unknown as MeshData;
+}
+
+async function blobBytes(blob: Blob): Promise<Uint8Array> {
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+/** Decode a byte buffer as Latin-1 so we can substring-search ASCII content
+ *  regardless of any binary bytes around it (the 3MF/OBJ ZIPs use STORE so
+ *  the text is embedded verbatim). */
+function asLatin1(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return s;
+}
+
+describe('export attribution + STL header safety', () => {
+  it('STL header never exceeds 80 bytes and the triangle count is intact', async () => {
+    const bytes = await blobBytes(buildSTL(tri()).blob);
+    // Binary STL: 80-byte header, then a uint32 triangle count at byte 80.
+    const dv = new DataView(bytes.buffer);
+    const count = dv.getUint32(80, true);
+    expect(count).toBe(1);
+    // The header region is exactly 80 bytes by construction; assert the buffer
+    // is at least header(80) + count(4) + one triangle(50).
+    expect(bytes.length).toBe(80 + 4 + 50);
+  });
+
+  it('STL header carries the Partwright attribution within the 80-byte window', async () => {
+    const bytes = await blobBytes(buildSTL(tri()).blob);
+    const header = asLatin1(bytes.subarray(0, 80));
+    expect(header).toContain('Partwright partwrightstudio.com');
+  });
+
+  it('STL attribution is dropped (never truncated past byte 80) for a very long title', async () => {
+    // Even an extreme custom name must not push the header past 80 bytes.
+    const longName = 'x'.repeat(200);
+    const bytes = await blobBytes(buildSTL(tri(), longName).blob);
+    const dv = new DataView(bytes.buffer);
+    // The triangle count at byte 80 must still read 1 — proof byte 80 wasn't
+    // overwritten by header overflow.
+    expect(dv.getUint32(80, true)).toBe(1);
+  });
+
+  it('3MF embeds Partwright application metadata and the studio URL', async () => {
+    const text = asLatin1(await blobBytes(build3MF(tri()).blob));
+    expect(text).toContain('<metadata name="Application">Partwright');
+    expect(text).toContain('www.partwrightstudio.com');
+  });
+
+  it('OBJ text carries the Partwright attribution comment + URL', async () => {
+    const text = asLatin1(await blobBytes(buildOBJ(tri()).blob));
+    expect(text).toContain('# Partwright');
+    expect(text).toContain('https://www.partwrightstudio.com');
+  });
+});

--- a/tests/unit/units.test.ts
+++ b/tests/unit/units.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// A minimal localStorage stub for the node test environment. units.ts reads
+// the persisted value at module-init, so we install the stub before importing.
+function installLocalStorageStub(): Map<string, string> {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+  });
+  return store;
+}
+
+describe('units', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to unitless (back-compat) when nothing is persisted', async () => {
+    installLocalStorageStub();
+    const { getUnits, get3MFUnitString, formatDimension } = await import('../../src/geometry/units');
+    expect(getUnits()).toBe('unitless');
+    // 3MF still requires a concrete unit — unitless maps to millimeter.
+    expect(get3MFUnitString()).toBe('millimeter');
+    // formatDimension shows no unit suffix when unitless.
+    expect(formatDimension(1)).toBe('1.00');
+  });
+
+  it('maps mm to millimeter and suffixes formatted dimensions', async () => {
+    installLocalStorageStub();
+    const { setUnits, get3MFUnitString, formatDimension } = await import('../../src/geometry/units');
+    setUnits('mm');
+    expect(get3MFUnitString()).toBe('millimeter');
+    expect(formatDimension(1)).toBe('1.00 mm');
+  });
+
+  it('maps cm and in to their 3MF unit strings', async () => {
+    installLocalStorageStub();
+    const { setUnits, get3MFUnitString } = await import('../../src/geometry/units');
+    setUnits('cm');
+    expect(get3MFUnitString()).toBe('centimeter');
+    setUnits('in');
+    expect(get3MFUnitString()).toBe('inch');
+  });
+
+  it('persists the chosen unit and restores it on a fresh module load', async () => {
+    const store = installLocalStorageStub();
+    const first = await import('../../src/geometry/units');
+    first.setUnits('cm');
+    expect(store.get('partwright-units')).toBe('cm');
+
+    // Simulate a reload: reset the module cache but keep the same storage.
+    vi.resetModules();
+    const second = await import('../../src/geometry/units');
+    expect(second.getUnits()).toBe('cm');
+  });
+
+  it('ignores a corrupt persisted value and falls back to unitless', async () => {
+    const store = installLocalStorageStub();
+    store.set('partwright-units', 'furlongs');
+    const { getUnits } = await import('../../src/geometry/units');
+    expect(getUnits()).toBe('unitless');
+  });
+});


### PR DESCRIPTION
Part of the **launch readiness** series (split out of #279).

- Persisted **units selector** (mm/cm/in) in the export menu; default stays `unitless` for back-compat.
- **Confirmation dialog** when exporting with no units set, or when the mesh is non-manifold / multi-component — UI path only; the `window.partwright` console API stays unguarded for agents.
- **Attribution metadata** ("made with Partwright" + URL) embedded in 3MF / STL / OBJ.

Cherry-picked onto current `main`; resolved a `main.ts` conflict by combining `main`'s new "fork before exporting" share guards with the new confirm gate (kept `main`'s `hasModelColorRegions()`).

- `npm run build` ✅ · `npm run test:unit` ✅ (incl. `units.test.ts`, `export.test.ts`) · new e2e `export-safety.spec.ts`

https://claude.ai/code/session_01CnFPgrhZRBBrV4sYsGtxXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnFPgrhZRBBrV4sYsGtxXj)_