### PR TITLE
feat: audit fixes — AppConfig migration, ? help tooltips, bug fixes

### DIFF
--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -258,7 +258,8 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
     return workingHistory;
   }
 
-  for (let iter = 0; Number.isFinite(maxIter) ? iter < maxIter : true; iter++) {
+  let iter = 0;
+  for (; Number.isFinite(maxIter) ? iter < maxIter : true; iter++) {
     // Give the browser a frame between iterations so an agent running
     // many tool round-trips doesn't lock up the page.
     if (iter > 0) await yieldToBrowser();
@@ -623,8 +624,7 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
   // and exits via end_turn / error / abort; under auto-continue the end_turn
   // exit is reached once the no-progress ceiling trips (so even infinity caps
   // can't spin forever on a model that never calls `finish`).
-  const reached = Number.isFinite(maxIter) ? maxIter : totalToolCalls;
-  callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason: 'iteration_cap', iterations: reached });
+  callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason: 'iteration_cap', iterations: iter });
   return workingHistory;
 }
 

--- a/src/ai/local.ts
+++ b/src/ai/local.ts
@@ -27,6 +27,7 @@ import type { LocalModelId, LocalModelInfo } from './localModels';
 import { isWebGpuAvailable, LOCAL_MODELS } from './localModels';
 import { loadSettings, type CustomLocalModel } from './settings';
 import { buildFallbackLadder, getCachedCeiling, getModelCeiling } from './modelMetadata';
+import { getConfig } from '../config/appConfig';
 
 // We can't statically type-import from @mlc-ai/web-llm without forcing it
 // into the main bundle, so we keep the engine handle untyped here and rely
@@ -77,13 +78,13 @@ function resolveCustomContextWindow(modelId: string): number | null {
  *  the actual prompt text; bump the constants in `buildLocalSystemPrompt` /
  *  `appendPromptToolDocs` if you change those. */
 function computeAttentionSink(info: LocalModelInfo): number {
-  const promptBudget = info.promptTier === 'medium' ? 1300 : 600;
+  const cfg = getConfig();
+  const promptBudget = info.promptTier === 'medium' ? cfg.ai.localPromptBudgetMedium : cfg.ai.localPromptBudgetSlim;
   // Native callers use the `tools` API field, not a system-prompt block,
   // so need minimal sink budget. Other models append a ~400-token compact
   // tool-docs block.
-  const toolsBudget = info.officialToolCalling ? 100 : 500;
-  const safetyMargin = 200;
-  return Math.min(2048, promptBudget + toolsBudget + safetyMargin);
+  const toolsBudget = info.officialToolCalling ? cfg.ai.localToolsBudgetNative : cfg.ai.localToolsBudgetPromptEngineered;
+  return Math.min(cfg.ai.localAttentionSinkMax, promptBudget + toolsBudget + cfg.ai.localAttentionSinkMargin);
 }
 
 function buildCustomModelEntries(webllm: typeof import('@mlc-ai/web-llm')): import('@mlc-ai/web-llm').ModelRecord[] {

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -39,9 +39,9 @@ export type GeminiModelId =
   | 'gemini-flash-latest'
   | 'gemini-flash-lite-latest';
 
-/** Either an Anthropic model name or a WebLLM model_id or a hosted-provider
- *  model id. The shape is the same at the type level (a string) so callers
- *  can treat it opaquely. */
+/** Statically-known model IDs for the four named providers. Custom endpoint
+ *  models are user-supplied strings; `activeModel()` returns `ModelId | string | null`
+ *  to cover that case. */
 export type ModelId = AnthropicModelId | LocalModelId | OpenaiModelId | GeminiModelId;
 
 /** Named bundles of toggle settings the user can flip between with a

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -48,6 +48,26 @@ export interface AppConfig {
     charsPerToken: number;
     /** Estimated tokens per image block at standard resolution. */
     imageTokenEstimate: number;
+    /** Geometry execution timeout for the manifold-js (mesh) engine (ms). */
+    geometryTimeoutManifoldMs: number;
+    /** Geometry execution timeout for the OpenSCAD engine (ms). SCAD compiles
+     *  BOSL2-style libraries from source per call — complex gear/thread models
+     *  can exceed a minute on slow hardware. */
+    geometryTimeoutScadMs: number;
+    /** Geometry execution timeout for the replicad/BREP (OpenCASCADE) engine (ms). */
+    geometryTimeoutReplicadMs: number;
+    /** Token budget for the system-prompt block in local (WebLLM) medium-tier models. */
+    localPromptBudgetMedium: number;
+    /** Token budget for the system-prompt block in local (WebLLM) slim-tier models. */
+    localPromptBudgetSlim: number;
+    /** Token budget for native tool-calling schemas in local models. */
+    localToolsBudgetNative: number;
+    /** Token budget for prompt-engineered tool schemas in local models. */
+    localToolsBudgetPromptEngineered: number;
+    /** Safety-margin tokens added to the attention-sink context window budget. */
+    localAttentionSinkMargin: number;
+    /** Hard cap on attention-sink tokens for local models. */
+    localAttentionSinkMax: number;
   };
   renderer: {
     /** Three.js camera field-of-view in degrees. Takes effect on page reload. */
@@ -60,6 +80,28 @@ export interface AppConfig {
     gridSize: number;
     /** Number of grid divisions. Takes effect on page reload. */
     gridDivisions: number;
+    /** Orientation gizmo canvas size in CSS pixels. */
+    gizmoSizePx: number;
+    /** Orientation gizmo corner margin in CSS pixels. */
+    gizmoMarginPx: number;
+    /** Gizmo label hit-detection radius in orthographic units (0–2 range). */
+    gizmoHitRadius: number;
+    /** Gizmo snap-to-face animation duration in seconds. */
+    gizmoSnapDurationSec: number;
+    /** OrbitControls damping factor — lower is snappier, higher is smoother. */
+    orbitDampingFactor: number;
+    /** Ambient light intensity in the 3D viewport (0–2 range). */
+    ambientLightIntensity: number;
+    /** Primary directional light intensity (0–2 range). */
+    primaryLightIntensity: number;
+    /** Secondary fill light intensity (0–2 range). */
+    secondaryLightIntensity: number;
+    /** Idle time (ms) before an unused offscreen multi-view renderer is disposed. */
+    offscreenIdleDisposeMs: number;
+    /** Pointer activity grace window (ms) that keeps on-demand rendering active. */
+    pointerGraceMs: number;
+    /** Max time (ms) to wait for thumbnail generation before giving up. */
+    thumbnailTimeoutMs: number;
   };
   import: {
     /** Vertex-weld tolerance for STL imports (world units). */
@@ -70,12 +112,32 @@ export interface AppConfig {
     voxelHeavyThreshold: number;
     /** Max image resolution (pixels per side) when importing for relief. */
     reliefMaxResolution: number;
+    /** Timeout (ms) for fetching a remote file by URL in the import-from-URL flow. */
+    remoteFetchTimeoutMs: number;
+    /** Color-distance threshold for matching swapped filament colors (0–1, lower = stricter). */
+    filamentMatchThreshold: number;
+    /** Confidence score below which the filament swap guide shows a warning (0–1). */
+    filamentConfidenceWarnThreshold: number;
   };
   ui: {
     /** How long toast notifications stay on screen (ms). */
     toastDurationMs: number;
     /** Hover-tooltip show delay (ms). */
     tooltipDelayMs: number;
+    /** Idle delay (ms) after the last keystroke before error annotations appear in the code editor. */
+    codeEditorErrorIdleMs: number;
+    /** Debounce delay (ms) for the surface-modifier live preview. */
+    surfacePreviewDebounceMs: number;
+    /** Debounce delay (ms) for the relief import 2D preview. */
+    reliefPreviewDebounceMs: number;
+    /** Debounce delay (ms) for the relief import 3D preview. */
+    reliefPreview3dDebounceMs: number;
+    /** Delay (ms) before the progress modal appears (hides fast operations). */
+    progressModalShowDelayMs: number;
+    /** Heartbeat interval (ms) for the cross-tab session leader lock. */
+    sessionLockHeartbeatMs: number;
+    /** Time (ms) after which a session lock heartbeat is considered stale. */
+    sessionLockStaleMs: number;
   };
 }
 
@@ -98,6 +160,15 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     maxOutputTokensGemini: 32768,
     charsPerToken: 4,
     imageTokenEstimate: 1500,
+    geometryTimeoutManifoldMs: 60_000,
+    geometryTimeoutScadMs: 180_000,
+    geometryTimeoutReplicadMs: 180_000,
+    localPromptBudgetMedium: 1300,
+    localPromptBudgetSlim: 600,
+    localToolsBudgetNative: 100,
+    localToolsBudgetPromptEngineered: 500,
+    localAttentionSinkMargin: 200,
+    localAttentionSinkMax: 2048,
   },
   renderer: {
     fov: 50,
@@ -105,16 +176,37 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     interactionRenderScale: 0.6,
     gridSize: 40,
     gridDivisions: 40,
+    gizmoSizePx: 128,
+    gizmoMarginPx: 8,
+    gizmoHitRadius: 0.4,
+    gizmoSnapDurationSec: 0.4,
+    orbitDampingFactor: 0.1,
+    ambientLightIntensity: 0.6,
+    primaryLightIntensity: 0.8,
+    secondaryLightIntensity: 0.3,
+    offscreenIdleDisposeMs: 10_000,
+    pointerGraceMs: 350,
+    thumbnailTimeoutMs: 4000,
   },
   import: {
     stlWeldTolerance: 1e-5,
     voxelDefaultMaxSize: 64,
     voxelHeavyThreshold: 250_000,
     reliefMaxResolution: 512,
+    remoteFetchTimeoutMs: 15_000,
+    filamentMatchThreshold: 0.18,
+    filamentConfidenceWarnThreshold: 0.9,
   },
   ui: {
     toastDurationMs: 2200,
     tooltipDelayMs: 150,
+    codeEditorErrorIdleMs: 800,
+    surfacePreviewDebounceMs: 250,
+    reliefPreviewDebounceMs: 120,
+    reliefPreview3dDebounceMs: 250,
+    progressModalShowDelayMs: 250,
+    sessionLockHeartbeatMs: 3000,
+    sessionLockStaleMs: 8000,
   },
 };
 

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -10,6 +10,7 @@ import { manifoldApiCompletion } from './apiCompletions';
 import type { SourceDiagnostic } from '../geometry/types';
 import { getTheme, onThemeChange, type Theme } from '../ui/theme';
 import { readPerTabPref, writePerTabPref } from '../storage/perTabPref';
