### PR TITLE
feat: add plan-first mode toggle to AI pane

### DIFF
--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -192,9 +192,12 @@ export async function streamTurn(
     model: spec.model,
     max_tokens,
     system,
-    tools,
     messages: spec.apiMessages,
   };
+  // Omit tools entirely when the list is empty — passing tools:[] causes the
+  // API to return malformed_function_call if the model tries to use a tool
+  // it remembers from earlier turns in the conversation.
+  if (tools.length > 0) params.tools = tools;
   // Only attach the thinking config when enabled — omitting it entirely keeps
   // the request (and the prompt cache) identical to the pre-feature path.
   if (budget > 0) {

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -527,11 +527,18 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
       // Map stop reason to a UI-friendly outcome so the panel can show
       // "✓ done" vs "⚠ model exited without final text" vs other.
       const hasText = result.text.trim().length > 0;
+      // In plan mode the tool list is empty; if the model still tried to call a
+      // tool it gets malformed_function_call from Anthropic. Any text it generated
+      // before the failed attempt is still valid, so treat it as end_turn rather
+      // than surfacing a confusing "stopped early" banner.
+      const effectiveStopReason = (result.stopReason === 'malformed_function_call' && toggles.planFirst)
+        ? 'end_turn'
+        : result.stopReason;
       let reason: TurnOutcomeReason = 'other';
-      if (result.stopReason === 'end_turn') reason = hasText ? 'end_turn' : 'empty_final';
-      else if (result.stopReason === 'max_tokens') reason = 'max_tokens';
-      else if (result.stopReason === 'refusal') reason = 'refusal';
-      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason, detail: result.stopReason, iterations: iter + 1 });
+      if (effectiveStopReason === 'end_turn') reason = hasText ? 'end_turn' : 'empty_final';
+      else if (effectiveStopReason === 'max_tokens') reason = 'max_tokens';
+      else if (effectiveStopReason === 'refusal') reason = 'refusal';
+      callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason, detail: effectiveStopReason, iterations: iter + 1 });
       return workingHistory;
     }
 

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -104,6 +104,7 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
     // the lean minimal preset — it's a cost-increasing autonomy feature, so it
     // belongs in the same "off to minimize spend" bucket as vision/thinking.
     autoResume: false,
+    planFirst: false,
     anthropicModel: 'claude-haiku-4-5',
   },
   standard: {
@@ -121,6 +122,7 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
     maxSpend: 'medium',
     thinking: 'high',
     autoResume: true,
+    planFirst: false,
     anthropicModel: 'claude-sonnet-4-6',
   },
   full: {
@@ -131,6 +133,7 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
     maxSpend: 'high',
     thinking: 'high',
     autoResume: true,
+    planFirst: false,
     anthropicModel: 'claude-opus-4-7',
   },
 };
