### PR TITLE
fix: price out-of-snapshot compaction model, surface local thinking, fix provider-pricing doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ A "🩺" button in the panel header opens `src/ui/aiDiagnosticsModal.ts`. Shows 
 1. Add the id to `Provider` in `src/ai/types.ts` and a `<name>Model` field to `ChatToggles` (+ default in `settings.ts`).
 2. Add a sibling case to `activeModel(toggles)`.
 3. Create `src/ai/<name>.ts` exporting `streamTurn`, `summarize`, `validateKey`, `resetClient` — same shape as `anthropic.ts`.
-4. Register pricing in `src/ai/cost.ts`'s `PROVIDER_PRICING`.
+4. Wire pricing. Pricing is catalog-driven: add the provider's models.dev id to `CATALOG_PROVIDER_ID` in `src/ai/catalog.ts` (e.g. Gemini's `google`) so `getPricing()` resolves real rates from the build-time snapshot. For specific cheap models the snapshot doesn't carry (e.g. an older compaction model), add an explicit entry to `KNOWN_MODEL_PRICING` in `src/ai/cost.ts`; everything else falls back to `FALLBACK_PRICING` there.
 5. Add a `<name>_MODEL_OPTIONS` array + `set<Name>Model` setter in `src/ai/settings.ts`.
 6. Add dispatch + compaction branches in `chatLoop.ts` / `compaction.ts`.
 7. Add a `buildHostedProviderSection(<name>, …)` call in `aiSettingsModal.ts`, a `PROVIDER_UI` entry in `aiKeyModal.ts`, and a `hostedConfig` entry in `aiPanel.ts`'s `renderModelPicker()`.

--- a/src/ai/cost.ts
+++ b/src/ai/cost.ts
@@ -30,6 +30,20 @@ const CACHE_WRITE_MULTIPLIER = 1.25;
  *  lie by reading "$0" when the user has typed in a new dated snapshot. */
 const FALLBACK_PRICING: CatalogPricing = { input: 3.0, output: 15.0 };
 
