### PR TITLE
feat: WASM/WebGL/low-memory startup hardening (launch readiness)

### DIFF
--- a/src/geometry/isolation.ts
+++ b/src/geometry/isolation.ts
@@ -1,0 +1,22 @@
+// Cross-origin isolation detection. manifold-3d (and the OpenSCAD / OCCT
+// engines) need SharedArrayBuffer, which is only available when the page is
+// cross-origin isolated (COOP + COEP headers). The coi-serviceworker.js shim
+// installs those headers and reloads ONCE to gain isolation, so on a first
+// visit `crossOriginIsolated` can be transiently false before that reload.
+//
+// These helpers are dependency-free so the decision logic can be unit-tested
+// without a browser. The actual reload-gating in main.ts uses a sessionStorage
+// flag so we don't flash the scary "not supported" message during the shim's
+// one legitimate reload.
+
+/** True when the environment can back a SharedArrayBuffer — the precondition
+ *  for the WASM engines. Reads `crossOriginIsolated` and `SharedArrayBuffer`
+ *  off the provided scope (defaults to globalThis) so tests can pass a stub. */
+export function isolationSupported(
+  scope: { crossOriginIsolated?: boolean; SharedArrayBuffer?: unknown } = globalThis as unknown as {
+    crossOriginIsolated?: boolean;
+    SharedArrayBuffer?: unknown;
+  },
+): boolean {
+  return scope.crossOriginIsolated === true && typeof scope.SharedArrayBuffer !== 'undefined';
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { resolveParamValues, pruneParamValues, type ParamSpec, type ParamValue } from './geometry/params';
 import { createParamsPanel, type ParamsPanelController } from './ui/paramsPanel';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
-import { initViewport, updateMesh, setOnMeshUpdate, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange } from './renderer/viewport';
+import { initViewport, updateMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange } from './renderer/viewport';
 import { renderCompositeCanvas, renderSingleView, renderSingleViewCanvas, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, EDGE_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode, type EdgeMode } from './renderer/multiview';
 import { generateId, getLatestVersion } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
@@ -209,6 +209,7 @@ import {
   type ExportOptions,
 } from './storage/sessionManager';
 import { isQuotaError } from './storage/quota';
+import { isolationSupported } from './geometry/isolation';
 import { acquireSession as acquireSessionLock, initSessionLeader, onOwnershipChange } from './storage/sessionLock';
 import { initViewerMode, isReadOnlyViewer } from './ui/viewerMode';
 import type { Version, Part } from './storage/db';
@@ -3776,14 +3777,56 @@ async function main() {
     showNotFoundPage();
   }
 
-  // Init geometry engine — wrapped in try/catch so editor/viewport still init on failure
+  // Init geometry engine — wrapped in try/catch so editor/viewport still init
+  // on failure. The WASM engines need SharedArrayBuffer, which requires
+  // cross-origin isolation (COOP+COEP). The coi-serviceworker.js shim installs
+  // those headers and reloads ONCE on a first visit to gain isolation, so a
+  // transient non-isolated state on the very first load is expected and must
+  // NOT flash the scary message — we gate on the shim having had its reload.
+  const COI_MISSING_MSG =
+    'This browser tab is not cross-origin isolated, so the WASM engine (which needs SharedArrayBuffer) can’t start. ' +
+    'This usually fixes itself on reload; if it persists, the required COOP/COEP headers aren’t reaching the page ' +
+    '(a proxy, extension, or unsupported browser can strip them).';
   setStatus(statusBar, 'loading', 'Loading WASM...');
-  try {
-    await initEngine();
-    engineOk = true;
-  } catch (e) {
-    console.error('WASM engine failed to load:', e);
-    setStatus(statusBar, 'error', 'WASM failed');
+  if (!isolationSupported()) {
+    // Has the COI shim already had a chance to reload this tab? It registers a
+    // service worker and reloads once; until a controller exists, that reload
+    // is still pending, so stay on the neutral "Loading…" message rather than
+    // alarming the user. We remember that we waited so a second non-isolated
+    // load (where the shim can't help) surfaces the explanation.
+    let coiReloadPending = false;
+    try {
+      const waited = sessionStorage.getItem('partwright-coi-waited') === '1';
+      const hasController = 'serviceWorker' in navigator && !!navigator.serviceWorker.controller;
+      coiReloadPending = !waited && !hasController && 'serviceWorker' in navigator;
+      if (coiReloadPending) sessionStorage.setItem('partwright-coi-waited', '1');
+    } catch {
+      // sessionStorage unavailable — treat as "no reload pending" and explain.
+      coiReloadPending = false;
+    }
+    if (!coiReloadPending) {
+      setStatus(statusBar, 'error', 'WASM unavailable (not cross-origin isolated)');
+      errorLog.capture({ level: 'error', source: 'engine', message: COI_MISSING_MSG });
+      showToast(COI_MISSING_MSG, { variant: 'warn', durationMs: 9000 });
+    }
+    // Either way, don't attempt initEngine — it would throw on the missing
+    // SharedArrayBuffer. engineOk stays false; the editor/viewport still init.
+  } else {
+    try {
+      await initEngine();
+      engineOk = true;
+    } catch (e) {
+      console.error('WASM engine failed to load:', e);
+      // Distinguish a genuine load failure from the COI-missing case (which we
+      // already handled above) so the message points at the right cause.
+      const coiMissing = !isolationSupported();
+      setStatus(statusBar, 'error', coiMissing ? 'WASM unavailable (not cross-origin isolated)' : 'WASM failed');
+      errorLog.capture({
+        level: 'error',
+        source: 'engine',
+        message: coiMissing ? COI_MISSING_MSG : `WASM engine failed to load: ${e instanceof Error ? e.message : String(e)}`,
+      });
+    }
   }
 
   // Init viewport
@@ -3791,6 +3834,14 @@ async function main() {
   // Keep the live triangle-count readout (and high-complexity warning) in sync
   // with every displayed mesh — runs, paint strokes, simplify, clear.
   setOnMeshUpdate((mesh) => refreshTriangleCount(mesh.numTri));
+  // Surface WebGL context loss / recovery as a toast (three.js auto-restores
+  // the GL programs; the viewport just pauses + resumes its render loop).
+  setOnContextLost(() => {
+    showToast('3D view paused — the graphics context was lost. Recovering…', { variant: 'warn', durationMs: 6000 });
+  });
+  setOnContextRestored(() => {
+    showToast('3D view recovered.', { variant: 'success' });
+  });
 
   // Customizer panel — a viewport overlay that surfaces the parameters a model
   // declares via api.params({...}). Editing a widget records the override and
@@ -3905,6 +3956,41 @@ async function main() {
   document.addEventListener('visibilitychange', () => {
     if (document.hidden) autosaveDraft();
   });
+
+  // One-time low-memory heads-up. On devices reporting <= 4 GB RAM
+  // (navigator.deviceMemory), the WASM engines + Three.js can get sluggish or
+  // OOM on heavy models. Shown as a DISMISSIBLE banner (not a toast — a toast
+  // can't be persistently dismissed) with the choice remembered in
+  // localStorage. deviceMemory is undefined in Firefox/Safari, so the
+  // typeof-number guard means those browsers never see it (no false alarm).
+  const LOWMEM_DISMISS_KEY = 'partwright-lowmem-dismissed';
+  function maybeShowLowMemoryNotice(): void {
+    const dm = (navigator as unknown as { deviceMemory?: unknown }).deviceMemory;
+    if (typeof dm !== 'number' || dm > 4) return;
+    try {
+      if (localStorage.getItem(LOWMEM_DISMISS_KEY) === '1') return;
+    } catch { /* localStorage unavailable — show it anyway */ }
+
+    const banner = document.createElement('div');
+    banner.id = 'lowmem-notice';
+    banner.className = 'flex items-center gap-3 px-4 py-2 text-xs bg-amber-900/30 border-b border-amber-700/40 text-amber-200';
+    const msg = document.createElement('span');
+    msg.className = 'flex-1';
+    msg.textContent = `Heads up: this device reports ${dm} GB of memory. Large or high-detail models may render slowly or run out of memory — lower the modeling quality (⚙) or simplify the mesh if things get sluggish.`;
+    const dismiss = document.createElement('button');
+    // 44px-tall hit area for touch while staying visually compact.
+    dismiss.className = 'shrink-0 -my-2 px-3 py-3 leading-none text-amber-300 hover:text-amber-100 transition-colors';
+    dismiss.setAttribute('aria-label', 'Dismiss low-memory notice');
+    dismiss.textContent = '✕';
+    dismiss.addEventListener('click', () => {
+      banner.remove();
+      try { localStorage.setItem(LOWMEM_DISMISS_KEY, '1'); } catch { /* best-effort */ }
+    });
+    banner.appendChild(msg);
+    banner.appendChild(dismiss);
+    // Sit at the very top of the editor UI, above the toolbar.
+    editorUI.insertBefore(banner, editorUI.firstChild);
+  }
 
   // When the user changes the modeling-quality preset, re-render the
   // current code so the new segment count takes effect immediately.
@@ -4209,6 +4295,7 @@ async function main() {
   if (!showLanding && !showHelpPage && !showCatalog && !showLegalPage && !showWhatsNew && !show404 && !hasShareHash()) {
     maybeStartTour();
     maybeShowShortcutsHint();
+    maybeShowLowMemoryNotice();
   }
 
   // A `#share=…` link opens the read-only preview INSTEAD of the normal editor

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -30,6 +30,22 @@ let controls: OrbitControls;
 let meshGroup: THREE.Group;
 let animationId: number;
 
+// === WebGL context-loss recovery ===
+// The GPU can drop the WebGL context (driver reset, tab backgrounded too long,
+// OOM). Three.js auto-recompiles its programs on restore, so we must NOT
+// recreate the renderer — we only pause the render loop while lost and resume
+// it on restore. preventDefault() on the lost event is REQUIRED for the
+// browser to fire 'restored' at all.
+let contextLost = false;
+let onContextLost: (() => void) | null = null;
+let onContextRestored: (() => void) | null = null;
+
+/** Hook fired when the WebGL context is lost (recoverable) and again when it
+ *  is restored. Lets the host surface a toast without viewport importing the
+ *  toast module (mirrors setOnMeshUpdate). */
+export function setOnContextLost(fn: () => void): void { onContextLost = fn; }
+export function setOnContextRestored(fn: () => void): void { onContextRestored = fn; }
+
 // === On-demand rendering ===
 // The render loop only paints a frame when something actually changed, instead
 // of re-rendering an idle scene 60×/second. The `needsRender` flag (set by
@@ -132,6 +148,24 @@ export function initViewport(container: HTMLElement): {
   renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
   renderer.setPixelRatio(baseDpr());
   renderer.localClippingEnabled = true;
+
+  // WebGL context-loss recovery. preventDefault() on 'lost' is what lets the
+  // browser restore the context; while lost we cancel the RAF loop so we don't
+  // spin calling render() on a dead context. On 'restored' three has already
+  // recompiled its GLSL, so we just resume the loop and force a repaint.
+  canvas.addEventListener('webglcontextlost', (event) => {
+    event.preventDefault();
+    contextLost = true;
+    if (animationId !== undefined) cancelAnimationFrame(animationId);
+    onContextLost?.();
+  }, false);
+  canvas.addEventListener('webglcontextrestored', () => {
+    contextLost = false;
+    needsRender = true;
+    onContextRestored?.();
+    // Restart the render loop (it was cancelled on loss).
+    animate();
+  }, false);
 
   controls = new OrbitControls(camera, canvas);
   controls.enableDamping = true;
@@ -278,6 +312,10 @@ export function initViewport(container: HTMLElement): {
   // Animate
   const timer = new Timer();
   function animate(timestamp?: number) {
+    // While the GL context is lost, stop the loop entirely — the 'restored'
+    // handler restarts it. (Guard in addition to the cancelAnimationFrame in
+    // the lost handler in case a queued frame fires before that runs.)
+    if (contextLost) return;
     animationId = requestAnimationFrame(animate);
     timer.update(timestamp);
     const delta = timer.getDelta();

--- a/tests/startup-resilience.spec.ts
+++ b/tests/startup-resilience.spec.ts
@@ -1,0 +1,87 @@
+// E2E coverage for startup / runtime resilience UX:
+//  - WebGL context loss + restore surfaces a recovery toast and the render
+//    loop resumes without errors (Item 5).
+//  - The low-memory notice shows on low-RAM devices, is dismissible, and stays
+//    dismissed across reloads; high-RAM devices never see it (Item 8).
+// Runs with no external network.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function openEditor(page: Page) {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+test.describe('WebGL context loss', () => {
+  test('loss then restore surfaces a recovery toast and resumes cleanly', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (m) => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+
+    await openEditor(page);
+
+    // Force a context loss via the standard debug extension, then restore it.
+    const ok = await page.evaluate(() => {
+      const canvas = document.getElementById('viewport') as HTMLCanvasElement | null;
+      const gl = canvas?.getContext('webgl2') || canvas?.getContext('webgl');
+      const ext = gl?.getExtension('WEBGL_lose_context');
+      if (!ext) return false;
+      ext.loseContext();
+      // The browser fires 'lost' asynchronously; restore shortly after.
+      setTimeout(() => ext.restoreContext(), 150);
+      return true;
+    });
+    expect(ok).toBe(true);
+
+    // The loss toast appears, then the recovery toast.
+    await expect(page.getByText('graphics context was lost')).toBeVisible({ timeout: 6000 });
+    await expect(page.getByText('3D view recovered')).toBeVisible({ timeout: 8000 });
+
+    // No uncaught console errors from the loss/restore cycle (the deliberate
+    // GL "context lost" info messages are not errors).
+    const fatal = consoleErrors.filter((t) => !/WebGL.*context/i.test(t));
+    expect(fatal).toEqual([]);
+  });
+});
+
+test.describe('Low-memory notice', () => {
+  test('shows on a low-RAM device, dismisses, and stays dismissed across reload', async ({ page }) => {
+    await page.addInitScript(() => {
+      try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+      Object.defineProperty(navigator, 'deviceMemory', { configurable: true, get: () => 4 });
+    });
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 20_000 });
+
+    const notice = page.locator('#lowmem-notice');
+    await expect(notice).toBeVisible({ timeout: 10_000 });
+    await expect(notice).toContainText('4 GB');
+
+    await notice.getByRole('button', { name: /Dismiss/i }).click();
+    await expect(notice).toHaveCount(0);
+
+    // The dismissal persists — a reload (same context → same localStorage)
+    // must not bring it back.
+    await page.reload();
+    await page.waitForSelector('text=Ready', { timeout: 20_000 });
+    await expect(page.locator('#lowmem-notice')).toHaveCount(0);
+  });
+
+  test('does not show on a high-RAM device', async ({ page }) => {
+    await page.addInitScript(() => {
+      try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+      Object.defineProperty(navigator, 'deviceMemory', { configurable: true, get: () => 8 });
+    });
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 20_000 });
+    // Give the editor a beat to finish init, then assert the notice is absent.
+    await page.waitForTimeout(500);
+    await expect(page.locator('#lowmem-notice')).toHaveCount(0);
+  });
+});

--- a/tests/unit/isolation.test.ts
+++ b/tests/unit/isolation.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { isolationSupported } from '../../src/geometry/isolation';
+
+describe('isolationSupported', () => {
+  it('is true only when crossOriginIsolated is true AND SharedArrayBuffer exists', () => {
+    expect(isolationSupported({ crossOriginIsolated: true, SharedArrayBuffer: class {} })).toBe(true);
+  });
+
+  it('is false when crossOriginIsolated is false', () => {
+    expect(isolationSupported({ crossOriginIsolated: false, SharedArrayBuffer: class {} })).toBe(false);
+  });
+
+  it('is false when crossOriginIsolated is undefined', () => {
+    expect(isolationSupported({ SharedArrayBuffer: class {} })).toBe(false);
+  });
+
+  it('is false when SharedArrayBuffer is missing even if isolated', () => {
+    expect(isolationSupported({ crossOriginIsolated: true })).toBe(false);
+    expect(isolationSupported({ crossOriginIsolated: true, SharedArrayBuffer: undefined })).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of the **launch readiness** series (split out of #279).

First-load resilience for the Hacker News crowd:
- Friendly explanatory message when the browser lacks cross-origin isolation / `SharedArrayBuffer` (instead of a bare "WASM failed") — common in in-app browsers / privacy modes.
- **WebGL context-loss recovery** in the viewport (no more silent black canvas).
- One-time dismissible **low-memory banner** (`navigator.deviceMemory ≤ 4`).

Cherry-picked onto current `main`; resolved a `main.ts` import conflict by adding only `isolationSupported` (not the autosave branch's `isQuotaError`, which this branch doesn't use).

- `npm run build` ✅ · `npm run test:unit` ✅ (incl. `isolation.test.ts`) · new e2e `startup-resilience.spec.ts`

https://claude.ai/code/session_01CnFPgrhZRBBrV4sYsGtxXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnFPgrhZRBBrV4sYsGtxXj)_