### PR TITLE
feat: add Resize modal with X/Y/Z sliders, uniform scaling, and live preview

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -108,9 +108,10 @@ import { runVoxelForPaint } from './geometry/engines/voxel';
 import type { VoxelGrid } from './geometry/voxel/grid';
 import * as voxelPaint from './color/voxelPaint';
 import { setActiveImports, getActiveImports, type ImportedMesh } from './import/importedMesh';
-import { applyFuzzy, applySmooth, applyVoxelize, defaultFuzzyOptions, defaultSmoothOptions, type ModifierResult } from './surface/modifiers';
+import { applyFuzzy, applySmooth, applyVoxelize, applyScale, defaultFuzzyOptions, defaultSmoothOptions, type ModifierResult } from './surface/modifiers';
 import { nearestTriangleMap } from './surface/colorTransfer';
 import { initSurfaceUI } from './ui/surfaceModal';
+import { initResizeUI } from './ui/resizeModal';
 import { generateRelief, generateReliefFromSvg } from './relief/imageToRelief';
 import { DEFAULT_RELIEF_OPTIONS, type ReliefOptions, type ReliefImportMode, type ReliefCommonOptions, type SeedRegion, type PreviewMode, type GenerateReliefResult } from './relief/types';
 import { computeReliefTriColors, getSwapGuideFor, setPreviewMode as ctlSetReliefPreviewMode, getPreviewMode as ctlGetReliefPreviewMode, isPreviewActive as isReliefPreviewActive } from './relief/reliefController';
@@ -5734,6 +5735,25 @@ async function main() {
         return await commitSurfaceModifier(buildSurfaceModifier('voxelize', opts, preserve), preserve);
       } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
     },
