### PR TITLE
feat: make Customize panel draggable and keep it on-screen on mobile

### DIFF
--- a/src/ui/paramsPanel.ts
+++ b/src/ui/paramsPanel.ts
@@ -197,10 +197,11 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
     const maxTop = (visBottom - pr.top) - rr.height - pad;
     const curLeft = rr.left - pr.left;
     const curTop = rr.top - pr.top;
-    // Math.max(min, …) guards the case where the panel is taller/wider than the
-    // visible area: pin to the top/left edge rather than pushing it off the other.
-    const left = Math.min(Math.max(curLeft, minLeft), Math.max(minLeft, maxLeft));
-    const top = Math.min(Math.max(curTop, minTop), Math.max(minTop, maxTop));
+    // Constrain the current position between min and max. The outer Math.max(min, …)
+    // wins when the panel is taller/wider than the visible area (maxLeft < minLeft):
+    // it pins to the top/left edge rather than pushing the panel off the other side.
+    const left = Math.max(minLeft, Math.min(curLeft, maxLeft));
+    const top = Math.max(minTop, Math.min(curTop, maxTop));
     if (dragged || Math.abs(left - curLeft) > 0.5 || Math.abs(top - curTop) > 0.5) {
       applyPos(left, top);
     }

--- a/src/ui/paramsPanel.ts
+++ b/src/ui/paramsPanel.ts
@@ -63,7 +63,7 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
   // that, and `touch-none` stops the browser claiming the gesture for scroll
   // before pointer-capture kicks in.
   const header = document.createElement('div');
-  header.className = 'flex items-center gap-2 px-2.5 py-1.5 border-b border-zinc-700/70 select-none cursor-move touch-none';
+  header.className = 'flex items-center gap-2 px-2.5 py-2 border-b border-zinc-700/70 select-none cursor-move touch-none';
 
   const title = document.createElement('span');
   title.className = 'text-xs font-medium text-zinc-300 flex-1 truncate';
@@ -184,6 +184,9 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
     const pad = 8;
     const pr = parent.getBoundingClientRect();
     const rr = root.getBoundingClientRect();
+    // Not laid out yet (parent still display:none mid tab-switch) — bail rather
+    // than clamp to a bogus zero-size rect.
+    if (rr.width === 0 || rr.height === 0) return;
     const visTop = Math.max(pr.top, 0);
     const visBottom = Math.min(pr.bottom, window.innerHeight);
     const visLeft = Math.max(pr.left, 0);
