### PR TITLE
fix: stop false "not watertight" warning and capture toasts in Diagnostic Log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ A "👁" button in the panel header opens `src/ui/aiReviewModal.ts`. The user pi
 
 #### AI Call Log (per-provider diagnostics)
 
-A "🩺" button in the panel header opens `src/ui/aiDiagnosticsModal.ts`. Shows the last 50 provider API calls from an in-memory ring buffer (`src/ai/diagnostics.ts`): provider/model/kind, duration, status, full error messages (errors auto-expand), token usage, stop reason, request summary. Filter (all/errors/successes), Clear, Copy JSON. This is distinct from the app-wide **Diagnostic Log** (`src/diagnostics/errorLog.ts`, toolbar ⚠ button) which captures uncaught errors/console warnings; the AI Call Log adds per-call detail (successes, tokens, the "empty_final" non-error case) the general log intentionally doesn't. To avoid double-listing, the AI Call Log mirrors to `console.info`/`console.debug` (not `warn`/`error`), and hard provider errors reach the app-wide log via `chatLoop`'s `onError → errorLog.capture({source:'ai'})`.
+A "🩺" button in the panel header opens `src/ui/aiDiagnosticsModal.ts`. Shows the last 50 provider API calls from an in-memory ring buffer (`src/ai/diagnostics.ts`): provider/model/kind, duration, status, full error messages (errors auto-expand), token usage, stop reason, request summary. Filter (all/errors/successes), Clear, Copy JSON. This is distinct from the app-wide **Diagnostic Log** (`src/diagnostics/errorLog.ts`, toolbar ⚠ button) which captures uncaught errors, intercepted `console.warn`/`console.error`, and every toast (see [User Messaging & the Diagnostic Log](#user-messaging--the-diagnostic-log)); the AI Call Log adds per-call detail (successes, tokens, the "empty_final" non-error case) the general log intentionally doesn't. To avoid double-listing, the AI Call Log mirrors to `console.info`/`console.debug` (not `warn`/`error`), and hard provider errors reach the app-wide log via `chatLoop`'s `onError → errorLog.capture({source:'ai'})`.
 
 #### Slash commands
 
@@ -314,6 +314,16 @@ The only exceptions are values that are truly structural constants (array indice
 ### Dead Code
 
 Don't export functions unless they're imported elsewhere. When removing usage of an exported function, delete the export too. Periodically grep for exported symbols to verify they have importers.
+
+### User Messaging & the Diagnostic Log
+
+There is **one** messaging system; use it, don't invent parallel ones. Every error, warning, or notice a user sees must also land in the central **Diagnostic Log** (`src/diagnostics/errorLog.ts`, toolbar ⚠ button) so there's a durable, reviewable record — the on-screen surface is transient, the log is the history.
+
+- **Transient notifications → `showToast` (`src/ui/toast.ts`).** A toast is the standard bottom-center, fades-away message for save/export confirmations, action feedback, and recoverable failures. Every `showToast` is **automatically mirrored** into the Diagnostic Log, so you don't capture separately for toasts. Variant maps to log level: `warn` → `'warn'`; `success`/`neutral` → `'info'` (routine activity, recorded but kept out of the unseen-error badge). Pass `{ log: false }` only for the rare toast that must stay screen-only, and `{ source }` to tag the subsystem (`'import'`, `'export'`, …).
+- **Variant semantics.** `success` = it worked; `neutral` = informational/in-progress; `warn` = something went wrong or was blocked. Pick by meaning, not color. Don't hand-roll `position:fixed` message nodes — route through `showToast`.
+- **Failures that don't toast → `errorLog.capture({ level, source, message, detail })` directly** with an explicit `source` tag. Anything caught in a `catch` that the user won't otherwise see (Worker/engine failures, background tasks) belongs in the log even when there's no toast.
+- **Persistent status ≠ transient notification.** Standing indicators that reflect *current* state — e.g. the viewport **printability pill** (`printabilityIndicatorEl` in `src/main.ts`), which stays up while the live model has print-blocking structural issues — are *status*, not toasts. They persist until the underlying state changes and must not be implemented as (or mistaken for) fading messages. Give them a `title` so users understand what they are.
+- **Don't assert what you didn't measure.** Render-only imports (e.g. colour reliefs) carry no `Manifold`, so `isManifold` is `false` for lack of measurement — *not* because the mesh is non-watertight. `computePrintability` treats that case (`manifoldStatus === 'render-only (not manifold)'`) as unverified rather than failed, so the pill doesn't cry "not watertight" about a mesh that was verified watertight at build time.
 
 ### Internal Links and Paths
 

--- a/src/diagnostics/errorLog.ts
+++ b/src/diagnostics/errorLog.ts
@@ -1,6 +1,11 @@
-// Central diagnostic log. Collects errors and warnings from all subsystems
-// into a single ring buffer, persisted to sessionStorage so entries survive
-// a page refresh within the same browser tab.
+// Central diagnostic log. Collects errors, warnings, and informational
+// activity (every showToast) from all subsystems into a single ring buffer,
+// persisted to sessionStorage so entries survive a page refresh within the
+// same browser tab.
+//
+// Levels: 'error' and 'warn' are problems; 'info' is routine activity (save /
+// export confirmations etc.) captured for a complete audit trail but kept out
+// of the unseen-error badge so it doesn't nag.
 //
 // Call errorLog.install() once at app startup to wire up:
 //   - window.onerror / unhandledrejection (uncaught JS errors)
@@ -9,7 +14,7 @@
 // Subsystems that don't go through console (e.g. geometry engine, AI turns)
 // should call errorLog.capture() directly with an explicit source tag.
 
-export type ErrorLevel = 'error' | 'warn';
+export type ErrorLevel = 'error' | 'warn' | 'info';
 export type ErrorSource =
   | 'engine'
   | 'ai'

--- a/src/geometry/statsComputation.ts
+++ b/src/geometry/statsComputation.ts
@@ -191,7 +191,14 @@ export function computeGeometryStats(
 export function computePrintability(geo: Record<string, unknown>): { printable: boolean; issues: string[] } {
   if (!geo || geo.status !== 'ok') return { printable: false, issues: ['no geometry'] };
   const issues: string[] = [];
-  if (geo.isManifold === false) issues.push('non-manifold mesh (not watertight)');
+  // Render-only imports (e.g. colour reliefs, which keep their per-colour seed
+  // ids by skipping Manifold.ofMesh) carry no Manifold to measure, so isManifold
+  // is false purely for lack of measurement — not because the mesh was found
+  // non-watertight. Claiming "not watertight" here is a false positive (a relief
+  // mesh is verified watertight at build time). Treat printability as unverified
+  // rather than failed in that case so we don't surface a bogus warning.
+  const renderOnly = geo.manifoldStatus === 'render-only (not manifold)';
+  if (geo.isManifold === false && !renderOnly) issues.push('non-manifold mesh (not watertight)');
   if (typeof geo.componentCount === 'number' && geo.componentCount > 1) {
     const enclosed = typeof geo.containedComponents === 'number' ? geo.containedComponents : 0;
     const floating = geo.componentCount - enclosed;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3685,7 +3685,12 @@ async function main() {
   // has structural issues that would prevent 3D printing (non-manifold or
   // disconnected components). Hidden when the model is printable.
   printabilityIndicatorEl = document.createElement('span');
-  printabilityIndicatorEl.className = 'absolute top-8 left-2 z-20 text-xs text-amber-300 font-mono bg-zinc-900/80 px-2 py-0.5 rounded border border-amber-700/60 pointer-events-none';
+  printabilityIndicatorEl.className = 'absolute top-8 left-2 z-20 text-xs text-amber-300 font-mono bg-zinc-900/80 px-2 py-0.5 rounded border border-amber-700/60 cursor-help';
+  // A persistent status indicator, not a transient toast: it stays up while the
+  // current model has structural issues that would prevent a clean 3D print.
+  // The title explains what it is so it doesn't read as a stray message (and is
+  // hoverable — hence no `pointer-events-none`).
+  printabilityIndicatorEl.title = 'This model has structural issues that may prevent a clean 3D print. Open the ⚠ Diagnostic Log in the toolbar for details.';
   printabilityIndicatorEl.style.display = 'none';
   viewportPane.appendChild(printabilityIndicatorEl);
 
@@ -10850,12 +10855,26 @@ async function main() {
     const warnings: string[] = [];
     const isBrep = getActiveLanguage() === 'replicad';
     if (geo.isManifold === false) {
-      warnings.push(
-        'isManifold: false — the mesh has non-manifold edges or gaps, so it is ' +
-        'not a watertight solid and will fail to slice / 3D-print with most tools. ' +
-        'Fix before finalizing: ensure boolean operands overlap by ≥ 0.5 units, ' +
-        'avoid zero-thickness walls, and check for duplicate faces.',
-      );
+      if (geo.manifoldStatus === 'render-only (not manifold)') {
+        // Render-only imports (colour reliefs, sculpted STLs) carry no Manifold,
+        // so watertightness was never measured — isManifold is false for lack of
+        // measurement, NOT a detected defect. Don't claim the mesh will fail to
+        // print; state the actual situation so the agent doesn't chase a phantom.
+        warnings.push(
+          'render-only import — no Manifold is available, so watertightness is ' +
+          'unverified (this is not a detected defect). Reliefs and sculpted STL ' +
+          'imports come in render-only to preserve per-vertex colour / order; they ' +
+          'still slice and print. Convert to a Manifold (e.g. re-run through ' +
+          'Manifold.ofMesh) only if you need booleans or a verified-solid check.',
+        );
+      } else {
+        warnings.push(
+          'isManifold: false — the mesh has non-manifold edges or gaps, so it is ' +
+          'not a watertight solid and will fail to slice / 3D-print with most tools. ' +
+          'Fix before finalizing: ensure boolean operands overlap by ≥ 0.5 units, ' +
+          'avoid zero-thickness walls, and check for duplicate faces.',
+        );
+      }
     }
     if (typeof geo.componentCount === 'number' && geo.componentCount > 1) {
       const cc = geo.componentCount;

--- a/src/ui/diagnosticsPanel.ts
+++ b/src/ui/diagnosticsPanel.ts
@@ -66,11 +66,18 @@ function buildEntryEl(entry: LogEntry): HTMLElement {
   top.appendChild(time);
 
   const levelEl = document.createElement('span');
-  levelEl.className =
-    entry.level === 'error'
-      ? 'text-[9px] font-bold tracking-wider text-red-400 shrink-0'
-      : 'text-[9px] font-bold tracking-wider text-amber-400 shrink-0';
-  levelEl.textContent = entry.level === 'error' ? '● ERR' : '● WARN';
+  const LEVEL_STYLE: Record<ErrorLevel, string> = {
+    error: 'text-red-400',
+    warn: 'text-amber-400',
+    info: 'text-sky-400',
+  };
+  const LEVEL_LABEL: Record<ErrorLevel, string> = {
+    error: '● ERR',
+    warn: '● WARN',
+    info: '● INFO',
+  };
+  levelEl.className = `text-[9px] font-bold tracking-wider shrink-0 ${LEVEL_STYLE[entry.level]}`;
+  levelEl.textContent = LEVEL_LABEL[entry.level];
   top.appendChild(levelEl);
 
   const sourceEl = document.createElement('span');
@@ -175,6 +182,7 @@ function buildPanel(): HTMLElement {
   filterGroup.appendChild(makeFilterChip('All', 'all'));
   filterGroup.appendChild(makeFilterChip('Errors', 'error'));
   filterGroup.appendChild(makeFilterChip('Warnings', 'warn'));
+  filterGroup.appendChild(makeFilterChip('Info', 'info'));
   header.appendChild(filterGroup);
   syncFilterChips();
 
@@ -241,10 +249,13 @@ export function initDiagnosticsPanel(): void {
 
   errorLog.subscribe((entries) => {
     if (!_isOpen) {
-      // entries.length === 0 means the log was cleared.
+      // entries.length === 0 means the log was cleared. Otherwise the newest
+      // entry sits at index 0 (capture unshifts). Only errors/warnings count
+      // toward the unseen-error badge — routine 'info' activity (save/export
+      // toasts) is logged for the record but must not nag the ⚠ button.
       if (entries.length === 0) {
         _unseenCount = 0;
-      } else {
+      } else if (entries[0] && entries[0].level !== 'info') {
         _unseenCount++;
       }
       setDiagnosticsToolbarBadge(_unseenCount);

--- a/src/ui/toast.ts
+++ b/src/ui/toast.ts
@@ -1,8 +1,16 @@
 // Lightweight, non-blocking toast. A single transient message pinned to the
 // bottom-center of the viewport — used for save confirmations and the
 // agent-UI warning.
+//
+// Every toast is also mirrored into the central Diagnostic Log (errorLog) so
+// the messaging users see on screen has a durable, reviewable record. The
+// fade-away toast is the transient surface; the Diagnostic Log (toolbar ⚠) is
+// the history. Variant maps to log level: warn → 'warn', everything else →
+// 'info' (routine activity, kept out of the error badge). Pass `log: false`
+// for the rare toast that should stay screen-only.
 
 import { getConfig } from '../config/appConfig';
+import { errorLog, type ErrorSource } from '../diagnostics/errorLog';
 
 export type ToastVariant = 'neutral' | 'success' | 'warn';
 
@@ -14,9 +22,32 @@ const VARIANT_STYLE: Record<ToastVariant, string> = {
 
 export function showToast(
   message: string,
-  opts: { variant?: ToastVariant; durationMs?: number } = {},
+  opts: {
+    variant?: ToastVariant;
+    durationMs?: number;
+    /** Set false to keep this toast screen-only (skip the Diagnostic Log). */
+    log?: boolean;
+    /** Subsystem tag for the Diagnostic Log entry (defaults to 'app'). */
+    source?: ErrorSource;
+  } = {},
 ): void {
-  const { variant = 'neutral', durationMs = getConfig().ui.toastDurationMs } = opts;
+  const {
+    variant = 'neutral',
+    durationMs = getConfig().ui.toastDurationMs,
+    log = true,
+    source = 'app',
+  } = opts;
+
+  // Mirror to the Diagnostic Log so on-screen messaging is reviewable later.
+  // warn toasts are problems; success/neutral are routine activity ('info').
+  if (log) {
+    errorLog.capture({
+      level: variant === 'warn' ? 'warn' : 'info',
+      source,
+      message,
+    });
+  }
+
   const toast = document.createElement('div');
   toast.textContent = message;
   toast.setAttribute('role', 'status');

--- a/tests/diagnostics-panel.spec.ts
+++ b/tests/diagnostics-panel.spec.ts
@@ -49,6 +49,32 @@ test.describe('Diagnostic log', () => {
     expect(diagZ).toBeGreaterThan(aiZ);
   });
 
+  // Every toast is mirrored into the Diagnostic Log so on-screen messaging has
+  // a durable record. warn → WARN (problem), success/neutral → INFO (routine
+  // activity, recorded but kept out of the unseen-error badge).
+  test('toasts are captured in the diagnostic log', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#btn-diagnostics');
+
+    await page.evaluate(async () => {
+      const { showToast } = await import('/src/ui/toast.ts');
+      showToast('toast-warn-marker', { variant: 'warn' });
+      showToast('toast-success-marker', { variant: 'success' });
+    });
+
+    await page.click('#btn-diagnostics');
+    const panel = page.locator('#diagnostics-panel');
+    await expect(panel).toBeVisible();
+
+    const warnRow = panel.locator('div.border-b', { hasText: 'toast-warn-marker' }).first();
+    await expect(warnRow).toBeVisible();
+    await expect(warnRow.getByText('● WARN')).toBeVisible();
+
+    const infoRow = panel.locator('div.border-b', { hasText: 'toast-success-marker' }).first();
+    await expect(infoRow).toBeVisible();
+    await expect(infoRow.getByText('● INFO')).toBeVisible();
+  });
+
   test('clicking a row expands it to show more detail', async ({ page }) => {
     const marker = 'diagnostic-expand-test-marker';
 

--- a/tests/relief.spec.ts
+++ b/tests/relief.spec.ts
@@ -56,6 +56,55 @@ test.describe('Relief Studio', () => {
     expect(Array.isArray(result.guide.bands)).toBe(true);
   });
 
+  // Regression: a colour (quantized) relief is imported render-only to keep its
+  // per-colour seed-region triangle ids, so it carries no Manifold and
+  // isManifold is false. The printability verdict used to translate that into
+  // "non-manifold mesh (not watertight)" — a false alarm pinned to the viewport
+  // — even though the relief mesh is verified watertight at build time. The
+  // render-only case must read as unverified, not failed: no bogus issue, no
+  // alarming geometry warning.
+  test('colour relief import does not raise a false "not watertight" verdict', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const result = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: Record<string, (...a: unknown[]) => unknown> }).partwright;
+      const c = document.createElement('canvas');
+      c.width = 48; c.height = 48;
+      const ctx = c.getContext('2d')!;
+      // Two distinct colour blocks → a quantized relief with per-colour seed
+      // regions → render-only import (the path that triggered the false alarm).
+      ctx.fillStyle = '#1a1a1a'; ctx.fillRect(0, 0, 24, 48);
+      ctx.fillStyle = '#e6e6e6'; ctx.fillRect(24, 0, 24, 48);
+      const src = c.toDataURL('image/png');
+
+      const created = await pw.importImageAsRelief({
+        src,
+        mode: 'quantized',
+        options: { resolution: 32, quantized: { output: 'relief', clusters: 2 } },
+      }) as { sessionId?: string; error?: string };
+      const geo = pw.getGeometryData() as {
+        isManifold?: boolean;
+        manifoldStatus?: string;
+        printability?: { printable?: boolean; issues?: string[] };
+        warnings?: string[];
+      };
+      return { created, geo };
+    });
+
+    expect(result.created.error).toBeFalsy();
+    // It really is a render-only import (no Manifold to measure)…
+    expect(result.geo.manifoldStatus).toBe('render-only (not manifold)');
+    expect(result.geo.isManifold).toBe(false);
+    // …so printability is "unverified", not a failed "not watertight" claim.
+    const issues = result.geo.printability?.issues ?? [];
+    expect(issues).not.toContain('non-manifold mesh (not watertight)');
+    expect(result.geo.printability?.printable).toBe(true);
+    // The AI-facing warning must not claim the mesh will fail to print either.
+    const warnings = result.geo.warnings ?? [];
+    expect(warnings.some((w) => /will fail to slice/.test(w))).toBe(false);
+  });
+
   // Regression: the import dropdown was 18rem wide anchored right-edge to the
   // button, so on a 375px viewport it slid off the left edge of the screen.
   // Mobile uses a viewport-edge fixed-position layout instead.


### PR DESCRIPTION
## Summary

Fixes the mysterious **"non-manifold mesh (not watertight)"** message that floats in the viewport after importing an image as a colour relief, and closes a gap in the messaging architecture: **toasts now land in the Diagnostic Log**.

### What that message actually was
It's the persistent **printability pill** (`printabilityIndicatorEl`), not a toast. A colour/quantized relief carries per-colour **seed regions** keyed to the mesh's own triangle order; `Manifold.ofMesh` reorders triangles, so the relief is deliberately imported **render-only** (no `Manifold`). With no manifold to measure, `computeGeometryStats` sets `isManifold:false` (`manifoldStatus: 'render-only (not manifold)'`), and `computePrintability` blindly turned that into `"non-manifold mesh (not watertight)"` — a **false alarm** on a mesh that's verified watertight at build time. `geometryWarnings` made the same false claim to the AI agent.

### Changes
- **Fix the false verdict at the source.** `computePrintability` and `geometryWarnings` now treat the render-only case as **unverified**, not failed — no bogus issue on the pill, and an accurate "render-only, watertightness unverified" note (instead of "will fail to print") for the AI.
- **Capture every toast in the Diagnostic Log.** `showToast` now mirrors into `errorLog`: `warn` → `'warn'`, `success`/`neutral` → a new `'info'` level. Info is recorded for the audit trail but kept **out of the unseen-error badge** so routine "Exported…" confirmations don't nag the ⚠ button. Adds an **Info** filter chip + `INFO` row styling to the diagnostics panel. A `{ log: false }` opt-out and `{ source }` tag are available.
- **Make the pill self-explanatory.** Added a `title` tooltip so it reads as persistent *status*, not a stray message.
- **Agent docs.** New **"User Messaging & the Diagnostic Log"** convention in `CLAUDE.md`: one messaging system, every error/warning reaches the log, persistent status ≠ transient toast, and "don't assert what you didn't measure." Updated the existing Diagnostic Log description.

## Test plan
- `npm run build` ✅ · `npm run test:unit` ✅ (564 passing)
- New e2e: relief regression (colour relief raises no false verdict) + diagnostics toast-capture (WARN/INFO rows). Ran `tests/relief.spec.ts` (25) + `tests/diagnostics-panel.spec.ts` (4) green locally.
- Manual: imported a 2-colour relief — pill no longer appears (title bar shows "imported (render-only)"); fired warn + success toasts and confirmed they appear as WARN/INFO rows in the Diagnostic Log.

https://claude.ai/code/session_01QUEZGH3FqBuaNgakwgGZjr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUEZGH3FqBuaNgakwgGZjr)_