### PR TITLE
chore: move catalog snapshot refresh from build-time to staging gate

### DIFF
--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -27,6 +27,8 @@ permissions:
 jobs:
   build-unit:
     runs-on: ubuntu-latest
+    outputs:
+      promote-sha: ${{ steps.commit-catalog.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -34,6 +36,20 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Refresh models catalog snapshot
+        id: commit-catalog
+        run: |
+          node scripts/refreshModelsSnapshot.mjs
+          if ! git diff --quiet src/ai/generated/modelsCatalog.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add src/ai/generated/modelsCatalog.json
+            git commit -m "chore: refresh models catalog snapshot"
+            git push origin HEAD:main
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          fi
       - name: Build (type-check + vite build)
         run: npm run build
       - name: Unit tests
@@ -71,7 +87,7 @@ jobs:
         run: npx playwright test --shard=${{ matrix.shard }}/3
 
   promote:
-    needs: e2e
+    needs: [build-unit, e2e]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -79,12 +95,14 @@ jobs:
           fetch-depth: 0
       # Reached only when build + unit + every e2e shard pass. Promotes the
       # green commit to staging, which Cloudflare deploys to the known-good
-      # staging preview.
+      # staging preview. Uses the SHA from build-unit, which may be one commit
+      # ahead of GITHUB_SHA if the catalog snapshot was refreshed.
       - name: Promote to staging
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin staging
+          git fetch origin staging main
           git checkout -B staging origin/staging
-          git merge --ff-only "$GITHUB_SHA" || git merge --no-edit "$GITHUB_SHA"
+          PROMOTE_SHA="${{ needs.build-unit.outputs.promote-sha }}"
+          git merge --ff-only "$PROMOTE_SHA" || git merge --no-edit "$PROMOTE_SHA"
           git push origin staging

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -87,32 +87,6 @@ function parseGitHubRepo(remoteUrl: string): string {
   return m ? m[1] : '';
 }
 
-// Refresh the models.dev catalog snapshot at the start of every production
-// build so the picker menus + cost meter ship with the latest data. Runs in
-// `build` only (not dev) so iterating on the dev server doesn't spam
-// models.dev on every restart — devs can refresh manually with
-// `npm run refresh-models` when they want the freshest data locally.
-//
-// The script is itself defensive: on any network failure it logs a warning
-// and exits 0, leaving the committed snapshot intact, so this hook can
-// never fail a build (CI / Cloudflare Pages stay green when models.dev is
-// down). Synchronous spawn keeps the build's task ordering simple.
-function catalogSnapshot(): Plugin {
-  return {
-    name: 'partwright-catalog-snapshot',
-    apply: 'build',
-    buildStart() {
-      try {
-        execSync('node scripts/refreshModelsSnapshot.mjs', { stdio: 'inherit' });
-      } catch (err) {
-        // The script soft-fails internally — anything reaching here is a
-        // crash (missing node, permissions). Don't break the build over it.
-        const msg = err instanceof Error ? err.message : String(err);
-        console.warn(`[partwright-catalog-snapshot] refresh script crashed: ${msg}`);
-      }
-    },
-  };
-}
 
 function resolveBuildInfo() {
   const git = (cmd: string): string => {
@@ -141,7 +115,7 @@ export default defineConfig({
   define: {
     __BUILD_INFO__: JSON.stringify(resolveBuildInfo()),
   },
-  plugins: [tailwindcss(), absoluteUrls(), markdownCharset(), catalogSnapshot(), dynamicSitemap()],
+  plugins: [tailwindcss(), absoluteUrls(), markdownCharset(), dynamicSitemap()],
   esbuild: {
     // .tsx files compile JSX via preact/jsx-runtime — keeps the bundle on
     // Preact without pulling in React. Vanilla .ts files in the rest of


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Remove the `catalogSnapshot` Vite plugin from `vite.config.ts` so `npm run build` no longer fetches from models.dev or rewrites `src/ai/generated/modelsCatalog.json`
- Add a dedicated "Refresh models catalog snapshot" step to the `staging-gate.yml` `build-unit` job that runs the script, commits any changes back to `main`, and outputs the resulting SHA
- Update the `promote` job to use that SHA (via `needs.build-unit.outputs.promote-sha`) instead of `$GITHUB_SHA`, so staging always includes the refreshed snapshot

## Why

Agents running `npm run build` as a pre-flight step were seeing `modelsCatalog.json` as dirty build-time churn and discarding the changes rather than including them. This made the catalog silently stale. Moving the refresh to the staging gate means it happens exactly once per promotion, gets committed with a clear `chore:` message, and never pollutes agent or PR check diffs.

## Test plan

- [ ] `npm run build` completes without touching `src/ai/generated/modelsCatalog.json`
- [ ] Staging gate: "Refresh models catalog snapshot" step runs `node scripts/refreshModelsSnapshot.mjs`, commits if the upstream catalog changed, pushes back to `main`
- [ ] Promote step fast-forwards staging to the post-refresh SHA when a catalog commit was made, or to `$GITHUB_SHA` when nothing changed

https://claude.ai/code/session_01Sy3oVxVodzut9bwxYK37mo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy3oVxVodzut9bwxYK37mo)_