@@ -192,6 +195,7 @@ function cloneToggles(t: ChatToggles): ChatToggles {
     maxSpend: t.maxSpend,
     thinking: t.thinking,
     autoResume: t.autoResume,
+    planFirst: t.planFirst,
     provider: t.provider,
     anthropicModel: t.anthropicModel,
     localModel: t.localModel,
@@ -281,6 +285,7 @@ export function applyPreset(settings: AiSettings, preset: Preset): AiSettings {
       maxSpend: p.maxSpend,
       thinking: p.thinking,
       autoResume: p.autoResume,
+      planFirst: p.planFirst,
       // Presets target Anthropic, but if the user is currently on a
       // different provider, keep them on it — the preset only adjusts
       // cost/scope/views.
@@ -437,6 +442,7 @@ export function setToggles(settings: AiSettings, partial: DeepPartial<ChatToggle
     maxSpend: partial.maxSpend ?? settings.toggles.maxSpend,
     thinking: partial.thinking ?? settings.toggles.thinking,
     autoResume: partial.autoResume ?? settings.toggles.autoResume,
+    planFirst: partial.planFirst ?? settings.toggles.planFirst,
     provider: partial.provider ?? settings.toggles.provider,
     anthropicModel: partial.anthropicModel ?? settings.toggles.anthropicModel,
     localModel: partial.localModel ?? settings.toggles.localModel,
@@ -519,6 +525,7 @@ function mergeWithDefaults(partial: LegacyAiSettings): AiSettings {
       maxSpend: tgls.maxSpend ?? DEFAULT_SETTINGS.toggles.maxSpend,
       thinking: tgls.thinking ?? DEFAULT_SETTINGS.toggles.thinking,
       autoResume: tgls.autoResume ?? DEFAULT_SETTINGS.toggles.autoResume,
+      planFirst: tgls.planFirst ?? DEFAULT_SETTINGS.toggles.planFirst,
       provider,
       anthropicModel: tgls.anthropicModel ?? legacyAnthropic ?? DEFAULT_SETTINGS.toggles.anthropicModel,
       localModel: validLocalModel,

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -280,6 +280,32 @@ export function loadAiMd(): Promise<string> {
  *  Sticking the active language in the suffix flips the prompt-vs-suffix
  *  signal ratio so the more-recent + more-specific instruction wins. */
 export function toggleSuffix(toggles: ChatToggles): string {
+  // Plan-mode turns get their own suffix that replaces the capabilities
+  // section entirely. The model's only job is to write a plan — showing
+  // "Run code: OFF" would trigger the "paste code in chat" fallback, which
+  // is exactly the wrong behavior here.
+  if (toggles.planFirst) {
+    const lang = currentLanguage();
+    const model = activeModel(toggles) ?? '(none picked)';
+    return [
+      '',
+      '## Session toggle state',
+      '',
+      `Active language: ${lang}`,
+      `Model: ${model}`,
+      '',
+      '**PLAN MODE — do NOT call any tools or write runnable code.**',
+      '',
+      'Your only job this turn is to outline your approach for the request:',
+      '- What you will build and the overall shape/structure',
+      '- Key design decisions and any trade-offs',
+      '- The concrete steps you will take to implement it',
+      '',
+      'If you need clarification before you can write a useful plan, ask your questions now.',
+      'The user will approve the plan (triggering a new turn with full tools) or reply to refine it further.',
+    ].join('\n');
+  }
+
   // Behavioural guidance for each capability that's currently OFF — tells the
   // model what to do instead of reaching for the disabled tool.
   const offGuidance: string[] = [];

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1138,6 +1138,11 @@ const AUTORESUME_GATED = new Set(['finish']);
 const NOTES_GATED = new Set(['addSessionNote']);
 
 export function buildToolList(toggles: ChatToggles): ToolDefinition[] {
+  // Plan-mode turns are tool-free — the model's only job is to write a plan.
+  // An empty list prevents any tool call, including always-available read
+  // tools that could otherwise be used to set code or query session state.
+  if (toggles.planFirst) return [];
+
   return ALL_TOOLS.filter(t => {
     if (ALWAYS_AVAILABLE.has(t.name)) return true;
     if (RUN_GATED.has(t.name)) return toggles.scope.runCode;

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -110,6 +110,12 @@ export interface ChatToggles {
    *  one-stop-per-end_turn behavior and is remembered across reloads.
    *  Per-session, like the other toggles. */
   autoResume: boolean;
+  /** Plan-first mode. When ON, the first turn on each user message asks the
+   *  model to produce a written plan (no tool calls) before executing anything.
+   *  After the plan is streamed the user can approve it (a follow-up turn
+   *  proceeds with full tools) or reject it (planning messages are removed from
+   *  history and the original input is restored). OFF by default. */
+  planFirst: boolean;
   /** Which backend the chat is talking to right now. */
   provider: Provider;
   /** Anthropic model for cloud chats. Plain string so dated snapshots

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1623,7 +1623,7 @@ function renderPlanApprovalBar(): void {
 
   const label = document.createElement('span');
   label.className = 'text-[11px] text-amber-200 flex-1';
-  label.textContent = '📋 Plan ready — review above, then approve or reject.';
+  label.textContent = '📋 Plan mode — type to refine, or approve/reject.';
   planApprovalBarEl.appendChild(label);
 
   const approveBtn = document.createElement('button');
@@ -2712,9 +2712,6 @@ async function sendMessage(): Promise<void> {
   // against the same transcript. The viewer overlay offers "Take control".
   if (!writeOwner) return;
   if (!inputEl) return;
-  // Block new sends while a plan is awaiting approval — the user must
-  // approve or reject it first.
-  if (state.pendingPlanApproval) return;
   const text = inputEl.value.trim();
   if (text.length === 0 && state.pendingImages.length === 0) return;
 
@@ -2761,28 +2758,39 @@ async function sendMessage(): Promise<void> {
   // if they had been scrolled up reading earlier history.
   pinTranscriptToBottom();
 
-  if (settings.toggles.planFirst) {
-    // Plan-first mode: run a planning turn (tools off, auto-continue off)
-    // asking the model to describe its approach before executing anything.
+  if (settings.toggles.planFirst || state.pendingPlanApproval) {
+    // Plan-first mode or an in-flight plan refinement: keep tools off so the
+    // model can't execute anything until the user approves. If this is a
+    // follow-up (pendingPlanApproval is already set), the user is replying to
+    // a clarifying question or asking the model to revise — just send the
+    // message as-is; the planning prefix is only for the very first turn.
     const planToggles: ChatToggles = {
       ...settings.toggles,
       scope: { runCode: false, saveVersions: false, paintFaces: false, sessionNotes: false },
       autoResume: false,
     };
-    const planPrefix =
-      'Before doing anything, write a concise plan for the following request. '
-      + 'Describe your approach, key steps, and any design decisions. '
-      + 'Do NOT call any tools or start building yet — I will approve or reject your plan first.\n\n'
-      + '---\n\n';
-    const planBlocks: ChatBlock[] = [];
-    if (capturedText.length > 0) planBlocks.push({ type: 'text', text: planPrefix + capturedText });
-    for (const img of capturedImages) planBlocks.push({ type: 'image', source: img });
 
-    state.pendingPlanApproval = {
-      originalText: capturedText,
-      originalImages: capturedImages,
-      historyLengthBefore: state.history.length,
-    };
+    let planBlocks: ChatBlock[];
+    if (state.pendingPlanApproval) {
+      // Refinement turn: plain user message, no prefix. historyLengthBefore
+      // stays fixed so Reject still removes all planning messages.
+      planBlocks = blocks;
+    } else {
+      // First planning turn: prefix with the planning instruction.
+      const planPrefix =
+        'Before doing anything, write a concise plan for the following request. '
+        + 'Describe your approach, key steps, and any design decisions. '
+        + 'Do NOT call any tools or start building yet — I will approve or reject your plan first.\n\n'
+        + '---\n\n';
+      planBlocks = [];
+      if (capturedText.length > 0) planBlocks.push({ type: 'text', text: planPrefix + capturedText });
+      for (const img of capturedImages) planBlocks.push({ type: 'image', source: img });
+      state.pendingPlanApproval = {
+        originalText: capturedText,
+        originalImages: capturedImages,
+        historyLengthBefore: state.history.length,
+      };
+    }
 
     await runTurnWithStallRetry(apiKey, planToggles, planBlocks);
     renderPlanApprovalBar();

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -2774,7 +2774,12 @@ async function sendMessage(): Promise<void> {
     if (state.pendingPlanApproval) {
       // Refinement turn: plain user message, no prefix. historyLengthBefore
       // stays fixed so Reject still removes all planning messages.
-      planBlocks = blocks;
+      // Refinement: remind the model it is still in plan mode so it doesn't
+      // switch to execution mode when it receives the information it asked for.
+      const refinePrefix = '[Plan refinement — revise or extend the plan only, do not call any tools or start building]: ';
+      planBlocks = [];
+      if (capturedText.length > 0) planBlocks.push({ type: 'text', text: refinePrefix + capturedText });
+      for (const img of capturedImages) planBlocks.push({ type: 'image', source: img });
     } else {
       // First planning turn: prefix with the planning instruction.
       const planPrefix =

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -52,6 +52,17 @@ interface PanelState {
    *  removed by one rewind operation. Popped by fast-forward to restore.
    *  Cleared when the user sends a new message (conversation has diverged). */
   rewindStack: ChatMessage[][];
+  /** Set when planFirst mode has generated a plan and is awaiting user
+   *  approval. Cleared on approve (which fires the real execution turn) or
+   *  reject (which removes planning messages from history and restores the
+   *  original input). null when no plan is pending. */
+  pendingPlanApproval: {
+    originalText: string;
+    originalImages: ImageSource[];
+    /** Length of state.history before the planning turn was sent, so
+     *  reject can remove exactly the planning messages that were added. */
+    historyLengthBefore: number;
+  } | null;
 }
 
 const state: PanelState = {
@@ -63,6 +74,7 @@ const state: PanelState = {
   inFlightController: null,
   queuedBlocks: [],
   rewindStack: [],
+  pendingPlanApproval: null,
 };
 
 /** Cached length of `public/ai.md` + PREAMBLE, in characters, populated
@@ -146,6 +158,7 @@ let forwardBtnRef: HTMLButtonElement | null = null;
 let drawerEl: HTMLElement | null = null;
 let transcriptEl: HTMLElement | null = null;
 let inputEl: HTMLTextAreaElement | null = null;
+let planApprovalBarEl: HTMLElement | null = null;
 
 // Slash-command autocomplete menu state. The menu sits just above the input
 // row and shows while the user is typing a "/command" token. `slashMenuItems`
@@ -291,6 +304,8 @@ export async function setActiveSession(sessionId: string | null): Promise<void> 
   // and the human's instructions almost never make sense out of context.
   state.queuedBlocks = [];
   renderQueuedBadge();
+  state.pendingPlanApproval = null;
+  renderPlanApprovalBar();
   await loadHistoryForCurrentSession();
   await applySessionAiPreference();
   renderTranscript();
@@ -705,6 +720,12 @@ function buildDrawer(): void {
   inputResizeStripe.className = 'absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-zinc-700 group-hover:bg-blue-500 group-[.is-dragging]:bg-blue-500 transition-colors';
   inputResizeHandle.appendChild(inputResizeStripe);
   root.appendChild(inputResizeHandle);
+
+  // Plan approval bar — shown after planFirst mode generates a plan, until
+  // the user approves (proceeds to execution) or rejects (restores input).
+  planApprovalBarEl = document.createElement('div');
+  planApprovalBarEl.className = 'px-3 py-2 border-t border-amber-700/60 bg-amber-900/20 flex items-center gap-2 shrink-0 hidden';
+  root.appendChild(planApprovalBarEl);
 
   // Bottom section — rewind, toggles, cost, input
   const bottomSection = document.createElement('div');
@@ -1258,6 +1279,15 @@ function renderToggleStrip(): void {
       renderToggleStrip();
     },
   ));
+  primary.appendChild(togglePill(
+    '📋 Plan',
+    toggles.planFirst,
+    'Plan first: when ON, the AI writes a step-by-step plan before doing any work. You approve or reject the plan before execution starts. Useful for complex requests where you want to review the approach first.',
+    () => {
+      applyToggleChange({ planFirst: !toggles.planFirst });
+      renderToggleStrip();
+    },
+  ));
 
   const retry = document.createElement('select');
   retry.className = 'px-1.5 py-0.5 rounded text-[10px] bg-zinc-800 border border-zinc-700 text-zinc-300 focus:outline-none';
@@ -1570,6 +1600,8 @@ async function clearCurrentChat(): Promise<void> {
     return;
   }
   state.history = [];
+  state.pendingPlanApproval = null;
+  renderPlanApprovalBar();
   broadcastChatChanged();
   renderTranscript();
   renderCostMeter();
@@ -1578,6 +1610,77 @@ async function clearCurrentChat(): Promise<void> {
 
 function formatDuration(ms: number): string {
   return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+function renderPlanApprovalBar(): void {
+  if (!planApprovalBarEl) return;
+  if (!state.pendingPlanApproval || state.inFlight) {
+    planApprovalBarEl.classList.add('hidden');
+    return;
+  }
+  planApprovalBarEl.classList.remove('hidden');
+  planApprovalBarEl.replaceChildren();
+
+  const label = document.createElement('span');
+  label.className = 'text-[11px] text-amber-200 flex-1';
+  label.textContent = '📋 Plan ready — review above, then approve or reject.';
+  planApprovalBarEl.appendChild(label);
+
+  const approveBtn = document.createElement('button');
+  approveBtn.className = 'shrink-0 px-2 py-1 rounded text-[11px] font-medium bg-blue-600 hover:bg-blue-500 text-white';
+  approveBtn.textContent = '✓ Approve';
+  approveBtn.title = 'Approve this plan and start building.';
+  approveBtn.addEventListener('click', () => { void approvePlan(); });
+  planApprovalBarEl.appendChild(approveBtn);
+
+  const rejectBtn = document.createElement('button');
+  rejectBtn.className = 'shrink-0 px-2 py-1 rounded text-[11px] text-zinc-300 bg-zinc-700 hover:bg-zinc-600';
+  rejectBtn.textContent = '✗ Reject';
+  rejectBtn.title = 'Reject this plan and edit your request.';
+  rejectBtn.addEventListener('click', () => { void rejectPlan(); });
+  planApprovalBarEl.appendChild(rejectBtn);
+}
+
+async function approvePlan(): Promise<void> {
+  if (!state.pendingPlanApproval) return;
+  state.pendingPlanApproval = null;
+  renderPlanApprovalBar();
+
+  const settings = loadSettings();
+  const apiKey = await preflightTurn(settings, () => { void approvePlan(); });
+  if (apiKey === PREFLIGHT_ABORT) return;
+
+  state.rewindStack = [];
+  progressState.retryCount = 0;
+  stalledByWatchdog = false;
+  pinTranscriptToBottom();
+  await runTurnWithStallRetry(apiKey, settings.toggles, [
+    { type: 'text', text: 'Plan approved. Please proceed.' },
+  ]);
+}
+
+async function rejectPlan(): Promise<void> {
+  if (!state.pendingPlanApproval) return;
+  const { originalText, originalImages, historyLengthBefore } = state.pendingPlanApproval;
+
+  const msgsToRemove = state.history.slice(historyLengthBefore);
+  if (msgsToRemove.length > 0) {
+    await deleteMessages(msgsToRemove.map(m => m.id));
+    state.history = state.history.slice(0, historyLengthBefore);
+  }
+
+  state.pendingPlanApproval = null;
+
+  if (inputEl) {
+    inputEl.value = originalText;
+    inputEl.dispatchEvent(new Event('input'));
+    inputEl.focus();
+  }
+  state.pendingImages = [...originalImages];
+  renderPendingImages();
+  renderPlanApprovalBar();
+  renderTranscript();
+  updateRewindButtons();
 }
 
 // === Transcript rendering ===
@@ -2609,6 +2712,9 @@ async function sendMessage(): Promise<void> {
   // against the same transcript. The viewer overlay offers "Take control".
   if (!writeOwner) return;
   if (!inputEl) return;
+  // Block new sends while a plan is awaiting approval — the user must
+  // approve or reject it first.
+  if (state.pendingPlanApproval) return;
   const text = inputEl.value.trim();
   if (text.length === 0 && state.pendingImages.length === 0) return;
 
@@ -2631,12 +2737,16 @@ async function sendMessage(): Promise<void> {
   const apiKey = await preflightTurn(settings, () => { void sendMessage(); });
   if (apiKey === PREFLIGHT_ABORT) return;
 
+  // Capture content before clearing the input so plan mode can restore it on reject.
+  const capturedText = text;
+  const capturedImages = [...state.pendingImages];
+
   const blocks: ChatBlock[] = [];
-  if (text.length > 0) blocks.push({ type: 'text', text });
+  if (capturedText.length > 0) blocks.push({ type: 'text', text: capturedText });
   // Only attach images the user added if vision is on. Iso views are
   // user-initiated via Show AI; pending images get sent regardless because
   // the user's intent is explicit when they attached them.
-  for (const img of state.pendingImages) blocks.push({ type: 'image', source: img });
+  for (const img of capturedImages) blocks.push({ type: 'image', source: img });
 
   inputEl.value = '';
   state.pendingImages = [];
@@ -2650,6 +2760,35 @@ async function sendMessage(): Promise<void> {
   // bottom so the user's own bubble and the streamed reply are visible even
   // if they had been scrolled up reading earlier history.
   pinTranscriptToBottom();
+
+  if (settings.toggles.planFirst) {
+    // Plan-first mode: run a planning turn (tools off, auto-continue off)
+    // asking the model to describe its approach before executing anything.
+    const planToggles: ChatToggles = {
+      ...settings.toggles,
+      scope: { runCode: false, saveVersions: false, paintFaces: false, sessionNotes: false },
+      autoResume: false,
+    };
+    const planPrefix =
+      'Before doing anything, write a concise plan for the following request. '
+      + 'Describe your approach, key steps, and any design decisions. '
+      + 'Do NOT call any tools or start building yet — I will approve or reject your plan first.\n\n'
+      + '---\n\n';
+    const planBlocks: ChatBlock[] = [];
+    if (capturedText.length > 0) planBlocks.push({ type: 'text', text: planPrefix + capturedText });
+    for (const img of capturedImages) planBlocks.push({ type: 'image', source: img });
+
+    state.pendingPlanApproval = {
+      originalText: capturedText,
+      originalImages: capturedImages,
+      historyLengthBefore: state.history.length,
+    };
+
+    await runTurnWithStallRetry(apiKey, planToggles, planBlocks);
+    renderPlanApprovalBar();
+    return;
+  }
+
   await runTurnWithStallRetry(apiKey, settings.toggles, blocks);
 }
 


### PR DESCRIPTION
## Summary

- Adds a **📋 Plan** toggle pill to the AI pane toggle strip (off by default)
- When ON, sending a message first runs a planning turn (all scope tools disabled, auto-continue off) that asks the model to describe its approach before doing any work
- After the plan streams, an amber approval bar appears between the transcript and the input with **✓ Approve** and **✗ Reject** buttons
- **Approve** fires a follow-up turn with full tools and original toggles: `"Plan approved. Please proceed."`
- **Reject** removes the planning messages from history + IndexedDB and restores the original text/images to the input box
- `pendingPlanApproval` state is cleared on session switch and chat clear so it never leaks across sessions

## Test plan

- [ ] Toggle 📋 Plan ON, type a request, hit Send — model streams a text-only plan, amber bar appears
- [ ] Approve — model proceeds to execute with normal tools
- [ ] Toggle 📋 Plan ON, type a request, hit Send — reject the plan — input box restores original text, planning messages removed from transcript
- [ ] Toggle 📋 Plan OFF — sends immediately as before (no approval step)
- [ ] Switch sessions while plan is pending — approval bar disappears, no stale state
- [ ] Clear chat while plan is pending — approval bar disappears

https://claude.ai/code/session_017ZbuGG95qd4Z9HgR1ZyXJs

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZbuGG95qd4Z9HgR1ZyXJs)_