### PR TITLE
feat: add Beta pill to landing nav and editor toolbar logo

### DIFF
--- a/src/ui/landing.ts
+++ b/src/ui/landing.ts
@@ -107,7 +107,7 @@ function buildNav(callbacks: LandingCallbacks): HTMLElement {
   // reading as the leading "P" of "Partwright".
   const brand = document.createElement('div');
   brand.className = 'flex items-center gap-2.5';
-  brand.innerHTML = `${partwrightMarkSvg(30)}<span class="font-display font-bold text-lg tracking-tight text-zinc-50">Partwright</span>`;
+  brand.innerHTML = `${partwrightMarkSvg(30)}<span class="font-display font-bold text-lg tracking-tight text-zinc-50">Partwright</span><span class="text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-amber-500/15 text-amber-400 border border-amber-500/25">Beta</span>`;
   nav.appendChild(brand);
 
   // Center links (desktop only)

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -171,7 +171,7 @@ export function createToolbar(
   logo.className = 'flex items-center gap-2 mr-4 bg-transparent border-0 p-0 cursor-pointer hover:opacity-80 transition-opacity';
   logo.title = 'Back to home';
   logo.setAttribute('aria-label', 'Partwright home');
-  logo.innerHTML = `${partwrightMarkSvg(20)}<span class="text-zinc-100 font-semibold tracking-tight">Partwright</span>`;
+  logo.innerHTML = `${partwrightMarkSvg(20)}<span class="text-zinc-100 font-semibold tracking-tight">Partwright</span><span class="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-amber-500/15 text-amber-400 border border-amber-500/25">Beta</span>`;
   logo.addEventListener('click', callbacks.onGoHome);
   toolbar.appendChild(logo);
 


### PR DESCRIPTION
## Summary

- Adds a small amber "BETA" pill next to the Partwright wordmark in the landing page navbar
- Adds the same pill in the editor toolbar top-left logo
- Uses `bg-amber-500/15 text-amber-400 border border-amber-500/25 rounded-full` — matches the brand's amber palette, subtle against dark backgrounds

## Test plan

- [ ] Visit `/` — confirm "Partwright BETA" pill appears in the nav top-left
- [ ] Visit `/editor` — confirm "Partwright BETA" pill appears in the toolbar top-left
- [ ] Pill should be readable but not distracting; clicking the logo still navigates home

https://claude.ai/code/session_0116rB9EgubKKoQWzmtHYGkM

---
_Generated by [Claude Code](https://claude.ai/code/session_0116rB9EgubKKoQWzmtHYGkM)_