### PR TITLE
fix: register getShareLink as an in-app AI chat tool

### DIFF
--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -419,6 +419,11 @@ const ALL_TOOLS: ToolDefinition[] = [
     input_schema: { type: 'object', properties: {} },
   },
   {
+    name: 'getShareLink',
+    description: 'Mint a self-contained, read-only share link for the current version — the link to hand the user when you are done. Commits the current buffer first (capturing unsaved edits), then encodes the whole design into the URL hash; nothing is uploaded to a server, and anyone can open the link anywhere and fork it into their own editable copy. Returns { url, encodedBytes } on success, or { error } (e.g. no session open, an older browser without CompressionStream, or a design too large to fit in a URL). Prefer this over a session/gallery URL, which only resolves against your own browser.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
     name: 'readDoc',
     description: 'Fetch one of the topic-specific docs from /ai/<name>.md. Use this when the core ai.md points you at a subdoc and you need its full content before writing code. Names: curves, bosl2, replicad, sdf, voxel, colors, print-safety, reference-images, file-io, annotations, relief.',
     input_schema: {
@@ -1068,6 +1073,11 @@ const ALWAYS_AVAILABLE = new Set([
   // can stop the model from spending a tool round-trip on notes the chat
   // transcript already records.
   'listSessionNotes',
+  // getShareLink is the "hand the design back to the user when done" action the
+  // system prompt steers every session toward, so it stays always-on like the
+  // other read-only session surfaces — gating it would resurrect the
+  // "Unknown tool: getShareLink" failure whenever the toggle was off.
+  'getShareLink',
   'readDoc',
   'findFaces',
   'listComponents',
@@ -1398,6 +1408,8 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.addSessionNote(input.text as string);
     case 'listSessionNotes':
       return api.listSessionNotes();
+    case 'getShareLink':
+      return api.getShareLink();
     case 'readDoc':
       return readSubdoc(input.name as string);
     case 'paintRegion':

--- a/tests/ai-sharelink-tool.spec.ts
+++ b/tests/ai-sharelink-tool.spec.ts
@@ -23,7 +23,7 @@ test.describe('getShareLink chat tool', () => {
     await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
   });
 
-  test('is always listed (even with every scope paused) and dispatches to the console API', async ({ page }) => {
+  test('is always listed (even with every toggle paused) and dispatches to the console API', async ({ page }) => {
     await page.goto('/editor');
     await waitForEngine(page);
 
@@ -46,10 +46,13 @@ test.describe('getShareLink chat tool', () => {
       const listFor = (t: any) => tools.buildToolList(t).map((d) => d.name);
       const listedDefault = listFor(baseToggles).includes('getShareLink');
       // The prompt steers EVERY session toward handing back a share link, so the
-      // tool must survive even when the user has paused running/saving/painting/notes.
-      const listedAllScopesOff = listFor({
+      // tool must survive with EVERY toggle paused — running, saving, painting,
+      // notes, and vision all off. That's the whole point of ALWAYS_AVAILABLE:
+      // no toggle can remove it (gating it is what caused the original failure).
+      const listedAllTogglesOff = listFor({
         ...baseToggles,
         scope: { runCode: false, saveVersions: false, paintFaces: false, sessionNotes: false },
+        vision: { ...baseToggles.vision, views: false },
       }).includes('getShareLink');
 
       // End-to-end dispatch: a session with a saved version so there's a design
@@ -62,12 +65,12 @@ test.describe('getShareLink chat tool', () => {
       await pw.runAndSave('const { Manifold } = api; return Manifold.cube([10, 10, 10], true);', 'base');
 
       const exec = await tools.executeTool('getShareLink', {});
-      return { listedDefault, listedAllScopesOff, exec, origin: location.origin };
+      return { listedDefault, listedAllTogglesOff, exec, origin: location.origin };
     });
 
-    // Always available — present with full scope and with every scope paused.
+    // Always available — present with full scope and with every toggle paused.
     expect(result.listedDefault).toBe(true);
-    expect(result.listedAllScopesOff).toBe(true);
+    expect(result.listedAllTogglesOff).toBe(true);
 
     // The call dispatched to window.partwright instead of throwing the old
     // "Unknown tool" error, and returned a self-contained hash URL.

--- a/tests/ai-sharelink-tool.spec.ts
+++ b/tests/ai-sharelink-tool.spec.ts
@@ -1,0 +1,81 @@
+// Regression: ai.md (the in-app chat system prompt) tells the agent to "hand
+// the user a share link" via getShareLink() as the last step of every session
+// — and to PREFER it over the session/gallery URLs — but getShareLink was only
+// wired into the window.partwright console API, never registered as a chat
+// tool. The call fell through dispatch()'s default branch and came back as
+// "Unknown tool: getShareLink", so the agent could never deliver the link it
+// was instructed to deliver. This covers that the tool is now listed
+// (always-available, like the other read-only session surfaces) and that it
+// dispatches to the console API end to end.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+test.describe('getShareLink chat tool', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('is always listed (even with every scope paused) and dispatches to the console API', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const result = await page.evaluate(async () => {
+      const tools = await import('/src/ai/tools.ts');
+      const baseToggles = {
+        vision: { views: true, resolution: 'medium', angles: 'auto' },
+        scope: { runCode: true, saveVersions: true, paintFaces: true, sessionNotes: true },
+        autoRetry: 0,
+        maxIterations: 'medium',
+        maxSpend: 'high',
+        thinking: 'off',
+        provider: 'anthropic',
+        anthropicModel: 'claude-haiku-4-5',
+        localModel: null,
+        openaiModel: 'gpt-5-mini',
+        geminiModel: 'gemini-flash-latest',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const listFor = (t: any) => tools.buildToolList(t).map((d) => d.name);
+      const listedDefault = listFor(baseToggles).includes('getShareLink');
+      // The prompt steers EVERY session toward handing back a share link, so the
+      // tool must survive even when the user has paused running/saving/painting/notes.
+      const listedAllScopesOff = listFor({
+        ...baseToggles,
+        scope: { runCode: false, saveVersions: false, paintFaces: false, sessionNotes: false },
+      }).includes('getShareLink');
+
+      // End-to-end dispatch: a session with a saved version so there's a design
+      // to encode (getShareLink commits the current buffer, then exports it).
+      const pw = (window as unknown as { partwright: {
+        createSession: (n?: string) => Promise<unknown>;
+        runAndSave: (code: string, label?: string) => Promise<unknown>;
+      } }).partwright;
+      await pw.createSession('sharelink-tool-test');
+      await pw.runAndSave('const { Manifold } = api; return Manifold.cube([10, 10, 10], true);', 'base');
+
+      const exec = await tools.executeTool('getShareLink', {});
+      return { listedDefault, listedAllScopesOff, exec, origin: location.origin };
+    });
+
+    // Always available — present with full scope and with every scope paused.
+    expect(result.listedDefault).toBe(true);
+    expect(result.listedAllScopesOff).toBe(true);
+
+    // The call dispatched to window.partwright instead of throwing the old
+    // "Unknown tool" error, and returned a self-contained hash URL.
+    expect(result.exec.isError).toBe(false);
+    expect(result.exec.content).not.toContain('Unknown tool');
+    const payload = JSON.parse(result.exec.content) as { url?: string; encodedBytes?: number; error?: string };
+    expect(payload.error).toBeUndefined();
+    expect(payload.url?.startsWith(`${result.origin}/editor#share=`)).toBe(true);
+    expect(payload.encodedBytes).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the runtime error **"Unknown tool: getShareLink"** that the in-app AI chat hits when it tries to hand the user a share link.

**Root cause (branch-independent — present on `main` too):** commit `e35c148` ("feat: add getShareLink API and recommend share links over gallery URL") added `getShareLink` to the `window.partwright` console API **and** wrote it into the `ai.md` system prompt as the final step of the recommended iteration pattern — *"When done, hand the user a share link: `await partwright.getShareLink()`"*, and to **prefer** it over the local-only `getSessionUrl()`/`getGalleryUrl()`. But it was never registered as an in-app AI **chat tool** in `src/ai/tools.ts`. So when any provider's assistant follows that prompt instruction, it emits a `getShareLink` tool call, which falls through `dispatch()`'s default branch and throws `Unknown tool: getShareLink` (`tools.ts:1545`). The assistant could never deliver the link it was explicitly told to deliver.

This is the same class of bug already fixed for `listRegions`, `saveVersion`, and `runAndExplain` — a console method referenced by the prompt/other tools but missing from the chat-tool registry.

> Note on the "I think it's using main" hypothesis: the gap exists on `main` and every current feature branch, so switching environments wouldn't have helped — the tool simply wasn't registered anywhere.

## What changed

`src/ai/tools.ts`:
- **Schema** — added a `getShareLink` entry to `ALL_TOOLS` (no inputs; returns `{ url, encodedBytes }` or `{ error }`).
- **Gating** — added `getShareLink` to `ALWAYS_AVAILABLE`. The prompt's "hand back a share link when done" instruction is unconditional and there's no "sharing" scope toggle, so gating it would just resurrect the same failure whenever a toggle was off. Same rationale as the other always-on read-only session surfaces.
- **Dispatch** — added `case 'getShareLink': return api.getShareLink();`. The dispatch `api` is `window.partwright`, which already implements `getShareLink` (→ `buildShareLink()`), so no engine-side change was needed.

`tests/ai-sharelink-tool.spec.ts` (new) — regression test mirroring `ai-listregions-tool.spec.ts`: asserts `getShareLink` is listed by `buildToolList` even with every scope paused, and that `executeTool('getShareLink', {})` dispatches to a real `…/editor#share=` URL instead of throwing "Unknown tool".

## Test plan

- `npm run build` — green (type-check clean).
- `npm run test:unit` — 476 passed.
- `npx playwright test tests/ai-sharelink-tool.spec.ts` — passes (lists + dispatches end-to-end).
- `npx playwright test tests/ai-listregions-tool.spec.ts tests/ai-saveversion-tool.spec.ts tests/ai-runandexplain-tool.spec.ts` — 3 passed (no regression in the shared dispatch/tool-list path).

_Heads-up for reviewers: this container started without `node_modules`; an `npm ci` was required before the build would pass. The `uninstallModal.tsx` JSX errors you may see on a fresh checkout are missing-dependency noise, not a code issue._

https://claude.ai/code/session_01QJqf2TUpxbdHAVHafk2HRx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJqf2TUpxbdHAVHafk2HRx)_