### PR TITLE
test: scope landing tour CTA locator to #landing-page (fixes deterministic shard-3 failure)

### DIFF
--- a/tests/tour-entry-points.spec.ts
+++ b/tests/tour-entry-points.spec.ts
@@ -33,7 +33,11 @@ test.describe('Guided tour entry points', () => {
 
   test('landing CTA opens the editor and starts the tour', async ({ page }) => {
     await page.goto('/');
-    const cta = page.getByRole('button', { name: 'Take the guided tour' });
+    // Scope to the landing subtree: the editor chrome (mounted but hidden in
+    // the same SPA DOM) carries a rail button #btn-tour with the same
+    // accessible name, so an unscoped getByRole can resolve to that hidden
+    // control on slower startups and time out waiting for it to be clickable.
+    const cta = page.locator('#landing-page').getByRole('button', { name: 'Take the guided tour' });
     await expect(cta).toBeVisible();
 
     await cta.click();


### PR DESCRIPTION
## Summary

Fixes a **pre-existing, deterministic e2e shard-3 failure on `main`** that has been blocking CI on every open PR. It is not caused by any feature change — it surfaces purely from CI startup timing.

`tests/tour-entry-points.spec.ts` → `landing CTA opens the editor and starts the tour` resolved its CTA with an **unscoped** locator:

```ts
const cta = page.getByRole('button', { name: 'Take the guided tour' });
```

Two controls share that accessible name:
- the **landing hero CTA** (`landing.ts:137`, button text "Take the guided tour"), and
- the **editor activity-rail button** `#btn-tour` (`layout.ts:244`, `aria-label="Take the guided tour"`).

The editor chrome is mounted (hidden) in the same SPA DOM as the landing overlay (`main.ts:3260`). On slower CI startups the editor button is in the accessibility tree when the test queries, so the unscoped locator resolves to the **hidden** `#btn-tour` and times out at `cta.click()` waiting for it to become visible (30s). On faster local hardware only the landing CTA matches, so it passes — which is why this reproduced 100% in CI but never locally.

### Fix

Scope the lookup to the landing subtree (`#btn-tour` lives outside `#landing-page`), so it can only match the visible landing CTA:

```ts
const cta = page.locator('#landing-page').getByRole('button', { name: 'Take the guided tour' });
```

Test-only change; app behavior is unchanged (real users click the visible CTA).

## Test plan

- `npx playwright test tests/tour-entry-points.spec.ts` — both entry-point tests pass (6.4s).
- Full shard 3 already passed locally on `main`; this hardens the one test that flips under CI timing.

## Why this matters

This single ambiguous locator is why e2e (3) was red on PRs #321, #322, #323, #325, #326 (and is almost certainly red on `main`'s own staging gate for its latest commits). Merging this first unblocks shard 3; the five feature PRs then re-sync onto `main` to pick it up.

Intended label: **bug**

https://claude.ai/code/session_011v1XCcLbbuTPDXxFLYvRk2

---
_Generated by [Claude Code](https://claude.ai/code/session_011v1XCcLbbuTPDXxFLYvRk2)_