### PR TITLE
fix: error panel pushes code up instead of overlaying it

### DIFF
--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -116,18 +116,17 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
 
   editorPane.appendChild(editorHeader);
 
-  // Overlay (absolutely positioned) so showing/hiding it never reflows the code
-  // or moves the caret. Anchored to the bottom of the editor pane; long errors
-  // scroll within it.
-  const editorErrorPanel = document.createElement('div');
-  editorErrorPanel.id = 'editor-error-panel';
-  editorErrorPanel.className = 'hidden absolute bottom-0 left-0 right-0 z-10 max-h-[45%] overflow-auto border-t border-red-500/40 bg-red-950/90 backdrop-blur-sm px-3 py-2 text-xs text-red-100 shadow-lg';
-  editorPane.appendChild(editorErrorPanel);
-
   const editorContainer = document.createElement('div');
   editorContainer.id = 'editor-container';
   editorContainer.className = 'flex-1 min-h-0 overflow-hidden';
   editorPane.appendChild(editorContainer);
+
+  // Sits below the editor so it pushes the code up rather than overlaying it.
+  // Long errors scroll within the panel; max-h caps how much space it can take.
+  const editorErrorPanel = document.createElement('div');
+  editorErrorPanel.id = 'editor-error-panel';
+  editorErrorPanel.className = 'hidden shrink-0 max-h-[45%] overflow-auto border-t border-red-500/40 bg-red-950/90 px-3 py-2 text-xs text-red-100';
+  editorPane.appendChild(editorErrorPanel);
 
   // === Splitter ===
   // Outer is a wide transparent grab strip (touch-friendly); inner stripe is the

--- a/tests/editor-live-errors.spec.ts
+++ b/tests/editor-live-errors.spec.ts
@@ -1,7 +1,7 @@
 // Live-error UX: auto-runs (typing) drive the preview but defer error surfacing
 // so the editor doesn't flicker an error / move the caret on every keystroke.
-// The error panel is a non-shifting overlay, and transient typing errors are
-// kept out of the diagnostic log.
+// The error panel sits below the editor and pushes it up; transient typing
+// errors are kept out of the diagnostic log.
 
 import { test, expect } from 'playwright/test';
 
@@ -44,12 +44,12 @@ test.describe('editor live errors', () => {
     await expect(panel).toContainText('zzznotdefined123');
   });
 
-  test('the error panel is an overlay (does not reflow the editor)', async ({ page }) => {
+  test('the error panel is inline (pushes the editor up, not an overlay)', async ({ page }) => {
     await openEditor(page);
     const panel = page.locator('#editor-error-panel');
     await replaceEditorWith(page, BAD);
     await expect(panel).toBeVisible({ timeout: 3000 });
-    await expect(panel).toHaveCSS('position', 'absolute');
+    await expect(panel).toHaveCSS('position', 'static');
   });
 
   test('transient typing errors stay out of the diagnostic log', async ({ page }) => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The SCAD/runtime error panel was `absolute bottom-0`, floating on top of the code editor and obscuring it
- Changed it to a normal flex item after the editor container so it pushes the code up instead
- Removed `absolute`, `bottom-0`, `left-0`, `right-0`, `z-10`, `backdrop-blur-sm`, `shadow-lg` — none needed for a flow-positioned element
- Reordered DOM: `editorContainer` now comes before `editorErrorPanel` in the flex column

## Test plan

- [ ] Trigger a SCAD error — error panel appears at the bottom, code scrolls up to stay visible
- [ ] Clear the error (edit the code) — panel hides, editor expands back to fill the space
- [ ] Long errors: panel scrolls internally, capped at 45% height

https://claude.ai/code/session_0155U7pDWnqRaU6oiU62yszZ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0155U7pDWnqRaU6oiU62yszZ)_