### PR TITLE
fix: drop stale paint when importing a new model

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2389,6 +2389,14 @@ async function main() {
   /** Drop an import wrapper for `components` into the current part: set the
    *  active imports, render, and save a version that carries the mesh data. */
   async function applyImportWrapper(components: ImportedMesh[], manifold: boolean): Promise<void> {
+    // Same reset as the other import chokepoints: an import wrapper replaces the
+    // part's geometry, so the previous part's regions can't survive (compose
+    // even rebuilds topology wholesale). Callers run preserveCurrentEditsIfNeeded
+    // first, so the painted version is already saved before we drop live paint —
+    // otherwise runCodeSync re-resolves stale regions onto the new mesh and locks
+    // the editor.
+    cancelVoxelPaintIfActive();
+    dropPaintState();
     const code = generateImportCode(components, { manifold });
     setActiveImports(components);
     setValue(code);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1605,10 +1605,43 @@ async function main() {
     return { sessionId: session.id };
   }
 
+  // Cancel an active voxel-paint session. Its live grid + per-triangle
+  // provenance map are bound to the OUTGOING code, so it must stop before we
+  // load or import different code — otherwise a later click/bake writes into the
+  // wrong model. Safe no-op when paint isn't active.
+  function cancelVoxelPaintIfActive(): void {
+    if (voxelPaint.isActive()) {
+      voxelPaint.deactivate();
+      syncVoxelPaintUI();
+    }
+  }
+
+  // Drop the outgoing target's paint state — color regions, the model-declared
+  // color underlay, and any in-flight subdivision worker job — then re-sync the
+  // editor lock. These live in module state the session/part layer doesn't own,
+  // so a fresh target (new session, new part, freshly imported model) must wipe
+  // them or it inherits the previous one's regions: the next runCodeSync
+  // re-resolves them onto the new mesh and the editor opens locked.
+  function dropPaintState(): void {
+    // Drop any in-flight subdivision worker job before clearing regions, so a
+    // late continuation can't stamp triangle ids onto regions that no longer
+    // exist (or overwrite the freshly-loaded mesh).
+    resetPaintWorkerState();
+    clearRegions();
+    clearModelColorRegions(); // model-declared underlay is module state too
+    syncLockState();
+  }
+
   // Import a raw code payload as a new session. Shared between file drop and the AI API.
   async function importCodePayload(code: string, language: Language, sessionName?: string): Promise<{ sessionId: string }> {
     if (language !== getActiveLanguage()) await switchLanguage(language);
     const session = await createSession(sessionName, language);
+    // A freshly imported model starts unpainted. Clear the previous session's
+    // live voxel paint and color regions before running, or runCodeSync
+    // re-resolves those stale regions onto the new mesh — e.g. a painted part's
+    // colors bleeding onto image→voxel art — and the editor opens locked.
+    cancelVoxelPaintIfActive();
+    dropPaintState();
     setValue(code);
     await runCodeSync(code);
     return { sessionId: session.id };
@@ -1624,6 +1657,11 @@ async function main() {
   async function importMeshPayload(mesh: ImportedMesh, sessionName: string, opts: { manifold: boolean; seedRegions?: SeedRegion[] } = { manifold: true }): Promise<{ sessionId: string }> {
     if (getActiveLanguage() !== 'manifold-js') await switchLanguage('manifold-js');
     const session = await createSession(sessionName, 'manifold-js');
+    // Fresh session: drop the previous model's paint before running the import
+    // wrapper (same reason as importCodePayload). seedRegions below are added
+    // AFTER this clear, so an imported colored mesh's own seeds survive.
+    cancelVoxelPaintIfActive();
+    dropPaintState();
     setActiveImports([mesh]);
     const code = generateImportCode([mesh], { manifold: opts.manifold });
     setValue(code);
@@ -2794,18 +2832,8 @@ async function main() {
   // Reset the editor to a blank starting point for a freshly created session.
   // Shared by the session bar's "+ New Session" button and the session modal's,
   // so both clear the previous session's code instead of leaving it behind.
-  // Reset the editor to a starter snippet, dropping stale paint state. Color
-  // regions live in module state that the session/part layer doesn't own, so a
-  // fresh target must clear them here — otherwise the new (unpainted) session or
-  // part inherits the previous one's regions and is born with a locked editor.
   function resetEditorToStarter(comment: string) {
-    // Drop any in-flight subdivision worker job before clearing regions, so a
-    // late continuation can't stamp triangle ids onto regions that no longer
-    // exist (or overwrite the freshly-loaded starter mesh).
-    resetPaintWorkerState();
-    clearRegions();
-    clearModelColorRegions(); // model-declared underlay is module state too
-    syncLockState();
+    dropPaintState();
     const freshCode = `// ${comment}\nconst { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);`;
     setValue(freshCode);
     runCode(freshCode);
@@ -3128,10 +3156,7 @@ async function main() {
     // live grid and provenance map are bound to the OUTGOING code, so a Bake
     // after navigation would write the wrong session's voxels into the new
     // editor. Also unlocks the editor and clears the floating panel.
-    if (voxelPaint.isActive()) {
-      voxelPaint.deactivate();
-      syncVoxelPaintUI();
-    }
+    cancelVoxelPaintIfActive();
     // Each version remembers the language it was authored in (per-version
     // since schema 1.8); fall back to the session-level hint, then to the
     // engine default. Lets a single session hold mixed JS + SCAD versions

--- a/tests/import-paint-reset.spec.ts
+++ b/tests/import-paint-reset.spec.ts
@@ -1,27 +1,65 @@
-import { test, expect } from 'playwright/test';
+import { test, expect, type Page } from 'playwright/test';
 
 // Regression: importing a fresh model must NOT inherit the previous painted
 // model's color regions.
 //
-// Color regions live in module state the session layer doesn't own. The import
-// chokepoints (importCodePayload / importMeshPayload) create a brand-new
-// session but used to leave that state untouched, so the next runCodeSync
-// re-resolved the old regions onto the freshly-imported mesh — a painted part's
-// colors bleeding onto image→voxel art — and the editor opened locked. The
-// fix drops paint state (dropPaintState() in src/main.ts) before running the
-// imported code. See the `for the image to voxel feature` bug report.
+// Color regions live in module state the session/part layer doesn't own. The
+// import chokepoints (importCodePayload / importMeshPayload / applyImportWrapper)
+// create or reseed a part but used to leave that state untouched, so the next
+// runCodeSync re-resolved the old regions onto the freshly-imported mesh — a
+// painted part's colors bleeding onto image→voxel art or an imported STL — and
+// the editor opened locked. The fix drops paint state (dropPaintState() in
+// src/main.ts) before running the imported code. See the
+// `for the image to voxel feature` bug report.
+
+/** A 10×10×10 binary-STL cube (12 triangles). Mirrors tests/import-target.spec.ts. */
+function buildCubeSTL(): Buffer {
+  const s = 5;
+  const v = [
+    [-s, -s, -s], [s, -s, -s], [s, s, -s], [-s, s, -s],
+    [-s, -s, s], [s, -s, s], [s, s, s], [-s, s, s],
+  ];
+  const faces = [
+    [v[0], v[2], v[1]], [v[0], v[3], v[2]],
+    [v[4], v[5], v[6]], [v[4], v[6], v[7]],
+    [v[0], v[1], v[5]], [v[0], v[5], v[4]],
+    [v[2], v[3], v[7]], [v[2], v[7], v[6]],
+    [v[0], v[4], v[7]], [v[0], v[7], v[3]],
+    [v[1], v[2], v[6]], [v[1], v[6], v[5]],
+  ];
+  const buf = new ArrayBuffer(84 + faces.length * 50);
+  const view = new DataView(buf);
+  view.setUint32(80, faces.length, true);
+  let off = 84;
+  for (const tri of faces) {
+    off += 12;
+    for (const vert of tri) {
+      view.setFloat32(off, vert[0], true); off += 4;
+      view.setFloat32(off, vert[1], true); off += 4;
+      view.setFloat32(off, vert[2], true); off += 4;
+    }
+    view.setUint16(off, 0, true); off += 2;
+  }
+  return Buffer.from(new Uint8Array(buf));
+}
+
+async function waitForEngine(page: Page) {
+  await page.goto('/editor');
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    undefined,
+    { timeout: 30_000 },
+  );
+}
 
 test.describe('import resets stale paint state', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/editor');
-    await page.waitForFunction(
-      () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
-      undefined,
-      { timeout: 30_000 },
-    );
+    // Suppress the first-visit tour so its backdrop doesn't eat the modal click.
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
   });
 
   test('image→voxel import drops a painted model’s regions and unlocks the editor', async ({ page }) => {
+    await waitForEngine(page);
     const result = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const pw = (window as any).partwright;
@@ -64,5 +102,42 @@ test.describe('import resets stale paint state', () => {
     expect(result.regionsAfter).toBe(0);
     expect(result.lockedAfter).toBe(false);
     expect(result.code).toContain('voxels.decode(');
+  });
+
+  test('STL "New part" import drops the previous part’s paint and unlocks the editor', async ({ page }) => {
+    await waitForEngine(page);
+
+    // Paint the current part: an in-memory region that also locks the editor.
+    const before = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('host');
+      await pw.runAndSave(`const { Manifold } = api; return Manifold.cube([10, 10, 10], true);`, 'base');
+      pw.paintFaces({ triangleIds: [0, 1], color: [0, 1, 0], name: 'green' });
+      return { regions: pw.listRegions().length, locked: !!document.getElementById('editor-lock-overlay') };
+    });
+    expect(before.regions).toBe(1);
+    expect(before.locked).toBe(true);
+
+    // Import an STL and route it to a brand-new part (→ applyImportWrapper).
+    await page.locator('#import-wrapper input[type="file"]').setInputFiles({
+      name: 'widget.stl',
+      mimeType: 'application/octet-stream',
+      buffer: buildCubeSTL(),
+    });
+    await page.getByRole('dialog').locator('[data-target="new-part"]').click();
+
+    // A second part appears, and the new part starts clean: no inherited paint.
+    await expect
+      .poll(() => page.evaluate(() => (window as unknown as { partwright: { listParts: () => unknown[] } }).partwright.listParts().length))
+      .toBe(2);
+    await expect
+      .poll(() => page.evaluate(() => (window as unknown as { partwright: { listRegions: () => unknown[] } }).partwright.listRegions().length))
+      .toBe(0);
+
+    // ...and the editor is no longer locked.
+    await expect(page.locator('#editor-lock-overlay')).toHaveCount(0);
+    const code = await page.evaluate(() => (window as unknown as { partwright: { getCode: () => string } }).partwright.getCode());
+    expect(code).toContain('Manifold.ofMesh(api.imports[0])');
   });
 });

--- a/tests/import-paint-reset.spec.ts
+++ b/tests/import-paint-reset.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from 'playwright/test';
+
+// Regression: importing a fresh model must NOT inherit the previous painted
+// model's color regions.
+//
+// Color regions live in module state the session layer doesn't own. The import
+// chokepoints (importCodePayload / importMeshPayload) create a brand-new
+// session but used to leave that state untouched, so the next runCodeSync
+// re-resolved the old regions onto the freshly-imported mesh — a painted part's
+// colors bleeding onto image→voxel art — and the editor opened locked. The
+// fix drops paint state (dropPaintState() in src/main.ts) before running the
+// imported code. See the `for the image to voxel feature` bug report.
+
+test.describe('import resets stale paint state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForFunction(
+      () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+      undefined,
+      { timeout: 30_000 },
+    );
+  });
+
+  test('image→voxel import drops a painted model’s regions and unlocks the editor', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+
+      // 1. Paint a manifold-js model so the region store + editor lock are live.
+      await pw.createSession('painted-cube');
+      await pw.runAndSave(`const { Manifold } = api; return Manifold.cube([10, 10, 10], true);`, 'v1');
+      const paint = pw.paintFaces({ triangleIds: [0, 1], color: [1, 0, 0], name: 'red' });
+      const regionsBefore = pw.listRegions().length;
+      const lockedBefore = !!document.getElementById('editor-lock-overlay');
+
+      // 2. Build a tiny opaque image and import it as voxels (→ importCodePayload).
+      const canvas = document.createElement('canvas');
+      canvas.width = 8;
+      canvas.height = 8;
+      const ctx = canvas.getContext('2d')!;
+      ctx.fillStyle = '#3366ff';
+      ctx.fillRect(0, 0, 8, 8);
+      const dataUrl = canvas.toDataURL('image/png');
+      const imported = await pw.importImageAsVoxels(dataUrl, { maxSize: 8 });
+
+      // 3. After import: no leftover regions, editor unlocked, voxel code loaded.
+      const regionsAfter = pw.listRegions().length;
+      const lockedAfter = !!document.getElementById('editor-lock-overlay');
+      const code = pw.getCode();
+      return { paint, regionsBefore, lockedBefore, imported, regionsAfter, lockedAfter, code };
+    });
+
+    // Painting created exactly one region and locked the editor...
+    expect(result.paint.error).toBeFalsy();
+    expect(result.regionsBefore).toBe(1);
+    expect(result.lockedBefore).toBe(true);
+
+    // ...the voxel import succeeded...
+    expect(result.imported.error).toBeFalsy();
+    expect(result.imported.voxelCount).toBeGreaterThan(0);
+
+    // ...and the freshly-imported voxel art starts clean: no inherited paint,
+    // editor unlocked, procedural voxel code in the editor.
+    expect(result.regionsAfter).toBe(0);
+    expect(result.lockedAfter).toBe(false);
+    expect(result.code).toContain('voxels.decode(');
+  });
+});


