### PR TITLE
feat: add slash commands to the AI chat input

### DIFF
--- a/src/ai/slashCommands.ts
+++ b/src/ai/slashCommands.ts
@@ -1,0 +1,91 @@
+// Slash-command parsing for the AI chat input. Pure logic — no DOM, no app
+// state — so it lives in the fast unit tier (tests/unit/slashCommands.test.ts).
+// The panel (src/ui/aiPanel.ts) owns the handlers and the autocomplete menu;
+// the command *names + descriptions* are defined here and the panel's handler
+// map is type-checked against `SlashCommandName`, so a command can't be
+// half-wired (a name with no handler, or a handler with no name).
+
+export interface SlashCommandSpec {
+  /** Canonical name, without the leading slash. */
+  name: string;
+  /** One-line description shown in /help and the autocomplete menu. */
+  summary: string;
+  /** Alternate spellings (without the slash) that resolve to this command. */
+  aliases?: readonly string[];
+}
+
+/** The slash commands offered in the AI input. Each mirrors a one-click
+ *  header action so the whole chat-management surface is keyboard-reachable.
+ *  Order is the display order in /help and the autocomplete menu. */
+export const SLASH_COMMANDS = [
+  { name: 'compact', summary: 'Summarize older turns and promote insights to session notes' },
+  { name: 'clear', summary: 'Delete this chat from your browser (saved versions & notes are kept)' },
+  { name: 'review', summary: 'Have a different provider/model review the current session' },
+  { name: 'export', summary: 'Download the conversation as a Markdown file' },
+  { name: 'models', summary: 'Open AI settings — provider, model, and API key', aliases: ['model', 'settings'] },
+  { name: 'help', summary: 'List the available slash commands', aliases: ['commands'] },
+] as const satisfies readonly SlashCommandSpec[];
+
+export type SlashCommandName = (typeof SLASH_COMMANDS)[number]['name'];
+
+/** The commands as a uniform `SlashCommandSpec[]` view. `SLASH_COMMANDS` is
+ *  `as const` so `SlashCommandName` can be derived as a literal union, but that
+ *  narrow type means members declared without `aliases` have no such property —
+ *  iterating through this widened view lets the helpers read `.aliases`
+ *  uniformly. */
+const COMMAND_SPECS: readonly SlashCommandSpec[] = SLASH_COMMANDS;
+
+/** Resolve a typed token (canonical name or alias, case-insensitive) to its
+ *  canonical command name, or null if it matches nothing. */
+export function resolveSlashCommand(token: string): SlashCommandName | null {
+  const t = token.toLowerCase();
+  for (const cmd of COMMAND_SPECS) {
+    if (cmd.name === t) return cmd.name as SlashCommandName;
+    if (cmd.aliases?.some((a) => a === t)) return cmd.name as SlashCommandName;
+  }
+  return null;
+}
+
+export interface ParsedSlashCommand {
+  /** Canonical command name if the token matched one, else null (unknown). */
+  name: SlashCommandName | null;
+  /** The bareword the user typed after '/', lowercased (for feedback). */
+  token: string;
+}
+
+/** Parse a committed input as a slash command. Returns null when the text is
+ *  not a slash-command invocation at all — i.e. it isn't a single bare
+ *  "/word" token (with optional surrounding whitespace). That guard keeps a
+ *  normal message that merely *starts* with a slash — a path like
+ *  "/usr/bin/env ..." or a phrase like "/think it over" — from being
+ *  hijacked: only a lone "/word" is a command. An unknown bare word still
+ *  returns a result (with `name: null`) so the caller can warn rather than
+ *  silently forward "/flush" to the model. */
+export function parseSlashCommand(text: string): ParsedSlashCommand | null {
+  const match = /^\s*\/([a-zA-Z][\w-]*)\s*$/.exec(text);
+  if (!match) return null;
+  const token = match[1].toLowerCase();
+  return { name: resolveSlashCommand(token), token };
+}
+
+/** Commands whose name or an alias starts with `prefix` (case-insensitive,
+ *  no slash). An empty prefix returns every command. Definition order is
+ *  preserved. Drives the autocomplete menu. */
+export function matchSlashCommands(prefix: string): SlashCommandSpec[] {
+  const p = prefix.toLowerCase();
+  if (p === '') return [...COMMAND_SPECS];
+  return COMMAND_SPECS.filter(
+    (cmd) => cmd.name.startsWith(p) || (cmd.aliases?.some((a) => a.startsWith(p)) ?? false),
+  );
+}
+
+/** For the live autocomplete menu: given the current raw input, return the
+ *  command-name prefix to filter by, or null when the menu should be hidden.
+ *  The menu shows only while the user is still typing the command token —
+ *  "/", "/cl", "/clear" — and hides the moment a space is typed (the token is
+ *  complete; anything after it is arguments) or the text isn't a leading
+ *  slash token at all. */
+export function slashMenuPrefix(text: string): string | null {
+  const match = /^\/([a-zA-Z][\w-]*)?$/.exec(text);
+  return match ? (match[1] ?? '').toLowerCase() : null;
+}

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -28,6 +28,7 @@ import { onTabSync, publishTabSync } from '../storage/tabSync';
 import { onOwnershipChange } from '../storage/sessionLock';
 import { ensureModelLoaded, effectiveContextCeiling, interruptLocal, isModelLoaded, resolveLocalModel } from '../ai/local';
 import { activeModel, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type ImageSource, type PersistedToolResult, type Provider, type TurnOutcomeReason } from '../ai/types';
