### PR TITLE
feat: refresh guided tour and add discoverable launch points

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2891,6 +2891,9 @@ async function main() {
     onOpenCatalog: () => { void showCatalogPage(); },
     onToggleDiagnostics: () => { toggleDiagnosticsPanel(); },
     onOpenSessionList: () => showSessionList(),
+    // The rail only renders inside the editor, so the tour's spotlight targets
+    // already exist — start it directly without re-navigating.
+    onStartTour: () => { resetTour(); startTour(); },
   });
 
   // Parts rail — IDE-style list of the session's parts.
@@ -3229,6 +3232,21 @@ async function main() {
     updateDocumentTitle({ page: 'editor' });
   }
 
+  // Launch the guided tour from an entry point outside the editor (the landing
+  // CTA or the help page button): the tour spotlights editor chrome, so make
+  // sure we're in the editor with a live session before it starts.
+  async function takeGuidedTour() {
+    updateAppHistory('/editor', 'push');
+    transitionToEditor();
+    await ensureEditorReady();
+    if (!getState().session) {
+      await createSession();
+      runCode(defaultCode);
+    }
+    resetTour();
+    startTour();
+  }
+
   async function ensureLandingPage() {
     if (!landingEl) {
       landingEl = await createLandingPage(overlayContainer, {
@@ -3236,6 +3254,7 @@ async function main() {
         onOpenHelp: () => showHelp(),
         onOpenCatalog: () => { void showCatalogPage(); },
         onOpenWhatsNew: () => showWhatsNewPage(),
+        onTakeTour: () => { void takeGuidedTour(); },
         onOpenSession: openSessionFromLanding,
         onLoadCatalogEntry: handleCatalogEntryLoad,
       });
@@ -3293,17 +3312,7 @@ async function main() {
             void syncEditorFromURL();
           }
         },
-        onStartTour: async () => {
-          updateAppHistory('/editor', 'push');
-          transitionToEditor();
-          await ensureEditorReady();
-          if (!getState().session) {
-            await createSession();
-            runCode(defaultCode);
-          }
-          resetTour();
-          startTour();
-        },
+        onStartTour: () => { void takeGuidedTour(); },
       });
     }
     overlayContainer.classList.remove('hidden');

