### PR TITLE
fix: re-import .vox files from Recent Imports as voxel sessions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2576,6 +2576,33 @@ async function main() {
         openReliefImportFlow(file, savedOpts);
         return;
       }
+      // VOX re-imports rebuild the voxel session from the original bytes via the
+      // same handler as a fresh import. The .vox blob is binary, so the code
+      // fall-through below (which reads it as text and opens it as manifold-js)
+      // dumped garbage into the editor and never switched to the voxel language.
+      if (entry.source === 'VOX') {
+        const cur = getState();
+        if (cur.session && cur.versionCount > 0) {
+          const ok = await showInlineConfirm(
+            editorUI,
+            `Re-import "${entry.filename}" as a new session? Your current session will be kept.`,
+          );
+          if (!ok) return;
+        }
+        const file = new File([entry.blob], entry.filename, { type: entry.blob.type });
+        await handleVoxImport(file);
+        return;
+      }
+      // STEP re-imports reopen the BREP-vs-tessellated-mesh target modal, same as
+      // a fresh STEP import; the code fall-through below would import the raw STEP
+      // text as manifold-js source.
+      if (entry.source === 'STEP') {
+        const file = new File([entry.blob], entry.filename, { type: entry.blob.type });
+        await handleStepImport(file);
+        return;
+      }
+      // Remaining sources are raw code (JS / SCAD): read the blob as text and
+      // open it as a new session in the matching language.
       const cur = getState();
       if (cur.session && cur.versionCount > 0) {
         const ok = await showInlineConfirm(

--- a/tests/voxel-engine.spec.ts
+++ b/tests/voxel-engine.spec.ts
@@ -8,6 +8,51 @@ import { test, expect } from 'playwright/test';
 // run would error) — so these assertions are the real-WASM proof the mesher is
 // correct. Also exercises the image → voxel import through the DOM decode path.
 
+/** Hand-build a tiny binary MagicaVoxel .vox (MAIN > SIZE + XYZI, default
+ *  palette) so the .vox re-import test needs no fixture file. Mirrors the
+ *  byte layout in tests/unit/vox.test.ts. */
+function buildVoxBlob(): Buffer {
+  const size = { x: 2, y: 2, z: 1 };
+  const voxels = [
+    { x: 0, y: 0, z: 0, i: 1 },
+    { x: 1, y: 0, z: 0, i: 1 },
+    { x: 0, y: 1, z: 0, i: 1 },
+  ];
+
+  const sizeChunk = new Uint8Array(24);
+  const sdv = new DataView(sizeChunk.buffer);
+  sizeChunk.set([0x53, 0x49, 0x5a, 0x45]); // "SIZE"
+  sdv.setUint32(4, 12, true);
+  sdv.setUint32(12, size.x, true);
+  sdv.setUint32(16, size.y, true);
+  sdv.setUint32(20, size.z, true);
+
+  const xyziContent = 4 + voxels.length * 4;
+  const xyziChunk = new Uint8Array(12 + xyziContent);
+  const xdv = new DataView(xyziChunk.buffer);
+  xyziChunk.set([0x58, 0x59, 0x5a, 0x49]); // "XYZI"
+  xdv.setUint32(4, xyziContent, true);
+  xdv.setUint32(12, voxels.length, true);
+  voxels.forEach((v, k) => {
+    const off = 16 + k * 4;
+    xyziChunk[off] = v.x; xyziChunk[off + 1] = v.y; xyziChunk[off + 2] = v.z; xyziChunk[off + 3] = v.i;
+  });
+
+  const childrenBytes = sizeChunk.length + xyziChunk.length;
+  const mainChunk = new Uint8Array(12);
+  mainChunk.set([0x4d, 0x41, 0x49, 0x4e]); // "MAIN"
+  new DataView(mainChunk.buffer).setUint32(8, childrenBytes, true);
+
+  const header = new Uint8Array(8);
+  header.set([0x56, 0x4f, 0x58, 0x20]); // "VOX "
+  new DataView(header.buffer).setUint32(4, 150, true);
+
+  const out = new Uint8Array(header.length + mainChunk.length + childrenBytes);
+  let off = 0;
+  for (const chunk of [header, mainChunk, sizeChunk, xyziChunk]) { out.set(chunk, off); off += chunk.length; }
+  return Buffer.from(out);
+}
+
 test.describe('voxel engine', () => {
   test.beforeEach(async ({ page }) => {
     // Dismiss the product tour up front so its backdrop can't intercept the
@@ -59,6 +104,45 @@ test.describe('voxel engine', () => {
     await recent.click();
     await expect(page.getByText('Image → Voxel', { exact: true })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Make a part from an image', { exact: true })).toHaveCount(0);
+  });
+
+  test('re-importing a .vox file from Recent Imports reopens it as a voxel session', async ({ page }) => {
+    // Reads { language, editor code } from the live partwright API in one hop.
+    const readState = () => page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { getActiveLanguage(): string; getCode(): string } }).partwright;
+      return { lang: pw.getActiveLanguage(), code: pw.getCode() };
+    });
+
+    // Import a real binary .vox through the shared file input → voxel session.
+    await page.locator('#import-wrapper input[type="file"]').first()
+      .setInputFiles({ name: 'cube.vox', mimeType: 'application/octet-stream', buffer: buildVoxBlob() });
+
+    // It lands as a voxel session whose code rebuilds the grid via voxels.decode(...).
+    // Poll on the code (not the language): importCodePayload flips the engine
+    // language before it sets the editor buffer, so the code is the reliable
+    // "import finished" signal.
+    await expect.poll(async () => (await readState()).code, { timeout: 10_000 }).toContain('voxels.decode');
+    expect((await readState()).lang).toBe('voxel');
+
+    // Switch to a manifold-js buffer so the re-import has to switch the language
+    // BACK — proving the re-click does the full voxel-import flow, not a no-op.
+    await page.evaluate(() => (window as unknown as { partwright: { setActiveLanguage(l: string): Promise<void> } })
+      .partwright.setActiveLanguage('manifold-js'));
+    await expect.poll(async () => (await readState()).lang).toBe('manifold-js');
+
+    // Re-click the VOX entry in Recent Imports (no version saved yet, so no
+    // "keep current session?" confirm fires).
+    await page.locator('#btn-import').click();
+    const recent = page.locator('#import-recent-list button', { hasText: 'cube.vox' }).first();
+    await expect(recent).toBeVisible();
+    await expect(recent.getByText('VOX', { exact: true })).toBeVisible();
+    await recent.click();
+
+    // The regression: it switches BACK to the voxel language and rebuilds the grid
+    // via voxels.decode(...). Before the fix it stayed on manifold-js with the raw
+    // binary .vox bytes read as text and dumped into the editor as garbage.
+    await expect.poll(async () => (await readState()).code, { timeout: 10_000 }).toContain('voxels.decode');
+    expect((await readState()).lang).toBe('voxel');
   });
 
   test('switching to voxel renders a watertight, colored, manifold mesh', async ({ page }) => {


### PR DESCRIPTION
## Summary

Importing a `.vox` file works, but **re-importing it by clicking its entry in the Recent Imports list** did not switch to the voxel language — it dumped garbage into the code editor.

**Root cause:** `handleReimportInboxEntry` (`src/main.ts`) has explicit branches for `JSON`, `STL`, `IMAGE`/`SVG`, but `VOX` (and `STEP`) fell through to the bottom block that does `await entry.blob.text()` + `importCodePayload(code, 'manifold-js', …)`. A `.vox` file is **binary**, so reading it as text produced raw bytes (`VOX␀ MAIN … SIZE … XYZI …`) in the editor and opened a `manifold-js` session instead of a voxel one. (`STEP` had the same latent defect — the raw STEP text was imported as `manifold-js` source.)

**Fix:** Route `VOX` and `STEP` re-imports through the same handlers a fresh import uses, by reconstructing a `File` from the stored blob (mirroring how the `STL` branch already works):

- `VOX` → `handleVoxImport(file)` → rebuilds the voxel session via `voxels.decode(...)` and switches to the voxel language.
- `STEP` → `handleStepImport(file)` → reopens the BREP-vs-tessellated-mesh target modal.

The remaining fall-through now handles only raw-code sources (`JS` / `SCAD`), which is exactly what its `entry.source === 'SCAD' ? 'scad' : 'manifold-js'` logic and `/\.(js|scad)$/i` name-strip already assumed.

## Test plan

- [x] `npm run build` (tsc + vite) — clean
- [x] `npm run test:unit` — 406 passing
- [x] `npx playwright test tests/voxel-engine.spec.ts` — 14 passing (incl. the new test)
- [x] New e2e regression test `re-importing a .vox file from Recent Imports reopens it as a voxel session`: imports a hand-built binary `.vox`, switches away to `manifold-js`, then re-imports from Recent Imports and asserts the language switches **back** to `voxel` with `voxels.decode(...)` code.
- [x] Verified the test **fails without the fix** — the editor receives the raw `VOX␀ MAIN … XYZI …` bytes as text (the exact reported garbage).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01RsNpjgnqbzbE8kTukfdDvE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsNpjgnqbzbE8kTukfdDvE)_