### PR TITLE
feat: add preserve colors checkbox to resize modal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5851,22 +5851,25 @@ async function main() {
       } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
     },
     /** Non-destructive viewport preview of a scale operation (no version saved). */
-    previewScale(sx: number, sy: number, sz: number): { ok: true } | { error: string } {
+    previewScale(sx: number, sy: number, sz: number, opts?: { preserveColor?: boolean }): { ok: true } | { error: string } {
       try {
         if (!currentMeshData) return { error: 'No model loaded' };
-        const result = applyScale(meshForModifier(false), sx, sy, sz);
-        previewSurfaceModifier(result, false);
+        const preserve = opts?.preserveColor ?? false;
+        const result = applyScale(meshForModifier(preserve), sx, sy, sz);
+        previewSurfaceModifier(result, preserve);
         return { ok: true };
       } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
     },
     /** Discard a live scale preview and restore the current model's mesh. */
     clearScalePreview(): { ok: true } { clearSurfacePreview(); return { ok: true }; },
     /** Scale the current model and save as a new version.
-     *  sx/sy/sz are multiplicative factors (1 = no change, 2 = double, 0.5 = half). */
-    async scaleModel(sx: number, sy: number, sz: number) {
+     *  sx/sy/sz are multiplicative factors (1 = no change, 2 = double, 0.5 = half).
+     *  `preserveColor` (default true) re-resolves paint regions onto the scaled mesh. */
+    async scaleModel(sx: number, sy: number, sz: number, opts?: { preserveColor?: boolean }) {
       try {
         if (!currentMeshData) return { error: 'No model loaded' };
-        return await commitSurfaceModifier(applyScale(meshForModifier(false), sx, sy, sz), false);
+        const preserve = opts?.preserveColor ?? true;
+        return await commitSurfaceModifier(applyScale(meshForModifier(preserve), sx, sy, sz), preserve);
       } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
     },
     /** Run code string and update all views. Returns geometry data object. */

--- a/src/ui/resizeModal.ts
+++ b/src/ui/resizeModal.ts
@@ -10,10 +10,11 @@ import { registerCommands } from './commandPalette';
 type ApplyResult = { error?: string; label?: string } | Record<string, unknown>;
 
 export interface ResizeApi {
-  scaleModel(sx: number, sy: number, sz: number): Promise<ApplyResult>;
-  previewScale(sx: number, sy: number, sz: number): { ok: true } | { error: string };
+  scaleModel(sx: number, sy: number, sz: number, opts?: { preserveColor?: boolean }): Promise<ApplyResult>;
+  previewScale(sx: number, sy: number, sz: number, opts?: { preserveColor?: boolean }): { ok: true } | { error: string };
   clearScalePreview(): { ok: true };
   getGeometryData(): { boundingBox?: { min?: number[]; max?: number[] } | null } | Record<string, unknown>;
+  modelHasColor(): boolean;
 }
 
 type ScaleMode = 'percent' | 'units';
@@ -60,6 +61,9 @@ export function openResizeModal(api: ResizeApi): void {
   // Max values for sliders (user-configurable)
   let maxPct = 500;
   let maxRaw = Math.max(...size) * 5 || 100;
+
+  let preserveColor = true;
+  const hasColor = api.modelHasColor();
 
   let previewDirty = false;
   let previewTimer: number | undefined;
@@ -184,6 +188,20 @@ export function openResizeModal(api: ResizeApi): void {
   const axisContainer = el('div', 'space-y-3 mb-4');
   body.append(axisContainer);
 
+  // ---- Preserve colors checkbox (only when the model has paint) ----
+  if (hasColor) {
+    const colorRow = el('label', 'flex items-center gap-2 mb-3 text-xs text-zinc-300 cursor-pointer');
+    const colorCheck = el('input', 'accent-sky-500');
+    colorCheck.type = 'checkbox';
+    colorCheck.checked = preserveColor;
+    colorCheck.addEventListener('change', () => {
+      preserveColor = colorCheck.checked;
+      schedulePreview();
+    });
+    colorRow.append(colorCheck, el('span', '', 'Preserve colors (best-effort)'));
+    body.append(colorRow);
+  }
+
   // ---- Current size display ----
   const sizeInfo = el('div', 'text-[11px] text-zinc-500 mb-3');
   if (bbox) {
@@ -294,7 +312,7 @@ export function openResizeModal(api: ResizeApi): void {
         status.textContent = '';
         return;
       }
-      const r = api.previewScale(sx, sy, sz);
+      const r = api.previewScale(sx, sy, sz, { preserveColor });
       if ((r as { error?: string }).error) {
         status.textContent = `Preview error: ${(r as { error: string }).error}`;
       } else {
@@ -334,7 +352,7 @@ export function openResizeModal(api: ResizeApi): void {
     status.textContent = 'Working…';
     try {
       const [sx, sy, sz] = getScaleFactors();
-      const result = await api.scaleModel(sx, sy, sz);
+      const result = await api.scaleModel(sx, sy, sz, { preserveColor });
       const err = (result as { error?: string })?.error;
       if (err) {
         status.textContent = `Error: ${err}`;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a "Preserve colors (best-effort)" checkbox to the Resize panel, shown only when the model has paint
- Threads `preserveColor` through `scaleModel` and `previewScale` in `main.ts`, defaulting to `true`
- Carries colors via the same nearest-triangle centroid-mapping used by simplify/smooth — since scaling doesn't change topology, the transfer is essentially lossless

## Test plan

- [ ] Open a painted model, open the Resize panel — checkbox should appear
- [ ] Resize with checkbox checked — colors should be preserved after apply
- [ ] Resize with checkbox unchecked — colors should be cleared (same as old behavior)
- [ ] Open an unpainted model, open the Resize panel — checkbox should not appear
- [ ] CI build + unit + e2e shards green

https://claude.ai/code/session_014HYVWg6px7EdrmG8nLNbaC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014HYVWg6px7EdrmG8nLNbaC)_