@@ -207,6 +210,9 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
   let startX = 0, startY = 0, startLeft = 0, startTop = 0;
 
   header.addEventListener('pointerdown', (e) => {
+    // Only the primary (left) mouse button starts a drag — right/middle click
+    // should still raise the context menu / be ignored. Touch & pen pass through.
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
     // Don't start a drag from the Reset / close buttons — let them click.
     if ((e.target as HTMLElement).closest('button')) return;
     const parent = root.offsetParent as HTMLElement | null;

--- a/src/ui/paramsPanel.ts
+++ b/src/ui/paramsPanel.ts
@@ -59,8 +59,11 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
   // Header: a "Customize" title, a Reset button, and a close (×) button. Closing
   // hides the whole panel; the viewport "Customize" toggle pill reopens it (see
   // onVisibilityChange), so the close → reopen loop is always discoverable.
+  // The header also doubles as a drag handle (see below) — `cursor-move` hints
+  // that, and `touch-none` stops the browser claiming the gesture for scroll
+  // before pointer-capture kicks in.
   const header = document.createElement('div');
-  header.className = 'flex items-center gap-2 px-2.5 py-1.5 border-b border-zinc-700/70 select-none';
+  header.className = 'flex items-center gap-2 px-2.5 py-1.5 border-b border-zinc-700/70 select-none cursor-move touch-none';
 
   const title = document.createElement('span');
   title.className = 'text-xs font-medium text-zinc-300 flex-1 truncate';
@@ -104,6 +107,11 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
 
   function applyVisibility(): void {
     root.classList.toggle('hidden', !isOpen());
+    // Once visible, keep it fully inside the screen. Deferred a frame so the
+    // panel has laid out (it can't be measured while `hidden`). This is what
+    // rescues the mobile case where the default bottom-left anchor put the
+    // panel's bottom edge below the fold.
+    if (isOpen()) requestAnimationFrame(clampIntoView);
     notify();
   }
 
@@ -151,6 +159,88 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
   }
 
   closeBtn.addEventListener('click', () => { userClosed = true; applyVisibility(); });
+
+  // --- Dragging --------------------------------------------------------------
+  // The header is a drag handle so the panel can be repositioned on both desktop
+  // and touch — pointer events cover mouse, touch, and stylus uniformly. Position
+  // is tracked as inline left/top (relative to the offset parent); until the user
+  // drags, the panel keeps its CSS-default bottom-left anchor.
+  let dragged = false;
+
+  function applyPos(left: number, top: number): void {
+    root.style.left = `${left}px`;
+    root.style.top = `${top}px`;
+    root.style.right = 'auto';
+    root.style.bottom = 'auto';
+  }
+
+  // Clamp the panel fully inside the visible intersection of its offset parent
+  // and the window, so it can never sit (even partly) off-screen. Only switches
+  // to explicit positioning when it actually needs to move (or the user already
+  // dragged it), so the default desktop placement keeps its CSS anchor.
+  function clampIntoView(): void {
+    const parent = root.offsetParent as HTMLElement | null;
+    if (!parent || root.classList.contains('hidden')) return;
+    const pad = 8;
+    const pr = parent.getBoundingClientRect();
+    const rr = root.getBoundingClientRect();
+    const visTop = Math.max(pr.top, 0);
+    const visBottom = Math.min(pr.bottom, window.innerHeight);
+    const visLeft = Math.max(pr.left, 0);
+    const visRight = Math.min(pr.right, window.innerWidth);
+    const minLeft = (visLeft - pr.left) + pad;
+    const minTop = (visTop - pr.top) + pad;
+    const maxLeft = (visRight - pr.left) - rr.width - pad;
+    const maxTop = (visBottom - pr.top) - rr.height - pad;
+    const curLeft = rr.left - pr.left;
+    const curTop = rr.top - pr.top;
+    // Math.max(min, …) guards the case where the panel is taller/wider than the
+    // visible area: pin to the top/left edge rather than pushing it off the other.
+    const left = Math.min(Math.max(curLeft, minLeft), Math.max(minLeft, maxLeft));
+    const top = Math.min(Math.max(curTop, minTop), Math.max(minTop, maxTop));
+    if (dragged || Math.abs(left - curLeft) > 0.5 || Math.abs(top - curTop) > 0.5) {
+      applyPos(left, top);
+    }
+  }
+
+  let dragPointerId: number | null = null;
+  let startX = 0, startY = 0, startLeft = 0, startTop = 0;
+
+  header.addEventListener('pointerdown', (e) => {
+    // Don't start a drag from the Reset / close buttons — let them click.
+    if ((e.target as HTMLElement).closest('button')) return;
+    const parent = root.offsetParent as HTMLElement | null;
+    if (!parent) return;
+    const pr = parent.getBoundingClientRect();
+    const rr = root.getBoundingClientRect();
+    startLeft = rr.left - pr.left;
+    startTop = rr.top - pr.top;
+    startX = e.clientX;
+    startY = e.clientY;
+    dragPointerId = e.pointerId;
+    dragged = true;
+    header.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  });
+
+  header.addEventListener('pointermove', (e) => {
+    if (dragPointerId !== e.pointerId) return;
+    applyPos(startLeft + (e.clientX - startX), startTop + (e.clientY - startY));
+  });
+
+  function endDrag(e: PointerEvent): void {
+    if (dragPointerId !== e.pointerId) return;
+    dragPointerId = null;
+    if (header.hasPointerCapture(e.pointerId)) header.releasePointerCapture(e.pointerId);
+    clampIntoView();
+  }
+  header.addEventListener('pointerup', endDrag);
+  header.addEventListener('pointercancel', endDrag);
+
+  // Keep it on-screen across viewport changes (rotate, resize, mobile chrome
+  // show/hide). The panel is a singleton created once for the app's lifetime,
+  // so the window listener never needs removing.
+  window.addEventListener('resize', () => { if (isOpen()) clampIntoView(); });
 
   return {
     element: root,

--- a/tests/customizer.spec.ts
+++ b/tests/customizer.spec.ts
@@ -278,4 +278,34 @@ return v;`;
     expect(out.v1.params).toMatchObject({ width: 20, hollow: false });
     expect(xDim(out.v1.geo)).toBeCloseTo(20, 0);
   });
+
+  test('the panel header is a drag handle that repositions it (and keeps it on-screen)', async ({ page }) => {
+    await page.evaluate((code) => (window as unknown as { partwright: PW }).partwright.run(code), PARAM_MODEL);
+    const panel = page.locator('#params-panel');
+    await expect(panel).toBeVisible();
+
+    const before = await panel.boundingBox();
+    if (!before) throw new Error('no panel box');
+
+    // Grab the header (the "Customize" title area) and drag it up-and-right —
+    // the panel starts bottom-left, so there's room that way without clamping.
+    // Pointer/mouse events route to the header's drag handler.
+    const title = panel.locator('text=Customize').first();
+    const titleBox = await title.boundingBox();
+    if (!titleBox) throw new Error('no title box');
+    const grabX = titleBox.x + titleBox.width / 2;
+    const grabY = titleBox.y + titleBox.height / 2;
+    await page.mouse.move(grabX, grabY);
+    await page.mouse.down();
+    await page.mouse.move(grabX + 80, grabY - 80, { steps: 8 });
+    await page.mouse.up();
+
+    const after = await panel.boundingBox();
+    if (!after) throw new Error('no panel box after drag');
+    // It followed the pointer (moved up and right) and stayed fully on screen.
+    expect(after.y).toBeLessThan(before.y - 20);
+    expect(after.x).toBeGreaterThan(before.x + 10);
+    expect(after.y).toBeGreaterThanOrEqual(0);
+    expect(after.x).toBeGreaterThanOrEqual(0);
+  });
 });


### PR DESCRIPTION
## Summary

The parameters / **Customize** panel (`src/ui/paramsPanel.ts`) opened with a fixed `bottom-2 left-2` anchor inside the viewport container. On mobile that could push the panel's bottom edge below the visible viewport (its offset parent extends past the fold), so the lower part of the panel was cut off. There was also no way to move it.

This PR:

- **Makes the header a drag handle.** Touching/clicking the title area and dragging repositions the panel — implemented with Pointer Events (`pointerdown`/`pointermove`/`pointerup` + `setPointerCapture`), so it works identically for mouse, touch, and stylus. The header gets `cursor-move` (affordance) and `touch-none` (so the browser doesn't claim the gesture for scrolling). Dragging never starts from the Reset / close buttons.
- **Keeps the panel fully on-screen.** A `clampIntoView()` pass runs whenever the panel opens, after a drag ends, and on window resize. It constrains the panel to the visible intersection of its offset parent and the window — this is what fixes the mobile "bottom is off the screen" report. Until it actually needs to move, the panel keeps its CSS default bottom-left placement (so desktop behavior is unchanged).

Position is tracked as inline `left`/`top` relative to the offset parent. The panel is a singleton created once for the app's lifetime, so the `resize` listener needs no teardown.

## Test plan

- `npm run build` — clean (tsc + vite).
- `npm run test:unit` — 56 passing.
- `npm run test:e2e -- customizer.spec.ts` — 2 passing, including a new **header drag repositions the panel** test that drags the title and asserts the panel follows the pointer and stays on screen.

https://claude.ai/code/session_01EGfZuwt6n9hmy9BxvuxeSa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGfZuwt6n9hmy9BxvuxeSa)_