+    /** Non-destructive viewport preview of a scale operation (no version saved). */
+    previewScale(sx: number, sy: number, sz: number): { ok: true } | { error: string } {
+      try {
+        if (!currentMeshData) return { error: 'No model loaded' };
+        const result = applyScale(meshForModifier(false), sx, sy, sz);
+        previewSurfaceModifier(result, false);
+        return { ok: true };
+      } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
+    },
+    /** Discard a live scale preview and restore the current model's mesh. */
+    clearScalePreview(): { ok: true } { clearSurfacePreview(); return { ok: true }; },
+    /** Scale the current model and save as a new version.
+     *  sx/sy/sz are multiplicative factors (1 = no change, 2 = double, 0.5 = half). */
+    async scaleModel(sx: number, sy: number, sz: number) {
+      try {
+        if (!currentMeshData) return { error: 'No model loaded' };
+        return await commitSurfaceModifier(applyScale(meshForModifier(false), sx, sy, sz), false);
+      } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
+    },
     /** Run code string and update all views. Returns geometry data object. */
     async run(code?: string): Promise<Record<string, unknown>> {
       assertString(code, 'run(code)', { optional: true, allowEmpty: false });
@@ -10151,6 +10171,8 @@ async function main() {
 
   // Surface modifiers UI (viewport ✦ Surface button + command-palette entries).
   initSurfaceUI(partwrightAPI as unknown as Parameters<typeof initSurfaceUI>[0]);
+  // Resize/scale UI (viewport ⇲ Resize button + command-palette entry).
+  initResizeUI(partwrightAPI as unknown as Parameters<typeof initResizeUI>[0]);
 
   // Log API availability for AI agents
   console.info('Partwright: AI agents should use window.partwright -- start with partwright.help(). window.mainifold remains as a legacy alias. See /llms.txt');

--- a/src/surface/modifiers.ts
+++ b/src/surface/modifiers.ts
@@ -18,6 +18,7 @@ import { smoothSurface, type SmoothOptions } from './smoothSurface';
 import { voxelizeMesh, type VoxelizeOptions } from './voxelizeMesh';
 import { extractPositions, bboxOf } from './meshSubdivide';
 import { encodeGrid } from '../geometry/voxel/grid';
+import { scaleMesh } from './scaleMesh';
 import { meshGrid } from '../geometry/voxel/mesher';
 
 export type SurfaceModifierId = 'fuzzy' | 'smooth' | 'voxelize';
@@ -103,6 +104,28 @@ export function applySmooth(mesh: MeshData, opts: SmoothOptions): ModifierManifo
 export interface VoxelizeModifierOptions extends VoxelizeOptions {
   /** Emit a `.smooth()` call so the voxels render with rounded corners. */
   smooth?: boolean;
+}
+
+export function applyScale(
+  mesh: MeshData,
+  sx: number,
+  sy: number,
+  sz: number,
+): ModifierManifoldResult {
+  const baked = scaleMesh(mesh, sx, sy, sz);
+  const uniform = sx === sy && sy === sz;
+  const desc = uniform
+    ? `${(sx * 100).toFixed(1)}%`
+    : `X×${sx.toFixed(4)} Y×${sy.toFixed(4)} Z×${sz.toFixed(4)}`;
+  return {
+    kind: 'manifold',
+    label: `scaled (${desc})`,
+    mesh: baked,
+    code: manifoldWrapper([
+      `Scaled on ${today()} — ${desc}.`,
+      `The resized mesh is baked onto api.imports[0]. Open the Resize panel to scale further.`,
+    ]),
+  };
 }
 
 export function applyVoxelize(mesh: MeshData, opts: VoxelizeModifierOptions): ModifierVoxelResult {

--- a/src/surface/scaleMesh.ts
+++ b/src/surface/scaleMesh.ts
@@ -1,0 +1,17 @@
+import type { MeshData } from '../geometry/types';
+
+/** Scale vertex positions in-place by per-axis factors and return the modified mesh. */
+export function scaleMesh(mesh: MeshData, sx: number, sy: number, sz: number): MeshData {
+  const props = new Float32Array(mesh.vertProperties);
+  const np = mesh.numProp;
+  for (let i = 0; i < mesh.numVert; i++) {
+    props[i * np]     *= sx;
+    props[i * np + 1] *= sy;
+    props[i * np + 2] *= sz;
+  }
+  return {
+    ...mesh,
+    vertProperties: props,
+    triVerts: new Uint32Array(mesh.triVerts),
+  };
+}

--- a/src/ui/resizeModal.ts
+++ b/src/ui/resizeModal.ts
@@ -1,0 +1,393 @@
+// Resize/scale modal — a right-aligned, draggable panel that lets the user
+// scale the current model along X, Y, and Z independently or uniformly.
+// Uses the same bake-to-mesh strategy as the surface modifiers: Apply saves
+// a new version with the scaled geometry on api.imports[0], so undo is just
+// the version history. No code locking — the original parametric code is
+// untouched; the scaled result is its own version.
+
+import { registerCommands } from './commandPalette';
+
+type ApplyResult = { error?: string; label?: string } | Record<string, unknown>;
+
+export interface ResizeApi {
+  scaleModel(sx: number, sy: number, sz: number): Promise<ApplyResult>;
+  previewScale(sx: number, sy: number, sz: number): { ok: true } | { error: string };
+  clearScalePreview(): { ok: true };
+  getGeometryData(): { boundingBox?: { min?: number[]; max?: number[] } | null } | Record<string, unknown>;
+}
+
+type ScaleMode = 'percent' | 'units';
+
+let openModal: HTMLDivElement | null = null;
+
+function el<K extends keyof HTMLElementTagNameMap>(tag: K, cls = '', text = ''): HTMLElementTagNameMap[K] {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (text) e.textContent = text;
+  return e;
+}
+
+function getBbox(api: ResizeApi): { size: [number, number, number]; min: [number, number, number]; max: [number, number, number] } | null {
+  try {
+    const gd = api.getGeometryData() as { boundingBox?: { min?: number[]; max?: number[] } | null };
+    const bb = gd?.boundingBox;
+    if (bb?.min && bb?.max) {
+      const mn = bb.min as number[];
+      const mx = bb.max as number[];
+      return {
+        min: [mn[0], mn[1], mn[2]],
+        max: [mx[0], mx[1], mx[2]],
+        size: [mx[0] - mn[0], mx[1] - mn[1], mx[2] - mn[2]],
+      };
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+export function openResizeModal(api: ResizeApi): void {
+  if (openModal) { openModal.remove(); openModal = null; }
+
+  const bbox = getBbox(api);
+  const size = bbox?.size ?? [10, 10, 10];
+
+  // State
+  let mode: ScaleMode = 'percent';
+  let uniform = true;
+  // Percent values (100 = no change)
+  let pctX = 100, pctY = 100, pctZ = 100;
+  // Raw unit values (initialized to current size)
+  let rawX = size[0], rawY = size[1], rawZ = size[2];
+  // Max values for sliders (user-configurable)
+  let maxPct = 500;
+  let maxRaw = Math.max(...size) * 5 || 100;
+
+  let previewDirty = false;
+  let previewTimer: number | undefined;
+
+  // The panel is absolutely positioned so the user can drag it anywhere.
+  // Default: right edge of the viewport, vertically centered.
+  const panel = el('div', 'fixed z-[60] bg-zinc-900 text-zinc-100 rounded-lg border border-zinc-700 shadow-xl w-[min(94vw,360px)] select-none');
+  panel.style.right = '12px';
+  panel.style.top = '50%';
+  panel.style.transform = 'translateY(-50%)';
+
+  // Drag logic for the panel header
+  let dragState: { startX: number; startY: number; origLeft: number; origTop: number } | null = null;
+
+  function startDrag(e: PointerEvent) {
+    if ((e.target as HTMLElement).closest('button,input,select,label')) return;
+    e.preventDefault();
+    const rect = panel.getBoundingClientRect();
+    panel.style.transform = '';
+    panel.style.left = `${rect.left}px`;
+    panel.style.top = `${rect.top}px`;
+    panel.style.right = '';
+    dragState = { startX: e.clientX, startY: e.clientY, origLeft: rect.left, origTop: rect.top };
+    panel.setPointerCapture(e.pointerId);
+    document.body.style.userSelect = 'none';
+  }
+  function moveDrag(e: PointerEvent) {
+    if (!dragState || !panel.hasPointerCapture(e.pointerId)) return;
+    const left = dragState.origLeft + e.clientX - dragState.startX;
+    const top = dragState.origTop + e.clientY - dragState.startY;
+    const maxLeft = window.innerWidth - 20;
+    const maxTop = window.innerHeight - 20;
+    panel.style.left = `${Math.max(0, Math.min(left, maxLeft))}px`;
+    panel.style.top = `${Math.max(0, Math.min(top, maxTop))}px`;
+  }
+  function endDrag(e: PointerEvent) {
+    if (!dragState || !panel.hasPointerCapture(e.pointerId)) return;
+    panel.releasePointerCapture(e.pointerId);
+    dragState = null;
+    document.body.style.userSelect = '';
+  }
+  panel.addEventListener('pointerdown', startDrag);
+  panel.addEventListener('pointermove', moveDrag);
+  panel.addEventListener('pointerup', endDrag);
+  panel.addEventListener('pointercancel', endDrag);
+
+  // Header
+  const header = el('div', 'flex items-center justify-between px-4 py-3 border-b border-zinc-700 cursor-move');
+  header.append(el('h2', 'text-sm font-semibold', 'Resize model'));
+  const closeBtn = el('button', 'text-zinc-400 hover:text-zinc-100 text-lg leading-none cursor-pointer', '×');
+  closeBtn.style.cursor = 'pointer';
+  header.append(closeBtn);
+  panel.append(header);
+
+  const body = el('div', 'p-4');
+  panel.append(body);
+
+  const status = el('div', 'text-[11px] text-zinc-400 min-h-[1rem] mt-1');
+
+  // ---- Mode toggle (% / units) ----
+  const modeRow = el('div', 'flex items-center gap-2 mb-4');
+  modeRow.append(el('span', 'text-xs text-zinc-400', 'Scale by'));
+  const btnPct = el('button', '', '%');
+  const btnUnits = el('button', '', 'Raw units');
+  const ACTIVE_TAB = 'px-2.5 py-1 rounded text-xs bg-sky-600 text-white';
+  const IDLE_TAB = 'px-2.5 py-1 rounded text-xs bg-zinc-800 text-zinc-300 hover:bg-zinc-700';
+  function syncModeBtns() {
+    btnPct.className = mode === 'percent' ? ACTIVE_TAB : IDLE_TAB;
+    btnUnits.className = mode === 'units' ? ACTIVE_TAB : IDLE_TAB;
+  }
+  btnPct.addEventListener('click', () => { mode = 'percent'; syncModeBtns(); renderControls(); });
+  btnUnits.addEventListener('click', () => { mode = 'units'; syncModeBtns(); renderControls(); });
+  modeRow.append(btnPct, btnUnits);
+  body.append(modeRow);
+  syncModeBtns();
+
+  // ---- Uniform toggle ----
+  const uniformRow = el('label', 'flex items-center gap-2 mb-4 text-xs text-zinc-300 cursor-pointer');
+  const uniformCheck = el('input', 'accent-sky-500');
+  uniformCheck.type = 'checkbox';
+  uniformCheck.checked = uniform;
+  uniformCheck.addEventListener('change', () => {
+    uniform = uniformCheck.checked;
+    if (uniform) {
+      // Snap Y and Z to X when locking
+      pctY = pctX; pctZ = pctX;
+      rawY = rawX; rawZ = rawX;
+    }
+    renderControls();
+  });
+  uniformRow.append(uniformCheck, el('span', '', 'Uniform scaling (XYZ linked)'));
+  body.append(uniformRow);
+
+  // ---- Max value row ----
+  const maxRow = el('div', 'flex items-center gap-2 mb-3 text-xs text-zinc-400');
+  maxRow.append(el('span', '', 'Slider max:'));
+  const maxInput = el('input', 'w-20 bg-zinc-800 border border-zinc-600 rounded px-2 py-0.5 text-xs text-zinc-200 focus:border-blue-400 focus:outline-none');
+  maxInput.type = 'number';
+  maxInput.min = '1';
+  maxInput.step = '1';
+  const maxUnit = el('span', 'text-zinc-500', '');
+  function syncMaxInput() {
+    if (mode === 'percent') {
+      maxInput.value = String(maxPct);
+      maxUnit.textContent = '%';
+    } else {
+      maxInput.value = String(maxRaw.toFixed(2));
+      maxUnit.textContent = 'units';
+    }
+  }
+  maxInput.addEventListener('change', () => {
+    const v = parseFloat(maxInput.value);
+    if (!Number.isFinite(v) || v < 1) return;
+    if (mode === 'percent') maxPct = v;
+    else maxRaw = v;
+    renderControls();
+  });
+  maxRow.append(maxInput, maxUnit);
+  body.append(maxRow);
+
+  // ---- Axis controls container ----
+  const axisContainer = el('div', 'space-y-3 mb-4');
+  body.append(axisContainer);
+
+  // ---- Current size display ----
+  const sizeInfo = el('div', 'text-[11px] text-zinc-500 mb-3');
+  if (bbox) {
+    sizeInfo.textContent = `Current size: ${size[0].toFixed(2)} × ${size[1].toFixed(2)} × ${size[2].toFixed(2)} units`;
+  }
+  body.append(sizeInfo);
+
+  body.append(status);
+
+  // Footer
+  const footer = el('div', 'flex justify-end gap-2 px-4 pb-4');
+  const resetBtn = el('button', 'px-3 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-xs', 'Reset');
+  const cancelBtn = el('button', 'px-3 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs', 'Cancel');
+  const applyBtn = el('button', 'px-3 py-1.5 rounded bg-sky-600 hover:bg-sky-500 text-white text-xs font-medium', 'Apply');
+  footer.append(resetBtn, cancelBtn, applyBtn);
+  panel.append(footer);
+
+  // ---- Axis slider builder ----
+  function buildAxisControl(axis: 'X' | 'Y' | 'Z'): HTMLElement {
+    const wrap = el('div', 'text-xs text-zinc-300');
+    const labelRow = el('div', 'flex justify-between mb-1');
+    const label = el('span', 'font-mono font-semibold text-zinc-200', axis);
+    const readout = el('span', 'text-zinc-400 tabular-nums', '');
+    labelRow.append(label, readout);
+
+    const controlRow = el('div', 'flex items-center gap-2');
+    const slider = el('input', 'flex-1 accent-sky-500');
+    slider.type = 'range';
+    const numInput = el('input', 'w-20 bg-zinc-800 border border-zinc-600 rounded px-1 py-0.5 text-right text-zinc-200 font-mono focus:border-blue-400 focus:outline-none text-xs');
+    numInput.type = 'number';
+    controlRow.append(slider, numInput);
+    wrap.append(labelRow, controlRow);
+
+    function getValue() {
+      if (mode === 'percent') return axis === 'X' ? pctX : axis === 'Y' ? pctY : pctZ;
+      return axis === 'X' ? rawX : axis === 'Y' ? rawY : rawZ;
+    }
+    function getMax() { return mode === 'percent' ? maxPct : maxRaw; }
+    function getMin() { return mode === 'percent' ? 1 : 0.001; }
+    function getStep() { return mode === 'percent' ? 0.1 : 0.001; }
+
+    function updateDisplay() {
+      const v = getValue();
+      readout.textContent = mode === 'percent' ? `${v.toFixed(1)}%` : `${v.toFixed(3)}`;
+      numInput.value = mode === 'percent' ? v.toFixed(1) : v.toFixed(3);
+      slider.min = String(getMin());
+      slider.max = String(getMax());
+      slider.step = String(getStep());
+      slider.value = String(v);
+    }
+
+    function applyValue(v: number) {
+      const clamped = Math.max(getMin(), Math.min(getMax(), v));
+      if (mode === 'percent') {
+        if (axis === 'X' || uniform) pctX = clamped;
+        if (axis === 'Y' || uniform) pctY = clamped;
+        if (axis === 'Z' || uniform) pctZ = clamped;
+      } else {
+        if (axis === 'X' || uniform) rawX = clamped;
+        if (axis === 'Y' || uniform) rawY = clamped;
+        if (axis === 'Z' || uniform) rawZ = clamped;
+      }
+      if (uniform) renderControls();
+      else updateDisplay();
+      schedulePreview();
+    }
+
+    slider.addEventListener('input', () => applyValue(slider.valueAsNumber));
+    numInput.addEventListener('change', () => {
+      const v = parseFloat(numInput.value);
+      if (Number.isFinite(v)) applyValue(v);
+    });
+
+    updateDisplay();
+    return wrap;
+  }
+
+  function renderControls() {
+    syncMaxInput();
+    axisContainer.innerHTML = '';
+    const axes: ('X' | 'Y' | 'Z')[] = uniform ? ['X'] : ['X', 'Y', 'Z'];
+    for (const axis of axes) {
+      axisContainer.append(buildAxisControl(axis));
+    }
+    if (uniform) {
+      axisContainer.append(el('p', 'text-[11px] text-zinc-500 mt-1', 'All axes scale together. Uncheck "Uniform scaling" for independent control.'));
+    }
+  }
+
+  function getScaleFactors(): [number, number, number] {
+    if (mode === 'percent') {
+      return [pctX / 100, pctY / 100, pctZ / 100];
+    }
+    // raw units: factor = target / current
+    const sx = size[0] > 0 ? rawX / size[0] : 1;
+    const sy = size[1] > 0 ? rawY / size[1] : 1;
+    const sz = size[2] > 0 ? rawZ / size[2] : 1;
+    return [sx, sy, sz];
+  }
+
+  function schedulePreview() {
+    if (previewTimer !== undefined) clearTimeout(previewTimer);
+    status.textContent = 'Updating preview…';
+    previewTimer = window.setTimeout(() => {
+      const [sx, sy, sz] = getScaleFactors();
+      // Skip preview if scale is identity
+      if (Math.abs(sx - 1) < 0.0001 && Math.abs(sy - 1) < 0.0001 && Math.abs(sz - 1) < 0.0001) {
+        status.textContent = '';
+        return;
+      }
+      const r = api.previewScale(sx, sy, sz);
+      if ((r as { error?: string }).error) {
+        status.textContent = `Preview error: ${(r as { error: string }).error}`;
+      } else {
+        previewDirty = true;
+        status.textContent = 'Previewing — Apply to save a new version.';
+      }
+    }, 120);
+  }
+
+  function clearPreview() {
+    if (previewTimer !== undefined) { clearTimeout(previewTimer); previewTimer = undefined; }
+    if (previewDirty) { api.clearScalePreview(); previewDirty = false; }
+    status.textContent = '';
+  }
+
+  const close = () => {
+    clearPreview();
+    panel.remove();
+    openModal = null;
+  };
+
+  closeBtn.addEventListener('click', close);
+  cancelBtn.addEventListener('click', close);
+
+  resetBtn.addEventListener('click', () => {
+    pctX = pctY = pctZ = 100;
+    rawX = size[0]; rawY = size[1]; rawZ = size[2];
+    renderControls();
+    clearPreview();
+  });
+
+  applyBtn.addEventListener('click', async () => {
+    clearPreview();
+    applyBtn.disabled = true;
+    const prev = applyBtn.textContent;
+    applyBtn.textContent = 'Applying…';
+    status.textContent = 'Working…';
+    try {
+      const [sx, sy, sz] = getScaleFactors();
+      const result = await api.scaleModel(sx, sy, sz);
+      const err = (result as { error?: string })?.error;
+      if (err) {
+        status.textContent = `Error: ${err}`;
+        applyBtn.disabled = false;
+        applyBtn.textContent = prev ?? 'Apply';
+        return;
+      }
+      close();
+    } catch (e) {
+      status.textContent = `Error: ${e instanceof Error ? e.message : String(e)}`;
+      applyBtn.disabled = false;
+      applyBtn.textContent = prev ?? 'Apply';
+    }
+  });
+
+  renderControls();
+  document.body.append(panel);
+  openModal = panel;
+}
+
+const BTN_BASE =
+  'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur border border-zinc-700 text-zinc-200 hover:bg-zinc-700';
+
+export function initResizeUI(api: ResizeApi): void {
+  registerCommands([
+    {
+      id: 'resize-model',
+      title: 'Resize model',
+      hint: 'Modifier',
+      keywords: 'scale resize dimension size transform',
+      run: () => openResizeModal(api),
+    },
+  ]);
+
+  const mount = () => {
+    if (document.getElementById('resize-viewport-toggle')) return;
+    const anchor = document.getElementById('surface-viewport-toggle')
+      ?? document.getElementById('relief-viewport-toggle')
+      ?? document.getElementById('paint-toggle')
+      ?? document.querySelector<HTMLElement>('[id$="-viewport-toggle"]');
+    if (!anchor || !anchor.parentElement) return;
+    const btn = el('button', anchor.className || BTN_BASE);
+    btn.id = 'resize-viewport-toggle';
+    btn.textContent = '⇲ Resize';
+    btn.title = 'Scale the model along X, Y, and Z';
+    btn.addEventListener('click', () => openResizeModal(api));
+    anchor.after(btn);
+  };
+  let tries = 0;
+  const timer = setInterval(() => {
+    mount();
+    if (document.getElementById('resize-viewport-toggle') || ++tries > 20) clearInterval(timer);
+  }, 250);
+  mount();
+}
+


### PR DESCRIPTION
## Summary

- Adds a draggable **⇲ Resize** button to the viewport overlay (next to Surface/Relief/Paint) and a **Resize model** entry in the ⌘K command palette
- **Percentage mode**: scale each axis from 1% to 500% (configurable max)
- **Raw units mode**: type target dimensions in model units; scale factors are computed from the current bounding box
- **Uniform scaling** checkbox: when checked (default), a single X slider drives all three axes simultaneously; uncheck for independent XYZ control
- **Configurable slider max**: a "Slider max" field at the top lets the user raise the range ceiling without typing into the number input
- **Live preview**: debounced 120 ms mesh swap in the viewport — same non-destructive path as the Surface modifiers (no version saved until Apply)
- **Apply**: bakes the scaled geometry into a new version via `api.imports[0]` (`Manifold.ofMesh(...)`) — identical to how STL imports and surface modifiers land. No code locking: the original parametric source survives untouched in version history; the scaled result is a sibling version
- **Reset** button returns all axes to 100% / original dimensions
- Console API additions: `partwright.scaleModel(sx, sy, sz)`, `partwright.previewScale(sx, sy, sz)`, `partwright.clearScalePreview()`

**On code locking**: decided against it. The bake-to-mesh approach (same as fuzzy skin / smooth) means Apply creates a self-contained new version — the user can always step back in version history to the parametric original. Locking would add friction with no safety benefit since the mesh result is reversible.

## Test plan

- [ ] Open a session with a model loaded
- [ ] Click **⇲ Resize** in the viewport overlay — panel appears right-aligned and draggable
- [ ] Check **⌘K → Resize model** also opens the panel
- [ ] In % mode: drag the X slider — live preview updates in the viewport; readout shows correct %
- [ ] Toggle **Uniform scaling** off — three separate X/Y/Z sliders appear
- [ ] Set a different value per axis, confirm preview reflects non-uniform scale
- [ ] Toggle back to Uniform — Y and Z snap to X value
- [ ] Change **Slider max** to 1000%, confirm slider range extends
- [ ] Switch to **Raw units** mode — sliders initialize to current bounding box dimensions
- [ ] Click **Reset** — all values return to 100% / original size, preview clears
- [ ] Click **Apply** — new version saved, panel closes, viewport shows scaled model
- [ ] Check version history — new version labeled `scaled (X%)` or `scaled (X×… Y×… Z×…)`
- [ ] Click **Cancel** — preview clears, original model restored

https://claude.ai/code/session_01BUUCkyx1Jm4VUDzzBX1uwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUUCkyx1Jm4VUDzzBX1uwQ)_