### PR TITLE
feat: autosave drafts + storage-quota toasts (launch readiness)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -203,6 +203,7 @@ import {
   type ExportedSession,
   type ExportOptions,
 } from './storage/sessionManager';
+import { isQuotaError } from './storage/quota';
 import { acquireSession as acquireSessionLock, initSessionLeader, onOwnershipChange } from './storage/sessionLock';
 import { initViewerMode, isReadOnlyViewer } from './ui/viewerMode';
 import type { Version, Part } from './storage/db';
@@ -2939,7 +2940,22 @@ async function main() {
 
   // Global undo / redo / save shortcuts (OS-aware, focus/tool-routed).
   const saveVersionWithToast = async () => {
-    const result = await saveCurrentVersion();
+    let result;
+    try {
+      result = await saveCurrentVersion();
+    } catch (e) {
+      // An explicit Save that fails (e.g. a full quota) must surface the
+      // failure — never the "Saved" toast — so the user knows it didn't
+      // persist. No caller inspects the result, so a warn toast is the
+      // signal (we don't re-throw, which would just be an unhandled
+      // rejection through the `void` call sites).
+      if (isQuotaError(e)) {
+        showToast('Storage full — could not save this version. Free up space or export your work.', { variant: 'warn' });
+      } else {
+        showToast(e instanceof Error ? e.message : 'Save failed', { variant: 'warn' });
+      }
+      return;
+    }
     if ('error' in result) {
       showToast(result.error, { variant: 'warn' });
     } else if ('skipped' in result) {
@@ -3501,6 +3517,30 @@ async function main() {
     updateDocumentTitle({ page: 'editor' });
   }
 
+  // On a session open where we land on the LATEST version (the version the
+  // user would be actively editing — the URL pins ?v=<latest> after every
+  // save, so this is the normal reopen case), prefer an autosaved draft for
+  // the active language when it exists and differs from the code we just
+  // loaded. This is what makes editor autosave recover unsaved typing across a
+  // reload / crash. It is deliberately skipped when we loaded an OLDER version
+  // (explicit history navigation), so a stale draft never shadows a version
+  // the user intentionally went back to.
+  async function restoreDraftIfNewer(): Promise<void> {
+    const sid = getState().session?.id;
+    if (!sid) return;
+    // Only at the tip: if a specific older version is loaded, don't override it.
+    const current = getState().currentVersion;
+    if (current) {
+      const versions = await listCurrentVersions();
+      const latestIndex = versions.reduce((m, v) => Math.max(m, v.index), -Infinity);
+      if (current.index !== latestIndex) return;
+    }
+    const draft = await readDraft(sid, getActiveLanguage());
+    if (draft == null || draft === getValue()) return;
+    setValue(draft);
+    await runCodeSync(draft);
+  }
+
   async function syncEditorFromURL() {
     transitionToEditor();
     const tab = getTabFromURL();
@@ -3521,6 +3561,10 @@ async function main() {
         const version = await openSession(sessionId, versionIndex ?? undefined, partId ?? undefined);
         if (version) {
           await loadVersionIntoEditor(version);
+          // restoreDraftIfNewer self-gates: it only acts when this is the
+          // latest version (the tip the user edits), not an older one they
+          // navigated back to.
+          await restoreDraftIfNewer();
           if (tab === 'gallery') refreshGallery();
           if (tab === 'versions') refreshVersions();
           return;
@@ -3531,6 +3575,7 @@ async function main() {
         // generic default example.
         if (getState().session?.id === sessionId) {
           await loadPartIntoEditor(getState().currentVersion);
+          await restoreDraftIfNewer();
           if (tab === 'gallery') refreshGallery();
           if (tab === 'versions') refreshVersions();
           return;
@@ -3705,15 +3750,46 @@ async function main() {
     onClose: () => closeReliefStudio(),
   });
 
+  // Persist the editor's working buffer to the active session's draft so an
+  // accidental reload / tab-close / crash doesn't lose unsaved typing. Reads
+  // getActiveLanguage() + getValue() SYNCHRONOUSLY at fire time so the draft
+  // lands under the right (session, language) key — same key version-load and
+  // the language-toggle path use — and never writes OLD code under a NEW
+  // language. Skips when no session is open so we don't auto-create empty
+  // sessions (which would fight deleteIfEmpty on unload). Best-effort: a quota
+  // failure is swallowed with a warn toast since autosave is non-critical.
+  function autosaveDraft(): void {
+    const sid = getState().session?.id;
+    if (!sid) return;
+    const lang = getActiveLanguage();
+    const code = getValue();
+    void writeDraft(sid, lang, code).catch((e) => {
+      if (isQuotaError(e)) {
+        showToast('Storage full — could not autosave your draft. Free up space or export your work.', { variant: 'warn' });
+      }
+      // Other autosave failures are non-fatal and intentionally silent.
+    });
+  }
+
   // Init editor — only auto-run if auto-run is enabled. Auto-runs drive the
   // live preview but defer error surfacing (no panel/markers/log mid-keystroke);
   // the idle + blur hooks surface the held-back error gently once typing settles.
+  // The same idle/blur ticks autosave the draft. A programmatic setValue
+  // (version load / language switch) cancels the pending onIdle (see
+  // codeEditor.setValue), so autosave never fires for code the user didn't type.
   initEditor(editorContainer, defaultCode, (code: string) => {
     if (isAutoRun()) runCode(code, { surfaceErrors: false });
   }, 'manifold-js', {
     onEdit: () => clearEditorErrorPanel(editorErrorPanel),
-    onIdle: () => surfacePendingError(),
-    onBlur: () => surfacePendingError(),
+    onIdle: () => { surfacePendingError(); autosaveDraft(); },
+    onBlur: () => { surfacePendingError(); autosaveDraft(); },
+  });
+
+  // Autosave when the tab is hidden (switching apps, closing) — the most
+  // reliable "user is leaving" signal that still permits an async IDB write,
+  // unlike beforeunload which can't await. Singleton listener (main runs once).
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) autosaveDraft();
   });
 
   // When the user changes the modeling-quality preset, re-render the

--- a/src/storage/quota.ts
+++ b/src/storage/quota.ts
@@ -1,0 +1,16 @@
+// Detect a browser storage-quota-exceeded error across the various shapes
+// browsers throw it in. Dependency-free so it can be unit-tested in isolation.
+//
+// - Chrome/Edge: DOMException with name 'QuotaExceededError'
+// - Firefox: DOMException name 'NS_ERROR_DOM_QUOTA_REACHED' (code 1014)
+// - Safari: sometimes a plain Error whose message mentions "quota"
+// IndexedDB wraps these, so we also sniff the message text as a fallback.
+export function isQuotaError(e: unknown): boolean {
+  if (e == null) return false;
+  const err = e as { name?: unknown; code?: unknown; message?: unknown };
+  const name = typeof err.name === 'string' ? err.name : '';
+  if (name === 'QuotaExceededError' || name === 'NS_ERROR_DOM_QUOTA_REACHED') return true;
+  if (err.code === 22 || err.code === 1014) return true;
+  const message = typeof err.message === 'string' ? err.message : '';
+  return /quota/i.test(message);
+}

--- a/src/ui/sessionBar.ts
+++ b/src/ui/sessionBar.ts
@@ -15,6 +15,7 @@ import {
 import { onChange as onColorRegionsChange } from '../color/regions';
 import { onChange as onAnnotationStrokesChange } from '../annotations/annotations';
 import { showToast } from './toast';
+import { isQuotaError } from '../storage/quota';
 import { languageBadge } from './languageBadge';
 
 export interface SessionBarCallbacks {
@@ -192,7 +193,11 @@ function render(state: SessionState) {
     } catch (err) {
       // A failed save must not be silent \u2014 surface it so the user knows their
       // painted/edited state wasn't captured (rather than assume it saved).
-      showToast(`Couldn't save version: ${err instanceof Error ? err.message : String(err)}`, { variant: 'warn' });
+      if (isQuotaError(err)) {
+        showToast('Storage full \u2014 could not save this version. Free up space or export your work.', { variant: 'warn' });
+      } else {
+        showToast(`Couldn't save version: ${err instanceof Error ? err.message : String(err)}`, { variant: 'warn' });
+      }
     } finally {
       saving = false;
       saveBtn.disabled = false;

--- a/tests/autosave.spec.ts
+++ b/tests/autosave.spec.ts
@@ -1,0 +1,78 @@
+// E2E coverage for editor draft autosave. Typing into the editor, then the tab
+// going hidden (or going idle), persists the working buffer as a draft keyed by
+// (session, language). On reopening the session that draft is restored ahead of
+// the last saved version, so an accidental reload / crash doesn't lose unsaved
+// work. Runs with no external network.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function openEditor(page: Page) {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('partwright-tour-completed', '1');
+      // Keep the code pane visible (the AI drawer otherwise collapses it).
+      localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({ editorCollapsed: false }));
+    } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+async function replaceEditorWith(page: Page, text: string) {
+  await page.locator('.cm-content').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('Delete');
+  await page.keyboard.type(text, { delay: 5 });
+}
+
+const SAVED = 'const { Manifold } = api; return Manifold.cube([10, 10, 10], true);';
+// A distinctive draft that is NOT saved as a version.
+const DRAFT = 'const { Manifold } = api; return Manifold.sphere(7, 32); // DRAFT-MARKER-42';
+
+test.describe('editor autosave', () => {
+  test('restores an autosaved draft after a reload', async ({ page }) => {
+    await openEditor(page);
+
+    // Seed a session with one saved version (so the reopen baseline is the
+    // saved code, not the draft).
+    const sessionId = await page.evaluate(async (code) => {
+      const pw = (window as unknown as { partwright: {
+        createSession: (n?: string) => Promise<unknown>;
+        runAndSave: (c: string, l?: string) => Promise<unknown>;
+        currentSessionId?: () => string | null;
+      } }).partwright;
+      await pw.createSession('autosave-test');
+      await pw.runAndSave(code, 'v1');
+      // Pull the session id out of the URL the app maintains.
+      return new URLSearchParams(window.location.search).get('session');
+    }, SAVED);
+    expect(sessionId).toBeTruthy();
+
+    // Type an unsaved draft and wait past the idle autosave window (800ms).
+    await replaceEditorWith(page, DRAFT);
+    await page.waitForTimeout(1100);
+
+    // Simulate the tab being backgrounded — fires the visibilitychange
+    // autosave (best-effort persist before the page may go away).
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    // Give the async IDB write a beat to commit.
+    await page.waitForTimeout(300);
+
+    await page.reload();
+    await page.waitForSelector('text=Ready', { timeout: 20_000 });
+    await page.waitForFunction(
+      () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+      { timeout: 20_000 },
+    );
+
+    // The editor should show the DRAFT, not the saved v1 code.
+    await expect(page.locator('.cm-content')).toContainText('DRAFT-MARKER-42', { timeout: 10_000 });
+  });
+});

--- a/tests/unit/quota.test.ts
+++ b/tests/unit/quota.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { isQuotaError } from '../../src/storage/quota';
+
+describe('isQuotaError', () => {
+  it('detects the Chrome/Edge QuotaExceededError name', () => {
+    expect(isQuotaError({ name: 'QuotaExceededError' })).toBe(true);
+  });
+
+  it('detects the Firefox quota error name and code', () => {
+    expect(isQuotaError({ name: 'NS_ERROR_DOM_QUOTA_REACHED' })).toBe(true);
+    expect(isQuotaError({ code: 1014 })).toBe(true);
+  });
+
+  it('detects the legacy DOMException code 22', () => {
+    expect(isQuotaError({ code: 22 })).toBe(true);
+  });
+
+  it('falls back to a message containing "quota" (case-insensitive)', () => {
+    expect(isQuotaError(new Error('The quota has been exceeded.'))).toBe(true);
+    expect(isQuotaError({ message: 'QUOTA full' })).toBe(true);
+  });
+
+  it('returns false for unrelated errors and nullish values', () => {
+    expect(isQuotaError(new Error('boom'))).toBe(false);
+    expect(isQuotaError({ name: 'TypeError' })).toBe(false);
+    expect(isQuotaError(null)).toBe(false);
+    expect(isQuotaError(undefined)).toBe(false);
+    expect(isQuotaError('a string')).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of the **launch readiness** series (split out of #279).

- **Autosaves** the active editor draft on idle / blur / visibility-hidden and restores it on reload — only when at the latest version, so it never shadows an older version you navigated to.
- Surfaces a **"storage full" toast** on `QuotaExceededError` instead of failing the save silently.

Cherry-picked onto current `main`; resolved a `main.ts` conflict by keeping both `main`'s shared-preview block and the new autosave hooks.

- `npm run build` ✅ · `npm run test:unit` ✅ (incl. `quota.test.ts`) · new e2e `autosave.spec.ts`

https://claude.ai/code/session_01CnFPgrhZRBBrV4sYsGtxXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnFPgrhZRBBrV4sYsGtxXj)_