### PR TITLE
fix: show correct modeling language in session import preview

### DIFF
--- a/src/ui/importPreview.ts
+++ b/src/ui/importPreview.ts
@@ -2,65 +2,17 @@
 // it to IndexedDB. Built on the shared modalShell so Escape, click-outside,
 // and listener cleanup behave identically to the other AI / export dialogs.
 
-import type { ExportedSession } from '../storage/sessionManager';
 import { createModalShell } from './modalShell';
 import { BUTTON_PRIMARY, BUTTON_CANCEL } from './styleConstants';
 import { escapeHtml } from './htmlUtils';
+import { languageBadge } from './languageBadge';
+import { summarizeSessionImport, type SessionImportSummary } from './importSummary';
 
-export interface SessionImportSummary {
-  sessionName: string;
-  schemaVersion: string;
-  versionCount: number;
-  noteCount: number;
-  annotationCount: number;
-  referenceSides: string[];
-  language: string;
-  createdAt: number | null;
-  updatedAt: number | null;
-}
-
-/** Build a SessionImportSummary from a parsed .partwright.json payload. */
-export function summarizeSessionImport(data: ExportedSession): SessionImportSummary {
-  // Build a list of image labels for the import preview. Handle three shapes:
-  //   - current: array of {id, src, label?}
-  //   - pre-unification: array of {id, angle, src, label?} — fall back to angle
-  //   - pre-array: object map {front: 'url', ...} — use the keys
-  // Items with no label and no angle are listed as "(unlabeled)".
-  const imgs = data.session.images ?? data.session.referenceImages ?? null;
-  const referenceSides: string[] = [];
-  if (Array.isArray(imgs)) {
-    for (const item of imgs) {
-      const it = item as { label?: string; angle?: string };
-      const label = (it.label ?? '').trim() || (it.angle ? it.angle : '');
-      referenceSides.push(label || '(unlabeled)');
-    }
-  } else if (imgs && typeof imgs === 'object') {
-    for (const k of ['front', 'right', 'back', 'left', 'top', 'perspective'] as const) {
-      if ((imgs as Record<string, unknown>)[k]) referenceSides.push(k);
-    }
-  }
-  // Annotations live per-version since schema 1.3, but 1.2 files put them at
-  // the top level. Sum across both locations so the preview is accurate
-  // regardless of which schema the file was exported with. Versions can be
-  // absent for chat/notes-only exports — fall back to an empty list.
-  const versions = Array.isArray(data.versions) ? data.versions : [];
-  const perVersionAnnotations = versions.reduce(
-    (sum, v) => sum + (v.annotations?.length ?? 0),
-    0,
-  );
-  const topLevelAnnotations = data.annotations?.length ?? 0;
-  return {
-    sessionName: data.session.name || '(unnamed)',
-    schemaVersion: data.partwright ?? data.mainifold ?? 'unknown',
-    versionCount: versions.length,
-    noteCount: data.notes?.length ?? 0,
-    annotationCount: perVersionAnnotations + topLevelAnnotations,
-    referenceSides,
-    language: data.session.language ?? 'manifold-js',
-    createdAt: data.session.created ?? null,
-    updatedAt: data.session.updated ?? null,
-  };
-}
+// The pure summary logic lives in the DOM-free importSummary module so it can
+// be unit-tested without pulling in modalShell/document. Re-exported here so
+// existing importers (main.ts) keep a single import site for the feature.
+export { summarizeSessionImport };
+export type { SessionImportSummary };
 
 function formatTimestamp(ts: number | null): string {
   if (!ts) return '—';
@@ -113,7 +65,10 @@ export function showImportPreview(filename: string, summary: SessionImportSummar
       grid.appendChild(v);
     }
     addRow('Versions', String(summary.versionCount));
-    addRow('Language', summary.language);
+    addRow(
+      summary.languages.length > 1 ? 'Languages' : 'Language',
+      summary.languages.map((l) => languageBadge(l).label).join(', '),
+    );
     addRow('Notes', String(summary.noteCount));
     addRow('Annotations', String(summary.annotationCount));
     addRow('Reference images', summary.referenceSides.length ? summary.referenceSides.join(', ') : 'none');

--- a/src/ui/importSummary.ts
+++ b/src/ui/importSummary.ts
@@ -1,0 +1,95 @@
+// Pure summarization of a `.partwright.json` payload for the import-preview
+// modal. Kept DOM-free (no modalShell/document/escapeHtml imports) so the
+// logic — especially modeling-language resolution — can be unit-tested
+// directly, mirroring how languageFallback.ts was split out.
+
+import type { ExportedSession } from '../storage/sessionManager';
+import { effectiveVersionLanguage, asLanguage, type Language } from '../storage/languageFallback';
+
+export interface SessionImportSummary {
+  sessionName: string;
+  schemaVersion: string;
+  versionCount: number;
+  noteCount: number;
+  annotationCount: number;
+  referenceSides: string[];
+  /**
+   * Distinct modeling languages present across the file's versions, in
+   * first-seen order. Each is resolved through the per-version → session →
+   * default fallback chain (the same one openSession uses), then sanitized so
+   * a junk on-disk value can't leak through. A session created as manifold-js
+   * and later switched to another engine per-version (e.g. voxel) carries the
+   * engine on `versions[].language`, NOT at the session level — so this
+   * resolves to ['voxel'], matching the engine the editor lands on after
+   * import. Reading `session.language` alone (the old behavior) wrongly
+   * reported "manifold-js" for those sessions.
+   */
+  languages: Language[];
+  createdAt: number | null;
+  updatedAt: number | null;
+}
+
+/** Build a SessionImportSummary from a parsed .partwright.json payload. */
+export function summarizeSessionImport(data: ExportedSession): SessionImportSummary {
+  // Build a list of image labels for the import preview. Handle three shapes:
+  //   - current: array of {id, src, label?}
+  //   - pre-unification: array of {id, angle, src, label?} — fall back to angle
+  //   - pre-array: object map {front: 'url', ...} — use the keys
+  // Items with no label and no angle are listed as "(unlabeled)".
+  const imgs = data.session.images ?? data.session.referenceImages ?? null;
+  const referenceSides: string[] = [];
+  if (Array.isArray(imgs)) {
+    for (const item of imgs) {
+      const it = item as { label?: string; angle?: string };
+      const label = (it.label ?? '').trim() || (it.angle ? it.angle : '');
+      referenceSides.push(label || '(unlabeled)');
+    }
+  } else if (imgs && typeof imgs === 'object') {
+    for (const k of ['front', 'right', 'back', 'left', 'top', 'perspective'] as const) {
+      if ((imgs as Record<string, unknown>)[k]) referenceSides.push(k);
+    }
+  }
+  // Annotations live per-version since schema 1.3, but 1.2 files put them at
+  // the top level. Sum across both locations so the preview is accurate
+  // regardless of which schema the file was exported with. Versions can be
+  // absent for chat/notes-only exports — fall back to an empty list.
+  const versions = Array.isArray(data.versions) ? data.versions : [];
+  const perVersionAnnotations = versions.reduce(
+    (sum, v) => sum + (v.annotations?.length ?? 0),
+    0,
+  );
+  const topLevelAnnotations = data.annotations?.length ?? 0;
+
+  // Resolve the modeling language(s). The old code read only
+  // `data.session.language`, which is stale for sessions that were created as
+  // manifold-js and later switched to another engine per-version (the engine
+  // is recorded on versions[].language, not at the session level). Resolve
+  // each version through the canonical fallback chain — sanitizing both inputs
+  // through asLanguage so a junk on-disk value (e.g. "python") can't leak —
+  // and collect the distinct set in first-seen order.
+  const sessionLanguage = asLanguage(data.session.language);
+  const languages: Language[] = [];
+  for (const v of versions) {
+    const lang = effectiveVersionLanguage(
+      { language: asLanguage(v.language) },
+      { language: sessionLanguage },
+    );
+    if (!languages.includes(lang)) languages.push(lang);
+  }
+  // No versions (chat/notes-only export): fall back to the session-level hint.
+  if (languages.length === 0) {
+    languages.push(effectiveVersionLanguage(null, { language: sessionLanguage }));
+  }
+
+  return {
+    sessionName: data.session.name || '(unnamed)',
+    schemaVersion: data.partwright ?? data.mainifold ?? 'unknown',
+    versionCount: versions.length,
+    noteCount: data.notes?.length ?? 0,
+    annotationCount: perVersionAnnotations + topLevelAnnotations,
+    referenceSides,
+    languages,
+    createdAt: data.session.created ?? null,
+    updatedAt: data.session.updated ?? null,
+  };
+}

--- a/tests/unit/import-summary.test.ts
+++ b/tests/unit/import-summary.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeSessionImport } from '../../src/ui/importSummary';
+import type { ExportedSession } from '../../src/storage/sessionManager';
+
+type V = ExportedSession['versions'][number];
+
+/** Build a single exported version, optionally tagged with a language and a
+ *  count of (dummy) annotations. `language` accepts junk on purpose so we can
+ *  exercise the sanitize-on-read path. */
+function version(language?: string, annotationCount = 0): V {
+  return {
+    label: 'v',
+    code: 'return 1;',
+    timestamp: 0,
+    ...(language ? { language: language as V['language'] } : {}),
+    ...(annotationCount
+      ? { annotations: Array.from({ length: annotationCount }, () => ({})) as unknown as V['annotations'] }
+      : {}),
+  };
+}
+
+/** Build a minimal ExportedSession payload, overriding only what a test cares
+ *  about. */
+function payload(over: {
+  partwright?: string;
+  mainifold?: string;
+  session?: Partial<ExportedSession['session']>;
+  notes?: ExportedSession['notes'];
+  versions?: ExportedSession['versions'];
+  annotations?: ExportedSession['annotations'];
+} = {}): ExportedSession {
+  const { session, versions, ...rest } = over;
+  return {
+    partwright: '1.8',
+    session: { name: 'Test', created: 1, updated: 2, ...session },
+    versions: versions ?? [],
+    ...rest,
+  };
+}
+
+describe('summarizeSessionImport — language resolution', () => {
+  it('reports the per-version language even when the session-level field is absent (the voxel bug)', () => {
+    // A session created as manifold-js and switched to voxel carries the
+    // engine on versions[].language, not at the session level.
+    const summary = summarizeSessionImport(payload({ versions: [version('voxel'), version('voxel')] }));
+    expect(summary.languages).toEqual(['voxel']);
+  });
+
+  it('prefers the per-version language over a stale session-level language', () => {
+    const summary = summarizeSessionImport(
+      payload({ session: { language: 'manifold-js' }, versions: [version('voxel')] }),
+    );
+    expect(summary.languages).toEqual(['voxel']);
+  });
+
+  it('collects distinct languages across mixed-engine versions in first-seen order', () => {
+    const summary = summarizeSessionImport(
+      payload({ versions: [version(), version('voxel')] }),
+    );
+    // version() has no language ⇒ falls back to session (absent) ⇒ default.
+    expect(summary.languages).toEqual(['manifold-js', 'voxel']);
+  });
+
+  it('de-dups repeated languages while preserving order', () => {
+    const summary = summarizeSessionImport(
+      payload({ versions: [version('scad'), version('replicad'), version('scad')] }),
+    );
+    expect(summary.languages).toEqual(['scad', 'replicad']);
+  });
+
+  it('falls back to the session-level language when there are no versions', () => {
+    const summary = summarizeSessionImport(payload({ session: { language: 'voxel' }, versions: [] }));
+    expect(summary.languages).toEqual(['voxel']);
+  });
+
+  it('falls back to manifold-js when neither version nor session carries a language', () => {
+    const summary = summarizeSessionImport(payload({ versions: [] }));
+    expect(summary.languages).toEqual(['manifold-js']);
+  });
+
+  it('sanitizes a junk on-disk language, falling through to the session level', () => {
+    const summary = summarizeSessionImport(
+      payload({ session: { language: 'voxel' }, versions: [version('python')] }),
+    );
+    expect(summary.languages).toEqual(['voxel']);
+  });
+
+  it('sanitizes a junk on-disk language down to the default when nothing else applies', () => {
+    const summary = summarizeSessionImport(payload({ versions: [version('python')] }));
+    expect(summary.languages).toEqual(['manifold-js']);
+  });
+});
+
+describe('summarizeSessionImport — other fields', () => {
+  it('summarizes the core counts and metadata', () => {
+    const summary = summarizeSessionImport(
+      payload({
+        session: { name: 'My Part' },
+        notes: [{}, {}] as unknown as ExportedSession['notes'],
+        versions: [version('voxel', 2), version('voxel', 1)],
+      }),
+    );
+    expect(summary.sessionName).toBe('My Part');
+    expect(summary.versionCount).toBe(2);
+    expect(summary.noteCount).toBe(2);
+    expect(summary.annotationCount).toBe(3); // 2 + 1 per-version
+    expect(summary.schemaVersion).toBe('1.8');
+  });
+
+  it('falls back to "(unnamed)" and the legacy mainifold schema field', () => {
+    const summary = summarizeSessionImport(
+      payload({ partwright: undefined, mainifold: '1.2', session: { name: '' } }),
+    );
+    expect(summary.sessionName).toBe('(unnamed)');
+    expect(summary.schemaVersion).toBe('1.2');
+  });
+
+  it('counts top-level (schema 1.2) annotations alongside per-version ones', () => {
+    const summary = summarizeSessionImport(
+      payload({
+        versions: [version('manifold-js', 1)],
+        annotations: [{}, {}] as unknown as ExportedSession['annotations'],
+      }),
+    );
+    expect(summary.annotationCount).toBe(3); // 1 per-version + 2 top-level
+  });
+});


