### PR TITLE
feat: add JSON import merge + import from URL

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,9 +1,11 @@
 # connect-src below intentionally allows `https:` and http://localhost / 127.0.0.1
 # so a user-configured Custom (OpenAI-compatible) AI endpoint — e.g. a self-hosted
-# llama.cpp server — is reachable from the browser. The named hosts that follow are
-# the first-party cloud APIs + model CDN; they're subsumed by `https:` but kept as
-# documentation of expected traffic. Plain-HTTP LAN addresses still won't load on the
-# hosted HTTPS site (browser mixed-content rule) — only HTTPS endpoints or localhost.
+# llama.cpp server — is reachable from the browser. The same `https:` allowance also
+# backs the "Import from URL…" feature (fetching a remote .json/.stl/.step/.svg/.vox/
+# image over https), so the browser-side fetch isn't blocked by CSP. The named hosts
+# that follow are the first-party cloud APIs + model CDN; they're subsumed by `https:`
+# but kept as documentation of expected traffic. Plain-HTTP LAN addresses still won't
+# load on the hosted HTTPS site (browser mixed-content rule) — only HTTPS or localhost.
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp

--- a/src/import/urlImport.ts
+++ b/src/import/urlImport.ts
@@ -1,0 +1,135 @@
+// Pure, browser-API-free helpers for the "Import from URL…" flow.
+//
+// The flow accepts EITHER:
+//   (a) a Partwright share link (a full URL whose hash is `#share=…`, or a raw
+//       `#share=…` fragment) — decoded locally with NO network, OR
+//   (b) an http(s) URL to a remote file (.json / mesh / image / etc.) that the
+//       app fetches and routes through the existing data-import paths.
+//
+// Everything here is deterministic string logic so it can be unit-tested
+// without a DOM, network, or IndexedDB. The actual `fetch`, share decode, and
+// `File`-wrapping live in the caller (src/main.ts), which owns the side effects.
+
+import { classifyImportSource, type ImportSource } from './importInbox';
+
+/** Result of classifying a raw "Import from URL" text input. */
+export type ImportUrlParse =
+  | { kind: 'share'; hash: string }
+  | { kind: 'remote'; url: string }
+  | { kind: 'invalid'; reason: string };
+
+/** Hard cap on a remote response we'll buffer (~25 MB). Enforced against
+ *  `Content-Length` up front and against the streamed byte count as a backstop
+ *  for servers that omit or lie about the header. */
+export const MAX_REMOTE_BYTES = 25 * 1024 * 1024;
+
+/** Abort a stalled remote fetch after this long (~15s). */
+export const REMOTE_FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Classify a trimmed user input string into a share link, a remote http(s)
+ * URL, or an invalid input with a human-readable reason.
+ *
+ * Share detection comes first: a `#share=…` fragment (raw or embedded in any
+ * URL) is always treated as a local share decode, never a network fetch — even
+ * if the URL also has an http(s) scheme. Only `http:` / `https:` are accepted
+ * for the remote path; `file:`, `data:`, `blob:`, `javascript:` and friends are
+ * rejected so the fetch path can't be pointed at a local or inline resource.
+ */
+export function parseImportUrlInput(raw: string): ImportUrlParse {
+  const input = raw.trim();
+  if (!input) return { kind: 'invalid', reason: 'Enter a URL or share link.' };
+
+  // A raw `#share=…` fragment (no scheme/host) — local share decode.
+  if (input.startsWith('#share=')) {
+    const hash = input.slice('#share='.length);
+    return hash.length > 0
+      ? { kind: 'share', hash }
+      : { kind: 'invalid', reason: 'That share link is empty.' };
+  }
+
+  // Try to parse as an absolute URL. A bare `#share=…` is handled above; a
+  // relative input (no scheme) is rejected — we need an absolute http(s) URL.
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return { kind: 'invalid', reason: 'That doesn’t look like a valid URL.' };
+  }
+
+  // Share link embedded in a full URL — decode locally regardless of scheme.
+  if (url.hash.startsWith('#share=')) {
+    const hash = url.hash.slice('#share='.length);
+    return hash.length > 0
+      ? { kind: 'share', hash }
+      : { kind: 'invalid', reason: 'That share link is empty.' };
+  }
+
+  // Remote fetch path — only http(s). Reject file:, data:, blob:, etc.
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return {
+      kind: 'invalid',
+      reason: `Only http(s) URLs or share links are supported (got "${url.protocol}").`,
+    };
+  }
+
+  return { kind: 'remote', url: url.toString() };
+}
+
+/** Derive a sensible filename from a remote URL's path, falling back to a
+ *  generic name when the path has no usable last segment. */
+export function filenameFromUrl(url: string): string {
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return 'import';
+  }
+  const last = pathname.split('/').filter(Boolean).pop() ?? '';
+  // Strip query-ish residue and decode percent-encoding for a readable name.
+  let name = last;
+  try {
+    name = decodeURIComponent(last);
+  } catch {
+    // keep the raw segment if it isn't valid percent-encoding
+  }
+  return name || 'import';
+}
+
+/**
+ * Decide which import path a fetched remote resource should take, given the
+ * URL-derived filename and the response `Content-Type`. The filename's
+ * extension is authoritative (it's what `handleImportFile` keys off), so we try
+ * it first; only when the URL carries no recognizable extension do we sniff the
+ * Content-Type as a fallback. Returns null when neither yields a supported type.
+ */
+export function classifyRemoteResource(
+  filename: string,
+  contentType: string | null,
+): ImportSource | null {
+  const byName = classifyImportSource(filename);
+  if (byName) return byName;
+
+  const ct = (contentType ?? '').split(';')[0].trim().toLowerCase();
+  if (!ct) return null;
+  if (ct === 'application/json' || ct === 'text/json') return 'JSON';
+  if (ct === 'model/stl' || ct === 'application/sla' || ct === 'application/vnd.ms-pki.stl') return 'STL';
+  if (ct === 'model/step' || ct === 'application/step' || ct === 'application/p21') return 'STEP';
+  if (ct === 'image/svg+xml') return 'SVG';
+  if (ct.startsWith('image/')) return 'IMAGE';
+  return null;
+}
+
+/** A best-effort filename with an extension matching the resolved source, so
+ *  `handleImportFile` (which keys off the extension) still routes a
+ *  Content-Type-classified resource correctly even when the URL had no
+ *  extension. No-op when the filename already classifies the same way. */
+export function ensureExtensionForSource(filename: string, source: ImportSource): string {
+  if (classifyImportSource(filename) === source) return filename;
+  const ext: Record<ImportSource, string> = {
+    JSON: '.json', JS: '.js', SCAD: '.scad', STL: '.stl',
+    STEP: '.step', SVG: '.svg', VOX: '.vox', IMAGE: '.png',
+  };
+  const base = filename && filename !== 'import' ? filename : 'import';
+  return base + ext[source];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,6 +84,14 @@ import {
 } from './import/importInbox';
 import { createThumbnailFromImageData } from './import/imageThumbnail';
 import { showImportPreview, summarizeSessionImport } from './ui/importPreview';
+import { showImportUrlModal } from './ui/importUrlModal';
+import {
+  filenameFromUrl,
+  classifyRemoteResource,
+  ensureExtensionForSource,
+  MAX_REMOTE_BYTES,
+  REMOTE_FETCH_TIMEOUT_MS,
+} from './import/urlImport';
 import { showImportTargetModal } from './ui/importTargetModal';
 import { showImageVoxelImportModal } from './ui/imageVoxelImportModal';
 import { showStepImportTargetModal } from './ui/stepImportTargetModal';
@@ -194,6 +202,7 @@ import {
   getGalleryUrl,
   exportSession,
   importSession,
+  importSessionPartsIntoActive,
   clearAllSessions,
   saveImages as persistImages,
   getImagesFromSession,
@@ -2079,11 +2088,15 @@ async function main() {
       alert(`"${filename}" doesn't look like a Partwright session file.`);
       return false;
     }
-    const summary = summarizeSessionImport(data);
-    const ok = await showImportPreview(filename, summary);
-    if (!ok) return false;
-    await importSessionPayload(data);
-    return true;
+    // Show the destination chooser (new session vs merge) and import. The merge
+    // option is only offered when a session is open (gated inside
+    // importValidatedSession). A failure surfaces as a toast and returns false.
+    try {
+      return await importValidatedSession(data, filename);
+    } catch (e) {
+      showToast(`Import failed: ${(e as Error).message}`, { variant: 'warn' });
+      return false;
+    }
   }
 
   // Import a .partwright.json session, a raw .js / .scad file, or an .stl mesh
@@ -2152,6 +2165,164 @@ async function main() {
       alert(`Failed to import "${file.name}": ${(e as Error).message}`);
       return false;
     }
+  }
+
+  // === Import from URL ===
+
+  /** Decode + import a Partwright share link or raw `#share=…` hash WITHOUT any
+   *  network. Mirrors the decode+validate chain in enterSharedFromHash/onFork:
+   *  decodeShare → validateSessionPayload → validateSharePayloadShape, then runs
+   *  it through the same new-session / merge destination chooser as a file
+   *  import. Throws a human-readable message on any failure (the modal surfaces
+   *  it inline). */
+  async function importFromShareHash(hash: string): Promise<void> {
+    let payload: ExportedSession;
+    try {
+      const parsed = await decodeShare(hash);
+      const branded = validateSessionPayload(parsed);
+      if (!branded) throw new Error('not a Partwright payload');
+      payload = validateSharePayloadShape(branded);
+    } catch (e) {
+      if (e instanceof ShareUnsupportedError) {
+        throw new Error('That share link was made by a newer version of Partwright.');
+      }
+      throw new Error('That share link is invalid or corrupted.');
+    }
+    await importValidatedSession(payload, 'shared link');
+  }
+
+  /** Show the destination chooser (new session vs merge, the latter only when a
+   *  session is open) for an already-validated session payload, then import.
+   *  Returns whether the import committed (false when the user cancelled). */
+  async function importValidatedSession(data: ExportedSession, filename: string): Promise<boolean> {
+    const summary = summarizeSessionImport(data);
+    const cur = getState();
+    const mergeTargetName = cur.session
+      ? (cur.session.name?.trim() || 'current session')
+      : undefined;
+    const choice = await showImportPreview(filename, summary, { mergeTargetName });
+    if (choice === 'cancel') return false;
+    if (choice === 'merge') {
+      const result = await importSessionPartsIntoActive(data, async (code) => {
+        await runCodeSync(code);
+        return captureThumbnail();
+      });
+      if (result) {
+        const partWord = result.addedParts.length === 1 ? 'part' : 'parts';
+        showToast(`Merged ${result.addedParts.length} ${partWord} into this session.`, { variant: 'success' });
+        return true;
+      }
+    }
+    await importSessionPayload(data);
+    return true;
+  }
+
+  /** Fetch a remote http(s) file with a timeout + size cap, wrap it in a File,
+   *  and route it through the existing import pipeline (handleImportFile, which
+   *  itself routes JSON → the session-import path). Never evals fetched content.
+   *  Throws a human-readable message on any failure. */
+  async function importFromRemoteUrl(url: string): Promise<void> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REMOTE_FETCH_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(url, { signal: controller.signal, redirect: 'follow' });
+    } catch (e) {
+      clearTimeout(timer);
+      if ((e as Error).name === 'AbortError') throw new Error('The request timed out.');
+      throw new Error('Could not fetch that URL (network error or blocked by the remote server).');
+    }
+    if (!res.ok) {
+      clearTimeout(timer);
+      throw new Error(`The server responded ${res.status} ${res.statusText}.`);
+    }
+
+    // Up-front size guard from Content-Length when present.
+    const declared = Number(res.headers.get('content-length'));
+    if (Number.isFinite(declared) && declared > MAX_REMOTE_BYTES) {
+      clearTimeout(timer);
+      controller.abort();
+      throw new Error(`That file is too large (${(declared / 1048576).toFixed(1)} MB; limit 25 MB).`);
+    }
+
+    const contentType = res.headers.get('content-type');
+    const filename = filenameFromUrl(url);
+
+    // Classify before buffering so we can reject unsupported types early. The
+    // filename extension is authoritative; fall back to Content-Type.
+    const source = classifyRemoteResource(filename, contentType);
+    if (!source) {
+      clearTimeout(timer);
+      controller.abort();
+      throw new Error('Unsupported file type. Supported: .partwright.json, .stl, .step / .stp, .svg, .vox, or an image.');
+    }
+
+    // Stream the body with a hard byte cap as a backstop for servers that omit
+    // or under-report Content-Length.
+    let bytes: Uint8Array;
+    try {
+      bytes = await readBodyCapped(res, MAX_REMOTE_BYTES, controller);
+    } catch (e) {
+      clearTimeout(timer);
+      if ((e as Error).name === 'AbortError') throw new Error('The request timed out.');
+      throw e;
+    }
+    clearTimeout(timer);
+
+    const safeName = ensureExtensionForSource(filename, source);
+    const file = new File([bytes], safeName, { type: contentType ?? '' });
+    const ok = await handleImportFile(file);
+    if (!ok) {
+      // handleImportFile surfaces its own alert on hard failure; a soft "false"
+      // (e.g. user cancelled a sub-modal) shouldn't be reported as an error.
+      throw new Error('Import was cancelled or the file could not be read.');
+    }
+  }
+
+  /** Read a fetch Response body into a Uint8Array, aborting once the streamed
+   *  total exceeds `cap`. Falls back to a plain arrayBuffer() read (still cap-
+   *  checked) when the body isn't a readable stream. */
+  async function readBodyCapped(res: Response, cap: number, controller: AbortController): Promise<Uint8Array> {
+    const body = res.body;
+    if (!body || typeof body.getReader !== 'function') {
+      const buf = new Uint8Array(await res.arrayBuffer());
+      if (buf.byteLength > cap) throw new Error(`That file is too large (limit 25 MB).`);
+      return buf;
+    }
+    const reader = body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        total += value.byteLength;
+        if (total > cap) {
+          controller.abort();
+          try { await reader.cancel(); } catch { /* ignore */ }
+          throw new Error('That file is too large (limit 25 MB).');
+        }
+        chunks.push(value);
+      }
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) { out.set(c, offset); offset += c.byteLength; }
+    return out;
+  }
+
+  /** Open the "Import from URL…" modal and route the user's input to either the
+   *  local share decode or the size-capped remote fetch. */
+  function openImportFromUrl(): void {
+    showImportUrlModal({
+      onSubmit: async (parsed) => {
+        if (parsed.kind === 'share') {
+          await importFromShareHash(parsed.hash);
+        } else {
+          await importFromRemoteUrl(parsed.url);
+        }
+      },
+    });
   }
 
   /** Decode an image File/Blob into ImageData via an offscreen canvas. */
