### PR TITLE
feat: add custom OpenAI-compatible AI endpoint provider

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,13 @@
+# connect-src below intentionally allows `https:` and http://localhost / 127.0.0.1
+# so a user-configured Custom (OpenAI-compatible) AI endpoint — e.g. a self-hosted
+# llama.cpp server — is reachable from the browser. The named hosts that follow are
+# the first-party cloud APIs + model CDN; they're subsumed by `https:` but kept as
+# documentation of expected traffic. Plain-HTTP LAN addresses still won't load on the
+# hosted HTTPS site (browser mixed-content rule) — only HTTPS endpoints or localhost.
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://huggingface.co https://*.huggingface.co https://*.xethub.hf.co https://raw.githubusercontent.com; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' https: http://localhost:* http://127.0.0.1:* https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://huggingface.co https://*.huggingface.co https://*.xethub.hf.co https://raw.githubusercontent.com; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'
 
 /*.md
   Content-Type: text/markdown; charset=utf-8

--- a/src/ai/catalog.ts
+++ b/src/ai/catalog.ts
@@ -78,8 +78,11 @@ type RawCatalog = Record<string, RawProvider>;
 
 const CATALOG = catalogJson as unknown as RawCatalog;
 
-/** models.dev publishes Gemini models under the 'google' provider id. */
-const CATALOG_PROVIDER_ID: Record<Exclude<Provider, 'local'>, string> = {
+/** models.dev publishes Gemini models under the 'google' provider id.
+ *  'local' (WebLLM) and 'custom' (a user-supplied OpenAI-compatible endpoint)
+ *  have no catalog entry, so they're excluded here and `rawProvider` returns
+ *  null for them — callers then fall back to their per-provider defaults. */
+const CATALOG_PROVIDER_ID: Record<Exclude<Provider, 'local' | 'custom'>, string> = {
   anthropic: 'anthropic',
   openai: 'openai',
   gemini: 'google',
@@ -152,7 +155,7 @@ export interface ModelOption {
 }
 
 function rawProvider(provider: Provider): RawProvider | null {
-  if (provider === 'local') return null;
+  if (provider === 'local' || provider === 'custom') return null;
   return CATALOG[CATALOG_PROVIDER_ID[provider]] ?? null;
 }
 

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -14,6 +14,7 @@ import { streamTurn, buildApiMessages, type StreamCallbacks as AnthropicStreamCa
 import { streamLocalTurn, resolveLocalModel, type StreamCallbacks as LocalStreamCallbacks } from './local';
 import { streamTurn as streamTurnOpenai, type StreamCallbacks as OpenaiStreamCallbacks } from './openai';
 import { streamTurn as streamTurnGemini, type StreamCallbacks as GeminiStreamCallbacks } from './gemini';
+import { streamTurn as streamTurnCustom } from './custom';
 import { getKey, recordUsage, putMessages } from './db';
 import { recordEvent } from './diagnostics';
 import { buildToolList, executeTool } from './tools';
@@ -294,6 +295,23 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
           history: workingHistory,
           tools,
           thinking: toggles.thinking,
+        }, streamCallbacks, signal);
+      } else if (toggles.provider === 'custom') {
+        // Generic OpenAI-compatible endpoint (e.g. a self-hosted llama.cpp
+        // server). The base URL travels on toggles (serialized into the
+        // Worker); the API key is OPTIONAL — fall back to an empty string,
+        // which makes the provider omit the Authorization header.
+        if (!toggles.customBaseUrl.trim()) throw new Error('Custom endpoint URL is required. Open AI Settings → Custom to set it.');
+        if (!toggles.customModel.trim()) throw new Error('A model id is required for the custom endpoint. Open AI Settings → Custom to set or fetch one.');
+        const customKey = apiKey ?? (await getApiKey('custom')) ?? '';
+        result = await streamTurnCustom({
+          apiKey: customKey,
+          baseUrl: toggles.customBaseUrl,
+          model: toggles.customModel,
+          systemPrompt,
+          systemSuffix: toggleSuffix(toggles),
+          history: workingHistory,
+          tools,
         }, streamCallbacks, signal);
       } else {
         if (!toggles.localModel) throw new Error('No local model is selected. Open AI settings → Local model.');

--- a/src/ai/compaction.ts
+++ b/src/ai/compaction.ts
@@ -8,6 +8,7 @@
 import { summarize } from './anthropic';
 import { summarize as summarizeOpenai } from './openai';
 import { summarize as summarizeGemini } from './gemini';
+import { summarize as summarizeCustom } from './custom';
 import { summarizeLocal } from './local';
 import { recordEvent } from './diagnostics';
 import { turnCostUsd } from './cost';
@@ -15,12 +16,24 @@ import { getKey } from './db';
 import type { ChatMessage, ChatToggles, Provider } from './types';
 
 /** Per-provider cheap model used for compaction. The big models cost too
- *  much for a summarize call we'll fire after most longer sessions. */
-const COMPACTION_MODEL: Record<Exclude<Provider, 'local'>, string> = {
+ *  much for a summarize call we'll fire after most longer sessions. 'local'
+ *  and 'custom' aren't here: both reuse whatever model the session is already
+ *  on (there's no separate cheap tier to pick), handled as explicit branches
+ *  in proposeCompaction. */
+const COMPACTION_MODEL: Record<Exclude<Provider, 'local' | 'custom'>, string> = {
   anthropic: 'claude-haiku-4-5',
   openai: 'gpt-4o-mini',
   gemini: 'gemini-2.5-flash-lite',
 };
+
+/** Model id used in diagnostics for a compaction call — the cheap-tier model
+ *  for cloud providers, or the session's own model for local/custom (which
+ *  have no separate tier). */
+function compactionModelFor(toggles: ChatToggles): string {
+  if (toggles.provider === 'local') return toggles.localModel ?? '(no model)';
+  if (toggles.provider === 'custom') return toggles.customModel || '(no model)';
+  return COMPACTION_MODEL[toggles.provider];
+}
 
 export interface CompactionProposal {
   /** Plain-text summary of the conversation up to the kept tail. */
@@ -117,6 +130,18 @@ export async function proposeCompaction(
       text = r.text;
       usage = { inputTokens: r.usage.inputTokens, outputTokens: r.usage.outputTokens, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
       costUsd = 0;
+    } else if (ctx.toggles.provider === 'custom') {
+      // Self-hosted OpenAI-compatible endpoint. Reuse the session's own model
+      // (no cheap tier to pick), pass the base URL, and treat the optional
+      // key as empty when absent. Billed at $0, like local.
+      if (!ctx.toggles.customBaseUrl.trim()) throw new Error('Custom endpoint URL required for compaction.');
+      if (!ctx.toggles.customModel.trim()) throw new Error('A model id is required for the custom endpoint.');
+      compactionModel = ctx.toggles.customModel;
+      const key = ctx.apiKey ?? (await getKey('custom'))?.apiKey ?? '';
+      const r = await summarizeCustom(key, compactionModel, COMPACTION_SYSTEM, prompt, ctx.toggles.customBaseUrl);
+      text = r.text;
+      usage = r.usage;
+      costUsd = 0;
     } else {
       const apiKey = ctx.apiKey ?? (await getKey(ctx.toggles.provider))?.apiKey;
       if (!apiKey) throw new Error(`${ctx.toggles.provider} API key required for compaction.`);
@@ -132,7 +157,7 @@ export async function proposeCompaction(
   } catch (err) {
     recordEvent({
       provider: ctx.toggles.provider,
-      model: ctx.toggles.provider === 'local' ? (ctx.toggles.localModel ?? '(no model)') : COMPACTION_MODEL[ctx.toggles.provider],
+      model: compactionModelFor(ctx.toggles),
       kind: 'summarize',
       durationMs: Math.round(performance.now() - t0),
       status: 'error',

--- a/src/ai/cost.ts
+++ b/src/ai/cost.ts
@@ -31,7 +31,10 @@ const CACHE_WRITE_MULTIPLIER = 1.25;
 const FALLBACK_PRICING: CatalogPricing = { input: 3.0, output: 15.0 };
 
 function pricingFor(provider: string, model: string): CatalogPricing | null {
-  if (provider === 'local') return null;
+  // Local (WebGPU) and custom (self-hosted OpenAI-compatible endpoint) turns
+  // are free at the API level — the user paid for the hardware/electricity —
+  // so they're billed at $0. The cost meter still tracks total tokens.
+  if (provider === 'local' || provider === 'custom') return null;
   // The catalog is keyed by our internal Provider type; cast through string
   // because the call sites pass `provider` as a raw string (the same way
   // the rest of the cost meter does).

--- a/src/ai/custom.ts
+++ b/src/ai/custom.ts
@@ -1,0 +1,145 @@
+// Custom provider: a generic OpenAI-compatible HTTP endpoint the user points
+// us at — typically a self-hosted server like llama.cpp's `llama-server`,
+// vLLM, LM Studio, or Ollama's OpenAI-compatible shim. The wire format is
+// identical to OpenAI's Chat Completions API, so the streaming transport,
+// history conversion, tool schema, image handling, and dangling-tool-call
+// repair are all reused verbatim from src/ai/openai.ts — this module only
+// supplies the endpoint base URL and pins the Chat Completions path.
+//
+// Two things differ from the OpenAI provider proper:
+//   1. Auth is OPTIONAL. A home server often runs with no `--api-key`, so the
+//      Authorization header is omitted when no key is stored (handled by
+//      openai.ts's authHeaders).
+//   2. We never touch the Responses API (`/v1/responses`) — it's OpenAI-
+//      proprietary and self-hosted servers don't implement it. `streamTurn`
+//      passes `forceChatCompletions: true`, and we send `thinking: 'off'` so
+//      no `reasoning_effort` field is ever attached (arbitrary servers reject
+//      unknown fields).
+//
+// Mirrors the exported shape of the other providers (streamTurn / summarize /
+// validateKey / listModels / resetClient) so chatLoop.ts, compaction.ts, and
+// review.ts can dispatch via a sibling branch.
+
+import {
+  streamTurn as openaiStreamTurn,
+  summarize as openaiSummarize,
+  type StreamCallbacks,
+  type StreamResult,
+} from './openai';
+import type { ChatMessage, TurnUsage } from './types';
+import type { ToolDefinition } from './tools';
+
+export type { StreamCallbacks, StreamResult } from './openai';
+
+export interface CustomRequestSpec {
+  /** Optional — empty string means "no auth header". */
+  apiKey: string;
+  /** Base URL including any version path, e.g. http://localhost:8080/v1 */
+  baseUrl: string;
+  model: string;
+  systemPrompt: string;
+  systemSuffix: string;
+  history: ChatMessage[];
+  tools: ToolDefinition[];
+  maxTokens?: number;
+}
+
+/** Build the `/models` URL for the configured base. Trailing slash tolerated. */
+function modelsUrl(baseUrl: string): string {
+  return `${baseUrl.trim().replace(/\/+$/, '')}/models`;
+}
+
+function authHeaders(apiKey: string): HeadersInit {
+  const headers: Record<string, string> = {};
+  if (apiKey && apiKey.trim().length > 0) headers['Authorization'] = `Bearer ${apiKey.trim()}`;
+  return headers;
+}
+
+export function resetClient(): void {
+  // Stateless — each request opens its own fetch.
+}
+
+export async function streamTurn(
+  spec: CustomRequestSpec,
+  callbacks: StreamCallbacks = {},
+  signal?: AbortSignal,
+): Promise<StreamResult> {
+  return openaiStreamTurn(
+    {
+      apiKey: spec.apiKey,
+      model: spec.model,
+      systemPrompt: spec.systemPrompt,
+      systemSuffix: spec.systemSuffix,
+      history: spec.history,
+      tools: spec.tools,
+      maxTokens: spec.maxTokens,
+      // Self-hosted servers implement Chat Completions, not the Responses
+      // API; never send a reasoning request (see module header).
+      thinking: 'off',
+      baseUrl: spec.baseUrl,
+      forceChatCompletions: true,
+    },
+    callbacks,
+    signal,
+  );
+}
+
+/** Single-shot non-streaming call used by compaction + review. Delegates to
+ *  the OpenAI Chat Completions summarizer with the custom base URL. */
+export async function summarize(
+  apiKey: string,
+  model: string,
+  system: string,
+  user: string,
+  baseUrl: string,
+  maxTokens = 4096,
+): Promise<{ text: string; usage: TurnUsage }> {
+  return openaiSummarize(apiKey, model, system, user, maxTokens, baseUrl);
+}
+
+/** Probe the endpoint to confirm it's reachable and OpenAI-compatible. We
+ *  GET `{baseUrl}/models` — the cheapest universally-implemented endpoint —
+ *  rather than burning a chat completion (we don't know a valid model id
+ *  yet, and a self-hosted server may have only one loaded). Returns null on
+ *  success, or a human-readable error string. Used by the "Test connection"
+ *  button in the settings modal. */
+export async function validateConnection(baseUrl: string, apiKey: string): Promise<string | null> {
+  const base = baseUrl.trim();
+  if (base.length === 0) return 'Enter an endpoint URL first.';
+  if (!/^https?:\/\//i.test(base)) return 'URL must start with http:// or https://';
+  try {
+    const res = await fetch(modelsUrl(base), { method: 'GET', headers: authHeaders(apiKey) });
+    if (res.ok) return null;
+    if (res.status === 401 || res.status === 403) {
+      return `${res.status}: endpoint requires an API key (or the key is wrong).`;
+    }
+    const body = await res.text().catch(() => '');
+    return `${res.status}: ${body.slice(0, 200) || res.statusText || 'request failed'}`;
+  } catch (err) {
+    // Network error, CORS rejection, or mixed-content block (https page →
+    // http endpoint). The message is the most useful thing we can surface.
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+/** List the models the endpoint advertises. Unlike the OpenAI helper we do
+ *  NOT filter to gpt-/o- families — a self-hosted server serves whatever the
+ *  user loaded, under arbitrary ids. Throws on a non-OK response so the
+ *  caller can surface why the fetch failed. */
+export async function listModels(baseUrl: string, apiKey: string): Promise<{ id: string; label: string }[]> {
+  const base = baseUrl.trim();
+  if (base.length === 0) throw new Error('Enter an endpoint URL first.');
+  const res = await fetch(modelsUrl(base), { method: 'GET', headers: authHeaders(apiKey) });
+  if (!res.ok) {
+    if (res.status === 401 || res.status === 403) throw new Error('Endpoint requires an API key (or the key is wrong).');
+    const body = await res.text().catch(() => '');
+    throw new Error(`${res.status}: ${body.slice(0, 200) || res.statusText}`);
+  }
+  const data = await res.json().catch(() => ({})) as { data?: Array<{ id?: string }> };
+  const out: { id: string; label: string }[] = [];
+  for (const m of data.data ?? []) {
+    if (m.id) out.push({ id: m.id, label: m.id });
+  }
+  out.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
+  return out;
+}

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -41,8 +41,20 @@ import type { ToolDefinition } from './tools';
 import { readSseStream } from './sse';
 import { getCapabilities } from './catalog';
 
-const CHAT_URL = 'https://api.openai.com/v1/chat/completions';
-const RESPONSES_URL = 'https://api.openai.com/v1/responses';
+const OPENAI_BASE = 'https://api.openai.com/v1';
+const CHAT_URL = `${OPENAI_BASE}/chat/completions`;
+const RESPONSES_URL = `${OPENAI_BASE}/responses`;
+
+/** Resolve the chat-completions / responses URLs for a request. Defaults to
+ *  OpenAI's hosted endpoints; the custom provider (src/ai/custom.ts) threads
+ *  its own base (a llama.cpp / vLLM / LM Studio server) through
+ *  `OpenaiRequestSpec.baseUrl`. A trailing slash on the base is tolerated so
+ *  `http://host:8080/v1` and `http://host:8080/v1/` behave the same. */
+function endpointUrls(baseUrl?: string): { chat: string; responses: string } {
+  if (!baseUrl || baseUrl.trim().length === 0) return { chat: CHAT_URL, responses: RESPONSES_URL };
+  const base = baseUrl.trim().replace(/\/+$/, '');
+  return { chat: `${base}/chat/completions`, responses: `${base}/responses` };
+}
 
 /** OpenAI reasoning models (gpt-5 family + the o-series) accept a reasoning
  *  request and need to go to /v1/responses; chat / 4o / 4.1 / legacy models
@@ -70,11 +82,15 @@ function reasoningEffort(model: string, level: ChatToggles['thinking']): string 
   return level;
 }
 
+/** When `apiKey` is empty/whitespace we omit the Authorization header
+ *  entirely. A self-hosted OpenAI-compatible server commonly runs with no
+ *  auth (llama.cpp's `--api-key` is optional), and sending `Bearer ` with an
+ *  empty token makes some servers 401. OpenAI itself always passes a real
+ *  key, so its request shape is unchanged. */
 function authHeaders(apiKey: string): HeadersInit {
-  return {
-    'Authorization': `Bearer ${apiKey}`,
-    'Content-Type': 'application/json',
-  };
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey && apiKey.trim().length > 0) headers['Authorization'] = `Bearer ${apiKey}`;
+  return headers;
 }
 
 export function resetClient(): void {
@@ -164,19 +180,30 @@ export interface OpenaiRequestSpec {
   /** Extended-thinking level → reasoning `effort` (reasoning models only).
    *  'off' (default) omits the reasoning request. */
   thinking?: ChatToggles['thinking'];
+  /** Override the OpenAI base URL. Set by the custom provider to target a
+   *  self-hosted OpenAI-compatible server. Omitted (undefined) for OpenAI. */
+  baseUrl?: string;
+  /** Force the Chat Completions path regardless of the model name. The
+   *  custom provider sets this because self-hosted servers implement
+   *  `/v1/chat/completions` but not OpenAI's proprietary `/v1/responses`,
+   *  so a model id that happens to match the reasoning sniff (e.g. a model
+   *  the user named "o3-local") must NOT be routed to Responses. */
+  forceChatCompletions?: boolean;
 }
 
 /** Route per model: reasoning models go to the Responses API (gpt-5.5+
  *  require it for tools + reasoning), everything else to Chat Completions
- *  (where the older / legacy models live). */
+ *  (where the older / legacy models live). `forceChatCompletions` pins the
+ *  Chat path for OpenAI-compatible endpoints that lack the Responses API. */
 export async function streamTurn(
   spec: OpenaiRequestSpec,
   callbacks: StreamCallbacks = {},
   signal?: AbortSignal,
 ): Promise<StreamResult> {
-  return isReasoningModel(spec.model)
-    ? streamTurnResponses(spec, callbacks, signal)
-    : streamTurnChat(spec, callbacks, signal);
+  const useChat = spec.forceChatCompletions === true || !isReasoningModel(spec.model);
+  return useChat
+    ? streamTurnChat(spec, callbacks, signal)
+    : streamTurnResponses(spec, callbacks, signal);
 }
 
 // ---------------------------------------------------------------------------
@@ -242,7 +269,7 @@ async function streamTurnResponses(
 
   let res: Response;
   try {
-    res = await fetch(RESPONSES_URL, {
+    res = await fetch(endpointUrls(spec.baseUrl).responses, {
       method: 'POST',
       headers: authHeaders(spec.apiKey),
       body: JSON.stringify(body),
@@ -535,7 +562,7 @@ async function streamTurnChat(
 
   let res: Response;
   try {
-    res = await fetch(CHAT_URL, {
+    res = await fetch(endpointUrls(spec.baseUrl).chat, {
       method: 'POST',
       headers: authHeaders(spec.apiKey),
       body: JSON.stringify(body),
@@ -791,8 +818,11 @@ export async function summarize(
   system: string,
   user: string,
   maxTokens = 4096,
+  /** Override the base URL (custom OpenAI-compatible endpoint). Defaults to
+   *  OpenAI's hosted Chat Completions. */
+  baseUrl?: string,
 ): Promise<{ text: string; usage: TurnUsage }> {
-  const res = await fetch(CHAT_URL, {
+  const res = await fetch(endpointUrls(baseUrl).chat, {
     method: 'POST',
     headers: authHeaders(apiKey),
     body: JSON.stringify({

--- a/src/ai/review.ts
+++ b/src/ai/review.ts
@@ -8,12 +8,13 @@
 import { streamTurn as anthropicStreamTurn, buildApiMessages } from './anthropic';
 import { streamTurn as openaiStreamTurn } from './openai';
 import { streamTurn as geminiStreamTurn } from './gemini';
+import { streamTurn as customStreamTurn } from './custom';
 import { streamLocalTurn } from './local';
 import { turnCostUsd } from './cost';
 import { recordEvent } from './diagnostics';
 import { generateId } from '../storage/db';
 import { putMessages, getKey } from './db';
-import { providerLabel } from './settings';
+import { loadSettings, providerLabel } from './settings';
 import { captureIsoViews } from './images';
 import type {
   ChatBlock,
@@ -143,6 +144,24 @@ export async function runReview(
         tools: [],
         // See the Anthropic branch: Gemini's 32768 default is what keeps a
         // Pro/2.5 thinking reviewer from spending the ceiling on reasoning.
+      });
+      text = r.text;
+      usage = r.usage;
+    } else if (req.provider === 'custom') {
+      // Self-hosted OpenAI-compatible endpoint as the reviewer. Base URL
+      // comes from settings (the same endpoint the chat uses); the key is
+      // optional. The Chat Completions transport is reused via custom.ts.
+      const baseUrl = loadSettings().toggles.customBaseUrl;
+      if (!baseUrl.trim()) throw new Error('Custom endpoint URL required for review. Set it in AI Settings → Custom.');
+      const key = req.apiKey ?? (await getKey('custom'))?.apiKey ?? '';
+      const r = await customStreamTurn({
+        apiKey: key,
+        baseUrl,
+        model: req.model,
+        systemPrompt: REVIEW_SYSTEM,
+        systemSuffix: '',
+        history: [ephemeral],
+        tools: [],
       });
       text = r.text;
       usage = r.usage;

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -33,6 +33,7 @@ export interface AiSettings {
     local: string | null;
     openai: string | null;
     gemini: string | null;
+    custom: string | null;
   };
   /** User-added local models. Lets the user load any MLC-compiled model
    *  from Hugging Face (or anywhere) without us shipping it in the
@@ -88,7 +89,7 @@ export interface LocalContextSettings {
 const DEFAULT_OPENAI_MODEL: OpenaiModelId = 'gpt-5-mini';
 const DEFAULT_GEMINI_MODEL: GeminiModelId = 'gemini-flash-latest';
 
-const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatToggles, 'provider' | 'anthropicModel' | 'localModel' | 'openaiModel' | 'geminiModel'> & { anthropicModel: AnthropicModelId }> = {
+const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatToggles, 'provider' | 'anthropicModel' | 'localModel' | 'openaiModel' | 'geminiModel' | 'customModel' | 'customBaseUrl'> & { anthropicModel: AnthropicModelId }> = {
   minimal: {
     vision: { views: false, resolution: 'low', angles: 'auto' },
     scope: { runCode: true, saveVersions: true, paintFaces: false, sessionNotes: false },
@@ -134,6 +135,8 @@ const DEFAULT_TOGGLES: ChatToggles = {
   localModel: null,
   openaiModel: DEFAULT_OPENAI_MODEL,
   geminiModel: DEFAULT_GEMINI_MODEL,
+  customModel: '',
+  customBaseUrl: '',
 };
 
 const DEFAULT_SETTINGS: AiSettings = {
@@ -142,7 +145,7 @@ const DEFAULT_SETTINGS: AiSettings = {
   drawerOpen: true,
   editorCollapsed: null,
   autoCompactMode: 'off',
-  systemPromptOverrides: { anthropic: null, local: null, openai: null, gemini: null },
+  systemPromptOverrides: { anthropic: null, local: null, openai: null, gemini: null, custom: null },
   customLocalModels: [],
   localContext: { windowSizeOverride: null, sliding: false, stallTimeoutSec: 60 },
   aiPanelWidth: 420,
@@ -187,6 +190,8 @@ function cloneToggles(t: ChatToggles): ChatToggles {
     localModel: t.localModel,
     openaiModel: t.openaiModel,
     geminiModel: t.geminiModel,
+    customModel: t.customModel,
+    customBaseUrl: t.customBaseUrl,
   };
 }
 
@@ -226,12 +231,17 @@ export function reloadSettingsFromStorage(): AiSettings {
 export async function aiConnectionMode(): Promise<'disconnected' | 'cloud' | 'local'> {
   const settings = loadSettings();
   if (settings.toggles.provider === 'local' && settings.toggles.localModel) return 'local';
-  const [anthropic, openai, gemini] = await Promise.all([
+  // A configured custom endpoint counts as connected even with no key — the
+  // base URL is the real "is it set up" signal (auth is optional). Treated as
+  // 'cloud' since, like the hosted providers, it's a remote HTTP endpoint.
+  if (settings.toggles.customBaseUrl.trim().length > 0) return 'cloud';
+  const [anthropic, openai, gemini, custom] = await Promise.all([
     getKey('anthropic'),
     getKey('openai'),
     getKey('gemini'),
+    getKey('custom'),
   ]);
-  return (anthropic || openai || gemini) ? 'cloud' : 'disconnected';
+  return (anthropic || openai || gemini || custom) ? 'cloud' : 'disconnected';
 }
 
 export function applyPreset(settings: AiSettings, preset: Preset): AiSettings {
@@ -255,6 +265,8 @@ export function applyPreset(settings: AiSettings, preset: Preset): AiSettings {
       localModel: settings.toggles.localModel,
       openaiModel: settings.toggles.openaiModel,
       geminiModel: settings.toggles.geminiModel,
+      customModel: settings.toggles.customModel,
+      customBaseUrl: settings.toggles.customBaseUrl,
     },
   };
 }
@@ -374,6 +386,24 @@ export function setGeminiModel(settings: AiSettings, model: string): AiSettings 
   };
 }
 
+/** Set the model id sent to the custom OpenAI-compatible endpoint. */
+export function setCustomModel(settings: AiSettings, model: string): AiSettings {
+  return {
+    ...settings,
+    preset: 'custom',
+    toggles: { ...settings.toggles, customModel: model },
+  };
+}
+
+/** Set the base URL of the custom OpenAI-compatible endpoint (trimmed). */
+export function setCustomBaseUrl(settings: AiSettings, baseUrl: string): AiSettings {
+  return {
+    ...settings,
+    preset: 'custom',
+    toggles: { ...settings.toggles, customBaseUrl: baseUrl.trim() },
+  };
+}
+
 export function setToggles(settings: AiSettings, partial: DeepPartial<ChatToggles>): AiSettings {
   const next: ChatToggles = {
     vision: { ...settings.toggles.vision, ...(partial.vision ?? {}) },
@@ -387,6 +417,8 @@ export function setToggles(settings: AiSettings, partial: DeepPartial<ChatToggle
     localModel: partial.localModel ?? settings.toggles.localModel,
     openaiModel: partial.openaiModel ?? settings.toggles.openaiModel,
     geminiModel: partial.geminiModel ?? settings.toggles.geminiModel,
+    customModel: partial.customModel ?? settings.toggles.customModel,
+    customBaseUrl: partial.customBaseUrl ?? settings.toggles.customBaseUrl,
   };
   return { ...settings, preset: 'custom', toggles: next };
 }
@@ -466,12 +498,15 @@ function mergeWithDefaults(partial: LegacyAiSettings): AiSettings {
       localModel: validLocalModel,
       openaiModel: tgls.openaiModel ?? DEFAULT_SETTINGS.toggles.openaiModel,
       geminiModel: tgls.geminiModel ?? DEFAULT_SETTINGS.toggles.geminiModel,
+      customModel: tgls.customModel ?? DEFAULT_SETTINGS.toggles.customModel,
+      customBaseUrl: tgls.customBaseUrl ?? DEFAULT_SETTINGS.toggles.customBaseUrl,
     },
     systemPromptOverrides: {
       anthropic: overrides.anthropic ?? null,
       local: overrides.local ?? null,
       openai: overrides.openai ?? null,
       gemini: overrides.gemini ?? null,
+      custom: overrides.custom ?? null,
     },
     customLocalModels: Array.isArray(partial.customLocalModels) ? partial.customLocalModels : [],
     localContext: normalizeLocalContext(partial.localContext),
@@ -629,6 +664,7 @@ export function providerLabel(provider: Provider): string {
     case 'anthropic': return 'Anthropic Claude';
     case 'openai': return 'OpenAI';
     case 'gemini': return 'Google Gemini';
+    case 'custom': return 'Custom endpoint';
     case 'local': return 'Local model';
   }
 }

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -7,9 +7,12 @@
 import type { LocalModelId } from './localModels';
 
 /** Anthropic = hosted Claude (BYO API key). Local = WebLLM running on the
- *  user's GPU. OpenAI / Gemini = hosted, BYO key. Only one is active per
- *  chat at a time; switching is a UI affordance, not a per-turn decision. */
-export type Provider = 'anthropic' | 'local' | 'openai' | 'gemini';
+ *  user's GPU. OpenAI / Gemini = hosted, BYO key. Custom = a generic
+ *  OpenAI-compatible HTTP endpoint the user points us at (e.g. a llama.cpp
+ *  server on their LAN); base URL lives on ChatToggles and the API key is
+ *  optional. Only one is active per chat at a time; switching is a UI
+ *  affordance, not a per-turn decision. */
+export type Provider = 'anthropic' | 'local' | 'openai' | 'gemini' | 'custom';
 
 export type AnthropicModelId = 'claude-haiku-4-5' | 'claude-sonnet-4-6' | 'claude-opus-4-7';
 
@@ -114,6 +117,18 @@ export interface ChatToggles {
   openaiModel: string;
   /** Google Gemini model id. Same custom-id story as OpenAI. */
   geminiModel: string;
+  /** Model id sent to the custom OpenAI-compatible endpoint. Free-form —
+   *  a self-hosted server (llama.cpp, vLLM, LM Studio, …) serves whatever
+   *  the user loaded, so this is whatever id `/v1/models` reports (or they
+   *  typed). Lives in toggles (not the key record) so it serializes into
+   *  the agent Worker alongside `customBaseUrl`. */
+  customModel: string;
+  /** Base URL of the custom OpenAI-compatible endpoint, including any
+   *  version path (e.g. `http://localhost:8080/v1`). We append
+   *  `/chat/completions` and `/models` to it. Empty string = not configured.
+   *  Auth for this endpoint is optional — the API key, when present, lives
+   *  in the `aiKeys` store keyed by 'custom'. */
+  customBaseUrl: string;
 }
 
 /** Source of truth for the iteration-cap dropdown. The toggle pill,
@@ -328,6 +343,7 @@ export function activeModel(toggles: ChatToggles): ModelId | string | null {
     case 'anthropic': return toggles.anthropicModel;
     case 'openai': return toggles.openaiModel;
     case 'gemini': return toggles.geminiModel;
+    case 'custom': return toggles.customModel;
     case 'local': return toggles.localModel;
   }
 }

--- a/src/ui/aiKeyModal.tsx
+++ b/src/ui/aiKeyModal.tsx
@@ -38,7 +38,12 @@ interface ProviderUi {
   reset: () => void;
 }
 
-export type HostedProvider = Exclude<Provider, 'local'>;
+// 'custom' is deliberately excluded: it isn't a paste-an-API-key cloud
+// provider but a user-supplied OpenAI-compatible endpoint (base URL + an
+// OPTIONAL key), configured in its own AI Settings tab. Keeping it out of
+// HostedProvider means PROVIDER_UI / providerKeyMeta / validateAndStoreKey
+// stay cloud-only and unchanged.
+export type HostedProvider = Exclude<Provider, 'local' | 'custom'>;
 
 const PROVIDER_UI: Record<HostedProvider, ProviderUi> = {
   anthropic: {
@@ -219,7 +224,9 @@ function KeyFormFooter(props: {
 
 export async function showAiKeyModal(cb: AiKeyModalCallbacks): Promise<void> {
   const requested: Provider = cb.provider ?? 'anthropic';
-  if (requested === 'local') return; // local uses no key
+  // local uses no key; custom is configured in its own settings tab (base
+  // URL + optional key), not via this paste-a-key modal.
+  if (requested === 'local' || requested === 'custom') return;
   const providerId: HostedProvider = requested;
   const ui = PROVIDER_UI[providerId];
 

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -8,7 +8,7 @@ import { runTurn as runTurnInWorker, pushQueuedBlocks } from '../ai/agentWorkerC
 import { listMessages, GLOBAL_CHAT_BUCKET, putMessages, deleteMessages, getKey, clearChat, mergeChatBucket } from '../ai/db';
 import { proposeCompaction } from '../ai/compaction';
 import { captureIsoViews, fileToImageSource } from '../ai/images';
-import { loadSettings, saveSettings, setAnthropicModel, setOpenaiModel, setGeminiModel, setProvider, setLocalModel, setToggles, providerLabel, aiConnectionMode, ANTHROPIC_MODEL_OPTIONS, OPENAI_MODEL_OPTIONS, GEMINI_MODEL_OPTIONS, MAX_ITERATIONS_OPTIONS, MAX_SPEND_OPTIONS, THINKING_OPTIONS, RENDER_RESOLUTION_OPTIONS, VERIFY_ANGLE_OPTIONS, type AiSettings } from '../ai/settings';
+import { loadSettings, saveSettings, setAnthropicModel, setOpenaiModel, setGeminiModel, setCustomModel, setProvider, setLocalModel, setToggles, providerLabel, aiConnectionMode, ANTHROPIC_MODEL_OPTIONS, OPENAI_MODEL_OPTIONS, GEMINI_MODEL_OPTIONS, MAX_ITERATIONS_OPTIONS, MAX_SPEND_OPTIONS, THINKING_OPTIONS, RENDER_RESOLUTION_OPTIONS, VERIFY_ANGLE_OPTIONS, type AiSettings } from '../ai/settings';
 import { buildLocalSystemPrompt, buildMediumLocalSystemPrompt, buildSystemPrompt, loadAiMd } from '../ai/systemPrompt';
 import { estimateTurnCostUsd, formatUsd } from '../ai/cost';
 import { getLimits } from '../ai/catalog';
@@ -378,6 +378,9 @@ async function isProviderModelUsable(provider: Provider, model: string): Promise
   if (provider === 'local') {
     try { resolveLocalModel(model); return true; } catch { return false; }
   }
+  // Custom is usable once its endpoint URL is configured — the API key is
+  // optional, so don't gate on a stored key.
+  if (provider === 'custom') return loadSettings().toggles.customBaseUrl.trim().length > 0;
   return !!(await getKey(provider));
 }
 
@@ -403,7 +406,7 @@ async function applySessionAiPreference(): Promise<void> {
   hidePrefNotice();
   const pref = getState().session?.aiPreference;
   if (!pref) return;
-  const known: Provider[] = ['anthropic', 'openai', 'gemini', 'local'];
+  const known: Provider[] = ['anthropic', 'openai', 'gemini', 'custom', 'local'];
   const provider = pref.provider as Provider;
   if (!known.includes(provider)) return;
   if (!(await isProviderModelUsable(provider, pref.model))) {
@@ -420,6 +423,7 @@ async function applySessionAiPreference(): Promise<void> {
     case 'anthropic': next = setAnthropicModel(next, pref.model); break;
     case 'openai': next = setOpenaiModel(next, pref.model); break;
     case 'gemini': next = setGeminiModel(next, pref.model); break;
+    case 'custom': next = setCustomModel(next, pref.model); break;
     case 'local': next = setLocalModel(next, pref.model); break;
   }
   saveSettings(next);
@@ -939,6 +943,24 @@ function renderModelPicker(): void {
     return;
   }
 
+  // Custom OpenAI-compatible endpoint: a chip showing the configured model
+  // (or a prompt to configure), opening AI Settings on the Custom tab — the
+  // endpoint URL + model live there, like the local model lives in its modal.
+  if (settings.toggles.provider === 'custom') {
+    const customChip = document.createElement('button');
+    customChip.type = 'button';
+    customChip.className = 'h-6 px-2 inline-flex items-center rounded text-[11px] bg-sky-900/30 border border-sky-700/50 text-sky-200 hover:bg-sky-900/50';
+    customChip.textContent = settings.toggles.customModel.trim() || 'Configure endpoint';
+    customChip.title = settings.toggles.customBaseUrl.trim()
+      ? `Custom endpoint: ${settings.toggles.customBaseUrl} · model: ${settings.toggles.customModel || '(none set)'}. Click to configure.`
+      : 'No custom endpoint configured yet. Click to set the base URL and model.';
+    customChip.addEventListener('click', () => {
+      void showAiSettingsModal({ onChange: afterAiSettingsChange }, { initialTab: 'custom' });
+    });
+    modelPickerEl.appendChild(customChip);
+    return;
+  }
+
   const chip = document.createElement('button');
   chip.type = 'button';
   chip.className = 'h-6 px-2 inline-flex items-center rounded text-[11px] bg-emerald-900/30 border border-emerald-700/50 text-emerald-200 hover:bg-emerald-900/50';
@@ -1313,6 +1335,33 @@ function panelStatusUpdate(): void {
     hint.appendChild(switchLink);
     hint.appendChild(document.createTextNode(' for better quality.'));
     panelStatusEl.appendChild(hint);
+    return;
+  }
+  // Custom OpenAI-compatible endpoint: readiness is the base URL + model
+  // (the API key is optional), so don't run the cloud-key check below — it
+  // would falsely report "Not connected" for a keyless self-hosted server.
+  if (settings.toggles.provider === 'custom') {
+    panelStatusEl.replaceChildren();
+    panelStatusEl.classList.remove('hidden', 'text-emerald-400', 'text-amber-400', 'text-blue-300');
+    const needsUrl = settings.toggles.customBaseUrl.trim().length === 0;
+    const needsModel = settings.toggles.customModel.trim().length === 0;
+    if (needsUrl || needsModel) {
+      panelStatusEl.classList.add('text-amber-400');
+      panelStatusEl.appendChild(document.createTextNode(needsUrl ? 'Custom endpoint not configured. ' : 'No model set for the endpoint. '));
+      const link = document.createElement('button');
+      link.className = 'underline text-amber-200 hover:text-amber-100';
+      link.textContent = needsUrl ? 'Set endpoint URL' : 'Choose a model';
+      link.addEventListener('click', () => {
+        void showAiSettingsModal(
+          { onChange: () => { renderTranscript(); renderToggleStrip(); renderCostMeter(); renderModelPicker(); renderPromptChip(); panelStatusUpdate(); } },
+          { initialTab: 'custom' },
+        );
+      });
+      panelStatusEl.appendChild(link);
+      panelStatusEl.appendChild(document.createTextNode('.'));
+    } else {
+      panelStatusEl.classList.add('hidden');
+    }
     return;
   }
   // Hosted providers (anthropic / openai / gemini) all need a key. When the
@@ -2147,8 +2196,20 @@ async function preflightTurn(
   onReady: () => void,
 ): Promise<string | undefined | typeof PREFLIGHT_ABORT> {
   let apiKey: string | undefined;
-  if (settings.toggles.provider !== 'local') {
-    // Hosted provider (anthropic / openai / gemini): need a stored key.
+  if (settings.toggles.provider === 'custom') {
+    // Custom OpenAI-compatible endpoint: needs a base URL + model; the API
+    // key is OPTIONAL (a stored one is used when present, else no auth). Send
+    // the user to the Custom settings tab if it isn't configured yet.
+    if (!settings.toggles.customBaseUrl.trim() || !settings.toggles.customModel.trim()) {
+      void showAiSettingsModal(
+        { onChange: () => { panelStatusUpdate(); renderModelPicker(); renderToggleStrip(); renderCostMeter(); onReady(); } },
+        { initialTab: 'custom' },
+      );
+      return PREFLIGHT_ABORT;
+    }
+    apiKey = (await getKey('custom'))?.apiKey;
+  } else if (settings.toggles.provider !== 'local') {
+    // Hosted cloud provider (anthropic / openai / gemini): need a stored key.
     const provider = settings.toggles.provider;
     const key = await getKey(provider);
     if (!key) {
@@ -2787,7 +2848,11 @@ async function maybeAutoCompact(): Promise<void> {
   }
 
   let apiKey: string | undefined;
-  if (settings.toggles.provider !== 'local') {
+  if (settings.toggles.provider === 'custom') {
+    // Optional key; skip silently if the endpoint isn't fully configured.
+    if (!settings.toggles.customBaseUrl.trim() || !settings.toggles.customModel.trim()) return;
+    apiKey = (await getKey('custom'))?.apiKey;
+  } else if (settings.toggles.provider !== 'local') {
     const key = await getKey(settings.toggles.provider);
     if (!key) return;
     apiKey = key.apiKey;
@@ -2839,7 +2904,16 @@ async function runCompact(): Promise<void> {
   }
   const settings = loadSettings();
   let apiKey: string | undefined;
-  if (settings.toggles.provider !== 'local') {
+  if (settings.toggles.provider === 'custom') {
+    // Custom endpoint: API key optional; route to the Custom tab if the
+    // endpoint isn't configured yet.
+    if (!settings.toggles.customBaseUrl.trim() || !settings.toggles.customModel.trim()) {
+      void showAiSettingsModal({ onChange: () => panelStatusUpdate() }, { initialTab: 'custom' });
+      return;
+    }
+    apiKey = (await getKey('custom'))?.apiKey;
+    setTransientStatus('Summarizing the conversation…');
+  } else if (settings.toggles.provider !== 'local') {
     const provider = settings.toggles.provider;
     const key = await getKey(provider);
     if (!key) {

--- a/src/ui/aiReviewModal.tsx
+++ b/src/ui/aiReviewModal.tsx
@@ -12,6 +12,7 @@ import { getKey } from '../ai/db';
 import { formatUsd, estimateTurnCostUsd } from '../ai/cost';
 import { showAiKeyModal } from './aiKeyModal';
 import { showAiLocalModal } from './aiLocalModal';
+import { showAiSettingsModal } from './aiSettingsModal';
 import { mountPreactModal } from './preact/mount';
 import { isModelLoaded, resolveLocalModel } from '../ai/local';
 import type { ChatMessage, Provider } from '../ai/types';
@@ -28,8 +29,8 @@ export interface ReviewModalCallbacks {
   onReviewPosted: (msg: ChatMessage) => void;
 }
 
-const HOSTED_PROVIDERS: Provider[] = ['anthropic', 'openai', 'gemini'];
-const ALL_PROVIDERS: Provider[] = ['anthropic', 'openai', 'gemini', 'local'];
+const HOSTED_PROVIDERS: Provider[] = ['anthropic', 'openai', 'gemini', 'custom'];
+const ALL_PROVIDERS: Provider[] = ['anthropic', 'openai', 'gemini', 'custom', 'local'];
 
 interface ReviewState {
   provider: Provider;
@@ -48,6 +49,9 @@ function modelOptionsFor(p: Provider): { id: string; label: string }[] {
     case 'anthropic': return ANTHROPIC_MODEL_OPTIONS;
     case 'openai': return OPENAI_MODEL_OPTIONS;
     case 'gemini': return GEMINI_MODEL_OPTIONS;
+    // Custom endpoints have no curated catalog — the configured model is
+    // surfaced via the "(custom)" fallback option in the picker.
+    case 'custom': return [];
     case 'local': return [];
   }
 }
@@ -58,6 +62,7 @@ function defaultModelFor(p: Provider): string {
     case 'anthropic': return settings.toggles.anthropicModel;
     case 'openai': return settings.toggles.openaiModel;
     case 'gemini': return settings.toggles.geminiModel;
+    case 'custom': return settings.toggles.customModel;
     case 'local': return settings.toggles.localModel ?? '';
   }
 }
@@ -188,7 +193,9 @@ function ReviewBody(props: { state: Signal<ReviewState> }) {
     const focusChars = focus.length;
     const tokens = Math.round((codeChars + notesChars + focusChars + 800) / 4) + (context?.snapshot ? 1500 : 0);
     const est = estimateTurnCostUsd(provider, model, 0, tokens, 200);
-    costText = provider === 'local' ? 'Local model: free at the API level.' : `Estimated cost: ~${formatUsd(est)}`;
+    costText = (provider === 'local' || provider === 'custom')
+      ? 'Self-hosted model: free at the API level.'
+      : `Estimated cost: ~${formatUsd(est)}`;
   }
 
   return (
@@ -214,11 +221,23 @@ function ReviewBody(props: { state: Signal<ReviewState> }) {
       {runError && <div class="text-xs text-red-400">{runError}</div>}
       {noKeyForProvider && (
         <div class="text-xs text-amber-400 flex items-center gap-2">
-          <span>No key for {providerLabel(noKeyForProvider)}. </span>
+          <span>{noKeyForProvider === 'custom' ? "Custom endpoint isn't configured. " : `No key for ${providerLabel(noKeyForProvider)}. `}</span>
           <button
             type="button"
             class="underline text-amber-200 hover:text-amber-100"
             onClick={() => {
+              if (noKeyForProvider === 'custom') {
+                // Custom is configured in the settings modal, not the key modal.
+                void showAiSettingsModal({
+                  onChange: () => {
+                    const s = loadSettings();
+                    const ok = s.toggles.customBaseUrl.trim().length > 0 && s.toggles.customModel.trim().length > 0;
+                    const nextAvail: Record<Provider, boolean> = { ...availability, custom: ok };
+                    state.value = { ...state.value, noKeyForProvider: ok ? null : noKeyForProvider, availability: nextAvail, model: defaultModelFor('custom') };
+                  },
+                }, { initialTab: 'custom' });
+                return;
+              }
               void showAiKeyModal({
                 provider: noKeyForProvider,
                 onConnected: () => {
@@ -227,7 +246,7 @@ function ReviewBody(props: { state: Signal<ReviewState> }) {
                 },
               });
             }}
-          >Connect now</button>
+          >{noKeyForProvider === 'custom' ? 'Configure' : 'Connect now'}</button>
         </div>
       )}
       <p class="text-[10px] text-zinc-500">{costText}</p>
@@ -296,6 +315,9 @@ export async function showAiReviewModal(cb: ReviewModalCallbacks): Promise<void>
     anthropic: !!(await getKey('anthropic')),
     openai: !!(await getKey('openai')),
     gemini: !!(await getKey('gemini')),
+    // Custom is "available" as a reviewer once both its endpoint URL and a
+    // model id are set (the API key is optional).
+    custom: settings.toggles.customBaseUrl.trim().length > 0 && settings.toggles.customModel.trim().length > 0,
     local: !!settings.toggles.localModel,
   };
   const defaultProvider: Provider =

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -222,11 +222,12 @@ export function createHelpPage(
       id: 'ai-browser',
       heading: 'AI assistant in the browser',
       body:
-        'Partwright includes a built-in AI assistant. It runs entirely from your browser: you choose a provider and (for cloud providers) paste your own API key, and every request goes directly from your browser to that provider — Partwright never sees the key or the conversation. Four providers are supported:' +
+        'Partwright includes a built-in AI assistant. It runs entirely from your browser: you choose a provider and (for cloud providers) paste your own API key, and every request goes directly from your browser to that provider — Partwright never sees the key or the conversation. Five providers are supported:' +
         '<ul class="list-disc list-inside mt-2 space-y-1 text-zinc-400">' +
         '<li><strong class="text-zinc-300">Anthropic</strong> — Claude (Haiku / Sonnet / Opus), with prompt caching. Keys look like <code class="text-emerald-400 bg-zinc-800 px-1 rounded">sk-ant-…</code>.</li>' +
         '<li><strong class="text-zinc-300">OpenAI</strong> — GPT and reasoning (o-series / gpt-5) models.</li>' +
         '<li><strong class="text-zinc-300">Google Gemini</strong> — Gemini models, including thinking models with a reasoning box.</li>' +
+        '<li><strong class="text-zinc-300">Custom (OpenAI-compatible)</strong> — Point at any self-hosted OpenAI-compatible endpoint (a <code>llama.cpp</code> server, vLLM, LM Studio, …) by setting its base URL and model. The API key is optional; turns are free at the API level.</li>' +
         '<li><strong class="text-zinc-300">Local (WebGPU)</strong> — Runs a model fully in your browser via WebLLM. No API key, no network traffic per turn; the weights download once into the browser cache (needs a WebGPU-capable browser).</li>' +
         '</ul><br>' +
         '<strong class="text-zinc-300">Connecting:</strong>' +

--- a/src/ui/preact/settingsModal.tsx
+++ b/src/ui/preact/settingsModal.tsx
@@ -15,10 +15,11 @@
 import { useEffect, useRef } from 'preact/hooks';
 import { signal, useSignal, type Signal } from '@preact/signals';
 
-import { deleteKey, getKey } from '../../ai/db';
+import { deleteKey, getKey, putKey } from '../../ai/db';
 import { resetClient, listModels as listAnthropicModels } from '../../ai/anthropic';
 import { resetClient as resetOpenaiClient, listModels as listOpenaiModels } from '../../ai/openai';
 import { resetClient as resetGeminiClient, listModels as listGeminiModels } from '../../ai/gemini';
+import { listModels as listCustomModels, validateConnection as validateCustomConnection } from '../../ai/custom';
 import { formatUsd } from '../../ai/cost';
 import { providerKeyMeta, validateAndStoreKey, type HostedProvider } from '../aiKeyModal';
 import { renderLocalPicker } from '../aiLocalModal';
@@ -31,6 +32,8 @@ import {
   setAnthropicModel,
   setOpenaiModel,
   setGeminiModel,
+  setCustomModel,
+  setCustomBaseUrl,
   providerLabel,
   AUTO_COMPACT_OPTIONS,
   ANTHROPIC_MODEL_OPTIONS,
@@ -56,6 +59,7 @@ const TABS = [
   { id: 'anthropic' as const, label: 'Anthropic (cloud)' },
   { id: 'openai' as const, label: 'OpenAI (cloud)' },
   { id: 'gemini' as const, label: 'Gemini (cloud)' },
+  { id: 'custom' as const, label: 'Custom (OpenAI)' },
   { id: 'local' as const, label: 'Local (WebGPU)' },
 ];
 
@@ -86,7 +90,9 @@ export function SettingsModalBody(props: {
         <EnableRow viewedTab={tab.value} cb={cb} />
         {tab.value === 'local'
           ? <LocalTab cb={cb} close={close} />
-          : <HostedTab provider={tab.value} cb={cb} close={close} switchTab={t => { tab.value = t; }} />}
+          : tab.value === 'custom'
+            ? <CustomTab cb={cb} close={close} />
+            : <HostedTab provider={tab.value} cb={cb} close={close} switchTab={t => { tab.value = t; }} />}
       </div>
       <Divider />
       <ApiTimeoutSection cb={cb} />
@@ -111,7 +117,11 @@ function EnableRow(props: { viewedTab: Provider; cb: AiSettingsCallbacks }) {
   const hasKey = useSignal<boolean | null>(null);
 
   useEffect(() => {
+    // local is always "ready"; custom's readiness is the base URL (a setting,
+    // read synchronously below) not a stored key — skip the getKey probe for
+    // both. Cloud providers gate Enable on a stored key.
     if (viewedTab === 'local') { hasKey.value = true; return; }
+    if (viewedTab === 'custom') { hasKey.value = null; return; }
     let cancelled = false;
     hasKey.value = null;
     void getKey(viewedTab).then(k => { if (!cancelled) hasKey.value = !!k; });
@@ -121,7 +131,11 @@ function EnableRow(props: { viewedTab: Provider; cb: AiSettingsCallbacks }) {
   const settings = settingsSignal.value;
   const isActive = settings.toggles.provider === viewedTab;
   const label = providerLabel(viewedTab);
-  const ready = hasKey.value === true;
+  // Custom is enableable once its endpoint URL is set (the API key is
+  // optional); every cloud provider needs a stored key.
+  const ready = viewedTab === 'custom'
+    ? settings.toggles.customBaseUrl.trim().length > 0
+    : hasKey.value === true;
 
   // For local, `hasKey` is forced true above, so the "Connect your … key"
   // branch never fires for local; that's why there's no local-specific
@@ -130,7 +144,9 @@ function EnableRow(props: { viewedTab: Provider; cb: AiSettingsCallbacks }) {
     ? 'Chat turns are sent to this provider.'
     : ready
       ? `Viewing settings only — click Enable to send chat turns through ${label}.`
-      : `Connect your ${label} key below to enable it.`;
+      : viewedTab === 'custom'
+        ? 'Set the endpoint URL below to enable it.'
+        : `Connect your ${label} key below to enable it.`;
 
   return (
     <div class={'flex items-center justify-between gap-3 rounded border px-3 py-2 ' + (
@@ -150,7 +166,9 @@ function EnableRow(props: { viewedTab: Provider; cb: AiSettingsCallbacks }) {
           disabled={!ready}
           title={ready
             ? `Switch the active provider to ${label}. You can switch back any time.`
-            : `Connect your ${label} key before enabling it.`}
+            : viewedTab === 'custom'
+              ? 'Set the endpoint URL before enabling it.'
+              : `Connect your ${label} key before enabling it.`}
           onClick={() => {
             setSettings(setProvider(loadSettings(), viewedTab));
             cb.onChange();
@@ -488,6 +506,177 @@ function LoadModelsRow(props: {
   );
 }
 
+// === Custom (OpenAI-compatible) tab ===
+
+/** A generic OpenAI-compatible endpoint — a self-hosted llama.cpp / vLLM /
+ *  LM Studio server, etc. Base URL + model id persist to settings (so they
+ *  serialize into the agent Worker); the OPTIONAL API key lives in the aiKeys
+ *  store keyed by 'custom'. */
+function CustomTab(props: { cb: AiSettingsCallbacks; close: () => void }) {
+  const { cb, close } = props;
+  const settings = settingsSignal.value;
+
+  const url = useSignal(settings.toggles.customBaseUrl);
+  const model = useSignal(settings.toggles.customModel);
+  const keyVal = useSignal('');
+  const hasKey = useSignal<boolean | null>(null);
+  const models = useSignal<{ id: string; label: string }[]>([]);
+  const status = useSignal('');
+  const statusErr = useSignal(false);
+  const busy = useSignal(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getKey('custom').then(k => { if (!cancelled) hasKey.value = !!k; });
+    return () => { cancelled = true; };
+  }, [keyVersion.value]);
+
+  // Effective key for test/fetch: the just-typed value wins, else the stored one.
+  async function effectiveKey(): Promise<string> {
+    if (keyVal.value.trim()) return keyVal.value.trim();
+    return (await getKey('custom'))?.apiKey ?? '';
+  }
+
+  function persistUrl(): void { setSettings(setCustomBaseUrl(loadSettings(), url.value)); cb.onChange(); }
+  function persistModel(id: string): void {
+    model.value = id;
+    setSettings(setCustomModel(loadSettings(), id.trim()));
+    cb.onChange();
+  }
+
+  async function testConnection(): Promise<void> {
+    busy.value = true; status.value = 'Testing…'; statusErr.value = false;
+    persistUrl();
+    const err = await validateCustomConnection(url.value, await effectiveKey());
+    busy.value = false;
+    statusErr.value = !!err;
+    status.value = err ?? 'Connected — endpoint reachable.';
+  }
+
+  async function fetchModels(): Promise<void> {
+    busy.value = true; status.value = 'Loading models…'; statusErr.value = false;
+    persistUrl();
+    try {
+      const list = await listCustomModels(url.value, await effectiveKey());
+      models.value = list;
+      statusErr.value = false;
+      status.value = list.length ? `${list.length} model(s) found.` : 'Endpoint reported no models.';
+      // Auto-select when the server serves exactly one and nothing's chosen.
+      if (!model.value.trim() && list.length === 1) persistModel(list[0].id);
+    } catch (err) {
+      statusErr.value = true;
+      status.value = err instanceof Error ? err.message : String(err);
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  async function saveKey(): Promise<void> {
+    const k = keyVal.value.trim();
+    if (!k) return;
+    const existing = await getKey('custom');
+    await putKey({
+      provider: 'custom',
+      apiKey: k,
+      createdAt: existing?.createdAt ?? Date.now(),
+      lastUsed: Date.now(),
+      totalInputTokens: existing?.totalInputTokens ?? 0,
+      totalOutputTokens: existing?.totalOutputTokens ?? 0,
+      totalCostUsd: existing?.totalCostUsd ?? 0,
+    });
+    keyVal.value = '';
+    bumpKeyVersion();
+    cb.onChange();
+  }
+
+  async function removeKey(): Promise<void> {
+    await deleteKey('custom');
+    bumpKeyVersion();
+    cb.onChange();
+  }
+
+  return (
+    <>
+      <Section label="About">
+        {/* eslint-disable-next-line react/no-danger */}
+        <p class="text-[11px] text-zinc-300 leading-snug" dangerouslySetInnerHTML={{ __html: 'Point Partwright at any <strong>OpenAI-compatible</strong> chat endpoint — a self-hosted <code>llama.cpp</code> server, vLLM, LM Studio, or similar. Requests use the <code>/v1/chat/completions</code> shape with the full <code>ai.md</code> system prompt; turns are billed at $0 (you run the hardware). The optional API key is stored only in this browser.' }} />
+        {/* eslint-disable-next-line react/no-danger */}
+        <div class="rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-[11px] text-amber-200 leading-snug" dangerouslySetInnerHTML={{ __html: '<strong>Connectivity:</strong> the endpoint must allow this site via <strong>CORS</strong>. When Partwright is served over HTTPS, the endpoint must be HTTPS too (browsers block <code>https→http</code>) — except <code>http://localhost</code>, which is exempt. For llama.cpp, run <code>llama-server</code> and pass <code>--api-key</code> only if you want auth.' }} />
+      </Section>
+      <Divider />
+      <Section label="Endpoint">
+        <label class="flex flex-col gap-1">
+          <span class="text-xs text-zinc-400">Base URL</span>
+          <input
+            type="text"
+            placeholder="http://localhost:8080/v1"
+            class="w-full px-3 py-2 rounded bg-zinc-900 border border-zinc-600 text-zinc-100 text-sm font-mono placeholder:text-zinc-600 focus:outline-none focus:border-blue-500"
+            spellcheck={false}
+            value={url.value}
+            onInput={e => { url.value = (e.currentTarget as HTMLInputElement).value; }}
+            onChange={persistUrl}
+          />
+          <span class="text-[10px] text-zinc-500">Include the version path (most servers serve under <code>/v1</code>). We append <code>/chat/completions</code> and <code>/models</code>.</span>
+        </label>
+        <div class="flex items-center gap-2 flex-wrap">
+          <SecondaryButton label="Test connection" size="sm" disabled={busy.value} onClick={() => { void testConnection(); }} />
+          <SecondaryButton label="Fetch models" size="sm" disabled={busy.value} onClick={() => { void fetchModels(); }} />
+          {status.value && <span class={'text-[10px] ' + (statusErr.value ? 'text-red-400' : 'text-emerald-400')}>{status.value}</span>}
+        </div>
+      </Section>
+      <Divider />
+      <Section label="Model">
+        <label class="flex flex-col gap-1">
+          <span class="text-xs text-zinc-400">Model id</span>
+          <input
+            type="text"
+            placeholder="e.g. llama-3.3-70b-instruct"
+            class="w-full px-3 py-2 rounded bg-zinc-900 border border-zinc-600 text-zinc-100 text-sm font-mono placeholder:text-zinc-600 focus:outline-none focus:border-blue-500"
+            spellcheck={false}
+            value={model.value}
+            onInput={e => { model.value = (e.currentTarget as HTMLInputElement).value; }}
+            onChange={() => persistModel(model.value)}
+          />
+        </label>
+        {models.value.length > 0 && (
+          <div class="flex flex-wrap gap-1">
+            {models.value.map(m => (
+              <Pill key={m.id} active={model.value === m.id} label={m.label} onClick={() => persistModel(m.id)} />
+            ))}
+          </div>
+        )}
+        <span class="text-[10px] text-zinc-500">Use <strong>Fetch models</strong> above to list what the endpoint serves, or type the id directly.</span>
+      </Section>
+      <Divider />
+      <Section label="API key (optional)">
+        {hasKey.value === true ? (
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-[11px] text-emerald-300">A key is stored for this endpoint.</span>
+            <button type="button" class="text-[11px] text-red-300 hover:text-red-200 underline" onClick={() => { void removeKey(); }}>Remove key</button>
+          </div>
+        ) : (
+          <div class="flex items-center gap-2">
+            <input
+              type="password"
+              placeholder="leave blank if the endpoint needs no auth"
+              class="flex-1 px-3 py-2 rounded bg-zinc-900 border border-zinc-600 text-zinc-100 text-sm font-mono placeholder:text-zinc-600 focus:outline-none focus:border-blue-500"
+              spellcheck={false}
+              autocomplete="off"
+              value={keyVal.value}
+              onInput={e => { keyVal.value = (e.currentTarget as HTMLInputElement).value; }}
+              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); void saveKey(); } }}
+            />
+            <SecondaryButton label="Save key" size="sm" disabled={!keyVal.value.trim()} onClick={() => { void saveKey(); }} />
+          </div>
+        )}
+        <span class="text-[10px] text-zinc-500">Sent as <code>Authorization: Bearer …</code>. Many home servers run with no key — leave this blank then.</span>
+      </Section>
+      <Divider />
+      <SystemPromptSection provider="custom" close={close} cb={cb} />
+    </>
+  );
+}
+
 // === Local tab ===
 
 function LocalTab(props: { cb: AiSettingsCallbacks; close: () => void }) {
@@ -684,9 +873,13 @@ function SystemPromptSection(props: { provider: Provider; close: () => void; cb:
     ? (override !== null
       ? '<strong>Custom prompt active</strong> — your override is sent to local models instead of the built-in tier.'
       : '<strong>Built-in</strong> — a compact prompt tuned for local models, with the <code>readDoc</code> tool to pull in detailed subdocs on demand. The exact tier (Slim ~700 tok / Medium ~1.1K tok) depends on the active model; click to view or pin a different tier.')
-    : (override !== null
-      ? '<strong>Custom prompt active</strong> — your override is sent to Claude instead of the full <code>ai.md</code>.'
-      : '<strong>Built-in</strong> — the full <code>public/ai.md</code> (~12.5K tokens) cached on Anthropic\'s side. Subdocs are fetched on demand via the <code>readDoc</code> tool.');
+    : provider === 'custom'
+      ? (override !== null
+        ? '<strong>Custom prompt active</strong> — your override is sent to the endpoint instead of the full <code>ai.md</code>.'
+        : '<strong>Built-in</strong> — the full <code>public/ai.md</code> (~12.5K tokens) is sent to your endpoint, with subdocs fetched on demand via the <code>readDoc</code> tool. If your model has a small context window, click to trim or replace it.')
+      : (override !== null
+        ? '<strong>Custom prompt active</strong> — your override is sent to Claude instead of the full <code>ai.md</code>.'
+        : '<strong>Built-in</strong> — the full <code>public/ai.md</code> (~12.5K tokens) cached on Anthropic\'s side. Subdocs are fetched on demand via the <code>readDoc</code> tool.');
 
   return (
     <Section label="System prompt">

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -585,13 +585,14 @@ test.describe('Multi-provider AI', () => {
     await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
     // The modal is tabbed by provider — one tab per provider. Only the
     // viewed tab's section renders, so we assert the tab strip has all
-    // four, then walk each hosted tab and confirm its Connect button.
+    // five, then walk each hosted tab and confirm its Connect button.
     const tabLabels = await page.evaluate(() =>
       Array.from(document.querySelectorAll('button')).map(b => (b.textContent ?? '').trim())
     );
     expect(tabLabels.some(l => /^Anthropic \(cloud\)/.test(l))).toBe(true);
     expect(tabLabels.some(l => /^OpenAI \(cloud\)/.test(l))).toBe(true);
     expect(tabLabels.some(l => /^Gemini \(cloud\)/.test(l))).toBe(true);
+    expect(tabLabels.some(l => /^Custom \(OpenAI\)/.test(l))).toBe(true);
     expect(tabLabels.some(l => /^Local \(WebGPU\)/.test(l))).toBe(true);
 
     // Scope to the modal shell so the assertions can't accidentally match
@@ -605,6 +606,32 @@ test.describe('Multi-provider AI', () => {
     // Switch to the Gemini tab → its Connect button appears.
     await page.locator('button:has-text("Gemini (cloud)")').dispatchEvent('click');
     await expect(modal.locator('button:has-text("Connect Google Gemini")')).toBeVisible();
+  });
+
+  test('Custom tab configures a self-hosted endpoint and gates Enable on the URL', async ({ page }) => {
+    await page.goto('/editor');
+    await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch {} });
+    await page.reload();
+    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    await openAiPanel(page);
+    await page.locator('#ai-panel button[title^="AI settings"]').dispatchEvent('click');
+    await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
+
+    const modal = page.locator('.bg-zinc-800.rounded-xl').filter({ hasText: 'AI Settings' });
+    await page.locator('button:has-text("Custom (OpenAI)")').dispatchEvent('click');
+
+    // The custom config UI renders: base URL input + the connection helpers.
+    const urlInput = modal.locator('input[placeholder="http://localhost:8080/v1"]');
+    await expect(urlInput).toBeVisible();
+    await expect(modal.locator('button:has-text("Test connection")')).toBeVisible();
+    await expect(modal.locator('button:has-text("Fetch models")')).toBeVisible();
+
+    // Enable is gated on the endpoint URL (the API key is optional), so it's
+    // disabled until a URL is set, then flips on — no key required.
+    await expect(modal.locator('button:has-text("Enable Custom endpoint")')).toBeDisabled();
+    await urlInput.fill('http://localhost:8080/v1');
+    await modal.locator('input[placeholder^="e.g. llama"]').fill('my-model');
+    await expect(modal.locator('button:has-text("Enable Custom endpoint")')).toBeEnabled();
   });
 
   test('Enable is gated on a connected key, except local', async ({ page }) => {
@@ -908,5 +935,80 @@ test.describe('Capability suffix', () => {
     expect(onSuffix).not.toContain('Paint is OFF');
     // The override directive that tells the model the list beats earlier turns.
     expect(onSuffix).toContain('OVERRIDES anything said earlier');
+  });
+
+  // === Custom OpenAI-compatible endpoint ===
+  // The custom provider reuses the OpenAI Chat Completions transport but
+  // targets a user-supplied base URL (e.g. a self-hosted llama.cpp server),
+  // omits the Authorization header when no key is set, and NEVER uses the
+  // Responses API (self-hosted servers don't implement /v1/responses).
+  test('Custom endpoint targets its base URL, omits auth when keyless, and forces Chat Completions', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    const sent = await page.evaluate(async () => {
+      const custom = await import('/src/ai/custom.ts');
+      let url = '';
+      let captured = '';
+      let authHeader: string | null = null;
+      const origFetch = window.fetch;
+      // @ts-expect-error test stub
+      window.fetch = async (input: unknown, init: { body?: string; headers?: Record<string, string> }) => {
+        url = String(input);
+        captured = String(init?.body ?? '');
+        authHeader = new Headers(init?.headers as HeadersInit).get('authorization');
+        const body = 'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n';
+        return new Response(new Blob([body]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+      };
+      try {
+        // The model name deliberately matches the reasoning sniff (gpt-5.5) to
+        // prove the custom path still uses Chat Completions, not /v1/responses.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await custom.streamTurn({ apiKey: '', baseUrl: 'http://example.test/v1', model: 'gpt-5.5', systemPrompt: 'sys', systemSuffix: '', history: [] as any, tools: [] });
+      } finally {
+        window.fetch = origFetch;
+      }
+      return { url, authHeader, body: JSON.parse(captured) };
+    });
+    expect(sent.url).toBe('http://example.test/v1/chat/completions');
+    expect(sent.url).not.toContain('/responses');
+    // No key → no Authorization header (keyless self-hosted server).
+    expect(sent.authHeader).toBeNull();
+    // Chat-shaped body, and no reasoning request (custom always sends thinking off).
+    expect(Array.isArray(sent.body.messages)).toBe(true);
+    expect(sent.body.max_completion_tokens).toBeGreaterThan(0);
+    expect(sent.body.reasoning_effort).toBeUndefined();
+  });
+
+  test('Custom listModels hits /models with auth when keyed, and does not filter ids', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    const out = await page.evaluate(async () => {
+      const custom = await import('/src/ai/custom.ts');
+      let url = '';
+      let authHeader: string | null = null;
+      const origFetch = window.fetch;
+      // @ts-expect-error test stub
+      window.fetch = async (input: unknown, init: { headers?: Record<string, string> }) => {
+        url = String(input);
+        authHeader = new Headers(init?.headers as HeadersInit).get('authorization');
+        const body = JSON.stringify({ data: [{ id: 'my-local-llama-3.3' }, { id: 'whisper-tiny' }] });
+        return new Response(body, { status: 200, headers: { 'Content-Type': 'application/json' } });
+      };
+      let ids: string[] = [];
+      try {
+        // Trailing slash on the base URL should be trimmed before appending /models.
+        const models = await custom.listModels('http://example.test/v1/', 'secret-key');
+        ids = models.map(m => m.id);
+      } finally {
+        window.fetch = origFetch;
+      }
+      return { url, authHeader, ids };
+    });
+    expect(out.url).toBe('http://example.test/v1/models');
+    expect(out.authHeader).toBe('Bearer secret-key');
+    // Unlike the OpenAI helper, no gpt-/o- filter — a self-hosted server's
+    // arbitrary ids all come through (even a "whisper" id OpenAI would drop).
+    expect(out.ids).toContain('my-local-llama-3.3');
+    expect(out.ids).toContain('whisper-tiny');
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -163,11 +163,13 @@ export default defineConfig({
       'Cross-Origin-Embedder-Policy': 'require-corp',
       // Mirror the production CSP (public/_headers) so an accidental new
       // external call surfaces here in dev instead of slipping through to
-      // production. The ONLY intentional delta is in connect-src: dev also
-      // allows the localhost WebSocket that Vite uses for HMR/live-reload,
-      // which production has no equivalent of. Keep the host allowlist below
-      // in sync with public/_headers.
-      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' ws://localhost:* ws://127.0.0.1:* https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://huggingface.co https://*.huggingface.co https://*.xethub.hf.co https://raw.githubusercontent.com; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'",
+      // production. connect-src allows `https:` + http://localhost / 127.0.0.1
+      // so a user-configured Custom (OpenAI-compatible) endpoint — e.g. a
+      // self-hosted llama.cpp server — works (matches _headers). The dev-only
+      // delta is the localhost WebSocket Vite uses for HMR/live-reload, which
+      // production has no equivalent of. Keep the host allowlist in sync with
+      // public/_headers.
+      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' ws://localhost:* ws://127.0.0.1:* https: http://localhost:* http://127.0.0.1:* https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://huggingface.co https://*.huggingface.co https://*.xethub.hf.co https://raw.githubusercontent.com; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'",
     },
     fs: {
       // Relax strict fs access for WASM files in node_modules


### PR DESCRIPTION
## Summary

Adds a fifth AI provider — **Custom (OpenAI-compatible)** — so you can point Partwright at any OpenAI-compatible chat endpoint instead of a hosted cloud provider. The motivating use case is a **self-hosted [llama.cpp](https://github.com/ggml-org/llama.cpp) server** running at home, but it works equally for vLLM, LM Studio, Ollama's OpenAI shim, etc.

You configure it in a new **Custom (OpenAI)** tab in AI Settings:
- **Base URL** (e.g. `http://localhost:8080/v1`)
- **Model id** — type it, or click **Fetch models** to list what the endpoint serves (via `GET /models`, unfiltered — self-hosted servers use arbitrary ids)
- **Optional API key** — llama.cpp's `--api-key` is optional, so auth is too. When no key is set, no `Authorization` header is sent.
- **Test connection** button to confirm reachability before enabling.

### How it works
- **Transport reuse:** `src/ai/custom.ts` is a thin wrapper over the existing OpenAI Chat Completions transport. `openai.ts` gained an optional `baseUrl` and a `forceChatCompletions` flag, and now omits the `Authorization` header when the key is empty. No duplicated streaming/tool/image/repair logic.
- **Always Chat Completions, never Responses:** self-hosted servers implement `/v1/chat/completions` but not OpenAI's proprietary `/v1/responses`, so the custom path is pinned to Chat Completions and never sends `reasoning_effort` (which arbitrary servers would reject).
- **Data model:** base URL + model live on `ChatToggles` (so they serialize into the agent Worker); the optional key lives in the `aiKeys` IndexedDB store keyed by `'custom'`. A configured base URL counts as "connected" — the key isn't required to enable the provider.
- **Billed at $0** (self-hosted), like the local provider.
- Wired through every provider touch point: types, settings (incl. presets/back-compat merge/system-prompt overrides), chat loop, **compaction**, **cross-provider review**, cost, the header model-picker chip, panel status, preflight, and the AI Settings + Review modals.

### CSP / connectivity
The app's CSP `connect-src` was a closed allowlist of just the known cloud APIs, which would have blocked every request to a user-supplied endpoint in production *and* local dev (the e2e tests stub `fetch`, so they didn't surface this). `connect-src` now also allows `https:` (any HTTPS host) plus `http://localhost:*` / `http://127.0.0.1:*`, in both `public/_headers` and the `vite.config.ts` dev mirror. This is the minimal effective relaxation: plain-HTTP LAN addresses stay blocked by the browser's mixed-content rule on the hosted HTTPS site anyway, so only HTTPS endpoints or localhost are reachable there. The named first-party hosts are kept as intent documentation. Self-hosted connectivity caveats (CORS + mixed-content) are surfaced inline in the Custom tab and in `/help`.

### Backwards compatibility
Old localStorage settings blobs and old `KeyRecord`s are unaffected — `customModel`/`customBaseUrl` default to empty and the `systemPromptOverrides.custom` key is merged in with a `null` default. No IndexedDB schema bump (a new provider is just a new string key in the existing `aiKeys` store).

## Test plan
- `npm run build` ✅ (tsc + vite)
- `npm run test:unit` ✅ (452 passing)
- New e2e (`tests/ai-providers.spec.ts`):
  - Custom endpoint targets its base URL, omits auth when keyless, forces Chat Completions (even for a `gpt-5.5`-named model), sends no `reasoning_effort`.
  - `listModels` hits `/models` with auth when keyed, trims a trailing slash, and does **not** filter ids.
  - Custom settings tab renders the config UI and gates **Enable** on the URL (key optional).
- Note: a live round-trip to a real llama.cpp server can't run in CI (no external network), so coverage is request-shape tests — the same approach the repo uses for the Anthropic thinking path. CSP can't be exercised by stubbed-fetch tests either; it was fixed after a review pass flagged it.

### Manual verification suggestion (for the requester)
Run `llama-server -m <model.gguf> --host 0.0.0.0 --port 8080`, then in AI Settings → Custom set base URL `http://localhost:8080/v1`, click **Fetch models**, pick the model, and chat. Add `--api-key <key>` on the server + paste the same key if you want auth.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017duQmzRsL77Q7AfaWRNRCc