### PR TITLE
feat: add remove background, double-sided, and mirror options to relief/keychain import

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1888,6 +1888,8 @@ async function main() {
       paintingMode: q.paintingMode === 'multi-color' ? 'multi-color' : 'single-nozzle',
       invertHeights: !!q.invertHeights,
       manualBackground: q.manualBackground,
+      doubleSided: !!q.doubleSided,
+      backMirror: q.backMirror !== false,
     };
   }
 
@@ -1900,6 +1902,7 @@ async function main() {
       maxHeight: Math.max(0.1, Math.min(100, num(c.maxHeight, 3))),
       resolution: Math.max(8, Math.min(512, Math.floor(num(c.resolution, 200)))),
       smoothing: Math.max(0, Math.min(20, num(c.smoothing, 0))),
+      removeBackground: !!c.removeBackground,
     };
   }
 

--- a/src/relief/imageToRelief.ts
+++ b/src/relief/imageToRelief.ts
@@ -265,7 +265,7 @@ export function sampleImageToGrid(image: ImageData, opts: ReliefOptions): Height
   if (opts.common.removeBackground) {
     const colorsU8 = new Uint8Array(count * 3);
     for (let i = 0; i < count * 3; i++) colorsU8[i] = clamp255(rgb[i]);
-    const bgMask = detectBackgroundMask(colorsU8, w, h);
+    const bgMask = pickBackgroundMask(colorsU8, image, w, h, cropToPixels(image, opts.crop) ?? undefined);
     for (let i = 0; i < count; i++) {
       if (bgMask[i] === 0) heights[i] = 0;
     }
@@ -682,13 +682,14 @@ export function generateRelief(image: ImageData, opts: ReliefOptions = DEFAULT_R
   // its top face — the keychain workflow. Only applies to quantized mode
   // (luminance is always a heightmap).
   if (opts.mode === 'quantized' && grid.colors && opts.quantized.output !== 'relief') {
-    return buildQuantizedTile(grid, opts);
+    return buildQuantizedTile(grid, opts, image);
   }
 
   // For stepped relief with removeBackground, zero out height for background
   // cells so they print as the base only (no raised colour terrace).
   if (opts.common.removeBackground && opts.mode === 'quantized' && grid.colors) {
-    const bgMask = detectBackgroundMask(grid.colors, grid.width, grid.height);
+    const cropPx = cropToPixels(image, opts.crop) ?? undefined;
+    const bgMask = pickBackgroundMask(grid.colors, image, grid.width, grid.height, cropPx);
     for (let i = 0; i < grid.heights.length; i++) {
       if (bgMask[i] === 0) grid.heights[i] = 0;
     }
@@ -716,7 +717,7 @@ export function generateRelief(image: ImageData, opts: ReliefOptions = DEFAULT_R
 }
 
 /** Build the flat colour-tile result for quantized mode with output !== 'relief'. */
-function buildQuantizedTile(grid: HeightGrid, opts: ReliefOptions): GenerateReliefResult {
+function buildQuantizedTile(grid: HeightGrid, opts: ReliefOptions, sourceImage?: ImageData): GenerateReliefResult {
   const colors = grid.colors!;
   const W = grid.width, H = grid.height;
   const tileOpts: TileOptions = {
@@ -744,7 +745,7 @@ function buildQuantizedTile(grid: HeightGrid, opts: ReliefOptions): GenerateReli
   // background and intersect it with the existing shape mask so background
   // pixels are cut out of even rect/rounded/circle tiles.
   if (opts.common.removeBackground && opts.quantized.output !== 'silhouette') {
-    const fgMask = detectBackgroundMask(colors, W, H);
+    const fgMask = pickBackgroundMask(colors, sourceImage ?? null, W, H);
     const shapeMask = buildCellMask(W, H, tileOpts, shape);
     const combined = new Uint8Array(W * H);
     for (let i = 0; i < W * H; i++) combined[i] = shapeMask[i] & fgMask[i];
@@ -857,6 +858,77 @@ function mapBucketsToRegions(byColor: Map<number, { color: [number, number, numb
     seedRegions.push({ color: bucket.color, triangleIds: bucket.triangleIds, name: `Region ${++i}` });
   }
   return seedRegions;
+}
+
+/**
+ * Downsample the alpha channel of an ImageData to (targetW × targetH) using
+ * the same box-average + Y-flip as downsample() so the result aligns with the
+ * colour grid. Returns null when the image is fully opaque (no cell has mean
+ * alpha < 128), signalling that colour-based detection should be used instead.
+ * Otherwise returns a 0/1 mask: 1 = foreground (alpha ≥ 128), 0 = background.
+ */
+function tryAlphaBasedMask(
+  image: ImageData,
+  targetW: number,
+  targetH: number,
+  cropPx?: { left: number; top: number; right: number; bottom: number },
+): Uint8Array | null {
+  const imgW = image.width, imgH = image.height;
+  const cl = cropPx ? Math.max(0, Math.floor(cropPx.left)) : 0;
+  const ct = cropPx ? Math.max(0, Math.floor(cropPx.top)) : 0;
+  const cr = cropPx ? Math.min(imgW, Math.floor(cropPx.right)) : imgW;
+  const cb = cropPx ? Math.min(imgH, Math.floor(cropPx.bottom)) : imgH;
+  const srcW = Math.max(1, cr - cl), srcH = Math.max(1, cb - ct);
+  const src = image.data;
+  const count = targetW * targetH;
+  const avgAlpha = new Float32Array(count);
+
+  for (let cy = 0; cy < targetH; cy++) {
+    const fcy = targetH - 1 - cy; // Y-flip: grid row 0 = image bottom
+    const y0 = ct + Math.floor((fcy * srcH) / targetH);
+    const y1 = Math.max(y0 + 1, ct + Math.floor(((fcy + 1) * srcH) / targetH));
+    for (let cx = 0; cx < targetW; cx++) {
+      const x0 = cl + Math.floor((cx * srcW) / targetW);
+      const x1 = Math.max(x0 + 1, cl + Math.floor(((cx + 1) * srcW) / targetW));
+      let sum = 0, n = 0;
+      for (let sy = y0; sy < y1; sy++) {
+        for (let sx = x0; sx < x1; sx++) {
+          sum += src[(sy * imgW + sx) * 4 + 3];
+          n++;
+        }
+      }
+      avgAlpha[cy * targetW + cx] = n > 0 ? sum / n : 255;
+    }
+  }
+
+  // Return null (fall through to colour detection) if the image is fully opaque.
+  let hasTransparent = false;
+  for (let i = 0; i < count; i++) {
+    if (avgAlpha[i] < 128) { hasTransparent = true; break; }
+  }
+  if (!hasTransparent) return null;
+
+  const mask = new Uint8Array(count);
+  for (let i = 0; i < count; i++) mask[i] = avgAlpha[i] >= 128 ? 1 : 0;
+  return mask;
+}
+
+/**
+ * Pick the best available background mask: alpha channel (if the image has
+ * transparency), otherwise border-colour detection on the downsampled RGB.
+ */
+function pickBackgroundMask(
+  colors: Uint8Array,
+  image: ImageData | null,
+  w: number,
+  h: number,
+  cropPx?: { left: number; top: number; right: number; bottom: number },
+): Uint8Array {
+  if (image) {
+    const alphaMask = tryAlphaBasedMask(image, w, h, cropPx);
+    if (alphaMask) return alphaMask;
+  }
+  return detectBackgroundMask(colors, w, h);
 }
 
 /** Approximate background detection: the dominant exact colour on the image

--- a/src/relief/imageToRelief.ts
+++ b/src/relief/imageToRelief.ts
@@ -60,7 +60,7 @@ export function preprocessRgb(rgb: Float32Array, w: number, h: number, p: Prepro
     rgb[o + 2] = b < 0 ? 0 : b > 255 ? 255 : b;
   }
 }
-import { buildTileMesh, type TileOptions, type TileShape } from './tileMesh';
+import { buildTileMesh, buildCellMask, type TileOptions, type TileShape } from './tileMesh';
 import { parseSvgToTile } from '../import/parsers/svg';
 
 const LUMA_R = 0.2126;
@@ -259,6 +259,16 @@ export function sampleImageToGrid(image: ImageData, opts: ReliefOptions): Height
     if (invert) l = 1 - l;
     if (g !== 1) l = Math.pow(l, g);
     heights[i] = quantizeHeight(l * maxHeight, levels, maxHeight);
+  }
+
+  // Zero out background cells so they print as base only.
+  if (opts.common.removeBackground) {
+    const colorsU8 = new Uint8Array(count * 3);
+    for (let i = 0; i < count * 3; i++) colorsU8[i] = clamp255(rgb[i]);
+    const bgMask = detectBackgroundMask(colorsU8, w, h);
+    for (let i = 0; i < count; i++) {
+      if (bgMask[i] === 0) heights[i] = 0;
+    }
   }
 
   return { width: w, height: h, heights };
@@ -675,6 +685,15 @@ export function generateRelief(image: ImageData, opts: ReliefOptions = DEFAULT_R
     return buildQuantizedTile(grid, opts);
   }
 
+  // For stepped relief with removeBackground, zero out height for background
+  // cells so they print as the base only (no raised colour terrace).
+  if (opts.common.removeBackground && opts.mode === 'quantized' && grid.colors) {
+    const bgMask = detectBackgroundMask(grid.colors, grid.width, grid.height);
+    for (let i = 0; i < grid.heights.length; i++) {
+      if (bgMask[i] === 0) grid.heights[i] = 0;
+    }
+  }
+
   // Stepped relief (both painting modes) uses the continuous height-grid mesh.
   // It is a closed 2-manifold (verified by isEdgeManifold inside
   // buildReliefMesh) so it slices and prints; an earlier experiment that built
@@ -706,7 +725,9 @@ function buildQuantizedTile(grid: HeightGrid, opts: ReliefOptions): GenerateReli
     holes: opts.quantized.holes,
     chamferMm: opts.quantized.chamferMm,
   };
-  const shape: TileShape = opts.quantized.output === 'silhouette'
+
+  // Compute the base shape for the tile.
+  let shape: TileShape = opts.quantized.output === 'silhouette'
     ? {
         kind: 'mask',
         mask: opts.quantized.manualBackground
@@ -718,8 +739,28 @@ function buildQuantizedTile(grid: HeightGrid, opts: ReliefOptions): GenerateReli
       : opts.quantized.shape === 'circle'
         ? { kind: 'circle' }
         : { kind: 'rect' };
-  const { mesh, cellTriIds } = buildTileMesh(W, H, tileOpts, shape);
+
+  // When removeBackground is on for a non-silhouette tile, detect the
+  // background and intersect it with the existing shape mask so background
+  // pixels are cut out of even rect/rounded/circle tiles.
+  if (opts.common.removeBackground && opts.quantized.output !== 'silhouette') {
+    const fgMask = detectBackgroundMask(colors, W, H);
+    const shapeMask = buildCellMask(W, H, tileOpts, shape);
+    const combined = new Uint8Array(W * H);
+    for (let i = 0; i < W * H; i++) combined[i] = shapeMask[i] & fgMask[i];
+    shape = { kind: 'mask', mask: combined };
+  }
+
+  const { mesh, cellTriIds, cellTriIdsBottom } = buildTileMesh(W, H, tileOpts, shape);
   const seedRegions = seedRegionsFromCellGrid(colors, cellTriIds, W, H);
+
+  // Double-sided: paint the bottom face too, using mirrored or same colors.
+  if (opts.quantized.doubleSided && opts.quantized.output === 'flat') {
+    const mirror = opts.quantized.backMirror !== false;
+    const bottomRegions = seedRegionsFromCellGridBottom(colors, cellTriIdsBottom, W, H, mirror);
+    return { mesh, grid, seedRegions: mergeRegions(seedRegions, bottomRegions) };
+  }
+
   return { mesh, grid, seedRegions };
 }
 
@@ -747,7 +788,7 @@ function seedRegionsFromReliefGrid(grid: HeightGrid): SeedRegion[] {
 //  retro-fit colours onto a slanted continuous mesh.)
 
 /** Tile variant: cellTriIds carries -1 for excluded cells (shape/hole/edge),
- *  so only included cells contribute. */
+ *  so only included cells contribute. Top-face (CCW from +Z). */
 function seedRegionsFromCellGrid(colors: Uint8Array, cellTriIds: Int32Array, W: number, H: number): SeedRegion[] {
   const byColor = new Map<number, { color: [number, number, number]; triangleIds: number[] }>();
   for (let y = 0; y < H; y++) {
@@ -763,6 +804,50 @@ function seedRegionsFromCellGrid(colors: Uint8Array, cellTriIds: Int32Array, W: 
     }
   }
   return mapBucketsToRegions(byColor);
+}
+
+/** Bottom-face variant for double-sided tiles. When `mirror` is true, cell
+ *  (x, y) on the bottom takes its colour from (W-1-x, y) on the image so the
+ *  tile looks identical from both sides when flipped. */
+function seedRegionsFromCellGridBottom(
+  colors: Uint8Array,
+  cellTriIdsBottom: Int32Array,
+  W: number,
+  H: number,
+  mirror: boolean,
+): SeedRegion[] {
+  const byColor = new Map<number, { color: [number, number, number]; triangleIds: number[] }>();
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      const cell = y * W + x;
+      const t0 = cellTriIdsBottom[cell * 2];
+      if (t0 < 0) continue;
+      const srcX = mirror ? W - 1 - x : x;
+      const src = y * W + srcX;
+      const r = colors[src * 3], g = colors[src * 3 + 1], b = colors[src * 3 + 2];
+      const key = (r << 16) | (g << 8) | b;
+      let bucket = byColor.get(key);
+      if (!bucket) { bucket = { color: [r / 255, g / 255, b / 255], triangleIds: [] }; byColor.set(key, bucket); }
+      bucket.triangleIds.push(t0, cellTriIdsBottom[cell * 2 + 1]);
+    }
+  }
+  return mapBucketsToRegions(byColor);
+}
+
+/** Merge two sets of seed regions, combining triangle lists for matching colours. */
+function mergeRegions(a: SeedRegion[], b: SeedRegion[]): SeedRegion[] {
+  const byKey = new Map<number, SeedRegion>();
+  for (const r of a) {
+    const k = (Math.round(r.color[0] * 255) << 16) | (Math.round(r.color[1] * 255) << 8) | Math.round(r.color[2] * 255);
+    byKey.set(k, { ...r, triangleIds: [...r.triangleIds] });
+  }
+  for (const r of b) {
+    const k = (Math.round(r.color[0] * 255) << 16) | (Math.round(r.color[1] * 255) << 8) | Math.round(r.color[2] * 255);
+    const existing = byKey.get(k);
+    if (existing) existing.triangleIds.push(...r.triangleIds);
+    else byKey.set(k, { ...r, triangleIds: [...r.triangleIds] });
+  }
+  return Array.from(byKey.values());
 }
 
 function mapBucketsToRegions(byColor: Map<number, { color: [number, number, number]; triangleIds: number[] }>): SeedRegion[] {

--- a/src/relief/tileMesh.ts
+++ b/src/relief/tileMesh.ts
@@ -18,10 +18,13 @@ export interface TileOptions {
 
 export interface TileMeshResult {
   mesh: ReliefMesh;
+  /** Top-face triangle ids per cell (2 per cell, -1 for excluded). */
   cellTriIds: Int32Array;
+  /** Bottom-face triangle ids per cell (2 per cell, -1 for excluded). */
+  cellTriIdsBottom: Int32Array;
 }
 
-function buildCellMask(W: number, H: number, opts: TileOptions, shape: TileShape): Uint8Array {
+export function buildCellMask(W: number, H: number, opts: TileOptions, shape: TileShape): Uint8Array {
   const count = W * H;
   const mask = new Uint8Array(count);
   if (W < 2 || H < 2) return mask;
@@ -109,6 +112,8 @@ function isEdgeManifold(triVerts: Uint32Array, numTri: number): boolean {
 function emptyMesh(W: number, H: number): TileMeshResult {
   const cellTriIds = new Int32Array(2 * W * H);
   cellTriIds.fill(-1);
+  const cellTriIdsBottom = new Int32Array(2 * W * H);
+  cellTriIdsBottom.fill(-1);
   return {
     mesh: {
       vertProperties: new Float32Array(0),
@@ -119,6 +124,7 @@ function emptyMesh(W: number, H: number): TileMeshResult {
       watertight: true,
     },
     cellTriIds,
+    cellTriIdsBottom,
   };
 }
 
@@ -212,6 +218,8 @@ export function buildTileMesh(
   const triVerts = new Uint32Array(numTri * 3);
   const cellTriIds = new Int32Array(2 * W * H);
   cellTriIds.fill(-1);
+  const cellTriIdsBottom = new Int32Array(2 * W * H);
+  cellTriIdsBottom.fill(-1);
 
   let ti = 0;
   const tri = (a: number, b: number, c: number): number => {
@@ -248,8 +256,11 @@ export function buildTileMesh(
       const b = botIdx(x + 1, y);
       const c = botIdx(x + 1, y + 1);
       const d = botIdx(x, y + 1);
-      tri(a, c, b);
-      tri(a, d, c);
+      const id0 = tri(a, c, b);
+      const id1 = tri(a, d, c);
+      const base = 2 * (y * W + x);
+      cellTriIdsBottom[base] = id0;
+      cellTriIdsBottom[base + 1] = id1;
     }
   }
 
@@ -310,5 +321,6 @@ export function buildTileMesh(
       watertight,
     },
     cellTriIds,
+    cellTriIdsBottom,
   };
 }

--- a/src/relief/types.ts
+++ b/src/relief/types.ts
@@ -77,6 +77,10 @@ export interface ReliefCommonOptions {
   resolution: number;
   /** Gaussian-ish blur radius in pixels applied before sampling (0 = none). */
   smoothing: number;
+  /** Auto-detect and remove the background by sampling border pixel colours.
+   *  For flat tiles, cuts background cells from the tile shape; for stepped
+   *  relief and luminance, sets background cells to height 0 (base only). */
+  removeBackground: boolean;
 }
 
 /** Luminance-relief specific knobs. */
@@ -139,6 +143,12 @@ export interface QuantizedOptions {
    *  background instead of auto-detecting from the image's border colours.
    *  The user picks it by clicking the source thumbnail. */
   manualBackground?: [number, number, number];
+  /** Build the tile with the image on both the top and bottom faces.
+   *  Only applies to output='flat'. */
+  doubleSided: boolean;
+  /** When doubleSided is true, mirror the image horizontally on the back face
+   *  so the tile looks correct when flipped over. Default: true. */
+  backMirror: boolean;
 }
 
 export interface ReliefOptions {
@@ -165,6 +175,7 @@ export const DEFAULT_RELIEF_OPTIONS: ReliefOptions = {
     maxHeight: 3,
     resolution: 200,
     smoothing: 0,
+    removeBackground: false,
   },
   luminance: { invert: false, gamma: 1, levels: 16 },
   quantized: {
@@ -178,6 +189,8 @@ export const DEFAULT_RELIEF_OPTIONS: ReliefOptions = {
     holes: [],
     paintingMode: 'single-nozzle',
     invertHeights: false,
+    doubleSided: false,
+    backMirror: true,
   },
   preprocess: { brightness: 0, contrast: 0, saturation: 0, levelsLow: 0, levelsHigh: 255 },
 };

--- a/src/ui/reliefImportModal.ts
+++ b/src/ui/reliefImportModal.ts
@@ -184,6 +184,7 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
   sliderControl(imageSection.grid, 'Saturation', '', () => opts.preprocess.saturation, v => (opts.preprocess.saturation = v), { min: -1, max: 1, step: 0.05 });
   sliderControl(imageSection.grid, 'Black point', '', () => opts.preprocess.levelsLow, v => (opts.preprocess.levelsLow = v), { min: 0, max: 254, step: 1, int: true });
   sliderControl(imageSection.grid, 'White point', '', () => opts.preprocess.levelsHigh, v => (opts.preprocess.levelsHigh = v), { min: 1, max: 255, step: 1, int: true });
+  const removeBgRow = checkboxControl(imageSection.grid, 'Remove background (auto-detect)', () => opts.common.removeBackground, v => (opts.common.removeBackground = v));
 
   const commonSection = makeSection('Geometry');
   const luminanceSection = makeSection('Luminance mapping');
@@ -244,6 +245,10 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
   // default (bright = tall) makes the background occlude the figure from a
   // top-down view; turning this on raises the subject instead.
   const invertHeightsRow = checkboxControl(tileSection.grid, 'Invert (dark = tall)', () => opts.quantized.invertHeights, v => (opts.quantized.invertHeights = v));
+  // Double-sided: paint the back face of the tile too (useful for keychains
+  // and pendants that are visible from both sides).
+  const doubleSidedRow = checkboxControl(tileSection.grid, 'Double sided', () => opts.quantized.doubleSided, v => { opts.quantized.doubleSided = v; syncMode(); });
+  const backMirrorRow = checkboxControl(tileSection.grid, 'Mirror back face', () => opts.quantized.backMirror, v => (opts.quantized.backMirror = v));
   // Inline hint: a single-nozzle swap print needs one printable layer band per
   // cluster. If maxHeight < (clusters - 1) × layerHeight, two clusters land in
   // the same band and the slicer would have to swap mid-layer. Surface the
@@ -964,9 +969,10 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
     const shape = isQ ? o.quantized.shape : 'rect';
     const hasShape = isQ && out === 'flat' && (shape === 'rounded' || shape === 'circle');
     const hasSilhouette = isQ && out === 'silhouette' && !!grid.colors;
+    const hasRemoveBg = o.common.removeBackground && !!grid.colors && out !== 'silhouette';
     const holes = isQ ? o.quantized.holes : [];
     const hasHole = holes.length > 0;
-    if (!hasShape && !hasSilhouette && !hasHole) return null;
+    if (!hasShape && !hasSilhouette && !hasRemoveBg && !hasHole) return null;
 
     const widthMm = o.common.widthMm;
     const heightMm = widthMm * (h / w);
@@ -979,6 +985,8 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
     if (hasSilhouette && grid.colors) {
       const mb = o.quantized.manualBackground;
       mask.set(mb ? bgMaskFromColor(grid.colors, w, h, mb) : detectBackgroundMask(grid.colors, w, h));
+    } else if (hasRemoveBg && grid.colors) {
+      mask.set(detectBackgroundMask(grid.colors, w, h));
     } else {
       mask.fill(1);
     }
@@ -1056,6 +1064,12 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
     // Same gating for the invert-heights toggle — it only changes the
     // cluster→Z mapping for stepped reliefs.
     invertHeightsRow.classList.toggle('hidden', !showPaintingMode);
+    // Remove background: not useful for SVG (fills are already discrete paths).
+    removeBgRow.classList.toggle('hidden', isSvg);
+    // Double-sided and mirror only apply to flat tiles (not silhouette or relief).
+    const showDoubleSided = !isSvg && opts.mode === 'quantized' && opts.quantized.output === 'flat';
+    doubleSidedRow.classList.toggle('hidden', !showDoubleSided);
+    backMirrorRow.classList.toggle('hidden', !showDoubleSided || !opts.quantized.doubleSided);
     // Layer-fit hint — visible only when a single-nozzle stepped relief can't
     // fit one printable layer band per cluster given the current settings. syncEnabled
     // is what actually toggles createBtn.disabled; here we just paint the


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Remove background (auto-detect)**: new checkbox in the Image section of the relief/keychain wizard. Detects background pixels from border colours using the same `detectBackgroundMask` heuristic as the voxel importer. For flat tiles, cuts background cells from the tile shape (intersected with any rect/rounded/circle outline). For stepped relief and luminance modes, zeroes background cell heights so they print as the base thickness only. Hidden for SVG imports.

- **Double sided**: new checkbox in the Tile section, flat tile mode only. Paints both the top *and* bottom faces of the tile with the image by generating seed regions for bottom-face triangles (tracked via a new `cellTriIdsBottom` field in `TileMeshResult`).

- **Mirror back face**: shown below Double sided when it's enabled. When on (default), mirrors the image horizontally on the back face so the tile looks identical from both sides when flipped over — the expected behaviour for a keychain/pendant. When off, back face uses the same left-to-right orientation as the front.

## Test plan

- [ ] Open the relief/keychain wizard with a photo on a solid background → enable "Remove background" → 2D preview shows checkerboard on background cells; generated tile has subject cut out
- [ ] Same with a rounded-rect or circle shape → background intersects with shape mask correctly
- [ ] Stepped relief mode with "Remove background" → background cells flatten to base height
- [ ] Luminance mode with "Remove background" → background cells flatten to base height  
- [ ] "Remove background" is hidden when an SVG is loaded
- [ ] Enable "Double sided" on a flat tile → generates; importing into studio shows both top and bottom faces painted with the image
- [ ] Enable "Mirror back face" (on by default) → back face colours are horizontally mirrored; disable it → back face uses same orientation as front
- [ ] "Double sided" and "Mirror back face" are hidden when output is not flat tile (silhouette, stepped relief)
- [ ] Old saved presets (missing `removeBackground`/`doubleSided`/`backMirror`) still load correctly with defaults

https://claude.ai/code/session_01Djvcib3W7BKeD5Ji7r2Xgy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Djvcib3W7BKeD5Ji7r2Xgy)_