### PR TITLE
feat: SCAD customizer parity — top-level vars become Customizer knobs

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -70,7 +70,7 @@ Reach for the right tool the first time. If the table sends you to a subdoc, fet
 |---|---|---|---|
 | Cube / sphere / cylinder | `Manifold.cube/sphere/cylinder(...)` | `cube()`, `sphere()`, `cylinder()` | `BREP.box([w,d,h])`, `BREP.sphere(r)`, `BREP.cylinder(r, h)` |
 | Boolean union / difference / intersection | `.add(o)`, `.subtract(o)`, `.intersect(o)` | `union(){...}`, `difference(){...}`, `intersection(){...}` | `.fuse(o)` / `.cut(o)` / `.intersect(o)`, or `BREP.fuseAll([a,b,c])` / `BREP.cutAll([body,…holes])` / `BREP.intersectAll([…])` for N-way |
-| Expose tweakable knobs (make it customizable) | `api.params({...})` at the top → live Parameters panel; `partwright.getParams()`/`setParams({...})` to drive | (not in SCAD yet) | `api.params({...})` — same as manifold-js (also works in voxel sessions) |
+| Expose tweakable knobs (make it customizable) | `api.params({...})` at the top → live Parameters panel; `partwright.getParams()`/`setParams({...})` to drive | top-level vars + OpenSCAD customizer annotations (`x = 30; // [10:100]`) → same panel | `api.params({...})` — same as manifold-js (also works in voxel sessions) |
 | 2D shape extruded to 3D | `cs.extrude(h, nDiv?, twist?, scaleTop?)` | `linear_extrude(h, twist=, slices=, scale=) polygon(...)` | (use manifold-js + BREP for one piece) |
 | Surface of revolution (vase, lens, bottle) | `cs.revolve(n?, degrees?)` | `rotate_extrude(angle=) polygon(...)` | (use manifold-js) |
 | Smooth curve from a few points | `Curves.bezier(controls)` -> `/ai/curves.md` | `bezier_curve()` (BOSL2) -> `/ai/bosl2.md` | (use manifold-js Curves) |
