### PR TITLE
refactor: move verbose CLAUDE.md sections to skills and reference docs

### DIFF
--- a/.claude/skills/add-provider.md
+++ b/.claude/skills/add-provider.md
@@ -1,0 +1,17 @@
+# Add Hosted Provider
+
+Full checklist for wiring a new cloud AI provider into the in-app chat. Run when adding a provider beyond the existing Anthropic/OpenAI/Gemini/Local set.
+
+See `docs/ai-internals.md` for per-provider wire-format details (thinking levels, routing) to use as reference when implementing `streamTurn`.
+
+## Steps
+
+1. Add the id to `Provider` in `src/ai/types.ts` and a `<name>Model` field to `ChatToggles` (+ default in `settings.ts`).
+2. Add a sibling case to `activeModel(toggles)` in `src/ai/types.ts`.
+3. Create `src/ai/<name>.ts` exporting `streamTurn`, `summarize`, `validateKey`, `resetClient` — same shape as `anthropic.ts`.
+4. **Wire pricing.** Add the provider's models.dev id to `CATALOG_PROVIDER_ID` in `src/ai/catalog.ts` so `getPricing()` resolves real rates from the build-time snapshot. For specific models the snapshot doesn't carry, add explicit entries to `KNOWN_MODEL_PRICING` in `src/ai/cost.ts`; everything else falls back to `FALLBACK_PRICING`.
+5. Add a `<name>_MODEL_OPTIONS` array + `set<Name>Model` setter in `src/ai/settings.ts`.
+6. Add dispatch + compaction branches in `chatLoop.ts` / `compaction.ts`.
+7. Add a `buildHostedProviderSection(<name>, …)` call in `aiSettingsModal.ts`, a `PROVIDER_UI` entry in `aiKeyModal.ts`, and a `hostedConfig` entry in `aiPanel.ts`'s `renderModelPicker()`.
+
+After implementing, run `npm run test:unit` (provider request-shape tests) and the AI chat e2e spec: `npx playwright test --grep "AI chat"`.

--- a/.claude/skills/release.md
+++ b/.claude/skills/release.md
@@ -1,0 +1,56 @@
+# Release
+
+Create a production release from staging — discovers existing docs, drafts updates, and opens the staging → production PR.
+
+## Prerequisites
+
+- `staging` is known-good: the staging gate has passed and `staging.mainifold.pages.dev` looks right.
+- Clean working tree (or on a fresh branch).
+
+## Steps
+
+### 1. Gather what changed
+
+```bash
+git fetch origin production staging
+git log origin/production..origin/staging --oneline
+```
+
+Pull the corresponding PR titles from GitHub for human-readable summaries of each commit.
+
+### 2. Discover existing user-facing docs
+
+Search for:
+- A changelog file (`CHANGELOG.md`, `public/changelog.md`, or similar)
+- The `/help` route source (grep for where `HelpPage` or `/help` content is rendered)
+- Any "what's new" section in `public/ai.md`
+
+Read the current state of each to match format and voice.
+
+### 3. Draft documentation updates
+
+Based on commits/PRs since last release, write:
+- A new changelog entry (date + bullet points). Group into Features, Bug Fixes, Improvements. Skip internal refactors/chores unless user-visible.
+- Help page additions for any new features users need to know about.
+- `public/ai.md` updates if any `window.partwright` API, tool schemas, or agent workflow changed.
+
+Show the drafts to the user and incorporate feedback before committing.
+
+### 4. Commit docs on a release branch
+
+```bash
+git checkout -b release/$(date +%Y-%m-%d) origin/staging
+# write doc updates
+git add <doc files>
+git commit -m "docs: update changelog and help for $(date +%Y-%m-%d) release"
+git push -u origin release/$(date +%Y-%m-%d)
+```
+
+### 5. Open the staging → production PR
+
+Create a **draft** PR from the release branch into `production`. Title: `chore: release YYYY-MM-DD`. Body should include:
+- Summary of what's in this release (the changelog entry)
+- Link to `staging.mainifold.pages.dev` for final validation
+- Confirmation that the staging gate passed
+
+Label it `ignore-for-release`. Flag the PR to the user — production is protected and requires human review before merging.

--- a/.claude/skills/smoke-test.md
+++ b/.claude/skills/smoke-test.md
@@ -1,0 +1,20 @@
+# Smoke Test
+
+Manually verify the app after touching routing, Vite config, index.html, or initialization code. Start the dev server (`npm run dev`) then check each item in a browser:
+
+1. **Landing page**: Navigate to `http://localhost:5173/` — shows hero section ("Partwright", "AI-driven parametric CAD in your browser"), CTA buttons, Recent Sessions grid (or empty state).
+2. **Open Editor**: Click "Open Editor" — URL changes to `/editor`, status shows "Ready" (green), code editor on left with default example, 3D model renders on right.
+3. **WASM engine loads**: Status pill says "Ready" (green), NOT "Loading WASM…" or "WASM failed". If "WASM failed": check `coi-serviceworker.js` (no 404), `manifold.wasm` (no 403 — if 403, check `server.fs.strict` in vite.config.ts), COEP/COOP headers present on responses.
+4. **Help page**: Click `?` in toolbar — navigates to `/help`, shows help content. "Back" returns to the editor.
+5. **AI agent bypass**: `http://localhost:5173/editor` goes straight to the editor. `window.partwright.renderViews({views:"box"})` returns a 6-face composite PNG data URL.
+6. **Session loading**: Click a session tile on the landing page — loads session code in editor, shows session name in session bar, URL updates to `/editor?session=<id>`.
+7. **Build**: `npm run build` succeeds with no TypeScript errors.
+8. **Paint mode**: Click Paint button in viewport overlay — color picker panel appears. Click a face — paints the coplanar region in the selected color. Paint button badge shows region count.
+9. **Editor lock**: After painting, editor shows lock banner ("This version has color regions applied.") and is read-only. Run button disabled.
+10. **Unlock modal**: Click "Unlock to edit" — modal shows two options. Clicking "Unlock editor" with default "preserve" saves the colored version and creates a new uncolored version. Editor unlocks.
+11. **Gallery badges**: Colored versions show small color-swatch dots next to the version label.
+12. **Color export**: With regions painted, export GLB — file carries vertex colors. Export 3MF — includes `<basematerials>` and per-triangle `pid` attributes.
+13. **Annotations per-version**: Annotate v1, save v2 (annotations persist). Clear, draw a different annotation, save v3. Navigating v1↔v2↔v3 swaps annotations to match (v1 empty, v2 first set, v3 second set). Importing a schema-1.2 file (top-level `annotations`) attaches those annotations to the latest version.
+14. **Local model picker**: Click `✦ Connect AI` → follow "Run a local model in your browser" → second modal lists Small/Medium/Large/Vision with download sizes. WebGPU banner green on Chrome/Edge/Safari 26+, red elsewhere. "Use this model"/"Download X GB" only triggers a network request the first time; cached models show "Downloaded" pill and skip to GPU load.
+15. **STL import**: With no session (or expendable starter) — import lands directly as new session, no modal. With a real session — import-target modal shows New part / Add to current part / New session. "New part" is default. Editor shows `return Manifold.ofMesh(api.imports[0])` wrapper, mesh renders, version label is "imported". Editing the wrapper re-renders correctly. Close and reopen — imported mesh restores from IndexedDB.
+16. **Merge parts**: Check two+ parts in the Parts rail — bulk-action bar shows **Merge N** beside Delete. Opens modal: combine into new part (keeps originals) or merge into one (replaces). Works for hand-coded parts, not just imported. Current part's unsaved edits are saved first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,76 +100,11 @@ every shard is itself serial and contention-free while wall-clock time
 drops ~3×. `testMatch` is pinned to `**/*.spec.ts` so the unit
 tier's `.test.ts` files stay out of the Playwright run.
 