+import { matchSlashCommands, parseSlashCommand, slashMenuPrefix, type SlashCommandName, type SlashCommandSpec } from '../ai/slashCommands';
 import { errorLog } from '../diagnostics/errorLog';
 
 interface PanelState {
@@ -143,6 +144,13 @@ let forwardBtnRef: HTMLButtonElement | null = null;
 let drawerEl: HTMLElement | null = null;
 let transcriptEl: HTMLElement | null = null;
 let inputEl: HTMLTextAreaElement | null = null;
+
+// Slash-command autocomplete menu state. The menu sits just above the input
+// row and shows while the user is typing a "/command" token. `slashMenuItems`
+// is the currently-filtered list; `slashMenuIndex` is the keyboard highlight.
+let slashMenuEl: HTMLElement | null = null;
+let slashMenuItems: SlashCommandSpec[] = [];
+let slashMenuIndex = 0;
 
 /** "Stuck to bottom" detection for the transcript. The auto-scroll on every
  *  streamed delta used to fight the user when they scrolled up to read earlier
@@ -617,6 +625,7 @@ function buildDrawer(): void {
 
   // Transcript
   transcriptEl = document.createElement('div');
+  transcriptEl.id = 'ai-transcript';
   transcriptEl.className = 'flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-3';
   root.appendChild(transcriptEl);
 
@@ -674,15 +683,36 @@ function buildDrawer(): void {
   inputRow.className = 'px-3 pt-2 pb-2 border-t border-zinc-700 flex flex-col gap-2 flex-1 min-h-0';
 
   const ta = document.createElement('textarea');
-  ta.placeholder = 'Ask the AI to model something...';
+  ta.placeholder = 'Ask the AI to model something…  (type / for commands)';
   ta.rows = 2;
   ta.className = 'w-full flex-1 min-h-0 px-2 py-1.5 rounded bg-zinc-800 border border-zinc-600 text-zinc-100 text-sm placeholder:text-zinc-500 focus:outline-none focus:border-blue-500 resize-none';
   ta.addEventListener('keydown', e => {
+    // When the slash-command menu is open it owns the arrow/Tab/Enter/Escape
+    // keys so the user can navigate and run a command without it being sent
+    // to the model as a message.
+    if (isSlashMenuOpen()) {
+      if (e.key === 'ArrowDown') { e.preventDefault(); moveSlashSelection(1); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); moveSlashSelection(-1); return; }
+      if (e.key === 'Tab') { e.preventDefault(); completeSlashSelection(); return; }
+      if (e.key === 'Escape') { e.preventDefault(); hideSlashMenu(); return; }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        const cmd = slashMenuItems[slashMenuIndex];
+        if (cmd) runSlashCommand(cmd.name as SlashCommandName);
+        return;
+      }
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
+      // A bare "/command" runs the command instead of being sent as a message.
+      if (maybeRunSlashCommand()) return;
       void sendMessage();
     }
   });
+  ta.addEventListener('input', () => { updateSlashMenu(); });
+  // Hide the menu when focus genuinely leaves the input. Row clicks keep focus
+  // (they preventDefault on mousedown), so this fires only on a real blur.
+  ta.addEventListener('blur', () => { window.setTimeout(() => hideSlashMenu(), 120); });
   ta.addEventListener('paste', e => {
     if (!e.clipboardData) return;
     for (const item of Array.from(e.clipboardData.items)) {
@@ -763,6 +793,8 @@ function buildDrawer(): void {
   sendBtn.className = 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 disabled:cursor-not-allowed';
   sendBtn.textContent = 'Send';
   sendBtn.addEventListener('click', () => {
+    // A bare "/command" runs the command rather than being sent/queued.
+    if (maybeRunSlashCommand()) return;
     // While a turn is in flight, Send queues — the agent picks the
     // message up at the next natural pause (between tool round-trips or
     // at end-of-turn) without us aborting the current run. Stop is the
@@ -775,6 +807,14 @@ function buildDrawer(): void {
   });
   sendBtnRef = sendBtn;
   inputBtnRow.appendChild(sendBtn);
+
+  // Slash-command autocomplete menu — sits directly above the input row,
+  // hidden until the user starts typing a "/command". Normal flow (not a
+  // floating overlay) so it never trips Playwright's viewport hit-test.
+  slashMenuEl = document.createElement('div');
+  slashMenuEl.id = 'ai-slash-menu';
+  slashMenuEl.className = 'mx-3 mb-1 rounded border border-zinc-700 bg-zinc-800/95 shadow-lg max-h-44 overflow-y-auto hidden shrink-0';
+  bottomSection.appendChild(slashMenuEl);
 
   inputRow.appendChild(inputBtnRow);
   bottomSection.appendChild(inputRow);
@@ -2294,6 +2334,128 @@ async function preflightTurn(
     }
   }
   return apiKey;
+}
+
+// === Slash commands ===
+//
+// A bare "/command" typed in the input runs a panel action instead of being
+// sent to the model. Each command mirrors a header button, giving the whole
+// chat-management surface a keyboard path. The command names live in the pure
+// `slashCommands` module; this map binds each to its handler and is type-
+// checked against `SlashCommandName`, so adding a name there without a handler
+// here (or vice versa) is a compile error.
+const SLASH_HANDLERS: Record<SlashCommandName, () => void> = {
+  compact: () => { void runCompact(); },
+  clear: () => { void clearCurrentChat(); },
+  review: () => { void launchReview(); },
+  export: () => { exportCurrentChat(); },
+  models: () => { void showAiSettingsModal({ onChange: afterAiSettingsChange }); },
+  help: () => { openSlashHelp(); },
+};
+
+/** Interpret the current input as a slash command. Returns true when it was a
+ *  slash-command invocation — known commands run, unknown ones surface a hint
+ *  — so the caller skips the normal send/queue path. Returns false for any
+ *  ordinary message (which then sends as usual). */
+function maybeRunSlashCommand(): boolean {
+  if (!inputEl) return false;
+  const parsed = parseSlashCommand(inputEl.value);
+  if (!parsed) return false;
+  if (parsed.name) {
+    runSlashCommand(parsed.name);
+  } else {
+    hideSlashMenu();
+    setTransientStatus(`Unknown command /${parsed.token} — type /help to list commands.`);
+  }
+  return true;
+}
+
+/** Run a resolved command: dismiss the menu, clear the input, dispatch. */
+function runSlashCommand(name: SlashCommandName): void {
+  hideSlashMenu();
+  if (inputEl) inputEl.value = '';
+  SLASH_HANDLERS[name]();
+}
+
+function isSlashMenuOpen(): boolean {
+  return !!slashMenuEl && !slashMenuEl.classList.contains('hidden') && slashMenuItems.length > 0;
+}
+
+/** Re-filter the menu against the current input and show or hide it. Called on
+ *  every input event: shows while the user is mid-"/command", hides once a
+ *  space is typed or the leading slash is gone. */
+function updateSlashMenu(): void {
+  if (!inputEl) return;
+  const prefix = slashMenuPrefix(inputEl.value);
+  if (prefix === null) { hideSlashMenu(); return; }
+  showSlashMenu(prefix);
+}
+
+/** Open the menu showing every command — the /help action. */
+function openSlashHelp(): void {
+  showSlashMenu('');
+  inputEl?.focus();
+}
+
+function showSlashMenu(prefix: string): void {
+  slashMenuItems = matchSlashCommands(prefix);
+  slashMenuIndex = 0;
+  renderSlashMenu();
+}
+
+function hideSlashMenu(): void {
+  slashMenuItems = [];
+  slashMenuIndex = 0;
+  if (slashMenuEl) {
+    slashMenuEl.replaceChildren();
+    slashMenuEl.classList.add('hidden');
+  }
+}
+
+function moveSlashSelection(delta: number): void {
+  if (slashMenuItems.length === 0) return;
+  slashMenuIndex = (slashMenuIndex + delta + slashMenuItems.length) % slashMenuItems.length;
+  renderSlashMenu();
+}
+
+/** Tab-complete the highlighted command into the input, then re-filter so the
+ *  menu narrows to the now-exact token. */
+function completeSlashSelection(): void {
+  const cmd = slashMenuItems[slashMenuIndex];
+  if (!cmd || !inputEl) return;
+  inputEl.value = `/${cmd.name}`;
+  updateSlashMenu();
+}
+
+function renderSlashMenu(): void {
+  if (!slashMenuEl) return;
+  if (slashMenuItems.length === 0) { hideSlashMenu(); return; }
+  slashMenuEl.replaceChildren();
+
+  const header = document.createElement('div');
+  header.className = 'px-2 py-1 text-[10px] uppercase tracking-wide text-zinc-500 border-b border-zinc-700/60 sticky top-0 bg-zinc-800/95';
+  header.textContent = 'Slash commands';
+  slashMenuEl.appendChild(header);
+
+  slashMenuItems.forEach((cmd, i) => {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = `w-full text-left px-2 py-1.5 flex flex-col gap-0.5 ${i === slashMenuIndex ? 'bg-zinc-700' : 'hover:bg-zinc-700/50'}`;
+    const nameEl = document.createElement('span');
+    nameEl.className = 'text-[12px] font-medium text-blue-300';
+    nameEl.textContent = `/${cmd.name}`;
+    const sumEl = document.createElement('span');
+    sumEl.className = 'text-[10px] text-zinc-400';
+    sumEl.textContent = cmd.summary;
+    row.append(nameEl, sumEl);
+    // Keep focus in the textarea so the click handler can clear it and the
+    // blur-hide never races the click.
+    row.addEventListener('mousedown', e => e.preventDefault());
+    row.addEventListener('click', () => { runSlashCommand(cmd.name as SlashCommandName); });
+    slashMenuEl!.appendChild(row);
+  });
+
+  slashMenuEl.classList.remove('hidden');
 }
 
 async function sendMessage(): Promise<void> {

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -819,17 +819,23 @@ function buildDrawer(): void {
   sendBtnRef = sendBtn;
   inputBtnRow.appendChild(sendBtn);
 
-  // Slash-command autocomplete menu — sits directly above the input row,
-  // hidden until the user starts typing a "/command". Normal flow (not a
-  // floating overlay) so it never trips Playwright's viewport hit-test.
-  slashMenuEl = document.createElement('div');
-  slashMenuEl.id = 'ai-slash-menu';
-  slashMenuEl.className = 'mx-3 mb-1 rounded border border-zinc-700 bg-zinc-800/95 shadow-lg max-h-44 overflow-y-auto hidden shrink-0';
-  bottomSection.appendChild(slashMenuEl);
-
   inputRow.appendChild(inputBtnRow);
   bottomSection.appendChild(inputRow);
   root.appendChild(bottomSection);
+
+  // Slash-command autocomplete menu — a floating overlay anchored just above
+  // the input. It uses `position: fixed` (coordinates set in
+  // positionSlashMenu() from the textarea's rect) so it overlays the content
+  // above the input instead of taking flow space — the textarea never changes
+  // size or shape. Fixed positioning also escapes the bottom section's
+  // `overflow-hidden`, which would otherwise clip an upward-growing menu.
+  slashMenuEl = document.createElement('div');
+  slashMenuEl.id = 'ai-slash-menu';
+  slashMenuEl.className = 'fixed z-50 rounded border border-zinc-600 bg-zinc-800 shadow-xl max-h-56 overflow-y-auto hidden';
+  root.appendChild(slashMenuEl);
+  // Keep the overlay glued to the input if the viewport (or panel) resizes
+  // while it's open. Keystrokes already reposition via renderSlashMenu().
+  window.addEventListener('resize', () => { if (isSlashMenuOpen()) positionSlashMenu(); });
 
   // Drag-drop image handling
   root.addEventListener('dragover', e => { e.preventDefault(); root.classList.add('ring-2', 'ring-blue-500'); });
@@ -2480,6 +2486,20 @@ function renderSlashMenu(): void {
   });
 
   slashMenuEl.classList.remove('hidden');
+  positionSlashMenu();
+}
+
+/** Anchor the floating menu just above the input, matching its width. Uses
+ *  the textarea's viewport rect with `position: fixed`, so the overlay never
+ *  reflows the input and isn't clipped by the bottom section. */
+function positionSlashMenu(): void {
+  if (!slashMenuEl || !inputEl) return;
+  const r = inputEl.getBoundingClientRect();
+  slashMenuEl.style.left = `${Math.round(r.left)}px`;
+  slashMenuEl.style.width = `${Math.round(r.width)}px`;
+  // Pin the menu's bottom edge 6px above the input's top; it grows upward.
+  slashMenuEl.style.bottom = `${Math.round(window.innerHeight - r.top + 6)}px`;
+  slashMenuEl.style.top = 'auto';
 }
 
 async function sendMessage(): Promise<void> {

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -147,10 +147,13 @@ let inputEl: HTMLTextAreaElement | null = null;
 
 // Slash-command autocomplete menu state. The menu sits just above the input
 // row and shows while the user is typing a "/command" token. `slashMenuItems`
-// is the currently-filtered list; `slashMenuIndex` is the keyboard highlight.
+// is the currently-filtered list; `slashMenuIndex` is the keyboard highlight;
+// `slashMenuUserSelected` records whether the user has explicitly arrowed to a
+// choice (so a stray Enter on a bare "/" doesn't fire the default command).
 let slashMenuEl: HTMLElement | null = null;
 let slashMenuItems: SlashCommandSpec[] = [];
 let slashMenuIndex = 0;
+let slashMenuUserSelected = false;
 
 /** "Stuck to bottom" detection for the transcript. The auto-scroll on every
  *  streamed delta used to fight the user when they scrolled up to read earlier
@@ -697,8 +700,16 @@ function buildDrawer(): void {
       if (e.key === 'Escape') { e.preventDefault(); hideSlashMenu(); return; }
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
-        const cmd = slashMenuItems[slashMenuIndex];
-        if (cmd) runSlashCommand(cmd.name as SlashCommandName);
+        // Only run on Enter when the choice is unambiguous: the user has
+        // explicitly highlighted an item (arrow keys), or the filter has
+        // narrowed to a single command. A bare "/" — or any prefix matching
+        // several commands — leaves the highlight on whatever is first, so a
+        // stray Enter would silently fire that command (e.g. /compact). In
+        // that case consume the Enter and keep the menu open to refine.
+        if (slashSelectionConfirmed()) {
+          const cmd = slashMenuItems[slashMenuIndex];
+          if (cmd) runSlashCommand(cmd.name as SlashCommandName);
+        }
         return;
       }
     }
@@ -2400,12 +2411,16 @@ function openSlashHelp(): void {
 function showSlashMenu(prefix: string): void {
   slashMenuItems = matchSlashCommands(prefix);
   slashMenuIndex = 0;
+  // Re-filtering resets the highlight, so any prior explicit selection is
+  // stale — require fresh confirmation before Enter runs anything.
+  slashMenuUserSelected = false;
   renderSlashMenu();
 }
 
 function hideSlashMenu(): void {
   slashMenuItems = [];
   slashMenuIndex = 0;
+  slashMenuUserSelected = false;
   if (slashMenuEl) {
     slashMenuEl.replaceChildren();
     slashMenuEl.classList.add('hidden');
@@ -2415,7 +2430,16 @@ function hideSlashMenu(): void {
 function moveSlashSelection(delta: number): void {
   if (slashMenuItems.length === 0) return;
   slashMenuIndex = (slashMenuIndex + delta + slashMenuItems.length) % slashMenuItems.length;
+  slashMenuUserSelected = true;
   renderSlashMenu();
+}
+
+/** Whether an Enter press should run the highlighted command: true once the
+ *  user has explicitly arrowed to a choice, or the filter has narrowed to a
+ *  single command (typing the full name, or a unique prefix). Guards against a
+ *  stray Enter on an ambiguous menu firing the first command. */
+function slashSelectionConfirmed(): boolean {
+  return slashMenuUserSelected || slashMenuItems.length === 1;
 }
 
 /** Tab-complete the highlighted command into the input, then re-filter so the

--- a/tests/ai-slash-commands.spec.ts
+++ b/tests/ai-slash-commands.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect, type Page } from 'playwright/test';
+import { openAiPanel, waitForEditorReady } from './helpers/aiPanel';
+
+// Network-free coverage for the AI input's slash commands. The commands run
+// panel actions (compact / clear / review / export / models / help) instead of
+// sending the text to a provider, so none of this needs a live AI key. Chat is
+// seeded straight into IndexedDB where a command needs an existing transcript.
+
+const MENU = '#ai-slash-menu';
+
+async function createSession(page: Page, name: string): Promise<string> {
+  await page.waitForFunction(() => !!(window as unknown as { partwright?: { createSession?: unknown } }).partwright?.createSession);
+  return page.evaluate(async (n) => {
+    const w = window as unknown as { partwright: { createSession: (name: string) => Promise<{ id: string }> } };
+    return (await w.partwright.createSession(n)).id;
+  }, name);
+}
+
+/** Insert one chat row so clear/export have something to act on. */
+async function seedChat(page: Page, sessionId: string): Promise<void> {
+  await page.evaluate(async (sid) => {
+    const db: IDBDatabase = await new Promise((res, rej) => {
+      const r = indexedDB.open('partwright');
+      r.onsuccess = () => res(r.result);
+      r.onerror = () => rej(r.error);
+    });
+    const tx = db.transaction('aiChats', 'readwrite');
+    tx.objectStore('aiChats').put({ id: 'seed-1', sessionId: sid, role: 'user', blocks: [{ type: 'text', text: 'Design a widget bracket' }], createdAt: Date.now(), seq: 0 });
+    await new Promise<void>((res, rej) => { tx.oncomplete = () => res(); tx.onerror = () => rej(tx.error); });
+    db.close();
+  }, sessionId);
+}
+
+test.beforeEach(async ({ page }) => {
+  // Suppress the first-run guided tour — its backdrop intercepts clicks.
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+  });
+});
+
+test.describe('AI slash commands', () => {
+  test('typing "/" opens the autocomplete menu; a normal message does not', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    await openAiPanel(page);
+    const panel = page.locator('#ai-panel');
+    const input = panel.locator('textarea');
+    const menu = page.locator(MENU);
+
+    await expect(menu).toBeHidden();
+
+    await input.click();
+    await input.pressSequentially('/');
+    await expect(menu).toBeVisible();
+    // Lists the commands with descriptions.
+    await expect(menu).toContainText('/compact');
+    await expect(menu).toContainText('/clear');
+    await expect(menu).toContainText('/help');
+    await expect(menu).toContainText('/models');
+
+    // Narrowing the token filters the list.
+    await input.pressSequentially('cl');
+    await expect(menu).toContainText('/clear');
+    await expect(menu).not.toContainText('/compact');
+
+    // Tab completes the highlighted command into the input.
+    await input.press('Tab');
+    await expect(input).toHaveValue('/clear');
+
+    // A space after the token (now an argument) closes the menu...
+    await input.pressSequentially(' x');
+    await expect(menu).toBeHidden();
+
+    // ...and a plain message never opens it.
+    await input.fill('just a normal message');
+    await expect(menu).toBeHidden();
+  });
+
+  test('/help opens the full command menu', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    await openAiPanel(page);
+    const panel = page.locator('#ai-panel');
+    const input = panel.locator('textarea');
+    const menu = page.locator(MENU);
+
+    await input.fill('/help');
+    await input.press('Enter');
+
+    await expect(menu).toBeVisible();
+    await expect(menu).toContainText('/compact');
+    await expect(menu).toContainText('/review');
+    await expect(menu).toContainText('/export');
+    // Running the command clears the typed text.
+    await expect(input).toHaveValue('');
+  });
+
+  test('an unknown slash command warns and is not sent', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    await openAiPanel(page);
+    const panel = page.locator('#ai-panel');
+    const input = panel.locator('textarea');
+
+    await input.fill('/bogus');
+    await input.press('Enter');
+
+    await expect(panel).toContainText('Unknown command /bogus');
+    // The text is kept in the box (not sent, not cleared) so the user can fix it.
+    await expect(input).toHaveValue('/bogus');
+    // It never became a chat bubble (the status line legitimately echoes it,
+    // so scope the check to the transcript).
+    await expect(page.locator('#ai-transcript')).not.toContainText('/bogus');
+  });
+
+  test('/clear empties the seeded transcript', async ({ page }) => {
+    page.on('dialog', d => d.accept()); // the clear confirmation
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    const id = await createSession(page, 'Slash Clear');
+    await seedChat(page, id);
+
+    await page.goto(`/editor?session=${id}`);
+    await waitForEditorReady(page);
+    await openAiPanel(page);
+    const panel = page.locator('#ai-panel');
+    await expect(panel).toContainText('Design a widget bracket');
+
+    const input = panel.locator('textarea');
+    await input.fill('/clear');
+    await input.press('Enter');
+
+    await expect(panel).toContainText('Chat cleared.');
+    await expect(panel).not.toContainText('Design a widget bracket');
+  });
+
+  test('/export downloads a Markdown transcript', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    const id = await createSession(page, 'Slash Export');
+    await seedChat(page, id);
+
+    await page.goto(`/editor?session=${id}`);
+    await waitForEditorReady(page);
+    await openAiPanel(page);
+    const panel = page.locator('#ai-panel');
+    await expect(panel).toContainText('Design a widget bracket');
+
+    const input = panel.locator('textarea');
+    const downloadPromise = page.waitForEvent('download');
+    await input.fill('/export');
+    await input.press('Enter');
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.md$/);
+  });
+});