+import { getConfig } from '../config/appConfig';
 
 /** Replicad/BREP sessions reuse the JavaScript editor since they're written
  *  as JS (`api.BREP.box(...)`), but we still track them as a distinct
@@ -22,8 +23,6 @@ let debounceTimer: number | null = null;
 let idleTimer: number | null = null;
 let activeDiagnostics: Diagnostic[] = [];
 
-/** How long typing must be idle before deferred error UI is surfaced. */
-const ERROR_IDLE_MS = 800;
 let currentLanguage: EditorLanguage = 'manifold-js';
 // Per-tab (with a shared seed for fresh tabs) so toggling auto-format in one
 // window doesn't flip it in another open window.
@@ -176,7 +175,7 @@ export function initEditor(
           if (idleTimer !== null) clearTimeout(idleTimer);
           idleTimer = window.setTimeout(() => {
             hooks.onIdle?.(getValue());
-          }, ERROR_IDLE_MS);
+          }, getConfig().ui.codeEditorErrorIdleMs);
         }
       }),
       EditorView.domEventHandlers({

--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -7,6 +7,7 @@ import { replicadEngine } from './engines/replicad';
 import { voxelEngine } from './engines/voxel';
 import { getActiveImports } from '../import/importedMesh';
 import { getDefaultCircularSegments } from './qualitySettings';
+import { getConfig } from '../config/appConfig';
 
 export type { Language };
 export { isLanguage, DEFAULT_LANGUAGE };
@@ -107,18 +108,13 @@ const pendingSimplifies  = new Map<string, {
 // SCAD compiles BOSL2-style libraries from source per call, and complex
 // real-thread / gear-tooth math can comfortably push past a minute on a
 // slow CI runner — so it gets a much longer ceiling.
-const EXECUTE_TIMEOUT_MS: Record<Language, number> = {
-  'manifold-js': 60_000,
-  'scad':        180_000,
-  // BREP/replicad: OCCT booleans on complex parts (e.g. STEP-imported
-  // assemblies) can rival SCAD's worst cases, so use the same 3-minute
-  // ceiling as SCAD rather than the mesh kernel's tighter bound.
-  'replicad':    180_000,
-  // Voxel meshing is pure JS (no WASM); large grids are the only slow case,
-  // and the mesher is linear in occupied voxels — the manifold-js ceiling is
-  // ample headroom.
-  'voxel':       60_000,
-};
+function getExecuteTimeoutMs(lang: Language): number {
+  const cfg = getConfig();
+  if (lang === 'scad') return cfg.ai.geometryTimeoutScadMs;
+  if (lang === 'replicad') return cfg.ai.geometryTimeoutReplicadMs;
+  // manifold-js and voxel share the same ceiling
+  return cfg.ai.geometryTimeoutManifoldMs;
+}
 
 function rejectAllPending(err: Error): void {
   for (const p of pendingExecutions.values()) p.reject(err);
@@ -367,7 +363,7 @@ export async function executeCodeAsync(source: string, lang?: Language, paramOve
     triVerts:       m.triVerts.slice(),
   }));
 
-  const timeoutMs = EXECUTE_TIMEOUT_MS[l];
+  const timeoutMs = getExecuteTimeoutMs(l);
   return new Promise<MeshResult>((resolve, reject) => {
     // A hung WASM evaluation never posts a result back. Without a timeout the
     // promise (and the UI's "Running…" state) would wait forever.
@@ -417,7 +413,7 @@ export async function validateCodeAsync(source: string, lang?: Language): Promis
     initEngineWorker();
     await workerReady;
     const callId = `val-${++callIdCounter}`;
-    const timeoutMs = EXECUTE_TIMEOUT_MS[l];
+    const timeoutMs = getExecuteTimeoutMs(l);
     return new Promise<ValidateResult>((resolve, reject) => {
       // A hung validate never posts a result back. Mirror executeCodeAsync's
       // timeout so a stuck OpenSCAD parse restarts the worker (which rejects all
@@ -455,7 +451,7 @@ export async function exportLastBrepAsSTEP(): Promise<Blob | null> {
       if (pendingStepExports.has(callId)) {
         restartEngineWorker('STEP export timed out');
       }
-    }, EXECUTE_TIMEOUT_MS.replicad);
+    }, getExecuteTimeoutMs('replicad'));
     pendingStepExports.set(callId, {
       resolve: (b) => { clearTimeout(timer); resolve(b); },
       reject: (e) => { clearTimeout(timer); reject(e); },
@@ -479,7 +475,7 @@ export async function importSTEPToBrep(blob: Blob, filename: string): Promise<st
       if (pendingStepBrepImports.has(callId)) {
         restartEngineWorker('STEP→BREP import timed out');
       }
-    }, EXECUTE_TIMEOUT_MS.replicad);
+    }, getExecuteTimeoutMs('replicad'));
     pendingStepBrepImports.set(callId, {
       resolve: (n) => { clearTimeout(timer); resolve(n); },
       reject: (e) => { clearTimeout(timer); reject(e); },
@@ -502,7 +498,7 @@ export async function importSTEPToMesh(blob: Blob): Promise<MeshData> {
       if (pendingStepMeshImports.has(callId)) {
         restartEngineWorker('STEP→mesh import timed out');
       }
-    }, EXECUTE_TIMEOUT_MS.replicad);
+    }, getExecuteTimeoutMs('replicad'));
     pendingStepMeshImports.set(callId, {
       resolve: (m) => { clearTimeout(timer); resolve(m); },
       reject: (e) => { clearTimeout(timer); reject(e); },
@@ -522,7 +518,7 @@ export async function clearBrepImports(): Promise<void> {
       if (pendingClearBrepImports.has(callId)) {
         restartEngineWorker('clearBrepImports timed out');
       }
-    }, EXECUTE_TIMEOUT_MS.replicad);
+    }, getExecuteTimeoutMs('replicad'));
     pendingClearBrepImports.set(callId, {
       resolve: () => { clearTimeout(timer); resolve(); },
       reject: (e) => { clearTimeout(timer); reject(e); },
@@ -544,7 +540,7 @@ export async function clearBrepShape(): Promise<void> {
       if (pendingClearBrepShapes.has(callId)) {
         restartEngineWorker('clearBrepShape timed out');
       }
-    }, EXECUTE_TIMEOUT_MS.replicad);
+    }, getExecuteTimeoutMs('replicad'));
     pendingClearBrepShapes.set(callId, {
       resolve: () => { clearTimeout(timer); resolve(); },
       reject: (e) => { clearTimeout(timer); reject(e); },

--- a/src/import/urlImport.ts
+++ b/src/import/urlImport.ts
@@ -23,8 +23,6 @@ export type ImportUrlParse =
  *  for servers that omit or lie about the header. */
 export const MAX_REMOTE_BYTES = 25 * 1024 * 1024;
 
-/** Abort a stalled remote fetch after this long (~15s). */
-export const REMOTE_FETCH_TIMEOUT_MS = 15_000;
 
 /**
  * Classify a trimmed user input string into a share link, a remote http(s)

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,6 @@ import {
   classifyRemoteResource,
   ensureExtensionForSource,
   MAX_REMOTE_BYTES,
-  REMOTE_FETCH_TIMEOUT_MS,
 } from './import/urlImport';
 import { showImportTargetModal } from './ui/importTargetModal';
 import { showImageVoxelImportModal, type ImageVoxelModalResult } from './ui/imageVoxelImportModal';
@@ -566,7 +565,6 @@ function updateGeometryData(executionTimeMs?: number, sourceCode?: string) {
  *  the GPU readback never settles the callback. A thumbnail is non-essential, so
  *  we cap the wait and let the save proceed without it rather than hang forever
  *  (which silently blocked saving a painted version). */
-const THUMBNAIL_TIMEOUT_MS = 4000;
 
 function captureThumbnail(mesh: MeshData | null = currentMeshData): Promise<Blob | null> {
   if (!mesh) return Promise.resolve(null);
@@ -590,7 +588,7 @@ function captureThumbnail(mesh: MeshData | null = currentMeshData): Promise<Blob
     };
     // Bound the wait: if toBlob never calls back, resolve null so the caller
     // (save / snapshot) still completes.
-    const timer = setTimeout(() => finish(null), THUMBNAIL_TIMEOUT_MS);
+    const timer = setTimeout(() => finish(null), getConfig().renderer.thumbnailTimeoutMs);
     try {
       canvas.toBlob(b => finish(b), 'image/png');
     } catch {
@@ -2350,7 +2348,7 @@ async function main() {
    *  Throws a human-readable message on any failure. */
   async function importFromRemoteUrl(url: string): Promise<void> {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), REMOTE_FETCH_TIMEOUT_MS);
+    const timer = setTimeout(() => controller.abort(), getConfig().import.remoteFetchTimeoutMs);
     let res: Response;
     try {
       res = await fetch(url, { signal: controller.signal, redirect: 'follow' });

--- a/src/relief/swapGuide.ts
+++ b/src/relief/swapGuide.ts
@@ -8,16 +8,9 @@ import type { MeshData } from '../geometry/types';
 import type { ColorRegion } from '../color/regions';
 import type { Filament, HeightBand, SwapGuide, SwapInstruction } from './types';
 import { analyzeHeightBands } from './heightBands';
+import { getConfig } from '../config/appConfig';
 
 type RGB = [number, number, number];
-
-// Max RGB Euclidean distance (channels 0..1) for a band colour to claim a
-// library filament's name. ~0.18 ≈ a perceptibly close match without forcing
-// distant colours onto an unrelated filament.
-const FILAMENT_MATCH_THRESHOLD = 0.18;
-
-// Bands below this confidence get a horizontal-variation warning.
-const CONFIDENCE_WARN = 0.9;
 
 function hexToRgb(hex: string): RGB | null {
   const m = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
@@ -47,7 +40,7 @@ function matchFilament(color: RGB, filaments: readonly Filament[] | undefined): 
       bestName = f.name;
     }
   }
-  return bestDist <= FILAMENT_MATCH_THRESHOLD ? bestName : undefined;
+  return bestDist <= getConfig().import.filamentMatchThreshold ? bestName : undefined;
 }
 
 function sameColor(a: RGB, b: RGB): boolean {
@@ -88,7 +81,7 @@ export function buildSwapGuide(
       prevColor = band.color;
     }
 
-    if (band.confidence < CONFIDENCE_WARN) {
+    if (band.confidence < getConfig().import.filamentConfidenceWarnThreshold) {
       warnings.push(
         `Layers ${band.layerStart}–${band.layerEnd} mix colors at the same height; ` +
           `a single nozzle can't reproduce this — use AMS or constrain paint to Z-slabs.`,

--- a/src/renderer/multiview.ts
+++ b/src/renderer/multiview.ts
@@ -4,6 +4,7 @@ import type { MeshData } from '../geometry/types';
 import { buildStrokesGroup, disposeStrokesGroup } from '../annotations/annotationOverlay';
 import { presetIndex } from '../storage/db';
 import { CREASE_ANGLE_DEG, resolveEdgeMode, type EdgeMode } from './edgeMode';
+import { getConfig } from '../config/appConfig';
 export { EDGE_MODES, type EdgeMode } from './edgeMode';
 
 /** Composite-render angle sets accepted by `partwright.renderViews`.
@@ -115,7 +116,6 @@ let offRendererDisposeTimer: ReturnType<typeof setTimeout> | null = null;
 // at ~16 live WebGL contexts. We dispose the offscreen renderer after a short
 // idle window so GPU memory is reclaimed between user actions; the lazy branch
 // in getOffscreenRenderer re-creates it on the next render.
-const OFFSCREEN_IDLE_DISPOSE_MS = 10_000;
 
 function disposeOffscreenRenderer(): void {
   if (!offRenderer) return;
@@ -131,7 +131,7 @@ function scheduleOffscreenDispose(): void {
   offRendererDisposeTimer = setTimeout(() => {
     offRendererDisposeTimer = null;
     disposeOffscreenRenderer();
-  }, OFFSCREEN_IDLE_DISPOSE_MS);
+  }, getConfig().renderer.offscreenIdleDisposeMs);
 }
 
 function getOffscreenRenderer(size: number): THREE.WebGLRenderer {

--- a/src/renderer/orientationGizmo.ts
+++ b/src/renderer/orientationGizmo.ts
@@ -4,6 +4,7 @@
 import * as THREE from 'three';
 import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
 import type { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { getConfig } from '../config/appConfig';
 
 let viewHelper: ViewHelper | null = null;
 let mainCamera: THREE.PerspectiveCamera | null = null;
@@ -17,11 +18,6 @@ const snapTargetPos = new THREE.Vector3();
 const snapStartUp = new THREE.Vector3();
 const snapTargetUp = new THREE.Vector3();
 let snapProgress = 0;
-const SNAP_DURATION = 0.4; // seconds
-
-const GIZMO_SIZE = 128;
-const GIZMO_MARGIN = 8;
-const HIT_RADIUS = 0.4; // in orthographic units (-2 to 2 range)
 
 // Z-up view orientations: camera direction from target, camera up vector.
 // Top/bottom use a tiny Y offset to avoid degenerate lookAt when view dir is parallel to camera.up.
@@ -54,7 +50,7 @@ export function initOrientationGizmo(
   viewHelper = new ViewHelper(camera, canvas);
   viewHelper.setLabels('X', 'Y', 'Z');
   viewHelper.setLabelStyle('18px system-ui', '#ffffff', 14);
-  viewHelper.location = { top: GIZMO_MARGIN, right: GIZMO_MARGIN, bottom: 0, left: null };
+  viewHelper.location = { top: getConfig().renderer.gizmoMarginPx, right: getConfig().renderer.gizmoMarginPx, bottom: 0, left: null };
 
   // Fix negative axis sprites: default black is invisible on the dark viewport background
   viewHelper.children.forEach(child => {
@@ -84,16 +80,17 @@ function hitTestGizmo(clientX: number, clientY: number): string | null {
   if (!canvasEl || !mainCamera) return null;
 
   const rect = canvasEl.getBoundingClientRect();
-  const gizmoLeft = rect.right - GIZMO_SIZE - GIZMO_MARGIN;
-  const gizmoTop = rect.top + GIZMO_MARGIN;
+  const cfg = getConfig().renderer;
+  const gizmoLeft = rect.right - cfg.gizmoSizePx - cfg.gizmoMarginPx;
+  const gizmoTop = rect.top + cfg.gizmoMarginPx;
 
   const localX = clientX - gizmoLeft;
   const localY = clientY - gizmoTop;
-  if (localX < 0 || localX > GIZMO_SIZE || localY < 0 || localY > GIZMO_SIZE) return null;
+  if (localX < 0 || localX > cfg.gizmoSizePx || localY < 0 || localY > cfg.gizmoSizePx) return null;
 
   // Convert to gizmo's orthographic space (-2 to 2)
-  const orthoX = (localX / GIZMO_SIZE) * 4 - 2;
-  const orthoY = -((localY / GIZMO_SIZE) * 4 - 2);
+  const orthoX = (localX / cfg.gizmoSizePx) * 4 - 2;
+  const orthoY = -((localY / cfg.gizmoSizePx) * 4 - 2);
 
   const q = mainCamera.quaternion.clone().invert();
   let best: string | null = null;
@@ -103,7 +100,7 @@ function hitTestGizmo(clientX: number, clientY: number): string | null {
     const pos = new THREE.Vector3(x, y, z).applyQuaternion(q);
     const dx = orthoX - pos.x;
     const dy = orthoY - pos.y;
-    if (Math.sqrt(dx * dx + dy * dy) < HIT_RADIUS && pos.z > bestZ) {
+    if (Math.sqrt(dx * dx + dy * dy) < getConfig().renderer.gizmoHitRadius && pos.z > bestZ) {
       best = type;
       bestZ = pos.z;
     }
@@ -157,7 +154,7 @@ export function renderGizmo(renderer: THREE.WebGLRenderer): void {
 export function updateGizmo(delta: number): void {
   if (!snapAnimating || !mainCamera || !mainControls) return;
 
-  snapProgress = Math.min(1, snapProgress + delta / SNAP_DURATION);
+  snapProgress = Math.min(1, snapProgress + delta / getConfig().renderer.gizmoSnapDurationSec);
   const t = snapProgress * snapProgress * (3 - 2 * snapProgress); // smoothstep
 
   mainCamera.position.lerpVectors(snapStartPos, snapTargetPos, t);

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -56,7 +56,6 @@ export function setOnContextRestored(fn: () => void): void { onContextRestored =
 // difference between constant GPU churn and only working when the view moves.
 let needsRender = true;
 let lastPointerActivity = 0;
-const POINTER_GRACE_MS = 350;
 
 // === Adaptive resolution ===
 // Full (capped) device pixel ratio when the camera is still; a reduced ratio
@@ -168,7 +167,7 @@ export function initViewport(container: HTMLElement): {
 
   controls = new OrbitControls(camera, canvas);
   controls.enableDamping = true;
-  controls.dampingFactor = 0.1;
+  controls.dampingFactor = getConfig().renderer.orbitDampingFactor;
   controls.target.set(0, 0, 0);
 
   // On-demand rendering hooks: 'change' fires on every camera move (including
@@ -240,14 +239,14 @@ export function initViewport(container: HTMLElement): {
   }, { capture: true, passive: false });
 
   // Lighting
-  const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+  const ambient = new THREE.AmbientLight(0xffffff, getConfig().renderer.ambientLightIntensity);
   scene.add(ambient);
 
-  const dir1 = new THREE.DirectionalLight(0xffffff, 0.8);
+  const dir1 = new THREE.DirectionalLight(0xffffff, getConfig().renderer.primaryLightIntensity);
   dir1.position.set(10, -10, 15);
   scene.add(dir1);
 
-  const dir2 = new THREE.DirectionalLight(0xffffff, 0.3);
+  const dir2 = new THREE.DirectionalLight(0xffffff, getConfig().renderer.secondaryLightIntensity);
   dir2.position.set(-10, 10, -5);
   scene.add(dir2);
 
@@ -324,7 +323,7 @@ export function initViewport(container: HTMLElement): {
     // sets needsRender) whenever the camera actually moves, so inertia keeps the
     // loop painting until it settles.
     controls.update();
-    const pointerActive = performance.now() - lastPointerActivity < POINTER_GRACE_MS;
+    const pointerActive = performance.now() - lastPointerActivity < getConfig().renderer.pointerGraceMs;
     if (needsRender || pointerActive || isGizmoAnimating()) {
       renderer.render(scene, camera);
       renderGizmo(renderer);

--- a/src/storage/sessionLock.ts
+++ b/src/storage/sessionLock.ts
@@ -11,15 +11,12 @@
 // The public surface (onOwnershipChange / acquireSession) is unchanged, so the
 // UI keeps consuming "am I the writer?" the same way.
 
+import { getConfig } from '../config/appConfig';
+
 export interface OwnershipState {
   sessionId: string | null;
   owned: boolean;
 }
-
-const HEARTBEAT_MS = 3000;
-/** A leader is considered dead if its token hasn't been refreshed in this long
- *  (more than two missed heartbeats). */
-const STALE_MS = 8000;
 
 const tabId =
   (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
@@ -70,7 +67,7 @@ function clearOwnToken(sessionId: string): void {
 }
 
 function isStale(tok: LeaderToken | null): boolean {
-  return !tok || Date.now() - tok.ts > STALE_MS;
+  return !tok || Date.now() - tok.ts > getConfig().ui.sessionLockStaleMs;
 }
 
 function emit(): void {
@@ -147,7 +144,7 @@ export function initSessionLeader(): void {
     if (owned && currentSessionId) clearOwnToken(currentSessionId);
   });
 
-  setInterval(tick, HEARTBEAT_MS);
+  setInterval(tick, getConfig().ui.sessionLockHeartbeatMs);
 }
 
 /** Begin coordinating leadership for `sessionId` (or release when null).

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -32,23 +32,21 @@ function cloneConfig(c: AppConfig): AppConfig {
 
 interface FieldProps {
   label: string;
-  /** Shown after the number input in muted text, e.g. "ms" or "px". */
   unit?: string;
-  /** Hint displayed under the field. */
   hint?: string;
-  /** Suffix appended when the value differs from default, e.g. "default: 8". */
+  /** Detailed explanation shown in the "?" hover tooltip. */
+  tooltip?: string;
   defaultValue: number;
   value: number;
   min?: number;
   max?: number;
   step?: number;
-  /** When true the input shows an integer spinner (step defaults to 1). */
   integer?: boolean;
   onChange: (v: number) => void;
 }
 
 function Field(props: FieldProps) {
-  const { label, unit, hint, defaultValue, value, min, max, step, integer, onChange } = props;
+  const { label, unit, hint, tooltip, defaultValue, value, min, max, step, integer, onChange } = props;
   const changed = value !== defaultValue;
   const effectiveStep = step ?? (integer ? 1 : 'any');
 
@@ -67,6 +65,18 @@ function Field(props: FieldProps) {
     <div class="flex flex-col gap-1">
       <div class="flex items-center gap-2">
         <label class="text-xs font-medium text-zinc-300 flex-1">{label}</label>
+        {tooltip && (
+          <div class="relative group/tip">
+            <button
+              type="button"
+              aria-label={`Help: ${label}`}
+              class="flex items-center justify-center w-4 h-4 rounded-full bg-zinc-700 text-[9px] font-bold text-zinc-400 hover:bg-zinc-600 hover:text-zinc-200 transition-colors cursor-help select-none"
+            >?</button>
+            <div class="absolute right-0 bottom-6 z-50 w-60 rounded border border-zinc-600 bg-zinc-800 p-2 text-[10px] leading-snug text-zinc-300 shadow-lg opacity-0 pointer-events-none group-hover/tip:opacity-100 transition-opacity">
+              {tooltip}
+            </div>
+          </div>
+        )}
         {changed && (
           <span class="text-[9px] text-amber-400 border border-amber-400/30 rounded px-1 py-px uppercase tracking-wide">
             modified
@@ -147,6 +157,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Max consecutive auto-resumes"
           hint="Hard ceiling on nudges with no tool call before the loop stops. Resets on any tool call."
+          tooltip="When an AI turn ends without calling 'finish', auto-continue nudges the model to keep going. This cap prevents an infinite loop if the model repeatedly ignores the nudge — it trips after this many consecutive resume attempts with zero tool calls between them. Increase it for complex multi-step tasks that legitimately need many iterations."
           defaultValue={APP_CONFIG_DEFAULTS.ai.maxConsecutiveAutoResumes}
           value={c.ai.maxConsecutiveAutoResumes}
           min={1} max={64} integer
@@ -156,6 +167,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Slow-tool warning threshold"
           unit="ms"
           hint="Tool calls exceeding this time emit a console warning (does not affect behavior)."
+          tooltip="A diagnostic threshold only — no functional impact. When any AI tool call (e.g. runCode, renderViews) takes longer than this, a warning is logged in the browser console. Useful for identifying slow geometry evaluations or render bottlenecks. Raise it to silence warnings for expected slow operations."
           defaultValue={APP_CONFIG_DEFAULTS.ai.slowToolMs}
           value={c.ai.slowToolMs}
           min={50} max={30_000} integer
@@ -165,6 +177,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Tool-call timeout (Worker)"
           unit="ms"
           hint="If the main thread doesn't reply to a tool call within this time, the Worker aborts it."
+          tooltip="The AI agent runs in a background Worker and calls tools (geometry execution, rendering, etc.) on the main thread. If the main thread doesn't respond within this timeout — e.g. because WASM initialization is still in progress or the browser is paused — the Worker treats the call as failed and surfaces an error. Increase for very slow machines or complex BREP/SCAD evaluations."
           defaultValue={APP_CONFIG_DEFAULTS.ai.toolCallTimeoutMs}
           value={c.ai.toolCallTimeoutMs}
           min={5_000} max={600_000} integer
@@ -174,6 +187,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Diagnostics ring-buffer size"
           unit="events"
           hint="Max AI call log entries kept in memory."
+          tooltip="The AI Call Log (🩺 button in the AI panel header) stores the last N provider API calls in memory. Each entry includes request timing, token counts, stop reason, and any error details. Older entries are evicted when the buffer is full. Increase to keep more history for diagnosing intermittent issues; decrease to reduce memory use during long sessions."
           defaultValue={APP_CONFIG_DEFAULTS.ai.diagnosticsRingSize}
           value={c.ai.diagnosticsRingSize}
           min={10} max={500} integer
@@ -183,10 +197,100 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Max recent attachments"
           unit="images"
           hint="Images kept in the recent-attachments picker (IndexedDB rows)."
+          tooltip="The AI panel's image attachment picker shows recently used images so you can re-attach them without re-uploading. This cap controls how many are persisted in IndexedDB. Older images are evicted when the cap is reached. Increase to keep more images in the picker; decrease to free IndexedDB space on storage-constrained devices."
           defaultValue={APP_CONFIG_DEFAULTS.ai.maxAttachments}
           value={c.ai.maxAttachments}
           min={1} max={100} integer
           onChange={v => set('ai', 'maxAttachments', v)}
+        />
+      </Section>
+
+      <Section title="AI — geometry timeouts">
+        <div class="text-[10px] text-zinc-500 leading-snug">Execution timeout per modeling engine. The engine Worker is restarted if a run exceeds the ceiling.</div>
+        <Field
+          label="Manifold-JS timeout"
+          unit="ms"
+          tooltip="Wall-clock ceiling for a single manifold-js geometry evaluation. If the code run exceeds this, the engine Worker is restarted and an error is surfaced. The manifold-3d kernel is typically fast — this mainly guards against infinite loops in user code. Increase for extremely complex mesh operations."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.geometryTimeoutManifoldMs}
+          value={c.ai.geometryTimeoutManifoldMs}
+          min={5_000} max={600_000} integer
+          onChange={v => set('ai', 'geometryTimeoutManifoldMs', v)}
+        />
+        <Field
+          label="OpenSCAD timeout"
+          unit="ms"
+          tooltip="Wall-clock ceiling for a single OpenSCAD evaluation. SCAD compiles BOSL2-style libraries from source on every run, and complex gear or thread models can legitimately take over a minute on slow hardware. The 3-minute default gives ample headroom for heavy parametric models."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.geometryTimeoutScadMs}
+          value={c.ai.geometryTimeoutScadMs}
+          min={5_000} max={600_000} integer
+          onChange={v => set('ai', 'geometryTimeoutScadMs', v)}
+        />
+        <Field
+          label="BREP/replicad timeout"
+          unit="ms"
+          tooltip="Wall-clock ceiling for a single replicad/OpenCASCADE evaluation. OCCT Boolean operations on complex STEP-imported assemblies can rival SCAD's worst cases. Increase if you're working with large imported STEP files or heavily-filleted BREP models."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.geometryTimeoutReplicadMs}
+          value={c.ai.geometryTimeoutReplicadMs}
+          min={5_000} max={600_000} integer
+          onChange={v => set('ai', 'geometryTimeoutReplicadMs', v)}
+        />
+      </Section>
+
+      <Section title="AI — local model (WebLLM)">
+        <div class="text-[10px] text-zinc-500 leading-snug">Token budgets for the in-browser local model. Only used when the Local (WebGPU) provider is active.</div>
+        <Field
+          label="Prompt budget — medium tier"
+          unit="tokens"
+          tooltip="The portion of the local model's context window allocated to the system prompt when using a medium-tier model (e.g. Qwen-7B). Larger models can handle more context; reduce this if you're getting truncation errors on a small-context model."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.localPromptBudgetMedium}
+          value={c.ai.localPromptBudgetMedium}
+          min={200} max={4096} integer
+          onChange={v => set('ai', 'localPromptBudgetMedium', v)}
+        />
+        <Field
+          label="Prompt budget — slim tier"
+          unit="tokens"
+          tooltip="The portion of the context window for the system prompt when using a slim/small model. Slim models have tighter context windows, so the budget is lower to leave room for the conversation."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.localPromptBudgetSlim}
+          value={c.ai.localPromptBudgetSlim}
+          min={100} max={2048} integer
+          onChange={v => set('ai', 'localPromptBudgetSlim', v)}
+        />
+        <Field
+          label="Tool budget — native"
+          unit="tokens"
+          tooltip="Tokens reserved for tool-call schemas when the model supports native function calling. Native tool schemas are compact JSON — 100 tokens covers the full Partwright tool set."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.localToolsBudgetNative}
+          value={c.ai.localToolsBudgetNative}
+          min={50} max={1000} integer
+          onChange={v => set('ai', 'localToolsBudgetNative', v)}
+        />
+        <Field
+          label="Tool budget — prompt-engineered"
+          unit="tokens"
+          tooltip="Tokens reserved for tool schemas when they're injected as plain text (for models without native function calling). Prompt-engineering the schema requires more tokens than native calling."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.localToolsBudgetPromptEngineered}
+          value={c.ai.localToolsBudgetPromptEngineered}
+          min={100} max={2000} integer
+          onChange={v => set('ai', 'localToolsBudgetPromptEngineered', v)}
+        />
+        <Field
+          label="Attention sink margin"
+          unit="tokens"
+          tooltip="Safety buffer added when computing the total attention-sink context allocation. Prevents off-by-one overflows when the model's reported context length is approximate."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.localAttentionSinkMargin}
+          value={c.ai.localAttentionSinkMargin}
+          min={50} max={500} integer
+          onChange={v => set('ai', 'localAttentionSinkMargin', v)}
+        />
+        <Field
+          label="Attention sink max"
+          unit="tokens"
+          tooltip="Hard cap on the total attention-sink token budget (prompt + tools + margin). Prevents the local model from trying to allocate more context than it can physically handle."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.localAttentionSinkMax}
+          value={c.ai.localAttentionSinkMax}
+          min={512} max={8192} integer
+          onChange={v => set('ai', 'localAttentionSinkMax', v)}
         />
       </Section>
 
