### PR TITLE
feat: add enhance mode and color preservation to simplify panel

### DIFF
--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -100,6 +100,11 @@ const pendingSimplifies  = new Map<string, {
   reject: (e: Error) => void;
   onProgress: (fraction: number) => void;
 }>();
+const pendingEnhances = new Map<string, {
+  resolve: (r: EnhanceWorkerResult | null) => void;
+  reject: (e: Error) => void;
+  onProgress: (fraction: number) => void;
+}>();
 
 // Per-language hard-timeout for a single execute/validate call. The Worker
 // posts no result back if its WASM hangs, so without this the promise (and
@@ -125,6 +130,7 @@ function rejectAllPending(err: Error): void {
   for (const p of pendingClearBrepImports.values()) p.reject(err);
   for (const p of pendingClearBrepShapes.values()) p.reject(err);
   for (const p of pendingSimplifies.values()) p.reject(err);
+  for (const p of pendingEnhances.values()) p.reject(err);
   pendingExecutions.clear();
   pendingValidations.clear();
   pendingStepExports.clear();
@@ -133,6 +139,7 @@ function rejectAllPending(err: Error): void {
   pendingClearBrepImports.clear();
   pendingClearBrepShapes.clear();
   pendingSimplifies.clear();
+  pendingEnhances.clear();
 }
 
 /** Terminate an unresponsive Worker and reject everything in flight so the next
@@ -314,6 +321,35 @@ function handleEngineWorkerMessage(event: MessageEvent): void {
     return;
   }
 
+  if (msg.type === 'enhance_progress') {
+    const callId = msg.callId as string;
+    const pending = pendingEnhances.get(callId);
+    if (!pending) return;
+    pending.onProgress(msg.fraction as number);
+    return;
+  }
+
+  if (msg.type === 'enhance_result') {
+    const callId = msg.callId as string;
+    const pending = pendingEnhances.get(callId);
+    if (!pending) return;
+    pendingEnhances.delete(callId);
+    const error = msg.error as string | null;
+    if (error) {
+      pending.reject(new Error(error));
+      return;
+    }
+    if (msg.cancelled || !msg.mesh) {
+      pending.resolve(null);
+      return;
+    }
+    pending.resolve({
+      mesh: msg.mesh as MeshData,
+      triangleCount: msg.triangleCount as number,
+    });
+    return;
+  }
+
   if (msg.type === 'error') {
     const callId = msg.callId as string | null;
     const err = new Error(msg.message as string);
@@ -334,6 +370,8 @@ function handleEngineWorkerMessage(event: MessageEvent): void {
       pendingClearBrepShapes.delete(callId ?? '');
       pendingSimplifies.get(callId)?.reject(err);
       pendingSimplifies.delete(callId ?? '');
+      pendingEnhances.get(callId)?.reject(err);
+      pendingEnhances.delete(callId ?? '');
     }
   }
 }
@@ -627,6 +665,75 @@ export async function simplifyInWorker(
     const transfer: Transferable[] = [meshCopy.vertProperties.buffer, meshCopy.triVerts.buffer];
     engineWorker!.postMessage(
       { type: 'simplify', callId, mesh: meshCopy, targetTriangles, maxTolerance },
+      transfer,
+    );
+  });
+}
+
+// ── Enhance Worker client ───────────────────────────────────────────────────
+
+export interface EnhanceWorkerResult {
+  mesh: MeshData;
+  triangleCount: number;
+}
+
+export class EnhanceAbortError extends Error {
+  constructor(message = 'enhance aborted') {
+    super(message);
+    this.name = 'AbortError';
+  }
+}
+
+/** Run the mesh-budget enhance (refineToLength) search inside the geometry
+ *  Worker. Mirrors simplifyInWorker but adds triangles instead of removing
+ *  them. Resolves to null when no enhancement was needed/possible or the
+ *  caller aborted. */
+export async function enhanceInWorker(
+  mesh: MeshData,
+  targetTriangles: number,
+  maxEdgeLength: number,
+  onProgress: (fraction: number) => void,
+  signal?: AbortSignal,
+): Promise<EnhanceWorkerResult | null> {
+  if (signal?.aborted) throw new EnhanceAbortError();
+  initEngineWorker();
+  await workerReady;
+  const callId = `enhance-${++callIdCounter}`;
+
+  return new Promise<EnhanceWorkerResult | null>((resolve, reject) => {
+    let abortListener: (() => void) | null = null;
+    pendingEnhances.set(callId, {
+      resolve: (r) => {
+        if (signal && abortListener) signal.removeEventListener('abort', abortListener);
+        resolve(r);
+      },
+      reject: (e) => {
+        if (signal && abortListener) signal.removeEventListener('abort', abortListener);
+        reject(e);
+      },
+      onProgress,
+    });
+    if (signal) {
+      abortListener = () => {
+        engineWorker?.postMessage({ type: 'enhance_cancel', callId });
+        const pending = pendingEnhances.get(callId);
+        if (pending) {
+          pendingEnhances.delete(callId);
+          pending.reject(new EnhanceAbortError());
+        }
+      };
+      signal.addEventListener('abort', abortListener, { once: true });
+    }
+    const meshCopy: MeshData = {
+      vertProperties: mesh.vertProperties.slice(),
+      triVerts: mesh.triVerts.slice(),
+      numVert: mesh.numVert,
+      numTri: mesh.numTri,
+      numProp: mesh.numProp,
+    };
+    const transfer: Transferable[] = [meshCopy.vertProperties.buffer, meshCopy.triVerts.buffer];
+    engineWorker!.postMessage(
+      { type: 'enhance', callId, mesh: meshCopy, targetTriangles, maxEdgeLength },
       transfer,
     );
   });

--- a/src/geometry/engineWorker.ts
+++ b/src/geometry/engineWorker.ts
@@ -15,6 +15,8 @@
 //   { type: 'clearBrepShape',    callId }
 //   { type: 'simplify',          callId, mesh, targetTriangles, maxTolerance }
 //   { type: 'simplify_cancel',   callId }
+//   { type: 'enhance',           callId, mesh, targetTriangles, maxEdgeLength }
+//   { type: 'enhance_cancel',    callId }
 //
 // Protocol — Worker → Main:
 //   { type: 'ready' }
@@ -27,6 +29,8 @@
 //   { type: 'clearBrepShape_result',   callId, error }
 //   { type: 'simplify_progress',       callId, fraction }
 //   { type: 'simplify_result',         callId, mesh, triangleCount, tolerance, cancelled, error }
+//   { type: 'enhance_progress',        callId, fraction }
+//   { type: 'enhance_result',          callId, mesh, triangleCount, cancelled, error }
 //   { type: 'error',                   callId, message }
 //
 // Mesh typed arrays are transferred (zero-copy) to the main thread.
@@ -40,7 +44,7 @@ import { ensureBrepLoaded, sourceUsesBrep, parseStepBlob, pushPendingBrepImport,
 import { setActiveImports, type ImportedMesh } from '../import/importedMesh';
 import { setCircularSegmentsOverride } from './qualitySettings';
 import type { Language } from './engines/types';
-import { simplifyToTriangleBudget } from './simplify';
+import { simplifyToTriangleBudget, enhanceToTriangleBudget } from './simplify';
 import type { MeshData } from './types';
 
 /** Per-callId cancel flags for in-flight simplify jobs. The simplify loop
@@ -48,6 +52,7 @@ import type { MeshData } from './types';
  *  message has a chance to land and flip this flag — the loop checks it on
  *  each iteration boundary and bails out cleanly. */
 const simplifyCancelFlags = new Map<string, boolean>();
+const enhanceCancelFlags = new Map<string, boolean>();
 
 let manifoldReady = false;
 
@@ -292,6 +297,85 @@ self.onmessage = async (event: MessageEvent) => {
   if (msg.type === 'simplify_cancel') {
     const { callId } = msg as unknown as { callId: string };
     if (simplifyCancelFlags.has(callId)) simplifyCancelFlags.set(callId, true);
+    return;
+  }
+
+  // ── enhance ────────────────────────────────────────────────────────────
+  if (msg.type === 'enhance') {
+    const { callId, mesh, targetTriangles, maxEdgeLength } = msg as unknown as {
+      callId: string;
+      mesh: MeshData;
+      targetTriangles: number;
+      maxEdgeLength: number;
+    };
+    if (!manifoldReady) {
+      self.postMessage({
+        type: 'enhance_result', callId, mesh: null, triangleCount: 0,
+        cancelled: false, error: 'Geometry engine not initialised — try again after loading completes.',
+      });
+      return;
+    }
+    enhanceCancelFlags.set(callId, false);
+    const mod = getManifoldModule();
+    let baseManifold: { delete?: () => void } | null = null;
+    try {
+      baseManifold = mod.Manifold.ofMesh(mesh);
+      const result = await enhanceToTriangleBudget(
+        baseManifold as unknown as Parameters<typeof enhanceToTriangleBudget>[0],
+        targetTriangles,
+        maxEdgeLength,
+        (fraction) => {
+          self.postMessage({ type: 'enhance_progress', callId, fraction });
+          return new Promise<void>(r => setTimeout(r, 0));
+        },
+        () => enhanceCancelFlags.get(callId) === true,
+      );
+      const cancelled = enhanceCancelFlags.get(callId) === true;
+      enhanceCancelFlags.delete(callId);
+      if (cancelled) {
+        self.postMessage({
+          type: 'enhance_result', callId, mesh: null, triangleCount: 0,
+          cancelled: true, error: null,
+        });
+      } else if (result) {
+        const transfer: Transferable[] = [
+          result.mesh.vertProperties.buffer,
+          result.mesh.triVerts.buffer,
+        ];
+        if (result.mesh.mergeFromVert) transfer.push(result.mesh.mergeFromVert.buffer);
+        if (result.mesh.mergeToVert)   transfer.push(result.mesh.mergeToVert.buffer);
+        if (result.mesh.runIndex)      transfer.push(result.mesh.runIndex.buffer);
+        if (result.mesh.runOriginalID) transfer.push(result.mesh.runOriginalID.buffer);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (self as any).postMessage({
+          type: 'enhance_result', callId,
+          mesh: result.mesh, triangleCount: result.triangleCount,
+          cancelled: false, error: null,
+        }, transfer);
+      } else {
+        self.postMessage({
+          type: 'enhance_result', callId,
+          mesh: null, triangleCount: 0, cancelled: false, error: null,
+        });
+      }
+    } catch (err) {
+      enhanceCancelFlags.delete(callId);
+      self.postMessage({
+        type: 'enhance_result', callId, mesh: null, triangleCount: 0,
+        cancelled: false, error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      if (baseManifold && typeof baseManifold.delete === 'function') {
+        try { baseManifold.delete(); } catch { /* already freed */ }
+      }
+    }
+    return;
+  }
+
+  // ── enhance_cancel ──────────────────────────────────────────────────────
+  if (msg.type === 'enhance_cancel') {
+    const { callId } = msg as unknown as { callId: string };
+    if (enhanceCancelFlags.has(callId)) enhanceCancelFlags.set(callId, true);
     return;
   }
 

--- a/src/geometry/simplify.ts
+++ b/src/geometry/simplify.ts
@@ -12,6 +12,7 @@ import type { MeshData } from './types';
 export interface SimplifiableManifold {
   numTri(): number;
   simplify(tolerance?: number): SimplifiableManifold;
+  refineToLength?(length: number): SimplifiableManifold;
   getMesh(): {
     vertProperties: Float32Array;
     triVerts: Uint32Array;
@@ -157,6 +158,89 @@ export async function simplifyToTriangleBudget(
     mesh: toMeshData(final),
     triangleCount: final.numTri(),
     tolerance,
+  };
+  release(final);
+  if (onProgress) await onProgress(1);
+  return result;
+}
+
+export type EnhanceResult = SimplifyResult;
+
+/** Find the coarsest refineToLength pass that brings a manifold's triangle
+ *  count up to at least `targetTriangles`, by binary-searching the edge-length
+ *  threshold. Returns null when the manifold already meets the target, when
+ *  refineToLength is not available, or when the caller requests cancellation.
+ *
+ *  `maxEdgeLength` bounds the coarse end of the search — pass roughly the
+ *  bounding-box diagonal; beyond that refineToLength is a no-op. */
+export async function enhanceToTriangleBudget(
+  manifold: SimplifiableManifold,
+  targetTriangles: number,
+  maxEdgeLength: number,
+  onProgress?: SimplifyProgress,
+  shouldCancel?: () => boolean,
+): Promise<EnhanceResult | null> {
+  if (typeof manifold.refineToLength !== 'function') return null;
+  const baseTri = manifold.numTri();
+  const target = Math.floor(targetTriangles);
+  if (!Number.isFinite(target) || target <= baseTri) return null;
+  if (!(maxEdgeLength > 0)) return null;
+
+  // Binary-search: find the LARGEST edge-length (coarsest refinement) that
+  // produces at most `target` triangles. Smaller lengths → more triangles.
+  let lo = 0;
+  let hi = maxEdgeLength;
+
+  // Best length found so far (largest l giving ≤ target and > baseTri).
+  let bestLen = -1;
+  // Fallback: smallest l (finest) giving ≤ target (even if ≤ baseTri, unlikely).
+  let finestValidLen = -1;
+  let finestValidCount = Infinity;
+
+  const totalSteps = SEARCH_ITERATIONS + 1;
+
+  for (let i = 0; i < SEARCH_ITERATIONS; i++) {
+    const mid = (lo + hi) / 2;
+    let n: number | null = null;
+    try {
+      const candidate = manifold.refineToLength!(mid);
+      n = candidate.numTri();
+      release(candidate);
+    } catch {
+      hi = mid;
+    }
+
+    if (n !== null) {
+      if (n <= target && n < finestValidCount) {
+        finestValidCount = n;
+        finestValidLen = mid;
+      }
+
+      if (n > target) {
+        lo = mid; // too fine — coarsen by increasing l
+      } else if (n > baseTri) {
+        bestLen = mid; // enhancement within budget — try coarser (larger l)
+        lo = mid;
+      } else {
+        hi = mid; // not enough refinement — need smaller l
+      }
+    }
+
+    if (onProgress) await onProgress((i + 1) / totalSteps);
+    if (shouldCancel && shouldCancel()) return null;
+  }
+
+  const length = bestLen >= 0 ? bestLen : finestValidLen;
+  if (length < 0) {
+    if (onProgress) await onProgress(1);
+    return null;
+  }
+
+  const final = manifold.refineToLength!(length);
+  const result: EnhanceResult = {
+    mesh: toMeshData(final),
+    triangleCount: final.numTri(),
+    tolerance: length,
   };
   release(final);
   if (onProgress) await onProgress(1);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4912,8 +4912,29 @@ async function main() {
   // Baseline mesh with triColors baked in (set when the panel opens with paint
   // active). Used as the color source for all carry operations in this session.
   let simplifyBaselineColoredMesh: MeshData | null = null;
-  // Serialized paint regions from the baseline — restored when the user resets.
+  // Serialized paint (user) regions from the baseline — restored when the user resets.
   let simplifyBaselineRegions: SerializedColorRegion[] | null = null;
+  // Model color region snapshot — these come from code declarations, not user paint,
+  // so they aren't captured by serializeRegions(). Captured separately at open time.
+  let simplifyBaselineModelRegions: Array<{ name: string; color: [number, number, number]; triangles: Set<number> }> | null = null;
+
+  // Restore the baseline mesh and all its color state (user regions + model regions).
+  // Used by simplify/enhance's "already at full detail" early-out and by Reset.
+  function restoreBaselineColors(baseline: MeshData): void {
+    if (simplifyBaselineColoredMesh) {
+      resetPaintWorkerState();
+      clearRegions();
+      clearModelColorRegions();
+      applyLiveGeometry(baseline);
+      if (simplifyBaselineModelRegions && simplifyBaselineModelRegions.length > 0) {
+        setModelColorRegions(simplifyBaselineModelRegions);
+      }
+      rehydrateColorRegions({ colorRegions: simplifyBaselineRegions ?? [] });
+      updateMesh(applyTriColorsIfVisible(baseline), { skipAutoFrame: true });
+    } else {
+      applyLiveGeometryWithColor(baseline);
+    }
+  }
 
   // Replace the live geometry with `mesh`: rebuild the queryable Manifold and
   // refresh the viewport, paint-adjacency map, stats, and clip bounds. Mirrors
@@ -4984,6 +5005,9 @@ async function main() {
         if (modelHasColor()) {
           simplifyBaselineColoredMesh = applyTriColors(currentMeshData);
           simplifyBaselineRegions = serializeRegions();
+          simplifyBaselineModelRegions = getModelRegions().map(r => ({
+            name: r.name, color: [...r.color] as [number, number, number], triangles: new Set(r.triangles),
+          }));
         }
       }
       return {
@@ -5003,16 +5027,7 @@ async function main() {
 
       // Dragging the target back to (or above) full detail is just a restore.
       if (targetTriangles >= baseline.numTri) {
-        if (simplifyBaselineRegions) {
-          resetPaintWorkerState();
-          clearRegions();
-          clearModelColorRegions();
-          applyLiveGeometry(baseline);
-          rehydrateColorRegions({ colorRegions: simplifyBaselineRegions });
-          updateMesh(applyTriColorsIfVisible(baseline), { skipAutoFrame: true });
-        } else {
-          applyLiveGeometryWithColor(baseline);
-        }
+        restoreBaselineColors(baseline);
         await onProgress(1);
         return { triangleCount: baseline.numTri };
       }
@@ -5051,16 +5066,7 @@ async function main() {
       const coloredBaseline = preserveColor ? simplifyBaselineColoredMesh : null;
 
       if (targetTriangles <= baseline.numTri) {
-        if (simplifyBaselineRegions) {
-          resetPaintWorkerState();
-          clearRegions();
-          clearModelColorRegions();
-          applyLiveGeometry(baseline);
-          rehydrateColorRegions({ colorRegions: simplifyBaselineRegions });
-          updateMesh(applyTriColorsIfVisible(baseline), { skipAutoFrame: true });
-        } else {
-          applyLiveGeometryWithColor(baseline);
-        }
+        restoreBaselineColors(baseline);
         await onProgress(1);
         return { triangleCount: baseline.numTri };
       }
@@ -5095,16 +5101,7 @@ async function main() {
 
     reset() {
       if (!simplifyBaselineMesh) return;
-      if (simplifyBaselineRegions) {
-        resetPaintWorkerState();
-        clearRegions();
-        clearModelColorRegions();
-        applyLiveGeometry(simplifyBaselineMesh);
-        rehydrateColorRegions({ colorRegions: simplifyBaselineRegions });
-        updateMesh(applyTriColorsIfVisible(simplifyBaselineMesh), { skipAutoFrame: true });
-      } else {
-        applyLiveGeometryWithColor(simplifyBaselineMesh);
-      }
+      restoreBaselineColors(simplifyBaselineMesh);
     },
 
     async save() {
@@ -11100,6 +11097,7 @@ async function main() {
       simplifyBaselineMesh = null;
       simplifyBaselineColoredMesh = null;
       simplifyBaselineRegions = null;
+      simplifyBaselineModelRegions = null;
       refreshSimplifyIfOpen();
       setStatus(statusBar, 'ready', 'Ready');
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5128,10 +5128,9 @@ async function main() {
           savedOriginal = !!(await saveVersion(originalCode, original.geometryData, original.thumbnail));
         }
 
-        const label = reduced.numTri < baseline.numTri
-          ? `simplified-${reduced.numTri}tri`
-          : `enhanced-${reduced.numTri}tri`;
-        const baked = toImportedMesh(label, reduced);
+        const versionLabel = reduced.numTri < baseline.numTri ? 'simplified' : 'enhanced';
+        const importFilename = `${versionLabel}-${reduced.numTri}tri`;
+        const baked = toImportedMesh(importFilename, reduced);
         const code = generateImportCode([baked], { manifold: true });
         setActiveImports([baked]);
         setValue(code);
@@ -5149,7 +5148,7 @@ async function main() {
           }
         }
         const thumbnail = await captureThumbnail();
-        await saveVersion(code, geoData, thumbnail, label, undefined, {
+        await saveVersion(code, geoData, thumbnail, versionLabel, undefined, {
           force: true,
           importedMeshes: [baked],
         });

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@
 import './style.css';
 import { errorLog } from './diagnostics/errorLog';
 import { initDiagnosticsPanel, toggleDiagnosticsPanel } from './ui/diagnosticsPanel';
-import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, exportLastBrepAsSTEP, importSTEPToBrep, importSTEPToMesh, clearBrepImports, clearBrepShape, simplifyInWorker, type Language } from './geometry/engine';
+import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, exportLastBrepAsSTEP, importSTEPToBrep, importSTEPToMesh, clearBrepImports, clearBrepShape, simplifyInWorker, enhanceInWorker, type Language } from './geometry/engine';
 import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { resolveParamValues, pruneParamValues, type ParamSpec, type ParamValue } from './geometry/params';
 import { createParamsPanel, type ParamsPanelController } from './ui/paramsPanel';
@@ -4909,6 +4909,11 @@ async function main() {
   // imported-style version. The baseline persists across panel open/close and
   // is cleared whenever a code run replaces the geometry.
   let simplifyBaselineMesh: MeshData | null = null;
+  // Baseline mesh with triColors baked in (set when the panel opens with paint
+  // active). Used as the color source for all carry operations in this session.
+  let simplifyBaselineColoredMesh: MeshData | null = null;
+  // Serialized paint regions from the baseline — restored when the user resets.
+  let simplifyBaselineRegions: SerializedColorRegion[] | null = null;
 
   // Replace the live geometry with `mesh`: rebuild the queryable Manifold and
   // refresh the viewport, paint-adjacency map, stats, and clip bounds. Mirrors
@@ -4931,40 +4936,83 @@ async function main() {
     syncClipSliderBounds();
   }
 
+  /** Apply geometry and ensure colors from the regions module are re-rendered.
+   *  `applyLiveGeometry` calls `updateMesh(mesh)` which bypasses color regions;
+   *  this overrides that with a colored repaint when regions are active. */
+  function applyLiveGeometryWithColor(mesh: MeshData): void {
+    applyLiveGeometry(mesh);
+    if (hasColorRegions() || hasModelColorRegions()) {
+      updateMesh(applyTriColorsIfVisible(mesh), { skipAutoFrame: true });
+    }
+  }
+
+  /** Transfer colors from `src` (which must have `.triColors`) onto `dest` via
+   *  nearest-triangle centroid mapping. Returns `dest` with `triColors` added. */
+  function carryColorsToMesh(src: MeshData, dest: MeshData): MeshData {
+    const srcColors = src.triColors!;
+    const nearest = nearestTriangleMap(src, dest);
+    const triColors = new Uint8Array(dest.numTri * 3);
+    for (let t = 0; t < dest.numTri; t++) {
+      const o = nearest[t];
+      if (o >= 0) {
+        triColors[t * 3]     = srcColors[o * 3];
+        triColors[t * 3 + 1] = srcColors[o * 3 + 1];
+        triColors[t * 3 + 2] = srcColors[o * 3 + 2];
+      }
+    }
+    return { ...dest, triColors };
+  }
+
   const simplifyHandlers: SimplifyHandlers = {
     open(userInitiated) {
       if (userInitiated) {
-        // Don't let two overlay panels share the top-right slot.
+        // Don’t let two overlay panels share the top-right slot.
         if (isPaintOpen()) closePaintMenu();
         if (isAnnotateOpen()) closeAnnotateMenu();
         closeMeasureIfActive();
       }
       if (!currentMeshData) {
-        return { ok: false, reason: 'Run some code first — there’s no model to simplify.' };
+        return { ok: false, reason: "Run some code first — there’s no model to simplify." };
       }
       if (!currentManifold) {
-        return { ok: false, reason: 'Simplify needs a solid (manifold) model. Render-only imports can’t be reduced.' };
+        return { ok: false, reason: "Simplify needs a solid (manifold) model. Render-only imports can’t be reduced." };
       }
-      if (hasColorRegions()) {
-        return { ok: false, reason: 'Clear paint regions before simplifying — reducing triangles would invalidate them.' };
+      if (!simplifyBaselineMesh) {
+        simplifyBaselineMesh = currentMeshData;
+        // Snapshot colors once so all carry operations in this session use the
+        // same source — even after apply clears the regions module state.
+        if (modelHasColor()) {
+          simplifyBaselineColoredMesh = applyTriColors(currentMeshData);
+          simplifyBaselineRegions = serializeRegions();
+        }
       }
-      if (!simplifyBaselineMesh) simplifyBaselineMesh = currentMeshData;
       return {
         ok: true,
         info: {
           baseTriangles: simplifyBaselineMesh.numTri,
           currentTriangles: currentMeshData.numTri,
+          hasColor: simplifyBaselineColoredMesh != null,
         },
       };
     },
 
-    async apply(targetTriangles, onProgress, signal) {
+    async apply(targetTriangles, preserveColor, onProgress, signal) {
       const baseline = simplifyBaselineMesh;
       if (!baseline) return null;
-      // Dragging the target back to (or above) full detail is just a restore —
-      // no search to run, so report it as instantly complete.
+      const coloredBaseline = preserveColor ? simplifyBaselineColoredMesh : null;
+
+      // Dragging the target back to (or above) full detail is just a restore.
       if (targetTriangles >= baseline.numTri) {
-        applyLiveGeometry(baseline);
+        if (simplifyBaselineRegions) {
+          resetPaintWorkerState();
+          clearRegions();
+          clearModelColorRegions();
+          applyLiveGeometry(baseline);
+          rehydrateColorRegions({ colorRegions: simplifyBaselineRegions });
+          updateMesh(applyTriColorsIfVisible(baseline), { skipAutoFrame: true });
+        } else {
+          applyLiveGeometryWithColor(baseline);
+        }
         await onProgress(1);
         return { triangleCount: baseline.numTri };
       }
@@ -4974,9 +5022,6 @@ async function main() {
         : 0;
       if (!(diag > 0)) return null;
 
-      // Run the binary-search reduction off the main thread so a heavy mesh
-      // doesn't freeze the viewport. The worker reports progress per
-      // iteration and honors `signal` for Cancel.
       const result = await simplifyInWorker(
         baseline,
         targetTriangles,
@@ -4984,38 +5029,97 @@ async function main() {
         (fraction) => { void onProgress(fraction); },
         signal,
       );
-      // The search yields to the event loop, so a code run can replace the
-      // geometry mid-flight. If the baseline moved, our result is stale —
-      // drop it rather than clobber the freshly-run mesh.
       if (simplifyBaselineMesh !== baseline) return null;
       if (!result) {
-        applyLiveGeometry(baseline);
+        applyLiveGeometryWithColor(baseline);
         return null;
       }
-      applyLiveGeometry(result.mesh);
+      if (coloredBaseline?.triColors) {
+        resetPaintWorkerState();
+        clearRegions();
+        clearModelColorRegions();
+        applyLiveGeometry(carryColorsToMesh(coloredBaseline, result.mesh));
+      } else {
+        applyLiveGeometry(result.mesh);
+      }
+      return { triangleCount: result.triangleCount };
+    },
+
+    async enhance(targetTriangles, preserveColor, onProgress, signal) {
+      const baseline = simplifyBaselineMesh;
+      if (!baseline) return null;
+      const coloredBaseline = preserveColor ? simplifyBaselineColoredMesh : null;
+
+      if (targetTriangles <= baseline.numTri) {
+        if (simplifyBaselineRegions) {
+          resetPaintWorkerState();
+          clearRegions();
+          clearModelColorRegions();
+          applyLiveGeometry(baseline);
+          rehydrateColorRegions({ colorRegions: simplifyBaselineRegions });
+          updateMesh(applyTriColorsIfVisible(baseline), { skipAutoFrame: true });
+        } else {
+          applyLiveGeometryWithColor(baseline);
+        }
+        await onProgress(1);
+        return { triangleCount: baseline.numTri };
+      }
+      const bbox = bboxFromMesh(baseline);
+      const diag = bbox
+        ? Math.hypot(bbox.max[0] - bbox.min[0], bbox.max[1] - bbox.min[1], bbox.max[2] - bbox.min[2])
+        : 0;
+      if (!(diag > 0)) return null;
+
+      const result = await enhanceInWorker(
+        baseline,
+        targetTriangles,
+        diag,
+        (fraction) => { void onProgress(fraction); },
+        signal,
+      );
+      if (simplifyBaselineMesh !== baseline) return null;
+      if (!result) {
+        applyLiveGeometryWithColor(baseline);
+        return null;
+      }
+      if (coloredBaseline?.triColors) {
+        resetPaintWorkerState();
+        clearRegions();
+        clearModelColorRegions();
+        applyLiveGeometry(carryColorsToMesh(coloredBaseline, result.mesh));
+      } else {
+        applyLiveGeometry(result.mesh);
+      }
       return { triangleCount: result.triangleCount };
     },
 
     reset() {
-      if (simplifyBaselineMesh) applyLiveGeometry(simplifyBaselineMesh);
+      if (!simplifyBaselineMesh) return;
+      if (simplifyBaselineRegions) {
+        resetPaintWorkerState();
+        clearRegions();
+        clearModelColorRegions();
+        applyLiveGeometry(simplifyBaselineMesh);
+        rehydrateColorRegions({ colorRegions: simplifyBaselineRegions });
+        updateMesh(applyTriColorsIfVisible(simplifyBaselineMesh), { skipAutoFrame: true });
+      } else {
+        applyLiveGeometryWithColor(simplifyBaselineMesh);
+      }
     },
 
     async save() {
       const baseline = simplifyBaselineMesh;
       if (!getState().session) {
-        return { ok: false, message: 'Open a session before saving.' };
+        return { ok: false, message: "Open a session before saving." };
       }
-      if (!currentMeshData || !baseline || currentMeshData.numTri >= baseline.numTri) {
-        return { ok: false, message: 'Reduce the model first, then save.' };
+      if (!currentMeshData || !baseline || currentMeshData.numTri === baseline.numTri) {
+        return { ok: false, message: "Simplify or enhance the model first, then save." };
       }
       try {
         const reduced = currentMeshData;
+        // triColors on the live mesh (set by carry) — used to persist colors.
+        const carriedColors = reduced.triColors ?? null;
 
-        // Preserve the pre-simplify model as its own version first, so baking the
-        // reduced mesh (which overwrites the editor with an import wrapper) never
-        // silently discards the full-detail original. Skip when the editor already
-        // matches the current saved version (formatting-aware, so a version saved
-        // with raw code isn't re-saved just because the editor reformatted it).
         const originalCode = getValue();
         const current = getState().currentVersion;
         let savedOriginal = false;
@@ -5024,14 +5128,28 @@ async function main() {
           savedOriginal = !!(await saveVersion(originalCode, original.geometryData, original.thumbnail));
         }
 
-        const baked = toImportedMesh(`simplified-${reduced.numTri}tri`, reduced);
+        const label = reduced.numTri < baseline.numTri
+          ? `simplified-${reduced.numTri}tri`
+          : `enhanced-${reduced.numTri}tri`;
+        const baked = toImportedMesh(label, reduced);
         const code = generateImportCode([baked], { manifold: true });
         setActiveImports([baked]);
         setValue(code);
         await runCodeSync(code);
+        let geoData = getGeometryDataObj();
+        if (carriedColors && currentMeshData && geoData) {
+          const { regions } = buildCarriedColorRegions(
+            { ...reduced, triColors: carriedColors },
+            carriedColors,
+            currentMeshData,
+          );
+          if (regions.length > 0) {
+            rehydrateColorRegions({ ...geoData, colorRegions: regions });
+            geoData = enrichGeometryDataWithColors(getGeometryDataObj());
+          }
+        }
         const thumbnail = await captureThumbnail();
-        const geometryData = getGeometryDataObj();
-        await saveVersion(code, geometryData, thumbnail, 'simplified', undefined, {
+        await saveVersion(code, geoData, thumbnail, label, undefined, {
           force: true,
           importedMeshes: [baked],
         });
@@ -5039,7 +5157,7 @@ async function main() {
         return {
           ok: true,
           message: savedOriginal
-            ? `Saved original + simplified (${tri} triangles).`
+            ? `Saved original + result (${tri} triangles).`
             : `Saved as a new version (${tri} triangles).`,
         };
       } catch (e) {
@@ -10981,6 +11099,8 @@ async function main() {
       // A fresh run replaces the geometry, so any simplify baseline is stale.
       // Drop it and let an open panel re-snapshot the new mesh.
       simplifyBaselineMesh = null;
+      simplifyBaselineColoredMesh = null;
+      simplifyBaselineRegions = null;
       refreshSimplifyIfOpen();
       setStatus(statusBar, 'ready', 'Ready');
     }

--- a/src/ui/simplifyUI.ts
+++ b/src/ui/simplifyUI.ts
@@ -201,14 +201,15 @@ function syncModeUI(): void {
     numberInput.max = String(base);
     numberInput.value = String(info.currentTriangles);
   } else {
-    // Enhance: range from base up to 8× base.
+    // Enhance: slider goes up to 8× base, but the number input accepts any
+    // value ≥ base — the user can type beyond the slider range.
     const max = base * 8;
     const defaultTarget = base * 2;
     slider.min = String(base);
     slider.max = String(max);
     slider.value = String(defaultTarget);
     numberInput.min = String(base);
-    numberInput.max = String(max);
+    numberInput.removeAttribute('max');
     numberInput.value = String(defaultTarget);
   }
 }
@@ -254,8 +255,10 @@ function showResult(count: number): void {
 function clampTarget(raw: number): number {
   if (!info) return raw;
   const min = Number(slider?.min ?? 4);
-  const max = Number(slider?.max ?? info.baseTriangles * 8);
   if (!Number.isFinite(raw)) return mode === 'simplify' ? info.baseTriangles : info.baseTriangles * 2;
+  // Enhance: only enforce the minimum — the user can type beyond the slider range.
+  if (mode === 'enhance') return Math.max(min, Math.round(raw));
+  const max = Number(slider?.max ?? info.baseTriangles);
   return Math.max(min, Math.min(max, Math.round(raw)));
 }
 
@@ -437,14 +440,14 @@ function buildPanel(): HTMLElement {
   numberInput.addEventListener('input', () => {
     if (applying) return;
     const t = clampTarget(Number(numberInput!.value));
-    if (slider) slider.value = String(t);
+    if (slider) slider.value = String(Math.min(Number(slider.max), t));
     updateApplyEnabled();
   });
   numberInput.addEventListener('change', () => {
     if (applying) return;
     const t = clampTarget(Number(numberInput!.value));
     numberInput!.value = String(t);
-    if (slider) slider.value = String(t);
+    if (slider) slider.value = String(Math.min(Number(slider.max), t));
     updateApplyEnabled();
   });
   row.appendChild(numberInput);

--- a/src/ui/simplifyUI.ts
+++ b/src/ui/simplifyUI.ts
@@ -1,15 +1,14 @@
-// Simplify mode UI — a viewport-overlay button (next to Measure) that opens a
-// popup panel for reducing the model's triangle count. The user drags a slider
-// or types an exact "max triangles" value, then clicks Apply to run the
-// reduction; the shared progress modal (with a Cancel button) tracks the
-// search on heavy models. An optional "Save as version" bakes the reduced mesh
-// into a new saved version.
+// Simplify/Enhance mode UI — a viewport-overlay button that opens a popup panel
+// for either reducing (simplify) or increasing (enhance) the model's triangle
+// count. A mode toggle switches between the two operations; a "Preserve colors
+// (best-effort)" checkbox carries paint through the topology change via
+// nearest-triangle centroid transfer. The shared progress modal (with a Cancel
+// button) tracks the worker search on heavy models.
 //
 // Opening the panel auto-enables the viewport's mesh-edges (wireframe) overlay
-// so the user can see what they're reducing, and restores the previous setting
-// on close. The apply runs in the geometry Worker; closing the panel doesn't
-// cancel it, and reopening shows the in-flight state — the progress modal
-// stays visible the whole time.
+// so the user can see what they're changing, and restores the previous setting
+// on close. Operations run in the geometry Worker; closing the panel doesn't
+// cancel them, and reopening shows the in-flight state.
 //
 // This module is intentionally a leaf: it never imports the other overlay tools
 // (paint / annotate / measure). Those modules call forceDeactivate() here when
@@ -21,6 +20,8 @@ import { isWireframeVisible, setWireframeVisible } from '../renderer/viewport';
 export interface SimplifyOpenInfo {
   baseTriangles: number;
   currentTriangles: number;
+  /** True when the model carries paint that could be preserved. */
+  hasColor: boolean;
 }
 
 export interface SimplifySaveResult {
@@ -28,28 +29,36 @@ export interface SimplifySaveResult {
   message: string;
 }
 
-/** Reports apply progress as a fraction in [0, 1]. Awaited by the handler so
- *  the UI can repaint the progress bar between binary-search iterations. */
+/** Reports apply/enhance progress as a fraction in [0, 1]. */
 export type SimplifyProgress = (fraction: number) => void | Promise<void>;
 
+export type SimplifyMode = 'simplify' | 'enhance';
+
 export interface SimplifyHandlers {
-  /** Snapshot the current model as the simplify baseline. Returns its triangle
-   *  count (and the count currently on screen), or a reason when the model
-   *  can't be simplified right now. When `userInitiated` is true (the user
-   *  clicked the toolbar button) the implementation should also close the other
-   *  overlay tools so panels don't stack. */
+  /** Snapshot the current model as the baseline. Returns its triangle count
+   *  (and the count currently on screen), or a reason when the model can't be
+   *  operated on right now. When `userInitiated` is true the implementation
+   *  should also close other overlay tools so panels don't stack. */
   open(userInitiated: boolean): { ok: true; info: SimplifyOpenInfo } | { ok: false; reason: string };
-  /** Simplify the baseline down to at most `targetTriangles` and show it live,
-   *  reporting progress via `onProgress`. The optional `signal` lets the
-   *  caller (the modal's Cancel button) interrupt the worker. Returns the
+  /** Simplify the baseline down to at most `targetTriangles` and show it live.
+   *  `preserveColor` carries paint through the topology change. Returns the
    *  achieved triangle count, null if nothing changed, or throws an AbortError
    *  when cancelled. */
   apply(
     targetTriangles: number,
+    preserveColor: boolean,
     onProgress: SimplifyProgress,
     signal?: AbortSignal,
   ): Promise<{ triangleCount: number } | null>;
-  /** Restore the un-simplified baseline mesh to the viewport. */
+  /** Enhance the baseline up toward `targetTriangles` and show it live.
+   *  `preserveColor` carries paint through the topology change. */
+  enhance(
+    targetTriangles: number,
+    preserveColor: boolean,
+    onProgress: SimplifyProgress,
+    signal?: AbortSignal,
+  ): Promise<{ triangleCount: number } | null>;
+  /** Restore the baseline mesh to the viewport (with original colors). */
   reset(): void;
   /** Bake the mesh currently on screen into a new saved version. */
   save(): Promise<SimplifySaveResult>;
@@ -57,6 +66,8 @@ export interface SimplifyHandlers {
 
 const BTN_INACTIVE = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
 const BTN_ACTIVE = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-blue-500/20 backdrop-blur text-blue-400 [@media(hover:hover)]:hover:bg-blue-500/30 transition-colors border border-blue-500/30';
+const MODE_INACTIVE = 'flex-1 px-2 py-1 rounded text-xs text-zinc-400 bg-zinc-700/50 [@media(hover:hover)]:hover:bg-zinc-600/50 transition-colors border border-zinc-600/40';
+const MODE_ACTIVE = 'flex-1 px-2 py-1 rounded text-xs text-blue-300 bg-blue-500/20 transition-colors border border-blue-500/40';
 
 let simplifyBtn: HTMLButtonElement | null = null;
 let panel: HTMLElement | null = null;
@@ -69,22 +80,28 @@ let controlsEl: HTMLElement | null = null;
 let applyBtn: HTMLButtonElement | null = null;
 let resetBtn: HTMLButtonElement | null = null;
 let saveBtn: HTMLButtonElement | null = null;
+let colorCheckbox: HTMLInputElement | null = null;
+let colorRow: HTMLElement | null = null;
+let simplifyModeBtn: HTMLButtonElement | null = null;
+let enhanceModeBtn: HTMLButtonElement | null = null;
 let handlers: SimplifyHandlers | null = null;
 let info: SimplifyOpenInfo | null = null;
+let mode: SimplifyMode = 'simplify';
 // The target reflected in the live mesh (Apply is a no-op until it changes).
 let appliedTarget = 0;
+// The mode that was active when the last apply ran.
+let appliedMode: SimplifyMode = 'simplify';
 // The triangle count currently on screen (drives the Save button's enabled
 // state) — set every time the applied result changes.
 let appliedCount = 0;
 let applying = false;
-/** AbortController for the in-flight apply. Lives across panel close/reopen
- *  so the modal's Cancel button reaches the right worker job even after the
- *  panel itself was dismissed. Cleared in the apply's finally. */
+/** AbortController for the in-flight apply/enhance. Lives across panel
+ *  close/reopen so the modal's Cancel button reaches the right worker job. */
 let applyAbort: AbortController | null = null;
-/** The viewport wireframe state captured when the panel opened. Restored on
- *  close so users who had edges off get them back; users who had them on see
- *  no visible change. */
+/** The viewport wireframe state captured when the panel opened. */
 let prevWireframeVisible: boolean | null = null;
+/** Whether color preservation is currently requested. */
+let preserveColor = true;
 
 export function initSimplifyUI(controlsContainer: HTMLElement, h: SimplifyHandlers): void {
   handlers = h;
@@ -93,7 +110,7 @@ export function initSimplifyUI(controlsContainer: HTMLElement, h: SimplifyHandle
   simplifyBtn.id = 'simplify-toggle';
   simplifyBtn.className = BTN_INACTIVE;
   simplifyBtn.textContent = '⬢ Simplify';
-  simplifyBtn.title = 'Reduce the model’s triangle count';
+  simplifyBtn.title = 'Reduce or enhance the model’s triangle count';
   simplifyBtn.addEventListener('click', toggle);
 
   // Sit immediately before Measure so the overlay reads Paint · Simplify · Measure.
@@ -118,8 +135,7 @@ export function refreshSimplifyIfOpen(): void {
   if (isSimplifyOpen()) refresh(false);
 }
 
-/** Close the panel without touching the applied geometry. Other overlay tools
- *  call this when they open; Escape calls it too. */
+/** Close the panel without touching the applied geometry. */
 export function forceDeactivate(): void {
   if (!isSimplifyOpen()) return;
   closePanel();
@@ -137,9 +153,6 @@ function openPanel(): void {
   if (!handlers || !panel) return;
   panel.classList.remove('hidden');
   if (simplifyBtn) simplifyBtn.className = BTN_ACTIVE;
-  // Force mesh-edges on while simplifying so the user can SEE what they're
-  // reducing — restored on close. Stored once per open cycle so a mid-session
-  // toggle inside the panel isn't lost.
   if (prevWireframeVisible === null) {
     prevWireframeVisible = isWireframeVisible();
     if (!prevWireframeVisible) setWireframeVisible(true);
@@ -147,14 +160,6 @@ function openPanel(): void {
   refresh(true);
 }
 
-/** (Re)read the current model as the baseline and populate the controls. Used
- *  on open and again after a successful save (the baked mesh becomes the new
- *  baseline).
- *
- *  Survives an in-flight apply: if we reopen mid-apply (the modal is still
- *  showing the progress bar), we mirror the locked state in the panel —
- *  controls disabled, status line says "Working…" — so reopening doesn't make
- *  the user think the work was lost. */
 function refresh(userInitiated: boolean): void {
   if (!handlers) return;
   const res = handlers.open(userInitiated);
@@ -167,38 +172,50 @@ function refresh(userInitiated: boolean): void {
   info = res.info;
   showControls();
 
-  const base = info.baseTriangles;
-  // A small floor keeps the left end of the slider useful without offering
-  // targets so low the geometry can't possibly reach them.
-  const min = Math.max(4, Math.min(base, Math.round(base * 0.02) || 4));
-  if (slider) {
-    slider.min = String(min);
-    slider.max = String(base);
-    slider.value = String(info.currentTriangles);
-  }
-  if (numberInput) {
-    numberInput.min = String(min);
-    numberInput.max = String(base);
-    numberInput.value = String(info.currentTriangles);
-  }
-  // If a previous apply is still running (we closed and reopened mid-flight),
-  // keep `appliedTarget` whatever it was — overwriting it would make the
-  // Apply button enable while the worker is mid-search. The applying flag
-  // already locks the controls; just mirror the in-flight message.
+  // Show/hide the color preservation row based on whether the model has paint.
+  if (colorRow) colorRow.classList.toggle('hidden', !info.hasColor);
+
+  syncModeUI();
   if (!applying) appliedTarget = info.currentTriangles;
-  if (originalEl) originalEl.textContent = `Original: ${base.toLocaleString()} triangles`;
+  if (originalEl) originalEl.textContent = `Original: ${info.baseTriangles.toLocaleString()} triangles`;
   if (statusEl) statusEl.textContent = applying ? 'Working… (progress shown in the modal)' : '';
   showResult(info.currentTriangles);
   if (applying) setControlsDisabled(true);
   else updateApplyEnabled();
 }
 
+/** Sync slider/input bounds and label for the current mode. */
+function syncModeUI(): void {
+  if (!info || !slider || !numberInput) return;
+  const base = info.baseTriangles;
+
+  if (simplifyModeBtn) simplifyModeBtn.className = mode === 'simplify' ? MODE_ACTIVE : MODE_INACTIVE;
+  if (enhanceModeBtn)  enhanceModeBtn.className  = mode === 'enhance'  ? MODE_ACTIVE : MODE_INACTIVE;
+
+  if (mode === 'simplify') {
+    const min = Math.max(4, Math.min(base, Math.round(base * 0.02) || 4));
+    slider.min = String(min);
+    slider.max = String(base);
+    slider.value = String(info.currentTriangles);
+    numberInput.min = String(min);
+    numberInput.max = String(base);
+    numberInput.value = String(info.currentTriangles);
+  } else {
+    // Enhance: range from base up to 8× base.
+    const max = base * 8;
+    const defaultTarget = base * 2;
+    slider.min = String(base);
+    slider.max = String(max);
+    slider.value = String(defaultTarget);
+    numberInput.min = String(base);
+    numberInput.max = String(max);
+    numberInput.value = String(defaultTarget);
+  }
+}
+
 function closePanel(): void {
   panel?.classList.add('hidden');
   if (simplifyBtn) simplifyBtn.className = BTN_INACTIVE;
-  // Restore the wireframe overlay to whatever it was before we opened. A still-
-  // running apply doesn't get cancelled (the modal stays up) — the user can
-  // reopen and the post-state will be reflected via refresh().
   if (prevWireframeVisible !== null) {
     setWireframeVisible(prevWireframeVisible);
     prevWireframeVisible = null;
@@ -222,40 +239,47 @@ function showResult(count: number): void {
   if (!info || !resultEl) return;
   appliedCount = count;
   const base = info.baseTriangles;
-  const pct = base > 0 ? Math.round((1 - count / base) * 100) : 0;
-  resultEl.textContent = `Result: ${count.toLocaleString()} triangles (−${pct}%)`;
+  if (count < base) {
+    const pct = base > 0 ? Math.round((1 - count / base) * 100) : 0;
+    resultEl.textContent = `Result: ${count.toLocaleString()} triangles (−${pct}%)`;
+  } else if (count > base) {
+    const pct = base > 0 ? Math.round((count / base - 1) * 100) : 0;
+    resultEl.textContent = `Result: ${count.toLocaleString()} triangles (+${pct}%)`;
+  } else {
+    resultEl.textContent = `Result: ${count.toLocaleString()} triangles`;
+  }
   updateSaveEnabled();
 }
 
 function clampTarget(raw: number): number {
   if (!info) return raw;
-  const min = slider ? Number(slider.min) : 4;
-  const max = info.baseTriangles;
-  if (!Number.isFinite(raw)) return max;
+  const min = Number(slider?.min ?? 4);
+  const max = Number(slider?.max ?? info.baseTriangles * 8);
+  if (!Number.isFinite(raw)) return mode === 'simplify' ? info.baseTriangles : info.baseTriangles * 2;
   return Math.max(min, Math.min(max, Math.round(raw)));
 }
 
-/** The target the controls currently express (slider/number input). */
 function currentTarget(): number {
   return clampTarget(Number(numberInput?.value ?? slider?.value ?? appliedTarget));
 }
 
 function updateApplyEnabled(): void {
   if (!applyBtn) return;
-  applyBtn.disabled = applying || !info || currentTarget() === appliedTarget;
+  applyBtn.disabled = applying || !info || (currentTarget() === appliedTarget && mode === appliedMode);
 }
 
 function updateSaveEnabled(): void {
   if (!saveBtn) return;
-  saveBtn.disabled = applying || !info || appliedCount >= info.baseTriangles;
+  saveBtn.disabled = applying || !info || appliedCount === info.baseTriangles;
 }
 
-/** Lock the controls while an apply runs; unlock re-derives each button's
- *  enabled state from the applied result. */
 function setControlsDisabled(disabled: boolean): void {
   if (slider) slider.disabled = disabled;
   if (numberInput) numberInput.disabled = disabled;
   if (resetBtn) resetBtn.disabled = disabled;
+  if (simplifyModeBtn) simplifyModeBtn.disabled = disabled;
+  if (enhanceModeBtn) enhanceModeBtn.disabled = disabled;
+  if (colorCheckbox) colorCheckbox.disabled = disabled;
   if (disabled) {
     if (applyBtn) applyBtn.disabled = true;
     if (saveBtn) saveBtn.disabled = true;
@@ -268,8 +292,10 @@ function setControlsDisabled(disabled: boolean): void {
 async function runApply(): Promise<void> {
   if (!handlers || !info || applying) return;
   const target = currentTarget();
-  if (target === appliedTarget) return;
+  if (target === appliedTarget && mode === appliedMode) return;
   const baseline = info;
+  const currentMode = mode;
+  const doPreserveColor = preserveColor && info.hasColor;
 
   applying = true;
   applyAbort = new AbortController();
@@ -277,41 +303,44 @@ async function runApply(): Promise<void> {
   setControlsDisabled(true);
   if (statusEl) statusEl.textContent = '';
 
-  // The modal is global — it survives the simplify panel closing, so the user
-  // can dismiss the panel mid-apply and still see / cancel the work.
+  const title = currentMode === 'simplify' ? 'Simplifying mesh' : 'Enhancing mesh';
+  const searchMsg = currentMode === 'simplify'
+    ? 'Searching for the gentlest tolerance…'
+    : 'Searching for the finest edge length…';
+
   const progressId = startProgress({
-    title: 'Simplifying mesh',
-    message: 'Searching for the gentlest tolerance…',
+    title,
+    message: searchMsg,
     onCancel: () => abort.abort(),
   });
 
   try {
-    const r = await handlers.apply(
+    const handler = currentMode === 'simplify' ? handlers.apply : handlers.enhance;
+    const r = await handler.call(
+      handlers,
       target,
+      doPreserveColor,
       (fraction) => {
         const pct = Math.max(0, Math.min(100, Math.round(fraction * 100)));
-        updateProgress(progressId, fraction, `Simplifying… ${pct}%`);
+        updateProgress(progressId, fraction, `${currentMode === 'simplify' ? 'Simplifying' : 'Enhancing'}… ${pct}%`);
       },
       abort.signal,
     );
     appliedTarget = target;
+    appliedMode = currentMode;
     showResult(r ? r.triangleCount : baseline.baseTriangles);
     if (statusEl) statusEl.textContent = '';
   } catch (e) {
-    // AbortError is the cancel path; surface it as a clean status line
-    // (not a "failed:" — the user asked for this).
     const err = e as Error;
     if (err?.name === 'AbortError') {
       if (statusEl) statusEl.textContent = 'Cancelled.';
     } else {
-      if (statusEl) statusEl.textContent = `Simplify failed: ${err.message}`;
+      if (statusEl) statusEl.textContent = `${currentMode === 'simplify' ? 'Simplify' : 'Enhance'} failed: ${err.message}`;
     }
   } finally {
     applying = false;
     applyAbort = null;
     endProgress(progressId);
-    // If the panel was closed mid-apply, controls are already hidden — just
-    // re-derive enabled state so a reopen reflects the fresh post-state.
     setControlsDisabled(false);
   }
 }
@@ -320,12 +349,12 @@ function buildPanel(): HTMLElement {
   const p = document.createElement('div');
   p.id = 'simplify-panel';
   p.className = 'hidden absolute top-10 right-2 z-20 bg-zinc-800/95 backdrop-blur border border-zinc-600/60 rounded-lg p-2.5 shadow-xl';
-  p.style.minWidth = '230px';
-  p.style.maxWidth = '270px';
+  p.style.minWidth = '240px';
+  p.style.maxWidth = '280px';
 
   const title = document.createElement('div');
   title.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1.5 font-medium';
-  title.textContent = 'Simplify mesh';
+  title.textContent = 'Simplify / Enhance';
   p.appendChild(title);
 
   originalEl = document.createElement('div');
@@ -334,12 +363,41 @@ function buildPanel(): HTMLElement {
   originalEl.textContent = 'Original: —';
   p.appendChild(originalEl);
 
-  // Wrapper that hides everything interactive when the model can't be simplified.
+  // Mode toggle: Simplify | Enhance
+  const modeRow = document.createElement('div');
+  modeRow.className = 'flex gap-1 mb-2';
+
+  simplifyModeBtn = document.createElement('button');
+  simplifyModeBtn.textContent = 'Simplify';
+  simplifyModeBtn.title = 'Reduce triangle count';
+  simplifyModeBtn.className = MODE_ACTIVE;
+  simplifyModeBtn.addEventListener('click', () => {
+    if (applying || mode === 'simplify') return;
+    mode = 'simplify';
+    if (info) syncModeUI();
+    updateApplyEnabled();
+  });
+  modeRow.appendChild(simplifyModeBtn);
+
+  enhanceModeBtn = document.createElement('button');
+  enhanceModeBtn.textContent = 'Enhance';
+  enhanceModeBtn.title = 'Increase triangle count for smoother geometry';
+  enhanceModeBtn.className = MODE_INACTIVE;
+  enhanceModeBtn.addEventListener('click', () => {
+    if (applying || mode === 'enhance') return;
+    mode = 'enhance';
+    if (info) syncModeUI();
+    updateApplyEnabled();
+  });
+  modeRow.appendChild(enhanceModeBtn);
+  p.appendChild(modeRow);
+
+  // Controls wrapper (hidden when no model is available)
   controlsEl = document.createElement('div');
 
   const label = document.createElement('label');
   label.className = 'block text-[10px] text-zinc-500 uppercase tracking-wider mb-1 font-medium';
-  label.textContent = 'Max triangles';
+  label.textContent = 'Target triangles';
   label.htmlFor = 'simplify-input';
   controlsEl.appendChild(label);
 
@@ -354,7 +412,6 @@ function buildPanel(): HTMLElement {
   slider.max = '100';
   slider.step = '1';
   slider.value = '100';
-  // Moving the slider only sets the target; Apply runs the reduction.
   slider.addEventListener('input', () => {
     if (applying) return;
     const t = clampTarget(Number(slider!.value));
@@ -385,18 +442,33 @@ function buildPanel(): HTMLElement {
   row.appendChild(numberInput);
   controlsEl.appendChild(row);
 
+  // Color preservation (hidden when model has no paint)
+  colorRow = document.createElement('div');
+  colorRow.className = 'hidden flex items-center gap-1.5 mb-2';
+  colorCheckbox = document.createElement('input');
+  colorCheckbox.type = 'checkbox';
+  colorCheckbox.id = 'simplify-preserve-color';
+  colorCheckbox.className = 'accent-blue-400 cursor-pointer';
+  colorCheckbox.checked = true;
+  colorCheckbox.addEventListener('change', () => {
+    preserveColor = colorCheckbox!.checked;
+    updateApplyEnabled();
+  });
+  const colorLabel = document.createElement('label');
+  colorLabel.htmlFor = 'simplify-preserve-color';
+  colorLabel.className = 'text-xs text-zinc-300 cursor-pointer select-none';
+  colorLabel.textContent = 'Preserve colors (best-effort)';
+  colorRow.append(colorCheckbox, colorLabel);
+  controlsEl.appendChild(colorRow);
+
   applyBtn = document.createElement('button');
   applyBtn.id = 'simplify-apply';
   applyBtn.className = 'w-full px-2 py-1.5 rounded text-xs font-medium bg-blue-500/30 text-blue-200 [@media(hover:hover)]:hover:bg-blue-500/40 transition-colors border border-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed mb-2';
   applyBtn.textContent = 'Apply';
-  applyBtn.title = 'Reduce the mesh to the target triangle count';
+  applyBtn.title = 'Apply the target triangle count';
   applyBtn.disabled = true;
   applyBtn.addEventListener('click', () => { void runApply(); });
   controlsEl.appendChild(applyBtn);
-
-  // Progress bar + Cancel are shown in the shared modal (src/ui/progressModal.ts),
-  // not in this panel — that way closing the panel mid-apply doesn't hide
-  // the work, and the same UI covers both paint and simplify.
 
   resultEl = document.createElement('div');
   resultEl.id = 'simplify-result';
@@ -411,13 +483,14 @@ function buildPanel(): HTMLElement {
   resetBtn.id = 'simplify-reset';
   resetBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-700/70 text-zinc-300 [@media(hover:hover)]:hover:bg-zinc-600/70 transition-colors border border-zinc-600/50';
   resetBtn.textContent = 'Reset';
-  resetBtn.title = 'Restore the full-detail mesh';
+  resetBtn.title = 'Restore the original mesh';
   resetBtn.addEventListener('click', () => {
     if (!info || applying) return;
     handlers?.reset();
     appliedTarget = info.baseTriangles;
-    if (slider) slider.value = String(info.baseTriangles);
-    if (numberInput) numberInput.value = String(info.baseTriangles);
+    appliedMode = 'simplify';
+    if (slider) slider.value = String(info.currentTriangles);
+    if (numberInput) numberInput.value = String(info.currentTriangles);
     showResult(info.baseTriangles);
     if (statusEl) statusEl.textContent = '';
     updateApplyEnabled();
@@ -428,15 +501,13 @@ function buildPanel(): HTMLElement {
   saveBtn.id = 'simplify-save';
   saveBtn.className = 'px-2 py-1 rounded text-xs bg-blue-500/30 text-blue-200 [@media(hover:hover)]:hover:bg-blue-500/40 transition-colors border border-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed';
   saveBtn.textContent = 'Save as version';
-  saveBtn.title = 'Bake the reduced mesh into a new saved version';
+  saveBtn.title = 'Bake the current mesh into a new saved version';
   saveBtn.disabled = true;
   saveBtn.addEventListener('click', async () => {
     if (!handlers || !saveBtn || applying) return;
     saveBtn.disabled = true;
     if (statusEl) statusEl.textContent = 'Saving…';
     const res = await handlers.save();
-    // Re-baseline so the panel reflects the freshly saved (reduced) mesh, then
-    // surface the result message (refresh() clears the status line first).
     if (res.ok) refresh(false);
     if (statusEl) statusEl.textContent = res.message;
   });

--- a/src/ui/simplifyUI.ts
+++ b/src/ui/simplifyUI.ts
@@ -352,10 +352,18 @@ function buildPanel(): HTMLElement {
   p.style.minWidth = '240px';
   p.style.maxWidth = '280px';
 
-  const title = document.createElement('div');
-  title.className = 'text-[10px] text-zinc-500 uppercase tracking-wider mb-1.5 font-medium';
-  title.textContent = 'Simplify / Enhance';
-  p.appendChild(title);
+  const header = document.createElement('div');
+  header.className = 'flex items-center justify-between mb-1.5';
+  const titleEl = document.createElement('div');
+  titleEl.className = 'text-[10px] text-zinc-500 uppercase tracking-wider font-medium';
+  titleEl.textContent = 'Simplify / Enhance';
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'text-zinc-500 [@media(hover:hover)]:hover:text-zinc-200 transition-colors leading-none text-base';
+  closeBtn.textContent = '✕';
+  closeBtn.title = 'Close';
+  closeBtn.addEventListener('click', closePanel);
+  header.append(titleEl, closeBtn);
+  p.appendChild(header);
 
   originalEl = document.createElement('div');
   originalEl.id = 'simplify-original';


### PR DESCRIPTION
## Summary

- **Enhance mode**: The simplify panel now has a **Simplify / Enhance** mode toggle. Enhance uses `refineToLength` binary search (16 iterations, same pattern as simplify) to increase triangle count toward a target budget up to 8× the baseline. The slider and number input show "Target triangles" and work symmetrically for both modes.
- **Color preservation**: A **"Preserve colors (best-effort)"** checkbox appears when the model has paint. Both simplify and enhance carry colors through the topology change via `nearestTriangleMap` centroid transfer — same approach as the texture/surface modifier feature. Colors display as `triColors` on the live preview mesh.
- **Correct reset**: Baseline paint regions are snapshotted on first apply and restored when the user clicks Reset, so the original painted mesh comes back with its colors intact.
- **Persistent save**: Save converts the carried `triColors` back to serializable `{ kind: 'triangles' }` regions via `buildCarriedColorRegions`, matching the surface modifier save path, so colors survive across reloads.
- **Removed the hard block**: Previously, opening the simplify panel on a painted model showed "Clear paint regions before simplifying." That block is gone — color carry replaces it.

## Test plan

- [ ] Open simplify panel on an unpainted model — behaves as before (no color checkbox)
- [ ] Open simplify panel on a painted model — "Preserve colors (best-effort)" checkbox appears
- [ ] Simplify with preserve-colors ON — simplified mesh shows carried colors
- [ ] Simplify with preserve-colors OFF — simplified mesh shows no colors
- [ ] Click Reset after simplify with colors — original mesh with original paint restored
- [ ] Switch to Enhance mode — slider range extends above baseline (up to 8×)
- [ ] Enhance with preserve-colors ON — enhanced mesh shows carried colors
- [ ] Save after simplify/enhance with colors — reloading the saved version shows colors
- [ ] Apply multiple times (without save) — colors always carry from the original baseline

https://claude.ai/code/session_01Tz19DrHrTNRBmBkQ1bMy1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tz19DrHrTNRBmBkQ1bMy1U)_