### PR TITLE
fix: per-part draft persistence and toolbar language sync on part switch

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3624,9 +3624,9 @@ async function main() {
   // under whatever engine the previously-active part left behind (e.g. voxel,
   // where `api.Manifold` is undefined). This is the mixed-language case a JSON
   // merge creates: a voxel Part 2 alongside an unsaved manifold-js Part 1.
-  async function loadPartIntoEditor(version: Version | null) {
+  async function loadPartIntoEditor(version: Version | null, opts: { skipDraftSave?: boolean } = {}) {
     if (version) {
-      await loadVersionIntoEditor(version);
+      await loadVersionIntoEditor(version, opts);
     } else {
       if (getActiveLanguage() !== 'manifold-js') await switchLanguage('manifold-js');
       startNewPartInEditor();
@@ -3675,8 +3675,19 @@ async function main() {
   // Parts rail — IDE-style list of the session's parts.
   createPartList(partsRail, {
     onSelectPart: async (partId: string) => {
+      // Save the outgoing part's draft BEFORE changePart runs — after that
+      // call getState().currentPart is already the incoming part, so saving
+      // inside loadVersionIntoEditor would land under the wrong id.
+      const { session, currentPart } = getState();
+      if (session && currentPart) {
+        await writeDraft(session.id, getActiveLanguage(), getValue(), currentPart.id);
+      }
       const version = await changePart(partId);
-      await loadPartIntoEditor(version);
+      // skipDraftSave: the outgoing draft was already saved above.
+      await loadPartIntoEditor(version, { skipDraftSave: true });
+      // Restore the incoming part's unsaved work (if any) on top of the
+      // saved version that loadPartIntoEditor just loaded.
+      await restoreDraftIfNewer();
     },
     onCreatePart: async () => {
       // Structural part edits are leader-only — a read-only viewer must not
@@ -3695,6 +3706,7 @@ async function main() {
       const result = await deletePart(partId);
       if (result && wasCurrent) {
         await loadPartIntoEditor(getState().currentVersion);
+        await restoreDraftIfNewer();
       }
     },
     onDeleteParts: async (partIds: string[]) => {
@@ -3704,6 +3716,7 @@ async function main() {
       // (deleteParts reports this via newCurrent).
       if (result && result.newCurrent) {
         await loadPartIntoEditor(getState().currentVersion);
+        await restoreDraftIfNewer();
       }
     },
     onMergeParts: async (partIds: string[]) => {
@@ -3979,7 +3992,7 @@ async function main() {
     void ensureEngineStarted();
   }
 
-  async function loadVersionIntoEditor(version: Version) {
+  async function loadVersionIntoEditor(version: Version, opts: { skipDraftSave?: boolean } = {}) {
     // Cancel any active voxel paint before loading a different version — its
     // live grid and provenance map are bound to the OUTGOING code, so a Bake
     // after navigation would write the wrong session's voxels into the new
@@ -3992,11 +4005,20 @@ async function main() {
     // language boundary we stash the current editor buffer as a draft for
     // the previous language first, so navigate ↔ toggle round-trips don't
     // silently drop work-in-progress in the language we're leaving.
+    // skipDraftSave is set by onSelectPart, which saves the outgoing draft
+    // before calling changePart (ensuring it lands under the correct part id).
     const versionLang = effectiveVersionLanguage(version, getState().session);
     if (versionLang !== getActiveLanguage()) {
-      const sid = getState().session?.id;
-      if (sid) await writeDraft(sid, getActiveLanguage(), getValue());
+      if (!opts.skipDraftSave) {
+        const sid = getState().session?.id;
+        const pid = getState().currentPart?.id;
+        if (sid) await writeDraft(sid, getActiveLanguage(), getValue(), pid);
+      }
       await switchLanguage(versionLang);
+    } else {
+      // Engine is already on the right language but the toolbar might have
+      // drifted (e.g. a previous same-language part was active) — sync it.
+      setToolbarLanguage(versionLang);
     }
     setActiveImports((version.importedMeshes ?? []) as ImportedMesh[]);
     setValue(version.code);
@@ -4520,6 +4542,7 @@ async function main() {
   async function restoreDraftIfNewer(): Promise<void> {
     const sid = getState().session?.id;
     if (!sid) return;
+    const pid = getState().currentPart?.id;
     // Only at the tip: if a specific older version is loaded, don't override it.
     const current = getState().currentVersion;
     if (current) {
@@ -4527,7 +4550,7 @@ async function main() {
       const latestIndex = versions.reduce((m, v) => Math.max(m, v.index), -Infinity);
       if (current.index !== latestIndex) return;
     }
-    const draft = await readDraft(sid, getActiveLanguage());
+    const draft = await readDraft(sid, getActiveLanguage(), pid);
     if (draft == null || draft === getValue()) return;
     setValue(draft);
     await runCodeSync(draft);
@@ -4845,9 +4868,10 @@ async function main() {
   function autosaveDraft(): void {
     const sid = getState().session?.id;
     if (!sid) return;
+    const pid = getState().currentPart?.id;
     const lang = getActiveLanguage();
     const code = getValue();
-    void writeDraft(sid, lang, code).catch((e) => {
+    void writeDraft(sid, lang, code, pid).catch((e) => {
       if (isQuotaError(e)) {
         showToast('Storage full — could not autosave your draft. Free up space or export your work.', { variant: 'warn' });
       }
@@ -5571,15 +5595,16 @@ async function main() {
       await createSession(undefined, prevLang);
     }
     const sid = getState().session?.id;
+    const pid = getState().currentPart?.id;
     if (sid) {
       // Persist the previous language's working buffer so flipping back
       // restores it exactly. Both languages stay live in IDB until the
-      // session is deleted.
-      await writeDraft(sid, prevLang, currentCode);
+      // part/session is deleted.
+      await writeDraft(sid, prevLang, currentCode, pid);
     }
     await applyEngineLanguage(lang);
     let nextCode: string | null = null;
-    if (sid) nextCode = await readDraft(sid, lang);
+    if (sid) nextCode = await readDraft(sid, lang, pid);
     if (nextCode === null) {
       nextCode = lang === 'scad' ? DRAFT_STUB_SCAD
         : lang === 'replicad' ? DRAFT_STUB_REPLICAD

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -109,14 +109,16 @@ export interface Version {
   paramValues?: Record<string, number | boolean | string>;
 }
 
-/** Editor working buffer scoped to (session, language). One per language per
- *  session: switching the toolbar's language toggle stashes the previous
- *  language's code here and restores the target language's. Persisted so a
- *  reload doesn't lose in-progress work in either language. Cascade-deleted
- *  with the session. */
+/** Editor working buffer scoped to (session, part, language). One slot per
+ *  (part, language): switching parts or the toolbar language toggle stashes the
+ *  outgoing code here and restores the target slot's. Persisted so a reload
+ *  doesn't lose in-progress work. Cascade-deleted with the session (sessionId
+ *  index); individual part drafts are also pruned when the part is deleted. */
 export interface SessionDraft {
-  /** Composite key: `${sessionId}:${language}`. Lets the cascade delete on
-   *  session removal walk a simple `sessionId` index. */
+  /** Composite key: `${sessionId}:${partId}:${language}` (with partId) or
+   *  legacy `${sessionId}:${language}` (pre-per-part drafts). The cascade
+   *  delete on session removal uses the `sessionId` index, which covers both
+   *  formats. */
   id: string;
   sessionId: string;
   language: 'manifold-js' | 'scad' | 'replicad' | 'voxel';
@@ -124,8 +126,8 @@ export interface SessionDraft {
   updatedAt: number;
 }
 
-function draftId(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel'): string {
-  return `${sessionId}:${language}`;
+function draftId(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', partId?: string): string {
+  return partId ? `${sessionId}:${partId}:${language}` : `${sessionId}:${language}`;
 }
 
 export interface SessionNote {
@@ -930,17 +932,17 @@ export async function clearAllData(): Promise<void> {
   await txComplete(txn);
 }
 
-// === Editor drafts (per session, per language) ===
+// === Editor drafts (per session, per part, per language) ===
 
-export async function getDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel'): Promise<SessionDraft | null> {
+export async function getDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', partId?: string): Promise<SessionDraft | null> {
   const store = await tx('drafts', 'readonly');
-  return reqToPromise(store.get(draftId(sessionId, language))) as Promise<SessionDraft | null>;
+  return reqToPromise(store.get(draftId(sessionId, language, partId))) as Promise<SessionDraft | null>;
 }
 
-export async function setDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', code: string): Promise<void> {
+export async function setDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', code: string, partId?: string): Promise<void> {
   const store = await tx('drafts', 'readwrite');
   const row: SessionDraft = {
-    id: draftId(sessionId, language),
+    id: draftId(sessionId, language, partId),
     sessionId,
     language,
     code,
@@ -950,9 +952,9 @@ export async function setDraft(sessionId: string, language: 'manifold-js' | 'sca
   await txComplete(store.transaction);
 }
 
-export async function deleteDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel'): Promise<void> {
+export async function deleteDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', partId?: string): Promise<void> {
   const store = await tx('drafts', 'readwrite');
-  store.delete(draftId(sessionId, language));
+  store.delete(draftId(sessionId, language, partId));
   await txComplete(store.transaction);
 }
 
@@ -960,6 +962,18 @@ export async function listDrafts(sessionId: string): Promise<SessionDraft[]> {
   const store = await tx('drafts', 'readonly');
   const index = store.index('sessionId');
   return reqToPromise(index.getAll(IDBKeyRange.only(sessionId))) as Promise<SessionDraft[]>;
+}
+
+/** Delete all per-part drafts for a given part. Called when a part is removed
+ *  so its stashed buffers don't accumulate. */
+export async function deletePartDrafts(sessionId: string, partId: string): Promise<void> {
+  const all = await listDrafts(sessionId);
+  const prefix = `${sessionId}:${partId}:`;
+  const toDelete = all.filter(d => d.id.startsWith(prefix));
+  if (toDelete.length === 0) return;
+  const store = await tx('drafts', 'readwrite');
+  for (const d of toDelete) store.delete(d.id);
+  await txComplete(store.transaction);
 }
 
 // === Relief source images (per session) ===

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -31,6 +31,7 @@ import {
   setDraft as dbSetDraft,
   deleteDraft as dbDeleteDraft,
   listDrafts as dbListDrafts,
+  deletePartDrafts as dbDeletePartDrafts,
   legacyImagesObjectToArray,
   generateId,
   type Session,
@@ -548,31 +549,37 @@ export async function renameSession(id: string, newName: string): Promise<void> 
   publishTabSync({ kind: 'session-meta', sessionId: id });
 }
 
-// === Editor drafts (per session, per language) ===
+// === Editor drafts (per session, per part, per language) ===
 //
-// Each session keeps a per-language draft slot — manifold-js, SCAD, and
-// replicad (BREP) each get their own — so flipping the toolbar's language
-// toggle preserves whatever the user (or the AI) was writing in the previous
-// language. Drafts are persisted so a reload doesn't lose them; they're
-// cascade-deleted when the session is.
+// Each part keeps a per-language draft slot — manifold-js, SCAD, replicad,
+// and voxel each get their own — so switching parts or flipping the toolbar's
+// language toggle preserves whatever the user (or the AI) was writing.
+// Drafts are persisted so a reload doesn't lose them; they're cascade-deleted
+// with the session (via sessionId index) and pruned when a part is deleted.
 
-/** Read the working buffer for a session in a given language. Returns null
- *  when no draft has been stashed yet (caller should fall back to a stub). */
-export async function readDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel'): Promise<string | null> {
-  const row = await dbGetDraft(sessionId, language);
+/** Read the working buffer for a (session, part, language) triple. Pass
+ *  `partId` to scope the draft to a specific part; omit for legacy session-
+ *  wide access. Returns null when no draft exists yet. */
+export async function readDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', partId?: string): Promise<string | null> {
+  const row = await dbGetDraft(sessionId, language, partId);
   return row ? row.code : null;
 }
 
-/** Write the working buffer for a session in a given language. Idempotent —
- *  the row is upserted by composite key. */
-export async function writeDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', code: string): Promise<void> {
-  await dbSetDraft(sessionId, language, code);
+/** Write the working buffer for a (session, part, language) triple. Idempotent
+ *  — the row is upserted by composite key. */
+export async function writeDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', code: string, partId?: string): Promise<void> {
+  await dbSetDraft(sessionId, language, code, partId);
 }
 
-/** Drop the working buffer for a (session, language) pair — used when the
- *  caller wants to force the next language switch to land on a stub. */
-export async function clearDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel'): Promise<void> {
-  await dbDeleteDraft(sessionId, language);
+/** Drop the working buffer for a (session, part, language) triple. */
+export async function clearDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', partId?: string): Promise<void> {
+  await dbDeleteDraft(sessionId, language, partId);
+}
+
+/** Delete all drafts stashed for a specific part (all languages). Called when
+ *  the part is removed so its buffers don't accumulate. */
+export async function deletePartDrafts(sessionId: string, partId: string): Promise<void> {
+  await dbDeletePartDrafts(sessionId, partId);
 }
 
 /** All drafts stashed for a session, ordered by language. */
@@ -746,6 +753,7 @@ export async function deletePart(partId: string): Promise<DeletePartResult | nul
   if (parts.length <= 1) return null; // keep at least one part
 
   await dbDeletePart(partId);
+  void dbDeletePartDrafts(currentState.session.id, partId).catch(() => {});
 
   const remaining = parts.filter(p => p.id !== partId);
   const wasCurrent = currentState.currentPart?.id === partId;
@@ -791,6 +799,8 @@ export async function deleteParts(partIds: string[]): Promise<DeletePartsResult 
 
   const deletedSet = new Set(targets.map(p => p.id));
   await dbDeleteParts(targets.map(p => p.id));
+  const sid = currentState.session.id;
+  for (const id of deletedSet) void dbDeletePartDrafts(sid, id).catch(() => {});
 
   const remaining = parts.filter(p => !deletedSet.has(p.id));
   const currentId = currentState.currentPart?.id;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Toolbar language sync**: After deleting or switching to a same-language part (e.g. SCAD → SCAD), the toolbar could show the wrong language (manifold-js) while the editor had SCAD code. `loadVersionIntoEditor` only called `setToolbarLanguage` when the engine language *changed*; added an `else` branch to always sync the toolbar to the effective version language.

- **Per-part draft persistence**: Drafts were keyed `(sessionId, language)`, so all parts in a session shared one draft slot per language. Autosaves and language-toggle buffers from Part 2 overwrote Part 1's draft, and `restoreDraftIfNewer` could load the wrong part's code after a reload or part switch. Migrated to `(sessionId, partId, language)` keys throughout.

Key behavioral changes:
- `onSelectPart` now saves the outgoing part's draft *before* `changePart` updates `currentPart` (so the draft lands under the correct part id), then calls `restoreDraftIfNewer` after loading so any unsaved work on the incoming part is surfaced.
- `autosaveDraft`, `restoreDraftIfNewer`, and `switchLanguageWithDrafts` all pass the current part id.
- Part deletion cleans up the deleted part's draft entries.
- Old `(sessionId, language)` keys are orphaned but harmlessly swept when the session is deleted (the `sessionId` index covers both key formats).

## Test plan

- [ ] Create a session with two SCAD parts (via AI or New Part + language toggle). Delete the second part — the first part should show SCAD selected in the toolbar, not manifold-js.
- [ ] Switch between two same-language parts with unsaved edits — edits on Part 1 should be preserved when switching away and back.
- [ ] Language toggle (SCAD ↔ JS) within a part still round-trips correctly; toggling back restores that part's previous buffer, not another part's.
- [ ] Part deletion cleans up drafts (no storage leak).
- [ ] Reload mid-edit on a multi-part session: `restoreDraftIfNewer` restores unsaved work for the correct part.

https://claude.ai/code/session_01A2hbMWXN8bxEL2zVkhMNaE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2hbMWXN8bxEL2zVkhMNaE)_