### PR TITLE
fix: make GLB export bake all colors and unify export feedback

### DIFF
--- a/src/export/gltf.ts
+++ b/src/export/gltf.ts
@@ -1,7 +1,8 @@
 import * as THREE from 'three';
-import { getScene } from '../renderer/viewport';
+import { getScene, withExportColors } from '../renderer/viewport';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
 import { downloadBlob, getExportFilename } from './download';
+import type { MeshData } from '../geometry/types';
 
 export interface BuiltExport {
   blob: Blob;
@@ -62,8 +63,8 @@ function assertFiniteExportableScene(scene: THREE.Object3D): void {
 // malformed GLB. Since a broken export is far worse than a missing credit, we
 // leave GLB attribution out rather than fight the exporter.
 
-/** Build the GLB blob for the current scene without triggering a download. */
-export async function buildGLB(customName?: string): Promise<BuiltExport> {
+/** Serialize the live scene to a GLB blob, hiding non-exportable helpers first. */
+async function serializeSceneToGLB(customName?: string): Promise<BuiltExport> {
   const scene = getScene();
   const exporter = new GLTFExporter();
 
@@ -86,8 +87,25 @@ export async function buildGLB(customName?: string): Promise<BuiltExport> {
   }
 }
 
-export async function exportGLB(customName?: string): Promise<string> {
-  const built = await buildGLB(customName);
+/** Build the GLB blob for the current model without triggering a download.
+ *
+ *  Pass `coloredMesh` (the result of `applyTriColors(currentMeshData)`) so the
+ *  GLB bakes ALL color regions regardless of the viewport's paint-visibility
+ *  flags — matching OBJ/3MF export semantics. The live scene's coloring is
+ *  visibility-aware (`applyTriColorsIfVisible`), so without this the GLB would
+ *  silently drop painted colors whenever the paint toggle (or a per-region eye)
+ *  is off. When the mesh has no regions, `applyTriColors` returns it unchanged
+ *  and the swapped geometry matches the display, so the no-paint case is
+ *  unaffected. Omit `coloredMesh` to serialize the scene exactly as displayed. */
+export async function buildGLB(customName?: string, coloredMesh?: MeshData | null): Promise<BuiltExport> {
+  if (coloredMesh) {
+    return withExportColors(coloredMesh, () => serializeSceneToGLB(customName));
+  }
+  return serializeSceneToGLB(customName);
+}
+
+export async function exportGLB(customName?: string, coloredMesh?: MeshData | null): Promise<string> {
+  const built = await buildGLB(customName, coloredMesh);
   downloadBlob(built.blob, built.filename, 'GLB');
   return built.filename;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ import { export3MF, build3MF } from './export/threemf';
 import { exportVOX, buildVOX } from './export/vox';
 import { assertFiniteMesh } from './export/meshClean';
 import { exportSessionJSON, exportRawCode, buildSessionJSON, buildRawCode } from './export/session';
-import { blobToBase64, downloadBlob } from './export/download';
+import { blobToBase64, downloadBlob, getExportFilename } from './export/download';
 import {
   listExports as listInboxExports,
   getExport as getInboxExport,
@@ -2741,12 +2741,37 @@ async function main() {
     return showExportConfirm(info);
   }
 
+  // One standardized "nothing to export" toast for every mesh export action, so
+  // the feedback is consistent instead of some formats silently no-op'ing and
+  // others (GLB) producing a bogus empty file.
+  const noGeometryToast = () => showToast('No geometry to export — run a model first.', { variant: 'warn' });
+
+  /** The MeshData to feed an export: bakes ALL color regions when any are
+   *  present (independent of viewport paint visibility) so every format ships
+   *  the same colors; otherwise the mesh as-is. */
+  const coloredMeshForExport = (mesh: MeshData): MeshData =>
+    (hasColorRegions() || hasModelColorRegions()) ? applyTriColors(mesh) : mesh;
+
+  /** Non-blocking heads-up that a multi-part session exports only the active
+   *  part (mesh exports consume the single `currentMeshData`). Mirrors the
+   *  share-link warning so users aren't silently handed one part of an
+   *  assembly. */
+  const notifyMultiPartExport = () => {
+    const parts = getState().parts;
+    if (parts.length > 1) {
+      const partName = getState().currentPart?.name ?? 'the current part';
+      showToast(`Exporting only "${partName}" — ${parts.length} parts in this session. Merge parts first to export them together.`, { variant: 'neutral' });
+    }
+  };
+
   const actionExportGLB = async () => {
     if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
+    if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('GLB'))) return;
     try {
-      if (currentMeshData) assertFiniteMesh(currentMeshData);
-      const filename = await exportGLB();
+      assertFiniteMesh(currentMeshData);
+      notifyMultiPartExport();
+      const filename = await exportGLB(undefined, coloredMeshForExport(currentMeshData));
       showToast(`Exported ${filename}`, { variant: 'success' });
     } catch (e) {
       showToast(e instanceof Error ? e.message : 'GLB export failed', { variant: 'warn' });
@@ -2754,23 +2779,26 @@ async function main() {
   };
   const actionExportSTL = async () => {
     if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
-    if (!currentMeshData) return;
+    if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('STL'))) return;
+    notifyMultiPartExport();
     try { showToast(`Exported ${exportSTL(currentMeshData)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : 'STL export failed', { variant: 'warn' }); }
   };
   const actionExportOBJ = async () => {
     if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
-    if (!currentMeshData) return;
+    if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('OBJ'))) return;
-    try { showToast(`Exported ${exportOBJ((hasColorRegions() || hasModelColorRegions()) ? applyTriColors(currentMeshData) : currentMeshData)}`, { variant: 'success' }); }
+    notifyMultiPartExport();
+    try { showToast(`Exported ${exportOBJ(coloredMeshForExport(currentMeshData))}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : 'OBJ export failed', { variant: 'warn' }); }
   };
   const actionExport3MF = async () => {
     if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
-    if (!currentMeshData) return;
+    if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('3MF'))) return;
-    try { showToast(`Exported ${export3MF((hasColorRegions() || hasModelColorRegions()) ? applyTriColors(currentMeshData) : currentMeshData)}`, { variant: 'success' }); }
+    notifyMultiPartExport();
+    try { showToast(`Exported ${export3MF(coloredMeshForExport(currentMeshData))}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
   };
   // The integer VoxelGrid behind a voxel session. The engine meshes in the
@@ -2795,6 +2823,28 @@ async function main() {
     }
     try { showToast(`Exported ${exportVOX(grid)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : 'VOX export failed', { variant: 'warn' }); }
+  };
+  // STEP — BREP (replicad) sessions only. Shared by the toolbar callback and the
+  // command palette so the worker round-trip + download convention live in one
+  // place. (The partwrightAPI.exportSTEP const is defined further down main(), so
+  // inlining the worker call here avoids a TDZ on toolbar build.)
+  const actionExportSTEP = async () => {
+    if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
+    try {
+      const blob = await exportLastBrepAsSTEP();
+      if (!blob) {
+        showToast('No BREP shape available. Run a model in BREP mode first.', { variant: 'warn' });
+        return;
+      }
+      // Route through the shared download helper so STEP gets the same filename
+      // convention (date/unit suffix, sanitization), unified revoke, and a
+      // Recent Exports entry as every other format.
+      const filename = getExportFilename('step');
+      downloadBlob(blob, filename, 'STEP');
+      showToast(`Exported ${filename}`, { variant: 'success' });
+    } catch (e) {
+      showToast(`STEP export failed: ${e instanceof Error ? e.message : String(e)}`, { variant: 'warn' });
+    }
   };
 
   // Hard cap on the encoded share string. Browsers and chat apps choke on very
@@ -2906,32 +2956,7 @@ async function main() {
     onExportOBJ: actionExportOBJ,
     onExport3MF: actionExport3MF,
     onExportVOX: actionExportVOX,
-    onExportSTEP: async () => {
-      // Inlined rather than calling partwrightAPI.exportSTEP because that
-      // const is defined further down main() — using it here would land in
-      // the TDZ on toolbar-build (and TS would flag a "used before
-      // declaration" anyway). The underlying worker round-trip is the same.
-      try {
-        const blob = await exportLastBrepAsSTEP();
-        if (!blob) {
-          showToast('No BREP shape available. Run a model in BREP mode first.', { variant: 'warn' });
-          return;
-        }
-        const state = getState();
-        const base = state.session?.name ?? 'model';
-        const versionLabel = state.currentVersion?.label;
-        const name = `${base}${versionLabel ? '_' + versionLabel : ''}.step`;
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = name;
-        a.click();
-        setTimeout(() => URL.revokeObjectURL(url), 1000);
-        showToast(`Exported ${name}`, { variant: 'success' });
-      } catch (e) {
-        showToast(`STEP export failed: ${e instanceof Error ? e.message : String(e)}`, { variant: 'warn' });
-      }
-    },
+    onExportSTEP: actionExportSTEP,
     onExportSessionJSON: async () => {
       if (!getState().session) {
         alert('No active session to export. Save a version first.');
@@ -3170,7 +3195,14 @@ async function main() {
     { id: 'export-stl', title: 'Export STL', hint: 'Export', keywords: 'download print', run: actionExportSTL, enabled: () => currentMeshData !== null },
     { id: 'export-obj', title: 'Export OBJ', hint: 'Export', keywords: 'download wavefront', run: actionExportOBJ, enabled: () => currentMeshData !== null },
     { id: 'export-3mf', title: 'Export 3MF', hint: 'Export', keywords: 'download print color', run: actionExport3MF, enabled: () => currentMeshData !== null },
-    { id: 'export-vox', title: 'Export VOX', hint: 'Export', keywords: 'download magicavoxel voxel goxel', run: actionExportVOX, enabled: () => getActiveLanguage() === 'voxel' && currentMeshData !== null },
+    // VOX exports the voxel grid (getCurrentVoxelGrid), not currentMeshData, so
+    // gate on the active language — the grid is re-derived on demand inside the
+    // action, which also toasts if there's nothing to export. (Re-running the
+    // model inside an `enabled` predicate would be far too heavy.)
+    { id: 'export-vox', title: 'Export VOX', hint: 'Export', keywords: 'download magicavoxel voxel goxel', run: actionExportVOX, enabled: () => getActiveLanguage() === 'voxel' },
+    // STEP exports the retained BREP shape, only available in replicad sessions
+    // (mirrors the toolbar's STEP gating); the action toasts if no shape exists.
+    { id: 'export-step', title: 'Export STEP', hint: 'Export', keywords: 'download brep cad solidworks fusion freecad', run: () => { void actionExportSTEP(); }, enabled: () => getActiveLanguage() === 'replicad' },
     { id: 'share-link', title: 'Share design (copy link)', hint: 'Share', keywords: 'url public link copy fork readonly', run: () => { void actionShareLink(); }, enabled: canShare },
     { id: 'toggle-ai', title: 'Toggle AI panel', hint: 'View', keywords: 'chat assistant drawer', run: () => toggleAiPanel() },
     { id: 'toggle-diagnostics', title: 'Toggle diagnostic log', hint: 'View', keywords: 'errors warnings console', run: () => toggleDiagnosticsPanel() },
@@ -4810,26 +4842,30 @@ async function main() {
     /** Export current model as GLB download. Optional filename override. */
     async exportGLB(filename?: string) {
       assertString(filename, 'exportGLB(filename)', { optional: true });
-      if (currentMeshData) assertFiniteMesh(currentMeshData);
-      await exportGLB(filename);
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      assertFiniteMesh(currentMeshData);
+      await exportGLB(filename, coloredMeshForExport(currentMeshData));
     },
 
     /** Export current model as STL download. Optional filename override. */
     exportSTL(filename?: string) {
       assertString(filename, 'exportSTL(filename)', { optional: true });
-      if (currentMeshData) exportSTL(currentMeshData, filename);
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      exportSTL(currentMeshData, filename);
     },
 
     /** Export current model as OBJ download. Optional filename override. */
     exportOBJ(filename?: string) {
       assertString(filename, 'exportOBJ(filename)', { optional: true });
-      if (currentMeshData) exportOBJ((hasColorRegions() || hasModelColorRegions()) ? applyTriColors(currentMeshData) : currentMeshData, filename);
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      exportOBJ(coloredMeshForExport(currentMeshData), filename);
     },
 
     /** Export current model as 3MF download. Optional filename override. */
     export3MF(filename?: string) {
       assertString(filename, 'export3MF(filename)', { optional: true });
-      if (currentMeshData) export3MF((hasColorRegions() || hasModelColorRegions()) ? applyTriColors(currentMeshData) : currentMeshData, filename);
+      if (!currentMeshData) return { error: 'No geometry loaded' };
+      export3MF(coloredMeshForExport(currentMeshData), filename);
     },
 
     /** Export the current voxel grid as a MagicaVoxel `.vox` download. Voxel
@@ -4858,18 +4894,11 @@ async function main() {
         if (!blob) {
           return { ok: false as const, error: 'No BREP shape available. Switch to BREP language (setActiveLanguage("replicad")) and run a model first.' };
         }
-        const state = getState();
-        const base = state.session?.name ?? 'model';
-        const versionLabel = state.currentVersion?.label;
-        const name = filename ?? `${base}${versionLabel ? '_' + versionLabel : ''}.step`;
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = name;
-        a.click();
-        // Revoke after a tick so Safari/older browsers actually finish the
-        // download. Matches the pattern used by exportGLB/exportSTL.
-        setTimeout(() => URL.revokeObjectURL(url), 1000);
+        // Route through the shared download helper so STEP gets the standard
+        // filename convention, unified revoke, and a Recent Exports entry like
+        // every other format.
+        const name = getExportFilename('step', filename);
+        downloadBlob(blob, name, 'STEP');
         return { ok: true as const, filename: name, sizeBytes: blob.size };
       } catch (e) {
         return { ok: false as const, error: e instanceof Error ? e.message : String(e) };

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -587,6 +587,45 @@ export function getScene(): THREE.Scene {
   return scene;
 }
 
+/** Run `fn` (typically a GLB export pass that serializes `getScene()`) with the
+ *  display mesh's geometry temporarily swapped to one carrying `coloredMesh`'s
+ *  fully-baked triangle colors, then restore the original geometry no matter how
+ *  `fn` settles.
+ *
+ *  GLB export reads the live scene, whose colors come from the viewport's
+ *  visibility-aware coloring (paint toggle off → no colors; a hidden region →
+ *  skipped). Exports must bake ALL regions regardless of those UI flags, matching
+ *  OBJ/3MF. Callers pass `applyTriColors(currentMeshData)` so the swapped geometry
+ *  is the unindexed, per-triangle-colored layout the exporter should serialize.
+ *  When the mesh has no color regions, `applyTriColors` returns it unchanged and
+ *  the swapped geometry is the same uncolored layout as the display — so the
+ *  no-paint case is unaffected. */
+export async function withExportColors<T>(coloredMesh: MeshData, fn: () => Promise<T>): Promise<T> {
+  // The solid + wireframe meshes share one geometry object (see updateMesh); the
+  // clip-cap holds a clone. Swap every meshGroup child that references the solid
+  // geometry to the colored one, then restore on the way out.
+  const solid = meshGroup.children.find(
+    (c): c is THREE.Mesh => c instanceof THREE.Mesh && c.name !== 'wireframe' && c.name !== 'clip-cap',
+  );
+  if (!solid) return fn();
+
+  const original = solid.geometry as THREE.BufferGeometry;
+  const exportGeometry = meshGLToBufferGeometry(coloredMesh);
+  const swapped: THREE.Mesh[] = [];
+  for (const child of meshGroup.children) {
+    if (child instanceof THREE.Mesh && child.geometry === original) {
+      child.geometry = exportGeometry;
+      swapped.push(child);
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const child of swapped) child.geometry = original;
+    exportGeometry.dispose();
+  }
+}
+
 export function getCamera(): THREE.PerspectiveCamera {
   return camera;
 }


### PR DESCRIPTION
## Summary

Focused consistency fixes across the export subsystem so every format behaves the same way and no data is silently dropped.

- **A (data loss): GLB now bakes ALL painted colors regardless of viewport paint visibility.** Previously `buildGLB` serialized the live scene, whose mesh is colored via the visibility-aware `applyTriColorsIfVisible` — so turning the global paint toggle off (or hiding a region's eye) made GLB export with *no* colors, while OBJ/3MF kept them. New `withExportColors()` helper in `viewport.ts` temporarily swaps the display mesh geometry to the fully-baked colored layout (`applyTriColors`) for the export pass and restores it in a `finally`, disposing the temp geometry. `buildGLB`/`exportGLB` gained an optional `coloredMesh` param; the no-paint case is unchanged (`applyTriColors` returns the mesh untouched).
- **B (bug): GLB export with no geometry no longer produces a bogus empty "successful" file.** `actionExportGLB` now early-returns with the standardized "no geometry" toast (the toolbar GLB item routes through this action, so it's covered too).
- **C (inconsistency): STEP export now uses the shared download path.** Both the toolbar callback and the console `exportSTEP` route through `downloadBlob(...)` + `getExportFilename('step', ...)`, so STEP gets the standard filename convention (date/unit suffix, sanitization), the unified blob-URL revoke, and a Recent Exports inbox entry like every other format. Extracted a shared `actionExportSTEP` reused by the toolbar and the new palette command.
- **D (inconsistency): one standardized "No geometry to export — run a model first." toast** across GLB/STL/OBJ/3MF UI actions (STL/OBJ/3MF previously failed silently), plus a consistent `{ error: 'No geometry loaded' }` return from the console `exportGLB/STL/OBJ/3MF` variants.
- **E (usability): multi-part notice.** A non-blocking neutral toast ("Exporting only \"<part>\" — N parts in this session…") fires when the session has >1 part, mirroring the share-link warning. What gets exported is unchanged (still the active `currentMeshData`).
- **F (usability): added an `export-step` command-palette entry**, gated on `getActiveLanguage() === 'replicad'` (mirrors the toolbar's STEP gating).
- **G (polish): fixed the `export-vox` palette guard** to gate on the voxel language — the signal VOX export actually depends on (`getCurrentVoxelGrid`) — instead of `currentMeshData`. Gating on language (not by re-deriving the grid) keeps the `enabled` predicate cheap; the action itself toasts if there's no grid.

Also DRY'd the repeated `(hasColorRegions() || hasModelColorRegions()) ? applyTriColors(mesh) : mesh` into a `coloredMeshForExport()` helper used by all four mesh formats.

Did **not** touch `toImportedMesh` `format:'stl'` (owned by another PR).

## Test plan

- `npm run build` — passes (no TS errors).
- `npm run test:unit` — 452/452 pass.
- e2e not run locally (per task scope); relevant existing specs remain compatible:
  - `brep-integration.spec.ts` asserts `exportSTEP().filename` matches `/\.step$/` (still true — `getExportFilename` appends `.step`) and the no-shape error path is unchanged.
  - `feedback-a11y.spec.ts` asserts an STL "Exported …\.stl" toast — unchanged.
- Manual smoke recommended on the draft: paint a face, toggle paint visibility off, export GLB → colors present; export GLB with no model → "no geometry" toast (no file); STEP export in a replicad session → appears in Recent Exports with date/unit filename; STEP palette entry appears only in replicad sessions; VOX palette entry enabled in voxel sessions.

## Deferred

- None.

https://claude.ai/code/session_011v1XCcLbbuTPDXxFLYvRk2

---
_Generated by [Claude Code](https://claude.ai/code/session_011v1XCcLbbuTPDXxFLYvRk2)_