### PR TITLE
feat: persist recent imports/exports across refresh

### DIFF
--- a/src/export/exportInbox.ts
+++ b/src/export/exportInbox.ts
@@ -1,8 +1,17 @@
-// Recent-exports inbox: an in-memory ring buffer of the last N export blobs the
-// app produced. Both the toolbar (Recent Exports list) and the AI console API
-// read from this — so an export the human triggered remains downloadable and
-// inspectable without re-running the geometry.
+// Recent-exports inbox: a newest-first ring buffer of the last N export blobs
+// the app produced. Both the toolbar (Recent Exports list) and the AI console
+// API read from this — so an export the human triggered remains downloadable
+// and inspectable without re-running the geometry.
+//
+// The buffer lives in memory (so reads stay synchronous) but is mirrored to
+// IndexedDB on every mutation and rehydrated on boot, so the Recent Exports
+// list survives a page refresh. Persistence is best-effort: if IndexedDB is
+// unavailable the in-memory list still works for the session.
 
+import { applyInboxMutation, clearInboxStore, getInboxRecords } from '../storage/db';
+import { reconcileInbox } from '../storage/inboxBuffer';
+
+const STORE = 'exportInbox';
 const MAX_ENTRIES = 10;
 
 export interface ExportInboxEntry {
@@ -41,8 +50,14 @@ export function registerExport(
     timestamp: Date.now(),
   };
   entries.unshift(entry);
-  while (entries.length > MAX_ENTRIES) entries.pop();
+  const evicted: string[] = [];
+  while (entries.length > MAX_ENTRIES) {
+    const popped = entries.pop();
+    if (popped) evicted.push(popped.id);
+  }
   notify();
+  // Mirror to IndexedDB: persist the new entry, drop any overflowed id.
+  void applyInboxMutation(STORE, entry, evicted).catch(err => console.debug('exportInbox persist failed', err));
   return entry;
 }
 
@@ -61,6 +76,28 @@ export function clearExports(): void {
   if (entries.length === 0) return;
   entries.length = 0;
   notify();
+  void clearInboxStore(STORE).catch(err => console.debug('exportInbox clear failed', err));
+}
+
+/** Rehydrate the in-memory buffer from IndexedDB on boot so the Recent Exports
+ *  list survives a refresh. Safe to call once at startup; merges with anything
+ *  already registered this session and reconciles storage back to the cap. */
+export async function hydrateExportInbox(): Promise<void> {
+  let persisted: ExportInboxEntry[];
+  try {
+    persisted = await getInboxRecords<ExportInboxEntry>(STORE);
+  } catch (err) {
+    console.debug('exportInbox hydrate failed', err);
+    return;
+  }
+  if (persisted.length === 0) return;
+  const { merged, staleIds } = reconcileInbox(entries, persisted, MAX_ENTRIES);
+  entries.length = 0;
+  entries.push(...merged);
+  notify();
+  if (staleIds.length > 0) {
+    void applyInboxMutation(STORE, null, staleIds).catch(err => console.debug('exportInbox reconcile failed', err));
+  }
 }
 
 /** Subscribe to inbox changes. Returns an unsubscribe fn. */

--- a/src/import/importInbox.ts
+++ b/src/import/importInbox.ts
@@ -1,8 +1,17 @@
-// Recent-imports inbox: an in-memory ring buffer of the last N files the user
+// Recent-imports inbox: a newest-first ring buffer of the last N files the user
 // imported. Mirrors the Recent Exports inbox so the toolbar's Import dropdown
 // can offer one-click re-import. Holds the underlying Blob so a re-import does
 // not require the user to re-pick the file from disk.
+//
+// The buffer lives in memory (so reads stay synchronous) but is mirrored to
+// IndexedDB on every mutation and rehydrated on boot, so the Recent Imports
+// list survives a page refresh. Persistence is best-effort: if IndexedDB is
+// unavailable the in-memory list still works for the session.
 