@@ -195,6 +299,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Anthropic — Low"
           unit="tokens"
+          tooltip="The 'budget_tokens' sent to Anthropic's API when thinking level is set to Low. A higher budget gives the model more space to reason before answering, improving accuracy on complex geometry tasks at the cost of latency and token spend."
           defaultValue={APP_CONFIG_DEFAULTS.ai.thinkingBudgetAnthropicLow}
           value={c.ai.thinkingBudgetAnthropicLow}
           min={1024} max={100_000} integer
@@ -203,6 +308,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Anthropic — Medium"
           unit="tokens"
+          tooltip="The thinking budget for Anthropic models at Medium thinking level. Suitable for moderately complex CAD tasks — the model can work through multi-step geometry without the cost of High."
           defaultValue={APP_CONFIG_DEFAULTS.ai.thinkingBudgetAnthropicMedium}
           value={c.ai.thinkingBudgetAnthropicMedium}
           min={1024} max={100_000} integer
@@ -211,6 +317,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Anthropic — High"
           unit="tokens"
+          tooltip="The thinking budget for Anthropic models at High thinking level. Use for the most complex parametric or BREP tasks. Note that Anthropic requires max_tokens > budget_tokens, so the 'Anthropic answer headroom' field below must also be large enough."
           defaultValue={APP_CONFIG_DEFAULTS.ai.thinkingBudgetAnthropicHigh}
           value={c.ai.thinkingBudgetAnthropicHigh}
           min={1024} max={200_000} integer
