### PR TITLE
fix: address voxel workflow friction — stale geometry, patch whitespace, enclosed component warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "partwright-cad",
       "version": "0.0.0",
+      "license": "LicenseRef-PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
         "@codemirror/lang-javascript": "^6.2.5",

--- a/public/ai.md
+++ b/public/ai.md
@@ -151,6 +151,9 @@ The main reference splits into focused subdocs. **Fetch each by calling `readDoc
 - **Passing a bare index or id instead of `{index}` / `{id}`** -- `loadVersion` and `forkVersion` take an object with exactly one of `{index: number}` or `{id: string}`, e.g. `loadVersion({index: 2})` or `loadVersion({id: "Kx3Pq9mA2wEr"})`. Bare `loadVersion(2)` will return `{error: "...target must be { index: number } or { id: string }..."}`.
 - **Passing the wrong object shape to `setImages`, `setReferenceGeometry`, `query`, `runAndAssert`, etc.** -- the API rejects unknown keys and wrong-type values. See [Argument validation](#argument-validation).
 - **Doing `setCode` then `run` when you meant `runAndSave`.** `setCode` doesn't auto-run, `run` doesn't save and doesn't validate, and the gallery won't see the version. `runAndSave(code, label, assertions)` does all three atomically -- prefer it for committed iterations. See also [`runAndSave` is for committed iterations; `runIsolated` is for sanity checks](#runandsave-is-for-committed-iterations-runisolated-is-for-sanity-checks).
+- **Passing a short stub to `runAndSave` intending to "save current state".** `runAndSave(code, ...)` is **authoritative**: it overwrites the editor with `code`, runs it, and saves the result. Passing anything other than the full intended code will replace the editor and save a broken version. To snapshot the editor as-is (e.g. after painting), call `saveVersion(label?)` instead — it captures the current code + geometry + colors without re-running.
+- **Querying stale geometry after `setCode`.** `setCode` updates the editor but does NOT re-run. Calling `getGeometryData()` or `query()` after `setCode` (without a subsequent `runAndSave`/`run`) returns the geometry from the previous execution. The result now includes `stale: true` when the editor code hash doesn't match the last-run hash — treat this as a signal to run first.
+- **No "fork from current editor" path.** `forkVersion({index}, ...)` forks a *saved* version. If your best code is unsaved in the editor, first call `await saveVersion("checkpoint")` to commit it as a version, then `forkVersion({index: <that index>}, ...)` from there. `listVersions()` shows the new index.
 
 ## Argument validation
 
@@ -374,12 +377,18 @@ await partwright.getSessionContext()     // -> {session, versions[], notes[], cu
 }
 ```
 
+Extra fields that appear conditionally:
+- **`containedComponents: N`** — present when N components are fully enclosed inside another solid (e.g. sealed interior voids in a voxel shell). These are excluded from `maxComponents` assertion checks and from the floater warning, since they can't detach in print. Use `runAndExplain(code)` to inspect them individually.
+- **`stale: true`** — present when the editor code has changed since the last execution (e.g. `setCode` was called without a subsequent run). Stats reflect the *previous* run. Call `runAndSave`/`run` before relying on component counts or other metrics.
+- **`warnings: string[]`** — present when the geometry has printability issues (non-manifold, free-floating components, etc.).
+
 On error: `{"status":"error","error":"...","executionTimeMs":2,"codeHash":"..."}`
 
 ### Common errors
 - `Code must return a Manifold object` -- forgot `return` statement
 - `function _Cylinder called with N arguments` -- wrong arg count
 - Geometry looks wrong -- check `isManifold` and `componentCount` (failed booleans = extra components)
+- `componentCount > 1` with `containedComponents` present -- the extra components are sealed interior voids, not true floaters. No fix needed for printing; use `runAndExplain` if you need to inspect them.
 
 ## Writing model code (manifold-js)
 

--- a/src/ai/patch.ts
+++ b/src/ai/patch.ts
@@ -21,10 +21,38 @@ export function truncateForError(s: string, max = 80): string {
   return oneLine.length > max ? `${oneLine.slice(0, max)}…` : oneLine;
 }
 