+/** Explicit prices for known cheap models the build-time catalog snapshot
+ *  doesn't carry (it's filtered to the last year of releases, so an
+ *  older-but-still-used id like `gpt-4o-mini` drops out). Without these, a
+ *  catalog miss falls through to the Sonnet-tier `FALLBACK_PRICING`
+ *  ($3/$15 per 1M) and over-reports cost ~5–40×. Compaction's per-provider
+ *  cheap model (`COMPACTION_MODEL` in compaction.ts) is the main caller that
+ *  hit this — its `gemini-2.5-flash-lite` / `claude-haiku-4-5` ids are in the
+ *  snapshot, but `gpt-4o-mini` is not. Keyed `provider/model`; rates are USD
+ *  per 1M tokens. */
+const KNOWN_MODEL_PRICING: Record<string, CatalogPricing> = {
+  // gpt-4o-mini: $0.15 in / $0.60 out, cached input $0.075.
+  'openai/gpt-4o-mini': { input: 0.15, output: 0.6, cacheRead: 0.075 },
+};
+
 function pricingFor(provider: string, model: string): CatalogPricing | null {
   // Local (WebGPU) and custom (self-hosted OpenAI-compatible endpoint) turns
   // are free at the API level — the user paid for the hardware/electricity —
@@ -40,6 +54,10 @@ function pricingFor(provider: string, model: string): CatalogPricing | null {
   // the rest of the cost meter does).
   const fromCatalog = getPricing(provider as Provider, model);
   if (fromCatalog) return fromCatalog;
+  // Known-but-out-of-snapshot ids get their real price before the median
+  // fallback, so the cost meter doesn't massively over-report them.
+  const known = KNOWN_MODEL_PRICING[`${provider}/${model}`];
+  if (known) return known;
   // Hosted provider but unknown id — use the median fallback rather than
   // reporting $0, so the cost meter is conservative on novel snapshots.
   if (provider === 'anthropic' || provider === 'openai' || provider === 'gemini') {

--- a/src/ai/local.ts
+++ b/src/ai/local.ts
@@ -468,6 +468,12 @@ export async function ensureModelLoaded(modelId: string, opts: LoadOptions = {})
 
 export interface StreamCallbacks {
   onText?: (delta: string) => void;
+  /** Reasoning deltas from a local `<think>` block. Routed to the panel's
+   *  collapsible thinking box (mirroring Gemini/Anthropic) instead of the
+   *  answer bubble. Fired once post-stream with the full captured reasoning
+   *  — the live scanner suppresses `<think>` from `onText`, so this is the
+   *  channel that surfaces it. */
+  onThinking?: (delta: string) => void;
   onToolStart?: (toolUseId: string, toolName: string) => void;
 }
 
@@ -480,9 +486,11 @@ export interface StreamResult {
    *  emitted an unclosed `<tool_call>` block (a crash, likely). chatLoop
    *  surfaces a "response was cut off" message and skips re-prompting. */
   truncated?: boolean;
-  /** Reasoning text if surfaced. Local `<think>` blocks are stripped and
-   *  hidden today, so this stays undefined; present so chatLoop reads
-   *  `result.thinking` uniformly across providers. */
+  /** Reasoning text if surfaced. Reasoning-style local models emit a
+   *  `<think>...</think>` block; we strip it from the answer (so the bubble
+   *  stays clean) and surface it here + via `onThinking` so chatLoop renders
+   *  the same collapsible thinking box Gemini/Anthropic get. Undefined when
+   *  the model emitted no reasoning. */
   thinking?: string;
   /** Anthropic-only thinking-block replay payload — always undefined here.
    *  Declared for a uniform `StreamResult` across the provider union. */
@@ -694,6 +702,11 @@ export async function streamLocalTurn(spec: LocalRequestSpec, callbacks: StreamC
   // (which would also rebroadcast them to the model on the next turn).
   // Unclosed `<think>` tails (truncation) just get dropped.
   const withoutThink = stripThinkBlocks(rawText);
+  // Surface the reasoning the scanner suppressed from the live bubble so the
+  // panel can render the same collapsible thinking box hosted providers get.
+  // (The answer text — `cleanedText` below — stays free of the `<think>` body.)
+  const thinkText = extractThinkBlocks(rawText);
+  if (thinkText.length > 0) callbacks.onThinking?.(thinkText);
 
   let toolCalls: PersistedToolCall[] = [];
   let cleanedText: string;
@@ -722,6 +735,7 @@ export async function streamLocalTurn(spec: LocalRequestSpec, callbacks: StreamC
     stopReason: normStop,
     usage,
     truncated: truncatedMidToolCall || (truncatedMaxTokens && toolCalls.length === 0),
+    thinking: thinkText.length > 0 ? thinkText : undefined,
   };
 }
 
@@ -801,6 +815,22 @@ function stripThinkBlocks(text: string): string {
   // Then strip any trailing unclosed block (truncation).
   const unclosed = completed.indexOf(THINK_OPEN);
   return unclosed >= 0 ? completed.slice(0, unclosed).trimEnd() : completed.trimEnd();
+}
+
+/** Inverse of stripThinkBlocks: pull the reasoning OUT of completed
+ *  `<think>...</think>` blocks so it can drive the panel's thinking box.
+ *  Truncated (unclosed) blocks are skipped — a partial chain-of-thought the
+ *  user never saw isn't worth surfacing. Multiple blocks are joined with a
+ *  blank line. Returns '' when there's no reasoning. */
+function extractThinkBlocks(text: string): string {
+  const out: string[] = [];
+  const re = /<think>([\s\S]*?)<\/think>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const body = m[1].trim();
+    if (body.length > 0) out.push(body);
+  }
+  return out.join('\n\n');
 }
 
 /** Build a compact tool-use instruction block to append to the system

--- a/tests/unit/cost.test.ts
+++ b/tests/unit/cost.test.ts
@@ -58,6 +58,39 @@ describe('turnCostUsd no-double-count contract', () => {
   }
 });
 
+describe('known-model pricing for out-of-snapshot compaction models', () => {
+  // The bug we're guarding against: gpt-4o-mini is the OpenAI compaction model
+  // but isn't in the build-time catalog snapshot (filtered to last-year
+  // releases). A catalog miss fell through to the Sonnet-tier FALLBACK_PRICING
+  // ($3/$15 per 1M), over-reporting the summarize call ~5–40×. cost.ts now
+  // carries an explicit KNOWN_MODEL_PRICING entry for it.
+  test('gpt-4o-mini priced at its real (cheap) rate, not the Sonnet fallback', () => {
+    const usage = {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+    };
+    const cost = turnCostUsd('openai', 'gpt-4o-mini', usage);
+    // Real gpt-4o-mini: $0.15 in + $0.60 out per 1M = $0.75.
+    expect(cost).toBeCloseTo(0.75, 6);
+    // Must be far below the $3 + $15 = $18 Sonnet-tier fallback.
+    const fallback = turnCostUsd('openai', 'totally-unknown-model-xyz', usage);
+    expect(fallback).toBeGreaterThan(cost * 10);
+  });
+
+  test('cached gpt-4o-mini input uses the discounted cache-read rate', () => {
+    const cost = turnCostUsd('openai', 'gpt-4o-mini', {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 1_000_000,
+    });
+    // cacheRead $0.075 per 1M.
+    expect(cost).toBeCloseTo(0.075, 6);
+  });
+});
+
 describe('formatUsd', () => {
   test('zero shows as $0', () => {
     expect(formatUsd(0)).toBe('$0');


### PR DESCRIPTION
## Summary

Originally a broad AI-consistency pass; **slimmed** after several AI PRs (#331/#332/#334 + the custom OpenAI-compatible provider) merged to `main` and independently covered or contradicted most of it. This keeps only the still-unique, uncontested fixes:

- **Compaction cost no longer over-reports for `gpt-4o-mini`.** It's OpenAI's compaction model (`COMPACTION_MODEL` in `compaction.ts`) but isn't in the build-time catalog snapshot (filtered to last-year releases), so a catalog miss fell through to the Sonnet-tier `FALLBACK_PRICING` ($3/$15 per 1M) and over-reported ~5–40×. Added an explicit `KNOWN_MODEL_PRICING` entry with its real rate ($0.15 in / $0.60 out, cached $0.075). `gemini-2.5-flash-lite` / `claude-haiku-4-5` are already in the snapshot. (`src/ai/cost.ts` + unit tests in `tests/unit/cost.test.ts`.)
- **Local (WebGPU) reasoning models now surface their CoT in the thinking box.** The stripped `<think>` content was discarded; it's now routed to `onThinking` + `result.thinking` so local gets the same collapsible thinking box Gemini/Anthropic do. The answer bubble stays free of the `<think>` body. (`src/ai/local.ts`.)
- **(docs)** Corrected the "add a provider" pricing step in CLAUDE.md — pricing is catalog-driven (`CATALOG_PROVIDER_ID` in `catalog.ts` + `KNOWN_MODEL_PRICING`/`FALLBACK_PRICING` in `cost.ts`), not a non-existent `PROVIDER_PRICING` map.

## Dropped from the original scope (now redundant or contested on `main`)

- **Gemini answer-text `thoughtSignature` replay** — `main` already implements this (with `thoughtSignature`/`textThoughtSignature` field naming); keeping a second implementation would duplicate/diverge.
- **Cross-provider reviewer honoring the thinking level** — `main`'s `review.ts` already threads thinking.
- **`validateKey` → `/v1/models` for Anthropic/OpenAI** — `main` deliberately keeps validateKey on the generation endpoint (documented in `anthropic.ts`: "intentionally hit /v1/messages … so we exercise the same code path the chat will use"). Not overriding that recent decision here.

## Test plan

- `npm run build` — clean (type-check passes).
- `npm run test:unit` — 478 pass, incl. new cases pinning the gpt-4o-mini rate and its discounted cache-read rate.
- e2e on CI shards.
- Rebuilt on the latest `main` (post #322/#324/#331/#332/#334), so it merges cleanly.

Intended label: **bug**, **documentation**

https://claude.ai/code/session_011v1XCcLbbuTPDXxFLYvRk2