@@ -220,6 +327,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Gemini — Low"
           unit="tokens"
+          tooltip="The thinking budget for Gemini models at Low level. Gemini combines reasoning and answer tokens in one ceiling — setting this too high can crowd out the answer."
           defaultValue={APP_CONFIG_DEFAULTS.ai.thinkingBudgetGeminiLow}
           value={c.ai.thinkingBudgetGeminiLow}
           min={1024} max={100_000} integer
@@ -228,6 +336,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Gemini — Medium"
           unit="tokens"
+          tooltip="The thinking budget for Gemini at Medium level. See the Gemini max output tokens field — the total output ceiling must be at least this large."
           defaultValue={APP_CONFIG_DEFAULTS.ai.thinkingBudgetGeminiMedium}
           value={c.ai.thinkingBudgetGeminiMedium}
           min={1024} max={100_000} integer
@@ -236,6 +345,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Gemini — High"
           unit="tokens"
+          tooltip="The thinking budget for Gemini at High level. The Gemini max output tokens must exceed this value to avoid 400 errors from the API."
           defaultValue={APP_CONFIG_DEFAULTS.ai.thinkingBudgetGeminiHigh}
           value={c.ai.thinkingBudgetGeminiHigh}
           min={1024} max={200_000} integer
@@ -245,6 +355,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Anthropic answer headroom"
           unit="tokens"
           hint="Output token headroom above the thinking budget (API requires max_tokens > budget)."
