### PR TITLE
feat: show import target modal for JS/SCAD files and fix import lifecycle

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1731,6 +1731,9 @@ async function main() {
     // colors bleeding onto image→voxel art — and the editor opens locked.
     cancelVoxelPaintIfActive();
     dropPaintState();
+    // Clear stale params panel immediately so old controls don't linger while
+    // the new model is loading — syncParamsPanel runs again after the run.
+    syncParamsPanel(undefined);
     setValue(code);
     await runCodeSync(code);
     return { sessionId: session.id };
@@ -2198,27 +2201,11 @@ async function main() {
   // Import a .partwright.json session, a raw .js / .scad file, or an .stl mesh
   // into a new session. Returns whether the import committed (so callers know
   // if the inbox should be updated).
-  async function handleImportFile(file: File, options: { skipPreActiveConfirm?: boolean } = {}): Promise<boolean> {
+  async function handleImportFile(file: File): Promise<boolean> {
     const source = classifyImportSource(file.name);
     if (!source) {
       alert(`Unsupported file type: ${file.name}\n\nSupported: .partwright.json, .js, .scad, .stl, .step / .stp, .vox, .svg, .png / .jpg / .gif / .webp / .avif`);
       return false;
-    }
-
-    // Raw code imports don't get a preview modal of their own — confirm before clobber.
-    // JSON imports skip this confirm because the preview modal already serves as
-    // confirmation; STL and STEP imports skip it because their target modals let
-    // the user choose where the import should go; IMAGE imports skip it because
-    // the image→voxel parameter modal (with its own Cancel) serves the same role.
-    if (!options.skipPreActiveConfirm && source !== 'JSON' && source !== 'STL' && source !== 'STEP' && source !== 'IMAGE' && source !== 'SVG') {
-      const cur = getState();
-      if (cur.session && cur.versionCount > 0) {
-        const ok = await showInlineConfirm(
-          editorUI,
-          `Open "${file.name}" as a new session? Your current session will be kept.`,
-        );
-        if (!ok) return false;
-      }
     }
 
     try {
@@ -2229,9 +2216,7 @@ async function main() {
       } else if (source === 'JS' || source === 'SCAD') {
         const code = await file.text();
         const lang: Language = source === 'SCAD' ? 'scad' : 'manifold-js';
-        const sessionName = file.name.replace(/\.(js|scad)$/i, '');
-        await importCodePayload(code, lang, sessionName);
-        committed = true;
+        committed = await placeImportedCodeFile(code, lang, file.name);
       } else if (source === 'STL') {
         const parsed = await parseSTLFile(file);
         if (parsed) {
@@ -2942,6 +2927,9 @@ async function main() {
     cancelVoxelPaintIfActive();
     dropPaintState();
     if (getActiveLanguage() !== language) await switchLanguage(language);
+    // Clear stale params panel immediately so old controls don't linger while
+    // the new model is loading.
+    syncParamsPanel(undefined);
     setValue(code);
     await runCodeSync(code);
     const thumbnail = await captureThumbnail();
@@ -3104,6 +3092,41 @@ async function main() {
     return composeMeshIntoCurrentPart(parsed.mesh);
   }
 
+  /** Place an imported code file (JS / SCAD) into the session, showing a target
+   *  modal when there is real existing work. Options: new part, replace current
+   *  part, or new session. Distinct from placeImportedCode (which handles
+   *  generated code / voxel / BREP with a compose-into current-part path). */
+  async function placeImportedCodeFile(code: string, lang: Language, filename: string): Promise<boolean> {
+    const sessionName = filename.replace(/\.(js|scad)$/i, '');
+    const state = getState();
+    if (!state.session || currentPartIsExpendable()) {
+      await importCodePayload(code, lang, sessionName);
+      return true;
+    }
+    const partLabel = state.currentPart?.name ? `"${state.currentPart.name}"` : 'the current part';
+    const target = await showImportTargetModal({
+      filename,
+      title: 'Import code',
+      currentPartName: state.currentPart?.name ?? null,
+      canAddToCurrent: true,
+      currentPartTitle: `Replace current part — ${partLabel}`,
+      currentPartDesc: "Replace this part's code with the imported file. The current code is saved as a version first.",
+      recommend: 'new-part',
+    });
+    if (!target) return false;
+    if (target === 'new-session') {
+      await importCodePayload(code, lang, sessionName);
+    } else if (target === 'new-part') {
+      await preserveCurrentEditsIfNeeded();
+      await seedNewPartWithCode(code, sessionName, lang);
+    } else {
+      // current-part: replace current part's code with the imported file.
+      await preserveCurrentEditsIfNeeded();
+      await applyCodeToCurrentPart(code, lang);
+    }
+    return true;
+  }
+
   function mergedPartName(names: string[]): string {
     const joined = names.join(' + ');
     return joined.length <= 40 ? joined : `Merged (${names.length} parts)`;
@@ -3231,20 +3254,11 @@ async function main() {
         await handleStepImport(file);
         return;
       }
-      // Remaining sources are raw code (JS / SCAD): read the blob as text and
-      // open it as a new session in the matching language.
-      const cur = getState();
-      if (cur.session && cur.versionCount > 0) {
-        const ok = await showInlineConfirm(
-          editorUI,
-          `Re-import "${entry.filename}" as a new session? Your current session will be kept.`,
-        );
-        if (!ok) return;
-      }
+      // Remaining sources are raw code (JS / SCAD): show the target modal so
+      // the user can choose new part, replace current, or new session.
       const code = await entry.blob.text();
       const lang: Language = entry.source === 'SCAD' ? 'scad' : 'manifold-js';
-      const sessionName = entry.filename.replace(/\.(js|scad)$/i, '');
-      await importCodePayload(code, lang, sessionName);
+      await placeImportedCodeFile(code, lang, entry.filename);
     } catch (e) {
       alert(`Failed to re-import "${entry.filename}": ${(e as Error).message}`);
     }
@@ -10826,6 +10840,11 @@ async function main() {
     const surfaceErrors = opts.surfaceErrors ?? true;
     const myGen = ++_runGeneration;
     _running = true;
+    // Ensure status shows "Running..." regardless of how this run was triggered
+    // (runCode sets it before the RAF; import paths call runCodeSync directly).
+    setStatus(statusBar, 'running', 'Running...');
+    clearEditorDiagnostics();
+    clearEditorErrorPanel(editorErrorPanel);
     const t0 = performance.now();
     // Feed the Customizer's current overrides into the model's api.params(...).
     const result = await executeCodeAsync(src, undefined, currentParamValues);

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { resolveParamValues, pruneParamValues, type ParamSpec, type ParamValue } from './geometry/params';
 import { createParamsPanel, type ParamsPanelController } from './ui/paramsPanel';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
-import { initViewport, updateMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange } from './renderer/viewport';
+import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange } from './renderer/viewport';
 import { renderCompositeCanvas, renderSingleView, renderSingleViewCanvas, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, EDGE_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode, type EdgeMode } from './renderer/multiview';
 import { generateId, getLatestVersion } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
@@ -1731,6 +1731,7 @@ async function main() {
     // colors bleeding onto image→voxel art — and the editor opens locked.
     cancelVoxelPaintIfActive();
     dropPaintState();
+    clearMesh();
     // Clear stale params panel immediately so old controls don't linger while
     // the new model is loading — syncParamsPanel runs again after the run.
     syncParamsPanel(undefined);
@@ -3629,6 +3630,7 @@ async function main() {
   // 'cube')". This is the mixed-language case a JSON merge creates: a voxel
   // Part 2 alongside the default unsaved manifold-js Part 1.
   async function loadPartIntoEditor(version: Version | null) {
+    clearMesh();
     if (version) {
       await loadVersionIntoEditor(version);
     } else {
@@ -3679,6 +3681,9 @@ async function main() {
   // Parts rail — IDE-style list of the session's parts.
   createPartList(partsRail, {
     onSelectPart: async (partId: string) => {
+      // Save any unsaved non-starter edits (e.g. imported SCAD with errors) so
+      // they survive the switch and are loadable when the user returns here.
+      await preserveCurrentEditsIfNeeded();
       const version = await changePart(partId);
       await loadPartIntoEditor(version);
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -2927,6 +2927,7 @@ async function main() {
     // re-resolves stale regions onto the new mesh and locks the editor.
     cancelVoxelPaintIfActive();
     dropPaintState();
+    clearMesh();
     if (getActiveLanguage() !== language) await switchLanguage(language);
     // Clear stale params panel immediately so old controls don't linger while
     // the new model is loading.

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -342,6 +342,19 @@ export function setOnMeshUpdate(fn: (mesh: MeshData) => void): void {
   onMeshUpdate = fn;
 }
 
+export function clearMesh(): void {
+  while (meshGroup.children.length > 0) {
+    const child = meshGroup.children[0];
+    meshGroup.remove(child);
+    if (child instanceof THREE.Mesh) {
+      child.geometry.dispose();
+      const mat = child.material;
+      if (Array.isArray(mat)) mat.forEach(m => m.dispose());
+      else if (mat) mat.dispose();
+    }
+  }
+}
+
 export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boolean }): void {
   // Clear previous
   while (meshGroup.children.length > 0) {

--- a/src/ui/importTargetModal.tsx
+++ b/src/ui/importTargetModal.tsx
@@ -16,6 +16,10 @@ export interface ImportTargetOptions {
   addDisabledReason?: string;
   recommend?: ImportTarget;
   addReplacesStarter?: boolean;
+  /** Override title text for the 'current-part' choice (e.g. for code imports). */
+  currentPartTitle?: string;
+  /** Override description text for the 'current-part' choice. */
+  currentPartDesc?: string;
   /** Modal heading. Defaults to "Import mesh"; image/voxel/BREP imports pass a
    *  noun-appropriate title (e.g. "Import voxels", "Import STEP"). */
   title?: string;
@@ -42,10 +46,10 @@ function buildChoices(opts: ImportTargetOptions): Choice[] {
     },
     {
       target: 'current-part',
-      title: opts.addReplacesStarter ? `Use for current part — ${partLabel}` : `Add to current part — ${partLabel}`,
-      desc: opts.addReplacesStarter
+      title: opts.currentPartTitle ?? (opts.addReplacesStarter ? `Use for current part — ${partLabel}` : `Add to current part — ${partLabel}`),
+      desc: opts.currentPartDesc ?? (opts.addReplacesStarter
         ? 'Make this mesh the contents of the current (empty) part.'
-        : 'Combine it with the geometry already in this part (composed as separate components).',
+        : 'Combine it with the geometry already in this part (composed as separate components).'),
       disabled: !opts.canAddToCurrent,
       disabledReason: opts.addDisabledReason,
     },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **SCAD/JS file imports now show a 3-option modal** ("New part", "Replace current part", "New session") instead of a plain inline confirm that only offered a new session. "Replace current part" saves the current code as a version first so nothing is lost.
- **Status bar shows "Running..." immediately** on any import — `runCodeSync` now always sets the status and clears diagnostics at the top, so import paths that bypass `runCode` (which previously left status at "Ready") now show the correct state.
- **Customize panel clears immediately** — `importCodePayload` and `applyCodeToCurrentPart` now call `syncParamsPanel(undefined)` before the run starts, so stale controls from the previous model disappear right away rather than lingering until the new model finishes loading.
- Re-import via the Recent Imports inbox also shows the same 3-option modal (was an inline confirm).

## Test plan

- [ ] Drop a `.scad` file onto the editor when another session is open — modal appears with "New part" (default), "Replace current part", and "New session"
- [ ] "New part" adds a new part to the current session with the SCAD code
- [ ] "Replace current part" replaces the active part's code; previous version is saved
- [ ] "New session" behaves like the old behavior (creates a brand new session)
- [ ] Cancel dismisses the modal and makes no changes
- [ ] Drop a second `.scad` file when the editor has no session open — goes straight to import (no modal, no confirm)
- [ ] Status bar shows "Running..." immediately when a SCAD file is imported (not "Ready" during the run)
- [ ] If the previous model had Customize parameters, they disappear from the panel as soon as the import starts, not after it finishes
- [ ] Re-import from Recent Imports inbox also shows the modal for JS/SCAD entries
- [ ] STL import modal still works unchanged

https://claude.ai/code/session_015Ru7CDt7JdTqwkRY4Rm8Pz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ru7CDt7JdTqwkRY4Rm8Pz)_