+import { applyInboxMutation, clearInboxStore, getInboxRecords } from '../storage/db';
+import { reconcileInbox } from '../storage/inboxBuffer';
+
+const STORE = 'importInbox';
 const MAX_ENTRIES = 10;
 
 export type ImportSource = 'JSON' | 'JS' | 'SCAD' | 'STL' | 'STEP' | 'IMAGE' | 'VOX' | 'SVG';
@@ -59,8 +68,9 @@ function importKey(filename: string, metadata?: unknown): string {
  *  image with the same tweaks should leave the recent list tidy. */
 export function registerImport(blob: Blob, filename: string, source: ImportSource, metadata?: unknown, thumbnail?: string): ImportInboxEntry {
   const key = importKey(filename, metadata);
+  const evicted: string[] = [];
   const existingIdx = entries.findIndex(e => importKey(e.filename, e.metadata) === key);
-  if (existingIdx >= 0) entries.splice(existingIdx, 1);
+  if (existingIdx >= 0) evicted.push(entries.splice(existingIdx, 1)[0].id);
   const entry: ImportInboxEntry = {
     id: `imp_${Date.now().toString(36)}_${nextSeq++}`,
     blob,
@@ -72,8 +82,13 @@ export function registerImport(blob: Blob, filename: string, source: ImportSourc
     thumbnail,
   };
   entries.unshift(entry);
-  while (entries.length > MAX_ENTRIES) entries.pop();
+  while (entries.length > MAX_ENTRIES) {
+    const popped = entries.pop();
+    if (popped) evicted.push(popped.id);
+  }
   notify();
+  // Mirror to IndexedDB: drop the deduped/overflowed ids, persist the new entry.
+  void applyInboxMutation(STORE, entry, evicted).catch(err => console.debug('importInbox persist failed', err));
   return entry;
 }
 
@@ -92,6 +107,28 @@ export function clearImports(): void {
   if (entries.length === 0) return;
   entries.length = 0;
   notify();
+  void clearInboxStore(STORE).catch(err => console.debug('importInbox clear failed', err));
+}
+
+/** Rehydrate the in-memory buffer from IndexedDB on boot so the Recent Imports
+ *  list survives a refresh. Safe to call once at startup; merges with anything
+ *  already registered this session and reconciles storage back to the cap. */
+export async function hydrateImportInbox(): Promise<void> {
+  let persisted: ImportInboxEntry[];
+  try {
+    persisted = await getInboxRecords<ImportInboxEntry>(STORE);
+  } catch (err) {
+    console.debug('importInbox hydrate failed', err);
+    return;
+  }
+  if (persisted.length === 0) return;
+  const { merged, staleIds } = reconcileInbox(entries, persisted, MAX_ENTRIES);
+  entries.length = 0;
+  entries.push(...merged);
+  notify();
+  if (staleIds.length > 0) {
+    void applyInboxMutation(STORE, null, staleIds).catch(err => console.debug('importInbox reconcile failed', err));
+  }
 }
 
 /** Subscribe to inbox changes. Returns an unsubscribe fn. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,10 +72,12 @@ import {
   getExport as getInboxExport,
   clearExports as clearInboxExports,
   registerExport as registerInboxExport,
+  hydrateExportInbox,
 } from './export/exportInbox';
 import {
   registerImport,
   classifyImportSource,
+  hydrateImportInbox,
   type ImportInboxEntry,
   type ImportMetadata,
 } from './import/importInbox';
@@ -1546,6 +1548,13 @@ async function main() {
 
   // Apply persisted theme before any UI renders
   initTheme();
+
+  // Rehydrate the Recent Imports / Recent Exports lists from IndexedDB so they
+  // survive a refresh. Fire-and-forget: each notifies its subscribers (the
+  // toolbar dropdowns) when the load completes, so boot isn't blocked on IDB
+  // and the order relative to toolbar mount doesn't matter.
+  void hydrateImportInbox();
+  void hydrateExportInbox();
 
   // Remove loading splash as soon as JS takes over
   document.getElementById('loading-splash')?.remove();

--- a/src/storage/dataInventory.ts
+++ b/src/storage/dataInventory.ts
@@ -4,9 +4,9 @@
 
 import { openPartwrightDB } from './db';
 
-export type StoreName = 'sessions' | 'versions' | 'parts' | 'notes' | 'aiKeys' | 'aiChats' | 'aiAttachments';
+export type StoreName = 'sessions' | 'versions' | 'parts' | 'notes' | 'aiKeys' | 'aiChats' | 'aiAttachments' | 'importInbox' | 'exportInbox';
 
-export const ALL_STORES: StoreName[] = ['sessions', 'versions', 'parts', 'notes', 'aiKeys', 'aiChats', 'aiAttachments'];
+export const ALL_STORES: StoreName[] = ['sessions', 'versions', 'parts', 'notes', 'aiKeys', 'aiChats', 'aiAttachments', 'importInbox', 'exportInbox'];
 
 export const STORE_LABELS: Record<StoreName, string> = {
   sessions: 'Sessions',
@@ -16,6 +16,8 @@ export const STORE_LABELS: Record<StoreName, string> = {
   aiKeys: 'AI API keys',
   aiChats: 'AI chat messages',
   aiAttachments: 'Image attachments',
+  importInbox: 'Recent imports',
+  exportInbox: 'Recent exports',
 };
 
 function reqToPromise<T>(req: IDBRequest<T>): Promise<T> {
@@ -171,7 +173,9 @@ async function clearModelCaches(): Promise<void> {
  *  in-memory state is rebuilt from the now-empty stores. */
 export async function wipeData(sel: WipeSelection): Promise<void> {
   const stores: StoreName[] = [];
-  if (sel.modelingData) stores.push('sessions', 'versions', 'parts', 'notes');
+  // The Recent Imports / Exports lists cache imported & exported model files,
+  // so they ride along with the modeling-data category (and thus a full wipe).
+  if (sel.modelingData) stores.push('sessions', 'versions', 'parts', 'notes', 'importInbox', 'exportInbox');
   if (sel.chats) stores.push('aiChats');
   if (sel.apiKeys) stores.push('aiKeys');
   if (sel.attachments) stores.push('aiAttachments');

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -132,7 +132,7 @@ const DB_NAME = 'partwright';
 const LEGACY_DB_NAME = 'mainifold';
 const LEGACY_MIGRATION_KEY = 'partwright-migrated-mainifold-db';
 const PARTS_MIGRATION_KEY = 'partwright-migrated-parts';
-const DB_VERSION = 7;
+const DB_VERSION = 8;
 
 /** Opens the partwright IndexedDB. Exposed so the AI subsystem can attach
  *  its own stores (`aiKeys`, `aiChats`) without duplicating the connection. */
@@ -218,6 +218,19 @@ function openDB(): Promise<IDBDatabase> {
       // the session-delete cascade can drop it with a direct key delete.
       if (!db.objectStoreNames.contains('reliefSources')) {
         db.createObjectStore('reliefSources', { keyPath: 'sessionId' });
+      }
+      // v8: persisted recent-imports / recent-exports inboxes. Each holds the
+      // last N files the user imported / exported (with the underlying Blob) so
+      // the toolbar's Recent lists survive a page refresh. The newest-first
+      // order and the 10-entry cap are enforced by the in-memory ring buffers
+      // (src/import/importInbox.ts, src/export/exportInbox.ts) — these stores
+      // just mirror each mutation. Keyed by the entry id so a dedupe/overflow
+      // eviction maps to a direct key delete.
+      if (!db.objectStoreNames.contains('importInbox')) {
+        db.createObjectStore('importInbox', { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains('exportInbox')) {
+        db.createObjectStore('exportInbox', { keyPath: 'id' });
       }
     };
     req.onsuccess = () => {
@@ -977,5 +990,52 @@ export async function deleteReliefSourceRecord(sessionId: string): Promise<void>
   if (!db.objectStoreNames.contains('reliefSources')) return;
   const txn = db.transaction('reliefSources', 'readwrite');
   txn.objectStore('reliefSources').delete(sessionId);
+  await txComplete(txn);
+}
+
+// === Recent-imports / recent-exports inboxes (persisted ring buffers) ===
+//
+// Storage primitives for the import/export inboxes. The ring-buffer semantics
+// (dedupe, newest-first ordering, 10-entry cap) live in the inbox modules;
+// db.ts only mirrors the resulting mutations to IndexedDB so the lists survive
+// a refresh. Records are stored by their `id` and carry a Blob (structured-
+// clone handles it). Stores only exist from v8, so every accessor guards on
+// `objectStoreNames.contains` like the v7 reliefSources accessors above.
+
+export type InboxStore = 'importInbox' | 'exportInbox';
+
+/** All persisted entries for an inbox, used to rehydrate the in-memory buffer
+ *  on boot. Order isn't guaranteed by IndexedDB; the caller re-sorts. */
+export async function getInboxRecords<T>(store: InboxStore): Promise<T[]> {
+  const db = await openDB();
+  if (!db.objectStoreNames.contains(store)) return [];
+  const txn = db.transaction(store, 'readonly');
+  const records = await reqToPromise(txn.objectStore(store).getAll()) as T[];
+  await txComplete(txn);
+  return records;
+}
+
+/** Apply one ring-buffer mutation in a single transaction: drop the ids evicted
+ *  by a dedupe or overflow, then put the freshly-added entry. */
+export async function applyInboxMutation<T extends { id: string }>(
+  store: InboxStore,
+  put: T | null,
+  deleteIds: string[],
+): Promise<void> {
+  const db = await openDB();
+  if (!db.objectStoreNames.contains(store)) return;
+  const txn = db.transaction(store, 'readwrite');
+  const os = txn.objectStore(store);
+  for (const id of deleteIds) os.delete(id);
+  if (put) os.put(put);
+  await txComplete(txn);
+}
+
+/** Empty an inbox store (backs the toolbar's "Clear" action). */
+export async function clearInboxStore(store: InboxStore): Promise<void> {
+  const db = await openDB();
+  if (!db.objectStoreNames.contains(store)) return;
+  const txn = db.transaction(store, 'readwrite');
+  txn.objectStore(store).clear();
   await txComplete(txn);
 }

--- a/src/storage/inboxBuffer.ts
+++ b/src/storage/inboxBuffer.ts
@@ -1,0 +1,47 @@
+// Pure ring-buffer reconciliation shared by the recent-imports and
+// recent-exports inboxes. Both keep an in-memory, newest-first, capped buffer
+// that's mirrored to IndexedDB; on boot they merge whatever was persisted back
+// into memory. That merge is identical for both, so it lives here as a pure
+// function (no IndexedDB, no DOM) — which also makes it unit-testable.
+
+export interface InboxItem {
+  id: string;
+  timestamp: number;
+}
+
+export interface ReconcileResult<T> {
+  /** The buffer to keep in memory: newest-first, deduped by id, capped. */
+  merged: T[];
+  /** Persisted ids that didn't survive the merge/cap and should be evicted
+   *  from storage so IndexedDB stays in sync with (and bounded like) memory. */
+  staleIds: string[];
+}
+
+/**
+ * Merge persisted entries back into the in-memory buffer during hydration.
+ *
+ * - Entries already in memory win over persisted ones with the same id (a fresh
+ *   register that raced boot keeps its newer copy).
+ * - The union is sorted newest-first and truncated to `cap`.
+ * - Any persisted id that falls outside the capped result is reported in
+ *   `staleIds` so the caller can delete it (keeps storage bounded even if the
+ *   cap shrank between releases, or an overflow eviction was missed).
+ */
+export function reconcileInbox<T extends InboxItem>(
+  inMemory: T[],
+  persisted: T[],
+  cap: number,
+): ReconcileResult<T> {
+  const byId = new Map<string, T>();
+  for (const e of inMemory) byId.set(e.id, e);
+  for (const e of persisted) if (!byId.has(e.id)) byId.set(e.id, e);
+
+  const merged = [...byId.values()]
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, Math.max(0, cap));
+
+  const keptIds = new Set(merged.map(e => e.id));
+  const staleIds = persisted.filter(e => !keptIds.has(e.id)).map(e => e.id);
+
+  return { merged, staleIds };
+}

--- a/src/ui/dataExplorer.ts
+++ b/src/ui/dataExplorer.ts
@@ -50,6 +50,8 @@ function recordLabel(store: StoreName, rec: Record<string, unknown>): string {
     case 'aiKeys': return String(rec.provider ?? '');
     case 'aiChats': return `${String(rec.role ?? '?')} · ${truncate(blocksToText(rec.blocks), 50)}`;
     case 'aiAttachments': return String(rec.label || rec.mediaType || rec.id || '');
+    case 'importInbox':
+    case 'exportInbox': return `${String(rec.source ?? '')} · ${String(rec.filename ?? rec.id ?? '')}`.trim();
   }
 }
 

--- a/tests/inbox-persistence.spec.ts
+++ b/tests/inbox-persistence.spec.ts
@@ -1,0 +1,98 @@
+// The Recent Imports / Recent Exports lists used to be in-memory only, so a
+// page refresh wiped them. They're now mirrored to IndexedDB and rehydrated on
+// boot. These tests import / export something, reload the page, and assert the
+// entry is still there (and, for exports, still re-downloadable from its
+// persisted Blob).
+
+import { test, expect } from 'playwright/test';
+
+/** Wait until the console API is attached (`window.partwright.run` exists). */
+async function waitForApp(page: import('playwright/test').Page): Promise<void> {
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    undefined,
+    { timeout: 30_000 },
+  );
+}
+
+test.describe('recent imports/exports persist across reload', () => {
+  test.beforeEach(async ({ page }) => {
+    // Suppress the guided tour so its backdrop can't intercept toolbar clicks.
+    // addInitScript re-runs on reload, so the suppression survives the refresh.
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+    await page.goto('/editor');
+    await waitForApp(page);
+  });
+
+  test('Recent Imports survive a page refresh', async ({ page }) => {
+    // Import a small PNG through the shared file input → voxel modal → commit.
+    const dataUrl = await page.evaluate(() => {
+      const c = document.createElement('canvas');
+      c.width = 8; c.height = 8;
+      const x = c.getContext('2d')!;
+      x.fillStyle = '#3399ff'; x.fillRect(0, 0, 8, 8);
+      return c.toDataURL('image/png');
+    });
+    const buffer = Buffer.from(dataUrl.split(',')[1], 'base64');
+
+    await page.locator('#import-wrapper input[type="file"]').first()
+      .setInputFiles({ name: 'logo.png', mimeType: 'image/png', buffer });
+
+    await expect(page.getByText('Image → Voxel', { exact: true })).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: 'Import', exact: true }).click();
+
+    // It lands in Recent Imports.
+    await page.locator('#btn-import').click();
+    await expect(page.locator('#import-recent-list button', { hasText: 'logo.png' }).first())
+      .toBeVisible({ timeout: 10_000 });
+
+    // Refresh — the in-memory inbox is gone, so this only passes if it
+    // rehydrated from IndexedDB.
+    await page.reload();
+    await waitForApp(page);
+
+    await page.locator('#btn-import').click();
+    await expect(page.locator('#import-recent-list button', { hasText: 'logo.png' }).first())
+      .toBeVisible({ timeout: 10_000 });
+  });
+
+  test('Recent Exports survive a page refresh and stay re-downloadable', async ({ page }) => {
+    // Swallow the browser downloads the export triggers so nothing hangs.
+    page.on('download', (d) => { void d.path().catch(() => {}); });
+
+    // The starter part renders a box; wait for the engine to be Ready so
+    // exportSTL has a current mesh to serialize.
+    await page.waitForSelector('text=Ready', { timeout: 30_000 });
+
+    // Trigger an STL export; retry until the inbox records it (guards against a
+    // race where the first call lands before the initial mesh is set). The
+    // hidden list's children update on every inbox change, so counting them
+    // works without opening the dropdown.
+    await expect.poll(async () => {
+      if (await page.locator('#export-recent-list button').count() === 0) {
+        await page.evaluate(() => {
+          (window as unknown as { partwright?: { exportSTL?: () => void } }).partwright?.exportSTL?.();
+        });
+      }
+      return page.locator('#export-recent-list button').count();
+    }, { timeout: 20_000 }).toBeGreaterThan(0);
+
+    await page.locator('#btn-export').click();
+    const before = page.locator('#export-recent-list button', { hasText: 'STL' }).first();
+    await expect(before).toBeVisible({ timeout: 10_000 });
+
+    // Refresh and confirm the export is still listed.
+    await page.reload();
+    await waitForApp(page);
+
+    await page.locator('#btn-export').click();
+    const after = page.locator('#export-recent-list button', { hasText: 'STL' }).first();
+    await expect(after).toBeVisible({ timeout: 10_000 });
+
+    // The persisted Blob is intact: re-clicking the entry re-downloads it.
+    const downloadPromise = page.waitForEvent('download', { timeout: 10_000 });
+    await after.click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.stl$/i);
+  });
+});