+          tooltip="Anthropic's API requires that max_tokens > budget_tokens. This value is added on top of the active thinking budget to set max_tokens. If you raise a thinking budget above the current Anthropic max output tokens limit, raise this headroom too to avoid API 400 errors."
           defaultValue={APP_CONFIG_DEFAULTS.ai.answerHeadroomTokens}
           value={c.ai.answerHeadroomTokens}
           min={1024} max={50_000} integer
@@ -256,6 +367,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Anthropic max output tokens"
           unit="tokens"
+          tooltip="The max_tokens value sent to Anthropic's API on every turn. This is the total output ceiling including any thinking tokens. If you've set a High thinking budget above this value, the API will error — raise both together."
           defaultValue={APP_CONFIG_DEFAULTS.ai.maxOutputTokensAnthropic}
           value={c.ai.maxOutputTokensAnthropic}
           min={1024} max={200_000} integer
@@ -264,6 +376,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="OpenAI max output tokens"
           unit="tokens"
+          tooltip="The max_output_tokens (Responses API) or max_tokens (Chat Completions) value sent to OpenAI. Reasoning models (o1/o3/o4/gpt-5) route to the Responses API; all others use Chat Completions — this cap applies to both. Increase for very long code generation turns."
           defaultValue={APP_CONFIG_DEFAULTS.ai.maxOutputTokensOpenai}
           value={c.ai.maxOutputTokensOpenai}
           min={1024} max={200_000} integer
