### PR TITLE
feat: add api.text() / api.textSection() to manifold-js sandbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "js-beautify": "^1.15.4",
         "manifold-3d": "^3.3.2",
         "openscad-wasm-prebuilt": "^1.2.0",
+        "opentype.js": "^2.0.0",
         "preact": "^10.29.2",
         "replicad": "^0.23.1",
         "replicad-opencascadejs": "^0.23.0",
@@ -2973,19 +2974,12 @@
       "license": "GPL-2.0-or-later"
     },
     "node_modules/opentype.js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
-      "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-2.0.0.tgz",
+      "integrity": "sha512-kCyjv6xdDY1W/jLWZ/L3QhhTlKUqDZMQ5+Jdlw12b3dXkKNpYBqqlMMj0YDQPShWFTMwgZI1hG14kN3XUDSg/A==",
       "license": "MIT",
-      "dependencies": {
-        "string.prototype.codepointat": "^0.2.1",
-        "tiny-inflate": "^1.0.3"
-      },
       "bin": {
         "ot": "bin/ot"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -3162,6 +3156,22 @@
       "resolved": "https://registry.npmjs.org/replicad-opencascadejs/-/replicad-opencascadejs-0.23.0.tgz",
       "integrity": "sha512-igS4U9dgclqAoLAI8rLJxDJAKH2iRMRHlUwFAl5L2Q5yrP0F33D8VKlk7rZ1AFb/zQVWrouNXMK4G2QfLDYVGQ==",
       "license": "MIT"
+    },
+    "node_modules/replicad/node_modules/opentype.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
+      "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
+      "license": "MIT",
+      "dependencies": {
+        "string.prototype.codepointat": "^0.2.1",
+        "tiny-inflate": "^1.0.3"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/rollup": {
       "version": "4.59.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "js-beautify": "^1.15.4",
     "manifold-3d": "^3.3.2",
     "openscad-wasm-prebuilt": "^1.2.0",
+    "opentype.js": "^2.0.0",
     "preact": "^10.29.2",
     "replicad": "^0.23.1",
     "replicad-opencascadejs": "^0.23.0",

--- a/public/ai.md
+++ b/public/ai.md
@@ -44,8 +44,8 @@ Partwright supports four modeling engines. The table below covers the three soli
 | Kernel | manifold-3d mesh | OpenSCAD CSG | OpenCASCADE B-rep |
 | Best for | Algorithmic geometry, smooth curves, mesh-level ops (`warp`/`levelSet`/`smoothOut`), painting | Mechanical parts with BOSL2 (threads, gears, attachables), porting existing `.scad` files | True edge fillets/chamfers, exact surfaces, STEP export, mechanical-CAD interop |
 | Code style | `return Manifold.cube([10,10,10], true);` | `cube([10,10,10], center=true);` | `return BREP.box([10,10,10]).fillet(2);` |
-| Unique strengths | `Curves.loft/sweep/naca4`; `levelSet`/`warp`/`smoothOut` (mesh-level) | BOSL2's `cuboid(rounding=)`, `skin()`, `path_sweep()`, `threaded_rod()`, `spur_gear()` | Exact `fillet()`/`chamfer()`, `.blobSTEP()` export, BREP shapes survive across runs |
-| Limitations | Must learn the manifold-3d API | Slower per-run (~100-300ms WASM init); `text()` needs Liberation Sans font family (1.6 MB lazy-loaded on first use) | No `warp`/`levelSet`; no `Curves` helpers; 10 MB WASM lazy-load on first use |
+| Unique strengths | `Curves.loft/sweep/naca4`; `api.text()`; `levelSet`/`warp`/`smoothOut` (mesh-level) | BOSL2's `cuboid(rounding=)`, `skin()`, `path_sweep()`, `threaded_rod()`, `spur_gear()` | Exact `fillet()`/`chamfer()`, `.blobSTEP()` export, BREP shapes survive across runs |
+| Limitations | Must learn the manifold-3d API | Slower per-run (~100-300ms WASM init); `text()` shares same Liberation Sans fonts as manifold-js | No `warp`/`levelSet`; no `Curves` helpers; 10 MB WASM lazy-load on first use |
 
 **Crucial:** You can ALSO use the BREP namespace **inside a manifold-js session** without switching languages — `api.BREP.box(...).fillet(r)`, then `api.BREP.toManifold(shape, api.Manifold)` to drop back into the Manifold world. This is the right move for "one feature needs an exact fillet" without committing to a BREP-only session. Switch to the **replicad** language only when you need STEP export of the *combined* shape, or when the part is dominated by BREP operations. See `/ai/replicad.md` for the full BREP API.
 
@@ -81,6 +81,7 @@ Reach for the right tool the first time. If the table sends you to a subdoc, fet
 | Wing, hull, fuselage (varying profile along axis) | `Curves.loft([profA, profB], [zA, zB])` -> `/ai/curves.md` | BOSL2 `skin([profiles], z=, slices=)` -> `/ai/bosl2.md` | (use manifold-js Curves) |
 | Handle, tube, propeller (profile along 3D path) | `Curves.sweep(profile, pathPoints)` | BOSL2 `path_sweep(profile, path)` | (use manifold-js Curves) |
 | Revolve around an arbitrary axis | `Curves.revolveAxis(profile, [ax,ay,az])` | `rotate([...]) rotate_extrude() polygon()` | (use manifold-js Curves) |
+| 3D text / embossed label | **`api.text("Hi", {size, height, font, spacing, center})` → Manifold** (Liberation Sans; fonts lazy-loaded ~1.6 MB on first use); `api.textSection(...)` → CrossSection for custom extrusion | `text("Hi", size=10, font="Liberation Sans:style=Regular")` | (use manifold-js) |
 | Round/chamfer all sharp edges of a solid | `Curves.fillet(solid, {angle: 60})` (mesh-smoothing) | BOSL2 `cuboid(rounding=...)`, `round3d(...)` | **`.fillet(radius)` / `.chamfer(distance)` -> `/ai/replicad.md` (exact, BREP-true)** |
 | Round/chamfer ONLY specific edges (e.g. top rim only) | (not available) | BOSL2 `edge_profile()` (rough) | **`.fillet(r, {minZ, maxZ, nearPoint+withinDist, parallelToPlane, inDirection})` — selective, BREP-only. See `/ai/replicad.md` for the full EdgeFilter.** |
 | STEP export | (not available) | (not available) | **`partwright.exportSTEP()` after a BREP-language run -> `/ai/replicad.md`** |
@@ -403,6 +404,7 @@ const { Manifold, CrossSection, Curves, setCircularSegments } = api;
 **Sandbox environment:** The `api` object provides:
 - `Manifold` and `CrossSection` -- the raw manifold-3d bindings
 - `Curves` -- helpers for smooth/organic shapes (loft, sweep, bezier, arc, naca4, polyline with fillet, arbitrary-axis revolve, fillet/chamfer, pattern arrays). See **[/ai/curves.md](/ai/curves.md)**.
+- `text(str, opts)` / `textSection(str, opts)` -- extruded or 2D text from Liberation Sans. See **[Text](#text--api-text--api-textsection)** below.
 - `params` -- declare tweakable **Customizer** knobs that surface as sliders/toggles in the viewport (see below).
 - `sdf` -- signed-distance-field builder for smooth blends, twists, gyroids, and shells. Tree-of-expressions style, lowered to a Manifold via `.build()`. See **[/ai/sdf.md](/ai/sdf.md)**.
 - `setCircularSegments`, `setMinCircularAngle`, `setMinCircularEdgeLength` -- global curve resolution defaults.
@@ -569,6 +571,33 @@ if (api.volumeDelta(body, after) === 0) throw new Error("subtract did nothing");
 
 For smooth curve helpers (`loft`, `sweep`, `naca4`, `bezier`, `polyline` with fillet, etc.), see **[/ai/curves.md](/ai/curves.md)**.
 
+### Text — `api.text` / `api.textSection`
+
+Produces 3D extruded text (or a 2D `CrossSection`) from the Liberation Sans font family. Uses the same TTF files as the OpenSCAD engine — ~1.6 MB, lazy-loaded on the first run that calls `api.text` or `api.textSection`.
+
+```js
+// 3D extruded text — returns a Manifold
+const label = api.text("HELLO", {
+  size:     10,          // character height in model units (default: 10)
+  height:   2,           // extrusion depth along Z (default: 2)
+  font:     'regular',   // 'regular' | 'bold' | 'italic' | 'bold-italic' (default: 'regular')
+  spacing:  1.0,         // advance-width multiplier: >1 widens gaps, <1 compresses (default: 1.0)
+  center:   false,       // if true, center the bounding box on the origin (default: false)
+  segments: 8,           // bezier subdivision per curve segment (default: 8)
+});
+return Manifold.cube([40, 20, 5]).subtract(label.translate([2, 5, 3]));
+
+// 2D cross-section — returns a CrossSection (for revolve, custom extrude, etc.)
+const cs = api.textSection("AB", { size: 10, center: true });
+return cs.extrude(5, 4, 45); // twisted extrusion
+```
+
+**Notes:**
+- `size` is the font's em-size. Cap height ≈ 72% of `size` for Liberation Sans (so `size: 10` → caps ~7.2 units tall).
+- The baseline sits at `y = 0`; ascenders extend above, descenders below.
+- Holes in characters (inside of "O", "B", "P", etc.) are handled correctly via the even-odd fill rule.
+- `api.text` and `api.textSection` are also available as `api.Curves.text` / `api.Curves.textSection`.
+
 ## Writing OpenSCAD code
 
 When the engine is set to `scad`, code is compiled by OpenSCAD (WASM) instead of running as JavaScript.
@@ -587,7 +616,7 @@ When the engine is set to `scad`, code is compiled by OpenSCAD (WASM) instead of
 **BOSL2 library is bundled** -- start your file with `include <BOSL2/std.scad>` to unlock rounded cuboids, skin/loft, sweep, threaded rods, gears, attachables, and pattern distributors. See **[/ai/bosl2.md](/ai/bosl2.md)**. First BOSL2 run on a fresh page fetches ~4 MB of library source (one-time, then cached).
 
 **Known limitations:**
-- `text()` uses Liberation Sans (Regular/Bold/Italic/BoldItalic). The font files (~1.6 MB) are lazy-loaded on the first run that uses `text()`. Other font names will silently produce no geometry.
+- `text()` uses Liberation Sans (Regular/Bold/Italic/BoldItalic) — same font set as `api.text()` in manifold-js. Font files (~1.6 MB) are lazy-loaded on the first run that uses `text()`. Other font names will silently produce no geometry.
 - External `.scad` libraries (other than the bundled BOSL2) can't be `include`d -- there's no filesystem to read from.
 - Each SCAD run creates a fresh WASM instance (~100-300ms overhead). For fast iteration, manifold-js is snappier.
 

--- a/src/geometry/curves.ts
+++ b/src/geometry/curves.ts
@@ -13,6 +13,8 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { textToContours, type TextOptions } from './textGlyphs';
+
 type Vec2 = [number, number];
 type Vec3 = [number, number, number];
 
@@ -22,6 +24,10 @@ type CurvesAPI = {
   bezier: (controls: Vec2[], segments?: number) => Vec2[];
   naca4: (code: string, opts?: NACAOptions) => Vec2[];
   polyline: (points: Vec2[], opts?: PolylineOptions) => any;
+
+  // Text
+  text: (str: string, opts?: TextExtrudeOptions) => any;
+  textSection: (str: string, opts?: TextSectionOptions) => any;
 
   // 3D constructors
   loft: (profiles: any[], heights: number[], opts?: LoftOptions) => any;
@@ -83,6 +89,14 @@ interface RingCopyOptions {
   radius?: number;
   angle?: number;
 }
+
+type TextSectionOptions = TextOptions & {
+  center?: boolean;
+};
+
+type TextExtrudeOptions = TextSectionOptions & {
+  height?: number;
+};
 
 // ---------------------------------------------------------------------------
 
@@ -682,17 +696,64 @@ function makePatterns(module: any) {
 }
 
 // ---------------------------------------------------------------------------
+// Text helpers — api.text() and api.textSection()
+// Fonts are pre-loaded by the Worker before run(); these are synchronous.
+// ---------------------------------------------------------------------------
+
+function makeTextHelpers(module: any) {
+  const { CrossSection } = module;
+
+  function textSection(str: string, opts: TextSectionOptions = {}): any {
+    if (typeof str !== 'string' || str.length === 0) {
+      throw new Error('api.textSection: first argument must be a non-empty string');
+    }
+    const contours = textToContours(str, opts);
+    if (contours.length === 0) {
+      throw new Error(`api.textSection: no glyph outlines produced for "${str}" — the string may contain only whitespace or unsupported characters`);
+    }
+    let cs = CrossSection.ofPolygons(contours);
+    if (opts.center) {
+      // Compute bounding box from the CrossSection's polygon data.
+      const polygons: Vec2[][] = cs.toPolygons();
+      let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+      for (const ring of polygons) {
+        for (const pt of ring) {
+          if (pt[0] < minX) minX = pt[0];
+          if (pt[0] > maxX) maxX = pt[0];
+          if (pt[1] < minY) minY = pt[1];
+          if (pt[1] > maxY) maxY = pt[1];
+        }
+      }
+      cs = cs.translate([-(minX + maxX) / 2, -(minY + maxY) / 2]);
+    }
+    return cs;
+  }
+
+  function text(str: string, opts: TextExtrudeOptions = {}): any {
+    const height = opts.height ?? 2;
+    need(typeof height === 'number' && Number.isFinite(height) && height > 0, 'api.text: height must be a positive number');
+    const cs = textSection(str, opts);
+    return cs.extrude(height);
+  }
+
+  return { text, textSection };
+}
+
+// ---------------------------------------------------------------------------
 // Factory — builds the Curves namespace given a manifold-3d module instance.
 // ---------------------------------------------------------------------------
 
 export function createCurvesNamespace(module: any): CurvesAPI {
   const { CrossSection } = module;
   const patterns = makePatterns(module);
+  const textHelpers = makeTextHelpers(module);
   return {
     arc,
     bezier,
     naca4,
     polyline: makePolyline(CrossSection),
+    text: textHelpers.text,
+    textSection: textHelpers.textSection,
     loft: makeLoft(module),
     sweep: makeSweep(module),
     revolveAxis: makeRevolveAxis(module),

--- a/src/geometry/curves.ts
+++ b/src/geometry/curves.ts
@@ -711,7 +711,11 @@ function makeTextHelpers(module: any) {
     if (contours.length === 0) {
       throw new Error(`api.textSection: no glyph outlines produced for "${str}" — the string may contain only whitespace or unsupported characters`);
     }
-    let cs = CrossSection.ofPolygons(contours);
+    // Use EvenOdd fill rule: font contours after Y-flip are CW (the default
+    // "Positive" fill rule only fills CCW regions, producing empty output).
+    // EvenOdd is also ideal for glyphs with holes (O, B, P): the inner
+    // contour is enclosed by 2 boundaries (even = not filled = hole). ✓
+    let cs = CrossSection.ofPolygons(contours, 'EvenOdd');
     if (opts.center) {
       // Compute bounding box from the CrossSection's polygon data.
       const polygons: Vec2[][] = cs.toPolygons();

--- a/src/geometry/engineWorker.ts
+++ b/src/geometry/engineWorker.ts
@@ -41,6 +41,7 @@ import { runScadAsync, openscadEngine } from './engines/openscad';
 import { runReplicadAsync, replicadEngine, getLastBrepShape, clearLastBrepShape } from './engines/replicad';
 import { voxelEngine } from './engines/voxel';
 import { ensureBrepLoaded, sourceUsesBrep, parseStepBlob, pushPendingBrepImport, clearPendingBrepImports } from './brepRuntime';
+import { sourceUsesManifoldText, preloadTextFonts } from './textGlyphs';
 import { setActiveImports, type ImportedMesh } from '../import/importedMesh';
 import { setCircularSegmentsOverride } from './qualitySettings';
 import type { Language } from './engines/types';
@@ -141,6 +142,11 @@ self.onmessage = async (event: MessageEvent) => {
         // critical path for everyone else.
         if (sourceUsesBrep(code as string)) {
           await ensureBrepLoaded();
+        }
+        // Pre-load Liberation Sans fonts if the code calls api.text / api.textSection.
+        // Same lazy-load pattern as BREP — fonts are cached after the first run.
+        if (sourceUsesManifoldText(code as string)) {
+          await preloadTextFonts();
         }
         result = manifoldJsEngine.run(code as string, params ?? undefined);
       }

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -3,6 +3,7 @@ import { javaScriptSyntaxDiagnostics, runtimeDiagnostic } from '../sourceDiagnos
 import { createCurvesNamespace } from '../curves';
 import { createMeshOpsNamespace } from '../meshOps';
 import { createParamCapture } from '../params';
+import { preloadTextFonts } from '../textGlyphs';
 import { getDefaultCircularSegments } from '../qualitySettings';
 import { getActiveImports } from '../../import/importedMesh';
 import { createSdfNamespace, SdfNode } from '../sdf';
@@ -106,6 +107,10 @@ export const manifoldJsEngine: Engine = {
     manifoldModule.setup();
     curvesNamespace = createCurvesNamespace(manifoldModule);
     meshOpsNamespace = createMeshOpsNamespace(manifoldModule);
+    // Kick off font pre-loading in the background so they're ready by the
+    // time the first api.text() call hits, even if the per-run regex didn't
+    // fire (e.g. destructured alias or api.Curves.text).
+    preloadTextFonts().catch(() => { /* will surface as a clear error at call time */ });
   },
 
   isReady() {

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -245,6 +245,9 @@ export const manifoldJsEngine: Engine = {
       BREP,
       meshOps: meshOpsNamespace,
       sdf: sdfNamespace,
+      // Text helpers — flat aliases so agents can write api.text(...) directly.
+      text: curvesNamespace.text,
+      textSection: curvesNamespace.textSection,
       // Flat aliases for the most-used meshOps verbs — agents reach for shorter
       // names like `api.intersects(a,b)` and `api.placeOn(part, table)` much more
       // often than they reach for the namespace, so we promote those to api.* too.

--- a/src/geometry/textGlyphs.ts
+++ b/src/geometry/textGlyphs.ts
@@ -28,7 +28,11 @@ const fontCache = new Map<FontVariant, Font>();
 let loadPromise: Promise<void> | null = null;
 
 export function sourceUsesManifoldText(code: string): boolean {
-  return /\bapi\.text\s*\(/.test(code) || /\bapi\.textSection\s*\(/.test(code);
+  // Match api.text(, api.textSection(, api.Curves.text(, api.Curves.textSection(
+  return /\bapi\.(?:Curves\.)?textSection\s*\(/.test(code) ||
+         /\bapi\.(?:Curves\.)?text\s*\(/.test(code) ||
+         /\bCurves\.textSection\s*\(/.test(code) ||
+         /\bCurves\.text\s*\(/.test(code);
 }
 
 export async function preloadTextFonts(): Promise<void> {
@@ -79,7 +83,12 @@ export function textToContours(text: string, opts: TextOptions = {}): Vec2[][] {
 
   const font = fontCache.get(variant);
   if (!font) {
-    throw new Error('api.text: fonts not loaded — this should not happen in a manifold-js session. File a bug.');
+    throw new Error(
+      'api.text: Liberation Sans fonts are not yet loaded. ' +
+      'This usually means the text-detection heuristic did not fire before this run. ' +
+      'Use `api.text(...)` or `api.Curves.text(...)` directly (not a destructured alias) ' +
+      'so the engine can pre-load the fonts. The next run will work once fonts are cached.',
+    );
   }
 
   if (spacing === 1.0) {

--- a/src/geometry/textGlyphs.ts
+++ b/src/geometry/textGlyphs.ts
@@ -1,0 +1,163 @@
+/**
+ * Text-to-geometry helpers for the manifold-js sandbox.
+ *
+ * Lazy-loads opentype.js + Liberation Sans font files on first use
+ * (same font set the OpenSCAD engine uses), then converts glyph outlines
+ * into Vec2[][] contours suitable for CrossSection.ofPolygons().
+ *
+ * The Worker pre-loads fonts before calling manifoldJsEngine.run() whenever
+ * sourceUsesManifoldText() fires — so api.text / api.textSection are
+ * always synchronous from inside user code.
+ */
+
+import type { Font } from 'opentype.js';
+
+type Vec2 = [number, number];
+
+export type FontVariant = 'regular' | 'bold' | 'italic' | 'bold-italic';
+
+const FONT_FILES: Record<FontVariant, string> = {
+  regular: 'LiberationSans-Regular.ttf',
+  bold: 'LiberationSans-Bold.ttf',
+  italic: 'LiberationSans-Italic.ttf',
+  'bold-italic': 'LiberationSans-BoldItalic.ttf',
+};
+const FONTS_PREFIX = '/openscad-libs/fonts';
+
+const fontCache = new Map<FontVariant, Font>();
+let loadPromise: Promise<void> | null = null;
+
+export function sourceUsesManifoldText(code: string): boolean {
+  return /\bapi\.text\s*\(/.test(code) || /\bapi\.textSection\s*\(/.test(code);
+}
+
+export async function preloadTextFonts(): Promise<void> {
+  if (loadPromise) return loadPromise;
+  loadPromise = (async () => {
+    const variants = Object.keys(FONT_FILES) as FontVariant[];
+    const [opentype, ...buffers] = await Promise.all([
+      import('opentype.js'),
+      ...variants.map(async (v) => {
+        const r = await fetch(`${FONTS_PREFIX}/${FONT_FILES[v]}`);
+        if (!r.ok) throw new Error(`api.text: failed to fetch font "${v}": ${r.status}`);
+        return r.arrayBuffer();
+      }),
+    ]);
+    for (let i = 0; i < variants.length; i++) {
+      fontCache.set(variants[i], opentype.parse(buffers[i]));
+    }
+  })();
+  return loadPromise;
+}
+
+export interface TextOptions {
+  size?: number;
+  font?: FontVariant;
+  spacing?: number;
+  segments?: number;
+}
+
+/** Convert text to an array of closed 2D contours (one per glyph subpath).
+ *  Contours use model coordinates (Y-up). CrossSection.ofPolygons with the
+ *  even-odd fill rule handles holes (inside of "O", "B", etc.) automatically. */
+export function textToContours(text: string, opts: TextOptions = {}): Vec2[][] {
+  const size = opts.size ?? 10;
+  const variant = opts.font ?? 'regular';
+  const spacing = opts.spacing ?? 1.0;
+  const segments = opts.segments ?? 8;
+
+  if (typeof size !== 'number' || !Number.isFinite(size) || size <= 0) {
+    throw new Error('api.text: size must be a positive number');
+  }
+  if (typeof segments !== 'number' || !Number.isInteger(segments) || segments < 1) {
+    throw new Error('api.text: segments must be a positive integer');
+  }
+  const validVariants: FontVariant[] = ['regular', 'bold', 'italic', 'bold-italic'];
+  if (!validVariants.includes(variant)) {
+    throw new Error(`api.text: font must be one of ${validVariants.map(v => `"${v}"`).join(', ')}`);
+  }
+
+  const font = fontCache.get(variant);
+  if (!font) {
+    throw new Error('api.text: fonts not loaded — this should not happen in a manifold-js session. File a bug.');
+  }
+
+  if (spacing === 1.0) {
+    const path = font.getPath(text, 0, 0, size);
+    return pathCommandsToContours(path.commands, segments);
+  }
+
+  // Custom spacing: lay out glyph-by-glyph, scaling advance width by the multiplier.
+  const scale = size / font.unitsPerEm;
+  const all: Vec2[][] = [];
+  let x = 0;
+  for (const char of text) {
+    const glyph = font.charToGlyph(char);
+    if (!glyph) continue;
+    const glyphPath = glyph.getPath(x, 0, size);
+    all.push(...pathCommandsToContours(glyphPath.commands, segments));
+    x += (glyph.advanceWidth ?? 0) * scale * spacing;
+  }
+  return all;
+}
+
+/** Bounding rect of a set of contours. */
+export function contourBounds(contours: Vec2[]): { minX: number; maxX: number; minY: number; maxY: number } {
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (const pt of contours) {
+    if (pt[0] < minX) minX = pt[0];
+    if (pt[0] > maxX) maxX = pt[0];
+    if (pt[1] < minY) minY = pt[1];
+    if (pt[1] > maxY) maxY = pt[1];
+  }
+  return { minX, maxX, minY, maxY };
+}
+
+// ---------------------------------------------------------------------------
+
+function sampleBezier(pts: Vec2[], segments: number): Vec2[] {
+  const out: Vec2[] = [];
+  for (let i = 0; i <= segments; i++) {
+    const t = i / segments;
+    const work = pts.map((p): Vec2 => [p[0], p[1]]);
+    for (let r = work.length - 1; r > 0; r--) {
+      for (let j = 0; j < r; j++) {
+        work[j] = [work[j][0] * (1 - t) + work[j + 1][0] * t, work[j][1] * (1 - t) + work[j + 1][1] * t];
+      }
+    }
+    out.push(work[0]);
+  }
+  return out;
+}
+
+function pathCommandsToContours(commands: import('opentype.js').PathCommand[], segments: number): Vec2[][] {
+  const contours: Vec2[][] = [];
+  let current: Vec2[] = [];
+  let cx = 0, cy = 0;
+
+  const push = (x: number, y: number) => { cx = x; cy = y; current.push([x, -y]); };
+
+  for (const cmd of commands) {
+    if (cmd.type === 'M') {
+      if (current.length >= 3) contours.push(current);
+      current = [];
+      push(cmd.x, cmd.y);
+    } else if (cmd.type === 'L') {
+      push(cmd.x, cmd.y);
+    } else if (cmd.type === 'Q') {
+      const sampled = sampleBezier([[cx, -cy], [cmd.x1, -cmd.y1], [cmd.x, -cmd.y]], segments);
+      for (let i = 1; i < sampled.length; i++) current.push(sampled[i]);
+      cx = cmd.x; cy = cmd.y;
+    } else if (cmd.type === 'C') {
+      const sampled = sampleBezier([[cx, -cy], [cmd.x1, -cmd.y1], [cmd.x2, -cmd.y2], [cmd.x, -cmd.y]], segments);
+      for (let i = 1; i < sampled.length; i++) current.push(sampled[i]);
+      cx = cmd.x; cy = cmd.y;
+    } else if (cmd.type === 'Z') {
+      if (current.length >= 3) contours.push(current);
+      current = [];
+    }
+  }
+  if (current.length >= 3) contours.push(current);
+
+  return contours;
+}


### PR DESCRIPTION
## Summary

- Adds `api.text(str, opts)` → `Manifold` and `api.textSection(str, opts)` → `CrossSection` to the manifold-js sandbox, so agents can produce 3D text without switching to SCAD
- Uses the same Liberation Sans TTFs already bundled for the OpenSCAD engine (~1.6 MB, lazy-loaded on first use), plus opentype.js (~238 KB chunk, dynamically imported)
- Follows the same pre-load-before-run pattern as BREP: `engineWorker` detects `api.text`/`api.textSection` in the source and awaits `preloadTextFonts()` before calling `manifoldJsEngine.run()`, so both helpers are synchronous from inside user code
- Updates `ai.md` with a new text row in the engine decision table, a full `api.text` reference section with examples, and a routing hint so agents reach for manifold-js first

## API

```js
// 3D extruded text (Manifold)
api.text("HELLO", {
  size:     10,        // em-size in model units (default: 10)
  height:   2,         // extrusion depth along Z (default: 2)
  font:     'regular', // 'regular' | 'bold' | 'italic' | 'bold-italic'
  spacing:  1.0,       // advance-width multiplier
  center:   false,     // center bounding box on origin
  segments: 8,         // bezier subdivision per curve
})

// 2D cross-section (CrossSection) — for revolve, custom extrude, etc.
api.textSection("AB", { size: 10, center: true })

// Also available as api.Curves.text / api.Curves.textSection
```

## Test plan

- [ ] `api.text("HELLO", {size: 10, height: 3})` renders correct extruded text in manifold-js session
- [ ] Holes in characters ("O", "B", "P") are empty (even-odd fill rule)
- [ ] `font: 'bold'` / `'italic'` / `'bold-italic'` produce visibly different letterforms
- [ ] `center: true` centers the text at the origin
- [ ] `api.textSection(...)` returns a CrossSection usable with `.extrude()`, `.revolve()`, etc.
- [ ] First run with `api.text` lazy-loads fonts (~1.6 MB + opentype.js); subsequent runs use cache
- [ ] SCAD `text()` still works (shared font files, independent code paths)
- [ ] e2e suite green

https://claude.ai/code/session_01VNDvGUAwLKYHe7GFvQdxFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNDvGUAwLKYHe7GFvQdxFQ)_