@@ -3044,6 +3215,7 @@ async function main() {
       exportRawCode(getValue(), getActiveLanguage());
     },
     onImportFile: async (file) => { await handleImportFile(file); },
+    onImportFromURL: () => { openImportFromUrl(); },
     onImportInboxEntry: handleReimportInboxEntry,
     onCreateRelief: () => {
       // If the active session is itself a relief, reopen the wizard pre-loaded

--- a/src/main.ts
+++ b/src/main.ts
@@ -1630,7 +1630,14 @@ async function main() {
   // Import an already-parsed session payload. Used by both file import and the
   // window.partwright.importSessionData() API so AI agents can bypass the file picker.
   async function importSessionPayload(data: ExportedSession): Promise<{ sessionId: string }> {
-    const session = await importSession(data, async (code) => {
+    // Seed the active-imports register with each version's own meshes before
+    // running its code: `Manifold.ofMesh(api.imports[0])` only reproduces this
+    // version's geometry (and thus a correct thumbnail) if the register holds
+    // these meshes — otherwise the run captures a stale, previously-loaded part.
+    // importSession resets the register to the latest version's imports when it
+    // finishes, so no manual restore is needed here.
+    const session = await importSession(data, async (code, importedMeshes) => {
+      setActiveImports(importedMeshes ?? []);
       await runCodeSync(code);
       return captureThumbnail();
     });
@@ -2203,10 +2210,19 @@ async function main() {
     const choice = await showImportPreview(filename, summary, { mergeTargetName });
     if (choice === 'cancel') return false;
     if (choice === 'merge') {
-      const result = await importSessionPartsIntoActive(data, async (code) => {
+      // The regen callback runs each imported version's code to snapshot a
+      // thumbnail. Code like `Manifold.ofMesh(api.imports[0])` reads the active-
+      // imports register, so we must seed it with *that* version's meshes
+      // before running — otherwise the run produces the host (previously
+      // selected) part's geometry and the captured thumbnail is stale. Restore
+      // the host's own imports afterwards so the closing re-render is correct.
+      const hostImports = getActiveImports();
+      const result = await importSessionPartsIntoActive(data, async (code, importedMeshes) => {
+        setActiveImports(importedMeshes ?? []);
         await runCodeSync(code);
         return captureThumbnail();
       });
+      setActiveImports(hostImports);
       if (result) {
         // Merging an imported version with no embedded thumbnail runs that
         // version's code through runCodeSync to capture one — which leaves the
@@ -3547,7 +3563,10 @@ async function main() {
       setValue(code);
       runCode(code);
     },
-    async (code: string) => {
+    async (code: string, importedMeshes) => {
+      // Seed this version's imported meshes so `api.imports[0]` resolves to its
+      // own geometry when the thumbnail is regenerated (else a stale capture).
+      setActiveImports(importedMeshes ?? []);
       await runCodeSync(code);
       return captureThumbnail();
     },
@@ -6669,7 +6688,10 @@ async function main() {
       let warning: string | null = null;
       const session = await importSession(
         data,
-        async (code: string) => {
+        async (code: string, importedMeshes) => {
+          // Seed this version's imported meshes so `api.imports[0]` resolves to
+          // its own geometry when regenerating the thumbnail (else a stale part).
+          setActiveImports(importedMeshes ?? []);
           await runCodeSync(code);
           return captureThumbnail();
         },

--- a/src/main.ts
+++ b/src/main.ts
@@ -2208,6 +2208,13 @@ async function main() {
         return captureThumbnail();
       });
       if (result) {
+        // Merging an imported version with no embedded thumbnail runs that
+        // version's code through runCodeSync to capture one — which leaves the
+        // viewport showing the last imported geometry while the editor still
+        // shows the active version's code. Re-render the active version so the
+        // editor text and viewport agree again.
+        const st = getState();
+        if (st.currentVersion) await runCodeSync(st.currentVersion.code);
         const partWord = result.addedParts.length === 1 ? 'part' : 'parts';
         showToast(`Merged ${result.addedParts.length} ${partWord} into this session.`, { variant: 'success' });
         return true;
@@ -2235,6 +2242,26 @@ async function main() {
     if (!res.ok) {
       clearTimeout(timer);
       throw new Error(`The server responded ${res.status} ${res.statusText}.`);
+    }
+
+    // Defense-in-depth: parseImportUrlInput only vetted the *initial* URL's
+    // scheme. With redirect: 'follow', the final URL could in theory be a
+    // non-http(s) scheme; browsers already block http(s)→file:/data: redirects,
+    // but re-check the resolved URL before touching the body just in case.
+    if (res.url) {
+      let finalProtocol: string;
+      try {
+        finalProtocol = new URL(res.url).protocol;
+      } catch {
+        clearTimeout(timer);
+        controller.abort();
+        throw new Error('The remote server redirected to an invalid URL.');
+      }
+      if (finalProtocol !== 'http:' && finalProtocol !== 'https:') {
+        clearTimeout(timer);
+        controller.abort();
+        throw new Error(`The remote server redirected to an unsupported URL (got "${finalProtocol}").`);
+      }
     }
 
     // Up-front size guard from Content-Length when present.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3306,10 +3306,20 @@ async function main() {
 
   // Load a part's active version into the editor, or reset to a blank part when
   // the part has no saved versions yet.
+  //
+  // A saved version carries its own language and `loadVersionIntoEditor` swaps
+  // the engine to match. A version-less part falls back to the manifold-js
+  // starter, so the engine MUST be on manifold-js before we seed + run it —
+  // otherwise the starter's `Manifold.cube(...)` runs under whatever engine the
+  // previously-active part left behind (e.g. voxel, where `api.Manifold` is
+  // undefined) and throws "Cannot read properties of undefined (reading
+  // 'cube')". This is the mixed-language case a JSON merge creates: a voxel
+  // Part 2 alongside the default unsaved manifold-js Part 1.
   async function loadPartIntoEditor(version: Version | null) {
     if (version) {
       await loadVersionIntoEditor(version);
     } else {
+      if (getActiveLanguage() !== 'manifold-js') await switchLanguage('manifold-js');
       startNewPartInEditor();
     }
   }

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -1529,7 +1529,10 @@ export async function exportSession(
 
 export async function importSession(
   data: ExportedSession,
-  regenerateThumbnail?: (code: string) => Promise<Blob | null>,
+  regenerateThumbnail?: (
+    code: string,
+    importedMeshes: ImportedMesh[] | undefined,
+  ) => Promise<Blob | null>,
   onWarning?: (message: string) => void,
 ): Promise<Session> {
   const warning = getSchemaCompatibilityWarning(data);
@@ -1613,13 +1616,21 @@ export async function importSession(
         geometryData = { ...(geometryData ?? {}), colorRegions: regions };
       }
 
+      // This version's imported meshes (base64 buffers → ImportedMesh). Needed
+      // both for persistence below AND for the regenerate path: code like
+      // `Manifold.ofMesh(api.imports[0])` only reproduces this version's
+      // geometry if the active-imports register holds these meshes when the
+      // callback runs it — otherwise the run (and its captured thumbnail)
+      // reflects whatever was last in the register (a stale, wrong part).
+      const importedMeshes = deserializeImportedMeshes(v.importedMeshes);
+
       // Prefer an embedded thumbnail (schema 1.3+) — avoids re-running WASM
       // and gives us the exact image the exporter saw. Fall back to
       // regenerating from code when the field is absent.
       let thumbnail: Blob | null = null;
       if (v.thumbnail) thumbnail = dataURLToBlob(v.thumbnail);
       if (!thumbnail && regenerateThumbnail) {
-        thumbnail = await regenerateThumbnail(v.code);
+        thumbnail = await regenerateThumbnail(v.code, importedMeshes);
       }
 
       // Annotations: prefer the per-version field (1.3+). Fall back to the
@@ -1639,7 +1650,7 @@ export async function importSession(
         v.notes,
         v.timestamp,
         versionAnnotations,
-        deserializeImportedMeshes(v.importedMeshes),
+        importedMeshes,
         // Per-version language (schema 1.8+). Pre-1.8 files omit it; the
         // read path falls back to session-level via effectiveVersionLanguage.
         // Run unknown values through `asLanguage` so a malformed export
@@ -1728,7 +1739,10 @@ export interface MergePartsResult {
  */
 export async function importSessionPartsIntoActive(
   data: ExportedSession,
-  regenerateThumbnail?: (code: string) => Promise<Blob | null>,
+  regenerateThumbnail?: (
+    code: string,
+    importedMeshes: ImportedMesh[] | undefined,
+  ) => Promise<Blob | null>,
 ): Promise<MergePartsResult | null> {
   if (!currentState.session) return null;
   if (!data.session || typeof data.session !== 'object') {
@@ -1792,10 +1806,19 @@ export async function importSessionPartsIntoActive(
         geometryData = { ...(geometryData ?? {}), colorRegions: regions };
       }
 
+      // The imported meshes for this version (base64 buffers → ImportedMesh).
+      // Needed both for persistence AND for the regenerate path: code like
+      // `Manifold.ofMesh(api.imports[0])` only reproduces this version's
+      // geometry if the active-imports register holds *this* version's meshes
+      // when the regen callback runs it. Without them the callback would run
+      // against whatever was last in the register (the host/previous part), so
+      // the captured thumbnail would show the wrong — stale — geometry.
+      const importedMeshes = deserializeImportedMeshes(v.importedMeshes);
+
       // Prefer the embedded thumbnail (1.3+); fall back to regenerating.
       let thumbnail: Blob | null = null;
       if (v.thumbnail) thumbnail = dataURLToBlob(v.thumbnail);
-      if (!thumbnail && regenerateThumbnail) thumbnail = await regenerateThumbnail(v.code);
+      if (!thumbnail && regenerateThumbnail) thumbnail = await regenerateThumbnail(v.code, importedMeshes);
 
       // Annotations: per-version (1.3+) preferred; else top-level (1.2) on the
       // latest exported version only.
@@ -1816,7 +1839,7 @@ export async function importSessionPartsIntoActive(
         v.notes,
         v.timestamp,
         versionAnnotations,
-        deserializeImportedMeshes(v.importedMeshes),
+        importedMeshes,
         asLanguage(v.language),
         v.paramValues && typeof v.paramValues === 'object' ? v.paramValues : undefined,
       );

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -1703,3 +1703,132 @@ export async function importSession(
 
   return refreshedSession;
 }
+
+export interface MergePartsResult {
+  /** Parts appended to the current session. */
+  addedParts: Part[];
+  /** Total versions copied across all appended parts. */
+  versionCount: number;
+}
+
+/**
+ * Merge the parts of an exported session into the CURRENTLY OPEN session,
+ * appending each as a brand-new part (originals untouched, no navigation away).
+ *
+ * Each imported part's versions are copied across preserving `code`,
+ * per-version `language`, `colorRegions`, `annotations`, `thumbnail`,
+ * `geometryData`, `importedMeshes` (base64 mesh buffers), and `paramValues`.
+ * Part and version ids are freshly minted by the db layer (dbCreatePart /
+ * dbSaveVersion), so there are no id collisions with the host session.
+ *
+ * Mirrors {@link importSession}'s reconstruction (legacy single-part files
+ * with no `parts[]` collapse into one part; the same color-region and
+ * top-level-annotation back-compat fallbacks apply) but writes into the
+ * existing session instead of a fresh one. Returns null if no session is open.
+ */
+export async function importSessionPartsIntoActive(
+  data: ExportedSession,
+  regenerateThumbnail?: (code: string) => Promise<Blob | null>,
+): Promise<MergePartsResult | null> {
+  if (!currentState.session) return null;
+  if (!data.session || typeof data.session !== 'object') {
+    throw new Error('Invalid session file: missing "session" data.');
+  }
+  const sessionId = currentState.session.id;
+
+  const versions = Array.isArray(data.versions) ? data.versions : [];
+  if (versions.length === 0) {
+    // A chat/notes-only export carries no parts to merge — nothing to append.
+    throw new Error('That file has no parts to merge.');
+  }
+
+  // Same top-level-annotation back-compat target as importSession: schema 1.2
+  // attached annotations to whichever version was most recent at export.
+  const latestExportedIndex = versions.reduce((m, v) => Math.max(m, v.index), -Infinity);
+
+  // Reconstruct part definitions (legacy files with no `parts[]` collapse into
+  // one default part) and group versions by their owning part's `order`.
+  const partDefs = (Array.isArray(data.parts) && data.parts.length > 0)
+    ? [...data.parts].sort((a, b) => a.order - b.order)
+    : [{ name: DEFAULT_PART_NAME, order: 0 }];
+
+  const versionsByOrder = new Map<number, ExportedSession['versions']>();
+  for (const v of versions) {
+    const order = v.part ?? 0;
+    const arr = versionsByOrder.get(order) ?? [];
+    arr.push(v);
+    versionsByOrder.set(order, arr);
+  }
+
+  // Append after whatever parts the host session already has, preserving the
+  // imported parts' relative order.
+  let nextOrder = currentState.parts.reduce((m, p) => Math.max(m, p.order), -1) + 1;
+  const addedParts: Part[] = [];
+  let copiedVersions = 0;
+
+  for (let i = 0; i < partDefs.length; i++) {
+    const def = partDefs[i];
+    const partVersions = versionsByOrder.get(def.order) ?? [];
+    // Skip an imported part that carries no versions — nothing to seed it with.
+    if (partVersions.length === 0) continue;
+
+    const part = await dbCreatePart(
+      sessionId,
+      (def.name && def.name.trim()) || `Part ${i + 1}`,
+      nextOrder++,
+    );
+    addedParts.push(part);
+
+    const sorted = [...partVersions].sort((a, b) => a.index - b.index);
+    for (const v of sorted) {
+      // Color regions: prefer the explicit (1.1+) field; fall back to the legacy
+      // nested location. Mirror back into geometryData so read paths find them.
+      const explicitRegions = v.colorRegions;
+      const nestedRegions = extractColorRegions(v.geometryData);
+      const regions = explicitRegions ?? nestedRegions;
+
+      let geometryData = v.geometryData;
+      if (regions && (!geometryData || !Array.isArray((geometryData as Record<string, unknown>).colorRegions))) {
+        geometryData = { ...(geometryData ?? {}), colorRegions: regions };
+      }
+
+      // Prefer the embedded thumbnail (1.3+); fall back to regenerating.
+      let thumbnail: Blob | null = null;
+      if (v.thumbnail) thumbnail = dataURLToBlob(v.thumbnail);
+      if (!thumbnail && regenerateThumbnail) thumbnail = await regenerateThumbnail(v.code);
+
+      // Annotations: per-version (1.3+) preferred; else top-level (1.2) on the
+      // latest exported version only.
+      let versionAnnotations: SerializedAnnotation[] | undefined = v.annotations;
+      if (!versionAnnotations && data.annotations && data.annotations.length > 0 && v.index === latestExportedIndex) {
+        versionAnnotations = data.annotations;
+      }
+
+      // dbSaveVersion mints a fresh version id and assigns the next per-part
+      // index, so the copied sequence preserves order without colliding.
+      await dbSaveVersion(
+        part.id,
+        sessionId,
+        v.code,
+        geometryData,
+        thumbnail,
+        v.label,
+        v.notes,
+        v.timestamp,
+        versionAnnotations,
+        deserializeImportedMeshes(v.importedMeshes),
+        asLanguage(v.language),
+        v.paramValues && typeof v.paramValues === 'object' ? v.paramValues : undefined,
+      );
+      copiedVersions++;
+    }
+  }
+
+  // Re-read the host session so the parts rail and counts reflect the appended
+  // parts. We deliberately stay on the current part/version — the merge adds
+  // parts alongside, it doesn't navigate away.
+  await reloadCurrentSessionFromDB();
+  broadcastPartChange();
+
+  return { addedParts, versionCount: copiedVersions };
+}

--- a/src/ui/importPreview.ts
+++ b/src/ui/importPreview.ts
@@ -43,9 +43,11 @@ export function showImportPreview(
   const canMerge = !!opts.mergeTargetName;
   return new Promise((resolve) => {
     let result: ImportDestination = 'cancel';
-    // Default destination when merging is on offer: keep the historical
-    // behavior (a new session) as the pre-selected choice.
-    let destination: 'new-session' | 'merge' = 'new-session';
+    // Default destination when merging is on offer: add the imported parts to
+    // the current project. Importing as a new part is the common intent and
+    // never clobbers existing work, so it's the pre-selected choice. (When no
+    // session is open, `canMerge` is false and a new session is the only path.)
+    let destination: 'new-session' | 'merge' = canMerge ? 'merge' : 'new-session';
     // Declared up front so updateNote() (which toggles its label) can close
     // over it before the footer wiring runs.
     const importBtn = document.createElement('button');
@@ -133,26 +135,28 @@ export function showImportPreview(
         fieldset.appendChild(row);
       };
 
+      // Order: the default (add as new part(s)) is listed first so it reads as
+      // the recommended choice.
+      makeChoice(
+        'merge',
+        'Add as new part(s) to current project',
+        `Adds the imported parts to "${opts.mergeTargetName}" — nothing is replaced.`,
+      );
       makeChoice(
         'new-session',
         'Open as new session',
         'Imports into a brand-new session. Your current session is kept.',
-      );
-      makeChoice(
-        'merge',
-        'Merge into current session',
-        `Append the imported parts to "${opts.mergeTargetName}" — no parts are replaced.`,
       );
       shell.body.appendChild(fieldset);
     }
 
     function updateNote(): void {
       if (canMerge && destination === 'merge') {
-        note.textContent = `Appends the imported parts to "${opts.mergeTargetName}". Existing parts are untouched.`;
+        note.textContent = `Adds the imported parts to "${opts.mergeTargetName}" as new part(s). Existing parts are untouched.`;
       } else {
         note.textContent = 'Imports as a new session — your current session is kept.';
       }
-      importBtn.textContent = canMerge && destination === 'merge' ? 'Merge' : 'Import';
+      importBtn.textContent = canMerge && destination === 'merge' ? 'Add parts' : 'Import';
     }
 
     // Code-execution warning. Importing a session runs each version's code in

--- a/src/ui/importPreview.ts
+++ b/src/ui/importPreview.ts
@@ -20,13 +20,35 @@ function formatTimestamp(ts: number | null): string {
   return d.toLocaleString();
 }
 
+/** Where a confirmed session import should land. `'cancel'` ⇒ dismissed. */
+export type ImportDestination = 'new-session' | 'merge' | 'cancel';
+
+export interface ImportPreviewOptions {
+  /** When set, offers a "Merge into current session" destination alongside the
+   *  default "Open as new session". The name is shown so the user knows what
+   *  they'd be merging into. Omit (or leave undefined) when no session is open. */
+  mergeTargetName?: string;
+}
+
 /**
- * Show a preview modal for a session import. Resolves true if the user
- * confirms, false if they cancel or dismiss.
+ * Show a preview modal for a session import. Resolves with the chosen
+ * destination — `'new-session'` (today's default), `'merge'` (only offered when
+ * `mergeTargetName` is set), or `'cancel'` when dismissed.
  */
-export function showImportPreview(filename: string, summary: SessionImportSummary): Promise<boolean> {
+export function showImportPreview(
+  filename: string,
+  summary: SessionImportSummary,
+  opts: ImportPreviewOptions = {},
+): Promise<ImportDestination> {
+  const canMerge = !!opts.mergeTargetName;
   return new Promise((resolve) => {
-    let result = false;
+    let result: ImportDestination = 'cancel';
+    // Default destination when merging is on offer: keep the historical
+    // behavior (a new session) as the pre-selected choice.
+    let destination: 'new-session' | 'merge' = 'new-session';
+    // Declared up front so updateNote() (which toggles its label) can close
+    // over it before the footer wiring runs.
+    const importBtn = document.createElement('button');
     const shell = createModalShell({
       title: 'Import session?',
       onClose: () => {
@@ -77,8 +99,61 @@ export function showImportPreview(filename: string, summary: SessionImportSummar
 
     const note = document.createElement('p');
     note.className = 'text-[11px] text-zinc-500 leading-relaxed';
-    note.textContent = 'Imports as a new session — your current session is kept.';
     shell.body.appendChild(note);
+
+    // Destination chooser — only when a session is open to merge into. The
+    // radios update both the live `destination` value and the helper note so
+    // the consequence of each choice stays visible.
+    if (canMerge) {
+      const fieldset = document.createElement('div');
+      fieldset.className = 'flex flex-col gap-1.5';
+
+      const makeChoice = (value: 'new-session' | 'merge', label: string, hint: string): void => {
+        const row = document.createElement('label');
+        row.className = 'flex items-start gap-2 cursor-pointer text-sm text-zinc-200';
+        const radio = document.createElement('input');
+        radio.type = 'radio';
+        radio.name = 'import-destination';
+        radio.value = value;
+        radio.className = 'mt-0.5 shrink-0';
+        radio.checked = value === destination;
+        radio.addEventListener('change', () => {
+          if (radio.checked) { destination = value; updateNote(); }
+        });
+        const text = document.createElement('div');
+        const title = document.createElement('div');
+        title.textContent = label;
+        const sub = document.createElement('div');
+        sub.className = 'text-[11px] text-zinc-500 leading-snug';
+        sub.textContent = hint;
+        text.appendChild(title);
+        text.appendChild(sub);
+        row.appendChild(radio);
+        row.appendChild(text);
+        fieldset.appendChild(row);
+      };
+
+      makeChoice(
+        'new-session',
+        'Open as new session',
+        'Imports into a brand-new session. Your current session is kept.',
+      );
+      makeChoice(
+        'merge',
+        'Merge into current session',
+        `Append the imported parts to "${opts.mergeTargetName}" — no parts are replaced.`,
+      );
+      shell.body.appendChild(fieldset);
+    }
+
+    function updateNote(): void {
+      if (canMerge && destination === 'merge') {
+        note.textContent = `Appends the imported parts to "${opts.mergeTargetName}". Existing parts are untouched.`;
+      } else {
+        note.textContent = 'Imports as a new session — your current session is kept.';
+      }
+      importBtn.textContent = canMerge && destination === 'merge' ? 'Merge' : 'Import';
+    }
 
     // Code-execution warning. Importing a session runs each version's code in
     // your browser (to regenerate thumbnails), so a malicious file could
@@ -93,19 +168,27 @@ export function showImportPreview(filename: string, summary: SessionImportSummar
     const cancelBtn = document.createElement('button');
     cancelBtn.className = BUTTON_CANCEL;
     cancelBtn.textContent = 'Cancel';
-    cancelBtn.addEventListener('click', () => { result = false; shell.close(); });
+    cancelBtn.addEventListener('click', () => { result = 'cancel'; shell.close(); });
     shell.footer.appendChild(cancelBtn);
 
-    const importBtn = document.createElement('button');
     importBtn.className = BUTTON_PRIMARY;
     importBtn.textContent = 'Import';
-    importBtn.addEventListener('click', () => { result = true; shell.close(); });
+    importBtn.addEventListener('click', confirmImport);
     shell.footer.appendChild(importBtn);
+
+    function confirmImport(): void {
+      result = canMerge ? destination : 'new-session';
+      shell.close();
+    }
+
+    // Now that the button exists, sync its label + the helper note to the
+    // initial destination (and reflect any later radio changes).
+    updateNote();
 
     // Modal shell handles Escape; we add an extra Enter-to-confirm shortcut
     // so the keyboard flow matches the previous standalone implementation.
     function onEnter(e: KeyboardEvent) {
-      if (e.key === 'Enter') { e.preventDefault(); result = true; shell.close(); }
+      if (e.key === 'Enter') { e.preventDefault(); confirmImport(); }
     }
     document.addEventListener('keydown', onEnter);
 

--- a/src/ui/importUrlModal.ts
+++ b/src/ui/importUrlModal.ts
@@ -1,0 +1,117 @@
+// "Import from URL…" modal. Accepts EITHER a Partwright share link (decoded
+// locally, no network) OR an http(s) URL to a remote file (fetched and routed
+// through the existing data-import paths). Built on the shared modalShell so
+// Escape, click-outside, and listener cleanup match the other dialogs.
+//
+// The modal is intentionally dumb about *how* the import happens — it parses
+// the input (via the pure `parseImportUrlInput` helper), shows inline
+// validation, and hands the parsed result to the caller's `onSubmit`. The
+// caller (main.ts) owns the share decode, the size-capped fetch, and the
+// routing into handleImportFile / the session-import path.
+
+import { createModalShell } from './modalShell';
+import { BUTTON_PRIMARY, BUTTON_CANCEL } from './styleConstants';
+import { parseImportUrlInput, type ImportUrlParse } from '../import/urlImport';
+
+export interface ImportUrlModalCallbacks {
+  /** Perform the import for a validated input. Throw (or reject) with a
+   *  human-readable message to surface it inline; the modal stays open so the
+   *  user can correct the URL. Resolve to close the modal. */
+  onSubmit: (parsed: Extract<ImportUrlParse, { kind: 'share' | 'remote' }>) => Promise<void>;
+}
+
+export function showImportUrlModal(callbacks: ImportUrlModalCallbacks): void {
+  const shell = createModalShell({
+    title: 'Import from URL',
+    maxWidth: 'lg',
+    onClose: () => {
+      document.removeEventListener('keydown', onKey);
+    },
+  });
+
+  const intro = document.createElement('p');
+  intro.className = 'text-[12px] text-zinc-400 leading-relaxed';
+  intro.textContent =
+    'Paste a Partwright share link, or an http(s) link to a file ' +
+    '(.json / .partwright.json, .stl, .step / .stp, .svg, .vox, or an image).';
+  shell.body.appendChild(intro);
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.inputMode = 'url';
+  input.placeholder = 'https://example.com/part.partwright.json  or  #share=…';
+  input.className =
+    'w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-sm text-zinc-100 ' +
+    'placeholder:text-zinc-600 focus:outline-none focus:border-blue-500';
+  shell.body.appendChild(input);
+
+  // Inline status line — validation errors, fetch errors, and progress.
+  const status = document.createElement('p');
+  status.className = 'text-[12px] leading-snug min-h-[1.25rem]';
+  shell.body.appendChild(status);
+
+  function setStatus(message: string, tone: 'error' | 'info' | 'none' = 'none'): void {
+    status.textContent = message;
+    status.className =
+      'text-[12px] leading-snug min-h-[1.25rem] ' +
+      (tone === 'error' ? 'text-red-400' : tone === 'info' ? 'text-zinc-400' : 'text-transparent');
+  }
+
+  const note = document.createElement('p');
+  note.className = 'rounded border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-[11px] text-zinc-500 leading-snug';
+  note.textContent =
+    'Remote files are fetched directly in your browser (no server), capped at 25 MB with a 15s timeout. ' +
+    'Importing a session runs its code to rebuild previews — only import from sources you trust.';
+  shell.body.appendChild(note);
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = BUTTON_CANCEL;
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => shell.close());
+  shell.footer.appendChild(cancelBtn);
+
+  const importBtn = document.createElement('button');
+  importBtn.className = BUTTON_PRIMARY;
+  importBtn.textContent = 'Import';
+  importBtn.addEventListener('click', () => { void submit(); });
+  shell.footer.appendChild(importBtn);
+
+  let busy = false;
+  async function submit(): Promise<void> {
+    if (busy) return;
+    const parsed = parseImportUrlInput(input.value);
+    if (parsed.kind === 'invalid') {
+      setStatus(parsed.reason, 'error');
+      input.focus();
+      return;
+    }
+
+    busy = true;
+    importBtn.disabled = true;
+    cancelBtn.disabled = true;
+    input.disabled = true;
+    importBtn.textContent = parsed.kind === 'share' ? 'Decoding…' : 'Fetching…';
+    setStatus(parsed.kind === 'share' ? 'Decoding share link…' : 'Fetching file…', 'info');
+
+    try {
+      await callbacks.onSubmit(parsed);
+      shell.close();
+    } catch (e) {
+      // Re-enable for a retry and surface the message inline.
+      busy = false;
+      importBtn.disabled = false;
+      cancelBtn.disabled = false;
+      input.disabled = false;
+      importBtn.textContent = 'Import';
+      setStatus((e as Error).message || 'Import failed.', 'error');
+      input.focus();
+    }
+  }
+
+  function onKey(e: KeyboardEvent): void {
+    if (e.key === 'Enter' && !busy) { e.preventDefault(); void submit(); }
+  }
+  document.addEventListener('keydown', onKey);
+
+  input.focus();
+}

--- a/src/ui/sessionList.ts
+++ b/src/ui/sessionList.ts
@@ -12,17 +12,23 @@ import {
   type Session,
   type ExportedSession,
 } from '../storage/sessionManager';
+import type { ImportedMesh } from '../import/importedMesh';
 import { getSessionLatestVersion, getSessionVersionCount } from '../storage/db';
 import { languageBadge } from './languageBadge';
 
 let modalEl: HTMLElement | null = null;
 let onLoadVersion: ((code: string) => void | Promise<void>) | null = null;
-let regenerateThumbnailFn: ((code: string) => Promise<Blob | null>) | null = null;
+type RegenerateThumbnailFn = (
+  code: string,
+  importedMeshes: ImportedMesh[] | undefined,
+) => Promise<Blob | null>;
+
+let regenerateThumbnailFn: RegenerateThumbnailFn | null = null;
 let onNewSessionFn: (() => void) | null = null;
 
 export function initSessionList(
   loadCode: (code: string) => void | Promise<void>,
-  regenerateThumbnail?: (code: string) => Promise<Blob | null>,
+  regenerateThumbnail?: RegenerateThumbnailFn,
   onNewSession?: () => void,
 ): void {
   onLoadVersion = loadCode;

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -34,6 +34,8 @@ export interface ToolbarCallbacks {
   onShareLink: () => void;
   onExportRawCode: () => void;
   onImportFile: (file: File) => void | Promise<void>;
+  /** Open the "Import from URL…" modal (share link or remote file URL). */
+  onImportFromURL: () => void;
   /** Re-import a blob already held in the inbox (e.g. recent-imports re-click). */
   onImportInboxEntry: (entry: ImportInboxEntry) => void | Promise<void>;
   /** Open the image → keychain / tile / stepped-relief import wizard. */
@@ -332,6 +334,16 @@ export function createToolbar(
     importInput.click();
   });
   importDropdown.appendChild(chooseFileOpt);
+
+  const fromUrlOpt = createDescribedItem(
+    'Import from URL…',
+    'Paste a Partwright share link, or an http(s) link to a session, mesh, or image file.',
+  );
+  fromUrlOpt.addEventListener('click', () => {
+    importDropdown.classList.add('hidden');
+    callbacks.onImportFromURL();
+  });
+  importDropdown.appendChild(fromUrlOpt);
 
   importDropdown.appendChild(createDivider());
   importDropdown.appendChild(createSectionHeader('Create'));

--- a/tests/import-merge-url.spec.ts
+++ b/tests/import-merge-url.spec.ts
@@ -15,15 +15,22 @@ async function openEditor(page: Page) {
   );
 }
 
+type ExportedVersion = { code: string; thumbnail?: string; part?: number };
+type ExportedPart = { name: string; order: number };
+type ExportedData = { versions: ExportedVersion[]; parts?: ExportedPart[] };
+
 type PW = {
   createSession: (n?: string) => Promise<unknown>;
   runAndSave: (c: string, l?: string) => Promise<unknown>;
-  exportSessionData: (id?: string) => Promise<{ data: unknown }>;
+  exportSessionData: (
+    id?: string,
+    opts?: { includeThumbnails?: boolean },
+  ) => Promise<{ data: ExportedData }>;
   listParts: () => { id: string; name: string }[];
 };
 
 test.describe('Import: merge + from-URL', () => {
-  test('JSON import offers "Merge into current session" and appends the parts', async ({ page }) => {
+  test('JSON import defaults to "Add as new part(s)" and appends the parts', async ({ page }) => {
     await openEditor(page);
 
     // Build an exported session payload from a throwaway session.
@@ -53,11 +60,13 @@ test.describe('Import: merge + from-URL', () => {
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible({ timeout: 6000 });
-    // The merge destination choice is offered because a session is open.
-    await expect(dialog).toContainText('Merge into current session');
-    await dialog.getByText('Merge into current session').click();
-    // The primary button relabels to "Merge".
-    const mergeBtn = dialog.getByRole('button', { name: 'Merge' });
+    // The merge destination choice is offered because a session is open, AND it
+    // is the pre-selected default — so the primary button already reads
+    // "Add parts" without the user touching the radios.
+    await expect(dialog).toContainText('Add as new part(s) to current project');
+    const mergeRadio = dialog.locator('input[type="radio"][value="merge"]');
+    await expect(mergeRadio).toBeChecked();
+    const mergeBtn = dialog.getByRole('button', { name: 'Add parts' });
     await expect(mergeBtn).toBeVisible();
     await mergeBtn.click();
     await expect(dialog).toBeHidden({ timeout: 10_000 });
@@ -71,6 +80,113 @@ test.describe('Import: merge + from-URL', () => {
     const sessionName = await page.evaluate(() =>
       new URLSearchParams(window.location.search).get('session'));
     expect(sessionName).toBeTruthy();
+  });
+
+  test('merging an imported-mesh part regenerates its OWN thumbnail (not the host part\'s)', async ({ page }) => {
+    await openEditor(page);
+
+    // Author an exported session whose only version renders an imported mesh
+    // (`Manifold.ofMesh(api.imports[0])`) and carries NO embedded thumbnail, so
+    // the merge MUST regenerate one by running that code. The bug under test:
+    // if the active-imports register isn't seeded with THIS version's mesh
+    // before the run, the capture reflects the host (previously selected) part
+    // instead — a stale thumbnail. The imported mesh here is a single triangle,
+    // visually distinct from the host part's sphere.
+    const json = await page.evaluate(() => {
+      // A closed tetrahedron — a valid watertight mesh so `Manifold.ofMesh`
+      // produces real geometry (a flat triangle would be non-manifold and the
+      // run would yield no mesh, leaving the thumbnail stale for the wrong
+      // reason). Large enough to fill the iso thumbnail frame.
+      const verts = new Float32Array([
+        0, 0, 0,
+        30, 0, 0,
+        0, 30, 0,
+        0, 0, 30,
+      ]);
+      // Outward-facing winding for the four faces.
+      const tris = new Uint32Array([
+        0, 2, 1,
+        0, 1, 3,
+        0, 3, 2,
+        1, 2, 3,
+      ]);
+      const toB64 = (arr: Float32Array | Uint32Array): string => {
+        const bytes = new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
+        let bin = '';
+        for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+        return btoa(bin);
+      };
+      const payload = {
+        partwright: '1.9',
+        session: { name: 'imported-source', created: Date.now(), updated: Date.now() },
+        parts: [{ name: 'Imported', order: 0 }],
+        versions: [{
+          index: 1,
+          part: 0,
+          // Mirrors the real import codegen wrapper: reads the imported mesh out
+          // of the sandbox's `api.imports[0]`. With the stale-capture bug, the
+          // register isn't seeded with THIS mesh before the run, so the code
+          // either errors (host has no imports) or renders the host part — and
+          // the captured thumbnail is wrong.
+          code: 'const { Manifold } = api;\nreturn Manifold.ofMesh(api.imports[0]);',
+          label: 'imported',
+          timestamp: Date.now(),
+          // No `thumbnail` field → forces regeneration on import/merge.
+          importedMeshes: [{
+            id: 'm1',
+            filename: 'tetra.stl',
+            format: 'stl',
+            numVert: 4,
+            numTri: 4,
+            numProp: 3,
+            vertProperties: toB64(verts),
+            triVerts: toB64(tris),
+          }],
+        }],
+      };
+      return JSON.stringify(payload);
+    });
+
+    // Host session: a sphere, with its own (regenerated) thumbnail.
+    await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('host-session');
+      await pw.runAndSave('const { Manifold } = api; return Manifold.sphere(8);', 'v1');
+    });
+
+    // Import → the chooser defaults to merge → confirm with "Add parts".
+    await page.locator('#import-wrapper input[type="file"]').setInputFiles({
+      name: 'imported.partwright.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(json, 'utf8'),
+    });
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 6000 });
+    await dialog.getByRole('button', { name: 'Add parts' }).click();
+    await expect(dialog).toBeHidden({ timeout: 10_000 });
+
+    await expect.poll(async () =>
+      page.evaluate(() => (window as unknown as { partwright: PW }).partwright.listParts().length),
+    ).toBe(2);
+
+    // Export the host session (with thumbnails) and inspect the two parts'
+    // thumbnails. The merged (imported) part is order 1; the host sphere is
+    // order 0. `exportSession` omits the `part` field when the order is 0.
+    const thumbs = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      const { data } = await pw.exportSessionData(undefined, { includeThumbnails: true });
+      const byPart = (order: number): string | undefined =>
+        data.versions.find((v) => (v.part ?? 0) === order)?.thumbnail;
+      return { host: byPart(0), imported: byPart(1) };
+    });
+
+    // The merged part carries a freshly regenerated, non-trivial PNG thumbnail…
+    expect(thumbs.imported).toBeTruthy();
+    expect(thumbs.imported!.startsWith('data:image/png')).toBe(true);
+    expect(thumbs.imported!.length).toBeGreaterThan(256);
+    // …and it is NOT a copy of the host sphere's thumbnail (the stale-capture
+    // bug produced an identical image because both runs read the host's mesh).
+    expect(thumbs.imported).not.toBe(thumbs.host);
   });
 
   test('"Import from URL…" rejects an unsupported scheme inline', async ({ page }) => {

--- a/tests/import-merge-url.spec.ts
+++ b/tests/import-merge-url.spec.ts
@@ -1,0 +1,121 @@
+// E2E for JSON import "Merge into current session" + the "Import from URL…"
+// modal's input validation. No external network is exercised.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function openEditor(page: Page) {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+type PW = {
+  createSession: (n?: string) => Promise<unknown>;
+  runAndSave: (c: string, l?: string) => Promise<unknown>;
+  exportSessionData: (id?: string) => Promise<{ data: unknown }>;
+  listParts: () => { id: string; name: string }[];
+};
+
+test.describe('Import: merge + from-URL', () => {
+  test('JSON import offers "Merge into current session" and appends the parts', async ({ page }) => {
+    await openEditor(page);
+
+    // Build an exported session payload from a throwaway session.
+    const json = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('source-session');
+      await pw.runAndSave('const { Manifold } = api; return Manifold.cube([6,6,6], true);', 'v1');
+      const { data } = await pw.exportSessionData();
+      return JSON.stringify(data);
+    });
+
+    // Switch to a DIFFERENT session that we will merge into.
+    const partsBefore = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('target-session');
+      await pw.runAndSave('const { Manifold } = api; return Manifold.sphere(5);', 'v1');
+      return pw.listParts().length;
+    });
+    expect(partsBefore).toBe(1);
+
+    // Import the source JSON through the toolbar file input.
+    await page.locator('#import-wrapper input[type="file"]').setInputFiles({
+      name: 'source.partwright.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(json, 'utf8'),
+    });
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 6000 });
+    // The merge destination choice is offered because a session is open.
+    await expect(dialog).toContainText('Merge into current session');
+    await dialog.getByText('Merge into current session').click();
+    // The primary button relabels to "Merge".
+    const mergeBtn = dialog.getByRole('button', { name: 'Merge' });
+    await expect(mergeBtn).toBeVisible();
+    await mergeBtn.click();
+    await expect(dialog).toBeHidden({ timeout: 10_000 });
+
+    // The current session now has its original part PLUS the merged one, and we
+    // did NOT navigate away to a new session.
+    await expect.poll(async () =>
+      page.evaluate(() => (window as unknown as { partwright: PW }).partwright.listParts().length),
+    ).toBe(2);
+
+    const sessionName = await page.evaluate(() =>
+      new URLSearchParams(window.location.search).get('session'));
+    expect(sessionName).toBeTruthy();
+  });
+
+  test('"Import from URL…" rejects an unsupported scheme inline', async ({ page }) => {
+    await openEditor(page);
+
+    await page.locator('#btn-import').click();
+    await page.getByText('Import from URL…').click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 6000 });
+    await expect(dialog).toContainText('Import from URL');
+
+    const input = dialog.locator('input[type="text"]');
+    await input.fill('file:///etc/passwd');
+    await dialog.getByRole('button', { name: 'Import' }).click();
+    // Inline validation error; the modal stays open (no network attempt).
+    await expect(dialog).toContainText('Only http(s) URLs or share links');
+    await expect(dialog).toBeVisible();
+  });
+
+  test('"Import from URL…" decodes a pasted share link with no network', async ({ page }) => {
+    await openEditor(page);
+
+    // Make a real share link via the console API, then close the session so the
+    // import lands cleanly as a new one.
+    const shareUrl = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW & { getShareLink: () => Promise<{ url?: string }> } }).partwright;
+      await pw.createSession('to-share');
+      await pw.runAndSave('const { Manifold } = api; return Manifold.cube([7,7,7], true);', 'v1');
+      const r = await pw.getShareLink();
+      return r.url ?? '';
+    });
+    expect(shareUrl).toContain('#share=');
+
+    await page.locator('#btn-import').click();
+    await page.getByText('Import from URL…').click();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 6000 });
+
+    await dialog.locator('input[type="text"]').fill(shareUrl);
+    await dialog.getByRole('button', { name: 'Import' }).click();
+
+    // The share preview modal opens (same chooser as a file import). Confirm a
+    // new-session import; the share decode happened entirely client-side.
+    const previewDialog = page.locator('[role="dialog"]');
+    await expect(previewDialog).toContainText('Import session', { timeout: 10_000 });
+  });
+});

--- a/tests/import-merge-url.spec.ts
+++ b/tests/import-merge-url.spec.ts
@@ -189,6 +189,89 @@ test.describe('Import: merge + from-URL', () => {
     expect(thumbs.imported).not.toBe(thumbs.host);
   });
 
+  test('switching between a manifold-js part and a merged voxel part runs each under its own engine', async ({ page }) => {
+    await openEditor(page);
+
+    // A source session whose single part is authored in the VOXEL language. We
+    // export it, then merge it into a manifold-js session — producing the mixed-
+    // language session the bug needs (manifold-js Part 1 + voxel Part 2).
+    const json = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW & {
+        setActiveLanguage: (l: string) => Promise<void>;
+      } }).partwright;
+      await pw.createSession('voxel-source');
+      await pw.setActiveLanguage('voxel');
+      // A minimal voxel model — `api.voxels()` exists only under the voxel
+      // engine (the manifold-js sandbox has `api.Manifold` instead).
+      await pw.runAndSave('const { voxels } = api; return voxels().fillBox([0,0,0],[5,5,5], "#88aaff");', 'v1');
+      const { data } = await pw.exportSessionData();
+      return JSON.stringify(data);
+    });
+
+    // The host: a fresh manifold-js session. Crucially Part 1 here is the
+    // DEFAULT, UNSAVED starter — it has no saved version, so switching back to
+    // it goes through the version-less `loadPartIntoEditor(null)` path. Re-run
+    // the starter so it's the active, render-clean manifold-js part.
+    await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW & { run: (c: string) => Promise<unknown> } }).partwright;
+      await pw.createSession('host-manifold');
+      await pw.run('const { Manifold } = api; return Manifold.cube([10,10,10], true);');
+    });
+
+    // Merge the voxel part in via the toolbar import → "Add parts".
+    await page.locator('#import-wrapper input[type="file"]').setInputFiles({
+      name: 'voxel.partwright.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(json, 'utf8'),
+    });
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 6000 });
+    await dialog.getByRole('button', { name: 'Add parts' }).click();
+    await expect(dialog).toBeHidden({ timeout: 10_000 });
+
+    // Two parts now: [0] = manifold-js host (unsaved starter), [1] = voxel.
+    await expect.poll(async () =>
+      page.evaluate(() => (window as unknown as { partwright: PW }).partwright.listParts().length),
+    ).toBe(2);
+
+    type PartChange = { active: string; error?: string };
+    const switchTo = (idx: number): Promise<PartChange> =>
+      page.evaluate(async (i: number) => {
+        const w = window as unknown as {
+          partwright: PW & {
+            changePart: (id: string) => Promise<unknown>;
+            getActiveLanguage: () => string;
+          };
+        };
+        const pw = w.partwright;
+        const parts = pw.listParts();
+        try {
+          await pw.changePart(parts[i].id);
+          return { active: pw.getActiveLanguage() };
+        } catch (e) {
+          return { active: pw.getActiveLanguage(), error: e instanceof Error ? e.message : String(e) };
+        }
+      }, idx);
+
+    // Switch to the voxel part (index 1): engine becomes voxel, no error.
+    const onVoxel = await switchTo(1);
+    expect(onVoxel.error).toBeUndefined();
+    expect(onVoxel.active).toBe('voxel');
+
+    // Switch back to the manifold-js host (index 0). This is the regression:
+    // before the fix, the version-less starter ran its `Manifold.cube(...)`
+    // under the still-active voxel engine and threw "Cannot read properties of
+    // undefined (reading 'cube')", leaving the language stuck on voxel.
+    const onHost = await switchTo(0);
+    expect(onHost.error).toBeUndefined();
+    expect(onHost.active).toBe('manifold-js');
+
+    // And the round-trip back to voxel still works cleanly.
+    const backToVoxel = await switchTo(1);
+    expect(backToVoxel.error).toBeUndefined();
+    expect(backToVoxel.active).toBe('voxel');
+  });
+
   test('"Import from URL…" rejects an unsupported scheme inline', async ({ page }) => {
     await openEditor(page);
 

--- a/tests/unit/urlImport.test.ts
+++ b/tests/unit/urlImport.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseImportUrlInput,
+  filenameFromUrl,
+  classifyRemoteResource,
+  ensureExtensionForSource,
+} from '../../src/import/urlImport';
+
+describe('parseImportUrlInput', () => {
+  it('rejects empty / whitespace input', () => {
+    expect(parseImportUrlInput('').kind).toBe('invalid');
+    expect(parseImportUrlInput('   ').kind).toBe('invalid');
+  });
+
+  it('treats a raw #share= fragment as a local share decode', () => {
+    const r = parseImportUrlInput('#share=abc123');
+    expect(r).toEqual({ kind: 'share', hash: 'abc123' });
+  });
+
+  it('rejects an empty share fragment', () => {
+    expect(parseImportUrlInput('#share=').kind).toBe('invalid');
+  });
+
+  it('extracts the share hash from a full share URL regardless of scheme', () => {
+    const r = parseImportUrlInput('https://www.partwrightstudio.com/editor#share=ZZZ');
+    expect(r).toEqual({ kind: 'share', hash: 'ZZZ' });
+  });
+
+  it('routes a plain https file URL to the remote path', () => {
+    const r = parseImportUrlInput('https://example.com/part.partwright.json');
+    expect(r).toEqual({ kind: 'remote', url: 'https://example.com/part.partwright.json' });
+  });
+
+  it('accepts http (mixed-content is enforced separately by the browser)', () => {
+    expect(parseImportUrlInput('http://example.com/a.stl').kind).toBe('remote');
+  });
+
+  it('rejects non-http(s) schemes (file:, data:, blob:, javascript:)', () => {
+    expect(parseImportUrlInput('file:///etc/passwd').kind).toBe('invalid');
+    expect(parseImportUrlInput('data:application/json,{}').kind).toBe('invalid');
+    expect(parseImportUrlInput('blob:https://x/y').kind).toBe('invalid');
+    expect(parseImportUrlInput('javascript:alert(1)').kind).toBe('invalid');
+  });
+
+  it('rejects a bare non-URL string', () => {
+    expect(parseImportUrlInput('not a url').kind).toBe('invalid');
+  });
+});
+
+describe('filenameFromUrl', () => {
+  it('takes the last path segment', () => {
+    expect(filenameFromUrl('https://x.com/a/b/part.stl')).toBe('part.stl');
+  });
+  it('decodes percent-encoding', () => {
+    expect(filenameFromUrl('https://x.com/my%20part.json')).toBe('my part.json');
+  });
+  it('ignores query strings', () => {
+    expect(filenameFromUrl('https://x.com/a.svg?token=xyz')).toBe('a.svg');
+  });
+  it('falls back to a generic name when there is no segment', () => {
+    expect(filenameFromUrl('https://x.com/')).toBe('import');
+  });
+});
+
+describe('classifyRemoteResource', () => {
+  it('prefers the filename extension', () => {
+    expect(classifyRemoteResource('a.stl', 'application/octet-stream')).toBe('STL');
+    expect(classifyRemoteResource('a.partwright.json', null)).toBe('JSON');
+  });
+  it('falls back to Content-Type when the name has no usable extension', () => {
+    expect(classifyRemoteResource('download', 'application/json')).toBe('JSON');
+    expect(classifyRemoteResource('download', 'image/png')).toBe('IMAGE');
+    expect(classifyRemoteResource('download', 'image/svg+xml')).toBe('SVG');
+    expect(classifyRemoteResource('download', 'model/step')).toBe('STEP');
+  });
+  it('returns null for unsupported types', () => {
+    expect(classifyRemoteResource('download', 'application/pdf')).toBeNull();
+    expect(classifyRemoteResource('download', null)).toBeNull();
+  });
+});
+
+describe('ensureExtensionForSource', () => {
+  it('leaves a matching filename untouched', () => {
+    expect(ensureExtensionForSource('a.json', 'JSON')).toBe('a.json');
+  });
+  it('appends the right extension when the name does not classify', () => {
+    expect(ensureExtensionForSource('download', 'JSON')).toBe('download.json');
+    expect(ensureExtensionForSource('download', 'IMAGE')).toBe('download.png');
+  });
+  it('uses a generic base for the fallback name', () => {
+    expect(ensureExtensionForSource('import', 'STL')).toBe('import.stl');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -165,7 +165,9 @@ export default defineConfig({
       // external call surfaces here in dev instead of slipping through to
       // production. connect-src allows `https:` + http://localhost / 127.0.0.1
       // so a user-configured Custom (OpenAI-compatible) endpoint — e.g. a
-      // self-hosted llama.cpp server — works (matches _headers). The dev-only
+      // self-hosted llama.cpp server — works (matches _headers). That same
+      // `https:` allowance also backs "Import from URL…" (fetching a remote
+      // file over https). The dev-only
       // delta is the localhost WebSocket Vite uses for HMR/live-reload, which
       // production has no equivalent of. Keep the host allowlist in sync with
       // public/_headers.


### PR DESCRIPTION
## Summary

Adds two import capabilities and hardens the merge flow:

- **JSON import merge** — importing a `.partwright.json` while a session is open now offers "Add as new part(s) to current project" (the default) alongside "New session". Selected parts are appended to the active session, preserving per-version code, language, color regions, annotations, thumbnails, imported meshes, and parameter values.
- **Import from URL** — a new "Import from URL…" entry accepts http(s) links and Partwright share links, fetched client-side with a timeout + size cap and scheme re-validation after redirects.

## Fix: part navigation under mixed-language sessions

The merge can create a mixed-language session (e.g. a voxel part appended next to the default manifold-js part). Switching parts must run each part's code under the engine that matches that part's current-version language, exactly like version navigation does (per the #321 per-version-language fix).

`loadVersionIntoEditor` already swaps the engine for a *saved* version, but the version-less branch of `loadPartIntoEditor` (a part with no saved versions — e.g. the default unsaved manifold-js starter) seeded and ran the starter under whatever engine the previously-active part left behind. So: merge a voxel part into a manifold-js session → click the voxel part (engine → voxel) → click back to the unsaved manifold-js Part 1 → the version-less path ran the starter's `Manifold.cube(...)` under the voxel engine (where `api.Manifold` is undefined) and threw **"Cannot read properties of undefined (reading 'cube')"**, leaving the language stuck on voxel.

The fix forces `manifold-js` before seeding the starter in the version-less branch, so part navigation is correct for mixed-language sessions in both directions.

## Test plan

- `tests/import-merge-url.spec.ts` covers the merge-default chooser, imported-mesh thumbnail regeneration, and the URL modal's scheme validation + share-link decode.
- **New e2e regression** in the same file: merge a voxel part into a manifold-js session, then switch Part 2 ↔ Part 1 and assert each renders with no error and the active language matches each part (manifold-js for the starter, voxel for the merged part).
- `tests/unit/urlImport.test.ts` covers URL/share-link parsing.
- Local preflight: `npm run build` and `npm run test:unit` both green. Full e2e runs on PR-checks CI.

https://claude.ai/code/session_011v1XCcLbbuTPDXxFLYvRk2