@@ -273,6 +386,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Gemini max output tokens"
           unit="tokens"
           hint="Combined ceiling for reasoning + answer on thinking models."
+          tooltip="The maxOutputTokens value for Gemini. For thinking-enabled models this is a shared ceiling for both reasoning tokens and the answer — if the thinking budget is close to this value, the model may not have room to output a response. Keep this well above your highest Gemini thinking budget."
           defaultValue={APP_CONFIG_DEFAULTS.ai.maxOutputTokensGemini}
           value={c.ai.maxOutputTokensGemini}
           min={1024} max={500_000} integer
@@ -282,6 +396,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Chars-per-token estimate"
           unit="chars"
           hint="Rough ratio used for token-count estimation in the context meter."
+          tooltip="The context-meter bar in the AI panel estimates token counts by dividing character counts by this ratio. It's a heuristic — actual tokenization varies by model and language. English prose averages ~4 chars/token; code with many symbols may be closer to 3. Adjust if the meter consistently over- or under-estimates."
           defaultValue={APP_CONFIG_DEFAULTS.ai.charsPerToken}
           value={c.ai.charsPerToken}
           min={1} max={20}
@@ -291,6 +406,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Image token estimate"
           unit="tokens"
           hint="Estimated tokens per attached image block (used in the context meter)."
+          tooltip="A flat per-image token estimate used by the context meter. Vision models process images at varying resolutions — the actual token cost depends on image size and provider. Anthropic charges ~1600 tokens for a standard image; Gemini varies by resolution. Adjust if the meter is clearly off for your typical attachments."
           defaultValue={APP_CONFIG_DEFAULTS.ai.imageTokenEstimate}
           value={c.ai.imageTokenEstimate}
           min={100} max={10_000} integer
@@ -302,6 +418,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Camera field-of-view"
           unit="°"
+          tooltip="The vertical field of view for the Three.js perspective camera. A narrower FOV (e.g. 30°) produces an orthographic-like projection good for inspecting flat faces; a wider FOV (e.g. 75°) gives a more immersive perspective. Takes effect after a page reload."
           defaultValue={APP_CONFIG_DEFAULTS.renderer.fov}
           value={c.renderer.fov}
           min={10} max={120} integer
@@ -310,6 +427,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Max device pixel ratio"
           hint="Cap on devicePixelRatio. Lower = less GPU work; higher = sharper on HiDPI screens."
+          tooltip="On Retina/HiDPI screens the browser's devicePixelRatio can be 2–3×, meaning the renderer draws 4–9× as many pixels. This cap limits the ratio to save GPU work. At 1.0 you get 1:1 pixel mapping (fastest); at 2.0 you get full Retina sharpness. Takes effect after a page reload."
           defaultValue={APP_CONFIG_DEFAULTS.renderer.maxPixelRatio}
           value={c.renderer.maxPixelRatio}
           min={0.5} max={4} step={0.5}
@@ -318,6 +436,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Interaction render scale"
           hint="Render resolution fraction during orbit/pan/zoom (0–1, lower = faster)."
+          tooltip="While you're actively orbiting, panning, or zooming, the viewport renders at this fraction of its full resolution to keep the frame rate smooth. At 0.6 (the default) each dimension is 60% of full resolution — 36% of total pixels. It snaps back to full resolution when you stop moving. Lower this on slow GPUs; raise it if you don't notice quality differences during orbit."
           defaultValue={APP_CONFIG_DEFAULTS.renderer.interactionRenderScale}
           value={c.renderer.interactionRenderScale}
           min={0.1} max={1} step={0.05}
@@ -326,6 +445,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Grid size"
           unit="units"
+          tooltip="The total side length of the ground-plane grid in model units. If your models are typically 200 units wide, set this to 400 or so to keep the grid visible around them. Takes effect after a page reload."
           defaultValue={APP_CONFIG_DEFAULTS.renderer.gridSize}
           value={c.renderer.gridSize}
           min={4} max={1000} integer
@@ -333,10 +453,105 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         />
         <Field
           label="Grid divisions"
+          tooltip="The number of cells the grid is divided into. Combined with grid size this sets the cell size: a 40-unit grid with 40 divisions gives 1-unit cells. Takes effect after a page reload."
           defaultValue={APP_CONFIG_DEFAULTS.renderer.gridDivisions}
           value={c.renderer.gridDivisions}
           min={2} max={200} integer
           onChange={v => set('renderer', 'gridDivisions', v)}
+        />
+        <Field
+          label="Ambient light intensity"
+          tooltip="The intensity of the omnidirectional ambient light in the viewport. Ambient light illuminates all surfaces equally regardless of normal direction — raising it reduces harsh shadows. Combined with the directional lights, the total scene illumination is ambient + primary + secondary. Takes effect after a page reload."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.ambientLightIntensity}
+          value={c.renderer.ambientLightIntensity}
+          min={0} max={3} step={0.05}
+          onChange={v => set('renderer', 'ambientLightIntensity', v)}
+        />
+        <Field
+          label="Primary light intensity"
+          tooltip="The intensity of the main directional light. This is the dominant light source that creates highlights and defines the model's primary shading. Raising it increases contrast; lowering it flattens the look. Takes effect after a page reload."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.primaryLightIntensity}
+          value={c.renderer.primaryLightIntensity}
+          min={0} max={3} step={0.05}
+          onChange={v => set('renderer', 'primaryLightIntensity', v)}
+        />
+        <Field
+          label="Secondary light intensity"
+          tooltip="The intensity of the secondary fill directional light, positioned on the opposite side from the primary. It softens harsh shadows cast by the primary light. Raising it produces a more evenly-lit appearance; setting it to 0 gives hard one-sided lighting. Takes effect after a page reload."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.secondaryLightIntensity}
+          value={c.renderer.secondaryLightIntensity}
+          min={0} max={2} step={0.05}
+          onChange={v => set('renderer', 'secondaryLightIntensity', v)}
+        />
+        <Field
+          label="Orbit damping factor"
+          tooltip="The inertia factor for OrbitControls. At 0 the camera stops instantly when you release the mouse; higher values (up to 1) add a momentum effect that coasts to a stop. The default 0.1 gives a slight coast. Takes effect after a page reload."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.orbitDampingFactor}
+          value={c.renderer.orbitDampingFactor}
+          min={0} max={0.9} step={0.05}
+          onChange={v => set('renderer', 'orbitDampingFactor', v)}
+        />
+        <Field
+          label="Orientation gizmo size"
+          unit="px"
+          tooltip="The canvas size in CSS pixels of the orientation gizmo (the XYZ cube in the viewport corner). Larger makes the axis labels easier to read; smaller keeps it out of the way. Takes effect after a page reload."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.gizmoSizePx}
+          value={c.renderer.gizmoSizePx}
+          min={48} max={256} integer
+          onChange={v => set('renderer', 'gizmoSizePx', v)}
+        />
+        <Field
+          label="Orientation gizmo margin"
+          unit="px"
+          tooltip="Distance in CSS pixels from the viewport corner to the gizmo. Increase if the gizmo overlaps toolbar buttons; decrease to tuck it closer to the edge. Takes effect after a page reload."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.gizmoMarginPx}
+          value={c.renderer.gizmoMarginPx}
+          min={0} max={32} integer
+          onChange={v => set('renderer', 'gizmoMarginPx', v)}
+        />
+        <Field
+          label="Gizmo hit radius"
+          tooltip="How close (in gizmo orthographic units, range 0–2) your click must land to an axis label to trigger a snap. A larger radius makes the labels easier to click; a smaller radius requires more precision. Takes effect after a page reload."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.gizmoHitRadius}
+          value={c.renderer.gizmoHitRadius}
+          min={0.1} max={1} step={0.05}
+          onChange={v => set('renderer', 'gizmoHitRadius', v)}
+        />
+        <Field
+          label="Gizmo snap duration"
+          unit="s"
+          tooltip="How long (in seconds) the animated snap-to-face transition takes when you click a gizmo axis label. Lower is snappier; higher is smoother. Takes effect after a page reload."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.gizmoSnapDurationSec}
+          value={c.renderer.gizmoSnapDurationSec}
+          min={0.05} max={2} step={0.05}
+          onChange={v => set('renderer', 'gizmoSnapDurationSec', v)}
+        />
+        <Field
+          label="Offscreen renderer idle timeout"
+          unit="ms"
+          tooltip="The multi-view render panel (used for AI snapshots) keeps its WebGL renderer alive after a render in case another is requested soon. If no render is requested within this window, it disposes the WebGL context and canvas to free GPU memory. Lower this if you're memory-constrained; raise it if multi-view renders feel slow to start. Takes effect without reload."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.offscreenIdleDisposeMs}
+          value={c.renderer.offscreenIdleDisposeMs}
+          min={1_000} max={300_000} integer
+          onChange={v => set('renderer', 'offscreenIdleDisposeMs', v)}
+        />
+        <Field
+          label="Pointer grace period"
+          unit="ms"
+          tooltip="How long after your last pointer movement the viewport continues rendering every frame (instead of only on demand). A longer grace period keeps the frame rate smooth during fast mouse movements; a shorter one conserves GPU time when you stop. Takes effect without reload."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.pointerGraceMs}
+          value={c.renderer.pointerGraceMs}
+          min={50} max={2_000} integer
+          onChange={v => set('renderer', 'pointerGraceMs', v)}
+        />
+        <Field
+          label="Thumbnail generation timeout"
+          unit="ms"
+          tooltip="Max time to wait for a session thumbnail render before giving up and saving without one. Thumbnails are rendered in the background when a session is saved. On slow hardware or with very complex geometry, the render may take longer than the default. Increase if your session list shows blank thumbnails."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.thumbnailTimeoutMs}
+          value={c.renderer.thumbnailTimeoutMs}
+          min={500} max={30_000} integer
+          onChange={v => set('renderer', 'thumbnailTimeoutMs', v)}
         />
       </Section>
 
