### PR TITLE
feat: add Ideas showcase page + in-pane AI prompt library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,7 @@ The app uses path-based routing for top-level pages and query parameters for vie
 - `/` — Landing page (hero + recent sessions grid)
 - `/editor` — Editor view (code + viewport)
 - `/catalog` — Curated catalog of premade sessions
+- `/ideas` — Ideas/showcase page: starter prompts, technique showcases, and interactive "use your own photo" flows. Backed by the `src/ideas/ideas.ts` dataset, which also powers the AI panel's 💡 prompt library + empty-state chips. Starter/technique tiles drop a prompt into the AI panel (populate, don't send — `prefillAiInput`); interactive tiles reuse the image→voxel and Relief import flows.
 - `/help` — Help/docs page
 
 **Query parameters** (on `/editor`):

--- a/src/ideas/ideas.ts
+++ b/src/ideas/ideas.ts
@@ -228,9 +228,8 @@ export function promptIdeas(): Idea[] {
   return IDEAS.filter((idea) => typeof idea.prompt === 'string' && idea.prompt.length > 0);
 }
 
-/** A short rotating-ish slice of starter prompts for the AI panel empty state.
- *  Deterministic (first N starters) so the chips don't jump around on every
- *  render. */
+/** A short slice of starter prompts for the AI panel empty state. Deterministic
+ *  (the first N starters) so the chips don't jump around on every render. */
 export function starterChipIdeas(limit = 4): Idea[] {
   return IDEAS.filter((idea) => idea.category === 'starter').slice(0, limit);
 }