--- a/tests/unit/inboxBuffer.test.ts
+++ b/tests/unit/inboxBuffer.test.ts
@@ -1,0 +1,65 @@
+// Unit tests for the pure ring-buffer reconciliation shared by the recent-
+// imports and recent-exports inboxes (src/storage/inboxBuffer.ts). No browser
+// or IndexedDB — just the merge/cap/dedupe/eviction math that runs on boot.
+
+import { describe, test, expect } from 'vitest';
+import { reconcileInbox, type InboxItem } from '../../src/storage/inboxBuffer';
+
+const item = (id: string, timestamp: number): InboxItem => ({ id, timestamp });
+
+describe('reconcileInbox', () => {
+  test('on a fresh boot, returns persisted entries newest-first', () => {
+    const persisted = [item('a', 100), item('b', 300), item('c', 200)];
+    const { merged, staleIds } = reconcileInbox([], persisted, 10);
+    expect(merged.map(e => e.id)).toEqual(['b', 'c', 'a']);
+    expect(staleIds).toEqual([]);
+  });
+
+  test('caps the result and reports the overflow as stale', () => {
+    const persisted = [item('a', 1), item('b', 2), item('c', 3), item('d', 4)];
+    const { merged, staleIds } = reconcileInbox([], persisted, 2);
+    // Newest two survive; the older two are evicted from storage.
+    expect(merged.map(e => e.id)).toEqual(['d', 'c']);
+    expect(staleIds.sort()).toEqual(['a', 'b']);
+  });
+
+  test('in-memory entries win over persisted ones with the same id', () => {
+    const inMemory = [{ id: 'a', timestamp: 999 }];
+    const persisted = [item('a', 100), item('b', 200)];
+    const { merged } = reconcileInbox(inMemory, persisted, 10);
+    const a = merged.find(e => e.id === 'a');
+    expect(a?.timestamp).toBe(999); // the live copy, not the stale persisted one
+    expect(merged.map(e => e.id)).toEqual(['a', 'b']); // 999 > 200, so a is first
+  });
+
+  test('merges a registered-during-boot entry with persisted ones', () => {
+    const inMemory = [item('new', 500)];
+    const persisted = [item('old1', 100), item('old2', 200)];
+    const { merged, staleIds } = reconcileInbox(inMemory, persisted, 10);
+    expect(merged.map(e => e.id)).toEqual(['new', 'old2', 'old1']);
+    expect(staleIds).toEqual([]);
+  });
+
+  test('keeps the freshest across both sources when capping', () => {
+    const inMemory = [item('live', 50)]; // oldest overall
+    const persisted = [item('p1', 100), item('p2', 200)];
+    const { merged, staleIds } = reconcileInbox(inMemory, persisted, 2);
+    expect(merged.map(e => e.id)).toEqual(['p2', 'p1']);
+    // 'live' didn't make the cap and isn't persisted; only persisted ids that
+    // were dropped count as stale, so nothing to evict from storage here.
+    expect(staleIds).toEqual([]);
+  });
+
+  test('empty persisted is a no-op (no stale evictions)', () => {
+    const { merged, staleIds } = reconcileInbox([item('a', 1)], [], 10);
+    expect(merged.map(e => e.id)).toEqual(['a']);
+    expect(staleIds).toEqual([]);
+  });
+
+  test('a zero cap evicts every persisted id', () => {
+    const persisted = [item('a', 1), item('b', 2)];
+    const { merged, staleIds } = reconcileInbox([], persisted, 0);
+    expect(merged).toEqual([]);
+    expect(staleIds.sort()).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Summary

The toolbar's **Recent Imports** and **Recent Exports** lists were in-memory ring buffers (`const entries = []`), so a page refresh wiped them. This persists both lists to IndexedDB and rehydrates them on boot, so they survive a refresh. The existing 10-entry cap is preserved (and now bounds the persisted stores too).

The design keeps the **synchronous in-memory API as the read path** — every existing caller (`listImports`/`listExports`/`getImport`/`getExport`, the toolbar subscriptions, the AI console API) is unchanged. IndexedDB is a write-through persistence layer plus a boot-time hydrate.

### What changed
- **`src/storage/db.ts`** — bump `DB_VERSION` 7 → 8 with a purely **additive** `onupgradeneeded` block creating two id-keyed stores (`importInbox`, `exportInbox`). Adds generic, guarded accessors `getInboxRecords` / `applyInboxMutation` / `clearInboxStore` (same `objectStoreNames.contains` guarding as the v7 `reliefSources` accessors).
- **`src/storage/inboxBuffer.ts`** (new) — pure, unit-tested `reconcileInbox()` that merges persisted entries back into the in-memory buffer on boot (in-memory wins on id collision, newest-first, capped, reports stale ids to evict). Shared by both inboxes to avoid duplicating the hydration logic.
- **`src/import/importInbox.ts` / `src/export/exportInbox.ts`** — write through to IndexedDB on `register` (persist the new entry, delete the deduped/overflowed ids in one transaction) and on `clear`; add `hydrateImportInbox()` / `hydrateExportInbox()`. Persistence is **best-effort** — every write is `void …catch(console.debug)`, so quota/private-mode failures degrade gracefully and the in-memory list still works for the session. The stored entries carry the underlying `Blob`, so re-import / re-download work after a reload.
- **`src/main.ts`** — fire-and-forget `hydrateImportInbox()` / `hydrateExportInbox()` early in boot. Each `notify()`s its toolbar subscribers when the load finishes, so the order relative to toolbar mount doesn't matter.
- **`src/storage/dataInventory.ts` / `src/ui/dataExplorer.ts`** — surface the two stores in the **Data** tab (count + drill-down with a Blob-size summary) and clear them under the modeling-data / full wipe, so a "Start fresh" doesn't orphan persisted blobs. They're intentionally left out of the per-session `deleteSession` cascade and `clearAllData` (clear-all-sessions), matching how the other global recent cache, `aiAttachments`, is treated.

### Backwards compatibility
The v8 upgrade only **adds** two empty stores — no existing store, index, or the legacy/parts migrations are touched, so old sessions/versions/parts load unchanged. Older DB connections (e.g. during another tab's upgrade) are guarded by `objectStoreNames.contains`.

## Test plan
- `npm run build` — clean (tsc type-check passes).
- `npm run test:unit` — 418 pass, including the new **`tests/unit/inboxBuffer.test.ts`** (7 cases: fresh-boot order, cap + stale eviction, id-collision precedence, boot-race merge, zero cap).
- New e2e **`tests/inbox-persistence.spec.ts`** (2 cases) — import a PNG → it appears in Recent Imports → **reload** → still there; export STL → it appears in Recent Exports → **reload** → still there **and** the persisted Blob re-downloads on click. Both pass locally.
- Re-ran adjacent existing suites locally: `tests/voxel-engine.spec.ts`, `tests/stl-import.spec.ts`, `tests/smoke.spec.ts` — 30 pass (the DB-version bump touches every page load).

https://claude.ai/code/session_01LFnAHwK5k131iAeTGCzNQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFnAHwK5k131iAeTGCzNQa)_