### PR TITLE
fix: request persistent storage so API keys survive mobile eviction

### DIFF
--- a/src/ai/db.ts
+++ b/src/ai/db.ts
@@ -3,6 +3,7 @@
 // second IndexedDB instance.
 
 import { openPartwrightDB } from '../storage/db';
+import { requestPersistentStorage } from '../storage/persist';
 import type { ChatMessage, KeyRecord, Provider } from './types';
 
 const KEYS_STORE = 'aiKeys';
@@ -42,6 +43,10 @@ export async function putKey(record: KeyRecord): Promise<void> {
   const txn = db.transaction(KEYS_STORE, 'readwrite');
   txn.objectStore(KEYS_STORE).put(record);
   await txComplete(txn);
+  // Saving a key is the moment its durability matters most. Ask the browser to
+  // make storage persistent so mobile (iOS Safari ITP) doesn't evict it later.
+  // Fire-and-forget: never block or fail the save on the request.
+  void requestPersistentStorage();
 }
 
 export async function deleteKey(provider: Provider): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,8 @@ import { showQualitySettingsModal } from './ui/qualitySettingsModal';
 import { combo, MOD_LABEL, SHIFT_LABEL, ALT_LABEL } from './ui/shortcutDefs';
 import { showToast } from './ui/toast';
 import { initAiPanel, setActiveSession as setAiActiveSession, toggleAiPanel, toggleAiPanelFromToolbar } from './ui/aiPanel';
-import { mergeChatBucket } from './ai/db';
+import { getKey, mergeChatBucket } from './ai/db';
+import { requestPersistentStorage } from './storage/persist';
 import { aiConnectionMode, reloadSettingsFromStorage, getRenderBudget, getSpendingSummary, setSpendingMode as applyAiSpendingMode } from './ai/settings';
 import { createLandingPage } from './ui/landing';
 import { createHelpPage } from './ui/help';
