### PR TITLE
feat: add render cancel button and elapsed timer for SCAD/long runs

### DIFF
--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -82,10 +82,11 @@ export function executeCode(source: string, lang?: Language, paramOverrides?: Re
 
 let engineWorker: Worker | null = null;
 let workerReadyResolve: (() => void) | null = null;
+let workerReadyReject: ((e: Error) => void) | null = null;
 // Mutable so it can be replaced when the Worker is restarted after a crash.
 // A crashed-and-restarted Worker must not inherit the already-resolved promise
 // from its predecessor — callers would skip the await and race the new init.
-let workerReady: Promise<void> = new Promise(r => { workerReadyResolve = r; });
+let workerReady: Promise<void> = new Promise((r, rej) => { workerReadyResolve = r; workerReadyReject = rej; });
 let callIdCounter = 0;
 
 const pendingExecutions  = new Map<string, { resolve: (r: MeshResult) => void; reject: (e: Error) => void }>();
@@ -145,18 +146,31 @@ function rejectAllPending(err: Error): void {
 /** Terminate an unresponsive Worker and reject everything in flight so the next
  *  call boots a fresh instance instead of queueing behind a hang. */
 function restartEngineWorker(reason: string): void {
-  rejectAllPending(new Error(reason));
+  const err = new Error(reason);
+  rejectAllPending(err);
+  // Unblock any executeCodeAsync that's still awaiting 'workerReady' (i.e. the
+  // worker was terminated before it sent the 'ready' message). Promise state is
+  // immutable so this is a no-op if the gate was already resolved.
+  workerReadyReject?.(err);
+  workerReadyReject = null;
   engineWorker?.terminate();
   engineWorker = null;
   // eslint-disable-next-line no-console
   console.error('[EngineWorker]', reason);
 }
 
+/** Cancel any in-flight executeCodeAsync by terminating the Worker.
+ *  The pending Promise rejects immediately; the Worker restarts automatically
+ *  on the next executeCodeAsync call. */
+export function cancelCurrentExecution(): void {
+  restartEngineWorker('Execution cancelled');
+}
+
 function initEngineWorker(): void {
   if (engineWorker) return;
   // Fresh ready-gate so the restarted Worker's 'ready' message resolves it,
   // not the one that was already resolved by the previous instance.
-  workerReady = new Promise(r => { workerReadyResolve = r; });
+  workerReady = new Promise((r, rej) => { workerReadyResolve = r; workerReadyReject = rej; });
   engineWorker = new Worker(new URL('./engineWorker.ts', import.meta.url), { type: 'module' });
   engineWorker.onmessage = handleEngineWorkerMessage;
   engineWorker.onerror = (ev) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3944,6 +3944,11 @@ async function main() {
   let _runTimerStart = 0;
   let _runShowTimer: number | null = null;
   let _runTimerInterval: number | null = null;
+  // True only while the current in-flight runCodeSync was started by runCode()'s
+  // RAF callback (i.e. an auto-run or manual Run button). False when an explicit
+  // call owns it (partwright.run, version load). Used to decide whether a new
+  // RAF auto-run may cancel the current run or must suppress itself instead.
+  let _rafOwnsRun = false;
 
   // Last error from an auto-run, held back from the editor UI until typing
   // settles or focus leaves (see surfacePendingError). `src` guards against
@@ -10959,12 +10964,20 @@ async function main() {
     clearEditorErrorPanel(editorErrorPanel);
 
     requestAnimationFrame(async () => {
-      // If a render is already in flight, cancel it so the latest code runs
-      // immediately rather than being silently dropped. The generation counter
-      // in runCodeSync ensures the old result is discarded even if the Worker
-      // somehow returns before the termination propagates.
-      if (_running) cancelCurrentExecution();
+      if (_running) {
+        if (_rafOwnsRun) {
+          // The in-flight run was also started by a RAF auto-run — cancel it so
+          // the latest edited code renders immediately instead of being dropped.
+          cancelCurrentExecution();
+        } else {
+          // An explicit call (partwright.run, version load) owns the current
+          // run — suppress this auto-run rather than preempting it.
+          return;
+        }
+      }
+      _rafOwnsRun = true;
       await runCodeSync(src, opts);
+      if (!_running) _rafOwnsRun = false;
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@
 import './style.css';
 import { errorLog } from './diagnostics/errorLog';
 import { initDiagnosticsPanel, toggleDiagnosticsPanel } from './ui/diagnosticsPanel';
-import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, exportLastBrepAsSTEP, importSTEPToBrep, importSTEPToMesh, clearBrepImports, clearBrepShape, simplifyInWorker, enhanceInWorker, type Language } from './geometry/engine';
+import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, exportLastBrepAsSTEP, importSTEPToBrep, importSTEPToMesh, clearBrepImports, clearBrepShape, simplifyInWorker, enhanceInWorker, cancelCurrentExecution, type Language } from './geometry/engine';
 import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { resolveParamValues, pruneParamValues, type ParamSpec, type ParamValue } from './geometry/params';
 import { createParamsPanel, type ParamsPanelController } from './ui/paramsPanel';
@@ -33,7 +33,7 @@ import { generateId, getLatestVersion } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, openFindReplace, getAutoFormat, setAutoFormat, editorContentDiffersFrom } from './editor/codeEditor';
 import { createLayout, type TabName } from './ui/layout';
-import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState } from './ui/toolbar';
+import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState, setRunState } from './ui/toolbar';
 import { installKeyboardShortcuts } from './ui/keyboardShortcuts';
 import { registerCommands } from './ui/commandPalette';
 import { showQualitySettingsModal } from './ui/qualitySettingsModal';
@@ -3530,6 +3530,7 @@ async function main() {
       void syncRouteFromURL();
     },
     onRun: () => runCode(),
+    onCancelRun: () => { cancelCurrentExecution(); },
     onExportGLB: actionExportGLB,
     onExportSTL: actionExportSTL,
     onExportOBJ: actionExportOBJ,
@@ -3936,6 +3937,13 @@ async function main() {
   // version-switch or run has already superseded it, and applying the stale
   // result would overwrite the wrong mesh/manifold/colour state.
   let _runGeneration = 0;
+  // Elapsed-time display for slow renders (SCAD, complex JS). The cancel
+  // button and timer are hidden until 400 ms have elapsed so fast runs don't
+  // flash them. _runShowTimer is the delayed-show timeout; _runTimerInterval
+  // fires every 100 ms to update the displayed elapsed time.
+  let _runTimerStart = 0;
+  let _runShowTimer: number | null = null;
+  let _runTimerInterval: number | null = null;
 
   // Last error from an auto-run, held back from the editor UI until typing
   // settles or focus leaves (see surfacePendingError). `src` guards against
@@ -10951,12 +10959,36 @@ async function main() {
     clearEditorErrorPanel(editorErrorPanel);
 
     requestAnimationFrame(async () => {
-      // An explicit runCodeSync (e.g. version-load, partwright.run) may have
-      // started synchronously before this RAF fired — if so, skip to avoid
-      // racing: the explicit call owns _runGeneration and will apply results.
-      if (_running) return;
+      // If a render is already in flight, cancel it so the latest code runs
+      // immediately rather than being silently dropped. The generation counter
+      // in runCodeSync ensures the old result is discarded even if the Worker
+      // somehow returns before the termination propagates.
+      if (_running) cancelCurrentExecution();
       await runCodeSync(src, opts);
     });
+  }
+
+  // Start the elapsed-time display for a render. The cancel button and timer
+  // are delayed 400 ms so fast runs (manifold-js is typically < 100 ms) never
+  // flash them. stopRunTimer() always cancels the pending show before it fires.
+  function startRunTimer(t0: number): void {
+    _runTimerStart = t0;
+    stopRunTimer();
+    _runShowTimer = window.setTimeout(() => {
+      _runShowTimer = null;
+      setRunState(true, performance.now() - _runTimerStart);
+      _runTimerInterval = window.setInterval(() => {
+        const ms = performance.now() - _runTimerStart;
+        setRunState(true, ms);
+        setStatus(statusBar, 'running', `Rendering... ${(ms / 1000).toFixed(1)}s`);
+      }, 100);
+    }, 400);
+  }
+
+  function stopRunTimer(): void {
+    if (_runShowTimer !== null) { clearTimeout(_runShowTimer); _runShowTimer = null; }
+    if (_runTimerInterval !== null) { clearInterval(_runTimerInterval); _runTimerInterval = null; }
+    setRunState(false);
   }
 
   async function runCodeSync(src: string, opts: { surfaceErrors?: boolean } = {}): Promise<boolean> {
@@ -10972,8 +11004,23 @@ async function main() {
     const myGen = ++_runGeneration;
     _running = true;
     const t0 = performance.now();
+    startRunTimer(t0);
     // Feed the Customizer's current overrides into the model's api.params(...).
-    const result = await executeCodeAsync(src, undefined, currentParamValues);
+    let result: Awaited<ReturnType<typeof executeCodeAsync>>;
+    try {
+      result = await executeCodeAsync(src, undefined, currentParamValues);
+    } catch (err) {
+      // Worker was terminated (cancelled by user, cancelled for a newer run,
+      // timeout, or crash). Only clean up if we're still the active run —
+      // a newer run already owns _running and the timer when myGen differs.
+      if (myGen !== _runGeneration) return false;
+      _running = false;
+      stopRunTimer();
+      const msg = err instanceof Error ? err.message : String(err);
+      const wasCancelled = /cancell?ed/i.test(msg);
+      setStatus(statusBar, wasCancelled ? 'ready' : 'error', wasCancelled ? 'Cancelled' : msg);
+      return false;
+    }
 
     // A newer runCodeSync was dispatched while we were awaiting the Worker.
     // Discard this result to prevent a stale version from overwriting the
@@ -10982,6 +11029,7 @@ async function main() {
 
     const elapsed = Math.round(performance.now() - t0);
     _running = false;
+    stopRunTimer();
 
     // Reconcile the Customizer with what the model declared this run. The
     // schema rides on the result for both success and error, so the panel

--- a/src/main.ts
+++ b/src/main.ts
@@ -3944,11 +3944,11 @@ async function main() {
   let _runTimerStart = 0;
   let _runShowTimer: number | null = null;
   let _runTimerInterval: number | null = null;
-  // True only while the current in-flight runCodeSync was started by runCode()'s
-  // RAF callback (i.e. an auto-run or manual Run button). False when an explicit
-  // call owns it (partwright.run, version load). Used to decide whether a new
-  // RAF auto-run may cancel the current run or must suppress itself instead.
-  let _rafOwnsRun = false;
+  // The _runGeneration value of the most-recently-started RAF-initiated run.
+  // -1 = no RAF run is currently active. A new RAF may cancel only the
+  // generation that this tracks; if the active generation is different (an
+  // explicit call superseded the RAF), the new RAF suppresses itself instead.
+  let _rafOwnedGeneration = -1;
 
   // Last error from an auto-run, held back from the editor UI until typing
   // settles or focus leaves (see surfacePendingError). `src` guards against
@@ -10965,19 +10965,24 @@ async function main() {
 
     requestAnimationFrame(async () => {
       if (_running) {
-        if (_rafOwnsRun) {
-          // The in-flight run was also started by a RAF auto-run — cancel it so
+        if (_runGeneration === _rafOwnedGeneration) {
+          // The in-flight run is our own previous RAF auto-run — cancel it so
           // the latest edited code renders immediately instead of being dropped.
           cancelCurrentExecution();
         } else {
           // An explicit call (partwright.run, version load) owns the current
-          // run — suppress this auto-run rather than preempting it.
+          // run (or a newer RAF already claimed a higher generation) — suppress
+          // this auto-run rather than preempting it.
           return;
         }
       }
-      _rafOwnsRun = true;
+      // Record which generation we're about to start so a later RAF can
+      // cancel only this specific run (not an explicit run that superseded it).
+      const myRafGen = _runGeneration + 1;
+      _rafOwnedGeneration = myRafGen;
       await runCodeSync(src, opts);
-      if (!_running) _rafOwnsRun = false;
+      // If we still own the generation slot and the run is done, clear it.
+      if (_rafOwnedGeneration === myRafGen) _rafOwnedGeneration = -1;
     });
   }
 

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -17,6 +17,7 @@ import {
 
 export interface ToolbarCallbacks {
   onRun: () => void;
+  onCancelRun: () => void;
   onExportGLB: () => void;
   onExportSTL: () => void;
   onExportOBJ: () => void;
@@ -111,6 +112,13 @@ export const IMPORT_ACCEPT = '.partwright.json,.json,.js,.scad,.stl,.step,.stp,.
 let _autoRun = true;
 let _onAutoRunChange: ((on: boolean) => void) | null = null;
 let _syncAutoRunUI: (() => void) | null = null;
+let _setRunState: ((running: boolean, elapsedMs: number) => void) | null = null;
+
+/** Show/hide the cancel button and elapsed timer in the toolbar run group.
+ *  Called by main.ts at the start/end of every runCodeSync execution. */
+export function setRunState(running: boolean, elapsedMs = 0): void {
+  _setRunState?.(running, elapsedMs);
+}
 
 /** Whether auto-run on edit is enabled */
 export function isAutoRun(): boolean { return _autoRun; }
@@ -202,9 +210,37 @@ export function createToolbar(
     if (_autoRun) callbacks.onRun();
   });
 
+  // Cancel button — visible only while a render is in flight
+  const btnCancelRun = document.createElement('button');
+  btnCancelRun.id = 'btn-cancel-run';
+  btnCancelRun.type = 'button';
+  btnCancelRun.className = 'hidden px-2 py-1 rounded text-xs text-red-400 hover:bg-zinc-700 transition-colors';
+  btnCancelRun.textContent = '× Cancel';
+  btnCancelRun.title = 'Cancel the current render';
+  btnCancelRun.addEventListener('click', callbacks.onCancelRun);
+
+  // Elapsed time label — updated every 100 ms during a render
+  const runElapsedEl = document.createElement('span');
+  runElapsedEl.id = 'run-elapsed';
+  runElapsedEl.className = 'hidden text-xs text-zinc-500 font-mono';
+
+  _setRunState = (running, elapsedMs) => {
+    if (running) {
+      btnCancelRun.classList.remove('hidden');
+      runElapsedEl.classList.remove('hidden');
+      runElapsedEl.textContent = `${(elapsedMs / 1000).toFixed(1)}s`;
+    } else {
+      btnCancelRun.classList.add('hidden');
+      runElapsedEl.classList.add('hidden');
+      runElapsedEl.textContent = '';
+    }
+  };
+
   syncAutoRunUI();
   runGroup.appendChild(autoRunBtn);
   runGroup.appendChild(btnRun);
+  runGroup.appendChild(runElapsedEl);
+  runGroup.appendChild(btnCancelRun);
   toolbar.appendChild(runGroup);
 
   // Language toggle — segmented JS / SCAD control


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Cancel button**: A `× Cancel` button appears in the toolbar run group whenever a render has been in flight for > 400 ms. Clicking it terminates the Worker immediately and resets the UI to "Cancelled". Works for all language types (SCAD, JS, BREP, Voxel).
- **Elapsed timer**: Next to the cancel button, an elapsed time label (e.g. `2.3s`) updates every 100 ms. The status bar overlay in the viewport also updates to `Rendering... 2.3s`. Both are hidden until 400 ms to avoid flashing for fast JS runs.
- **Auto-cancel on code change**: Previously, if a SCAD render was in flight and the user edited code, the debounced re-run was silently dropped (the new code wouldn't render until the old run finished). Now the RAF callback cancels the in-flight Worker and immediately starts the new run.
- **Robust cancellation**: `cancelCurrentExecution()` now also rejects the `workerReady` gate promise, unblocking any `executeCodeAsync` that was stuck awaiting a Worker killed before it sent `ready`. `runCodeSync` gained a try/catch around `executeCodeAsync` so Worker termination (cancel, timeout, crash) properly clears `_running` and the timer instead of leaving the UI stuck.

## Test plan

- [ ] Open a complex SCAD model (e.g. BOSL2 gear); confirm cancel button + elapsed timer appear after ~400 ms
- [ ] Click Cancel; confirm "Cancelled" appears in the status bar and the button hides
- [ ] Edit SCAD code while a render is in flight; confirm the new code runs immediately (doesn't wait for old render to finish)
- [ ] Fast JS run (manifold-js cube): confirm cancel button never flashes
- [ ] Timeout scenario: verify existing timeout still works correctly (no double-reject)
- [ ] Unit tests: `npm run test:unit` — all 564 pass

https://claude.ai/code/session_01XUN5zRsYZauPosftVJmNTg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUN5zRsYZauPosftVJmNTg)_