@@ -345,6 +560,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="STL weld tolerance"
           unit="units"
           hint="Initial vertex-merge threshold for STL imports. Larger = more aggressive welding."
+          tooltip="STL files store triangles as disconnected vertex triplets — adjacent triangles share edge vertices by value, not by reference. The weld step merges vertices within this distance to create a proper manifold mesh. Too small: gaps remain and boolean operations fail. Too large: nearby-but-intentionally-separate vertices merge, distorting the geometry. The default 1e-5 works for most models; very small-scale precision models may need 1e-6 or smaller."
           defaultValue={APP_CONFIG_DEFAULTS.import.stlWeldTolerance}
           value={c.import.stlWeldTolerance}
           min={1e-8} max={0.1} step={1e-6}
@@ -354,6 +570,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Voxel default max size"
           unit="voxels"
           hint="Default max voxel grid dimension for image → voxel imports."
+          tooltip="When importing an image as a voxel model, this caps the longest grid dimension. A 64-voxel grid produces at most 64×64×64 = 262,144 voxels. Larger grids produce more detailed models but take longer to mesh and paint. The import wizard lets you override this per-import; this is just the starting value."
           defaultValue={APP_CONFIG_DEFAULTS.import.voxelDefaultMaxSize}
           value={c.import.voxelDefaultMaxSize}
           min={4} max={256} integer
@@ -363,6 +580,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Voxel heavy-model threshold"
           unit="voxels"
           hint="Voxel count above which the import wizard shows a performance warning."
+          tooltip="The import wizard shows a 'this may be slow' warning when the resulting voxel count exceeds this threshold. The voxel mesher is linear in occupied voxels, so very large grids can take several seconds. Raise this if you have a fast machine and don't want the warning; lower it on slow hardware to get warned earlier."
           defaultValue={APP_CONFIG_DEFAULTS.import.voxelHeavyThreshold}
           value={c.import.voxelHeavyThreshold}
           min={10_000} max={5_000_000} integer
@@ -372,10 +590,39 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Relief max resolution"
           unit="px"
           hint="Maximum image resolution (pixels per side) for relief/keychain imports."
+          tooltip="Relief and keychain imports downsample the source image to this resolution before generating depth geometry. Higher resolutions produce more detailed reliefs but take longer to process and generate more triangles. The default 512 px balances detail against performance; for intricate designs or very large prints, try 1024 px."
           defaultValue={APP_CONFIG_DEFAULTS.import.reliefMaxResolution}
           value={c.import.reliefMaxResolution}
           min={32} max={4096} integer
           onChange={v => set('import', 'reliefMaxResolution', v)}
+        />
+        <Field
+          label="Remote fetch timeout"
+          unit="ms"
+          hint="Timeout for fetching a file by URL in the import-from-URL flow."
+          tooltip="When you import a model or image by URL, the app fetches it with this timeout. Slow or geographically distant servers may need a longer timeout. If you frequently see 'fetch timed out' errors on large files from slow hosts, increase this value."
+          defaultValue={APP_CONFIG_DEFAULTS.import.remoteFetchTimeoutMs}
+          value={c.import.remoteFetchTimeoutMs}
+          min={1_000} max={120_000} integer
+          onChange={v => set('import', 'remoteFetchTimeoutMs', v)}
+        />
+        <Field
+          label="Filament match threshold"
+          hint="Color-distance threshold for filament swap matching (lower = stricter)."
+          tooltip="The filament swap guide compares the relief's dominant colors against your filament palette using this distance threshold. Colors within this distance are considered a match. Smaller values require a very close color match before suggesting a swap; larger values are more permissive and may suggest swaps for loosely similar colors. The value is in perceptual color space (0–1 range)."
+          defaultValue={APP_CONFIG_DEFAULTS.import.filamentMatchThreshold}
+          value={c.import.filamentMatchThreshold}
+          min={0.01} max={1} step={0.01}
+          onChange={v => set('import', 'filamentMatchThreshold', v)}
+        />
+        <Field
+          label="Filament confidence warn threshold"
+          hint="Confidence score below which the swap guide shows a warning (0–1)."
+          tooltip="When the filament swap guide's confidence in its color matching is below this score, it shows a caution indicator. A score of 0.9 means it warns unless it's 90%+ confident. Lower this to suppress warnings on ambiguous matches; raise it to be warned more readily."
+          defaultValue={APP_CONFIG_DEFAULTS.import.filamentConfidenceWarnThreshold}
+          value={c.import.filamentConfidenceWarnThreshold}
+          min={0.1} max={1} step={0.05}
+          onChange={v => set('import', 'filamentConfidenceWarnThreshold', v)}
         />
       </Section>
 
@@ -384,6 +631,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Toast duration"
           unit="ms"
           hint="How long notification toasts stay on screen."
+          tooltip="The duration notifications (save confirmations, export success/error, etc.) remain visible before automatically dismissing. Raise this if you miss toasts; lower it if they feel intrusive."
           defaultValue={APP_CONFIG_DEFAULTS.ui.toastDurationMs}
           value={c.ui.toastDurationMs}
           min={500} max={15_000} integer
@@ -393,10 +641,75 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           label="Tooltip delay"
           unit="ms"
           hint="Hover delay before a tooltip appears."
+          tooltip="How long you must hover over a button or icon before its tooltip appears. Set to 0 for instant tooltips; increase if tooltips appear too eagerly while you move the mouse across the toolbar."
           defaultValue={APP_CONFIG_DEFAULTS.ui.tooltipDelayMs}
           value={c.ui.tooltipDelayMs}
           min={0} max={2000} integer
           onChange={v => set('ui', 'tooltipDelayMs', v)}
