### PR TITLE
fix: stop AI settings and preferences bleeding across browser tabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,21 @@ Every URL parameter the app writes must also be read back correctly everywhere:
 
 Always await `txn.oncomplete` before returning from functions that modify IndexedDB data. Awaiting individual request promises within a transaction is not sufficient — the transaction can still fail to commit after those promises resolve. Follow the pattern in `clearAllData()`.
 
+**Never `await` between a `get` and the `put`/`delete` that depends on it inside one readwrite transaction.** Awaiting yields the microtask queue and lets IndexedDB auto-commit the (now request-less) transaction before the write is queued — a `TransactionInactiveError`, and across two tabs a lost update. Issue the dependent write from inside the `get`'s `onsuccess` callback (chain further requests from *their* callbacks too), then await `txn.oncomplete` once. See `recordUsage`, `updateSession`, and `putAttachment` for the pattern.
+
+### Cross-Tab Isolation — No Data Bleed Between Windows
+
+The app runs in multiple browser windows/tabs at once, often each driving a **different session** (and a different AI provider). Tabs share one origin, so they share IndexedDB *and* localStorage; separate windows do **not** share JS module memory. The rule:
+
+> State must not bleed or cause side effects from one tab into another. The only times state should cross tabs are the **explicit** transitions: opening a session (incl. a previously-closed one) in a tab, or **taking control** of a session in another tab. Anything else changing in tab B must not silently alter tab A.
+
+Concretely, when adding a feature:
+
+- **Don't put session-scoped or task-scoped state in a single shared localStorage blob.** AI provider/model/toggles are **per-tab** working state (each window drives its own session) and are persisted **per-session** on the session record (`session.aiPreference`) so they carry over only on open / take-control — see `applySessionAiPreference` / `recordSessionAiPreference` in `aiPanel.ts` and `setSessionAiPreference` in `sessionManager.ts`. The live AI settings (`reloadSettingsFromStorage` in `ai/settings.ts`) deliberately **preserve this tab's `toggles`/`preset`** when a peer tab writes the shared blob — it adopts only genuinely-global, additive prefs (custom models, system-prompt overrides, panel width). Blindly adopting a peer's blob via the `storage` event was the cross-window provider-leak bug.
+- **App-level preferences that used to be one shared localStorage key should be per-tab** (units, render quality, editor auto-format). Use `readPerTabPref`/`writePerTabPref` (`src/storage/perTabPref.ts`): the live value is per-tab (sessionStorage) with a localStorage seed so a *fresh* tab still inherits the last choice, but already-open tabs never adopt a peer's change. Don't attach a `storage` listener that live-mirrors them.
+- **`storage`-event and `BroadcastChannel` handlers must scope to the receiving tab's own session** before acting — gate on `msg.sessionId === currentState.session?.id` (see `tabSync.ts` consumers and `sessionLock.ts`, which guards on its own session's leader-token key). Never adopt a peer's provider/model/toggles live.
+- **Truly-global state is the exception, and must be additive, not last-write-wins.** Custom local models and system-prompt overrides are shared across tabs on purpose; keep such writes merge-friendly so a peer tab's blob write can't clobber another tab's addition.
+
 ### Dead Code
 
 Don't export functions unless they're imported elsewhere. When removing usage of an exported function, delete the export too. Periodically grep for exported symbols to verify they have importers.