--- a/src/ideas/ideas.ts
+++ b/src/ideas/ideas.ts
@@ -1,0 +1,236 @@
+// The "Ideas" dataset — the single source of truth that powers BOTH discovery
+// surfaces:
+//   1. the /ideas gallery page (src/ui/ideasPage.ts), and
+//   2. the in-pane prompt library + empty-state chips (src/ui/aiPanel.ts,
+//      src/ui/aiPromptLibraryModal.tsx).
+//
+// An "idea" is a *starting point*, not a finished session (that's what the
+// catalog is for). Most ideas are just a prompt the user can drop into the AI
+// input and tweak; a few "interactive" ones kick off a built-in flow that
+// needs an input first (e.g. uploading a photo to voxelize).
+//
+// Kept dependency-free so the pure helpers below stay unit-testable and both
+// the page and the modal can import the list without a network fetch.
+
+export type IdeaCategory = 'starter' | 'technique' | 'interactive';
+
+/** Built-in interactive flow an "interactive" idea triggers. The handler lives
+ *  in main.ts (it needs the editor/session plumbing). */
+export type IdeaAction = 'photoToVoxel' | 'photoToRelief';
+
+export interface Idea {
+  /** Stable id / slug. */
+  id: string;
+  /** Tile heading. */
+  title: string;
+  /** One-line description shown under the title. */
+  blurb: string;
+  category: IdeaCategory;
+  /** Glyph shown on the tile (we ship no rendered thumbnails — these are
+   *  prompts, not finished models). */
+  emoji: string;
+  /** Free-text tags, used for search in the prompt library. */
+  tags?: string[];
+  /** The prompt dropped (verbatim) into the AI input. Present for `starter`
+   *  and `technique` ideas. */
+  prompt?: string;
+  /** Optional deep-link to a reference doc (opened in a new tab) so a curious
+   *  user can read how the technique works. */
+  learnMore?: string;
+  /** The interactive flow this tile starts. Present only for `interactive`
+   *  ideas (which have no `prompt`). */
+  action?: IdeaAction;
+}
+
+export interface IdeaCategoryDef {
+  id: IdeaCategory;
+  title: string;
+  blurb: string;
+}
+
+/** Section order on the /ideas page. */
+export const IDEA_CATEGORIES: IdeaCategoryDef[] = [
+  {
+    id: 'interactive',
+    title: 'Try it with your own photo',
+    blurb: 'Upload an image and turn it into a model right here — no AI key needed. A great first taste of what the tool can do.',
+  },
+  {
+    id: 'starter',
+    title: 'Starter prompts',
+    blurb: 'Not sure what to ask for? Pick one of these to drop a ready-made prompt into the AI panel — then tweak it before you send.',
+  },
+  {
+    id: 'technique',
+    title: 'Show me what’s possible',
+    blurb: 'Each of these spotlights a capability you might not discover on your own — implicit surfaces, true CAD fillets, voxels, and more. Open the prompt, or read how it works.',
+  },
+];
+
+export const IDEAS: Idea[] = [
+  // ---- Interactive (need an input first; handled in main.ts) ----
+  {
+    id: 'voxel-selfie',
+    title: 'Turn your photo into a voxel portrait',
+    blurb: 'Upload a selfie and get a colorful, blocky 3D version of it that you can refine and print.',
+    category: 'interactive',
+    emoji: '\u{1F9CA}', // ice cube — blocky/voxel feel
+    tags: ['voxel', 'photo', 'selfie', 'portrait', 'fun'],
+    action: 'photoToVoxel',
+    learnMore: '/ai/voxel.md',
+  },
+  {
+    id: 'relief-portrait',
+    title: 'Turn your photo into a smooth relief',
+    blurb: 'Upload a photo and emboss it as a smooth, printable relief tile (lithophane-style) — the non-blocky take.',
+    category: 'interactive',
+    emoji: '\u{1F5BC}\u{FE0F}', // framed picture
+    tags: ['relief', 'lithophane', 'photo', 'smooth', 'portrait'],
+    action: 'photoToRelief',
+    learnMore: '/ai/relief.md',
+  },
+
+  // ---- Starter prompts (drop-in AI prompts) ----
+  {
+    id: 'coffee-mug',
+    title: 'A coffee mug',
+    blurb: 'A classic to start with — a mug with a comfortable handle.',
+    category: 'starter',
+    emoji: '☕',
+    tags: ['mug', 'kitchen', 'beginner', 'hollow'],
+    prompt: 'Build a coffee mug about 90mm tall with a 5mm-thick wall, a rounded base, and a comfortable handle on the side.',
+  },
+  {
+    id: 'phone-stand',
+    title: 'A desk phone stand',
+    blurb: 'Holds your phone at a viewing angle with a cable pass-through.',
+    category: 'starter',
+    emoji: '\u{1F4F1}',
+    tags: ['phone', 'stand', 'desk', 'practical'],
+    prompt: 'Design a phone stand for my desk that holds the phone at about a 65° angle, with a slot at the front lip for the charging cable to pass through. Make it stable and printable without supports.',
+  },
+  {
+    id: 'snap-fit-box',
+    title: 'A box with a snap-fit lid',
+    blurb: 'A small parts box whose lid clicks shut.',
+    category: 'starter',
+    emoji: '\u{1F4E6}',
+    tags: ['box', 'lid', 'enclosure', 'storage'],
+    prompt: 'Create a small rectangular box, roughly 60×40×25mm, with 2mm walls and a separate snap-fit lid that clicks onto the rim. Arrange the box and lid side by side.',
+  },
+  {
+    id: 'name-keychain',
+    title: 'A name keychain',
+    blurb: 'Raised letters on a tag with a ring hole.',
+    category: 'starter',
+    emoji: '\u{1F511}',
+    tags: ['keychain', 'text', 'gift', 'name'],
+    prompt: 'Make a keychain: a rounded rectangular tag with my name in raised letters across the front and a hole in one corner for a keyring.',
+  },
+  {
+    id: 'gridfinity-bin',
+    title: 'A Gridfinity bin',
+    blurb: 'A 1×1 bin for the popular desktop organizing system.',
+    category: 'starter',
+    emoji: '\u{1F5C3}\u{FE0F}',
+    tags: ['gridfinity', 'organizer', 'storage', 'modular'],
+    prompt: 'Make a 1×1 Gridfinity bin compatible with the standard 42mm grid, with the usual stacking lip and a single open compartment.',
+  },
+  {
+    id: 'keycap',
+    title: 'A keyboard keycap',
+    blurb: 'A Cherry MX–style cap with a dished top.',
+    category: 'starter',
+    emoji: '⌨\u{FE0F}',
+    tags: ['keycap', 'keyboard', 'mx', 'mechanical'],
+    prompt: 'Design a Cherry MX compatible keycap (1u) with a slightly dished/concave top surface and the cross-shaped stem socket underneath.',
+  },
+
+  // ---- Technique showcases (prompt + "learn more") ----
+  {
+    id: 'parametric-customizer',
+    title: 'A part you can tweak with sliders',
+    blurb: 'Expose parameters so anyone can customize it without touching code.',
+    category: 'technique',
+    emoji: '\u{1F39B}\u{FE0F}',
+    tags: ['parametric', 'customizer', 'params', 'sliders'],
+    prompt: 'Make a parametric desk organizer that uses api.params({...}) to expose adjustable width, depth, number of compartments, and wall thickness, so I can tune it from the Customize panel.',
+    learnMore: '/ai.md',
+  },
+  {
+    id: 'sdf-gyroid',
+    title: 'A gyroid lattice (implicit surfaces)',
+    blurb: 'Smooth, organic infill built from a signed-distance field.',
+    category: 'technique',
+    emoji: '\u{1F300}',
+    tags: ['sdf', 'gyroid', 'lattice', 'implicit', 'organic'],
+    prompt: 'Use the SDF (signed-distance field) tools to build a gyroid lattice contained inside a rounded cube, around 40mm on a side.',
+    learnMore: '/ai/sdf.md',
+  },
+  {
+    id: 'brep-fillets',
+    title: 'True rounded edges (solid CAD)',
+    blurb: 'Exact, selective fillets on real solids via the BREP engine.',
+    category: 'technique',
+    emoji: '\u{1F529}',
+    tags: ['brep', 'fillet', 'chamfer', 'replicad', 'cad', 'step'],
+    prompt: 'Switch to the BREP engine and model a rectangular bracket with true selective fillets on its outer vertical edges and a chamfer around the top face.',
+    learnMore: '/ai/replicad.md',
+  },
+  {
+    id: 'voxel-pixel-art',
+    title: 'Voxel pixel-art',
+    blurb: 'Build a colorful model by stacking colored cubes.',
+    category: 'technique',
+    emoji: '\u{1F47E}',
+    tags: ['voxel', 'pixel', 'retro', 'color'],
+    prompt: 'Use the voxel builder to make a small piece of pixel-art — a red mushroom with white spots — then smooth its edges slightly.',
+    learnMore: '/ai/voxel.md',
+  },
+  {
+    id: 'lofted-vase',
+    title: 'A lofted vase (curves)',
+    blurb: 'Sweep and loft profiles into a flowing organic shape.',
+    category: 'technique',
+    emoji: '\u{1F3FA}',
+    tags: ['vase', 'loft', 'sweep', 'curves', 'organic'],
+    prompt: 'Use the Curves helpers to loft a vase: a circular base flowing up through a pinched waist to a wider, gently scalloped rim, hollowed out with a few-mm wall.',
+    learnMore: '/ai/curves.md',
+  },
+  {
+    id: 'scad-gear',
+    title: 'A spur gear (OpenSCAD + BOSL2)',
+    blurb: 'Lean on the BOSL2 library for parts with precise teeth and threads.',
+    category: 'technique',
+    emoji: '⚙\u{FE0F}',
+    tags: ['gear', 'openscad', 'bosl2', 'scad', 'mechanical'],
+    prompt: 'Switch to OpenSCAD and use BOSL2 to make a 20-tooth spur gear, 6mm thick, with a 5mm center bore.',
+    learnMore: '/ai/bosl2.md',
+  },
+];
+
+/** Case-insensitive search across title, blurb, tags, and prompt. A blank
+ *  query returns the list unchanged. Pure — unit tested. */
+export function filterIdeas(ideas: Idea[], query: string): Idea[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return ideas;
+  return ideas.filter((idea) => {
+    const hay = [idea.title, idea.blurb, idea.prompt ?? '', ...(idea.tags ?? [])]
+      .join(' ')
+      .toLowerCase();
+    return hay.includes(q);
+  });
+}
+
+/** Ideas that carry a prompt — the ones the prompt library and the empty-state
+ *  chips can surface (interactive ideas have an action, not a prompt). */
+export function promptIdeas(): Idea[] {
+  return IDEAS.filter((idea) => typeof idea.prompt === 'string' && idea.prompt.length > 0);
+}
+
+/** A short rotating-ish slice of starter prompts for the AI panel empty state.
+ *  Deterministic (first N starters) so the chips don't jump around on every
+ *  render. */
+export function starterChipIdeas(limit = 4): Idea[] {
+  return IDEAS.filter((idea) => idea.category === 'starter').slice(0, limit);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ import { registerCommands } from './ui/commandPalette';
 import { showQualitySettingsModal } from './ui/qualitySettingsModal';
 import { combo, MOD_LABEL, SHIFT_LABEL, ALT_LABEL } from './ui/shortcutDefs';
 import { showToast } from './ui/toast';
-import { initAiPanel, setActiveSession as setAiActiveSession, toggleAiPanel, toggleAiPanelFromToolbar } from './ui/aiPanel';
+import { initAiPanel, setActiveSession as setAiActiveSession, toggleAiPanel, toggleAiPanelFromToolbar, prefillAiInput } from './ui/aiPanel';
 import { getKey, mergeChatBucket } from './ai/db';
 import { requestPersistentStorage } from './storage/persist';
 import { aiConnectionMode, reloadSettingsFromStorage, getRenderBudget, getSpendingSummary, setSpendingMode as applyAiSpendingMode } from './ai/settings';
@@ -49,6 +49,8 @@ import { createLegalPage } from './ui/legal';
 import { showExportOptionsDialog } from './ui/exportOptionsDialog';
 import { showExportConfirm, hasExportWarning, type ExportWarningInfo } from './ui/exportConfirmModal';
 import { createCatalogPage, type CatalogManifestEntry } from './ui/catalog';
+import { createIdeasPage } from './ui/ideasPage';
+import type { Idea } from './ideas/ideas';
 import { createWhatsNewPage } from './ui/whatsNew';
 import { createNotFoundPage } from './ui/notFound';
 import { applyRouteMeta, routeTitle, type RouteName } from './seo/meta';
@@ -409,7 +411,7 @@ export type CoverageMode = typeof COVERAGE_MODES[number];
 const BASE_TITLE = 'Partwright';
 let _expectedTitle = 'Partwright — AI-Driven Parametric CAD in Your Browser';
 
-function updateDocumentTitle(context?: { page?: 'landing' | 'editor' | 'help' | '404' | 'catalog' | 'legal' | 'whats-new'; sessionName?: string | null }) {
+function updateDocumentTitle(context?: { page?: 'landing' | 'editor' | 'help' | '404' | 'catalog' | 'ideas' | 'legal' | 'whats-new'; sessionName?: string | null }) {
   let route: RouteName;
   let titleOverride: string | undefined;
   if (context?.page === 'landing' || (context?.page === undefined && shouldShowLanding())) {
@@ -418,6 +420,8 @@ function updateDocumentTitle(context?: { page?: 'landing' | 'editor' | 'help' | 
     route = 'help';
   } else if (context?.page === 'catalog') {
     route = 'catalog';
+  } else if (context?.page === 'ideas') {
+    route = 'ideas';
   } else if (context?.page === 'legal') {
     route = 'legal';
   } else if (context?.page === 'whats-new') {
@@ -1499,6 +1503,10 @@ function shouldShowCatalog(): boolean {
   return window.location.pathname === '/catalog' && !hasShareHash();
 }
 
+function shouldShowIdeas(): boolean {
+  return window.location.pathname === '/ideas' && !hasShareHash();
+}
+
 function shouldShowWhatsNew(): boolean {
   return window.location.pathname === '/whats-new';
 }
@@ -1510,7 +1518,7 @@ function shouldShowLegal(): boolean {
 function shouldShow404(): boolean {
   if (hasShareHash()) return false;
   const path = window.location.pathname;
-  return path !== '/' && path !== '' && path !== '/help' && path !== '/editor' && path !== '/catalog' && path !== '/legal' && path !== '/whats-new';
+  return path !== '/' && path !== '' && path !== '/help' && path !== '/editor' && path !== '/catalog' && path !== '/ideas' && path !== '/legal' && path !== '/whats-new';
 }
 
 /** True when the editor view is the active page. Editor-scoped command-palette
@@ -3305,6 +3313,7 @@ async function main() {
     { id: 'toggle-ai', title: 'Toggle AI panel', hint: 'View', keywords: 'chat assistant drawer', run: () => toggleAiPanel() },
     { id: 'toggle-diagnostics', title: 'Toggle diagnostic log', hint: 'View', keywords: 'errors warnings console', run: () => toggleDiagnosticsPanel() },
     { id: 'open-catalog', title: 'Open catalog', hint: 'Navigate', keywords: 'examples premade browse', run: () => { void showCatalogPage(); } },
+    { id: 'open-ideas', title: 'Open ideas', hint: 'Navigate', keywords: 'prompts examples inspiration showcase what can i do', run: () => { showIdeasPage(); } },
     { id: 'open-help', title: 'Open help', hint: 'Navigate', keywords: 'docs documentation guide', run: () => showHelp() },
     { id: 'open-whats-new', title: "Open what's new", hint: 'Navigate', keywords: 'changelog recent features updates release notes', run: () => showWhatsNewPage() },
     { id: 'open-quality', title: 'Modeling quality settings', hint: 'Settings', keywords: 'resolution curve segments smoothness', run: () => showQualitySettingsModal() },
@@ -3443,6 +3452,7 @@ async function main() {
     showEditorUI(landingEl, helpEl, editorUI);
     if (notFoundEl) notFoundEl.classList.add('hidden');
     if (catalogEl) catalogEl.classList.add('hidden');
+    if (ideasEl) ideasEl.classList.add('hidden');
     if (legalEl) legalEl.classList.add('hidden');
     overlayContainer.classList.add('hidden');
     window.dispatchEvent(new Event('resize'));
@@ -3539,6 +3549,7 @@ async function main() {
         onOpenEditor: openEditorFromLanding,
         onOpenHelp: () => showHelp(),
         onOpenCatalog: () => { void showCatalogPage(); },
+        onOpenIdeas: () => { showIdeasPage(); },
         onOpenWhatsNew: () => showWhatsNewPage(),
         onTakeTour: () => { void takeGuidedTour(); },
         onOpenSession: openSessionFromLanding,
@@ -3555,6 +3566,7 @@ async function main() {
     helpEl?.classList.add('hidden');
     notFoundEl?.classList.add('hidden');
     catalogEl?.classList.add('hidden');
+    ideasEl?.classList.add('hidden');
     legalEl?.classList.add('hidden');
     whatsNewEl?.classList.add('hidden');
     page.classList.remove('hidden');
@@ -3575,6 +3587,7 @@ async function main() {
     landingEl?.classList.add('hidden');
     helpEl?.classList.add('hidden');
     catalogEl?.classList.add('hidden');
+    ideasEl?.classList.add('hidden');
     legalEl?.classList.add('hidden');
     whatsNewEl?.classList.add('hidden');
     notFoundEl.classList.remove('hidden');
@@ -3606,6 +3619,7 @@ async function main() {
     if (landingEl) landingEl.classList.add('hidden');
     if (notFoundEl) notFoundEl.classList.add('hidden');
     if (catalogEl) catalogEl.classList.add('hidden');
+    if (ideasEl) ideasEl.classList.add('hidden');
     if (legalEl) legalEl.classList.add('hidden');
     if (whatsNewEl) whatsNewEl.classList.add('hidden');
     helpEl.classList.remove('hidden');
@@ -3636,6 +3650,7 @@ async function main() {
     if (landingEl) landingEl.classList.add('hidden');
     if (notFoundEl) notFoundEl.classList.add('hidden');
     if (catalogEl) catalogEl.classList.add('hidden');
+    if (ideasEl) ideasEl.classList.add('hidden');
     if (helpEl) helpEl.classList.add('hidden');
     legalEl.classList.remove('hidden');
     updateDocumentTitle({ page: 'legal' });
@@ -3660,6 +3675,7 @@ async function main() {
           }
         },
         onLoadEntry: handleCatalogEntryLoad,
+        onOpenIdeas: () => { showIdeasPage(); },
       });
     }
     overlayContainer.classList.remove('hidden');
@@ -3669,6 +3685,7 @@ async function main() {
     if (notFoundEl) notFoundEl.classList.add('hidden');
     if (legalEl) legalEl.classList.add('hidden');
     if (whatsNewEl) whatsNewEl.classList.add('hidden');
+    if (ideasEl) ideasEl.classList.add('hidden');
     catalogEl.classList.remove('hidden');
     updateDocumentTitle({ page: 'catalog' });
   }
@@ -3699,6 +3716,7 @@ async function main() {
     if (landingEl) landingEl.classList.add('hidden');
     if (helpEl) helpEl.classList.add('hidden');
     if (catalogEl) catalogEl.classList.add('hidden');
+    if (ideasEl) ideasEl.classList.add('hidden');
     if (notFoundEl) notFoundEl.classList.add('hidden');
     whatsNewEl.classList.remove('hidden');
     updateDocumentTitle({ page: 'whats-new' });
@@ -3716,6 +3734,83 @@ async function main() {
     await ensureEditorReady();
     await importSessionPayload(payload);
     updateDocumentTitle({ page: 'editor' });
+  }
+
+  // === Ideas page handlers ===
+
+  /** Enter the editor with a live session, ready for a hand-off. Used by the
+   *  ideas-page actions: they all start by getting the user into the editor
+   *  (pushing the history entry BEFORE any session mutation, same reason as
+   *  handleCatalogEntryLoad). */
+  async function enterEditorForIdea(): Promise<void> {
+    updateAppHistory('/editor', 'push');
+    transitionToEditor();
+    await ensureEditorReady();
+  }
+
+  // A starter/technique idea — drop its prompt into the AI panel (don't send).
+  async function handleIdeaUsePrompt(idea: Idea): Promise<void> {
+    await enterEditorForIdea();
+    if (window.location.pathname !== '/editor') return;
+    if (!getState().session) {
+      await createSession();
+      runCode(defaultCode);
+    }
+    updateDocumentTitle({ page: 'editor' });
+    prefillAiInput(idea.prompt ?? '');
+  }
+
+  // An interactive idea: turn the user's photo into a colored voxel session
+  // (reuses the existing image→voxel import flow, modal and all).
+  async function handleIdeaPhotoToVoxel(file: File): Promise<void> {
+    await enterEditorForIdea();
+    if (window.location.pathname !== '/editor') return;
+    await handleImageImport(file);
+    updateDocumentTitle({ page: 'editor' });
+  }
+
+  // An interactive idea: emboss the user's photo as a smooth relief tile
+  // (reuses the existing Relief import wizard).
+  async function handleIdeaPhotoToRelief(file: File): Promise<void> {
+    await enterEditorForIdea();
+    if (window.location.pathname !== '/editor') return;
+    openReliefImportFlow(file);
+    updateDocumentTitle({ page: 'editor' });
+  }
+
+  let ideasEl: HTMLElement | null = null;
+  let ideasHasAppBackTarget = false;
+  function showIdeasPage(options: { history?: 'push' | 'replace' | 'none' } = {}) {
+    const historyMode = options.history ?? 'push';
+    if (historyMode !== 'none') {
+      ideasHasAppBackTarget = currentURLPathAndSearch() !== '/ideas';
+      updateAppHistory('/ideas', historyMode);
+    }
+    if (!ideasEl) {
+      ideasEl = createIdeasPage(overlayContainer, {
+        onBack: () => {
+          if (ideasHasAppBackTarget) {
+            window.history.back();
+          } else {
+            updateAppHistory('/', 'replace');
+            void syncRouteFromURL();
+          }
+        },
+        onUsePrompt: handleIdeaUsePrompt,
+        onPhotoToVoxel: handleIdeaPhotoToVoxel,
+        onPhotoToRelief: handleIdeaPhotoToRelief,
+      });
+    }
+    overlayContainer.classList.remove('hidden');
+    editorUI.classList.add('hidden');
+    if (landingEl) landingEl.classList.add('hidden');
+    if (helpEl) helpEl.classList.add('hidden');
+    if (notFoundEl) notFoundEl.classList.add('hidden');
+    if (legalEl) legalEl.classList.add('hidden');
+    if (catalogEl) catalogEl.classList.add('hidden');
+    if (whatsNewEl) whatsNewEl.classList.add('hidden');
+    ideasEl.classList.remove('hidden');
+    updateDocumentTitle({ page: 'ideas' });
   }
 
   // === Shared-link preview mode (read-only) ===
@@ -3958,7 +4053,7 @@ async function main() {
     // Home — confusing because no editor / session is loaded to act on
     // it. /editor's own loader updates the AI session via onStateChange
     // when a session opens, so we don't need to set it explicitly here.
-    if (shouldShowLanding() || shouldShowHelp() || shouldShowCatalog() || shouldShowLegal() || shouldShowWhatsNew() || shouldShow404()) {
+    if (shouldShowLanding() || shouldShowHelp() || shouldShowCatalog() || shouldShowIdeas() || shouldShowLegal() || shouldShowWhatsNew() || shouldShow404()) {
       void setAiActiveSession(null);
     }
     // A share-link hash takes precedence over the normal editor sync on this
@@ -3972,6 +4067,8 @@ async function main() {
       showHelp({ history: 'none' });
     } else if (shouldShowCatalog()) {
       await showCatalogPage({ history: 'none' });
+    } else if (shouldShowIdeas()) {
+      showIdeasPage({ history: 'none' });
     } else if (shouldShowLegal()) {
       showLegal({ history: 'none' });
     } else if (shouldShowWhatsNew()) {
@@ -4009,6 +4106,7 @@ async function main() {
   const showLanding = shouldShowLanding();
   const showHelpPage = shouldShowHelp();
   const showCatalog = shouldShowCatalog();
+  const showIdeas = shouldShowIdeas();
   const showLegalPage = shouldShowLegal();
   const showWhatsNew = shouldShowWhatsNew();
   const show404 = shouldShow404();
@@ -4019,6 +4117,8 @@ async function main() {
     showHelp({ history: 'none' });
   } else if (showCatalog) {
     await showCatalogPage({ history: 'none' });
+  } else if (showIdeas) {
+    showIdeasPage({ history: 'none' });
   } else if (showLegalPage) {
     showLegal({ history: 'none' });
   } else if (showWhatsNew) {
@@ -4542,7 +4642,7 @@ async function main() {
 
   // Start guided tour on first visit (after editor fully renders) — but not over
   // a shared preview, which is a read-only landing surface for an external link.
-  if (!showLanding && !showHelpPage && !showCatalog && !showLegalPage && !showWhatsNew && !show404 && !hasShareHash()) {
+  if (!showLanding && !showHelpPage && !showCatalog && !showIdeas && !showLegalPage && !showWhatsNew && !show404 && !hasShareHash()) {
     maybeStartTour();
     maybeShowShortcutsHint();
     maybeShowLowMemoryNotice();
@@ -4554,7 +4654,7 @@ async function main() {
   // and degrades to a normal editable editor if the link is invalid. (The
   // editor + engine are ready here, so its internal ensureEditorReady resolves
   // immediately — no deadlock from awaiting it earlier in main().)
-  if (!showLanding && !showHelpPage && !showCatalog && !showLegalPage && !showWhatsNew && !show404 && engineOk) {
+  if (!showLanding && !showHelpPage && !showCatalog && !showIdeas && !showLegalPage && !showWhatsNew && !show404 && engineOk) {
     if (hasShareHash()) {
       await enterSharedFromHash();
     } else {
@@ -4669,7 +4769,7 @@ async function main() {
   }
 
   // Set initial editor title if we're on the editor page
-  if (!showLanding && !showHelpPage && !showCatalog && !showLegalPage && !showWhatsNew && !show404) {
+  if (!showLanding && !showHelpPage && !showCatalog && !showIdeas && !showLegalPage && !showWhatsNew && !show404) {
     updateDocumentTitle({ page: 'editor' });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3754,6 +3754,7 @@ async function main() {
     if (window.location.pathname !== '/editor') return;
     if (!getState().session) {
       await createSession();
+      setStatus(statusBar, 'ready', 'Ready');
       runCode(defaultCode);
     }
     updateDocumentTitle({ page: 'editor' });

--- a/src/seo/meta.ts
+++ b/src/seo/meta.ts
@@ -7,7 +7,7 @@
 // the path it's given (which is fine — the browser resolves relative URLs
 // against the current origin, and unfurl bots fetch each route fresh).
 
-export type RouteName = 'landing' | 'editor' | 'help' | 'catalog' | 'legal' | 'whats-new' | '404';
+export type RouteName = 'landing' | 'editor' | 'help' | 'catalog' | 'ideas' | 'legal' | 'whats-new' | '404';
 
 interface RouteMeta {
   title: string;
@@ -45,6 +45,13 @@ const ROUTE_META: Record<RouteName, RouteMeta> = {
     description:
       'Browse a curated catalog of example Partwright sessions: vases, gears, chess pieces, holiday ornaments and more. One click loads any example into the editor for inspection or remixing.',
     path: '/catalog',
+    ogImage: '/og-image.png',
+  },
+  ideas: {
+    title: `Ideas — ${BASE_TITLE}`,
+    description:
+      'Ideas to get you started with Partwright: ready-made AI prompts to drop into the chat, technique showcases (implicit surfaces, true CAD fillets, voxels), and interactive flows that turn your own photo into a voxel portrait or a smooth relief.',
+    path: '/ideas',
     ogImage: '/og-image.png',
   },
   legal: {

--- a/src/seo/sitemap.ts
+++ b/src/seo/sitemap.ts
@@ -21,6 +21,7 @@ export const SITEMAP_ROUTES: SitemapRoute[] = [
   { path: '/', changefreq: 'weekly', priority: 1.0 },
   { path: '/editor', changefreq: 'weekly', priority: 0.9 },
   { path: '/catalog', changefreq: 'weekly', priority: 0.8 },
+  { path: '/ideas', changefreq: 'weekly', priority: 0.8 },
   { path: '/help', changefreq: 'monthly', priority: 0.7 },
   { path: '/legal', changefreq: 'yearly', priority: 0.3 },
   { path: '/ai.md', changefreq: 'weekly', priority: 0.7 },

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -17,6 +17,8 @@ import { showAiKeyModal } from './aiKeyModal';
 import { showAiSettingsModal } from './aiSettingsModal';
 import { showAiReviewModal } from './aiReviewModal';
 import { showAiDiagnosticsModal } from './aiDiagnosticsModal';
+import { showAiPromptLibraryModal } from './aiPromptLibraryModal';
+import { starterChipIdeas } from '../ideas/ideas';
 import { showAiLocalModal } from './aiLocalModal';
 import { showSystemPromptModal } from './aiSystemPromptModal';
 import { showCompactConfirmModal } from './aiCompactModal';
@@ -301,6 +303,18 @@ export async function setActiveSession(sessionId: string | null): Promise<void> 
 export function toggleAiPanel(): void {
   if (state.open) hideDrawer();
   else showDrawer();
+}
+
+/** Open the AI panel (if closed) and drop `text` into the chat input without
+ *  sending it — the user reads/tweaks it and hits send themselves. Used by the
+ *  prompt library and the /ideas page so picking a prompt lands here. */
+export function prefillAiInput(text: string): void {
+  if (!state.open) showDrawer(false);
+  if (!inputEl) return;
+  inputEl.value = text;
+  inputEl.focus();
+  const end = text.length;
+  inputEl.setSelectionRange(end, end);
 }
 
 /** Re-render everything that an AI-settings change (provider / model / key)
@@ -630,6 +644,13 @@ function buildDrawer(): void {
   clearBtn.title = 'Clear the chat history for the current session. The conversation is removed from your browser; saved versions and notes are untouched.';
   clearBtn.addEventListener('click', () => { void clearCurrentChat(); });
   header.appendChild(clearBtn);
+
+  const promptsBtn = createIconButton('Prompt library', '💡');
+  promptsBtn.title = 'Prompt library — example prompts to try. Pick one to drop it into the chat box (you can edit it before sending).';
+  promptsBtn.addEventListener('click', () => {
+    showAiPromptLibraryModal({ onSelect: (idea) => prefillAiInput(idea.prompt ?? '') });
+  });
+  header.appendChild(promptsBtn);
 
   const diagBtn = createIconButton('AI Call Log', '🩺');
   diagBtn.title = 'AI Call Log — recent provider API calls: request shape, stop reason, token usage, full error messages. Open this when a turn ends with a confusing status.';
@@ -1561,6 +1582,48 @@ function formatDuration(ms: number): string {
 
 // === Transcript rendering ===
 
+/** Empty-state shown when a chat has no messages yet. Beyond the one-line
+ *  hint, it surfaces a few tappable starter-prompt chips (and a link to the
+ *  full prompt library) so a user who doesn't know what to ask for can get
+ *  going in one click — populate, don't send. */
+function renderEmptyState(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'flex-1 flex flex-col items-center justify-center gap-3 text-center px-6';
+
+  const hint = document.createElement('p');
+  hint.className = 'text-zinc-500 text-xs';
+  hint.textContent = state.sessionId === GLOBAL_CHAT_BUCKET
+    ? 'Open a session and ask the AI to model something — or start with one of these:'
+    : 'Ask the AI to model, modify, or describe this session — or start with one of these:';
+  wrap.appendChild(hint);
+
+  const chips = document.createElement('div');
+  chips.className = 'flex flex-wrap items-center justify-center gap-1.5';
+  for (const idea of starterChipIdeas(4)) {
+    chips.appendChild(buildPromptChip(`${idea.emoji} ${idea.title}`, idea.title, () => {
+      prefillAiInput(idea.prompt ?? '');
+    }));
+  }
+  // "More…" opens the full prompt library.
+  chips.appendChild(buildPromptChip('More ideas…', 'Browse the prompt library', () => {
+    showAiPromptLibraryModal({ onSelect: (idea) => prefillAiInput(idea.prompt ?? '') });
+  }));
+  wrap.appendChild(chips);
+
+  return wrap;
+}
+
+/** A small pill button used in the empty-state suggestion row. */
+function buildPromptChip(label: string, title: string, onClick: () => void): HTMLButtonElement {
+  const chip = document.createElement('button');
+  chip.type = 'button';
+  chip.className = 'px-2.5 py-1 rounded-full text-[11px] text-zinc-300 bg-zinc-800 border border-zinc-700 hover:border-zinc-500 hover:text-zinc-100 transition-colors';
+  chip.textContent = label;
+  chip.title = title;
+  chip.addEventListener('click', onClick);
+  return chip;
+}
+
 function renderTranscript(): void {
   if (!transcriptEl) return;
   // Measure before replaceChildren — clearing children clamps scrollTop, so
@@ -1570,12 +1633,7 @@ function renderTranscript(): void {
   const hasHistory = state.history.length > 0;
   const hasQueue = state.queuedBlocks.length > 0;
   if (!hasHistory && !hasQueue) {
-    const empty = document.createElement('div');
-    empty.className = 'flex-1 flex items-center justify-center text-zinc-600 text-xs text-center px-6';
-    empty.textContent = state.sessionId === GLOBAL_CHAT_BUCKET
-      ? 'Open a session and ask the AI to model something. Try: "Build a coffee mug, 80mm tall."'
-      : 'Ask the AI to model, modify, or describe this session.';
-    transcriptEl.appendChild(empty);
+    transcriptEl.appendChild(renderEmptyState());
     return;
   }
   for (const msg of state.history) {

--- a/src/ui/aiPromptLibraryModal.tsx
+++ b/src/ui/aiPromptLibraryModal.tsx
@@ -1,0 +1,75 @@
+// Prompt library modal — opened from the 💡 button in the AI panel header.
+// Lists the prompt-bearing ideas (starter + technique) with a search box so a
+// user who's staring at a blank chat input can find something to ask for.
+// Picking one drops the prompt into the input (populate, don't send) and
+// closes — the caller wires `onSelect`.
+
+import { useSignal } from '@preact/signals';
+import { IDEA_CATEGORIES, filterIdeas, promptIdeas, type Idea } from '../ideas/ideas';
+import { mountPreactModal } from './preact/mount';
+
+function PromptLibraryBody(props: { onPick: (idea: Idea) => void }) {
+  const query = useSignal('');
+  const all = promptIdeas();
+  const visible = filterIdeas(all, query.value);
+
+  // Group the visible ideas by category, preserving IDEA_CATEGORIES order.
+  const groups = IDEA_CATEGORIES
+    .map((cat) => ({ cat, items: visible.filter((i) => i.category === cat.id) }))
+    .filter((g) => g.items.length > 0);
+
+  return (
+    <>
+      <p class="text-xs text-zinc-400 leading-snug">
+        Pick a prompt to drop into the chat box — then tweak it before you send. Not sure what’s possible? These cover a lot of ground.
+      </p>
+      <input
+        type="text"
+        autofocus
+        placeholder="Search prompts (e.g. box, gear, voxel)…"
+        class="w-full px-2.5 py-1.5 rounded text-xs bg-zinc-900 border border-zinc-600 text-zinc-100 placeholder-zinc-500"
+        value={query.value}
+        onInput={(e) => { query.value = (e.currentTarget as HTMLInputElement).value; }}
+      />
+      <div class="flex flex-col gap-3">
+        {groups.length === 0
+          ? <p class="text-zinc-500 text-xs italic">No prompts match “{query.value}”.</p>
+          : groups.map((g) => (
+              <div key={g.cat.id} class="flex flex-col gap-1.5">
+                <div class="text-[10px] uppercase tracking-wider text-zinc-500">{g.cat.title}</div>
+                {g.items.map((idea) => (
+                  <button
+                    key={idea.id}
+                    type="button"
+                    class="flex items-start gap-2.5 text-left px-2.5 py-2 rounded border border-zinc-700 bg-zinc-900/40 hover:border-zinc-500 hover:bg-zinc-800 transition-colors"
+                    onClick={() => props.onPick(idea)}
+                  >
+                    <span class="text-lg leading-none mt-0.5">{idea.emoji}</span>
+                    <span class="flex flex-col min-w-0">
+                      <span class="text-xs font-medium text-zinc-100">{idea.title}</span>
+                      <span class="text-[11px] text-zinc-400 leading-snug">{idea.prompt}</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ))}
+      </div>
+    </>
+  );
+}
+
+export function showAiPromptLibraryModal(opts: { onSelect: (idea: Idea) => void }): void {
+  mountPreactModal(
+    { title: 'Prompt library', maxWidth: 'lg', scrollable: true },
+    (close) => ({
+      body: <PromptLibraryBody onPick={(idea) => { opts.onSelect(idea); close(); }} />,
+      footer: (
+        <button
+          type="button"
+          class="px-3 py-1.5 rounded text-xs text-zinc-200 bg-zinc-700 hover:bg-zinc-600"
+          onClick={close}
+        >Done</button>
+      ),
+    }),
+  );
+}

--- a/src/ui/catalog.ts
+++ b/src/ui/catalog.ts
@@ -28,6 +28,8 @@ export interface CatalogCallbacks {
   onBack: () => void;
   /** Called with the parsed session payload when a tile is clicked. */
   onLoadEntry: (entry: CatalogManifestEntry, payload: ExportedSession) => void | Promise<void>;
+  /** Optional: open the /ideas page (reciprocal cross-link in the header). */
+  onOpenIdeas?: () => void;
 }
 
 interface LoadedEntry {
@@ -136,6 +138,13 @@ export async function createCatalogPage(
   const intro = document.createElement('p');
   intro.className = 'w-full max-w-5xl px-6 -mt-4 mb-6 text-sm text-zinc-400 leading-relaxed';
   intro.textContent = 'Curated premade models, grouped by what makes each one tick — parametric, JavaScript, implicit-surface (SDF), OpenSCAD, and solid-CAD (BREP). Click a tile to import it as a fresh session you can edit.';
+  if (callbacks.onOpenIdeas) {
+    const ideasLink = document.createElement('button');
+    ideasLink.className = 'ml-1 text-teal-300 hover:text-teal-200 underline decoration-dotted';
+    ideasLink.textContent = 'Looking for ideas to try? →';
+    ideasLink.addEventListener('click', () => callbacks.onOpenIdeas!());
+    intro.appendChild(ideasLink);
+  }
   page.appendChild(intro);
 
   // Body: grid (loading / empty / error states handled below).

--- a/src/ui/ideasPage.ts
+++ b/src/ui/ideasPage.ts
@@ -1,0 +1,199 @@
+// The /ideas page — a discovery surface that answers "what could I even ask
+// for?". Unlike the catalog (curated *finished* sessions), each idea is a
+// *starting point*: a ready-made prompt you drop into the AI panel, or a
+// built-in interactive flow (e.g. photo → voxels) you run on your own input.
+//
+// Mirrors the structure of src/ui/catalog.ts (theme toggle, back header,
+// category sections, tile grid) so the two pages feel like siblings.
+
+import { partwrightMarkSvg } from './brand';
+import { getTheme, onThemeChange, toggleTheme } from './theme';
+import { IDEAS, IDEA_CATEGORIES, type Idea, type IdeaCategoryDef } from '../ideas/ideas';
+
+export interface IdeasCallbacks {
+  onBack: () => void;
+  /** A starter/technique idea was chosen — drop its prompt into the AI panel. */
+  onUsePrompt: (idea: Idea) => void | Promise<void>;
+  /** A "photo → voxels" interactive idea was triggered with a chosen image. */
+  onPhotoToVoxel: (file: File) => void | Promise<void>;
+  /** A "photo → relief" interactive idea was triggered with a chosen image. */
+  onPhotoToRelief: (file: File) => void | Promise<void>;
+}
+
+export function createIdeasPage(
+  container: HTMLElement,
+  callbacks: IdeasCallbacks,
+): HTMLElement {
+  const page = document.createElement('div');
+  page.id = 'ideas-page';
+  page.className = 'flex flex-col items-center w-full h-full overflow-auto bg-zinc-900 text-zinc-100 relative';
+
+  // Top-right theme toggle (mirrors catalog / landing).
+  const themeBtn = document.createElement('button');
+  themeBtn.textContent = 'Dark Mode';
+  const themeActive = 'absolute top-4 right-4 px-3 py-1 rounded text-xs font-medium transition-colors bg-zinc-700 text-zinc-100';
+  const themeInactive = 'absolute top-4 right-4 px-3 py-1 rounded text-xs font-medium transition-colors text-zinc-500 hover:text-zinc-300 border border-zinc-600';
+  const syncThemeBtn = (theme: 'light' | 'dark') => {
+    const on = theme === 'dark';
+    themeBtn.className = on ? themeActive : themeInactive;
+    themeBtn.title = on ? 'Dark mode on — click to switch to light' : 'Dark mode off — click to switch to dark';
+    themeBtn.setAttribute('aria-pressed', String(on));
+  };
+  syncThemeBtn(getTheme());
+  themeBtn.addEventListener('click', () => { toggleTheme(); });
+  onThemeChange(syncThemeBtn);
+  page.appendChild(themeBtn);
+
+  // Header: back button + logo + title
+  const header = document.createElement('div');
+  header.className = 'w-full max-w-5xl px-6 pt-10 pb-6 flex items-center gap-4';
+
+  const back = document.createElement('button');
+  back.className = 'flex items-center gap-1.5 px-3 py-1.5 rounded text-xs text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 transition-colors';
+  back.innerHTML = '← Back';
+  back.addEventListener('click', callbacks.onBack);
+  header.appendChild(back);
+
+  const titleWrap = document.createElement('div');
+  titleWrap.className = 'flex items-center gap-3';
+  titleWrap.innerHTML = `${partwrightMarkSvg(28)}<h1 class="text-2xl font-semibold tracking-tight">Ideas</h1>`;
+  header.appendChild(titleWrap);
+
+  page.appendChild(header);
+
+  const intro = document.createElement('p');
+  intro.className = 'w-full max-w-5xl px-6 -mt-4 mb-6 text-sm text-zinc-400 leading-relaxed';
+  intro.textContent = 'Not sure what Partwright can do? Start here. Pick a starter prompt to hand the AI, try a technique you didn’t know was possible, or turn one of your own photos into a model. Looking for finished models to remix instead? Browse the Catalog.';
+  page.appendChild(intro);
+
+  const body = document.createElement('div');
+  body.className = 'w-full max-w-5xl px-6 pb-16';
+  page.appendChild(body);
+
+  // Bucket ideas by category, render the non-empty sections in IDEA_CATEGORIES
+  // order (entry order within a section follows the dataset).
+  const buckets = new Map<string, Idea[]>();
+  for (const idea of IDEAS) {
+    const arr = buckets.get(idea.category);
+    if (arr) arr.push(idea);
+    else buckets.set(idea.category, [idea]);
+  }
+
+  for (const def of IDEA_CATEGORIES) {
+    const ideas = buckets.get(def.id);
+    if (!ideas || ideas.length === 0) continue;
+    body.appendChild(renderCategorySection(def, ideas, callbacks));
+  }
+
+  container.appendChild(page);
+  return page;
+}
+
+function renderCategorySection(def: IdeaCategoryDef, ideas: Idea[], callbacks: IdeasCallbacks): HTMLElement {
+  const section = document.createElement('section');
+  section.className = 'mb-10';
+  section.dataset.category = def.id;
+
+  const titleRow = document.createElement('div');
+  titleRow.className = 'flex items-baseline gap-2';
+  const h2 = document.createElement('h2');
+  h2.className = 'text-lg font-semibold text-zinc-100';
+  h2.textContent = def.title;
+  const count = document.createElement('span');
+  count.className = 'text-xs text-zinc-500 tabular-nums';
+  count.textContent = String(ideas.length);
+  titleRow.appendChild(h2);
+  titleRow.appendChild(count);
+  section.appendChild(titleRow);
+
+  const blurb = document.createElement('p');
+  blurb.className = 'text-xs text-zinc-400 mt-0.5 mb-3 leading-relaxed';
+  blurb.textContent = def.blurb;
+  section.appendChild(blurb);
+
+  const grid = document.createElement('div');
+  grid.className = 'grid gap-4';
+  grid.style.gridTemplateColumns = 'repeat(auto-fill, minmax(240px, 1fr))';
+  for (const idea of ideas) grid.appendChild(renderTile(idea, callbacks));
+  section.appendChild(grid);
+
+  return section;
+}
+
+function renderTile(idea: Idea, callbacks: IdeasCallbacks): HTMLElement {
+  // Card wrapper holds the main clickable button plus an optional footer link.
+  // (A "learn more" <a> can't nest inside the <button>, hence the wrapper.)
+  const card = document.createElement('div');
+  card.className = 'flex flex-col bg-zinc-800 rounded-lg border border-zinc-700 hover:border-zinc-500 transition-colors overflow-hidden';
+  card.dataset.ideaId = idea.id;
+
+  const btn = document.createElement('button');
+  btn.className = 'flex flex-col items-start gap-1.5 text-left px-4 py-3.5 cursor-pointer w-full';
+
+  const top = document.createElement('div');
+  top.className = 'flex items-center gap-2';
+  const emoji = document.createElement('span');
+  emoji.className = 'text-xl leading-none';
+  emoji.textContent = idea.emoji;
+  const name = document.createElement('div');
+  name.className = 'text-sm font-medium text-zinc-100';
+  name.textContent = idea.title;
+  top.appendChild(emoji);
+  top.appendChild(name);
+  btn.appendChild(top);
+
+  const desc = document.createElement('div');
+  desc.className = 'text-[11px] text-zinc-400 leading-snug';
+  desc.textContent = idea.blurb;
+  btn.appendChild(desc);
+
+  // Affordance label so it's obvious what a click does.
+  const cta = document.createElement('div');
+  cta.className = 'text-[10px] font-semibold mt-1';
+  if (idea.category === 'interactive') {
+    cta.classList.add('text-emerald-300');
+    cta.textContent = '\u{1F4F7} Upload a photo →';
+  } else {
+    cta.classList.add('text-blue-300');
+    cta.textContent = '✨ Use this prompt →';
+  }
+  btn.appendChild(cta);
+
+  card.appendChild(btn);
+
+  if (idea.category === 'interactive' && idea.action) {
+    // Hidden file picker per interactive tile.
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.accept = 'image/*';
+    fileInput.className = 'hidden';
+    const action = idea.action;
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files?.[0];
+      fileInput.value = ''; // allow re-picking the same file later
+      if (!file) return;
+      if (action === 'photoToVoxel') void callbacks.onPhotoToVoxel(file);
+      else if (action === 'photoToRelief') void callbacks.onPhotoToRelief(file);
+    });
+    card.appendChild(fileInput);
+    btn.addEventListener('click', () => fileInput.click());
+  } else {
+    btn.addEventListener('click', () => { void callbacks.onUsePrompt(idea); });
+  }
+
+  // Footer: "learn more" deep-link (opens the reference doc in a new tab).
+  if (idea.learnMore) {
+    const footer = document.createElement('div');
+    footer.className = 'px-4 pb-3 -mt-1';
+    const link = document.createElement('a');
+    link.href = idea.learnMore;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.className = 'text-[10px] text-zinc-500 hover:text-zinc-300 underline decoration-dotted';
+    link.textContent = 'Learn how it works →';
+    footer.appendChild(link);
+    card.appendChild(footer);
+  }
+
+  return card;
+}

--- a/src/ui/landing.ts
+++ b/src/ui/landing.ts
@@ -24,6 +24,7 @@ export interface LandingCallbacks {
   onOpenEditor: () => void;
   onOpenHelp: () => void;
   onOpenCatalog: () => void;
+  onOpenIdeas: () => void;
   onOpenWhatsNew: () => void;
   /** Open the editor and launch the first-visit guided tour. */
   onTakeTour: () => void;
@@ -112,6 +113,7 @@ function buildNav(callbacks: LandingCallbacks): HTMLElement {
   const links = document.createElement('nav');
   links.className = 'hidden md:flex items-center gap-7 text-sm text-zinc-400';
   const navItems: { label: string; onClick: () => void }[] = [
+    { label: 'Ideas', onClick: callbacks.onOpenIdeas },
     { label: 'Catalog', onClick: callbacks.onOpenCatalog },
     { label: 'How it works', onClick: callbacks.onOpenHelp },
     { label: 'For AI agents', onClick: scrollToAgentSection },

--- a/tests/ideas.spec.ts
+++ b/tests/ideas.spec.ts
@@ -1,0 +1,72 @@
+// The /ideas page is a discovery surface: category sections of starter
+// prompts, technique showcases, and interactive "use your own photo" flows.
+// Picking a starter prompt lands the user in the editor with the prompt
+// pre-filled in the AI panel (populate, don't send). This drives the real
+// page + routing against the static IDEAS dataset.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function gotoIdeas(page: Page) {
+  await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  await page.goto('/ideas');
+  await page.waitForSelector('#ideas-page section[data-category]', { timeout: 20_000 });
+}
+
+test.describe('Ideas page', () => {
+  test('renders category sections in order, each with a count, blurb, and tiles', async ({ page }) => {
+    await gotoIdeas(page);
+
+    const sections = page.locator('#ideas-page section[data-category]');
+    await expect(sections).toHaveCount(3);
+
+    const ids = await sections.evaluateAll((els) => els.map((e) => (e as HTMLElement).dataset.category));
+    expect(ids).toEqual(['interactive', 'starter', 'technique']);
+
+    const count = await sections.count();
+    for (let i = 0; i < count; i++) {
+      const sec = sections.nth(i);
+      await expect(sec.locator('h2')).toBeVisible();
+      await expect(sec.locator('h2 + span')).toHaveText(/^\d+$/);
+      await expect(sec.locator('p')).not.toBeEmpty();
+      expect(await sec.locator('div.grid > div').count()).toBeGreaterThan(0);
+    }
+  });
+
+  test('interactive tiles carry a hidden image file input', async ({ page }) => {
+    await gotoIdeas(page);
+    const interactive = page.locator('#ideas-page section[data-category="interactive"]');
+    const fileInputs = interactive.locator('input[type="file"]');
+    expect(await fileInputs.count()).toBeGreaterThan(0);
+    await expect(fileInputs.first()).toHaveAttribute('accept', 'image/*');
+  });
+
+  test('clicking a starter prompt opens the editor with the prompt pre-filled (not sent)', async ({ page }) => {
+    await gotoIdeas(page);
+    const starter = page.locator('#ideas-page section[data-category="starter"] div.grid > div button').first();
+    await expect(starter).toBeEnabled();
+    await starter.click();
+
+    await expect(page).toHaveURL(/\/editor/, { timeout: 20_000 });
+
+    // The AI panel opens and its input carries the chosen prompt — and the
+    // transcript shows no sent user message (populate, don't send).
+    const input = page.locator('#ai-panel textarea');
+    await expect(input).toBeVisible({ timeout: 20_000 });
+    await expect(input).not.toHaveValue('', { timeout: 20_000 });
+  });
+
+  test('the prompt library button in the AI panel lists example prompts', async ({ page }) => {
+    await gotoIdeas(page);
+    // Get into the editor first (any starter does it).
+    await page.locator('#ideas-page section[data-category="starter"] div.grid > div button').first().click();
+    await expect(page).toHaveURL(/\/editor/, { timeout: 20_000 });
+    await expect(page.locator('#ai-panel')).toBeVisible({ timeout: 20_000 });
+
+    // The 💡 prompt-library button opens a modal of prompts.
+    await page.locator('#ai-panel button[title^="Prompt library"]').click();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Prompt library');
+    expect(await dialog.locator('button').count()).toBeGreaterThan(1);
+  });
+});

--- a/tests/unit/ideas.test.ts
+++ b/tests/unit/ideas.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from 'vitest';
+import {
+  IDEAS,
+  IDEA_CATEGORIES,
+  filterIdeas,
+  promptIdeas,
+  starterChipIdeas,
+  type Idea,
+} from '../../src/ideas/ideas';
+
+// The Ideas dataset feeds both the /ideas gallery and the in-pane prompt
+// library. These tests lock the data invariants the UI relies on (ids unique,
+// prompts/actions present per category) and the pure search/selection helpers.
+
+describe('IDEAS dataset', () => {
+  test('every idea has a unique id', () => {
+    const ids = IDEAS.map((i) => i.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('each category in IDEA_CATEGORIES has at least one idea', () => {
+    for (const cat of IDEA_CATEGORIES) {
+      expect(IDEAS.some((i) => i.category === cat.id), `category ${cat.id} should be non-empty`).toBe(true);
+    }
+  });
+
+  test('starter and technique ideas carry a non-empty prompt', () => {
+    for (const idea of IDEAS.filter((i) => i.category === 'starter' || i.category === 'technique')) {
+      expect(typeof idea.prompt, `${idea.id} prompt`).toBe('string');
+      expect((idea.prompt ?? '').length, `${idea.id} prompt`).toBeGreaterThan(0);
+    }
+  });
+
+  test('interactive ideas declare a known action and carry no prompt', () => {
+    const knownActions = new Set(['photoToVoxel', 'photoToRelief']);
+    for (const idea of IDEAS.filter((i) => i.category === 'interactive')) {
+      expect(idea.prompt, `${idea.id} should not have a prompt`).toBeUndefined();
+      expect(idea.action, `${idea.id} action`).toBeDefined();
+      expect(knownActions.has(idea.action!), `${idea.id} action ${idea.action}`).toBe(true);
+    }
+  });
+
+  test('learnMore links are root-relative paths', () => {
+    for (const idea of IDEAS) {
+      if (idea.learnMore !== undefined) {
+        expect(idea.learnMore.startsWith('/'), `${idea.id} learnMore`).toBe(true);
+      }
+    }
+  });
+});
+
+describe('filterIdeas', () => {
+  const sample: Idea[] = [
+    { id: 'a', title: 'Coffee mug', blurb: 'a drinking vessel', category: 'starter', emoji: '☕', tags: ['kitchen'], prompt: 'make a mug' },
+    { id: 'b', title: 'Spur gear', blurb: 'mechanical part', category: 'technique', emoji: '⚙', tags: ['openscad', 'bosl2'], prompt: 'make a gear' },
+  ];
+
+  test('a blank query returns the list unchanged', () => {
+    expect(filterIdeas(sample, '')).toEqual(sample);
+    expect(filterIdeas(sample, '   ')).toEqual(sample);
+  });
+
+  test('matches title, case-insensitively', () => {
+    expect(filterIdeas(sample, 'COFFEE').map((i) => i.id)).toEqual(['a']);
+  });
+
+  test('matches a tag', () => {
+    expect(filterIdeas(sample, 'bosl2').map((i) => i.id)).toEqual(['b']);
+  });
+
+  test('matches blurb and prompt text', () => {
+    expect(filterIdeas(sample, 'vessel').map((i) => i.id)).toEqual(['a']);
+    expect(filterIdeas(sample, 'make a gear').map((i) => i.id)).toEqual(['b']);
+  });
+
+  test('a no-match query returns empty', () => {
+    expect(filterIdeas(sample, 'zzzznope')).toEqual([]);
+  });
+});
+
+describe('promptIdeas / starterChipIdeas', () => {
+  test('promptIdeas excludes interactive (prompt-less) ideas', () => {
+    const withPrompts = promptIdeas();
+    expect(withPrompts.length).toBeGreaterThan(0);
+    expect(withPrompts.every((i) => typeof i.prompt === 'string' && i.prompt.length > 0)).toBe(true);
+    expect(withPrompts.some((i) => i.category === 'interactive')).toBe(false);
+  });
+
+  test('starterChipIdeas returns only starters, capped at the limit', () => {
+    const chips = starterChipIdeas(3);
+    expect(chips.length).toBeLessThanOrEqual(3);
+    expect(chips.every((i) => i.category === 'starter')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a discovery layer that helps people understand what Partwright + AI can do — the gap the catalog doesn't fill. The catalog shows *finished things*; **Ideas** shows *what you could ask for* and gets you started. Both new surfaces are powered by a single shared dataset, `src/ideas/ideas.ts`.

### What's in it

1. **`/ideas` gallery page** (`src/ui/ideasPage.ts`) — mirrors the catalog's structure (theme toggle, back header, category sections, tile grid). Three sections:
   - **Interactive** — "use your own photo" flows (see below)
   - **Starter prompts** — ready-made prompts for common parts (mug, phone stand, snap-fit box, keychain, Gridfinity bin, keycap)
   - **Technique showcases** — capabilities people won't discover on their own (parametric customizer, SDF gyroid, true BREP fillets, voxel pixel-art, lofted vase, OpenSCAD gear), each with a "Learn how it works →" deep-link into the relevant `public/ai/*.md`.

2. **In-pane prompt library** (`src/ui/aiPromptLibraryModal.tsx`) — a 💡 button in the AI panel header opens a searchable list of prompts. The AI panel's **empty state** now shows tappable starter-prompt chips + a "More ideas…" link, so a user staring at a blank input has somewhere to start.

3. **Populate, don't send** — picking a starter/technique idea drops its prompt into the AI input via a new exported `prefillAiInput()` and focuses it; the user reads/tweaks before sending. This is the pedagogical point — people learn what to ask by editing real prompts.

4. **The flagship: "turn your photo into you"** — the two interactive ideas reuse mature existing flows rather than inventing parallel ones:
   - **Voxel portrait** → the existing image→voxel import (`handleImageImport`), so the user gets the full tuning modal (billboard/heightmap, posterize, …).
   - **Smooth relief** → the existing Relief import wizard (`openReliefImportFlow`). Framed honestly as a lithophane-style relief — a true organic photo→SDF reconstruction doesn't exist yet, so we don't pretend it does.

5. **Wiring** — `/ideas` route in `main.ts` (mirrors `/catalog`: `shouldShowIdeas`, `showIdeasPage`, history/back handling, AI-session reset), an "Open ideas" command-palette entry, an **Ideas** link in the landing nav, a reciprocal "Looking for ideas to try? →" link on `/catalog`, and `/ideas` added to SEO routes (`src/seo/meta.ts`) + the sitemap.

### Why a separate dataset (not the catalog manifest)?
An "idea" is a *prompt* (plus, for interactive ideas, a built-in action) — not a finished `.partwright.json` session. It's inlined as a typed TS constant (no network fetch, directly unit-testable) and imported by both the page and the modal, so the two surfaces never drift.

## Test plan
- [x] `npm run build` — clean (no TS errors)
- [x] `npm run test:unit` — 522 passed, incl. new `tests/unit/ideas.test.ts` (dataset invariants + pure `filterIdeas`/`promptIdeas`/`starterChipIdeas` helpers) and the updated sitemap test
- [x] `tests/ideas.spec.ts` (new e2e) — sections render in order; interactive tiles carry a hidden `image/*` file input; clicking a starter prompt opens the editor with the prompt pre-filled (not sent); the 💡 prompt-library modal lists prompts
- [x] `tests/catalog.spec.ts` + `tests/smoke.spec.ts` — still green (catalog cross-link + AI panel changes don't regress)

Let CI run the full sharded e2e suite on the draft.

https://claude.ai/code/session_01V1exhjJR7YLGJ4UsjbfmEJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1exhjJR7YLGJ4UsjbfmEJ)_