### PR TITLE
feat: require user confirmation before AI-initiated imports

### DIFF
--- a/src/ai/agentWorkerClient.ts
+++ b/src/ai/agentWorkerClient.ts
@@ -9,7 +9,7 @@
 //  • Forward abort: listen on input.signal and send { type: 'abort' }.
 //  • Expose pushQueuedBlocks() so aiPanel can relay mid-turn queued input.
 
-import { executeTool } from './tools';
+import { executeTool, CONFIRM_REQUIRED_TOOLS } from './tools';
 import { ingestEvent, type DiagnosticEvent } from './diagnostics';
 import type { RunTurnInput, RunTurnCallbacks } from './chatLoop';
 import type { ChatBlock, ChatMessage, PersistedToolResult } from './types';
@@ -58,6 +58,20 @@ async function handleMessage(event: MessageEvent): Promise<void> {
       name: string;
       input: Record<string, unknown>;
     };
+    if (CONFIRM_REQUIRED_TOOLS.has(name) && currentCallbacks?.confirmTool) {
+      const allowed = await currentCallbacks.confirmTool(name, input);
+      if (!allowed) {
+        getWorker().postMessage({
+          type: 'tool_result',
+          callId,
+          result: {
+            content: '[Declined by user — only call import tools when the user has explicitly requested an import]',
+            isError: true,
+          },
+        });
+        return;
+      }
+    }
     const result = await executeTool(name, input);
     getWorker().postMessage({ type: 'tool_result', callId, result });
     return;

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -17,7 +17,7 @@ import { streamTurn as streamTurnGemini, type StreamCallbacks as GeminiStreamCal
 import { streamTurn as streamTurnCustom } from './custom';
 import { getKey, recordUsage, putMessages } from './db';
 import { recordEvent } from './diagnostics';
-import { buildToolList, executeTool } from './tools';
+import { buildToolList, executeTool, CONFIRM_REQUIRED_TOOLS } from './tools';
 import { buildLocalSystemPrompt, buildMediumLocalSystemPrompt, buildSystemPrompt, loadAiMd, toggleSuffix } from './systemPrompt';
 import { loadSettings } from './settings';
 import { turnCostUsd } from './cost';
@@ -173,6 +173,10 @@ export interface RunTurnCallbacks {
   onAborted?: () => void;
   /** Unrecoverable error — the loop stops here. */
   onError?: (err: Error) => void;
+  /** Called before executing a tool that requires explicit user permission
+   *  (import tools). Return true to allow, false to decline. If absent, all
+   *  tools execute without a prompt. */
+  confirmTool?: (toolName: string, input: Record<string, unknown>) => Promise<boolean>;
 }
 
 /** Run one user turn through the agent loop. Returns the final history. */
@@ -647,6 +651,20 @@ async function executeAllWithRetry(
       callbacks.onToolResult?.(tc.id, tc.name, aborted);
       onEachResult?.(aborted, i);
       continue;
+    }
+    if (CONFIRM_REQUIRED_TOOLS.has(tc.name) && callbacks.confirmTool) {
+      const allowed = await callbacks.confirmTool(tc.name, tc.input);
+      if (!allowed) {
+        const declined: PersistedToolResult = {
+          toolUseId: tc.id,
+          content: '[Declined by user — only call import tools when the user has explicitly requested an import]',
+          isError: true,
+        };
+        results.push(declined);
+        callbacks.onToolResult?.(tc.id, tc.name, declined);
+        onEachResult?.(declined, i);
+        continue;
+      }
     }
     let attempt = 0;
     let result = await timedExecuteTool(tc.name, tc.input, executeToolFn);

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -942,7 +942,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'importImageAsRelief',
-    description: 'Generate a colour-printable Part from a raster image. By default produces a FLAT colour tile (keychain-style — paint regions on a thin tile, AMS-friendly). Pass quantized.output="silhouette" to cut the tile to the image\'s subject outline (background removed), or quantized.output="relief" for a stepped-height relief (each cluster gets its own Z layer). Pass mode="luminance" for a tonal embossment with no colour clusters. `src` is a data: or http(s) image URL. After creation, paint, then read getReliefSwapGuide() for the single-nozzle swap plan if relevant.',
+    description: 'Generate a colour-printable Part from a raster image. REQUIRES USER CONFIRMATION — only call when the user has explicitly asked to import an image. By default produces a FLAT colour tile (keychain-style — paint regions on a thin tile, AMS-friendly). Pass quantized.output="silhouette" to cut the tile to the image\'s subject outline (background removed), or quantized.output="relief" for a stepped-height relief (each cluster gets its own Z layer). Pass mode="luminance" for a tonal embossment with no colour clusters. `src` is a data: or http(s) image URL. After creation, paint, then read getReliefSwapGuide() for the single-nozzle swap plan if relevant.',
     input_schema: {
       type: 'object',
       properties: {
@@ -993,7 +993,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'importSvgAsRelief',
-    description: 'Generate a multi-colour tile Part from raw SVG text. Each `<path fill>` becomes one seed colour region with CRISP boundaries — no k-means clustering, so the SVG\'s exact colours and shapes are preserved. Vastly better than importImageAsRelief for vector logos, icons, and illustrations. Tile geometry knobs (output/shape/hole) work the same as importImageAsRelief; default output is "silhouette" so the tile takes the SVG\'s overall outline.',
+    description: 'Generate a multi-colour tile Part from raw SVG text. REQUIRES USER CONFIRMATION — only call when the user has explicitly asked to import an SVG. Each `<path fill>` becomes one seed colour region with CRISP boundaries — no k-means clustering, so the SVG\'s exact colours and shapes are preserved. Vastly better than importImageAsRelief for vector logos, icons, and illustrations. Tile geometry knobs (output/shape/hole) work the same as importImageAsRelief; default output is "silhouette" so the tile takes the SVG\'s overall outline.',
     input_schema: {
       type: 'object',
       properties: {
@@ -1111,6 +1111,13 @@ const ALWAYS_AVAILABLE = new Set([
   'importSvgAsRelief',
   'getReliefSwapGuide',
   'setReliefPreviewMode',
+]);
+
+/** Tools that require explicit user confirmation before executing.
+ *  The UI shows a blocking prompt and the model receives an error if declined. */
+export const CONFIRM_REQUIRED_TOOLS = new Set([
+  'importImageAsRelief',
+  'importSvgAsRelief',
 ]);
 
 const RUN_GATED = new Set(['runCode', 'setParams']);

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -2650,6 +2650,53 @@ function formatTurnOutcome(o: TurnOutcome): string {
  *  streamLocalTurn throws "Local model … is not loaded" even when the weights
  *  are cached and the model is resident in GPU on the main thread. Running the
  *  loop here reunites streamLocalTurn (and interruptLocal) with that engine. */
+/** Show a blocking overlay asking the user to allow or decline an AI-initiated
+ *  import. Resolves true (allow) or false (decline). */
+function showToolConfirmation(toolName: string): Promise<boolean> {
+  return new Promise(resolve => {
+    const label = toolName === 'importImageAsRelief'
+      ? 'import an image as a 3D relief'
+      : toolName === 'importSvgAsRelief'
+      ? 'import an SVG as a 3D relief tile'
+      : `run "${toolName}"`;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black/60';
+
+    const card = document.createElement('div');
+    card.className = 'bg-zinc-800 rounded-lg p-5 max-w-sm mx-4 shadow-xl border border-zinc-600';
+
+    const msg = document.createElement('p');
+    msg.className = 'text-sm text-zinc-200 mb-4';
+    msg.textContent = `The AI wants to ${label}. Allow this?`;
+
+    const btns = document.createElement('div');
+    btns.className = 'flex gap-2 justify-end';
+
+    const declineBtn = document.createElement('button');
+    declineBtn.className = 'px-3 py-1.5 text-sm rounded bg-zinc-700 hover:bg-zinc-600 text-zinc-200 transition-colors';
+    declineBtn.textContent = 'Decline';
+
+    const allowBtn = document.createElement('button');
+    allowBtn.className = 'px-3 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-500 text-white transition-colors';
+    allowBtn.textContent = 'Allow';
+
+    btns.appendChild(declineBtn);
+    btns.appendChild(allowBtn);
+    card.appendChild(msg);
+    card.appendChild(btns);
+    overlay.appendChild(card);
+    document.body.appendChild(overlay);
+
+    const done = (allowed: boolean) => {
+      overlay.remove();
+      resolve(allowed);
+    };
+    allowBtn.addEventListener('click', () => done(true));
+    declineBtn.addEventListener('click', () => done(false));
+  });
+}
+
 function runTurn(input: RunTurnInput, callbacks?: RunTurnCallbacks): Promise<ChatMessage[]> {
   return input.toggles.provider === 'local'
     ? runTurnOnMainThread(input, callbacks)
@@ -2770,6 +2817,7 @@ async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatTo
         renderTranscript();
         renderCostMeter();
       },
+      confirmTool: (toolName) => showToolConfirmation(toolName),
       onToolResult: (_id, _name, result) => {
         if (result.isError) setTransientStatus('A tool errored. The agent will retry or surface the issue.');
       },


### PR DESCRIPTION
## Summary

- `importImageAsRelief` and `importSvgAsRelief` now require explicit user confirmation before the AI can execute them
- A blocking Allow/Decline dialog appears over the app when the AI tries to call one of these tools unprompted
- If the user declines, the model receives a clear error message telling it to only use import tools when explicitly asked
- Tool descriptions updated to note the confirmation requirement, so models that read them know not to call imports speculatively

## How it works

- `CONFIRM_REQUIRED_TOOLS` set exported from `tools.ts` — easy to extend if more tools need the same gate
- `confirmTool?: (toolName, input) => Promise<boolean>` callback added to `RunTurnCallbacks` in `chatLoop.ts`
- The check runs in `executeAllWithRetry` (main-thread path) and in `agentWorkerClient.ts`'s `tool_call` handler (Worker path), so both execution modes are covered
- `aiPanel.ts` implements the callback with a simple modal overlay (Allow / Decline buttons)

## Test plan

- [ ] Start an AI session and ask the AI to do something unrelated to imports — confirm no dialog appears
- [ ] Ask the AI to import an image — confirm the Allow/Decline dialog appears before the import runs
- [ ] Click Decline — confirm the AI receives an error and responds appropriately (doesn't silently proceed)
- [ ] Click Allow — confirm the import proceeds normally

https://claude.ai/code/session_01WH6ZjKQKyNmsVAN73D83aa

---
_Generated by [Claude Code](https://claude.ai/code/session_01WH6ZjKQKyNmsVAN73D83aa)_