-### Multi-environment browser detection
-
-`playwright.config.ts` auto-picks the right Chromium binary so the same
-test command works on a developer laptop and inside the Anthropic Claude
-Code on the web sandbox without per-environment setup:
-
-- **Sandbox** (`/opt/pw-browsers/` exists): config picks the highest
-  installed `chromium-N` directory and uses its `chrome` binary directly
-  via `launchOptions.executablePath`. The version pinned by the
-  `playwright` npm package may differ from what's cached, but the
-  installed browser still satisfies the test runner — no download
-  needed (which is good, because the sandbox often blocks Chrome for
-  Testing's CDN).
-- **Local laptop** (no `/opt/pw-browsers/`): config leaves
-  `executablePath` unset, and Playwright finds its own cache at
-  `~/.cache/ms-playwright/` (Linux) or `~/Library/Caches/ms-playwright/`
-  (macOS). Run `npx playwright install chromium` once on a new machine.
-
-If the auto-detection picks the wrong binary, override it at the shell:
-
-```bash
-PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/path/to/chrome npm run test:e2e
-```
-
-### When AI agents need to run a browser test
-
-1. Don't reinstall browsers blindly. Check `/opt/pw-browsers/` first; the
-   sandbox image already has Chromium. `playwright.config.ts` handles the
-   wiring.
-2. The default Desktop Chrome viewport (1280×720) clips the AI panel's
-   toggle strip. The config sets 1280×900 — keep it that way for
-   anything that interacts with elements in the bottom half of the
-   panel.
-3. Tiny flex children of recently-transformed parents sometimes fail
-   Playwright's viewport hit-test (`Element is outside of the viewport`).
-   When the bounding box is verifiably inside, prefer
-   `locator.dispatchEvent('click')` over `locator.click({ force: true })`
-   — the latter still enforces the viewport bound.
-4. Each Playwright test gets a fresh `BrowserContext`, so localStorage
-   and IndexedDB are isolated by default. **Don't add `localStorage.clear()`
-   in `beforeEach`** unless you mean it — it'll fire on `page.reload()`
-   inside a test too, breaking any "state persists across reload"
-   assertion.
-5. Tests must run with no external network. The `validateKey` flow hits
-   `api.anthropic.com`; assert on the surfaced error message, not on
-   whether the request succeeded.
+See `docs/playwright-guide.md` for sandbox vs laptop Chromium binary detection and Playwright agent gotchas.
 
 ## Smoke Test — Verifying the App Works
 
-After any changes that touch routing, Vite config, index.html, or initialization code, verify these things still work:
-
-1. **Landing page**: Navigate to `http://localhost:5173/` — should show the hero section ("Partwright", "AI-driven parametric CAD in your browser"), CTA buttons, and a Recent Sessions grid (or empty state).
-2. **Open Editor**: Click "Open Editor" on the landing page — URL should change to `/editor`, status should show "Ready" (green), the code editor should appear on the left with a default example, and a 3D model should render in the viewport on the right.
-3. **WASM engine loads**: The status indicator (small pill in the top-left of the viewport) should say "Ready" in green, NOT "Loading WASM..." or "WASM failed". If it shows "WASM failed", check:
-   - `coi-serviceworker.js` loads without 404 (check Network tab)
-   - `manifold.wasm` loads without 403 (check Network tab) — if 403, check `server.fs.strict` in vite.config.ts
-   - COEP/COOP headers are present on responses (check Response Headers)
-4. **Help page**: Click the `?` icon in the toolbar — should navigate to `/help` and show the help content. "Back" should return to the editor.
-5. **AI agent bypass**: `http://localhost:5173/editor` should skip the landing page and go straight to the editor (Interactive tab). `window.partwright.renderViews({views:"box"})` returns a 6-face composite PNG data URL.
-6. **Session loading**: Click a session tile on the landing page — should load the session code in the editor, show the session name in the session bar, and update the URL to `/editor?session=<id>`.
-7. **Build**: `npm run build` should succeed with no TypeScript errors.
-8. **Paint mode**: Click the Paint button in the viewport overlay. A color picker panel should appear. Click a face on the model — it should paint the coplanar region in the selected color. The Paint button badge should show the region count.
-9. **Editor lock**: After painting a face, the editor should show a lock banner ("This version has color regions applied.") and become read-only. The run button should be disabled.
-10. **Unlock modal**: Click "Unlock to edit" — a modal should appear with two options (preserve/destructive). Clicking "Unlock editor" with the default "preserve" option should save the colored version and create a new uncolored version. The editor should unlock.
-11. **Gallery badges**: Colored versions in the gallery should show small color-swatch dots next to the version label.
-12. **Color export**: With color regions painted, export GLB — the file should carry vertex colors. Export 3MF — the file should include `<basematerials>` and per-triangle `pid` attributes.
-13. **Annotations are per-version**: Annotate v1, save v2 (annotations persist into v2). Clear annotations, draw a different one, save v3. Navigating v1↔v2↔v3 should swap annotations to match each version (v1 empty, v2 first set, v3 second set). Importing a schema-1.2 file (top-level `annotations`) should attach those annotations to the latest version on import.
-14. **Local model picker**: Click the `✦ Connect AI` (or `✦ AI`) chip → in the modal, follow "Run a local model in your browser". A second modal lists Small / Medium / Large / Vision options with download sizes. The WebGPU banner shows green on Chrome/Edge/Safari 26+ and red elsewhere. The "Use this model" / "Download X GB" button only triggers a network request the first time; cached models show a "Downloaded" pill and skip straight to GPU load. Closing the tab during a download cancels it cleanly.
-15. **STL import**: Click Import → "Choose file…" → pick an `.stl`. With no session open — **or when the only open part is an expendable starter** (a fresh `/editor` still showing the default code with no saved version) — the import lands directly as a new session named after the file, with **no modal** (there's no real work to protect). The **import-target modal** appears only when a session has real work to protect (a non-expendable part): choose **New part** (adds a separate part to the session — the default), **Add to / Use for current part** (composes the mesh into the current part's geometry via `Manifold.compose` — works for both imported-mesh and hand-coded parts), or **New session**. "New part" is the recommended default so an import never silently overwrites the current part; the part's unsaved code is saved first. In all cases the editor shows a short `return Manifold.ofMesh(api.imports[0])` wrapper (or a `Manifold.compose([...])` form when combined), the mesh renders, and the version label is "imported". Editing the wrapper (e.g. adding `.subtract(Manifold.cube([5,5,5], true))`) re-renders correctly. Closing and reopening the session must restore the imported mesh from IndexedDB.
-16. **Merge parts**: In the Parts rail, check two or more parts (the multi-select checkboxes used for bulk delete). The bulk-action bar gains a **Merge N** button beside Delete. Clicking it opens a modal to either **combine into a new part** (keeps the originals) or **merge into one part** (replaces the selected parts with the combination). Each selected part's latest version is baked to geometry and composed — so it works for hand-coded parts, not just imported ones (the case that used to fail with "No geometry data") — producing a new "merged" version that holds the inputs as separate compose components. The current part's unsaved edits are saved first, so no manual Save is needed before merging.
+Run `/smoke-test` to manually verify these flows after touching routing, Vite config, index.html, or initialization code.
 
 ## AI Agent Workflow & API Reference
 
@@ -180,36 +115,15 @@ For the full Manifold/CrossSection API, `window.partwright` console API, session
 The right-side AI drawer can drive Partwright through any of:
 
 - **Anthropic (cloud)** — user pastes their own API key (`src/ai/anthropic.ts`). Streams from Anthropic's hosted Claude with prompt caching on the long system prompt + tool list.
-- **OpenAI (cloud)** — `src/ai/openai.ts`. Raw `fetch` with SSE streaming; no extra SDK. The agent loop (`streamTurn`) routes **per model** (gated by `isReasoningModel`): reasoning models (gpt-5 family incl. gpt-5.5, o1/o3/o4) go to the **Responses API** (`/v1/responses`) because gpt-5.5+ reject `reasoning_effort` alongside function tools on `/v1/chat/completions` and direct callers to `/v1/responses`; every other / older model (gpt-4o, gpt-4.1, and legacy gpt-4 / gpt-3.5-turbo, some of which exist *only* on Chat Completions) stays on **Chat Completions** (`/v1/chat/completions`). The Responses path converts history to the `input` shape (`message`/`function_call`/`function_call_output` items linked by `call_id`); the Chat path uses the `messages`/`tool_calls`/`tool` shape. Both share the same dangling-tool-call repair, image handling, and review serialization. The non-tool, non-reasoning helpers (`validateKey`/`listModels`/`summarize`) always use `/v1/chat/completions` (works for every model).
-- **Google Gemini (cloud)** — `src/ai/gemini.ts`. Raw `fetch` against `generativelanguage.googleapis.com` with SSE streaming via `:streamGenerateContent?alt=sse`; no extra SDK. The Gemini wire format wants `functionResponse.response` as a plain object — `toFunctionResponseObject` unwraps the JSON-stringified tool result before sending, otherwise Gemini silently drops the message and returns zero candidates on the next turn. **Thought signatures (Gemini 3+):** the model attaches an opaque `thoughtSignature` that must be echoed back on the next request *in the exact part it was received on* — a missing one on a `functionCall` part is a hard 400, and a missing one on a text part silently degrades reasoning (the model bails out early with a tiny `end_turn`, the "Gemini stalls after thinking" symptom). In streaming the signature can ride the `functionCall` part, the answer text part, **or a trailing part whose text is empty** — so `consumeGeminiStream` captures it off *any* part (`pendingSignature`) and binds it to the first tool call (mandatory) or the answer text block (`textThoughtSignature` → persisted on the text `ChatBlock`, replayed by `buildGeminiContents`). Skipping empty-text parts is the classic bug here.
+- **OpenAI (cloud)** — `src/ai/openai.ts`. Raw `fetch` with SSE streaming; no extra SDK. Routes per model: reasoning models (`gpt-5*`, `o1/o3/o4`) use the Responses API (`/v1/responses`); all others use Chat Completions (`/v1/chat/completions`). See `docs/ai-internals.md` for routing details.
+- **Google Gemini (cloud)** — `src/ai/gemini.ts`. Raw `fetch` against `generativelanguage.googleapis.com` with SSE streaming via `:streamGenerateContent?alt=sse`; no extra SDK. Requires careful handling of `functionResponse.response` (plain object, not JSON string) and `thoughtSignature` echo-back. See `docs/ai-internals.md` for thought-signature and routing details.
 - **Local (WebGPU)** — runs a model entirely in the browser via [WebLLM](https://webllm.mlc.ai) (`src/ai/local.ts`). The user opts in from the AI settings modal and the weights download once into the browser cache. No API key, no network traffic per turn.
 
 API keys live in IndexedDB (`aiKeys` store, keyed by provider). `ChatToggles` carries a separate model id per provider (`anthropicModel`, `openaiModel`, `geminiModel`, `localModel`) so switching providers preserves each one's previous selection — see `activeModel(toggles)` in `src/ai/types.ts`.
 
 All providers share the same chat loop (`src/ai/chatLoop.ts`), the same tool schemas (`src/ai/tools.ts`), and the same `public/ai.md` system prompt (or its slim local variant) — only the request transport differs. `chatLoop` dispatches by `toggles.provider` via an if/else chain at the streamTurn call site. The WebLLM SDK is still loaded via dynamic `import()` so users who stick with hosted providers never pay the ~6 MB chunk download.
 
-#### Thinking box (reasoning models)
-
-Gemini 3 thinking models emit their reasoning as `thought:true` text parts (we opt in with `generationConfig.thinkingConfig.includeThoughts`). `gemini.ts` routes those to a separate channel (`StreamResult.thinking` + the `onThinking` stream callback) so they never bleed into the answer bubble. `chatLoop` persists the reasoning as a `'thinking'` `ChatBlock` (rendered above the answer); the panel shows a live indigo preview box while it streams (`renderLiveThinkingBox`), then collapses it into an expand/contract box (`renderThinkingBox`) once the next step — answer text or a tool call — begins. The `onThinking` delta beats the stall watchdog (via `onProgress({phase:'thinking'})`), so a long silent think doesn't trip a spurious abort. `'thinking'` blocks are display-only: no provider's request builder replays them as model text (re-feeding the prose wastes tokens).
-
-#### Thinking level (the 🧠 pill)
-
-`ChatToggles.thinking` (`off` | `low` | `medium` | `high`, default **off**) is a per-session knob in the toggle strip, sourced from `THINKING_LEVELS` in `types.ts`. Each provider maps it to its own wire format at request build time, so 'off' sends no thinking request at all and reproduces the pre-feature behavior:
-
-- **Anthropic** — `low/medium/high` enable extended thinking with `budget_tokens` 2048/8192/16384 (`THINKING_BUDGET` in `anthropic.ts`), and `max_tokens` is floated above the budget (the API requires `>`). Because the agent is a tool-use loop, the API requires the signed `thinking` block to precede each `tool_use` on replay: `collectResult` captures the blocks (with `signature`, plus any `redacted_thinking`) into `ChatMessage.thinkingBlocks`, and `assistantBlocksToApi` re-emits them first — but only when thinking is on for the current request (`buildApiMessages(history, { replayThinking })`). Sending them with thinking off, or replaying display prose, is never done. This path can't be exercised offline (no network in tests/sandbox), so it's covered by request-shape unit tests rather than a live round-trip.
-- **Gemini** — `off` only flips `includeThoughts:false` (deliberately NOT `thinkingBudget:0`, which some Pro models reject); `low/medium/high` set `includeThoughts:true` + a growing `thinkingBudget`. Note: this changed Gemini from always-on thinking to opt-in.
-- **OpenAI** — maps to the Responses `reasoning.effort` (`low/medium/high`), sent only for reasoning models (`gpt-5*`, `o1/o3/o4` — sniffed by `isReasoningModel`, which is also what routes them to the Responses endpoint). 'off' omits the `reasoning` field. Non-reasoning models go down the Chat Completions path, which never sends a reasoning request in either spelling, so they don't 400. OpenAI hides reasoning-model CoT, so this controls cost/quality but never surfaces a thinking box.
-- **Local** — no effect (WebLLM models reason on their own; `<think>` is still stripped).
-
-#### Auto-continue (the ♾ pill)
-
-`ChatToggles.autoResume` (boolean, **on by default** in the standard/full presets — off in the lean minimal preset; per-session) makes the agent keep working until the model explicitly signals completion by calling the **`finish`** sentinel tool, instead of stopping at every `end_turn`. It's the antidote to models (notably Gemini) that end a turn early without finishing the task. The default lives in `DEFAULT_TOGGLES_BY_PRESET`; turning it off writes a `custom` preset that the `??`-based `mergeWithDefaults` preserves across reloads (an explicit `false` is never overwritten by the on-by-default). When **on**:
-
-- `buildToolList` adds the `finish` tool (gated by `AUTORESUME_GATED` in `tools.ts`); `executeTool` short-circuits it to a sentinel ack (it never touches `window.partwright`). `toggleSuffix` appends an instruction telling the model to call `finish` only when truly done.
-- In `chatLoop`, a turn that ends with `end_turn` (text **or** empty) **without** a `finish` call appends a synthetic user nudge (`AUTO_RESUME_PROMPT`, persisted with `ChatMessage.autoResumeNudge` → rendered as a subtle divider, not a blue bubble) and loops again. A turn that **does** call `finish` runs any remaining tools, then stops cleanly with reason `end_turn`.
-- It's bounded by the existing **iteration cap** (the `for` loop) and **spend cap** (checked each iteration) — whichever trips first — so a model that never calls `finish` lands on the normal iteration-cap "Keep going" notice rather than looping forever. A queued human message takes priority over a `finish` stop (the loop delivers it instead of stopping).
-- A no-progress ceiling (`MAX_CONSECUTIVE_AUTO_RESUMES` in `chatLoop.ts`) caps consecutive nudges that make no progress (no tool call), resetting on any tool call — so even under infinite iteration + spend caps a model that never calls `finish` can't loop forever. The auto-resume nudge also handles the `empty_final` case: an empty assistant turn gets a `(no response)` placeholder so it isn't dropped by the request builders (which would otherwise leave two consecutive `user` turns — a hard 400 on Anthropic). A human message queued mid-turn is delivered on the resume path in preference to the synthetic nudge.
-- Turning it **off** is byte-for-byte the old behavior (no `finish` tool, no nudges, stop at each `end_turn`) and is remembered across reloads.
+See `docs/ai-internals.md` for per-provider thinking/auto-continue wire-format details (thinking box, thought signatures, thinking level mappings, auto-continue implementation, OpenAI routing).
 
 #### Cross-provider review
 
@@ -221,13 +135,7 @@ A "🩺" button in the panel header opens `src/ui/aiDiagnosticsModal.ts`. Shows 
 
 #### Adding a new hosted provider
 
-1. Add the id to `Provider` in `src/ai/types.ts` and a `<name>Model` field to `ChatToggles` (+ default in `settings.ts`).
-2. Add a sibling case to `activeModel(toggles)`.
-3. Create `src/ai/<name>.ts` exporting `streamTurn`, `summarize`, `validateKey`, `resetClient` — same shape as `anthropic.ts`.
-4. Wire pricing. Pricing is catalog-driven: add the provider's models.dev id to `CATALOG_PROVIDER_ID` in `src/ai/catalog.ts` (e.g. Gemini's `google`) so `getPricing()` resolves real rates from the build-time snapshot. For specific cheap models the snapshot doesn't carry (e.g. an older compaction model), add an explicit entry to `KNOWN_MODEL_PRICING` in `src/ai/cost.ts`; everything else falls back to `FALLBACK_PRICING` there.
-5. Add a `<name>_MODEL_OPTIONS` array + `set<Name>Model` setter in `src/ai/settings.ts`.
-6. Add dispatch + compaction branches in `chatLoop.ts` / `compaction.ts`.
-7. Add a `buildHostedProviderSection(<name>, …)` call in `aiSettingsModal.ts`, a `PROVIDER_UI` entry in `aiKeyModal.ts`, and a `hostedConfig` entry in `aiPanel.ts`'s `renderModelPicker()`.
+Run `/add-provider` for the full 7-step integration checklist.
 
 Key rules:
 - **Always use sessions** for user-requested geometry — never create files in `examples/`
@@ -288,9 +196,7 @@ The user pays for a non-default engine only when they reach for it:
 - **OpenCASCADE / replicad** — `await import('replicad')` + `await import('replicad-opencascadejs/...')` inside `ensureBrepLoaded()` in `src/geometry/brepRuntime.ts`. Triggered (a) in any manifold-js run whose code mentions `BREP`, or (b) on first replicad-language session run.
 - **WebLLM** — `await import('@mlc-ai/web-llm')` inside `src/ai/local.ts`. Triggered on first local-model use.
 
-Each loader is idempotent and caches the resolved module. Vite splits each one into its own chunk (verify by inspecting `npm run build` output — the OCCT WASM lands as `replicad_single-*.wasm` (~10 MB) outside the main bundle).
-
-When adding a new lazy-loaded module, follow `brepRuntime.ts`'s pattern: one `ensureXLoaded()` promise that's cached after success and cleared on failure so the next call retries.
+Each loader is idempotent and caches the resolved module. Vite splits each one into its own chunk. See `docs/architecture-notes.md` for the `ensureXLoaded()` pattern when adding new lazy-loaded modules.
 
 ## Coordinate System
 
@@ -301,7 +207,7 @@ When adding a new lazy-loaded module, follow `brepRuntime.ts`'s pattern: one `en
 
 ### Planning Files
 
-Write interstitial planning, design, and brainstorming documents to `.plans/` (gitignored). Do **not** write plan files to `docs/` — that directory is reserved for user-facing documentation that ships with the project.
+Write interstitial planning, design, and brainstorming documents to `.plans/` (gitignored). `docs/` is for **stable reference documentation that ships with the project** — both user-facing content (help page source, changelog) and developer/AI-agent reference docs (architecture notes, AI internals, test guides). Do **not** put ephemeral plan files or scratch notes in `docs/`.
 
 ### URL State
 
@@ -324,17 +230,7 @@ Any `/editor` URL bypasses the landing page entirely. Tab switching is handled i
 
 ### Browser History (Back Button) Preservation
 
-`updateURL()` in `src/storage/sessionManager.ts` uses `history.replaceState`, not push. That is intentional for in-place updates within the editor (switching versions, naming a session) — those should not pollute the back stack. But it is a trap when navigating *into* the editor from another top-level page (`/`, `/catalog`, `/help`):
-
-- If you call any session-mutating function (`openSession`, `createSession`, `closeSession`, or anything that calls `importSessionPayload`) BEFORE pushing the editor history entry, that internal `replaceState` will overwrite the page you came from and break the browser back button.
-- **Always push the destination history entry first**, then run the state change. See `handleCatalogEntryLoad` and `openSessionFromLanding` in `src/main.ts` for the canonical ordering.
-- For in-page "Back" buttons on top-level pages (catalog, help), prefer `window.history.back()` when there's a real previous entry on the stack — falling back to `replace` (not push) when the page was loaded directly by URL. See the `helpHasAppBackTarget` / `catalogHasAppBackTarget` patterns.
-
-When adding a new top-level page or any cross-page navigation, walk through the flow before merging:
-
-1. Where am I coming from? What's already on the back stack?
-2. What does `window.location` look like after every async step (especially DB or session operations)?
-3. After landing on the destination, does the browser back button take me to the prior page, not two pages back?
+`updateURL()` in `src/storage/sessionManager.ts` uses `history.replaceState`, not push — intentional for in-editor updates, but a trap for cross-page navigation. **Always push the destination history entry first**, then run any session-mutating call (`openSession`, `createSession`, `closeSession`, `importSessionPayload`). See `docs/architecture-notes.md` for the full pattern and the canonical examples in `src/main.ts`.
 
 ### Resource Lifecycle
 
@@ -364,12 +260,7 @@ The app runs in multiple browser windows/tabs at once, often each driving a **di
 
 > State must not bleed or cause side effects from one tab into another. The only times state should cross tabs are the **explicit** transitions: opening a session (incl. a previously-closed one) in a tab, or **taking control** of a session in another tab. Anything else changing in tab B must not silently alter tab A.
 
-Concretely, when adding a feature:
-
-- **Don't put session-scoped or task-scoped state in a single shared localStorage blob.** AI provider/model/toggles are **per-tab** working state (each window drives its own session) and are persisted **per-session** on the session record (`session.aiPreference`) so they carry over only on open / take-control — see `applySessionAiPreference` / `recordSessionAiPreference` in `aiPanel.ts` and `setSessionAiPreference` in `sessionManager.ts`. The live AI settings (`reloadSettingsFromStorage` in `ai/settings.ts`) deliberately **preserve this tab's `toggles`/`preset`** when a peer tab writes the shared blob — it adopts only genuinely-global, additive prefs (custom models, system-prompt overrides, panel width). Blindly adopting a peer's blob via the `storage` event was the cross-window provider-leak bug.
-- **App-level preferences that used to be one shared localStorage key should be per-tab** (units, render quality, editor auto-format). Use `readPerTabPref`/`writePerTabPref` (`src/storage/perTabPref.ts`): the live value is per-tab (sessionStorage) with a localStorage seed so a *fresh* tab still inherits the last choice, but already-open tabs never adopt a peer's change. Don't attach a `storage` listener that live-mirrors them.
-- **`storage`-event and `BroadcastChannel` handlers must scope to the receiving tab's own session** before acting — gate on `msg.sessionId === currentState.session?.id` (see `tabSync.ts` consumers and `sessionLock.ts`, which guards on its own session's leader-token key). Never adopt a peer's provider/model/toggles live.
-- **Truly-global state is the exception, and must be additive, not last-write-wins.** Custom local models and system-prompt overrides are shared across tabs on purpose; keep such writes merge-friendly so a peer tab's blob write can't clobber another tab's addition.
+See `docs/architecture-notes.md` for the concrete implementation patterns (per-tab prefs, `storage`-event scoping, global-state rules).
 
 ### Dead Code
 