### PR DESCRIPTION
## Summary

When a painted model was loaded and the user then imported a new model — most visibly via **image→voxel** — the previous model's paint bled onto the freshly-imported art, and the editor opened locked. (Reported: *"for the image to voxel feature. If there was already a painted model loaded the paint is applied to the voxel art which is pretty confusing."*)

**Root cause:** color regions live in module-global state that the session/part layer doesn't own. The import chokepoints create/reseed a part but never cleared that state, so the subsequent `runCodeSync` re-resolves the stale regions onto the new mesh (`runCodeSync`'s "re-apply existing color regions" path) — stamping a painted part's colors onto the imported model — and `syncLockState` was never re-run, leaving the editor locked. This is the same cleanup that `loadVersionIntoEditor` (version navigation) and `resetEditorToStarter` / the manual "+ new part" button already do — the import paths were the gap.

## Changes (`src/main.ts`)

- Extract two helpers from the existing reset paths:
  - `cancelVoxelPaintIfActive()` — stops a live voxel-paint session bound to the outgoing code (was inline in `loadVersionIntoEditor`).
  - `dropPaintState()` — clears color regions + the model-color underlay + any in-flight subdivision job, then re-syncs the editor lock (was inline in `resetEditorToStarter`).
- Call both before running imported code at **all three import chokepoints**:
  - `importCodePayload` — image→voxel, `.vox`, and `.js`/`.scad`/recent-code imports (the reported bug).
  - `importMeshPayload` — STL/STEP "import as new session" + the sessionless path. Its `seedRegions` are added *after* the clear, so a colored mesh's own seeds still survive.
  - `applyImportWrapper` — the STL import-target paths into an existing session (**New part** / **Add to current part** / expendable starter). Each caller runs `preserveCurrentEditsIfNeeded()` first, so the outgoing painted version is already saved before the live paint is dropped.