+/** Escape regex special characters in a string literal. */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Try matching `find` against `code` using whitespace-normalized matching.
+ *  Builds a regex from the find string's non-whitespace tokens separated by
+ *  \s+, so code that was auto-reformatted (e.g. a multi-line declaration
+ *  collapsed to one line) still matches. Returns the patched code on a unique
+ *  match, null if there are zero or multiple matches. */
+function tryWhitespaceFallback(code: string, find: string, replace: string): string | null {
+  const tokens = find.split(/\s+/).filter(t => t.length > 0);
+  if (tokens.length === 0) return null;
+  const pattern = tokens.map(escapeRegex).join('\\s+');
+  const regex = new RegExp(pattern, 'g');
+  const matches = [...code.matchAll(regex)];
+  if (matches.length !== 1) return null;
+  const m = matches[0];
+  return code.slice(0, m.index) + replace + code.slice(m.index! + m[0].length);
+}
+
 /** Apply ONE literal find/replace, requiring `find` to occur exactly once.
  *  Throws on a missing or ambiguous match. Replacement goes through
  *  split/join so `$`-sequences in `replace` are treated literally (unlike
- *  String.replace, which interprets `$&`, `$1`, etc.). */
+ *  String.replace, which interprets `$&`, `$1`, etc.).
+ *
+ *  When an exact match fails, falls back to whitespace-normalized matching —
+ *  the auto-formatter may reflow whitespace (e.g. expand/collapse multi-line
+ *  declarations) so a find string copied from one render of the code fails
+ *  against the reformatted version. The fallback matches if the tokens match
+ *  in order with any whitespace between them, and it applies only when the
+ *  match is unambiguous (exactly one occurrence). */
 export function applyLiteralPatch(code: string, find: unknown, replace: unknown, idx?: number): string {
   const where = idx === undefined ? 'patch' : `patches[${idx}]`;
   if (typeof find !== 'string' || find.length === 0) {
@@ -35,6 +63,9 @@ export function applyLiteralPatch(code: string, find: unknown, replace: unknown,
   }
   const occurrences = code.split(find).length - 1;
   if (occurrences === 0) {
+    // Exact match failed — try whitespace-normalized fallback before erroring
+    const fallback = tryWhitespaceFallback(code, find, replace);
+    if (fallback !== null) return fallback;
     throw new Error(`${where} find string not present in the code — nothing was changed. Read the current code and match the exact text including whitespace: "${truncateForError(find)}"`);
   }
   if (occurrences > 1) {

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -144,7 +144,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'getGeometryData',
-    description: 'Read the current geometry stats (volume, surfaceArea, vertexCount, triangleCount, isManifold, componentCount, boundingBox). Cheap — no re-execution.',
+    description: 'Read the current geometry stats (volume, surfaceArea, vertexCount, triangleCount, isManifold, componentCount, boundingBox). Cheap — no re-execution. Returns `stale: true` when the editor code changed since the last run (setCode without a subsequent run) — call runAndSave/run first if you need fresh stats. Returns `containedComponents: N` when N components are fully enclosed inside another solid and excluded from the floater check.',
     input_schema: { type: 'object', properties: {} },
   },
   {
@@ -623,7 +623,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'forkVersion',
-    description: 'Fork a prior version: load version N, apply new code or patches, validate against optional assertions, and save as a new version — all atomically. Use this to branch off a known-good version without the fragile loadVersion → getCode → modify → runAndSave chain. Provide either `code` (full replacement) or `patches` (find/replace array applied to the parent\'s code — more concise when only a few values change). Each patch\'s `find` MUST occur exactly once in the parent code; a find that matches zero or multiple times is an ERROR (the fork is rejected, not silently saved unchanged), so read the parent code first and copy the exact text including whitespace. Color regions on the parent are re-applied to the forked geometry automatically (each region\'s descriptor is re-resolved against the new mesh) unless you pass `carryColors: false` — no need to repaint after a geometry tweak. Returns {parent, version, geometry, diff (geometry stats), codeDiff (what actually changed in the source — verify your patch landed here), colors: {carried, dropped}, galleryUrl} on success, or {error} / {passed: false, failures} on failure.',
+    description: 'Fork a prior version: load version N, apply new code or patches, validate against optional assertions, and save as a new version — all atomically. Use this to branch off a known-good version without the fragile loadVersion → getCode → modify → runAndSave chain. Provide either `code` (full replacement) or `patches` (find/replace array applied to the parent\'s code — more concise when only a few values change). Each patch\'s `find` MUST occur exactly once in the parent code; a find that matches zero or multiple times is an ERROR (the fork is rejected, not silently saved unchanged), so read the parent code first and copy the exact text including whitespace. Patch matching is whitespace-flexible — if the exact text is not found, a whitespace-normalized match is tried automatically (handles auto-reformatted code). Color regions on the parent are re-applied to the forked geometry automatically (each region\'s descriptor is re-resolved against the new mesh) unless you pass `carryColors: false` — no need to repaint after a geometry tweak. To fork from unsaved editor code: call `saveVersion("checkpoint")` first to commit it, then `forkVersion({index: <that index>}, ...)`. Returns {parent, version, geometry, diff (geometry stats), codeDiff (what actually changed in the source — verify your patch landed here), colors: {carried, dropped}, galleryUrl} on success, or {error} / {passed: false, failures} on failure.',
     input_schema: {
       type: 'object',
       properties: {
@@ -734,7 +734,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'query',
-    description: 'Multi-query the current geometry in one call. Pass any combination of sliceAt (cross-section areas at given Z heights), decompose (component breakdown), boundingBox. Returns only the keys you asked for. Cheaper than separate calls.',
+    description: 'Multi-query the current geometry in one call. Pass any combination of sliceAt (cross-section areas at given Z heights), decompose (component breakdown), boundingBox. Returns only the keys you asked for. Cheaper than separate calls. Returns `stale: true` in both the top-level result and `stats` when the editor code changed since the last run — geometry reflects the previous execution.',
     input_schema: {
       type: 'object',
       properties: {

--- a/src/geometry/statsComputation.ts
+++ b/src/geometry/statsComputation.ts
@@ -74,10 +74,51 @@ export function computeGeometryStats(
     : null;
 
   let componentCount = 1;
+  let containedComponents = 0;
   if (manifold) {
     try {
       const parts = manifold.decompose();
       componentCount = parts.length;
+      if (parts.length > 1) {
+        // Identify enclosed components (fully inside another solid, or negative-volume
+        // artifacts). These won't detach in print and shouldn't trip floater warnings.
+        // Capped at 20 to bound intersection-check cost on large voxel models.
+        const LIMIT = Math.min(parts.length, 20);
+        interface PartInfo { vol: number; bb: { min: number[]; max: number[] } | null; m: Manifold }
+        const infos: PartInfo[] = [];
+        for (let i = 0; i < LIMIT; i++) {
+          const p = parts[i];
+          const bb = getBoundingBox(p);
+          const vol = (() => { try { return p.volume() as number; } catch { return 0; } })();
+          infos.push({ vol, bb, m: p });
+        }
+        for (let j = 0; j < infos.length; j++) {
+          const smaller = infos[j];
+          if (smaller.vol <= 0) { containedComponents++; continue; }
+          for (let i = 0; i < infos.length; i++) {
+            if (i === j) continue;
+            const larger = infos[i];
+            if (larger.vol <= smaller.vol || !larger.bb || !smaller.bb) continue;
+            // Fast bbox filter: smaller must fit inside larger's bbox
+            let inside = true;
+            for (let ax = 0; ax < 3 && inside; ax++) {
+              if (smaller.bb.min[ax] < larger.bb.min[ax] - 0.01 ||
+                  smaller.bb.max[ax] > larger.bb.max[ax] + 0.01) inside = false;
+            }
+            if (!inside) continue;
+            // Precise check: intersection volume ≈ smaller's volume → fully enclosed
+            try {
+              const ix = larger.m.intersect(smaller.m);
+              const ixVol = ix.volume() as number;
+              ix.delete();
+              if (Math.abs(ixVol - smaller.vol) <= smaller.vol * 0.05) {
+                containedComponents++;
+                break;
+              }
+            } catch { /* ignore — boolean failed, skip this pair */ }
+          }
+        }
+      }
       for (const p of parts) p.delete();
     } catch {
       // fallback
@@ -135,6 +176,7 @@ export function computeGeometryStats(
     isManifold,
     ...(manifoldStatus ? { manifoldStatus } : {}),
     componentCount,
+    ...(containedComponents > 0 ? { containedComponents } : {}),
     crossSections: quartileSlices,
     unit: getUnits(),
     executionTimeMs: executionTimeMs ?? null,
@@ -209,8 +251,15 @@ export function checkAssertions(stats: Record<string, unknown>, assertions: Geom
     failures.push(`volume ${v.toFixed(1)} > maxVolume ${assertions.maxVolume}`);
   if (assertions.isManifold !== undefined && im !== assertions.isManifold)
     failures.push(`isManifold is ${im}, expected ${assertions.isManifold}`);
-  if (assertions.maxComponents !== undefined && cc > assertions.maxComponents)
-    failures.push(`componentCount ${cc} > maxComponents ${assertions.maxComponents}`);
+  if (assertions.maxComponents !== undefined) {
+    const enclosed = (stats.containedComponents as number | undefined) ?? 0;
+    const freeFloating = cc - enclosed;
+    if (freeFloating > assertions.maxComponents)
+      failures.push(
+        `componentCount ${cc} > maxComponents ${assertions.maxComponents}` +
+        (enclosed > 0 ? ` (${enclosed} fully-enclosed interior component${enclosed > 1 ? 's' : ''} excluded from check)` : ''),
+      );
+  }
   if (assertions.genus !== undefined && g !== assertions.genus)
     failures.push(`genus ${g} !== expected ${assertions.genus}`);
   if (assertions.minGenus !== undefined && (g === null || g < assertions.minGenus))

--- a/src/geometry/statsComputation.ts
+++ b/src/geometry/statsComputation.ts
@@ -82,16 +82,15 @@ export function computeGeometryStats(
       if (parts.length > 1) {
         // Identify enclosed components (fully inside another solid, or negative-volume
         // artifacts). These won't detach in print and shouldn't trip floater warnings.
-        // Capped at 20 to bound intersection-check cost on large voxel models.
-        const LIMIT = Math.min(parts.length, 20);
+        // The two fast pre-filters (volume comparison + bbox containment) reject the
+        // vast majority of pairs cheaply, so the expensive WASM intersect() call is
+        // only reached for plausible containment candidates — safe without a count cap.
         interface PartInfo { vol: number; bb: { min: number[]; max: number[] } | null; m: Manifold }
-        const infos: PartInfo[] = [];
-        for (let i = 0; i < LIMIT; i++) {
-          const p = parts[i];
+        const infos: PartInfo[] = parts.map((p: Manifold) => {
           const bb = getBoundingBox(p);
           const vol = (() => { try { return p.volume() as number; } catch { return 0; } })();
-          infos.push({ vol, bb, m: p });
-        }
+          return { vol, bb, m: p };
+        });
         for (let j = 0; j < infos.length; j++) {
           const smaller = infos[j];
           if (smaller.vol <= 0) { containedComponents++; continue; }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4885,9 +4885,17 @@ async function main() {
 
     /** Get current geometry stats without re-running */
     getGeometryData(): Record<string, unknown> {
-      const geo = JSON.parse(geometryDataEl.textContent || '{}');
+      const geo = JSON.parse(geometryDataEl.textContent || '{}') as Record<string, unknown>;
       const warnings = geometryWarnings(geo);
-      return warnings.length > 0 ? { ...geo, warnings } : geo;
+      // Flag stale results: setCode() doesn't re-run, so the cached geometry may
+      // reflect a previous version of the code. Callers should run or runAndSave
+      // before relying on component counts or other stats.
+      const stale = typeof geo.codeHash === 'string' && simpleHash(getValue()) !== geo.codeHash;
+      return {
+        ...geo,
+        ...(stale ? { stale: true } : {}),
+        ...(warnings.length > 0 ? { warnings } : {}),
+      };
     },
 
     /** Get current editor code */
@@ -6823,8 +6831,13 @@ async function main() {
         } catch { /* ignore */ }
       }
 
-      // Include current stats for convenience
-      result.stats = JSON.parse(geometryDataEl.textContent || '{}');
+      // Include current stats for convenience, with a stale flag when the editor
+      // code doesn't match the last-executed code (setCode was called without run).
+      const rawStats = JSON.parse(geometryDataEl.textContent || '{}') as Record<string, unknown>;
+      const stale = typeof rawStats.codeHash === 'string' && simpleHash(getValue()) !== rawStats.codeHash;
+      if (stale) rawStats.stale = true;
+      result.stats = rawStats;
+      if (stale) result.stale = true;
 
       return result;
     },
@@ -9809,27 +9822,41 @@ async function main() {
     }
     if (typeof geo.componentCount === 'number' && geo.componentCount > 1) {
       const cc = geo.componentCount;
-      // Partwright exists to produce printable parts, so a multi-component
-      // result is almost always a failed union rather than a deliberate
-      // assembly. Frame it as a print defect and point at the exact tool that
-      // diagnoses it, instead of inviting the model to shrug it off.
-      let msg =
-        `componentCount: ${cc} — the model is ${cc} disconnected solids. ` +
-        `For 3D printing that means ${cc} separate pieces: any part not connected ` +
-        `to the main body floats free and will detach (or print in mid-air). ` +
-        `Unless you deliberately intend a multi-part assembly, the pieces must ` +
-        `volumetrically OVERLAP by ≥ 0.5 units to fuse into one solid — a shared ` +
-        `face or a point/edge touch is NOT enough.`;
-      msg += isBrep
-        ? ' In BREP this bites often: OCCT leaves non-overlapping or thinly-touching ' +
-          'shapes as a disconnected compound even after fuse / fuseAll (e.g. a thin ' +
-          'annular sliver of overlap frequently fails to bond). Call ' +
-          'runAndExplain(code) to list every component with a per-floater overlap ' +
-          'suggestion, then seat the piece a few units deeper into its neighbour and ' +
-          're-run until componentCount is 1.'
-        : ' Call runAndExplain(code) to see which pieces are disconnected and get a ' +
-          'concrete .translate() overlap suggestion for each floater.';
-      warnings.push(msg);
+      const enclosed = typeof geo.containedComponents === 'number' ? geo.containedComponents : 0;
+      const floating = cc - enclosed;
+      // Only warn about true floaters — fully-enclosed interior components (e.g.
+      // sealed voids inside voxel shells) won't detach in print and shouldn't
+      // block a single-piece assertion.
+      if (floating > 1) {
+        // Partwright exists to produce printable parts, so a multi-component
+        // result is almost always a failed union rather than a deliberate
+        // assembly. Frame it as a print defect and point at the exact tool that
+        // diagnoses it, instead of inviting the model to shrug it off.
+        let msg =
+          `componentCount: ${cc}${enclosed > 0 ? ` (${enclosed} enclosed interior void${enclosed > 1 ? 's' : ''} excluded)` : ''} — ` +
+          `the model has ${floating} disconnected solid${floating > 1 ? 's' : ''}. ` +
+          `For 3D printing that means ${floating} separate piece${floating > 1 ? 's' : ''}: any part not connected ` +
+          `to the main body floats free and will detach (or print in mid-air). ` +
+          `Unless you deliberately intend a multi-part assembly, the pieces must ` +
+          `volumetrically OVERLAP by ≥ 0.5 units to fuse into one solid — a shared ` +
+          `face or a point/edge touch is NOT enough.`;
+        msg += isBrep
+          ? ' In BREP this bites often: OCCT leaves non-overlapping or thinly-touching ' +
+            'shapes as a disconnected compound even after fuse / fuseAll (e.g. a thin ' +
+            'annular sliver of overlap frequently fails to bond). Call ' +
+            'runAndExplain(code) to list every component with a per-floater overlap ' +
+            'suggestion, then seat the piece a few units deeper into its neighbour and ' +
+            're-run until componentCount is 1.'
+          : ' Call runAndExplain(code) to see which pieces are disconnected and get a ' +
+            'concrete .translate() overlap suggestion for each floater.';
+        warnings.push(msg);
+      } else if (enclosed > 0) {
+        // All extra components are sealed interior voids — informational only
+        warnings.push(
+          `componentCount: ${cc} — ${enclosed} component${enclosed > 1 ? 's are' : ' is'} a sealed interior void fully enclosed within another solid. ` +
+          `These won't detach in print. Call runAndExplain(code) to inspect each component individually.`,
+        );
+      }
     }
     // Surface color regions that no longer resolve to any triangles on
     // the freshly-run mesh — descriptors are still serialized (so the

--- a/tests/unit/patch.test.ts
+++ b/tests/unit/patch.test.ts
@@ -31,6 +31,26 @@ describe('applyLiteralPatch', () => {
     expect(applyLiteralPatch('cost = PRICE;', 'PRICE', '$5')).toBe('cost = $5;');
     expect(applyLiteralPatch('a = TOKEN;', 'TOKEN', '$&b')).toBe('a = $&b;');
   });
+
+  test('falls back to whitespace-normalized match when exact fails', () => {
+    // Auto-formatter collapsed multi-line declaration to one line; patch find
+    // still has the original whitespace.
+    const code = 'const a = 1, b = 2;';
+    const find = 'const a = 1,\n  b = 2;';
+    expect(applyLiteralPatch(code, find, 'const a = 3, b = 4;')).toBe('const a = 3, b = 4;');
+  });
+
+  test('whitespace fallback still errors when normalized find is absent', () => {
+    expect(() => applyLiteralPatch('const a = 1;', 'const b = 2;', 'const b = 3;'))
+      .toThrow(/not present/);
+  });
+
+  test('whitespace fallback still errors when normalized find is ambiguous', () => {
+    // Two occurrences even after normalization
+    const code = 'const x = 1;\nconst x = 1;';
+    expect(() => applyLiteralPatch(code, 'const\nx = 1;', 'const x = 2;'))
+      .toThrow(/not present|matches \d+ places/);
+  });
 });
 
 describe('applyPatches', () => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Addresses four concrete issues from a voxel-session bug report. All changes are in the AI-facing tooling layer; no UI or engine changes.

- **Issue 2 — Stale geometry after `setCode`**: `getGeometryData()` and `query()` now include `stale: true` when the editor code has changed since the last run. Previously, calling `setCode(newCode)` then `query({decompose: true})` silently returned stats for the old code, causing wrong component counts and misdirected debugging.

- **Issue 3 — Brittle patch matching on reformatted code**: `applyLiteralPatch()` now falls back to whitespace-normalized matching when exact matching fails. Builds a regex from the find string's tokens (separated by `\s+`), so auto-formatter rewrites (collapsing/expanding multi-line declarations) no longer cause spurious "find string not present" errors. The fallback only applies when the normalized match is unambiguous.

- **Issue 5 — Enclosed interior voids counted as floaters**: `computeGeometryStats()` now detects components fully enclosed inside another solid (e.g. sealed voxel-shell interiors). A new `containedComponents: N` field is added to stats when N > 0. The `maxComponents` assertion and the "floats free and will detach" warning both exclude these enclosed components — a hollow voxel model with sealed interior cavities no longer fails a `{maxComponents: 1}` assertion or triggers a false alarm.

- **Issues 1 & 4 — Documentation**: Added anti-patterns to `ai.md` clarifying that `runAndSave(code)` is authoritative (overwrites the editor), `saveVersion()` snapshots current state without re-running, the new `stale`/`containedComponents` fields, and the `saveVersion()` → `forkVersion({index})` pattern for forking unsaved editor code.

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] `npm run test:unit` passes — 513 tests including 3 new patch whitespace-fallback tests
- [ ] CI e2e shards pass
- [ ] Verify: after `setCode(newCode)`, `getGeometryData()` returns `stale: true`; after `runAndSave(...)` it does not
- [ ] Verify: a patch find with different whitespace from the editor succeeds silently
- [ ] Verify: a voxel model with sealed interior cavities does not fail `{maxComponents: 1}` assertion and shows `containedComponents` in stats

https://claude.ai/code/session_012X48stkT5VJ6rJ9Kycs2Lk
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012X48stkT5VJ6rJ9Kycs2Lk)_