### PR TITLE
fix: preserve user-expanded thinking bubble state across transcript re-renders

### DIFF
--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1732,6 +1732,18 @@ function renderTranscript(): void {
   // Measure before replaceChildren — clearing children clamps scrollTop, so
   // any post-clear check would mis-report the user's intent.
   const pinned = isTranscriptPinnedToBottom();
+
+  // Preserve open state of thinking boxes the user manually expanded. Keyed
+  // by "messageId:index" so each box in a multi-thinking message is tracked
+  // independently.
+  const openThinkingBoxes = new Set<string>();
+  for (const msgEl of transcriptEl.querySelectorAll('[data-message-id]')) {
+    const msgId = (msgEl as HTMLElement).dataset.messageId!;
+    msgEl.querySelectorAll('details[data-thinking-box]').forEach((box, i) => {
+      if ((box as HTMLDetailsElement).open) openThinkingBoxes.add(`${msgId}:${i}`);
+    });
+  }
+
   transcriptEl.replaceChildren();
   const hasHistory = state.history.length > 0;
   const hasQueue = state.queuedBlocks.length > 0;
@@ -1750,6 +1762,17 @@ function renderTranscript(): void {
   if (hasQueue) {
     transcriptEl.appendChild(renderQueuedPreview());
   }
+
+  // Restore thinking boxes that were open before the re-render.
+  if (openThinkingBoxes.size > 0) {
+    for (const msgEl of transcriptEl.querySelectorAll('[data-message-id]')) {
+      const msgId = (msgEl as HTMLElement).dataset.messageId!;
+      msgEl.querySelectorAll('details[data-thinking-box]').forEach((box, i) => {
+        if (openThinkingBoxes.has(`${msgId}:${i}`)) (box as HTMLDetailsElement).open = true;
+      });
+    }
+  }
+
   if (pinned) pinTranscriptToBottom();
 }
 
@@ -2205,6 +2228,7 @@ function renderToolCallChip(name: string, input: Record<string, unknown>): HTMLE
  *  bury the actual reply. Indigo-tinted to read apart from tool chips. */
 function renderThinkingBox(text: string): HTMLElement {
   const chip = document.createElement('details');
+  chip.dataset.thinkingBox = '1';
   chip.className = 'max-w-[90%] text-[11px] rounded border border-indigo-800/50 bg-indigo-950/20 px-2 py-1';
   const summary = document.createElement('summary');
   summary.className = 'cursor-pointer text-indigo-300/90 select-none';


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- When a user manually opens a past thinking bubble (`🧠 Thinking`) and the AI replies, `renderTranscript()` wipes and rebuilds the entire DOM — silently recollapsing every `<details>` element to its default closed state.
- Fix: before clearing the transcript, snapshot which thinking boxes are open (keyed by `messageId:thinkingIndex`), then restore those `open` states after rebuilding.
- Added `data-thinking-box="1"` to the `<details>` element in `renderThinkingBox` so thinking boxes can be distinguished from tool-result `<details>` boxes during the snapshot/restore.

## Test plan

- [ ] Open an AI session with a model that produces thinking (e.g. Claude with extended thinking)
- [ ] Wait for a turn to complete, expand the `🧠 Thinking` bubble
- [ ] Send another message / wait for AI reply — the previously-opened thinking bubble should remain open
- [ ] Verify that thinking bubbles that were NOT manually opened stay collapsed as before
- [ ] Verify that the live pulsing thinking box during a new turn still auto-collapses when streaming begins

https://claude.ai/code/session_01M1zxumCNDdfhwWbKkJyAqw
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1zxumCNDdfhwWbKkJyAqw)_