### PR TITLE
fix: break Gemini malformed_function_call retry loop

### DIFF
--- a/src/ai/gemini.ts
+++ b/src/ai/gemini.ts
@@ -378,6 +378,15 @@ async function consumeGeminiStream(
     // 🩺 Diagnostics to see what came back.
     stopReason = 'end_turn';
   }
+  if (stopReason === 'malformed_function_call') {
+    // The model tried to call a function but emitted malformed JSON. Any
+    // text that leaked into the stream (e.g. "1}") is partial call payload,
+    // not a real answer. Strip it and the thought signature — replaying
+    // either on a retry feeds the model its own broken output and causes it
+    // to immediately attempt the same malformed call again (a hard loop).
+    collectedText = '';
+    answerSignature = undefined;
+  }
   return {
     text: collectedText,
     toolCalls,
@@ -431,7 +440,14 @@ function buildGeminiContents(history: ChatMessage[]): GeminiContent[] {
         if (tc.thoughtSignature) fcPart.thoughtSignature = tc.thoughtSignature;
         parts.push(fcPart);
       }
-      if (parts.length > 0) out.push({ role: 'model', parts });
+      if (parts.length === 0) {
+        // Preserve user/model alternation when the assistant message has no
+        // text or tool calls (e.g. after malformed_function_call stripping).
+        // Without a placeholder the model turn is skipped, leaving two
+        // consecutive user turns that Gemini rejects with a 400.
+        parts.push({ text: '.' });
+      }
+      out.push({ role: 'model', parts });
     } else {
       // Tool results first, on a user-role message with functionResponse
       // parts. `response` must be a plain object — Gemini's validator


### PR DESCRIPTION
## Summary

- **Root cause**: When Gemini returns `MALFORMED_FUNCTION_CALL`, the `68bf273` commit (thought-signature propagation) causes the thought signature from the *failed* function-call attempt to be stored on the assistant text block. On retry ("Keep going"), `buildGeminiContents` echoes that signature back to Gemini, which interprets it as "resume your function-calling reasoning chain" — causing it to immediately attempt the same malformed call again in a hard loop.
- **Fix 1**: In `consumeGeminiStream`, strip the leaked partial-JSON text (e.g. `"1}"`) and the thought signature when `stopReason === 'malformed_function_call'`, so history replay doesn't feed the model its own broken output.
- **Fix 2**: In `buildGeminiContents`, add a `{text: '.'}` placeholder for empty model turns — needed because stripping the text leaves the assistant message with no parts, which would skip the model turn entirely and leave two consecutive user turns that Gemini rejects with a 400.

## Test plan

- [ ] Use Gemini with a complex prompt that triggers a tool call — confirm normal tool-use flow is unaffected
- [ ] If you can reproduce the `malformed_function_call` scenario: confirm "Keep going" no longer loops into the same error; the retry either succeeds or fails with a different outcome
- [ ] Confirm unit tests pass (`npm run test:unit`)
- [ ] CI e2e shards green

https://claude.ai/code/session_01MdzQTaQ4xVn5epwbUDqPpV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdzQTaQ4xVn5epwbUDqPpV)_