### PR TITLE
fix: relief removeBackground now detects from pre-quantization RGB

### DIFF
--- a/src/relief/imageToRelief.ts
+++ b/src/relief/imageToRelief.ts
@@ -244,7 +244,21 @@ export function sampleImageToGrid(image: ImageData, opts: ReliefOptions): Height
   const count = w * h;
 
   if (opts.mode === 'quantized') {
-    return sampleQuantized(rgb, w, h, opts);
+    const grid = sampleQuantized(rgb, w, h, opts);
+    if (opts.common.removeBackground) {
+      // Detect background from pre-quantization RGB so exact-color matching in
+      // detectBackgroundMask doesn't hit subject pixels that share a cluster
+      // centroid with the background (the bug when using grid.colors, which
+      // collapses many colors to k representatives).
+      const colorsU8 = new Uint8Array(count * 3);
+      for (let i = 0; i < count * 3; i++) colorsU8[i] = clamp255(rgb[i]);
+      const bgMask = pickBackgroundMask(colorsU8, image, w, h, cropToPixels(image, opts.crop) ?? undefined);
+      grid.bgMask = bgMask;
+      for (let i = 0; i < count; i++) {
+        if (bgMask[i] === 0) grid.heights[i] = 0;
+      }
+    }
+    return grid;
   }
 
   // Luminance (and AI) mode.
@@ -685,16 +699,6 @@ export function generateRelief(image: ImageData, opts: ReliefOptions = DEFAULT_R
     return buildQuantizedTile(grid, opts, image);
   }
 
-  // For stepped relief with removeBackground, zero out height for background
-  // cells so they print as the base only (no raised colour terrace).
-  if (opts.common.removeBackground && opts.mode === 'quantized' && grid.colors) {
-    const cropPx = cropToPixels(image, opts.crop) ?? undefined;
-    const bgMask = pickBackgroundMask(grid.colors, image, grid.width, grid.height, cropPx);
-    for (let i = 0; i < grid.heights.length; i++) {
-      if (bgMask[i] === 0) grid.heights[i] = 0;
-    }
-  }
-
   // Stepped relief (both painting modes) uses the continuous height-grid mesh.
   // It is a closed 2-manifold (verified by isEdgeManifold inside
   // buildReliefMesh) so it slices and prints; an earlier experiment that built
@@ -743,9 +747,11 @@ function buildQuantizedTile(grid: HeightGrid, opts: ReliefOptions, sourceImage?:
 
   // When removeBackground is on for a non-silhouette tile, detect the
   // background and intersect it with the existing shape mask so background
-  // pixels are cut out of even rect/rounded/circle tiles.
+  // pixels are cut out of even rect/rounded/circle tiles. Prefer the pre-
+  // quantization bgMask (set by sampleImageToGrid) to avoid matching subject
+  // pixels that share a cluster centroid with the background color.
   if (opts.common.removeBackground && opts.quantized.output !== 'silhouette') {
-    const fgMask = pickBackgroundMask(colors, sourceImage ?? null, W, H);
+    const fgMask = grid.bgMask ?? pickBackgroundMask(colors, sourceImage ?? null, W, H);
     const shapeMask = buildCellMask(W, H, tileOpts, shape);
     const combined = new Uint8Array(W * H);
     for (let i = 0; i < W * H; i++) combined[i] = shapeMask[i] & fgMask[i];

--- a/src/relief/types.ts
+++ b/src/relief/types.ts
@@ -203,6 +203,9 @@ export interface HeightGrid {
   height: number;
   heights: Float32Array;
   colors?: Uint8Array;
+  /** Per-cell mask (1=keep, 0=background) detected from pre-quantization RGB.
+   *  Only set when removeBackground is enabled on a quantized-mode grid. */
+  bgMask?: Uint8Array;
 }
 
 /** A generated relief: a watertight (when possible) mesh plus the grid it came


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause**: `detectBackgroundMask` uses exact RGB color matching. After k-means clustering, `grid.colors` contains only `k` cluster centroids — dark subject pixels share the exact same centroid as the background (e.g., both map to `(0,0,0)`). Calling `detectBackgroundMask` on post-quantization colors therefore zeroed entire dark regions of the subject, not just the actual background.
- **Why voxel worked**: Voxel detects the background mask from the downsampled pre-quantization RGB (many distinct colors), so the exact-match only fires on the actual background pixels.
- **Fix**: Detect the background mask in `sampleImageToGrid` from the pre-quantization `rgb` float array (same data the luminance path already uses correctly), store it as `HeightGrid.bgMask`, and use that stored mask in both the stepped-relief height-zeroing path and the non-silhouette tile shape-cutting path in `buildQuantizedTile`.

## Test plan

- [ ] Load a black-background image in the relief import flow with "remove background" enabled (quantized mode) — confirm dark areas of the subject are preserved, only the background is removed
- [ ] Same test with a light-background image — background removed, subject intact
- [ ] Silhouette tile mode unaffected (uses its own border-detection on cluster colors, which is correct for that use case)
- [ ] Luminance mode unaffected (its path was already correct — no code change there)
- [ ] Voxel remove-background unaffected

https://claude.ai/code/session_013aWffzh9YgHkQ2LFxnsgjT
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013aWffzh9YgHkQ2LFxnsgjT)_