+        />
+        <Field
+          label="Code editor error idle delay"
+          unit="ms"
+          tooltip="After you stop typing, the code editor waits this long before showing error annotations (red underlines, error panel). This prevents the error display from flickering while you're mid-edit. Lower it for faster feedback; raise it if error annotations distract you while typing."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.codeEditorErrorIdleMs}
+          value={c.ui.codeEditorErrorIdleMs}
+          min={0} max={5_000} integer
+          onChange={v => set('ui', 'codeEditorErrorIdleMs', v)}
+        />
+        <Field
+          label="Surface preview debounce"
+          unit="ms"
+          tooltip="When adjusting parameters in the surface-modifier panel (texture, fuzzy, etc.), this debounce delays the preview render until you've stopped changing values for this long. Lower it for more responsive live preview; raise it if previewing is slow on your machine."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.surfacePreviewDebounceMs}
+          value={c.ui.surfacePreviewDebounceMs}
+          min={0} max={2_000} integer
+          onChange={v => set('ui', 'surfacePreviewDebounceMs', v)}
+        />
+        <Field
+          label="Relief 2D preview debounce"
+          unit="ms"
+          tooltip="Debounce delay for the 2D image preview in the relief import wizard. While you adjust sliders (brightness, contrast, depth), this delay prevents a new preview from firing on every pixel of slider movement. Lower = more responsive; raise if CPU spikes during slider drag."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.reliefPreviewDebounceMs}
+          value={c.ui.reliefPreviewDebounceMs}
+          min={0} max={2_000} integer
+          onChange={v => set('ui', 'reliefPreviewDebounceMs', v)}
+        />
+        <Field
+          label="Relief 3D preview debounce"
+          unit="ms"
+          tooltip="Debounce delay for the 3D geometry preview in the relief import wizard. The 3D preview involves geometry generation, which is more expensive than the 2D preview — this longer default avoids re-generating on every incremental slider change."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.reliefPreview3dDebounceMs}
+          value={c.ui.reliefPreview3dDebounceMs}
+          min={0} max={2_000} integer
+          onChange={v => set('ui', 'reliefPreview3dDebounceMs', v)}
+        />
+        <Field
+          label="Progress modal show delay"
+          unit="ms"
+          tooltip="The progress overlay (shown during paint subdivision, simplify, and other multi-second operations) waits this long before appearing. Operations that finish faster than this delay show no overlay at all — avoiding a flash for quick operations. Raise it to keep the overlay from appearing on fast machines; lower it to see progress sooner on slow ones."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.progressModalShowDelayMs}
+          value={c.ui.progressModalShowDelayMs}
+          min={0} max={2_000} integer
+          onChange={v => set('ui', 'progressModalShowDelayMs', v)}
+        />
+        <Field
+          label="Session lock heartbeat"
+          unit="ms"
+          tooltip="How often the active tab broadcasts its 'I am the session leader' heartbeat to other tabs watching the same session. If this tab goes silent (tab crash, sleep), other tabs detect staleness after the stale threshold elapses and take over. Reduce for faster failover detection; increase to reduce cross-tab storage activity."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.sessionLockHeartbeatMs}
+          value={c.ui.sessionLockHeartbeatMs}
+          min={500} max={30_000} integer
+          onChange={v => set('ui', 'sessionLockHeartbeatMs', v)}
+        />
+        <Field
+          label="Session lock stale threshold"
+          unit="ms"
+          hint="Time after which a silent heartbeat is considered stale."
+          tooltip="If the active tab's heartbeat hasn't been seen for this long, other tabs treat the session lock as stale and compete to take over. This should be at least 2–3× the heartbeat interval to avoid false positives (a single missed heartbeat shouldn't trigger takeover). Raise it if you see unexpected session takeovers during normal use."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.sessionLockStaleMs}
+          value={c.ui.sessionLockStaleMs}
+          min={1_000} max={60_000} integer
+          onChange={v => set('ui', 'sessionLockStaleMs', v)}
         />
       </Section>
 

--- a/src/ui/progressModal.tsx
+++ b/src/ui/progressModal.tsx
@@ -14,15 +14,20 @@
 
 import { render } from 'preact';
 import { signal, type Signal } from '@preact/signals';
+import { getConfig } from '../config/appConfig';
 
-const DEFAULT_SHOW_DELAY_MS = 250;
-let showDelayMs = DEFAULT_SHOW_DELAY_MS;
+// null = use getConfig(); set to non-null by __setProgressModalDelayForTests
+let showDelayMsOverride: number | null = null;
+
+function getShowDelay(): number {
+  return showDelayMsOverride ?? getConfig().ui.progressModalShowDelayMs;
+}
 
 /** Tests override the show delay to 0 so the Cancel button is hittable
  *  without racing the worker. Returns the previous value. */
 export function __setProgressModalDelayForTests(ms: number): number {
-  const prev = showDelayMs;
-  showDelayMs = Math.max(0, ms | 0);
+  const prev = getShowDelay();
+  showDelayMsOverride = Math.max(0, ms | 0);
   return prev;
 }
 
@@ -158,13 +163,13 @@ export function startProgress(opts: {
     showTimer = null;
   }
 
-  if (showDelayMs <= 0) {
+  if (getShowDelay() <= 0) {
     showModalNow();
   } else {
     showTimer = window.setTimeout(() => {
       showTimer = null;
       if (currentJob && currentJob.id === id) showModalNow();
-    }, showDelayMs);
+    }, getShowDelay());
   }
 
   return id;

--- a/src/ui/reliefImportModal.ts
+++ b/src/ui/reliefImportModal.ts
@@ -34,13 +34,11 @@ export interface ReliefImportModalOptions {
 }
 
 const PREVIEW_PX = 220;
-const DEBOUNCE_MS = 120;
 function getMaxResolution(): number { return getConfig().import.reliefMaxResolution; }
 // 3D preview rebuilds use a downscaled grid — mesh generation is fast at this
 // size and the wizard's static thumbnail doesn't benefit from print-quality
 // fidelity. Quality previews happen in the studio after Create.
 const PREVIEW_3D_RESOLUTION = 64;
-const PREVIEW_3D_DEBOUNCE_MS = 250;
 
 interface ModeDef {
   id: ReliefImportMode;
@@ -575,7 +573,7 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
   let preview3DTimer: number | undefined;
   function schedule3DPreview(): void {
     if (preview3DTimer !== undefined) window.clearTimeout(preview3DTimer);
-    preview3DTimer = window.setTimeout(render3DPreview, PREVIEW_3D_DEBOUNCE_MS);
+    preview3DTimer = window.setTimeout(render3DPreview, getConfig().ui.reliefPreview3dDebounceMs);
   }
   async function render3DPreview(): Promise<void> {
     if (!image && !svgText) {
@@ -864,7 +862,7 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
   // --- Preview rendering ---------------------------------------------------
   function schedulePreview(): void {
     if (previewTimer !== undefined) window.clearTimeout(previewTimer);
-    previewTimer = window.setTimeout(renderPreview, DEBOUNCE_MS);
+    previewTimer = window.setTimeout(renderPreview, getConfig().ui.reliefPreviewDebounceMs);
     schedule3DPreview();
   }
 

--- a/src/ui/surfaceModal.ts
+++ b/src/ui/surfaceModal.ts
@@ -11,6 +11,7 @@
 // trigger a debounced auto-preview; an explicit "Preview" button forces one.
 
 import { registerCommands } from './commandPalette';
+import { getConfig } from '../config/appConfig';
 
 type ApplyResult = { error?: string; label?: string } | Record<string, unknown>;
 type ModId = 'fuzzy' | 'smooth' | 'voxelize';
@@ -30,7 +31,6 @@ type Tab = ModId;
 
 const BTN_BASE =
   'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur border border-zinc-700 text-zinc-200 hover:bg-zinc-700';
-const PREVIEW_DEBOUNCE_MS = 250;
 
 let openModal: HTMLDivElement | null = null;
 
@@ -169,7 +169,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
   function schedulePreview() {
     if (previewTimer !== undefined) clearTimeout(previewTimer);
     status.textContent = 'Updating preview…';
-    previewTimer = window.setTimeout(runPreview, PREVIEW_DEBOUNCE_MS);
+    previewTimer = window.setTimeout(runPreview, getConfig().ui.surfacePreviewDebounceMs);
   }
   function clearPreviewIfDirty() {
     if (previewTimer !== undefined) { clearTimeout(previewTimer); previewTimer = undefined; }


### PR DESCRIPTION
## Summary

- **Bug fix (chatLoop.ts):** Fix `iteration_cap` callback to report the actual iteration count via `iter` (declared before the for-loop so it's in scope after the loop exits), removing the now-unnecessary `reached` variable
- **Doc fix (types.ts):** Add JSDoc to `ModelId` clarifying that custom-provider model strings are covered by `activeModel()`'s `string | null` return type
- **AppConfig migration:** Add 30 new tunable fields across all four config sections and replace all their hardcoded usages with `getConfig()` calls — geometry engine timeouts, local (WebLLM) token budgets, renderer light/gizmo/orbit constants, import fetch/filament thresholds, and UI debounce/heartbeat delays
- **Advanced Settings modal:** Add `tooltip` prop to the `Field` component (CSS-only hover popover using Tailwind `group/group-hover`) and add detailed `?` help tooltip text to every existing and new field; add two new sections (AI geometry timeouts, AI local model budgets) and all new fields to the Rendering, Import, and UI sections

**Files changed:** `src/ai/chatLoop.ts`, `src/ai/local.ts`, `src/ai/types.ts`, `src/config/appConfig.ts`, `src/editor/codeEditor.ts`, `src/geometry/engine.ts`, `src/import/urlImport.ts`, `src/main.ts`, `src/relief/swapGuide.ts`, `src/renderer/multiview.ts`, `src/renderer/orientationGizmo.ts`, `src/renderer/viewport.ts`, `src/storage/sessionLock.ts`, `src/ui/advancedSettingsModal.tsx`, `src/ui/progressModal.tsx`, `src/ui/reliefImportModal.ts`, `src/ui/surfaceModal.ts`

## Test plan

- [ ] `npm run build` passes (all errors are pre-existing in the repo, none introduced by this PR)
- [ ] `npm run test:unit` passes
- [ ] Advanced Settings modal opens and shows `?` buttons on every field; hovering shows the tooltip popover
- [ ] New sections (AI geometry timeouts, AI local model) appear and fields are editable/persistent
- [ ] Geometry engine timeouts now pull from `getConfig()` — changing them in Advanced Settings takes effect without a code change
- [ ] PR-checks e2e shards green

https://claude.ai/code/session_01WhHYLHBS51TJ5rFZhvga3R

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhHYLHBS51TJ5rFZhvga3R)_