@@ -430,39 +321,14 @@ Guardrails for automated work, learned the hard way:
 
 ### After Opening a PR
 
-Opening the **draft** PR (see [the standing instruction](#pull-requests--open-a-draft-when-the-work-looks-good) above) isn't the finish line — it's the start of the verification phase. PR-checks runs the full suite — build + unit, then the 3 e2e shards — on every push, draft or ready, so the draft gets full signal immediately. The task is done when every shard is green; marking the PR ready for review (step 6 below) is the final step, a review-readiness signal rather than a CI trigger.
+Opening the draft is the start of the verification phase, not the finish line. The task is done when every PR-checks shard is green.
 
-**1. Watch the full suite on the draft.** PR-checks runs build + unit **and** the 3 e2e shards on every push, draft included, so the draft gets full CI signal immediately — you don't flip to ready to trigger it. Subscribe to PR activity (`subscribe_pr_activity`) and watch the shards rather than running e2e locally up front. Run any deeper or manual verification the change warrants — e.g. exercising the affected UI in a browser per the [Smoke Test](#smoke-test--verifying-the-app-works) — alongside CI. Fall back to local `npm run test:e2e` only when iterating tight on a failure CI surfaced. Fix failures on the same branch (each push re-runs build + unit + e2e) until every shard goes green. Watching means watching mergeability too, not just the shards: if `main` advances and the branch goes out-of-date or conflicting, that's an actionable event — resolve it on the branch (step 4 below).
-
-**2. Kick off an automated review pass.** Right after pushing the draft, launch a review subagent (the Agent tool) over your branch diff against `origin/main` and the code it touches. Have it hunt specifically for problems your change may have introduced:
-
-- **Defects** — logic errors, unhandled cases, broken or orphaned call sites in the new code.
-- **Functionality dropped in a merge** — features or code paths silently lost while resolving conflicts or re-syncing with `origin/main`. Diff against what was there before, not just your own edits.
-- **Backwards-incompatible changes** — anything that breaks existing persisted data or files. Watch session/schema changes most closely: old sessions saved in IndexedDB, and previously exported files (GLB/3MF and any versioned schema), must still import and load. A schema bump needs a migration or back-compat read path, not a hard break.
-- **Security issues** — injection (command/SQL), XSS or unsafe HTML insertion, leaked API keys/secrets, or weakened CSP/COEP/COOP headers.
-
-Surface the results on the PR (a review comment, or fold clear fixes straight into the branch). If the pass turns up something ambiguous or large, raise it with the user rather than silently reworking.
-
-**3. Follow CI and auto-fix what you can.** Watch the PR's checks — the **PR-checks** workflow (build + unit, then the 3 sharded e2e jobs) and the Cloudflare Pages preview deployment — and **auto-fix failures when you can** by pushing a fix straight to the PR branch.
-
-1. Reproduce the failure locally first (`npm run build`, `npm run test:unit`, `npm run test:e2e`) so you're fixing the real cause, not guessing from the log.
-2. Re-sync with the latest `origin/main` if the branch has drifted (see the Deployment workflow), then commit and push the fix to the same PR branch.
-3. Re-check CI after the push, and keep iterating until the checks are green.
-
-Only push fixes you're confident in — failures clearly caused by your own changes. If a failure is ambiguous, unrelated to your changes, or would require a large refactor or a risky/destructive change to resolve, stop and ask the user instead of pushing speculative fixes.
-
-**4. Resolve merge conflicts when the base branch moves under the PR.** When you're watching a PR and `main` advances — the branch falls behind, or GitHub reports it no longer mergeable — treat that like a CI failure: an actionable event to fix on the branch, not something to park for a human. Bring it up to date: `git fetch origin main`, merge `origin/main` into the branch (or rebase onto it), resolve the conflicts, and push to the same PR branch.
-
-But the bar is an **integrated, working result — not just a clean merge.** A conflict is two intentions colliding, and clearing the markers is the easy part. Before you push:
-
-1. **Understand and respect the work you're merging in.** Read what actually landed on `main` since the branch diverged — the conflicting commits and the PRs/notes behind them — and reconcile your change *with* it. Keep both sides unless one genuinely supersedes the other; never drop someone else's recently merged work just to make your own side apply cleanly. (This is the clobbering trap the re-sync rule above warns about.)
-2. **Then prove it still works.** A resolution that compiles is not a resolution that's correct. Re-run `npm run build` + `npm run test:unit`, let PR-checks re-run the e2e shards on the push, and redo any manual/render verification the touched area warrants — per the automated review pass (step 2 above; watch for functionality silently dropped in the merge) and the [Smoke Test](#smoke-test--verifying-the-app-works). Treat the merged result as new code to verify, because it is.
-
-If the conflict is large, lands in code you don't understand, or resolving it would mean materially changing recently-merged behavior, **stop and ask** (`AskUserQuestion`) rather than push a speculative resolution — same bar as the CI auto-fix rule above.
-
-**5. Keep the PR description in sync with the branch.** Any time you push new work to an open PR — review fixes, CI fixes, or follow-up commits that go beyond the PR's original scope — re-check the PR description and update it to cover the *totality* of the work now on the branch, not just what existed when the PR was first opened. Fold the new changes into the Summary, refresh the Test plan, and bring the title, prefix, and labels back in line with the [commit & PR conventions](#commit--pr-conventions) if the scope has grown. The description and the branch diff should never tell different stories — don't let the description silently drift behind the work.
-
-**6. Mark ready for review, label, and confirm green.** Once every PR-checks shard plus the Cloudflare Pages preview are green and the automated review pass is clean, mark the PR ready for review (`update_pull_request` with `draft: false`) and apply the [release-note labels](#commit--pr-conventions). Marking ready is a review-readiness signal — CI already ran on the draft, so it doesn't re-trigger the suite. The task is done once CI is green. If verification surfaced something ambiguous or large, keep the PR in draft and raise it with the user instead of pushing speculative fixes.
+1. **Subscribe and watch CI.** Call `subscribe_pr_activity`. PR-checks runs build + unit + 3 e2e shards on every push, draft or ready — don't flip to ready to trigger it. Fix failures on the branch (each push re-runs the suite); fall back to local `npm run test:e2e` only when iterating tight on a CI failure.
+2. **Launch a review subagent** (Agent tool) over the diff vs `origin/main`. Hunt for: defects and unhandled cases; functionality silently dropped in a merge; backwards-incompatible schema changes (old IndexedDB sessions and exported files must still load); security issues (XSS, leaked keys, weakened CSP/COEP/COOP). Surface findings as PR comments or fold clear fixes into the branch; raise ambiguous/large ones with the user.
+3. **Auto-fix CI failures you're confident about.** Reproduce locally first. Re-sync `origin/main` if the branch has drifted, then push the fix. Ask the user for anything ambiguous, unrelated to your changes, or requiring a large refactor.
+4. **Resolve merge conflicts when `main` advances.** Treat a stale/conflicting branch like a CI failure — actionable, not parkable. Fetch + merge `origin/main`, resolve conflicts by reconciling both sides (never drop recently-merged work to make your side apply cleanly), then prove it still works: `npm run build` + `npm run test:unit`, let CI re-run e2e, redo any manual verification the touched area warrants. Stop and ask if the conflict is large or lands in code you don't understand.
+5. **Keep the PR description in sync** with the totality of what's on the branch — update Summary, Test plan, title/prefix/labels any time you push follow-up work.
+6. **Mark ready, label, confirm green.** Once every shard and the Cloudflare preview are green and the review pass is clean: `update_pull_request` with `draft: false`, apply [release-note labels](#commit--pr-conventions).
 
 ## Common Errors
 

--- a/docs/ai-internals.md
+++ b/docs/ai-internals.md
@@ -1,0 +1,43 @@
+# AI Provider Internals
+
+Reference for per-provider implementation details. Consult when modifying `chatLoop.ts`, `gemini.ts`, `anthropic.ts`, or `openai.ts`.
+
+## Thinking box (reasoning models)
+
+Gemini 3 thinking models emit reasoning as `thought:true` text parts (opt-in via `generationConfig.thinkingConfig.includeThoughts`). `gemini.ts` routes them to a separate channel (`StreamResult.thinking` + `onThinking` callback) so they never bleed into the answer bubble. `chatLoop` persists them as `'thinking'` `ChatBlock`s; the panel shows a live indigo box while streaming (`renderLiveThinkingBox`), then collapses it once the next step begins. `onThinking` beats the stall watchdog so a long think doesn't trip a spurious abort. `'thinking'` blocks are display-only — no provider replays them as model text.
+
+## Gemini thought signatures
+
+Gemini 3+ attaches an opaque `thoughtSignature` that must be echoed back on the exact part it was received on. A missing signature on a `functionCall` part is a hard 400; a missing one on a text part silently degrades reasoning (the "Gemini stalls after thinking" symptom — model bails with a tiny `end_turn`).
+
+In streaming, the signature can ride the `functionCall` part, the answer text part, **or a trailing part whose text is empty**. `consumeGeminiStream` captures it off any part (`pendingSignature`) and binds it to the first tool call (mandatory) or the answer text block (`textThoughtSignature` → persisted on the `ChatBlock`, replayed by `buildGeminiContents`). **Skipping empty-text parts is the classic bug here.**
+
+## Thinking level (the 🧠 pill)
+
+`ChatToggles.thinking` (`off` | `low` | `medium` | `high`, default **off**) maps per-provider at request build time:
+
+- **Anthropic** — `low/medium/high` enable extended thinking with `budget_tokens` 2048/8192/16384 (`THINKING_BUDGET` in `anthropic.ts`). `max_tokens` floats above the budget (API requires `>`). The signed `thinking` block must precede each `tool_use` on replay: `collectResult` captures blocks (with `signature` + any `redacted_thinking`) into `ChatMessage.thinkingBlocks`; `assistantBlocksToApi` re-emits them first — only when thinking is on for the current request (`buildApiMessages(history, { replayThinking })`). Never send them with thinking off; never replay display prose.
+- **Gemini** — `off` flips `includeThoughts:false` (deliberately NOT `thinkingBudget:0`, which some Pro models reject); `low/medium/high` set `includeThoughts:true` + growing `thinkingBudget`.
+- **OpenAI** — maps to `reasoning.effort` (`low/medium/high`) on the Responses API, sent only for reasoning models (`isReasoningModel`). `off` omits the field. Non-reasoning models go via Chat Completions and never see a reasoning request.
+- **Local** — no effect (`<think>` is stripped).
+
+## Auto-continue (the ♾ pill)
+
+`ChatToggles.autoResume` (boolean, **on by default** in standard/full presets) keeps the agent working until the model calls the **`finish`** sentinel tool instead of stopping at every `end_turn`. The default lives in `DEFAULT_TOGGLES_BY_PRESET`; turning it off writes a `custom` preset that `mergeWithDefaults` preserves (explicit `false` is never overwritten).
+
+When **on**:
+- `buildToolList` adds `finish` (gated by `AUTORESUME_GATED` in `tools.ts`); `executeTool` short-circuits it to a sentinel ack. `toggleSuffix` tells the model to call `finish` only when truly done.
+- A turn ending `end_turn` without `finish` appends a synthetic user nudge (`AUTO_RESUME_PROMPT`, persisted as `ChatMessage.autoResumeNudge` → rendered as a subtle divider, not a blue bubble) and loops again. A turn that calls `finish` runs remaining tools then stops cleanly.
+- Bounded by the iteration cap and spend cap. `MAX_CONSECUTIVE_AUTO_RESUMES` caps consecutive nudges that make no tool call — so a model that never calls `finish` can't loop forever.
+- An empty assistant turn gets a `(no response)` placeholder so request builders don't drop it (two consecutive `user` turns → hard 400 on Anthropic). A queued human message is delivered in preference to the synthetic nudge.
+
+Turning **off** is byte-for-byte the old behavior — no `finish` tool, no nudges, stop at each `end_turn`.
+
+## OpenAI routing (Chat Completions vs Responses API)
+
+`streamTurn` routes per model (gated by `isReasoningModel`):
+
+- **Reasoning models** (`gpt-5*`, `o1/o3/o4`) → Responses API (`/v1/responses`). These reject `reasoning_effort` alongside function tools on Chat Completions. History converts to `input` shape: `message`/`function_call`/`function_call_output` items linked by `call_id`.
+- **All other models** → Chat Completions (`/v1/chat/completions`). Uses `messages`/`tool_calls`/`tool` shape.
+
+Both share dangling-tool-call repair, image handling, and review serialization. Non-tool helpers (`validateKey`/`listModels`/`summarize`) always use Chat Completions.

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -1,0 +1,40 @@
+# Architecture Notes
+
+Reference for patterns that come up when extending the app. Consult when adding new engines, top-level pages, or cross-tab features.
+
+## Lazy WASM loading
+
+Each non-default engine is loaded on first use via a cached promise:
+
+- **manifold-3d** — eager on app boot (needed for `Manifold.ofMesh`, paint persistence, slicing).
+- **OpenSCAD** — `await import('openscad-wasm-prebuilt')` in `openscadEngine.init()`. Triggered on first SCAD session open or first SCAD run.
+- **OpenCASCADE / replicad** — `await import('replicad')` + WASM in `ensureBrepLoaded()` (`brepRuntime.ts`). Triggered by (a) `api.BREP.*` use in a manifold-js session, or (b) first replicad-language session run.
+- **WebLLM** — `await import('@mlc-ai/web-llm')` in `src/ai/local.ts`. Triggered on first local-model use.
+
+Each loader is idempotent and caches the resolved module. Vite splits each into its own chunk (verify via `npm run build` output — the OCCT WASM lands as `replicad_single-*.wasm` (~10 MB) outside the main bundle).
+
+When adding a new lazy-loaded module, follow `brepRuntime.ts`'s pattern: one `ensureXLoaded()` promise, cached after success and cleared on failure so the next call retries.
+
+## Browser history — back button preservation
+
+`updateURL()` in `sessionManager.ts` uses `history.replaceState`, not push — intentional for in-editor updates (version switching, rename) that shouldn't pollute the back stack. But it's a trap for cross-page navigation:
+
+- If any session-mutating function (`openSession`, `createSession`, `closeSession`, `importSessionPayload`) runs **before** you push the destination history entry, the internal `replaceState` overwrites the origin page and breaks the back button.
+- **Always push the destination entry first**, then run the state change. See `handleCatalogEntryLoad` and `openSessionFromLanding` in `src/main.ts` for the canonical ordering.
+- For in-page "Back" buttons on top-level pages (catalog, help), prefer `window.history.back()` when there's a real prior entry — falling back to `replace` (not push) when the page was loaded directly by URL. See `helpHasAppBackTarget` / `catalogHasAppBackTarget`.
+
+When adding a new top-level page or cross-page navigation, walk through:
+1. What's on the back stack before this navigation fires?
+2. What does `window.location` look like after each async step (especially DB or session ops)?
+3. Does back take the user to the prior page, not two pages back?
+
+## Cross-tab isolation — implementation patterns
+
+The rule: state must not bleed between tabs. The explicit exceptions are opening a session in a tab and taking control of a session in another tab.
+
+Concretely:
+
+- **Don't put session-scoped state in a shared localStorage blob.** AI provider/model/toggles are per-tab working state, persisted per-session on `session.aiPreference` and applied only on open/take-control — see `applySessionAiPreference`/`recordSessionAiPreference` in `aiPanel.ts` and `setSessionAiPreference` in `sessionManager.ts`. `reloadSettingsFromStorage` deliberately preserves this tab's `toggles`/`preset` when a peer tab writes the shared blob — it adopts only genuinely-global additive prefs (custom models, system-prompt overrides, panel width).
+- **App-level preferences** (units, render quality, editor auto-format) use `readPerTabPref`/`writePerTabPref` (`src/storage/perTabPref.ts`): live value in sessionStorage (per-tab) with a localStorage seed so a fresh tab still inherits the last choice. Don't attach a `storage` listener that live-mirrors them.
+- **`storage`-event and `BroadcastChannel` handlers** must gate on `msg.sessionId === currentState.session?.id` before acting — see `tabSync.ts` consumers and `sessionLock.ts`. Never adopt a peer's provider/model/toggles live.
+- **Truly-global state** (custom local models, system-prompt overrides) is the exception and must be additive/merge-friendly so a peer tab's write can't clobber another tab's addition.

--- a/docs/playwright-guide.md
+++ b/docs/playwright-guide.md
@@ -1,0 +1,22 @@
+# Playwright Guide
+
+## Multi-environment browser detection
+
+`playwright.config.ts` auto-picks the right Chromium binary so the same test command works on a developer laptop and inside the Claude Code on the web sandbox:
+
+- **Sandbox** (`/opt/pw-browsers/` exists): config picks the highest installed `chromium-N` directory and uses its `chrome` binary directly via `launchOptions.executablePath`. The version pinned by the `playwright` npm package may differ from what's cached, but the installed browser still satisfies the test runner — no download needed (the sandbox often blocks Chrome for Testing's CDN).
+- **Local laptop** (no `/opt/pw-browsers/`): config leaves `executablePath` unset, and Playwright finds its own cache at `~/.cache/ms-playwright/` (Linux) or `~/Library/Caches/ms-playwright/` (macOS). Run `npx playwright install chromium` once on a new machine.
+
+Override at the shell if needed:
+
+```bash
+PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/path/to/chrome npm run test:e2e
+```
+
+## AI agent gotchas
+
+1. **Don't reinstall browsers blindly.** Check `/opt/pw-browsers/` first; the sandbox image already has Chromium. `playwright.config.ts` handles the wiring.
+2. **Viewport size.** The default Desktop Chrome viewport (1280×720) clips the AI panel's toggle strip. The config sets 1280×900 — keep it that way for anything that interacts with elements in the bottom half of the panel.
+3. **Viewport hit-test.** Tiny flex children of recently-transformed parents sometimes fail Playwright's viewport hit-test (`Element is outside of the viewport`). When the bounding box is verifiably inside, prefer `locator.dispatchEvent('click')` over `locator.click({ force: true })` — the latter still enforces the viewport bound.
+4. **Fresh contexts.** Each Playwright test gets a fresh `BrowserContext`, so localStorage and IndexedDB are isolated by default. Don't add `localStorage.clear()` in `beforeEach` unless you mean it — it fires on `page.reload()` inside a test too, breaking any "state persists across reload" assertion.
+5. **No external network.** The `validateKey` flow hits `api.anthropic.com`; assert on the surfaced error message, not on whether the request succeeded.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Reduces CLAUDE.md from 480 → 345 lines (~150 lines, ~3,000 tokens) by extracting procedural checklists and implementation-detail reference into on-demand skills and docs
- All standing behavioral rules and instructions remain inline in CLAUDE.md; only reference material moves
- Adds three new slash-command skills and three reference docs

**New skills** (invoked with `/smoke-test`, `/add-provider`, `/release`):
- `.claude/skills/smoke-test.md` — the 16-item app verification checklist
- `.claude/skills/add-provider.md` — 7-step new AI provider integration checklist
- `.claude/skills/release.md` — staging→production release with doc drafting

**New reference docs** (consulted when working in the relevant area):
- `docs/ai-internals.md` — thinking box, Gemini thought signatures, thinking level per-provider mappings, auto-continue implementation, OpenAI Chat Completions vs Responses routing
- `docs/playwright-guide.md` — multi-env Chromium binary detection, Playwright agent gotchas
- `docs/architecture-notes.md` — lazy WASM `ensureXLoaded()` pattern, browser history push-before-mutate ordering, cross-tab isolation implementation patterns

## Test plan

- [ ] CLAUDE.md still contains all behavioral standing instructions (draft-PR-first, commit conventions, agent discipline, IndexedDB patterns, resource lifecycle, etc.)
- [ ] Each pointer in CLAUDE.md (`/smoke-test`, `docs/ai-internals.md`, etc.) resolves to an existing file/skill
- [ ] `/smoke-test` skill covers all 16 original checklist items
- [ ] `/add-provider` skill covers all 7 original steps
- [ ] `docs/ai-internals.md` covers thinking box, thought signatures, thinking level mappings, auto-continue, and OpenAI routing

https://claude.ai/code/session_017RtTfS5qcd4whjaVegdKaR
EOF

---
_Generated by [Claude Code](https://claude.ai/code/session_017RtTfS5qcd4whjaVegdKaR)_