### PR TITLE
fix: target landing guided-tour CTA by id to deflake e2e

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "partwright-cad",
       "version": "0.0.0",
+      "license": "LicenseRef-PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
         "@codemirror/lang-javascript": "^6.2.5",

--- a/src/ui/landing.ts
+++ b/src/ui/landing.ts
@@ -133,6 +133,7 @@ function buildHero(callbacks: LandingCallbacks): HTMLElement {
   ctas.appendChild(help);
 
   const tour = document.createElement('button');
+  tour.id = 'btn-landing-tour';
   tour.className = 'px-6 py-2.5 rounded-lg bg-transparent hover:bg-zinc-800 text-zinc-400 text-sm font-medium transition-colors';
   tour.textContent = 'Take the guided tour';
   tour.addEventListener('click', callbacks.onTakeTour);

--- a/tests/tour-entry-points.spec.ts
+++ b/tests/tour-entry-points.spec.ts
@@ -33,7 +33,11 @@ test.describe('Guided tour entry points', () => {
 
   test('landing CTA opens the editor and starts the tour', async ({ page }) => {
     await page.goto('/');
-    const cta = page.getByRole('button', { name: 'Take the guided tour' });
+    // Target the landing CTA by id, not by accessible name: the editor's rail
+    // button (#btn-tour) carries the same name ("Take the guided tour") and is
+    // present-but-hidden in the DOM on the landing route, so a name-based
+    // locator can bind to that hidden button and time out the click on CI.
+    const cta = page.locator('#btn-landing-tour');
     await expect(cta).toBeVisible();
 
     await cta.click();


### PR DESCRIPTION
## Summary

Deflakes `tests/tour-entry-points.spec.ts` — *"landing CTA opens the editor and starts the tour"* — which has been failing intermittently on CI across multiple sessions/PRs.

**Root cause:** the landing page's "Take the guided tour" CTA (`landing.ts`) and the editor's activity-rail button (`#btn-tour`, `layout.ts`) share the **same accessible name** ("Take the guided tour"). On the landing route the editor DOM is present-but-hidden, so the test's name-based locator —

```ts
page.getByRole('button', { name: 'Take the guided tour' })
```

— could resolve to the hidden rail button and time out the click (`element is not visible`, 30s). It passed on fast local machines but failed on loaded CI runners, so it surfaced as a flaky `e2e (3)` shard.

**Fix:** give the landing CTA a stable id (`#btn-landing-tour`) and target it by id in the test — mirroring how the *rail-button* test already uses `#btn-tour`. The id can't bind to the hidden editor button, removing the ambiguity. No user-visible behavior change.

## Test plan
- `npm run build` — clean.
- `npx playwright test tour-entry-points.spec.ts --repeat-each=5` — 10/10 pass (both entry-point tests, 5× each).

## Why a standalone PR
This is unrelated to any feature work — it's a pre-existing flake (introduced with `db56556 feat: add guided-tour launch points`) that's blocking the e2e gate for everyone, so it's split out to land quickly on its own.

https://claude.ai/code/session_01TsavoEF6pNJAzjowjYa2EX

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsavoEF6pNJAzjowjYa2EX)_