### PR TITLE
fix: make language help modal wider and scrollable

### DIFF
--- a/src/ui/languageHelpModal.ts
+++ b/src/ui/languageHelpModal.ts
@@ -71,6 +71,13 @@ export function showLanguageHelpModal(): Promise<void> {
   return new Promise((resolve) => {
     const shell = createModalShell({
       title: 'Pick a modeling language',
+      // Wider than the default 'md' so the four engine cards get room to
+      // breathe (and wrap less) on roomy screens, while `w-full` still lets
+      // it shrink to fit a phone. `scrollable` caps the height at the
+      // viewport and lets the body scroll instead of overflowing off-screen
+      // on short windows — the cards are taller than many laptop screens.
+      maxWidth: '2xl',
+      scrollable: true,
       onClose: () => resolve(),
     });
 
@@ -123,11 +130,14 @@ export function showLanguageHelpModal(): Promise<void> {
       shell.body.appendChild(wrapper);
     }
 
+    // Dismiss button lives in the shell's pinned footer (not the scrolling
+    // body) so it stays reachable without scrolling to the bottom of a long,
+    // scrollable card list.
     const closeBtn = document.createElement('button');
     closeBtn.type = 'button';
-    closeBtn.className = 'mt-2 px-3 py-1.5 rounded text-sm font-medium transition-colors bg-zinc-700 hover:bg-zinc-600 text-zinc-100';
+    closeBtn.className = 'px-3 py-1.5 rounded text-sm font-medium transition-colors bg-zinc-700 hover:bg-zinc-600 text-zinc-100';
     closeBtn.textContent = 'Got it';
     closeBtn.addEventListener('click', () => shell.close());
-    shell.body.appendChild(closeBtn);
+    shell.footer.appendChild(closeBtn);
   });
 }

--- a/src/ui/modalShell.ts
+++ b/src/ui/modalShell.ts
@@ -37,6 +37,20 @@ let modalSeq = 0;
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
+// Full, literal Tailwind class names per width. The scanner only emits classes
+// it sees as complete literal strings in source, so building this with
+// `max-w-${opts.maxWidth}` interpolation left the class invisible to it — and
+// `max-w-2xl` (never written literally anywhere else) got purged from the CSS
+// entirely, so every `'2xl'` modal silently rendered uncapped at full width.
+// Mapping to literals here keeps all sizes — `'2xl'` included — in the build.
+const MAX_WIDTH_CLASS: Record<NonNullable<ModalShellOptions['maxWidth']>, string> = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+  xl: 'max-w-xl',
+  '2xl': 'max-w-2xl',
+};
+
 function focusableIn(root: HTMLElement): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
     .filter(el => el.offsetParent !== null || el === document.activeElement);
@@ -53,7 +67,7 @@ export function createModalShell(opts: ModalShellOptions): ModalShell {
   // Remember what was focused so we can restore it when the modal closes.
   const previouslyFocused = document.activeElement as HTMLElement | null;
 
-  const maxW = `max-w-${opts.maxWidth ?? 'md'}`;
+  const maxW = MAX_WIDTH_CLASS[opts.maxWidth ?? 'md'];
   const maxH = opts.scrollable ? 'max-h-[calc(100vh-2rem)]' : '';
   const overlayPad = opts.scrollable ? 'p-4' : '';
 

--- a/tests/language-help-modal.spec.ts
+++ b/tests/language-help-modal.spec.ts
@@ -32,11 +32,10 @@ test.describe('Language help modal', () => {
       await expect(modal.getByText(badge, { exact: true })).toBeVisible();
     }
 
-    // Dismiss via "Got it" button — dispatchEvent because the modal's
-    // content is taller than the viewport on the 1280×900 test profile,
-    // and Playwright's click() refuses to scroll a button-in-modal into
-    // view (see CLAUDE.md tip about dispatchEvent for clipped flex
-    // children).
+    // Dismiss via "Got it" button — it lives in the modal's pinned footer
+    // (the body scrolls; the footer doesn't), so it stays reachable on short
+    // screens. dispatchEvent per the CLAUDE.md convention for clicking
+    // buttons inside modals reliably.
     await modal.getByRole('button', { name: 'Got it' }).dispatchEvent('click');
     await expect(modal).toBeHidden();
   });


### PR DESCRIPTION
## Summary

The **"?" language-help modal** (the question-mark button next to the JS / SCAD / BREP / VOXEL language toggle in the toolbar) opened at the default narrow `md` width with **no height cap and no overflow handling**. With four detailed engine cards, an intro, and a button, it overflowed off the bottom of shorter screens — and there was no way to scroll down to reach the lower cards or the "Got it" button.

This PR makes the modal fit the screen, and fixes a shared-modal CSS bug that surfaced while doing so.

### 1. Language-help modal (`src/ui/languageHelpModal.ts`)
- **Wider by default** — opened at `maxWidth: '2xl'` (≈42rem) instead of the default `md`, matching the precedent for other dense informational modals (`reliefImportModal`, `aiCompactModal`, `aiSystemPromptModal`). The shell is still `w-full`, so on a phone it shrinks to fit the viewport rather than forcing a fixed width.
- **Scrollable on short screens** — `scrollable: true` caps the modal height at `calc(100vh-2rem)` and lets the body scroll instead of running off-screen.
- **"Got it" button moved to the shell's pinned footer** (previously appended to the scrolling body, with the footer left empty) so it stays reachable without scrolling to the bottom of the card list.

No content, copy, or behavior of the cards themselves changed — only the modal's size/scroll layout.

### 2. Shared modal width bug (`src/ui/modalShell.ts`)
While verifying the change, an automated review pass found that `maxWidth: '2xl'` was a **no-op**. `createModalShell` built its width class via `` `max-w-${opts.maxWidth}` `` interpolation, but Tailwind v4's scanner only emits classes it sees as complete **literal** strings. `max-w-2xl` is never written literally anywhere in the source, so it was **purged from the CSS entirely** (verified: 0 occurrences in the built CSS, vs. 1 each for `sm/md/lg/xl` which appear literally elsewhere). The result: every `'2xl'` modal rendered uncapped at full width.

Fix: map each width to a full literal class name in `modalShell.ts` so all sizes survive the build. This is what makes the language-help modal's `2xl` actually take effect (a sane cap, not a full-width blowout), and **incidentally repairs four other modals** that were silently rendering full-width despite explicitly requesting `2xl`: the AI Call Log, Compact-conversation, AI system-prompt, and relief-import modals. After the fix, the built CSS contains `max-w-2xl` (and all five widths).

## Test plan

- [x] `npm run build` — passes; verified `max-w-2xl` now present in built CSS (was 0, now 1)
- [x] `npm run test:unit` — 452 passed
- [x] `tests/language-help-modal.spec.ts` (e2e) — passes locally with the combined change
- [x] **Full e2e shard 3 run locally — 99/99 passed**, confirming the shared `modalShell` change doesn't regress any modal-exercising test (share-link, simplify, versions, etc.). The earlier `e2e (3)` CI red did not reproduce locally and is unrelated to this branch — `language-help-modal.spec.ts` isn't even in shard 3 — so it was a flake; the re-push re-runs all shards.
- Manual: open `/editor`, click the **?** next to the language toggle. The modal is noticeably wider (capped ~42rem, not full-width) on a desktop window, scrolls within the viewport on a short window, and the "Got it" button stays pinned at the bottom.

https://claude.ai/code/session_01UHCHU8fg8TcEQo5WiyNg3c