### PR TITLE
feat: add Find/Replace button to editor header

### DIFF
--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -1,5 +1,6 @@
 import { EditorView } from '@codemirror/view';
 import { EditorState, Compartment, type Extension } from '@codemirror/state';
+import { openSearchPanel } from '@codemirror/search';
 import { javascript } from '@codemirror/lang-javascript';
 import { StreamLanguage } from '@codemirror/language';
 import { oneDark } from '@codemirror/theme-one-dark';
@@ -265,6 +266,11 @@ function applyFormat(code: string, lang: EditorLanguage): string {
   } catch {
     return code;
   }
+}
+
+export function openFindReplace(): void {
+  if (!editorView) return;
+  openSearchPanel(editorView);
 }
 
 export function formatCode(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ import { initViewport, updateMesh, setOnMeshUpdate, setOnContextLost, setOnConte
 import { renderCompositeCanvas, renderSingleView, renderSingleViewCanvas, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, EDGE_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode, type EdgeMode } from './renderer/multiview';
 import { generateId, getLatestVersion } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
-import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, getAutoFormat, setAutoFormat, editorContentDiffersFrom } from './editor/codeEditor';
+import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, openFindReplace, getAutoFormat, setAutoFormat, editorContentDiffersFrom } from './editor/codeEditor';
 import { createLayout, type TabName } from './ui/layout';
 import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState } from './ui/toolbar';
 import { installKeyboardShortcuts } from './ui/keyboardShortcuts';
@@ -3644,7 +3644,7 @@ async function main() {
   });
 
   // Create layout
-  const { editorContainer, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, clipControls, formatBtn, autoFormatToggle, switchTab, partsRail, togglePartsRail, collapseEditor, expandEditor } = createLayout(editorUI, {
+  const { editorContainer, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, clipControls, findReplaceBtn, formatBtn, autoFormatToggle, switchTab, partsRail, togglePartsRail, collapseEditor, expandEditor } = createLayout(editorUI, {
     onToggleAi: () => { void toggleAiPanelFromToolbar(); },
     onOpenCatalog: () => { void showCatalogPage(); },
     onToggleDiagnostics: () => { toggleDiagnosticsPanel(); },
@@ -3732,6 +3732,7 @@ async function main() {
     autoFormatToggle.className = on ? AUTO_FORMAT_ON_CLASS : AUTO_FORMAT_OFF_CLASS;
   }
   syncAutoFormatToggleUI();
+  findReplaceBtn.addEventListener('click', () => openFindReplace());
   formatBtn.addEventListener('click', () => formatCode());
   autoFormatToggle.addEventListener('click', () => {
     setAutoFormat(!getAutoFormat());

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -19,6 +19,7 @@ export interface LayoutElements {
   dataContainer: HTMLElement;
   statusBar: HTMLElement;
   clipControls: HTMLElement;
+  findReplaceBtn: HTMLButtonElement;
   formatBtn: HTMLButtonElement;
   autoFormatToggle: HTMLButtonElement;
   switchTab: (tab: TabName, options?: SwitchTabOptions) => void;
@@ -85,6 +86,13 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   const editorHeaderSpacer = document.createElement('div');
   editorHeaderSpacer.className = 'flex-1';
   editorHeader.appendChild(editorHeaderSpacer);
+
+  const findReplaceBtn = document.createElement('button');
+  findReplaceBtn.id = 'find-replace-btn';
+  findReplaceBtn.className = 'shrink-0 px-2 py-0.5 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700 text-xs leading-none border border-transparent hover:border-zinc-600';
+  findReplaceBtn.textContent = 'Find/Replace';
+  findReplaceBtn.title = 'Find/Replace (Ctrl+H)';
+  editorHeader.appendChild(findReplaceBtn);
 
   const formatBtn = document.createElement('button');
   formatBtn.id = 'format-btn';
@@ -642,7 +650,7 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
     window.dispatchEvent(new Event('resize'));
   });
 
-  return { editorPane, partsRail, editorContainer, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, clipControls, formatBtn, autoFormatToggle, switchTab, togglePartsRail, collapseEditor, expandEditor };
+  return { editorPane, partsRail, editorContainer, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, clipControls, findReplaceBtn, formatBtn, autoFormatToggle, switchTab, togglePartsRail, collapseEditor, expandEditor };
 }
 
 // Rail item base — a bottom accent border on mobile (horizontal strip) becomes


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a "Find/Replace" clickable button to the editor pane header, to the left of the existing "Format" button
- Clicking it opens the CodeMirror search/replace panel (same as `Ctrl+H`)
- Exports a new `openFindReplace()` function from `src/editor/codeEditor.ts` using `openSearchPanel` from `@codemirror/search`

## Test plan

- [ ] Open the editor at `/editor`
- [ ] Confirm "Find/Replace" button appears to the left of "Format" in the editor header
- [ ] Click it — the CodeMirror find/replace panel should open at the bottom of the editor
- [ ] Verify `Ctrl+H` / `Cmd+H` still works as before
- [ ] Verify "Format" button still works normally

https://claude.ai/code/session_012wMqdVMoFhWfR9C1gopXTr
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wMqdVMoFhWfR9C1gopXTr)_