@@ -403,7 +403,22 @@ Standard JavaScript globals (`Math`, `Array`, `Object`, `JSON`, `Date`, `console
 
 Declare the model's tweakable dimensions/options at the top via `api.params(schema)`. It returns an object of resolved values; a **Parameters panel** appears in the viewport so the user (or you) can adjust them with sliders/toggles/dropdowns and the model re-runs live — Tinkercad-style customization without leaving code. This is the preferred way to make a model reusable: expose the few dimensions someone would actually want to change.
 
-`api.params` works the same in **manifold-js, voxel, and BREP (replicad) sessions** — all three are JS sandboxes that share one implementation (SCAD is the exception and has no `api.params` yet). For `number`/`int` params the panel pairs a slider with an editable number field, so you can type an exact value (and exceed the slider's range when the spec declares no `max`).
+`api.params` works the same in **manifold-js, voxel, and BREP (replicad) sessions** — all three are JS sandboxes that share one implementation. For `number`/`int` params the panel pairs a slider with an editable number field, so you can type an exact value (and exceed the slider's range when the spec declares no `max`).
+
+**SCAD sessions** use OpenSCAD's own customizer convention instead of `api.params` (SCAD isn't a JS sandbox): annotate top-level variables and they surface in the *same* Parameters panel. Overrides are applied through OpenSCAD's native `-D` flag — no code rewriting. `getParams`/`setParams` and persistence work identically.
+
+```scad
+// Outer width            (a preceding line-comment becomes the tooltip)
+width = 30;     // [10:100]        slider 10..100
+rows  = 2;      // [1:1:6]         slider 1..6 step 1
+style = "flat"; // [flat, round]   dropdown of strings
+mode  = 1;      // [0:Off, 1:On]   dropdown (value:label)
+label = "PART"; // 12              text, max length 12
+solid = true;                      // checkbox
+cube([width, width, rows * 10]);
+```
+
+Only top-level literal assignments become knobs; variables inside modules/functions are ignored, and a `/* [Hidden] */` group suppresses its members. Vectors and expression-valued variables aren't customizable.
 
 ```js
 const { Manifold } = api;

--- a/src/geometry/engineWorker.ts
+++ b/src/geometry/engineWorker.ts
@@ -113,7 +113,7 @@ self.onmessage = async (event: MessageEvent) => {
       } else if (effectiveLang === 'scad') {
         // Ensure the OpenSCAD engine is loaded (lazy init).
         if (!openscadEngine.isReady()) await openscadEngine.init();
-        result = await runScadAsync(code as string);
+        result = await runScadAsync(code as string, params ?? undefined);
       } else if (effectiveLang === 'replicad') {
         // Full replicad-language session — lazy-init OCCT then evaluate as
         // BREP. Tessellation happens inside the engine before returning.

--- a/src/geometry/engines/openscad.ts
+++ b/src/geometry/engines/openscad.ts
@@ -6,6 +6,7 @@ import { getManifoldModule, manifoldJsEngine } from './manifoldJs';
 import { scadDiagnostics } from '../sourceDiagnostics';
 import { ensureBosl2InMemfs, sourceUsesBosl2 } from '../bosl2Loader';
 import { getDefaultCircularSegments } from '../qualitySettings';
+import { parseScadParams, buildScadDefines } from '../scadParams';
 
 /** Tiny passthrough module pre-injected into every SCAD compile so user code
  *  can write `label("name") <expr>;` without breaking. Duplicate declarations
@@ -128,8 +129,23 @@ export const openscadEngine: Engine = {
 
 /** Async run — creates a fresh WASM instance, compiles SCAD, parses STL or
  *  multi-object AMF (when `label()` is used to mark paintable regions), and
- *  round-trips through Manifold.ofMesh(). */
-export async function runScadAsync(source: string): Promise<MeshResult> {
+ *  round-trips through Manifold.ofMesh().
+ *
+ *  Customizer: top-level variables annotated in the OpenSCAD customizer style
+ *  (see `scadParams.ts`) surface as the same Parameters panel the JS engines
+ *  drive via `api.params`. The user's tweaks arrive as `paramOverrides` and are
+ *  applied through OpenSCAD's native `-D name=value` flag — no source
+ *  rewriting. The parsed schema rides on every result (success and error) so
+ *  the panel stays live, matching the other engines. */
+export async function runScadAsync(source: string, paramOverrides?: Record<string, unknown>): Promise<MeshResult> {
+  const schema = parseScadParams(source);
+  const paramsSchema = schema.length > 0 ? schema : undefined;
+  const defines = buildScadDefines(source, paramOverrides);
+  const result = await runScadInner(source, defines);
+  return paramsSchema ? { ...result, paramsSchema } : result;
+}
+
+async function runScadInner(source: string, defines: string[]): Promise<MeshResult> {
   if (!createFn) {
     const error = 'OpenSCAD engine not initialized.';
     return { mesh: null, manifold: null, error, diagnostics: scadDiagnostics(source, error) };
@@ -167,12 +183,12 @@ export async function runScadAsync(source: string): Promise<MeshResult> {
       // labelled construction. Any label-shape warnings (nested-in-boolean
       // etc.) are emitted as diagnostics on the result inside that helper,
       // so they surface even when the compile succeeds.
-      return runLabelAwareAsync(instance, source, stderr, labelScan);
+      return runLabelAwareAsync(instance, source, stderr, labelScan, defines);
     }
 
     // Fast path: no labels in source → single STL compile, single Manifold.
     // Functionally identical to the pre-label-support pipeline.
-    return runFlatStlAsync(instance, source, stderr);
+    return runFlatStlAsync(instance, source, stderr, defines);
   } catch (e: unknown) {
     let msg: string;
     if (typeof e === 'number' && instance?.formatException) {
@@ -196,12 +212,15 @@ async function runFlatStlAsync(
   instance: any,
   source: string,
   stderr: string[],
+  defines: string[],
 ): Promise<MeshResult> {
   // Seed $fn from the user's quality preset. The script can still
   // reassign $fn=… at the top level or pass $fn= per primitive to override.
+  // Customizer overrides follow as additional `-D` flags.
   const exitCode = instance.callMain([
     '--enable=manifold',
     '-D', `$fn=${getDefaultCircularSegments()}`,
+    ...defines,
     '--export-format=binstl',
     '-o', '/out.stl',
     '/in.scad',
@@ -252,11 +271,13 @@ async function runLabelAwareAsync(
   source: string,
   stderr: string[],
   labelScan: ReturnType<typeof scanScadLabels>,
+  defines: string[],
 ): Promise<MeshResult> {
   const exitCode = instance.callMain([
     '--enable=manifold',
     '--enable=lazy-union',
     '-D', `$fn=${getDefaultCircularSegments()}`,
+    ...defines,
     '--export-format=amf',
     '-o', '/out.amf',
     '/in.scad',

--- a/src/geometry/scadParams.ts
+++ b/src/geometry/scadParams.ts
@@ -1,0 +1,292 @@
+// SCAD Customizer parser — pure logic, no WASM/DOM.
+//
+// OpenSCAD has its own "customizer" convention: top-level variables become
+// tweakable parameters, with a trailing line comment describing the widget and
+// an optional preceding `// description` line. Groups are introduced by
+// `/* [Group] */` headers; a group literally named `Hidden` suppresses its
+// variables. Examples:
+//
+//   // Box width
+//   width = 30;        // [10:100]      → slider 10..100
+//   rows  = 2;         // [1:1:6]       → slider 1..6 step 1
+//   style = "flat";    // [flat, round] → dropdown
+//   mode  = 1;         // [0:Off, 1:On] → dropdown (value:label)
+//   label = "PARTS";   // 12            → text, maxlength 12
+//   solid = true;                       → checkbox
+//
+// We translate that into the SAME `ParamSpec[]` the JS engines produce via
+// `api.params({...})`, so the existing engine-agnostic Customizer panel renders
+// SCAD knobs with zero UI changes. Overrides are applied through OpenSCAD's
+// native `-D name=value` command-line flag (see `buildScadDefines`), so no
+// source rewriting is needed — the engine just passes extra `-D` args.
+//
+// This module is dependency-free so it lives in the fast vitest unit tier and
+// is reused by the OpenSCAD engine (schema capture + override defines).
+
+import { normalizeParamSchema, coerceParamValue, type ParamSpec, type ParamValue } from './params';
+
+/** The OpenSCAD literal kind a parameter was declared with. Drives `-D` value
+ *  quoting (strings are quoted, numbers/bools are not) independently of the
+ *  widget type the value maps to — e.g. a numeric dropdown is a `select`
+ *  ParamSpec but must be emitted to OpenSCAD as a bare number. */
+type ScadKind = 'number' | 'bool' | 'string';
+
+interface RawEntry {
+  key: string;
+  kind: ScadKind;
+  /** Raw spec object in the `api.params` shape, fed through normalizeParamSchema. */
+  raw: Record<string, unknown>;
+}
+
+const NUM_RE = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
+const ASSIGN_RE = /^([A-Za-z_]\w*)\s*=\s*(.+?)\s*;\s*(?:\/\/(.*))?$/;
+const GROUP_RE = /^\/\*\s*\[([^\]]*)\]\s*\*\/$/;
+
+function isNumericLiteral(s: string): boolean {
+  return NUM_RE.test(s.trim());
+}
+
+/** Strip line/block comments and string contents from one line for the sole
+ *  purpose of brace counting, threading multi-line block-comment state. We
+ *  blank out string bodies (keeping the quotes) so braces inside strings or
+ *  comments never affect depth. */
+function stripForDepth(line: string, inBlock: boolean): { code: string; inBlock: boolean } {
+  let out = '';
+  let i = 0;
+  let block = inBlock;
+  let str: '"' | "'" | null = null;
+  while (i < line.length) {
+    const c = line[i];
+    const next = line[i + 1];
+    if (block) {
+      if (c === '*' && next === '/') { block = false; i += 2; continue; }
+      i++; continue;
+    }
+    if (str) {
+      if (c === '\\') { i += 2; continue; }
+      if (c === str) { str = null; }
+      i++; continue;
+    }
+    if (c === '/' && next === '/') break;            // rest of line is a comment
+    if (c === '/' && next === '*') { block = true; i += 2; continue; }
+    if (c === '"' || c === "'") { str = c; i++; continue; }
+    out += c;
+    i++;
+  }
+  return { code: out, inBlock: block };
+}
+
+/** Parse a trailing-comment annotation into the relevant raw-spec fields, given
+ *  the variable's literal kind. Returns null when the annotation is empty (the
+ *  caller then falls back to a plain number/text widget). */
+function parseAnnotation(ann: string, kind: ScadKind): Record<string, unknown> | null {
+  const t = ann.trim();
+  if (t === '') return null;
+
+  const bracket = t.match(/^\[(.*)\]$/);
+  if (bracket) {
+    const inner = bracket[1].trim();
+    const parts = inner.split(',').map(p => p.trim()).filter(p => p.length > 0);
+
+    // Single segment with colon(s) and all-numeric pieces → a range
+    // `[min:max]` or `[min:step:max]`. Anything else with commas is a dropdown.
+    if (parts.length === 1 && parts[0].includes(':')) {
+      const segs = parts[0].split(':').map(s => s.trim());
+      if (segs.length >= 2 && segs.length <= 3 && segs.every(isNumericLiteral)) {
+        if (segs.length === 2) return { min: Number(segs[0]), max: Number(segs[1]) };
+        return { min: Number(segs[0]), step: Number(segs[1]), max: Number(segs[2]) };
+      }
+    }
+
+    if (parts.length > 0) {
+      // Dropdown — each part is `value` or `value:label`.
+      const options = parts.map(p => {
+        const ci = p.indexOf(':');
+        if (ci >= 0) {
+          const value = p.slice(0, ci).trim();
+          const label = p.slice(ci + 1).trim();
+          return label ? { value, label } : { value };
+        }
+        return { value: p };
+      });
+      return { __select: true, options };
+    }
+    return null;
+  }
+
+  // A bare number annotation: max-value for numbers, max-length for strings.
+  if (isNumericLiteral(t)) {
+    const n = Number(t);
+    if (kind === 'string') return { maxLength: Math.max(1, Math.floor(n)) };
+    return { max: n };
+  }
+
+  return null;
+}
+
+/** Collect raw customizer entries from SCAD source in declaration order. Only
+ *  top-level (brace-depth 0) simple-literal assignments are considered;
+ *  variables inside modules/functions/blocks and special `$vars` are ignored,
+ *  matching OpenSCAD's customizer. */
+function collect(source: string): RawEntry[] {
+  const lines = source.split(/\r?\n/);
+  const entries: RawEntry[] = [];
+  const seen = new Set<string>();
+  let hidden = false;
+  let pendingDesc: string | undefined;
+  let depth = 0;
+  let inBlock = false;
+
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
+
+    // Group header `/* [Name] */` — only meaningful outside a block comment and
+    // at top level. A group named "Hidden" suppresses its members.
+    if (!inBlock && depth === 0) {
+      const gm = trimmed.match(GROUP_RE);
+      if (gm) {
+        hidden = gm[1].trim().toLowerCase() === 'hidden';
+        pendingDesc = undefined;
+        continue;
+      }
+    }
+
+    const wasInBlock = inBlock;
+    const { code, inBlock: nowInBlock } = stripForDepth(rawLine, inBlock);
+    const startDepth = depth;
+    for (const ch of code) {
+      if (ch === '{') depth++;
+      else if (ch === '}') depth = Math.max(0, depth - 1);
+    }
+    inBlock = nowInBlock;
+
+    // A standalone `// description` line (not a group, not inside a block
+    // comment) attaches to the next assignment.
+    if (!wasInBlock && code.trim() === '' && trimmed.startsWith('//')) {
+      pendingDesc = trimmed.replace(/^\/\/\s?/, '').trim() || undefined;
+      continue;
+    }
+
+    // Only parse assignments that sit entirely at top level and outside a
+    // block comment. Match the *raw* line, not the depth-stripped `code` —
+    // stripForDepth blanks string literals (so braces inside them don't move
+    // depth), which would erase a string variable's value.
+    const desc = pendingDesc;
+    if (!(wasInBlock || nowInBlock) && startDepth === 0 && depth === 0) {
+      const m = trimmed.match(ASSIGN_RE);
+      if (m && !seen.has(m[1])) {
+        const key = m[1];
+        const valueLit = m[2].trim();
+        const ann = (m[3] ?? '').trim();
+        const entry = buildEntry(key, valueLit, ann, desc, hidden);
+        if (entry) { entries.push(entry); seen.add(key); }
+      }
+    }
+
+    // Reset the pending description on any non-comment line so a description
+    // only binds to an immediately-following assignment.
+    if (code.trim() !== '' || !trimmed.startsWith('//')) pendingDesc = undefined;
+  }
+
+  return entries;
+}
+
+function buildEntry(key: string, valueLit: string, ann: string, desc: string | undefined, hidden: boolean): RawEntry | null {
+  if (hidden) return null;
+
+  const help = desc && desc.length > 0 ? { help: desc } : {};
+
+  // Boolean checkbox.
+  if (valueLit === 'true' || valueLit === 'false') {
+    return { key, kind: 'bool', raw: { type: 'boolean', default: valueLit === 'true', ...help } };
+  }
+
+  // String literal — `"..."`.
+  const strMatch = valueLit.match(/^"((?:[^"\\]|\\.)*)"$/);
+  if (strMatch) {
+    const def = strMatch[1].replace(/\\"/g, '"');
+    const a = parseAnnotation(ann, 'string');
+    if (a && a.__select) {
+      return { key, kind: 'string', raw: { type: 'select', default: def, options: a.options, ...help } };
+    }
+    if (a && typeof a.maxLength === 'number') {
+      return { key, kind: 'string', raw: { type: 'text', default: def, maxLength: a.maxLength, ...help } };
+    }
+    return { key, kind: 'string', raw: { type: 'text', default: def, ...help } };
+  }
+
+  // Numeric literal.
+  if (isNumericLiteral(valueLit)) {
+    const def = Number(valueLit);
+    const a = parseAnnotation(ann, 'number');
+    if (a && a.__select) {
+      // Numeric dropdown — keep option values as strings (select contract) but
+      // remember the kind so the override is emitted unquoted.
+      return { key, kind: 'number', raw: { type: 'select', default: String(def), options: a.options, ...help } };
+    }
+    const min = a && typeof a.min === 'number' ? a.min : undefined;
+    const max = a && typeof a.max === 'number' ? a.max : undefined;
+    const step = a && typeof a.step === 'number' ? a.step : undefined;
+    const ints = [def, min, max, step].filter((n): n is number => typeof n === 'number');
+    const type = ints.every(n => Number.isInteger(n)) ? 'int' : 'number';
+    return {
+      key,
+      kind: 'number',
+      raw: {
+        type,
+        default: def,
+        ...(min !== undefined ? { min } : {}),
+        ...(max !== undefined ? { max } : {}),
+        ...(step !== undefined ? { step } : {}),
+        ...help,
+      },
+    };
+  }
+
+  // Vectors and expression defaults aren't customizable widgets — skip.
+  return null;
+}
+
+/** Normalize collected entries through the canonical validator, dropping any
+ *  that don't pass (e.g. a dropdown whose default isn't among its options).
+ *  Returns specs paired with their SCAD literal kind for define formatting. */
+function parseEntries(source: string): Array<{ spec: ParamSpec; kind: ScadKind }> {
+  const out: Array<{ spec: ParamSpec; kind: ScadKind }> = [];
+  for (const entry of collect(source)) {
+    try {
+      const [spec] = normalizeParamSchema({ [entry.key]: entry.raw });
+      if (spec) out.push({ spec, kind: entry.kind });
+    } catch {
+      // A malformed annotation shouldn't break the whole panel — skip it.
+    }
+  }
+  return out;
+}
+
+/** Parse the OpenSCAD customizer schema from source into the shared ParamSpec
+ *  form. Empty when the source declares no customizable top-level variables. */
+export function parseScadParams(source: string): ParamSpec[] {
+  return parseEntries(source).map(e => e.spec);
+}
+
+function formatScadValue(kind: ScadKind, value: ParamValue): string {
+  if (kind === 'bool') return value ? 'true' : 'false';
+  if (kind === 'string') return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  return String(value);
+}
+
+/** Build OpenSCAD `-D name=value` override flags for the parameters whose
+ *  override differs from the source default. Returns an interleaved arg array
+ *  ready to splice into a `callMain([...])` invocation, e.g.
+ *  `['-D', 'width=47', '-D', 'solid=false']`. */
+export function buildScadDefines(source: string, overrides?: Record<string, unknown>): string[] {
+  if (!overrides) return [];
+  const args: string[] = [];
+  for (const { spec, kind } of parseEntries(source)) {
+    if (!(spec.key in overrides)) continue;
+    const v = coerceParamValue(spec, overrides[spec.key]);
+    if (v === undefined || v === spec.default) continue;
+    args.push('-D', `${spec.key}=${formatScadValue(kind, v)}`);
+  }
+  return args;
+}

--- a/tests/customizer.spec.ts
+++ b/tests/customizer.spec.ts
@@ -153,6 +153,36 @@ return v;`;
     await expect(page.locator('#customize-toggle')).toContainText('Customize (1)');
   });
 
+  test('parameters work in a SCAD session (native customizer annotations)', async ({ page }) => {
+    // OpenSCAD customizer annotations (// [min:max], bare true/false) are parsed
+    // into the same schema; overrides apply through OpenSCAD's -D flag.
+    const SCAD_PARAM_MODEL = [
+      'width = 20; // [10:60]',
+      'tall = false;',
+      'cube([width, width, tall ? 40 : 10], center=true);',
+    ].join('\n');
+
+    const out = await page.evaluate(async (code) => {
+      const api = (window as unknown as { partwright: PW & { setActiveLanguage: (l: string) => Promise<void> } }).partwright;
+      await api.createSession('scad-customizer');
+      await api.setActiveLanguage('scad');
+      const geo = await api.run(code); // first SCAD run lazy-loads the WASM engine
+      const wide = await api.setParams({ width: 50 });
+      return {
+        schema: api.getParams().schema.map(s => s.key),
+        defaultX: (geo.boundingBox as { dimensions?: number[] }).dimensions?.[0] ?? -1,
+        wideX: (wide.geometry as { boundingBox: { dimensions: number[] } }).boundingBox.dimensions[0],
+      };
+    }, SCAD_PARAM_MODEL);
+
+    // Both top-level vars surfaced; width slider override re-runs via -D.
+    expect(out.schema).toEqual(['width', 'tall']);
+    expect(out.defaultX).toBeCloseTo(20, 0);
+    expect(out.wideX).toBeCloseTo(50, 0);
+    await expect(page.locator('#params-panel')).toBeVisible();
+    await expect(page.locator('#customize-toggle')).toContainText('Customize (2)');
+  });
+
   test('Customize toolbar pill toggles the panel, and close → reopen always works', async ({ page }) => {
     const pill = page.locator('#customize-toggle');
     const panel = page.locator('#params-panel');

--- a/tests/unit/scadParams.test.ts
+++ b/tests/unit/scadParams.test.ts
@@ -142,3 +142,30 @@ describe('buildScadDefines — override flags', () => {
     expect(buildScadDefines(SRC, {})).toEqual([]);
   });
 });
+
+describe('parseScadParams — robustness on malformed input', () => {
+  // The parser runs on arbitrary user source on every SCAD run, so it must
+  // degrade (skip the param) rather than throw on anything weird.
+  const WEIRD = [
+    '', '\n\n', '////', '/*', '*/', '/* [Hidden',
+    'x = ;', '= 5;', 'x = "unterminated;',
+    `${'a'.repeat(50_000)} = 5; // [0:9]`,
+    `x = 5; // [${'a'.repeat(50_000)}]`,
+    'x = 0x1F;', 'x = 1_000;', 'x = .5; // [0:1]', 'x = 5.; // [0:9]', 'x = +5; // [0:9]',
+  ];
+
+  it('never throws, for parse or define-building', () => {
+    for (const c of WEIRD) {
+      expect(() => parseScadParams(c)).not.toThrow();
+      expect(() => buildScadDefines(c, { x: 3 })).not.toThrow();
+    }
+  });
+
+  it('handles unusual but valid numeric literals; ignores non-OpenSCAD ones', () => {
+    expect(byKey('x = .5; // [0:1]').get('x')).toMatchObject({ type: 'number', default: 0.5 });
+    expect(byKey('x = +5; // [0:9]').get('x')).toMatchObject({ type: 'int', default: 5 });
+    // OpenSCAD has no hex or underscore numeric literals — skip rather than misparse.
+    expect(parseScadParams('x = 0x1F;')).toEqual([]);
+    expect(parseScadParams('x = 1_000;')).toEqual([]);
+  });
+});

--- a/tests/unit/scadParams.test.ts
+++ b/tests/unit/scadParams.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { parseScadParams, buildScadDefines } from '../../src/geometry/scadParams';
+
+function byKey(src: string) {
+  const map = new Map(parseScadParams(src).map(s => [s.key, s]));
+  return map;
+}
+
+describe('parseScadParams — widget inference', () => {
+  it('integer range slider from [min:max]', () => {
+    const s = byKey('width = 30; // [10:100]').get('width')!;
+    expect(s).toMatchObject({ key: 'width', type: 'int', default: 30, min: 10, max: 100 });
+  });
+
+  it('range with explicit step [min:step:max]', () => {
+    const s = byKey('rows = 2; // [1:1:6]').get('rows')!;
+    expect(s).toMatchObject({ type: 'int', default: 2, min: 1, max: 6, step: 1 });
+  });
+
+  it('float bounds/step yield a number (not int) widget', () => {
+    const s = byKey('gap = 2.5; // [0:0.5:5]').get('gap')!;
+    expect(s).toMatchObject({ type: 'number', default: 2.5, min: 0, max: 5, step: 0.5 });
+  });
+
+  it('plain number with no annotation → number widget, no bounds', () => {
+    const s = byKey('h = 12;').get('h')!;
+    expect(s.type).toBe('int');
+    expect(s.default).toBe(12);
+    expect(s.min).toBeUndefined();
+    expect(s.max).toBeUndefined();
+  });
+
+  it('bare-number annotation on a number is a max', () => {
+    const s = byKey('n = 3; // 10').get('n')!;
+    expect(s).toMatchObject({ type: 'int', default: 3, max: 10 });
+  });
+
+  it('boolean literal → checkbox', () => {
+    const s = byKey('solid = true;').get('solid')!;
+    expect(s).toMatchObject({ type: 'boolean', default: true });
+  });
+
+  it('string literal → text', () => {
+    const s = byKey('name = "PART";').get('name')!;
+    expect(s).toMatchObject({ type: 'text', default: 'PART' });
+  });
+
+  it('string with bare-number annotation → text maxLength', () => {
+    const s = byKey('tag = "ABC"; // 12').get('tag')!;
+    expect(s).toMatchObject({ type: 'text', default: 'ABC', maxLength: 12 });
+  });
+
+  it('string list → select dropdown', () => {
+    const s = byKey('style = "flat"; // [flat, beveled, round]').get('style')!;
+    expect(s.type).toBe('select');
+    expect(s.options?.map(o => o.value)).toEqual(['flat', 'beveled', 'round']);
+  });
+
+  it('numeric value:label list → select with labels', () => {
+    const s = byKey('mode = 1; // [0:Off, 1:On]').get('mode')!;
+    expect(s.type).toBe('select');
+    expect(s.default).toBe('1');
+    expect(s.options).toEqual([
+      { value: '0', label: 'Off' },
+      { value: '1', label: 'On' },
+    ]);
+  });
+
+  it('preceding // comment becomes the help text', () => {
+    const s = byKey('// Outer wall thickness\nwall = 2; // [1:5]').get('wall')!;
+    expect(s.help).toBe('Outer wall thickness');
+  });
+});
+
+describe('parseScadParams — what is excluded', () => {
+  it('ignores variables inside a module (brace depth > 0)', () => {
+    const src = 'w = 10; // [1:20]\nmodule foo() {\n  inner = 5; // [1:9]\n}\n';
+    const keys = parseScadParams(src).map(s => s.key);
+    expect(keys).toEqual(['w']);
+  });
+
+  it('suppresses a /* [Hidden] */ group', () => {
+    const src = 'shown = 1; // [0:2]\n/* [Hidden] */\nsecret = 9; // [0:10]\n';
+    const keys = parseScadParams(src).map(s => s.key);
+    expect(keys).toEqual(['shown']);
+  });
+
+  it('a later non-Hidden group re-enables parsing', () => {
+    const src = '/* [Hidden] */\na = 1;\n/* [Main] */\nb = 2; // [0:5]\n';
+    expect(parseScadParams(src).map(s => s.key)).toEqual(['b']);
+  });
+
+  it('skips vector and expression defaults', () => {
+    const src = 'v = [1,2,3];\ncalc = a * 2;\nok = 4; // [0:8]\n';
+    expect(parseScadParams(src).map(s => s.key)).toEqual(['ok']);
+  });
+
+  it('ignores special $vars and assignments in block comments', () => {
+    const src = '$fn = 64;\n/*\nnope = 5; // [0:9]\n*/\nreal = 7; // [0:9]\n';
+    expect(parseScadParams(src).map(s => s.key)).toEqual(['real']);
+  });
+
+  it('does not mistake braces inside strings for a block', () => {
+    const src = 'label = "a{b}c";\nsize = 3; // [1:9]\n';
+    expect(parseScadParams(src).map(s => s.key)).toEqual(['label', 'size']);
+  });
+});
+
+describe('buildScadDefines — override flags', () => {
+  const SRC = [
+    'width = 30; // [10:100]',
+    'solid = true;',
+    'name = "PART";',
+    'mode = 1; // [0:Off, 1:On]',
+  ].join('\n');
+
+  it('emits -D flags with correct quoting per literal kind', () => {
+    const args = buildScadDefines(SRC, { width: 47, solid: false, name: 'BOX', mode: '0' });
+    expect(args).toEqual([
+      '-D', 'width=47',
+      '-D', 'solid=false',
+      '-D', 'name="BOX"',
+      '-D', 'mode=0', // numeric dropdown → unquoted, despite being a select
+    ]);
+  });
+
+  it('skips overrides equal to the default and unknown keys', () => {
+    const args = buildScadDefines(SRC, { width: 30, bogus: 5 });
+    expect(args).toEqual([]);
+  });
+
+  it('clamps out-of-range numeric overrides before emitting', () => {
+    expect(buildScadDefines(SRC, { width: 999 })).toEqual(['-D', 'width=100']);
+  });
+
+  it('escapes quotes/backslashes in string overrides', () => {
+    expect(buildScadDefines(SRC, { name: 'a"b\\c' })).toEqual(['-D', 'name="a\\"b\\\\c"']);
+  });
+
+  it('returns nothing when there are no overrides', () => {
+    expect(buildScadDefines(SRC, undefined)).toEqual([]);
+    expect(buildScadDefines(SRC, {})).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Brings the **Customizer** to OpenSCAD sessions — the follow-up to #299, which made `api.params` engine-agnostic across the JS sandboxes (manifold-js, voxel, BREP). SCAD isn't a JS sandbox, so instead of `api.params` it uses **OpenSCAD's own customizer convention**: annotate top-level variables and they surface in the *same* Parameters panel, with overrides applied through OpenSCAD's native `-D` flag (no source rewriting).

```scad
// Outer width          (preceding line-comment → tooltip)
width = 30;     // [10:100]        slider 10..100
rows  = 2;      // [1:1:6]         slider 1..6 step 1
style = "flat"; // [flat, round]   dropdown
mode  = 1;      // [0:Off, 1:On]   dropdown (value:label)
label = "PART"; // 12              text, max length 12
solid = true;                      // checkbox
cube([width, width, rows * 10]);
```

### What's in it
- **`src/geometry/scadParams.ts`** (new, pure-logic): parses top-level assignments + annotations into the shared `ParamSpec[]`. Handles number/int ranges, bare-number max, booleans, string + numeric dropdowns (value/label), text maxlength, and the preceding-comment tooltip. Brace-depth tracking excludes variables inside modules/functions; a `/* [Hidden] */` group is suppressed; vectors/expression defaults are skipped. Reuses the canonical `normalizeParamSchema` validator so SCAD specs are identical to JS ones.
- **Overrides via `-D`**: `buildScadDefines()` emits `-D name=value` only for keys differing from the source default. Quoting follows the original SCAD literal kind, so a numeric dropdown (a `select` ParamSpec) is still emitted as a bare number, strings are quoted/escaped.
- **`openscad.ts`**: `runScadAsync` accepts `paramOverrides`, reports the parsed schema on **every** result (success and error, matching the parity established in #299), and threads `-D` defines into both the flat-STL and label-aware compile paths. The worker passes the run's `params` through.
- The Customizer panel, `getParams`/`setParams`, and per-version persistence are unchanged — this only feeds them a schema + overrides for SCAD.

### Bonus
Because it uses native annotations, **imported parametric `.scad` files get sliders automatically** (`.scad` import already existed).

## Test plan
- `npm run build` — clean.
- `npm run test:unit` — 474 pass, incl. 22 new `scadParams` cases (grammar inference, exclusions: module-internal vars / Hidden group / vectors / `$vars` / braces-in-strings, and `-D` quoting/clamping/escaping).
- `npx playwright test customizer.spec.ts` — 7 pass, incl. a new **SCAD-session** test (annotations parsed → panel shown → `setParams` re-runs via `-D` and changes geometry).
- `npx playwright test quality-scad.spec.ts` — still green (flat SCAD path unaffected).

## Scope
Group *sections* in the panel (`/* [Group] */` → collapsible UI) and `showIf` are intentionally out of scope — separate follow-ups. This parses Hidden but otherwise ignores group headers for now.

https://claude.ai/code/session_01TsavoEF6pNJAzjowjYa2EX

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsavoEF6pNJAzjowjYa2EX)_