- Refactor `resetEditorToStarter` and `loadVersionIntoEditor` to use the new helpers (behavior-preserving dedup).

## Test plan

- **New regression test** `tests/import-paint-reset.spec.ts`, two cases:
  - **image→voxel** (`importCodePayload`): paint a cube → import an image as voxels → assert no regions carry over, editor unlocks, voxel code loads.
  - **STL "New part"** (`applyImportWrapper`): paint the current part → import an STL as a new part → assert no regions carry over and the editor unlocks.
  - Both verified to **fail without the fix** (`regionsAfter` = 1) and **pass with it**.
- `npm run build` ✅ and `npm run test:unit` (411) ✅ on the merged state.
- Re-ran the affected e2e specs locally — `import-target` (3), `stl-import`, `voxel-paint` (6), `fork-color-carry` (8) — all green, confirming the refactor is behavior-preserving and colored-STL seeding still works.

## Review

An automated review pass over the diff confirmed the refactors are exactly behavior-preserving, `importMeshPayload` seedRegions survive the clear, and `dropPaintState`/`cancelVoxelPaintIfActive` are safe no-ops when nothing is painted. It surfaced the `applyImportWrapper` gap, which is now folded in (the third chokepoint above).

🤖 Generated with [Claude Code](https://claude.ai/code)