### PR TITLE
fix: stop the in-app AI from pasting share-link URLs into context

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -290,7 +290,7 @@ await partwright.listVersions()          // -> [{id, index, label, timestamp, st
 await partwright.loadVersion({index} | {id})  // Load version into editor -> {id, index, label, code, geometryData, labelsAvailable, labelCount} or {error}
 await partwright.forkVersion({index} | {id}, transformFn, label?, assertions?, carryColors=true) // Load + modify + validate + save atomically; carries parent colors -> {..., codeDiff, colors}
 await partwright.copyColorsFromVersion({index} | {id}) // Re-apply a prior version's colors onto the current mesh -> {source, carried, dropped}
-await partwright.getShareLink()          // -> {url, encodedBytes} read-only share link (or {error}); the link to hand the user when done
+await partwright.getShareLink()          // -> {url, encodedBytes} read-only share link (or {error}); external/console agents hand this to the user — in-app users click the toolbar Share (↗) button instead
 partwright.getGalleryUrl()               // -> URL for gallery view (local browser only)
 partwright.getSessionUrl()               // -> URL for this session (local browser only)
 await partwright.listSessions()          // -> [{id, name, updated}]
@@ -1056,7 +1056,9 @@ Read the notes and version history before making changes. The notes tell you:
 4. When satisfied, save: `runAndSave(modifiedCode, "v2 - improvements", assertions)` -- check the diff
 5. Use `query({sliceAt: [...], decompose: true})` for follow-up inspection without re-running
 6. Repeat.