--- a/src/ai/attachments.ts
+++ b/src/ai/attachments.ts
@@ -77,14 +77,23 @@ export async function putAttachment(img: ImageSource): Promise<string> {
   const db = await openPartwrightDB();
   const txn = db.transaction(STORE, 'readwrite');
   const store = txn.objectStore(STORE);
-  const existing = await reqToPromise(store.get(id)) as RecentAttachment | undefined;
-  if (existing) {
-    existing.lastUsedAt = now;
-    // Refresh the label too — a user re-uploading the same bytes under a
-    // different filename probably wants the latest name shown.
-    if (img.label) existing.label = img.label;
-    store.put(existing);
-  } else {
+  // Do the whole read→write→prune inside request callbacks so they all stay in
+  // ONE transaction. Awaiting between the get and the put lets IndexedDB
+  // auto-commit the txn before the put is queued (TransactionInactiveError),
+  // and across two tabs attaching the same image concurrently it drops one
+  // tab's write — the same hazard recordUsage/updateSession avoid by never
+  // awaiting mid-transaction.
+  const getReq = store.get(id);
+  getReq.onsuccess = () => {
+    const existing = getReq.result as RecentAttachment | undefined;
+    if (existing) {
+      existing.lastUsedAt = now;
+      // Refresh the label too — a user re-uploading the same bytes under a
+      // different filename probably wants the latest name shown.
+      if (img.label) existing.label = img.label;
+      store.put(existing);
+      return;
+    }
     const row: RecentAttachment = {
       id,
       data: img.data,
@@ -97,15 +106,19 @@ export async function putAttachment(img: ImageSource): Promise<string> {
     store.put(row);
     // Prune. Pull the full list inside the same txn so the count is
     // consistent — getAll on a live store with a pending put returns the
-    // post-put state. Drop the oldest beyond the cap.
-    const all = await reqToPromise(store.getAll()) as RecentAttachment[];
-    if (all.length > MAX_ATTACHMENTS) {
-      const oldest = all
-        .sort((a, b) => a.lastUsedAt - b.lastUsedAt)
-        .slice(0, all.length - MAX_ATTACHMENTS);
-      for (const drop of oldest) store.delete(drop.id);
-    }
-  }
+    // post-put state. Drop the oldest beyond the cap, still from inside a
+    // request callback so no await splits the transaction.
+    const allReq = store.getAll();
+    allReq.onsuccess = () => {
+      const all = allReq.result as RecentAttachment[];
+      if (all.length > MAX_ATTACHMENTS) {
+        const oldest = all
+          .sort((a, b) => a.lastUsedAt - b.lastUsedAt)
+          .slice(0, all.length - MAX_ATTACHMENTS);
+        for (const drop of oldest) store.delete(drop.id);
+      }
+    };
+  };
   await txComplete(txn);
   return id;
 }

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -218,15 +218,31 @@ export function onSettingsChange(fn: (settings: AiSettings) => void): () => void
   return () => listeners.delete(fn);
 }
 
-/** Drop the in-memory cache and re-read settings from localStorage, then
- *  notify listeners. Used when another tab writes settings (the `storage`
- *  event fires only in *other* tabs): our `cached` blob would otherwise shadow
- *  the peer tab's change forever, and the next `saveSettings` here would write
- *  the stale blob back and silently revert their edit. Returns the freshly
- *  loaded settings. */
+/** Re-read settings from localStorage when another tab wrote them (the
+ *  `storage` event fires only in *other* tabs), adopting the peer's changes to
+ *  genuinely-global, additive prefs (custom local models, system-prompt
+ *  overrides, panel width, drawer state, …) so this tab doesn't write a stale
+ *  blob back and silently revert their edit.
+ *
+ *  Crucially, this tab's live AI config — `provider`, every per-provider model
+ *  id, the whole `toggles` object, and `preset` — is PRESERVED, never adopted
+ *  from the peer. Those are per-tab/per-session state (each window drives its
+ *  own session), and blindly adopting a peer's provider/model here was the
+ *  cross-window provider-leak bug: a task in this tab would silently switch to
+ *  whatever provider another window selected. State only crosses tabs on the
+ *  explicit transitions handled elsewhere — opening a session or taking control
+ *  of one (see applySessionAiPreference). Returns the merged settings. */
 export function reloadSettingsFromStorage(): AiSettings {
+  const keepToggles = cached ? cloneToggles(cached.toggles) : null;
+  const keepPreset = cached ? cached.preset : null;
   cached = null;
   const next = loadSettings();
+  if (keepToggles) {
+    // `next` is the live `cached` object; restoring our toggles/preset in place
+    // means the next `saveSettings` writes them back, not the peer's.
+    next.toggles = keepToggles;
+    if (keepPreset) next.preset = keepPreset;
+  }
   for (const fn of listeners) fn(next);
   return next;
 }

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -9,6 +9,7 @@ import { js as jsBeautify } from 'js-beautify';
 import { manifoldApiCompletion } from './apiCompletions';
 import type { SourceDiagnostic } from '../geometry/types';
 import { getTheme, onThemeChange, type Theme } from '../ui/theme';
+import { readPerTabPref, writePerTabPref } from '../storage/perTabPref';
 
 /** Replicad/BREP sessions reuse the JavaScript editor since they're written
  *  as JS (`api.BREP.box(...)`), but we still track them as a distinct
@@ -24,7 +25,9 @@ let activeDiagnostics: Diagnostic[] = [];
 /** How long typing must be idle before deferred error UI is surfaced. */
 const ERROR_IDLE_MS = 800;
 let currentLanguage: EditorLanguage = 'manifold-js';
-let autoFormatEnabled: boolean = localStorage.getItem('editor-auto-format') !== 'false';
+// Per-tab (with a shared seed for fresh tabs) so toggling auto-format in one
+// window doesn't flip it in another open window.
+let autoFormatEnabled: boolean = readPerTabPref('editor-auto-format') !== 'false';
 const languageCompartment = new Compartment();
 const readOnlyCompartment = new Compartment();
 const themeCompartment = new Compartment();
@@ -292,7 +295,7 @@ export function getAutoFormat(): boolean {
 
 export function setAutoFormat(enabled: boolean): void {
   autoFormatEnabled = enabled;
-  localStorage.setItem('editor-auto-format', enabled ? 'true' : 'false');
+  writePerTabPref('editor-auto-format', enabled ? 'true' : 'false');
 }
 
 export function setEditorDiagnostics(diagnostics: SourceDiagnostic[]): void {

--- a/src/geometry/qualitySettings.ts
+++ b/src/geometry/qualitySettings.ts
@@ -1,9 +1,13 @@
-// Per-browser modeling quality settings. Controls the default circular
+// Per-tab modeling quality settings. Controls the default circular
 // segment count applied to every Manifold / OpenSCAD run. Scripts can
 // still override per-call (segment arg to sphere/cylinder/etc., or an
 // explicit setCircularSegments() / $fn assignment) — this is just the
 // starting default that primitives fall back to when no override is
-// given. Persisted to localStorage as one JSON blob.
+// given. Persisted per-tab (with a shared seed for fresh tabs) so changing
+// quality in one window doesn't silently re-render another open window's model
+// at a different segment count.
+
+import { readPerTabPref, writePerTabPref } from '../storage/perTabPref';
 
 const STORAGE_KEY = 'partwright-quality-settings-v1';
 
@@ -57,13 +61,11 @@ const listeners = new Set<(s: QualitySettings) => void>();
 
 export function loadQualitySettings(): QualitySettings {
   if (cached) return cached;
-  // localStorage is unavailable in Worker context; use defaults.
-  if (typeof localStorage === 'undefined') {
-    cached = { ...DEFAULT_SETTINGS };
-    return cached;
-  }
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    // Per-tab value (sessionStorage) with a fresh-tab seed (localStorage). Both
+    // are unavailable in the Worker context; readPerTabPref returns null there
+    // and we fall back to defaults.
+    const raw = readPerTabPref(STORAGE_KEY);
     if (raw) {
       const parsed = JSON.parse(raw) as Partial<QualitySettings>;
       cached = mergeWithDefaults(parsed);
@@ -78,12 +80,7 @@ export function loadQualitySettings(): QualitySettings {
 
 export function saveQualitySettings(next: QualitySettings): void {
   cached = next;
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-  } catch {
-    // localStorage may be full or disabled (private browsing). Settings
-    // remain applied for this session; we don't surface the failure.
-  }
+  writePerTabPref(STORAGE_KEY, JSON.stringify(next));
   for (const fn of listeners) fn(next);
 }
 

--- a/src/geometry/units.ts
+++ b/src/geometry/units.ts
@@ -1,21 +1,21 @@
 // Unit system declaration — metadata only, no coordinate transformation
 
+import { readPerTabPref, writePerTabPref } from '../storage/perTabPref';
+
 export type UnitSystem = 'mm' | 'cm' | 'in' | 'unitless';
 
 const STORAGE_KEY = 'partwright-units';
 const VALID_UNITS: readonly UnitSystem[] = ['mm', 'cm', 'in', 'unitless'];
 
 // Default MUST stay 'unitless' for back-compat (it drives export filenames and
-// the 3MF unit attribute). Persisted across sessions in localStorage so a
-// chosen unit sticks, but a fresh browser still starts unitless.
+// the 3MF unit attribute). Persisted per-tab (with a shared seed for fresh
+// tabs) so a chosen unit sticks for this window without retroactively changing
+// the unit — and thus the export unit attribute — of another open window. A
+// fresh browser still starts unitless.
 function readPersistedUnit(): UnitSystem {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored && (VALID_UNITS as readonly string[]).includes(stored)) {
-      return stored as UnitSystem;
-    }
-  } catch {
-    // localStorage unavailable (private mode / SSR) — fall through to default.
+  const stored = readPerTabPref(STORAGE_KEY);
+  if (stored && (VALID_UNITS as readonly string[]).includes(stored)) {
+    return stored as UnitSystem;
   }
   return 'unitless';
 }
@@ -24,11 +24,7 @@ let currentUnit: UnitSystem = readPersistedUnit();
 
 export function setUnits(unit: UnitSystem): void {
   currentUnit = unit;
-  try {
-    localStorage.setItem(STORAGE_KEY, unit);
-  } catch {
-    // Persisting is best-effort; the in-memory value still updates.
-  }
+  writePerTabPref(STORAGE_KEY, unit);
 }
 
 export function getUnits(): UnitSystem {

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -12,10 +12,17 @@ export interface Session {
    *  fall back to the first part by `order`. Set on every part switch so the
    *  editor restores to the part the user last worked on. */
   currentPartId?: string;
-  /** Last-used AI provider + model for this session, restored when the session
-   *  is reopened so each session remembers which assistant was driving it.
-   *  Plain strings to keep the storage layer decoupled from the AI types. */
-  aiPreference?: { provider: string; model: string };
+  /** Last-used AI config for this session, restored when the session is
+   *  (re)opened or taken control of in another tab — so each session carries
+   *  its own assistant/provider/model and toggle settings across tabs without
+   *  live-bleeding between concurrently-open windows.
+   *
+   *  `provider`/`model` are the human-readable summary (and the back-compat
+   *  shape pre-dating `toggles`). `toggles` is the full {@link ChatToggles}
+   *  snapshot (stored opaquely as a record to keep this storage layer decoupled
+   *  from the AI types) and `preset` mirrors the settings preset. Sessions saved
+   *  before this field gains `toggles` simply restore provider/model only. */
+  aiPreference?: { provider: string; model: string; toggles?: Record<string, unknown>; preset?: string };
 }
 
 /** A modeling target within a session. A session holds one or more parts; each

--- a/src/storage/perTabPref.ts
+++ b/src/storage/perTabPref.ts
@@ -1,0 +1,47 @@
+// A preference that is independent per browser tab, but seeds a fresh tab from
+// a shared "last used" default.
+//
+// The problem it solves: a preference kept in a single shared localStorage key
+// silently changes across windows. Two tabs open side by side snapshot the key
+// at load and never converge; worse, changing it in one tab retroactively
+// alters another tab the next time that tab reads/reloads — a cross-tab side
+// effect the user never asked for (the same class of bug as the AI-provider
+// leak). For app-level preferences (units, render quality, editor auto-format)
+// we want: each open tab is independent (no live bleed between windows), but a
+// brand-new tab still inherits your most recent choice.
+//
+// Implementation: the live value lives in sessionStorage (scoped to one tab,
+// survives reload of that tab, never shared and never fires `storage` events in
+// other tabs). localStorage holds only the "default for the next fresh tab"
+// seed. We never attach a `storage` listener, so a peer tab's write is never
+// adopted by an already-open tab. Both stores are accessed defensively so this
+// is safe in a Worker or private-mode context (both globals may be absent),
+// where it simply reports "no stored value" and callers fall back to defaults.
+//
+// Use this for genuinely app-level preferences. State that belongs to a session
+// (e.g. the AI provider/model/toggles) goes on the session record instead, so
+// it carries over only on the explicit open / take-control transitions.
+
+/** Read the per-tab value, falling back to the shared default seed for a fresh
+ *  tab. Returns null when neither store has it (or storage is unavailable). */
+export function readPerTabPref(key: string): string | null {
+  try {
+    const perTab = sessionStorage.getItem(key);
+    if (perTab !== null) return perTab;
+  } catch {
+    // sessionStorage unavailable (Worker / private mode) — try the seed.
+  }
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/** Write the per-tab value AND refresh the shared default seed. The seed only
+ *  affects tabs opened *after* this write — already-open tabs keep their own
+ *  per-tab value and never adopt this change live. */
+export function writePerTabPref(key: string, value: string): void {
+  try { sessionStorage.setItem(key, value); } catch { /* best-effort */ }
+  try { localStorage.setItem(key, value); } catch { /* best-effort */ }
+}

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -582,20 +582,43 @@ export async function listSessionDrafts(sessionId: string) {
 
 // === Per-session AI preference ===
 
-/** Remember which AI provider + model is driving the current session so it can
- *  be restored on reopen. No-op when nothing is open or the value is unchanged.
- *  Not broadcast to peer tabs on purpose — restoring on reload is the goal, not
- *  live-mirroring the active model across windows (which would fight the user). */
-export async function setSessionAiPreference(provider: string, model: string | null): Promise<void> {
+/** Remember the AI config driving the current session (provider, model, and the
+ *  full toggle snapshot + preset) so it can be restored when the session is
+ *  reopened or taken control of in another tab. No-op when nothing is open or
+ *  the value is unchanged. Deliberately NOT broadcast to peer tabs — restoring
+ *  on the explicit open / take-control transitions is the goal, not
+ *  live-mirroring the active model across windows (which would fight the user
+ *  and was the cross-window provider-leak bug). `toggles` is stored opaquely so
+ *  this layer stays decoupled from the AI types. */
+export async function setSessionAiPreference(
+  provider: string,
+  model: string | null,
+  toggles?: Record<string, unknown>,
+  preset?: string,
+): Promise<void> {
   if (!currentState.session || !model) return;
   // A read-only viewer must not mutate the shared session row, or it would
-  // clobber the leader's remembered provider/model (last reopen would win
-  // whatever the viewer last picked).
+  // clobber the leader's remembered config (last reopen would win whatever the
+  // viewer last picked).
   if (isViewerTab()) return;
   const cur = currentState.session.aiPreference;
-  if (cur && cur.provider === provider && cur.model === model) return;
+  const togglesSnap = toggles ?? cur?.toggles;
+  const presetVal = preset ?? cur?.preset;
+  // Skip the write when nothing meaningful changed (cheap + idempotent).
+  if (cur
+    && cur.provider === provider
+    && cur.model === model
+    && (cur.preset ?? undefined) === (presetVal ?? undefined)
+    && JSON.stringify(cur.toggles ?? null) === JSON.stringify(togglesSnap ?? null)) {
+    return;
+  }
   const id = currentState.session.id;
-  const aiPreference = { provider, model };
+  const aiPreference = {
+    provider,
+    model,
+    ...(togglesSnap ? { toggles: togglesSnap } : {}),
+    ...(presetVal ? { preset: presetVal } : {}),
+  };
   await dbUpdateSession(id, { aiPreference });
   if (currentState.session?.id === id) {
     currentState.session = { ...currentState.session, aiPreference };

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -23,11 +23,11 @@ import { showCompactConfirmModal } from './aiCompactModal';
 import { showAttachmentModal } from './aiAttachmentModal';
 import { putAttachment } from '../ai/attachments';
 import { exportChatMarkdown } from '../export/chat';
-import { getState, setSessionAiPreference } from '../storage/sessionManager';
+import { getState, setSessionAiPreference, refreshCurrentSession } from '../storage/sessionManager';
 import { onTabSync, publishTabSync } from '../storage/tabSync';
 import { onOwnershipChange } from '../storage/sessionLock';
 import { ensureModelLoaded, effectiveContextCeiling, interruptLocal, isModelLoaded, resolveLocalModel } from '../ai/local';
-import { activeModel, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type ImageSource, type PersistedToolResult, type Provider, type TurnOutcomeReason } from '../ai/types';
+import { activeModel, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type ImageSource, type PersistedToolResult, type Preset, type Provider, type TurnOutcomeReason } from '../ai/types';
 import { errorLog } from '../diagnostics/errorLog';
 
 interface PanelState {
@@ -384,24 +384,45 @@ async function isProviderModelUsable(provider: Provider, model: string): Promise
   return !!(await getKey(provider));
 }
 
-/** Record the active provider + model as the current session's preference so
- *  reopening the session restores it. Cheap and idempotent. */
+/** Record the active AI config (provider + model + the full toggle set +
+ *  preset) as the current session's preference so reopening — or taking control
+ *  of — the session in another tab restores exactly what this tab was using.
+ *  Cheap and idempotent (the storage layer skips no-op writes). Only ever
+ *  called on a real user-initiated change, never on load, so a freshly-opened
+ *  session the user hasn't touched keeps no stored config (and the global
+ *  default applies). */
 function recordSessionAiPreference(): void {
   const s = loadSettings();
   const model = activeModel(s.toggles);
   if (typeof model === 'string' && model.length > 0) {
-    void setSessionAiPreference(s.toggles.provider, model);
+    void setSessionAiPreference(
+      s.toggles.provider,
+      model,
+      s.toggles as unknown as Record<string, unknown>,
+      s.preset,
+    );
   }
 }
 
-/** On session open, restore the session's remembered provider/model into the
- *  active settings. If that model isn't available right now we keep the user's
- *  current model and show a non-blocking notice — without erasing the stored
- *  preference, so it snaps back once the model is available again. */
+/** Apply a user-initiated change from the toggle strip: write it to this tab's
+ *  settings AND persist the full toggle set as the session's remembered config,
+ *  so it carries over when the session is reopened or taken control of in
+ *  another tab. (Per-tab live; per-session persisted — never broadcast, so it
+ *  doesn't bleed into other open windows.) */
+function applyToggleChange(partial: Parameters<typeof setToggles>[1]): void {
+  saveSettings(setToggles(loadSettings(), partial));
+  recordSessionAiPreference();
+}
+
+/** Restore the session's remembered AI config into THIS tab's settings — called
+ *  on session open and when this tab takes control of the session (not live on
+ *  every peer write, so windows never bleed into each other). If the remembered
+ *  model isn't available right now we keep the user's current model and show a
+ *  non-blocking notice — without erasing the stored preference, so it snaps back
+ *  once the model is available again. */
 async function applySessionAiPreference(): Promise<void> {
-  // Only the writer applies its session's remembered model. A viewer (or a
-  // background tab) applying would rewrite the shared global settings blob and
-  // nudge the peer/owner tab's model via the settings storage event.
+  // Only the writer applies its session's remembered config. A viewer applying
+  // would mutate this tab's settings to mirror a session it can't drive.
   if (!writeOwner) return;
   hidePrefNotice();
   const pref = getState().session?.aiPreference;
@@ -414,17 +435,27 @@ async function applySessionAiPreference(): Promise<void> {
     return;
   }
   const cur = loadSettings();
-  // Already active — don't re-write settings. This makes the focus re-assert
-  // cheap and stops two tabs on different sessions from ping-ponging the global
-  // model through the cross-tab settings `storage` event.
-  if (cur.toggles.provider === provider && activeModel(cur.toggles) === pref.model) return;
-  let next = setProvider(cur, provider);
-  switch (provider) {
-    case 'anthropic': next = setAnthropicModel(next, pref.model); break;
-    case 'openai': next = setOpenaiModel(next, pref.model); break;
-    case 'gemini': next = setGeminiModel(next, pref.model); break;
-    case 'custom': next = setCustomModel(next, pref.model); break;
-    case 'local': next = setLocalModel(next, pref.model); break;
+  let next: AiSettings;
+  if (pref.toggles) {
+    // Full per-session toggle snapshot (current format): restore provider,
+    // every per-provider model id, and all the toggles in one shot. Skip when
+    // already applied so the focus / take-control re-assert is a cheap no-op
+    // (no needless settings write or transcript-shifting re-render).
+    const sameToggles = JSON.stringify(cur.toggles) === JSON.stringify(pref.toggles);
+    if (sameToggles && (!pref.preset || cur.preset === pref.preset)) return;
+    next = setToggles(cur, pref.toggles as unknown as Parameters<typeof setToggles>[1]);
+    if (pref.preset) next = { ...next, preset: pref.preset as Preset };
+  } else {
+    // Legacy {provider, model} only (sessions saved before toggles were stored).
+    if (cur.toggles.provider === provider && activeModel(cur.toggles) === pref.model) return;
+    next = setProvider(cur, provider);
+    switch (provider) {
+      case 'anthropic': next = setAnthropicModel(next, pref.model); break;
+      case 'openai': next = setOpenaiModel(next, pref.model); break;
+      case 'gemini': next = setGeminiModel(next, pref.model); break;
+      case 'custom': next = setCustomModel(next, pref.model); break;
+      case 'local': next = setLocalModel(next, pref.model); break;
+    }
   }
   saveSettings(next);
   renderModelPicker();
@@ -478,12 +509,24 @@ async function reloadChatFromPeer(sessionId: string): Promise<void> {
 function applyOwnership(owned: boolean): void {
   // No real session (global bucket) = no contention = always writable.
   const noRealSession = !state.sessionId || state.sessionId === GLOBAL_CHAT_BUCKET;
+  const wasOwner = writeOwner;
   writeOwner = noRealSession ? true : owned;
   // The whole-screen viewer overlay (viewerMode.ts) is the single "locked" UI
   // now; the send-disable + sendMessage guard stay as a backstop.
   if (sendBtnRef) sendBtnRef.disabled = !writeOwner;
   // Becoming a viewer mid-turn (another tab took control): stop our run.
   if (!writeOwner) stopActiveTurn();
+  // Gaining write-ownership of a real session — "Take control" in a new tab —
+  // is one of the explicit transitions where state SHOULD carry over from the
+  // tab that had it. Re-read the session from IndexedDB first (the previous
+  // writer persisted its config there without broadcasting), then apply it so
+  // this tab adopts that session's provider/model/toggles.
+  if (writeOwner && !wasOwner && !noRealSession) {
+    void (async () => {
+      await refreshCurrentSession();
+      await applySessionAiPreference();
+    })();
+  }
 }
 
 /** Abort any in-flight AI turn — used by the Stop button and when this tab
@@ -1049,7 +1092,7 @@ function renderToggleStrip(): void {
     toggles.vision.views,
     'Auto-render: lets the model call renderView() to take its own screenshots after paint / geometry changes. Each render ≈ 1500 tokens of input on the next turn — verification is valuable but it adds up. The 📷 Show AI button still works manually when this is OFF.',
     () => {
-      saveSettings(setToggles(loadSettings(), { vision: { views: !toggles.vision.views } }));
+      applyToggleChange({ vision: { views: !toggles.vision.views } });
       renderToggleStrip();
       renderCostMeter();
     },
@@ -1070,7 +1113,7 @@ function renderToggleStrip(): void {
   }
   resSel.value = toggles.vision.resolution;
   resSel.addEventListener('change', () => {
-    saveSettings(setToggles(loadSettings(), { vision: { resolution: resSel.value as ChatToggles['vision']['resolution'] } }));
+    applyToggleChange({ vision: { resolution: resSel.value as ChatToggles['vision']['resolution'] } });
     renderCostMeter();
   });
   adv.appendChild(resSel);
@@ -1088,7 +1131,7 @@ function renderToggleStrip(): void {
   }
   anglesSel.value = toggles.vision.angles;
   anglesSel.addEventListener('change', () => {
-    saveSettings(setToggles(loadSettings(), { vision: { angles: anglesSel.value as ChatToggles['vision']['angles'] } }));
+    applyToggleChange({ vision: { angles: anglesSel.value as ChatToggles['vision']['angles'] } });
   });
   adv.appendChild(anglesSel);
 
@@ -1097,7 +1140,7 @@ function renderToggleStrip(): void {
     toggles.scope.runCode,
     'Run code: allow the AI to execute geometry code (runCode, runAndSave). OFF makes it suggest code in chat without running.',
     () => {
-      saveSettings(setToggles(loadSettings(), { scope: { runCode: !toggles.scope.runCode } }));
+      applyToggleChange({ scope: { runCode: !toggles.scope.runCode } });
       renderToggleStrip();
     },
   ));
@@ -1106,7 +1149,7 @@ function renderToggleStrip(): void {
     toggles.scope.saveVersions,
     'Save versions: allow the AI to commit results to the gallery (runAndSave, loadVersion). OFF keeps the model in run-only / dry-run mode.',
     () => {
-      saveSettings(setToggles(loadSettings(), { scope: { saveVersions: !toggles.scope.saveVersions } }));
+      applyToggleChange({ scope: { saveVersions: !toggles.scope.saveVersions } });
       renderToggleStrip();
     },
   ));
@@ -1115,7 +1158,7 @@ function renderToggleStrip(): void {
     toggles.scope.paintFaces,
     'Paint: allow the AI to set color regions (paintInBox, paintSlab, paintNear, etc.). OFF by default — painting locks the editor and is the easiest place for the AI to over-select.',
     () => {
-      saveSettings(setToggles(loadSettings(), { scope: { paintFaces: !toggles.scope.paintFaces } }));
+      applyToggleChange({ scope: { paintFaces: !toggles.scope.paintFaces } });
       renderToggleStrip();
     },
   ));
@@ -1124,7 +1167,7 @@ function renderToggleStrip(): void {
     toggles.scope.sessionNotes,
     'Session notes: allow the AI to call addSessionNote to log design decisions. OFF saves a tool round-trip per note — the chat transcript already records the reasoning.',
     () => {
-      saveSettings(setToggles(loadSettings(), { scope: { sessionNotes: !toggles.scope.sessionNotes } }));
+      applyToggleChange({ scope: { sessionNotes: !toggles.scope.sessionNotes } });
       renderToggleStrip();
     },
   ));
@@ -1133,7 +1176,7 @@ function renderToggleStrip(): void {
     toggles.autoResume,
     'Auto-continue: the agent keeps working until it calls the finish tool to declare the task done — if a turn ends without calling finish, it is automatically resumed instead of stopping. Bounded by the ⟲ iteration cap and the $ spend cap (whichever trips first). Useful for models that tend to stop early (e.g. Gemini). ON by default; turn it OFF to stop at each end_turn as usual (your choice is remembered).',
     () => {
-      saveSettings(setToggles(loadSettings(), { autoResume: !toggles.autoResume }));
+      applyToggleChange({ autoResume: !toggles.autoResume });
       renderToggleStrip();
     },
   ));
@@ -1149,7 +1192,7 @@ function renderToggleStrip(): void {
   }
   retry.value = String(toggles.autoRetry);
   retry.addEventListener('change', () => {
-    saveSettings(setToggles(loadSettings(), { autoRetry: Number(retry.value) as 0 | 1 | 3 }));
+    applyToggleChange({ autoRetry: Number(retry.value) as 0 | 1 | 3 });
   });
   adv.appendChild(retry);
 
@@ -1168,7 +1211,7 @@ function renderToggleStrip(): void {
   }
   iterCap.value = toggles.maxIterations;
   iterCap.addEventListener('change', () => {
-    saveSettings(setToggles(loadSettings(), { maxIterations: iterCap.value as ChatToggles['maxIterations'] }));
+    applyToggleChange({ maxIterations: iterCap.value as ChatToggles['maxIterations'] });
   });
   adv.appendChild(iterCap);
 
@@ -1188,7 +1231,7 @@ function renderToggleStrip(): void {
   }
   spendCap.value = toggles.maxSpend;
   spendCap.addEventListener('change', () => {
-    saveSettings(setToggles(loadSettings(), { maxSpend: spendCap.value as ChatToggles['maxSpend'] }));
+    applyToggleChange({ maxSpend: spendCap.value as ChatToggles['maxSpend'] });
   });
   adv.appendChild(spendCap);
 
@@ -1209,7 +1252,7 @@ function renderToggleStrip(): void {
   }
   thinkSel.value = toggles.thinking;
   thinkSel.addEventListener('change', () => {
-    saveSettings(setToggles(loadSettings(), { thinking: thinkSel.value as ChatToggles['thinking'] }));
+    applyToggleChange({ thinking: thinkSel.value as ChatToggles['thinking'] });
     renderCostMeter();
   });
   adv.appendChild(thinkSel);
@@ -1814,7 +1857,7 @@ async function resumeFromNotice(noticeMsgId: string, raiseSpendCap: boolean): Pr
     const cur = loadSettings().toggles.maxSpend;
     const next = nextSpendTier(cur);
     if (next !== cur) {
-      saveSettings(setToggles(loadSettings(), { maxSpend: next }));
+      applyToggleChange({ maxSpend: next });
       renderToggleStrip();
       renderCostMeter();
     }


### PR DESCRIPTION
## Summary

Fixes a cross-window state-leakage bug (and several others of the same class). The reported symptom: with three windows open — each a different session driving a different AI provider (Gemini / OpenAI / Anthropic) — selecting a provider in one window silently switched another window's provider, that window's next turn then called (and got rate-limited by) a provider the user never chose there, and opening its AI settings showed the wrong provider.

**Root cause:** AI `provider` / model / all `toggles` lived in a single **global** `localStorage` blob (`partwright-ai-settings-v1`), and a `storage`-event handler in `main.ts` adopted a peer tab's entire blob wholesale via `reloadSettingsFromStorage()` with no session check. The per-session leader lock doesn't help here because it's keyed *per session id* — three windows on three different sessions are all "leaders". A per-session `aiPreference` "restore on focus" layer existed but only re-asserted on focus and re-broadcast/stomped the other windows.

Per maintainer direction, the AI config is now **per-tab**, persisted **per-session**, and carried over **only on the explicit transitions**: opening a session (incl. a previously-closed one) or **taking control** of one in a new tab.

## What changed

- **`ai/settings.ts`** — `reloadSettingsFromStorage()` now **preserves this tab's `toggles`/`preset`** when a peer tab writes the shared blob, adopting only genuinely-global *additive* prefs (custom local models, system-prompt overrides, panel width, …). The cross-window provider leak is closed at the source.
- **Per-session carry-over** — the session record's `aiPreference` is widened (additively, back-compat) to store the full `ChatToggles` snapshot + `preset` (`storage/db.ts`, `storage/sessionManager.ts`). `applySessionAiPreference` restores it on **open** and on **take-control** — re-reading the session from IndexedDB first (`applyOwnership` in `aiPanel.ts`) so it picks up the previous writer's latest config. A new `applyToggleChange` helper persists every toggle-strip change to the session. `recordSessionAiPreference` only writes on real user action (never on load), so a freshly-opened, untouched session keeps no stored config and the global default applies.
- **App preferences → per-tab** — `units`, render `quality`, and editor `auto-format` move to a per-tab store (sessionStorage) with a shared seed for fresh tabs via new `src/storage/perTabPref.ts`. Changing them in one window no longer silently alters another open window — including the **3MF/STL export unit attribute** (the one with a correctness impact).
- **`ai/attachments.ts`** — `putAttachment` no longer `await`s between `get` and `put` inside one readwrite transaction (the pattern CLAUDE.md and `recordUsage` warn against → `TransactionInactiveError` / cross-tab lost update). All read→write→prune now happens in request callbacks.
- **`CLAUDE.md`** — adds a "Cross-Tab Isolation — No Data Bleed Between Windows" guideline (and an explicit note on never awaiting between get/put in one txn) so future features don't reintroduce this class of bug.

## Scope notes (evaluated, intentionally not changed)

These report items were assessed and left alone, with reasons:
- **`recordUsage` token/cost counter** — already atomic: the `get`→`put` is in one transaction with no intervening `await`, and IndexedDB serializes readwrite txns on a store, so the "cross-tab lost update" can't actually occur. No fix needed.
- **Chat `seq` ordering** — guarded by the per-session leader lock + `mergeChatBucket` re-sequencing; take-control chat carry-over already works via the existing `reloadChatFromPeer` path. Deferred.
- **Shared geometry Worker state, agent-worker single-turn assumption, mid-turn provider mis-attribution, dead `resetClient`, diagnostics session tag** — these are **within a single tab** (each window has its own `new Worker` / JS context), so they don't bleed across tabs. Out of scope for this PR; noted for a possible follow-up.

## Test plan

- [x] `npm run build` (type-check) — clean
- [x] `npm run test:unit` — 510 passing (incl. the merged-in slash-command tests)
- [ ] PR-checks e2e shards (esp. `tests/ai-providers.spec.ts` — the provider-switch test relies on a fresh session having no stored config so localStorage still seeds it)
- [ ] Manual: open two windows on different sessions/providers; switch provider in one → the other must NOT change. Take control of a session in a new tab → it adopts that session's last provider/model/toggles.

This branch was re-synced with `origin/main` (merge included the new slash-commands + persist features); the merge touched only an import line in `aiPanel.ts`.

https://claude.ai/code/session_01VJpMaFYHjUtra3LQ3P5Sx8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJpMaFYHjUtra3LQ3P5Sx8)_