### PR DESCRIPTION
## Summary

Importing a recently-exported **voxel** session showed **"manifold-js"** as the Language in the import preview modal, even though the import then correctly switched the editor to voxel.

**Root cause:** `summarizeSessionImport` read only the *session-level* field (`data.session.language ?? 'manifold-js'`). But a session created as the default manifold-js and later switched to another engine records the engine **per-version** on `versions[].language`, leaving `session.language` absent/manifold-js. The real import path (`openSession`) lands on the latest version and resolves its *effective* language (`effectiveVersionLanguage` -> per-version -> session -> default), which is why it correctly "switched to voxel" -- but the preview never consulted the per-version field, so it reported the stale session-level value.

**Fix:** resolve the language(s) the same way `openSession` does -- per-version -> session -> default -- sanitizing both inputs through `asLanguage` so a junk on-disk value (e.g. `"python"`) can't leak through. Collect the **distinct set** across all versions (so mixed-engine sessions are represented), and render them with the app's friendly language labels (JS / SCAD / BREP / VOXEL) via `languageBadge`, matching the toolbar and gallery badges. The row pluralizes to "Languages" when more than one engine is present.

The pure summary logic moves into a new DOM-free `src/ui/importSummary.ts` module (re-exported from `importPreview.ts`, so `main.ts`'s import site is unchanged) so it can be unit-tested directly -- mirroring how `languageFallback.ts` was split out.

## Changes
- `src/ui/importSummary.ts` (new) -- `SessionImportSummary` + `summarizeSessionImport`, now resolving `languages: Language[]` via the effective-language chain.
- `src/ui/importPreview.ts` -- import/re-export from the new module; render friendly labels (pluralized for mixed sessions).
- `tests/unit/import-summary.test.ts` (new) -- covers the voxel bug, per-version-over-session precedence, mixed/de-duped sets, no-versions fallback, junk-value sanitization, and the other summary fields.

## Test plan
- [x] `npm run build` (tsc type-check + vite build) -- green
- [x] `npm run test:unit` -- 417 passed across 26 files (11 new in `import-summary.test.ts`)
- [x] Cloudflare Pages preview -- deploy successful
- [ ] e2e shards (fired on ready-for-review)
- [ ] Manual: export a voxel session -> JSON, re-import, confirm the preview's Language row reads **VOXEL** (not manifold-js); confirm a plain manifold-js session reads **JS** and a mixed session lists both.

https://claude.ai/code/session_015WuSriKkm2vf82MRcpG2qP