-7. When done, hand the user a **share link**: `const { url } = await partwright.getShareLink()`. This is a self-contained, read-only URL that encodes the whole design — anyone can open it anywhere and fork it into their own copy. Prefer it over `getSessionUrl()`/`getGalleryUrl()`, which only resolve against *your* browser's local storage and won't open for the user.
+7. When done, briefly say what you built — it's already saved as a version, so you don't need to produce any link.
+   - **In-app chat assistant:** do NOT mint or paste a share/export URL into the conversation. The encoded share link is enormous and pasting it just burns the user's tokens, and the user already has a **Share** button (↗) in the toolbar that builds one on demand. Just confirm the work is saved.
+   - **External / console agents** (driving Partwright from outside the browser, e.g. via the console or Claude Code) have no toolbar to click, so hand the user a **share link**: `const { url } = await partwright.getShareLink()` — a self-contained, read-only URL that encodes the whole design so anyone can open and fork it. Prefer it over `getSessionUrl()`/`getGalleryUrl()`, which only resolve against *your* browser's local storage and won't open for the user.
 
 ## Visual verification
 

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -35,7 +35,11 @@ See ai.md below for the full conventions.
 
 Be concise in chat. Long explanations cost tokens the user pays for. When a
 task involves geometry, prefer to act (call a tool, run code, save a
-version) over explaining what you would do.
+version) over explaining what you would do. Never paste a share or export
+link into chat: the user has a Share button (↗) and an export menu in the
+toolbar to get one themselves, and an encoded share URL is enormous —
+dropping one into the conversation just wastes the user's tokens. When the
+work is done, say so briefly; don't try to hand over a link.
 
 If a tool you would normally use isn't in your tool list, the user has
 turned it off in the cost-control toggle bar — don't ask for it back, and

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -419,11 +419,6 @@ const ALL_TOOLS: ToolDefinition[] = [
     input_schema: { type: 'object', properties: {} },
   },
   {
-    name: 'getShareLink',
-    description: 'Mint a self-contained, read-only share link for the current version — the link to hand the user when you are done. Commits the current buffer first (capturing unsaved edits), then encodes the whole design into the URL hash; nothing is uploaded to a server, and anyone can open the link anywhere and fork it into their own editable copy. Returns { url, encodedBytes } on success, or { error } (e.g. no session open, an older browser without CompressionStream, or a design too large to fit in a URL). Prefer this over a session/gallery URL, which only resolves against your own browser.',
-    input_schema: { type: 'object', properties: {} },
-  },
-  {
     name: 'readDoc',
     description: 'Fetch one of the topic-specific docs from /ai/<name>.md. Use this when the core ai.md points you at a subdoc and you need its full content before writing code. Names: curves, bosl2, replicad, sdf, voxel, colors, print-safety, reference-images, file-io, annotations, relief.',
     input_schema: {
@@ -1081,11 +1076,11 @@ const ALWAYS_AVAILABLE = new Set([
   // can stop the model from spending a tool round-trip on notes the chat
   // transcript already records.
   'listSessionNotes',
-  // getShareLink is the "hand the design back to the user when done" action the
-  // system prompt steers every session toward, so it stays always-on like the
-  // other read-only session surfaces — gating it would resurrect the
-  // "Unknown tool: getShareLink" failure whenever the toggle was off.
-  'getShareLink',
+  // getShareLink is intentionally NOT a chat tool. The encoded share URL is
+  // enormous, so returning it as a tool result would dump the whole design into
+  // the model's context for no benefit — the in-app user just clicks the toolbar
+  // Share button (↗). The capability lives on window.partwright.getShareLink()
+  // for EXTERNAL agents (no toolbar to click); see public/ai.md.
   'readDoc',
   'findFaces',
   'listComponents',
@@ -1427,8 +1422,6 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.addSessionNote(input.text as string);
     case 'listSessionNotes':
       return api.listSessionNotes();
-    case 'getShareLink':
-      return api.getShareLink();
     case 'readDoc':
       return readSubdoc(input.name as string);
     case 'paintRegion':

--- a/tests/ai-sharelink-tool.spec.ts
+++ b/tests/ai-sharelink-tool.spec.ts
@@ -1,12 +1,14 @@
-// Regression: ai.md (the in-app chat system prompt) tells the agent to "hand
-// the user a share link" via getShareLink() as the last step of every session
-// — and to PREFER it over the session/gallery URLs — but getShareLink was only
-// wired into the window.partwright console API, never registered as a chat
-// tool. The call fell through dispatch()'s default branch and came back as
-// "Unknown tool: getShareLink", so the agent could never deliver the link it
-// was instructed to deliver. This covers that the tool is now listed
-// (always-available, like the other read-only session surfaces) and that it
-// dispatches to the console API end to end.
+// The in-app chat assistant must NOT be able to mint a share link. The encoded
+// share URL is enormous, so returning it as a tool result would dump the whole
+// design into the model's context on every turn that follows — pure token waste,
+// since the in-app user can just click the toolbar Share button (↗). getShareLink
+// is therefore kept OFF the chat tool surface: no tool definition, not in
+// ALWAYS_AVAILABLE, and no dispatch case (so executeTool rejects it as unknown).
+//
+// The capability still exists for EXTERNAL agents — which have no toolbar to
+// click — via the window.partwright.getShareLink() console API. That path's full
+// encode round-trip is covered in share-link.spec.ts (T1b); here we just confirm
+// the console method is still wired so the two surfaces don't drift.
 
 import { test, expect, type Page } from 'playwright/test';
 
@@ -18,12 +20,12 @@ async function waitForEngine(page: Page) {
   );
 }
 
-test.describe('getShareLink chat tool', () => {
+test.describe('getShareLink is not an in-app chat tool', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
   });
 
-  test('is always listed (even with every toggle paused) and dispatches to the console API', async ({ page }) => {
+  test('never listed as a chat tool and rejected by dispatch, but still on the console API', async ({ page }) => {
     await page.goto('/editor');
     await waitForEngine(page);
 
@@ -36,6 +38,7 @@ test.describe('getShareLink chat tool', () => {
         maxIterations: 'medium',
         maxSpend: 'high',
         thinking: 'off',
+        autoResume: true,
         provider: 'anthropic',
         anthropicModel: 'claude-haiku-4-5',
         localModel: null,
@@ -44,41 +47,35 @@ test.describe('getShareLink chat tool', () => {
       };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const listFor = (t: any) => tools.buildToolList(t).map((d) => d.name);
-      const listedDefault = listFor(baseToggles).includes('getShareLink');
-      // The prompt steers EVERY session toward handing back a share link, so the
-      // tool must survive with EVERY toggle paused — running, saving, painting,
-      // notes, and vision all off. That's the whole point of ALWAYS_AVAILABLE:
-      // no toggle can remove it (gating it is what caused the original failure).
-      const listedAllTogglesOff = listFor({
+      // No toggle combination surfaces it: it isn't a tool. Check full scope and
+      // every scope/vision toggle paused (auto-continue off, so even the `finish`
+      // tool isn't in play).
+      const listedFullScope = listFor(baseToggles).includes('getShareLink');
+      const listedAllOff = listFor({
         ...baseToggles,
         scope: { runCode: false, saveVersions: false, paintFaces: false, sessionNotes: false },
         vision: { ...baseToggles.vision, views: false },
+        autoResume: false,
       }).includes('getShareLink');
 
-      // End-to-end dispatch: a session with a saved version so there's a design
-      // to encode (getShareLink commits the current buffer, then exports it).
-      const pw = (window as unknown as { partwright: {
-        createSession: (n?: string) => Promise<unknown>;
-        runAndSave: (code: string, label?: string) => Promise<unknown>;
-      } }).partwright;
-      await pw.createSession('sharelink-tool-test');
-      await pw.runAndSave('const { Manifold } = api; return Manifold.cube([10, 10, 10], true);', 'base');
-
+      // The dispatch case was removed, so reaching the tool by name falls through
+      // to the "Unknown tool" branch — the agent can't tunnel to the console API
+      // through the tool layer.
       const exec = await tools.executeTool('getShareLink', {});
-      return { listedDefault, listedAllTogglesOff, exec, origin: location.origin };
+
+      // The capability is preserved for external/console agents.
+      const onConsoleApi = typeof (window as unknown as {
+        partwright: { getShareLink?: unknown };
+      }).partwright.getShareLink === 'function';
+
+      return { listedFullScope, listedAllOff, exec, onConsoleApi };
     });
 
-    // Always available — present with full scope and with every toggle paused.
-    expect(result.listedDefault).toBe(true);
-    expect(result.listedAllTogglesOff).toBe(true);
-
-    // The call dispatched to window.partwright instead of throwing the old
-    // "Unknown tool" error, and returned a self-contained hash URL.
-    expect(result.exec.isError).toBe(false);
-    expect(result.exec.content).not.toContain('Unknown tool');
-    const payload = JSON.parse(result.exec.content) as { url?: string; encodedBytes?: number; error?: string };
-    expect(payload.error).toBeUndefined();
-    expect(payload.url?.startsWith(`${result.origin}/editor#share=`)).toBe(true);
-    expect(payload.encodedBytes).toBeGreaterThan(0);
+    expect(result.listedFullScope).toBe(false);
+    expect(result.listedAllOff).toBe(false);
+    expect(result.exec.isError).toBe(true);
+    expect(result.exec.content).toContain('Unknown tool');
+    // Still available to external agents (full round-trip covered in share-link.spec.ts T1b).
+    expect(result.onConsoleApi).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`getShareLink` mints a self-contained, read-only link that encodes the whole design into the URL hash. That capability exists for **external agents** — ones driving Partwright from outside the browser via the `window.partwright` console API — because they have no UI and need a programmatic way to hand the user a link when they finish.

But it was *also* registered as an **in-app chat tool**, and `ai.md` steered every in-app session to call it "when done". The encoded share URL is huge, so the tool result dumped the entire design into the model's context — and it stayed there on every following turn, wasting the user's tokens and degrading the model for no benefit. The in-app user never needs the assistant to do this: they can just click the toolbar **Share (↗)** button.

This PR scopes share-link generation to where it belongs (external/console agents) and keeps the in-app assistant from ever putting a giant URL into the conversation.

## Changes

- **`src/ai/tools.ts`** — Remove `getShareLink` from the in-app chat tool surface entirely: the tool definition, the `ALWAYS_AVAILABLE` entry, and the `dispatch()` case. (The old comment justifying its always-on status is replaced with one explaining why it's intentionally *not* a tool.)
- **`src/main.ts`** — Untouched. `window.partwright.getShareLink()` stays exactly as-is, so **external agents keep the capability**.
- **`public/ai.md`** — Rewrite the "when done" step to be audience-aware: the in-app assistant just confirms the work is saved and never pastes a link; external/console agents still use `getShareLink()`. The console-API reference line gets the same annotation.
- **`src/ai/systemPrompt.ts`** — Add an explicit guard to the in-app system preamble: never paste a share/export URL into chat (the user has a Share button / export menu for that).
- **`tests/ai-sharelink-tool.spec.ts`** — Rewrite to lock in the new contract: `getShareLink` is never listed as a chat tool (under any toggle combination) and `executeTool` rejects it as unknown, while the `window.partwright.getShareLink()` console API stays wired for external agents.

## Why not just shrink the returned URL?

External agents legitimately need the full URL in their result — that's the whole point of the tool for them. The problem is specific to the *in-app* surface, where the user has a button. So the fix is to remove the in-app tool, not to weaken the external one. `share-link.spec.ts` (T1b) still covers the console API end-to-end and is untouched.

## Test plan

Verified locally (Node 22, deps installed):

- [x] `npm run build` — `tsc` + `vite build` both pass, no type errors.
- [x] `npm run test:unit` — 497/497 unit tests pass (incl. `shareLink.test.ts`, which is untouched).
- [x] Automated diff review (subagent over the branch diff) — no issues: the `dispatch()` switch / `ALL_TOOLS` array / `ALWAYS_AVAILABLE` set are all well-formed, the `window.partwright.getShareLink()` console method + the external-agent prompt templates (`landing.ts`, `help.ts`) are intact, and the in-app vs. external doc split is consistent.
- [ ] PR-checks e2e shards (run on CI):
  - `tests/ai-sharelink-tool.spec.ts` — asserts the tool is never listed and dispatch rejects it; console API preserved.
  - `tests/share-link.spec.ts` — unchanged; confirms `partwright.getShareLink()` and the toolbar Share modal still work.

Cloudflare Pages preview deploy: ✅ successful.

https://claude.ai/code/session_01U8nY615bw1KKSUEXB45DEK