@@ -1567,6 +1568,18 @@ async function main() {
   // and the order relative to toolbar mount doesn't matter.
   void hydrateImportInbox();
   void hydrateExportInbox();
+
+  // If the user already has a saved API key, ask the browser to make storage
+  // persistent so it isn't evicted under storage pressure (mobile browsers,
+  // iOS Safari ITP especially, evict best-effort IndexedDB and wipe the key).
+  // New saves request this from putKey; this covers installs keyed before that
+  // shipped. Gated on having a key so we don't prompt (Firefox) unprompted users.
+  void (async () => {
+    const keyed = await Promise.all(
+      (['anthropic', 'openai', 'gemini', 'custom'] as const).map((p) => getKey(p)),
+    );
+    if (keyed.some(Boolean)) void requestPersistentStorage();
+  })();
 
   // Remove loading splash as soon as JS takes over
   document.getElementById('loading-splash')?.remove();

--- a/src/storage/persist.ts
+++ b/src/storage/persist.ts
@@ -1,0 +1,51 @@
+// Persistent-storage request helper.
+//
+// By default a browser keeps an origin's IndexedDB / Cache / OPFS data in
+// "best-effort" storage, which it is free to evict under storage pressure.
+// Mobile browsers are far more aggressive here than desktop — iOS Safari in
+// particular evicts best-effort storage after ~7 days without a visit (the
+// ITP storage cap), which is why saved API keys quietly vanish on mobile but
+// almost never on desktop.
+//
+// `navigator.storage.persist()` asks the browser to mark this origin's storage
+// as persistent so it is exempt from that eviction. On Chrome/Android the grant
+// is decided silently from engagement heuristics (no prompt); Firefox may
+// prompt; iOS Safari grants based on its own heuristics (e.g. installed to the
+// home screen). Requesting is harmless everywhere and is the standard mitigation
+// for vanishing client-side data.
+
+/** Resolves true once the origin's storage is persistent. */
+let granted = false;
+/** In-flight request so concurrent callers share one round-trip. */
+let inFlight: Promise<boolean> | null = null;
+
+/** Ask the browser to make this origin's storage persistent (eviction-exempt).
+ *
+ *  Idempotent and cheap to call repeatedly: once a grant succeeds we never
+ *  re-request, and concurrent calls share a single round-trip. A *denied*
+ *  request is NOT cached, so a later call (e.g. after the user saves a key and
+ *  engagement is higher) can succeed where an earlier one failed. Soft-fails on
+ *  browsers without the Storage API, so callers can fire-and-forget. */
+export async function requestPersistentStorage(): Promise<boolean> {
+  if (granted) return true;
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    const nav = typeof navigator !== 'undefined' ? navigator : null;
+    if (!nav?.storage?.persist) return false;
+    try {
+      // Already persistent (e.g. granted in a previous session)? Don't re-ask.
+      if (nav.storage.persisted && (await nav.storage.persisted())) {
+        granted = true;
+        return true;
+      }
+      const ok = await nav.storage.persist();
+      if (ok) granted = true;
+      return ok;
+    } catch {
+      return false;
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}

--- a/tests/persist.spec.ts
+++ b/tests/persist.spec.ts
@@ -6,6 +6,10 @@ import { test, expect } from 'playwright/test';
 // `navigator.storage.persist()` — once on its own merits, and again whenever a
 // key is saved via `putKey`. These tests stub the Storage API so they run with
 // no network and no real grant (headless Chromium denies persistence).
+//
+// Each test relies on its own fresh BrowserContext/page so the module-level
+// `granted`/`inFlight` singletons in persist.ts reset between tests — keep them
+// in separate tests; don't consolidate into one page or the cached grant leaks.
 
 test.describe('Persistent storage', () => {
   test('requestPersistentStorage calls persist() and is idempotent once granted', async ({ page }) => {

--- a/tests/persist.spec.ts
+++ b/tests/persist.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from 'playwright/test';
+
+// Regression coverage for persistent-storage durability of API keys.
+// Best-effort IndexedDB is evicted under storage pressure (mobile browsers,
+// iOS Safari ITP especially), wiping saved keys. We mitigate by requesting
+// `navigator.storage.persist()` — once on its own merits, and again whenever a
+// key is saved via `putKey`. These tests stub the Storage API so they run with
+// no network and no real grant (headless Chromium denies persistence).
+
+test.describe('Persistent storage', () => {
+  test('requestPersistentStorage calls persist() and is idempotent once granted', async ({ page }) => {
+    await page.goto('/editor');
+    const result = await page.evaluate(async () => {
+      let persistCalls = 0;
+      Object.defineProperty(navigator, 'storage', {
+        configurable: true,
+        value: {
+          persisted: async () => false,
+          persist: async () => { persistCalls++; return true; },
+        },
+      });
+      const mod = await import('/src/storage/persist.ts');
+      const first = await mod.requestPersistentStorage();
+      // Second call should short-circuit on the cached grant, not re-request.
+      const second = await mod.requestPersistentStorage();
+      return { first, second, persistCalls };
+    });
+    expect(result.first).toBe(true);
+    expect(result.second).toBe(true);
+    expect(result.persistCalls).toBe(1);
+  });
+
+  test('an already-persisted origin never re-requests', async ({ page }) => {
+    await page.goto('/editor');
+    const result = await page.evaluate(async () => {
+      let persistCalls = 0;
+      Object.defineProperty(navigator, 'storage', {
+        configurable: true,
+        value: {
+          persisted: async () => true,
+          persist: async () => { persistCalls++; return true; },
+        },
+      });
+      const mod = await import('/src/storage/persist.ts');
+      const granted = await mod.requestPersistentStorage();
+      return { granted, persistCalls };
+    });
+    expect(result.granted).toBe(true);
+    expect(result.persistCalls).toBe(0);
+  });
+
+  test('a denied request is not cached — a later call can still succeed', async ({ page }) => {
+    await page.goto('/editor');
+    const result = await page.evaluate(async () => {
+      let allow = false;
+      Object.defineProperty(navigator, 'storage', {
+        configurable: true,
+        value: {
+          persisted: async () => false,
+          persist: async () => allow,
+        },
+      });
+      const mod = await import('/src/storage/persist.ts');
+      const denied = await mod.requestPersistentStorage();
+      allow = true; // engagement improved (e.g. user saved a key)
+      const granted = await mod.requestPersistentStorage();
+      return { denied, granted };
+    });
+    expect(result.denied).toBe(false);
+    expect(result.granted).toBe(true);
+  });
+
+  test('soft-fails when the Storage API is unavailable', async ({ page }) => {
+    await page.goto('/editor');
+    const result = await page.evaluate(async () => {
+      Object.defineProperty(navigator, 'storage', { configurable: true, value: undefined });
+      const mod = await import('/src/storage/persist.ts');
+      return mod.requestPersistentStorage();
+    });
+    expect(result).toBe(false);
+  });
+
+  test('saving a key requests persistent storage', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    const persistCalls = await page.evaluate(async () => {
+      let calls = 0;
+      Object.defineProperty(navigator, 'storage', {
+        configurable: true,
+        value: {
+          persisted: async () => false,
+          persist: async () => { calls++; return true; },
+        },
+      });
+      const db = await import('/src/ai/db.ts');
+      await db.putKey({
+        provider: 'anthropic',
+        apiKey: 'sk-test',
+        createdAt: Date.now(),
+        lastUsed: Date.now(),
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalCostUsd: 0,
+      });
+      // putKey fires the request fire-and-forget; give the microtask a beat.
+      await new Promise((r) => setTimeout(r, 50));
+      return calls;
+    });
+    expect(persistCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

API keys appeared to get wiped frequently on mobile but not desktop. The cause is **storage eviction, not a bug in our save/clear paths**:

- Keys live in the `aiKeys` IndexedDB store, which sits in the browser's **best-effort** storage quota.
- We never call `navigator.storage.persist()`, so the data is eligible for eviction under storage pressure. Mobile browsers are far more aggressive here — **iOS Safari evicts best-effort storage after ~7 days without a visit** (its ITP storage cap). Desktop browsers almost never hit this, which is exactly the asymmetry that was reported.
- (Confirmed `clearAllData()` already preserves `aiKeys`, and `wipeData` only touches it when the user explicitly checks "API keys" in the Uninstall modal — so the in-app clear paths weren't to blame.)

The fix is the standard mitigation: ask the browser to mark this origin's storage as **persistent** (eviction-exempt).

## Changes

- **`src/storage/persist.ts`** (new) — `requestPersistentStorage()` helper wrapping `navigator.storage.persist()`. Idempotent (caches a successful grant, shares one in-flight request), does **not** cache a *denied* result so a later call with higher engagement can still succeed, and soft-fails on browsers without the Storage API so callers can fire-and-forget.
- **`src/ai/db.ts`** — `putKey()` fires `requestPersistentStorage()` after a successful write. Saving a key is the moment its durability matters most, and is a strong engagement signal, so it's a good time to request the grant. Fire-and-forget — never blocks or fails the save.
- **`src/main.ts`** — at boot, if any provider already has a saved key, request persistence. This covers installs that were keyed **before** this shipped (not just new saves). Gated on having a key so users with no key aren't shown Firefox's persistence prompt unprompted.

On Chrome/Android the grant is decided silently from engagement heuristics (no prompt); Firefox may prompt; iOS Safari grants on its own heuristics (e.g. home-screen install). Requesting is harmless everywhere.

## Test plan

- `npm run build` — green (type-check passes).
- `npm run test:unit` — 497 pass.
- New `tests/persist.spec.ts` (5 e2e cases, all green): persist() called + idempotent once granted; already-persisted origins never re-request; a denied request isn't cached (a later call still succeeds); soft-fails when the Storage API is absent; and **saving a key (`putKey`) requests persistence**. (Browser-API dependent, so e2e via `page.evaluate` per the repo's unit/e2e split, with the Storage API stubbed — headless Chromium denies real grants.)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01BdKbmYtkk4aeuGuwC6WKdE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdKbmYtkk4aeuGuwC6WKdE)_