### PR TITLE
chore: agent git/PR safeguards (discipline notes + PR-close/merge hook)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__github__merge_pull_request|mcp__github__update_pull_request",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -c 'if (.tool_name == \"mcp__github__merge_pull_request\") or (.tool_name == \"mcp__github__update_pull_request\" and .tool_input.state == \"closed\") then {hookSpecificOutput: {hookEventName: \"PreToolUse\", permissionDecision: \"ask\", permissionDecisionReason: \"Closing or merging a PR is irreversible and outward-facing. Confirm this was explicitly requested and is not a batched or speculative action.\"}} else empty end'",
+            "statusMessage": "Checking PR safety guard…"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,6 +404,15 @@ Subject is imperative and lowercase after the prefix: `feat: add light/dark mode
 
 Anything unlabeled lands in "Other Changes." That's fine for occasional internal cleanup, but features and fixes should always be labeled.
 
+### Agent working discipline (git, PRs, tool output)
+
+Guardrails for automated work, learned the hard way:
+
+- **Irreversible GitHub actions stand alone, after an explicit decision.** Closing or merging a PR, deleting a branch, or force-pushing is outward-facing and hard to undo. Never batch such a call in the same tool block as other work (a sibling call fires even if the call meant to gate it errored or was never answered), and never infer the go-ahead — issue it as its own step only when the user explicitly asked for it. A PR close/merge is never a default or a guess. (A `PreToolUse` hook in `.claude/settings.json` also pauses for confirmation before `merge_pull_request` and a `state: closed` `update_pull_request`, as a backstop.)
+- **A failed or unreadable tool result is not a success.** If a call errors (e.g. an `AskUserQuestion` that didn't validate) or its output comes back garbled / empty / out-of-order, re-run or re-verify state before proceeding — never act on an answer you didn't actually receive, and never treat a laggy/garbled shell as ground truth.
+- **Git is single-writer.** The working tree and index are shared mutable state. Don't run git mutations while a subagent is also touching the same checkout. Resolve merges/rebases inline yourself; if you must delegate git work to a subagent, give it an isolated worktree (`isolation: "worktree"`).
+- **Verify state between destructive git steps.** After a merge / rebase / reset, confirm `git status` and HEAD, and that local HEAD matches what you pushed, before moving on.
+
 ### After Opening a PR
 
 Opening the **draft** PR (see [the standing instruction](#pull-requests--open-a-draft-when-the-work-looks-good) above) isn't the finish line — it's the start of the verification phase. PR-checks runs the full suite — build + unit, then the 3 e2e shards — on every push, draft or ready, so the draft gets full signal immediately. The task is done when every shard is green; marking the PR ready for review (step 6 below) is the final step, a review-readiness signal rather than a CI trigger.


### PR DESCRIPTION
## Summary

Backstops against two process failures that happened during the image→voxel work, so they can't recur silently.

**1. `CLAUDE.md` → new "Agent working discipline (git, PRs, tool output)" subsection** (under Commit & PR Conventions):
- Irreversible GitHub actions (close/merge PR, delete branch, force-push) stand alone, after explicit intent — never batched with other calls (a sibling call fires even if the gating call errored), never inferred.
- A failed or unreadable tool result is not a success — re-verify before acting; don't treat a garbled/laggy shell as ground truth.
- Git is single-writer — don't mutate the tree while a subagent touches the same checkout; resolve merges inline or give the agent an isolated worktree.
- Verify state (`git status`, HEAD, local == pushed) between destructive git steps.

**2. `.claude/settings.json` → `PreToolUse` hook** as an enforced backstop (hints rely on the agent heeding them under load; this doesn't):
- A `jq` command that returns `permissionDecision: "ask"` before `mcp__github__merge_pull_request` and before `mcp__github__update_pull_request` when `state == "closed"`.
- Passes through (no prompt) on ordinary `update_pull_request` calls — body edits, `draft` flips, `state: open` — so the normal workflow is untouched.

### Why both

The CLAUDE.md notes guide behavior; the hook *enforces* the one that matters most (accidental close/merge) regardless of what the agent is doing, since that failure happened precisely under output-confusion when a hint wouldn't have been consulted.

## Test plan

- Hook command pipe-tested against the exact payloads, extracted back out of the committed `settings.json` and re-run:
  - `merge_pull_request` → **ask** ✓
  - `update_pull_request {state: "closed"}` → **ask** ✓
  - `update_pull_request {body: …}` / `{state: "open"}` → **no prompt** ✓
- `jq -e .` confirms `settings.json` is valid JSON.
- `npm run build` ✅ · `npm run test:unit` ✅ (497) — no source touched.

> Note: this only changes docs + agent config (no product code). The hook takes effect in new sessions / after reloading hooks; it doesn't alter runtime behavior of the app.

https://claude.ai/code/session_01Ww671N9NeGJehgHfqhkq2J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ww671N9NeGJehgHfqhkq2J)_