--- a/src/ui/landing.ts
+++ b/src/ui/landing.ts
@@ -22,6 +22,8 @@ export interface LandingCallbacks {
   onOpenHelp: () => void;
   onOpenCatalog: () => void;
   onOpenWhatsNew: () => void;
+  /** Open the editor and launch the first-visit guided tour. */
+  onTakeTour: () => void;
   onOpenSession: (sessionId: string) => void;
   /** Load a single catalog entry straight into the editor as a fresh session. */
   onLoadCatalogEntry: (entry: CatalogManifestEntry, payload: ExportedSession) => void | Promise<void>;
@@ -129,6 +131,12 @@ function buildHero(callbacks: LandingCallbacks): HTMLElement {
   help.textContent = 'How does this work?';
   help.addEventListener('click', callbacks.onOpenHelp);
   ctas.appendChild(help);
+
+  const tour = document.createElement('button');
+  tour.className = 'px-6 py-2.5 rounded-lg bg-transparent hover:bg-zinc-800 text-zinc-400 text-sm font-medium transition-colors';
+  tour.textContent = 'Take the guided tour';
+  tour.addEventListener('click', callbacks.onTakeTour);
+  ctas.appendChild(tour);
 
   hero.appendChild(ctas);
 

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -43,6 +43,8 @@ export interface CreateLayoutOptions {
   onToggleDiagnostics?: () => void;
   /** Open the session switcher list (rail header action). */
   onOpenSessionList?: () => void;
+  /** Launch the first-visit guided tour (rail utility item). */
+  onStartTour?: () => void;
 }
 
 export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOptions = {}): LayoutElements {
@@ -193,11 +195,11 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   rail.appendChild(tabData);
 
   // === Bottom utility group ===
-  // Catalog, Settings (quality), Diagnostics, and Help move out of the top
-  // toolbar so it can slim down. `md:mt-auto` on the first item pushes the whole
-  // cluster to the bottom of the desktop rail. Element ids are preserved
-  // (btn-catalog, btn-quality, btn-diagnostics, btn-help, btn-ai) so the tour
-  // and existing tests keep finding them.
+  // Catalog, Settings (quality), Diagnostics, Help, Guided tour, and About move
+  // out of the top toolbar so it can slim down. `md:mt-auto` on the first item
+  // pushes the whole cluster to the bottom of the desktop rail. Element ids are
+  // preserved (btn-catalog, btn-quality, btn-diagnostics, btn-help, btn-tour,
+  // btn-about, btn-ai) so the tour and existing tests keep finding them.
   const railActionClass = 'flex items-center gap-2 shrink-0 whitespace-nowrap px-3 py-2.5 md:py-2 text-sm md:text-[13px] font-medium text-zinc-400 border-b-2 md:border-b-0 border-transparent [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-800/60 transition-colors';
   const makeAction = (id: string, icon: string, label: string, onClick: () => void): HTMLButtonElement => {
     const b = document.createElement('button');
@@ -233,6 +235,14 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   });
   helpNavBtn.title = 'Help';
 
+  // Guided tour — explicit entry point to (re)play the spotlight walkthrough.
+  // Sits between Help and About so it reads as part of the "learn the app"
+  // cluster. The first-visit tour fires automatically; this lets users start
+  // it again on demand.
+  const tourNavBtn = makeAction('btn-tour', '🧭', 'Guided tour', () => opts.onStartTour?.());
+  tourNavBtn.title = 'Take the guided tour of the editor';
+  tourNavBtn.setAttribute('aria-label', 'Take the guided tour');
+
   // About — build/version info (commit, branch, links) for verifying which
   // Cloudflare branch/PR deploy you're testing.
   const aboutNavBtn = makeAction(
@@ -260,6 +270,7 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   rail.appendChild(qualityNavBtn);
   rail.appendChild(diagNavBtn);
   rail.appendChild(helpNavBtn);
+  rail.appendChild(tourNavBtn);
   rail.appendChild(aboutNavBtn);
   rail.appendChild(aiNavBtn);
 

--- a/src/ui/tour.ts
+++ b/src/ui/tour.ts
@@ -14,14 +14,14 @@ const STEPS: TourStep[] = [
     target: '#editor-container',
     title: 'Code Editor',
     description:
-      'Write code to create 3D geometry using primitives, booleans, and transforms. Supports JavaScript (manifold-3d API) and OpenSCAD (.scad). When an AI agent is driving, it writes and updates code here automatically.',
+      'Write code to create 3D geometry using primitives, booleans, and transforms. Partwright speaks four modeling languages, plus signed-distance fields (api.sdf) and customizer parameters (api.params) you can tune from a panel. When an AI agent is driving, it writes and updates code here automatically.',
     placement: 'right',
   },
   {
     target: '#lang-toggle',
-    title: 'Language Toggle',
+    title: 'Modeling Engine',
     description:
-      'Switch between JavaScript and OpenSCAD. Your draft in each language is preserved when you flip, and saved versions remember the engine they were authored in.',
+      'Pick the engine: JS (manifold-3d mesh), SCAD (OpenSCAD), BREP (replicad / OpenCASCADE — exact fillets, chamfers, and STEP export), or VOXEL (blocky colored cubes). Your draft in each language is preserved when you flip, and the “?” beside the toggle explains which engine fits your part.',
     placement: 'bottom',
   },
   {
@@ -46,10 +46,17 @@ const STEPS: TourStep[] = [
     placement: 'left',
   },
   {
+    target: '#measure-toggle',
+    title: 'Measure & Cross-Section',
+    description:
+      'Inspect a model without changing it: 📏 Measure the distance between two points, and ✂ Cross Section slices through it with a draggable plane. The same toolbar toggles the grid, bounding-box dimensions, and orbit lock.',
+    placement: 'left',
+  },
+  {
     target: '#paint-toggle',
     title: 'Paint Colors',
     description:
-      'Paint coplanar regions of the model in color for multi-color 3D prints (exported via 3MF or OBJ). Painting locks the version read-only until you unlock it; the AI can paint too when its Paint scope is on.',
+      'Paint coplanar regions for multi-color 3D prints (exported via 3MF or OBJ). Surface-following geodesic and airbrush brushes follow curvature, you can label and paint regions by name from code, and voxel models paint cube-by-cube. Painting locks the version read-only until you unlock it.',
     placement: 'left',
   },
   {
@@ -58,6 +65,13 @@ const STEPS: TourStep[] = [
     description:
       'Reduce a dense model’s triangle count to a target budget — great for shrinking imported STLs or heavy booleans. Set a target, click Apply to run it, then save the result as a new version.',
     placement: 'left',
+  },
+  {
+    target: '#parts-rail',
+    title: 'Multi-Part Sessions',
+    description:
+      'Hold several objects in one session — each part keeps its own code, versions, and preview. Select multiple parts to merge them into one or bulk-delete, and import external meshes as separate parts.',
+    placement: 'right',
   },
   {
     target: '#session-bar',
@@ -71,6 +85,13 @@ const STEPS: TourStep[] = [
     title: 'Reference Images',
     description:
       'Attach photos or renderings the model should match. Each image is tagged with an angle (front, right, etc.) and shown next to the matching elevation view for visual comparison.',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tab="Diff"]',
+    title: 'Compare Versions',
+    description:
+      'Open the Diff tab to compare any two versions side by side — both the code and the geometry stats — so you can see exactly what changed between iterations.',
     placement: 'bottom',
   },
   {
@@ -88,30 +109,38 @@ const STEPS: TourStep[] = [
     placement: 'bottom',
   },
   {
+    target: '#btn-quality',
+    title: 'Settings & Shortcuts',
+    description:
+      'Settings tunes curve quality — bump it to the Ultra tier for ultra-smooth exports. Press ⌘K / Ctrl+K anytime for the command palette, and ? for the keyboard shortcut cheat sheet (where you can also retake this tour).',
+    placement: 'right',
+  },
+  {
     target: '#btn-catalog',
     title: 'Catalog',
     description:
       'Browse a catalog of premade models. Open one as a starting point and tweak the code yourself — or hand it to the AI to remix.',
-    placement: 'bottom',
+    placement: 'right',
   },
   {
     target: '#import-wrapper',
     title: 'Import',
     description:
-      'Import an .stl mesh, a .js / .scad source file, or a full .partwright.json session. Imported meshes render right away and can be edited or combined with new geometry.',
+      'Import an .stl or .step mesh, a .js / .scad source file, a .vox model, or a full .partwright.json session. You can also turn an image into a printable relief, keychain, or tile — or into a colored voxel model — straight from the Import menu.',
     placement: 'bottom',
   },
   {
     target: '#export-wrapper',
     title: 'Export',
-    description: 'Download your model as GLB, STL, OBJ, or 3MF for 3D printing or other tools.',
+    description:
+      'Download your model as GLB, STL, OBJ, or 3MF for printing — plus STEP from BREP sessions for mechanical CAD. “Share link…” creates a read-only link anyone can preview and fork, with nothing uploaded.',
     placement: 'bottom',
   },
   {
     target: '#btn-ai',
     title: 'AI Chat',
     description:
-      'Chat with an AI to build and refine models for you. Use Anthropic, OpenAI, or Google Gemini with your own key — or run a model entirely in your browser with WebGPU, no key needed. Budget presets and the Thinking pill tune cost vs. quality, and the review button gets a second opinion from another provider.',
+      'Chat with an AI to build and refine models for you, in a docked, resizable panel. Use Anthropic, OpenAI, or Google Gemini with your own key — or run a model entirely in your browser with WebGPU, no key needed. Budget presets and the Thinking pill tune cost vs. quality, and the review button gets a second opinion from another provider.',
     placement: 'bottom',
   },
 ];
@@ -128,7 +157,7 @@ export function maybeStartTour(): void {
   if (localStorage.getItem(STORAGE_KEY)) return;
 
   const params = new URLSearchParams(window.location.search);
-  if (params.has('view') || params.has('session') || params.has('gallery') || params.has('versions') || params.has('images') || params.has('notes')) return;
+  if (params.has('view') || params.has('session') || params.has('gallery') || params.has('versions') || params.has('images') || params.has('diff') || params.has('notes') || params.has('data')) return;
 
   setTimeout(() => startTour(), 800);
 }

--- a/src/ui/tour.ts
+++ b/src/ui/tour.ts
@@ -112,7 +112,7 @@ const STEPS: TourStep[] = [
     target: '#btn-quality',
     title: 'Settings & Shortcuts',
     description:
-      'Settings tunes curve quality — bump it to the Ultra tier for ultra-smooth exports. Press ⌘K / Ctrl+K anytime for the command palette, and ? for the keyboard shortcut cheat sheet (where you can also retake this tour).',
+      'Settings tunes curve quality — bump it to the Ultra tier for ultra-smooth exports. Press ⌘K / Ctrl+K anytime for the command palette (where you can also retake this tour), and ? for the keyboard shortcut cheat sheet.',
     placement: 'right',
   },
   {

--- a/tests/tour-entry-points.spec.ts
+++ b/tests/tour-entry-points.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from 'playwright/test';
+
+// The guided tour can be (re)launched explicitly from two discoverable entry
+// points: a "Take the guided tour" CTA on the landing page, and a "Guided tour"
+// item (#btn-tour) in the editor's activity rail. (It also auto-starts on a
+// first visit — suppressed here so we exercise the buttons, not the auto-start.)
+
+test.describe('Guided tour entry points', () => {
+  test('rail button (#btn-tour) starts the tour in the editor', async ({ page }) => {
+    // Suppress the automatic first-visit tour so the only thing that can open
+    // the overlay is our click. The rail button resets + restarts regardless.
+    await page.addInitScript(() => {
+      try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+    });
+
+    await page.goto('/editor');
+    const tourBtn = page.locator('#btn-tour');
+    await expect(tourBtn).toBeVisible();
+    // Auto-start is suppressed, so no overlay until we click.
+    await expect(page.locator('.tour-tooltip')).toHaveCount(0);
+
+    await tourBtn.click();
+
+    const tooltip = page.locator('.tour-tooltip');
+    await expect(tooltip).toBeVisible({ timeout: 30000 });
+    await expect(tooltip).toContainText('Code Editor');
+    await expect(tooltip.getByRole('button', { name: 'Next' })).toBeVisible();
+
+    // Skip tears the overlay down.
+    await tooltip.getByRole('button', { name: 'Skip' }).click();
+    await expect(page.locator('.tour-tooltip')).toHaveCount(0);
+  });
+
+  test('landing CTA opens the editor and starts the tour', async ({ page }) => {
+    await page.goto('/');
+    const cta = page.getByRole('button', { name: 'Take the guided tour' });
+    await expect(cta).toBeVisible();
+
+    await cta.click();
+
+    // It routes into the editor and launches the tour there.
+    await expect(page).toHaveURL(/\/editor/, { timeout: 30000 });
+    const tooltip = page.locator('.tour-tooltip');
+    await expect(tooltip).toBeVisible({ timeout: 30000 });
+    await expect(tooltip).toContainText('Code Editor');
+  });
+});


### PR DESCRIPTION
## Summary

The first-visit guided tour had two problems: its content was **out of date** (it still described a two-language JS/OpenSCAD app), and it was **hard to relaunch** — only reachable from the ⌘K palette and a buried button on the Help page. This PR fixes both.

### 1. Refresh the tour content (15 → 19 steps)

The "Language Toggle" step only mentioned JS/OpenSCAD even though the toolbar now offers a **4-way JS / SCAD / BREP / VOXEL** control, and several shipped features had no step at all. No selectors were broken (`layout.ts` deliberately preserves the `data-tab` values and rail IDs "so the tour keeps finding them"), so this is a content refresh:

**Rewritten/refreshed steps**
- **Modeling Engine** (was "Language Toggle") — all four engines (JS / SCAD / BREP / VOXEL) + the per-engine "?" help.
- **Code Editor** — adds SDF (`api.sdf`) and customizer params (`api.params`).
- **Paint Colors** — geodesic + airbrush brushes, paint-by-name, voxel painting.
- **Import** — `.step` / `.vox`, the image→relief/keychain/tile wizard, image→voxel.
- **Export** — STEP (BREP sessions) + the "Share link…" read-only fork links.
- **AI Chat** — notes the docked, resizable panel.

**New steps** — Measure & Cross-Section (`#measure-toggle`), Multi-Part Sessions (`#parts-rail`), Compare Versions (`[data-tab="Diff"]`), Settings & Shortcuts (`#btn-quality` — quality/Ultra, ⌘K palette, `?` cheat sheet).

**Guard fix** — `maybeStartTour()` now also skips the first-run tour on `?diff` / `?data` deep links, matching `getViewState()`.

### 2. Add two discoverable ways to launch the tour

- **Landing page** — a "Take the guided tour" CTA beside "How does this work?". It opens the editor (creating a session if needed) and then starts the tour.
- **Activity rail** — a "Guided tour" item (`#btn-tour`, 🧭) between Help and About.

The landing CTA and the existing Help-page button now share one `takeGuidedTour()` helper (open editor → ensure session → start tour). The rail button starts the tour directly since its spotlight targets already exist in the editor.

### Notes
- The customizer `params-panel` is deliberately **not** a spotlight target — it's `hidden` by default, and the tour only checks element existence, not visibility, so a hidden target would render a 0×0 spotlight. It's described in the Code Editor step instead.
- All new targets verified visible & unconditionally rendered in the default first-visit `/editor` state.

## Test plan

- [x] `npm run build` — clean (no TypeScript errors)
- [x] `npm run test:unit` — 398 passed
- [x] New `tests/tour-entry-points.spec.ts` — both tests pass locally (rail button + landing CTA each open the tour)
- [ ] Full e2e shards green in CI
- [ ] Manual: from the landing page click "Take the guided tour" → lands in editor with the tour open; in the editor, the rail "Guided tour" item (between Help and About) reopens it

https://claude.ai/code/session_01VAbCwFmUgVJQosUQi58FH2