--- a/tests/ai-slash-commands.spec.ts
+++ b/tests/ai-slash-commands.spec.ts
@@ -49,6 +49,10 @@ test.describe('AI slash commands', () => {
 
     await expect(menu).toBeHidden();
 
+    // Capture the input box before the menu opens so we can prove the menu is
+    // an overlay that doesn't reflow / resize the textarea.
+    const inputBefore = await input.boundingBox();
+
     await input.click();
     await input.pressSequentially('/');
     await expect(menu).toBeVisible();
@@ -57,6 +61,15 @@ test.describe('AI slash commands', () => {
     await expect(menu).toContainText('/clear');
     await expect(menu).toContainText('/help');
     await expect(menu).toContainText('/models');
+
+    // The input keeps its size/position — the menu floats above it, it does
+    // not share the pane or push the textarea down.
+    const inputAfter = await input.boundingBox();
+    expect(inputAfter?.height).toBeCloseTo(inputBefore!.height, 0);
+    expect(inputAfter?.y).toBeCloseTo(inputBefore!.y, 0);
+    const menuBox = await menu.boundingBox();
+    // Menu sits entirely above the input's top edge.
+    expect(menuBox!.y + menuBox!.height).toBeLessThanOrEqual(inputAfter!.y + 1);
 
     // A stray Enter on the bare-"/" menu must NOT fire the first command
     // (/compact) — the choice is ambiguous, so Enter is a no-op that keeps the

--- a/tests/ai-slash-commands.spec.ts
+++ b/tests/ai-slash-commands.spec.ts
@@ -58,6 +58,13 @@ test.describe('AI slash commands', () => {
     await expect(menu).toContainText('/help');
     await expect(menu).toContainText('/models');
 
+    // A stray Enter on the bare-"/" menu must NOT fire the first command
+    // (/compact) — the choice is ambiguous, so Enter is a no-op that keeps the
+    // menu open. Nothing ran: the input still holds "/".
+    await input.press('Enter');
+    await expect(menu).toBeVisible();
+    await expect(input).toHaveValue('/');
+
     // Narrowing the token filters the list.
     await input.pressSequentially('cl');
     await expect(menu).toContainText('/clear');
@@ -74,6 +81,28 @@ test.describe('AI slash commands', () => {
     // ...and a plain message never opens it.
     await input.fill('just a normal message');
     await expect(menu).toBeHidden();
+  });
+
+  test('arrow-selecting a command and pressing Enter runs it', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    await openAiPanel(page);
+    const panel = page.locator('#ai-panel');
+    const input = panel.locator('textarea');
+    const menu = page.locator(MENU);
+
+    await input.click();
+    await input.pressSequentially('/');
+    await expect(menu).toBeVisible();
+
+    // ArrowUp wraps the highlight to the last command (/help); an explicit
+    // selection makes Enter act. /help clears the input and reopens the full
+    // menu — a network-free, observable effect.
+    await input.press('ArrowUp');
+    await input.press('Enter');
+    await expect(input).toHaveValue('');
+    await expect(menu).toBeVisible();
+    await expect(menu).toContainText('/compact');
   });
 
   test('/help opens the full command menu', async ({ page }) => {

--- a/tests/unit/slashCommands.test.ts
+++ b/tests/unit/slashCommands.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SLASH_COMMANDS,
+  parseSlashCommand,
+  resolveSlashCommand,
+  matchSlashCommands,
+  slashMenuPrefix,
+} from '../../src/ai/slashCommands';
+
+describe('resolveSlashCommand', () => {
+  it('resolves canonical names case-insensitively', () => {
+    expect(resolveSlashCommand('compact')).toBe('compact');
+    expect(resolveSlashCommand('CLEAR')).toBe('clear');
+    expect(resolveSlashCommand('Help')).toBe('help');
+  });
+
+  it('resolves aliases to their canonical name', () => {
+    expect(resolveSlashCommand('settings')).toBe('models');
+    expect(resolveSlashCommand('model')).toBe('models');
+    expect(resolveSlashCommand('commands')).toBe('help');
+  });
+
+  it('returns null for unknown tokens', () => {
+    expect(resolveSlashCommand('flush')).toBeNull();
+    expect(resolveSlashCommand('')).toBeNull();
+  });
+});
+
+describe('parseSlashCommand', () => {
+  it('parses a bare command with surrounding whitespace', () => {
+    expect(parseSlashCommand('/clear')).toEqual({ name: 'clear', token: 'clear' });
+    expect(parseSlashCommand('  /compact  ')).toEqual({ name: 'compact', token: 'compact' });
+    expect(parseSlashCommand('/CLEAR')).toEqual({ name: 'clear', token: 'clear' });
+  });
+
+  it('resolves an alias to its canonical name while keeping the typed token', () => {
+    expect(parseSlashCommand('/settings')).toEqual({ name: 'models', token: 'settings' });
+  });
+
+  it('returns a result with name=null for an unknown bare command', () => {
+    // Unknown commands still parse so the panel can warn instead of sending
+    // "/flush" to the model.
+    expect(parseSlashCommand('/flush')).toEqual({ name: null, token: 'flush' });
+  });
+
+  it('does NOT treat ordinary messages as commands', () => {
+    expect(parseSlashCommand('clear the chat please')).toBeNull(); // no leading slash
+    expect(parseSlashCommand('/clear the chat')).toBeNull();        // command + args → message
+    expect(parseSlashCommand('/usr/bin/env node')).toBeNull();      // a path, not a command
+    expect(parseSlashCommand('/')).toBeNull();                      // lone slash
+    expect(parseSlashCommand('//')).toBeNull();
+    expect(parseSlashCommand('')).toBeNull();
+    expect(parseSlashCommand('please /clear')).toBeNull();          // slash not leading
+  });
+});
+
+describe('matchSlashCommands', () => {
+  it('returns every command for an empty prefix', () => {
+    expect(matchSlashCommands('')).toHaveLength(SLASH_COMMANDS.length);
+  });
+
+  it('filters by canonical-name prefix', () => {
+    // 'c' also matches /help via its 'commands' alias.
+    expect(matchSlashCommands('c').map(c => c.name)).toEqual(['compact', 'clear', 'help']);
+    expect(matchSlashCommands('cl').map(c => c.name)).toEqual(['clear']);
+    expect(matchSlashCommands('comp').map(c => c.name)).toEqual(['compact']);
+  });
+
+  it('matches on alias prefixes too', () => {
+    // "set" only starts the alias "settings", which maps to /models.
+    expect(matchSlashCommands('set').map(c => c.name)).toEqual(['models']);
+  });
+
+  it('returns nothing for a prefix that matches no command', () => {
+    expect(matchSlashCommands('zzz')).toEqual([]);
+  });
+});
+
+describe('slashMenuPrefix', () => {
+  it('returns the partial token while the command is still being typed', () => {
+    expect(slashMenuPrefix('/')).toBe('');
+    expect(slashMenuPrefix('/cl')).toBe('cl');
+    expect(slashMenuPrefix('/CLEAR')).toBe('clear');
+  });
+
+  it('returns null once the menu should close', () => {
+    expect(slashMenuPrefix('/clear ')).toBeNull(); // trailing space → token complete
+    expect(slashMenuPrefix('/clear the chat')).toBeNull();
+    expect(slashMenuPrefix('hello')).toBeNull(); // not a slash token
+    expect(slashMenuPrefix(' /clear')).toBeNull(); // leading space → not a leading token
+    expect(slashMenuPrefix('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds **slash commands** to the AI chat input. Typing a bare `/command` runs a panel action instead of sending the text to the model, giving the chat-management surface a keyboard path that mirrors the header buttons.

Commands:

| Command | Action | Aliases |
|---|---|---|
| `/compact` | Summarize older turns and promote insights to session notes | — |
| `/clear` | Delete this chat from the browser (versions & notes untouched) | — |
| `/review` | Have a different provider/model review the current session | — |
| `/export` | Download the conversation as a Markdown file | — |
| `/models` | Open AI settings (provider / model / key) | `model`, `settings` |
| `/help` | List the available slash commands | `commands` |

`/compact` and `/clear` were the explicit ask; `/help` and `/models` were suggested. I added `/review` and `/export` too since they map cleanly to existing one-click header actions and round out the keyboard workflow. Each command simply invokes the same handler its header button already does.

### UX

- An **autocomplete menu** opens directly above the input as you type `/`, listing matching commands with one-line descriptions. **↑/↓** to navigate, **Tab** to complete the highlighted name, **Enter** to run, **Esc** to dismiss. Clicking a row runs it.
- **Enter only runs when the choice is unambiguous** — the user has arrow-selected an item, or the filter has narrowed to a single command (e.g. you typed `/clear` in full). A stray Enter on the bare-`/` menu (which highlights the first command by default) is a **no-op that keeps the menu open**, so it never silently fires `/compact`.
- `/help` opens the menu showing every command.
- **Unknown** commands (`/bogus`) surface a hint (“Unknown command /bogus — type /help to list commands.”) and keep the text in the box rather than sending it.
- A normal message that merely *starts* with a slash (a path like `/usr/bin/env …`, or `/clear the chat please`) is **not** hijacked — only a lone `/word` token is treated as a command.
- The input placeholder now hints `(type / for commands)`.

### Implementation

- **`src/ai/slashCommands.ts`** — new pure-logic module (no DOM/state): the command registry plus `parseSlashCommand`, `resolveSlashCommand` (alias-aware), `matchSlashCommands` (prefix filter for the menu), and `slashMenuPrefix` (menu show/hide rule). Lives in the fast unit tier.
- **`src/ui/aiPanel.ts`** — the autocomplete menu DOM + a `SLASH_HANDLERS` map binding each name to its panel action. The map is typed `Record<SlashCommandName, () => void>`, so adding a command name without a handler (or vice versa) is a **compile error** — the two can't drift. The slash check is inserted ahead of the existing send/queue paths for both Enter and the Send button; ordinary messages, mid-flight queueing, and Shift+Enter newlines are unaffected. Added a stable `id="ai-transcript"` to the transcript container for testability.

No schema, storage, or persisted-data changes; nothing to migrate. No network involved (commands are local panel actions). All menu DOM is built via `textContent` from static command metadata — no user input flows into the DOM as markup.

## Test plan

- **Unit** (`tests/unit/slashCommands.test.ts`): parsing, alias resolution, prefix matching, the menu-prefix rule, and the non-hijack boundaries (`/usr/bin/env`, `/clear the chat`, leading-space, lone `/`). 510 unit tests pass.
- **E2E** (`tests/ai-slash-commands.spec.ts`, network-free, chat seeded via IndexedDB):
  - typing `/` opens the menu, narrowing filters it, **Tab** completes, a space/normal message closes it;
  - a bare-`/` **Enter is a no-op** (menu stays, input keeps `/` — no accidental `/compact`);
  - **arrow-select + Enter** runs the highlighted command;
  - `/help` opens the full menu;
  - an unknown command warns and never becomes a chat bubble;
  - `/clear` empties a seeded transcript (confirm dialog accepted);
  - `/export` downloads a `.md` transcript.
- `npm run build` clean; adjacent panel specs (`chat-export`, `ai-call-log`) still green — no input/transcript regressions.

## Review

An automated review pass over the diff found no Critical/High issues and confirmed: type-drift prevention works (the handler map is bidirectionally enforced), no XSS/injection (all `textContent`, static metadata), and send/queue/Shift+Enter behavior preserved. Its one Medium finding — a bare-`/` Enter firing `/compact` — is fixed in this PR (the disambiguating-Enter behavior above).

https://claude.ai/code/session_015WWitmUB5vZoxoquNZLYUS