### PR TITLE
perf: grid-accelerate deriveSampleNormals (issue #405 track 1)

### DIFF
--- a/src/color/subdivide.ts
+++ b/src/color/subdivide.ts
@@ -323,33 +323,62 @@ function brushClassifier(stroke: BrushStroke): TriClassifier {
  *  the geometric normal of the base triangle whose surface is closest to it.
  *  Used for the `slab` constraint when a stroke descriptor doesn't carry stored
  *  normals (old sessions, or console paints that omit them). The sign is
- *  irrelevant — the slab test uses |offset| — so winding is not normalized. */
+ *  irrelevant — the slab test uses |offset| — so winding is not normalized.
+ *
+ *  Samples lie on the surface, so the closest base triangle sits in the sample's
+ *  own grid cell. We use the cached per-mesh triangle grid (already warm from the
+ *  footprint/geodesic passes) to test only that cell neighbourhood instead of
+ *  every triangle — turning the old O(samples × numTri) brute force, which is on
+ *  the default slab path, into O(samples × triangles-near-the-sample). The result
+ *  is identical: lowest triangle index wins ties (matching a linear scan), and a
+ *  full scan still backs up the rare empty-neighbourhood (off-surface) sample. */
 export function deriveSampleNormals(
   samples: [number, number, number][],
   base: MeshData,
 ): [number, number, number][] {
   const { triVerts, numTri } = base;
+  const grid = triGridFor(base);
+
+  // Unit geometric normal of base triangle t (winding not normalized).
+  const triNormal = (t: number): [number, number, number] => {
+    const a = triVertex(base, triVerts[t * 3]);
+    const b = triVertex(base, triVerts[t * 3 + 1]);
+    const c = triVertex(base, triVerts[t * 3 + 2]);
+    const ux = b[0] - a[0], uy = b[1] - a[1], uz = b[2] - a[2];
+    const vx = c[0] - a[0], vy = c[1] - a[1], vz = c[2] - a[2];
+    const nx = uy * vz - uz * vy, ny = uz * vx - ux * vz, nz = ux * vy - uy * vx;
+    const len = Math.hypot(nx, ny, nz) || 1;
+    return [nx / len, ny / len, nz / len];
+  };
+
+  const dist2 = (sx: number, sy: number, sz: number, t: number): number => {
+    const a = triVertex(base, triVerts[t * 3]);
+    const b = triVertex(base, triVerts[t * 3 + 1]);
+    const c = triVertex(base, triVerts[t * 3 + 2]);
+    const cp = closestPointOnTriangle(sx, sy, sz, a[0], a[1], a[2], b[0], b[1], b[2], c[0], c[1], c[2]);
+    const dx = cp[0] - sx, dy = cp[1] - sy, dz = cp[2] - sz;
+    return dx * dx + dy * dy + dz * dz;
+  };
+
   const out: [number, number, number][] = [];
   for (const s of samples) {
-    let best = Infinity;
-    let bn: [number, number, number] = [0, 0, 1];
-    for (let t = 0; t < numTri; t++) {
-      const a = triVertex(base, triVerts[t * 3]);
-      const b = triVertex(base, triVerts[t * 3 + 1]);
-      const c = triVertex(base, triVerts[t * 3 + 2]);
-      const cp = closestPointOnTriangle(s[0], s[1], s[2], a[0], a[1], a[2], b[0], b[1], b[2], c[0], c[1], c[2]);
-      const dx = cp[0] - s[0], dy = cp[1] - s[1], dz = cp[2] - s[2];
-      const d2 = dx * dx + dy * dy + dz * dz;
-      if (d2 < best) {
-        best = d2;
-        const ux = b[0] - a[0], uy = b[1] - a[1], uz = b[2] - a[2];
-        const vx = c[0] - a[0], vy = c[1] - a[1], vz = c[2] - a[2];
-        const nx = uy * vz - uz * vy, ny = uz * vx - ux * vz, nz = ux * vy - uy * vx;
-        const len = Math.hypot(nx, ny, nz) || 1;
-        bn = [nx / len, ny / len, nz / len];
+    let best = Infinity, bi = -1;
+    const box: Aabb = { min: [s[0], s[1], s[2]], max: [s[0], s[1], s[2]] };
+    for (const t of grid.query(box)) {
+      const d2 = dist2(s[0], s[1], s[2], t);
+      // Strictly-nearer wins; on an exact tie (sample on a shared edge) keep the
+      // lower index, so the result matches a 0..numTri linear scan's first-min.
+      if (d2 < best || (d2 === best && t < bi)) { best = d2; bi = t; }
+    }
+    if (bi < 0) {
+      // Empty neighbourhood — sample is off the surface. Fall back to a full
+      // scan so the normal is still the globally-closest triangle's.
+      for (let t = 0; t < numTri; t++) {
+        const d2 = dist2(s[0], s[1], s[2], t);
+        if (d2 < best) { best = d2; bi = t; }
       }
     }
-    out.push(bn);
+    out.push(bi >= 0 ? triNormal(bi) : [0, 0, 1]);
   }
   return out;
 }

--- a/tests/unit/subdivide.test.ts
+++ b/tests/unit/subdivide.test.ts
@@ -2,7 +2,7 @@
 // in/out test and the boundary-conforming clip). Pure geometry — no browser.
 
 import { describe, test, expect } from 'vitest';
-import { strokeSignedDist, sprayCoverage, airbrushDither, strokeFootprintTriangles, buildGeodesicField, type BrushStroke } from '../../src/color/subdivide';
+import { strokeSignedDist, sprayCoverage, airbrushDither, strokeFootprintTriangles, buildGeodesicField, deriveSampleNormals, type BrushStroke } from '../../src/color/subdivide';
 import { closestPointOnTriangle } from '../../src/color/adjacency';
 import type { MeshData } from '../../src/geometry/types';
 
@@ -260,6 +260,98 @@ describe('buildGeodesicField', () => {
     expect(field.reachableAt(6, 5, 0)).toBe(true);    // near sheet, within radius
     expect(field.reachableAt(5, 5, 0.5)).toBe(false); // directly above, far sheet — gapped
     expect(field.reachableAt(6, 5, 0.5)).toBe(false); // far sheet, within radius but disconnected
+  });
+});
+
+describe('deriveSampleNormals', () => {
+  // Shared-vertex wrinkled plane grid: (n+1)² verts, 2·n² tris, each with a
+  // distinct orientation (the wrinkle tilts every triangle), so a wrong nearest
+  // pick would surface as a wrong normal.
+  function wrinkledGrid(n: number, wrinkle: number): MeshData {
+    const side = n + 1;
+    const verts: number[] = [];
+    for (let j = 0; j < side; j++) {
+      for (let i = 0; i < side; i++) {
+        verts.push(i, j, wrinkle * Math.sin(i * 0.6) * Math.cos(j * 0.6));
+      }
+    }
+    const tris: number[] = [];
+    const vi = (i: number, j: number) => j * side + i;
+    for (let j = 0; j < n; j++) {
+      for (let i = 0; i < n; i++) {
+        tris.push(vi(i, j), vi(i + 1, j), vi(i + 1, j + 1));
+        tris.push(vi(i, j), vi(i + 1, j + 1), vi(i, j + 1));
+      }
+    }
+    return {
+      vertProperties: new Float32Array(verts),
+      triVerts: new Uint32Array(tris),
+      numVert: side * side, numTri: tris.length / 3, numProp: 3,
+    };
+  }
+
+  /** The old brute-force algorithm: nearest triangle over the whole mesh
+   *  (lowest index wins ties), then its geometric normal. */
+  function brute(samples: [number, number, number][], base: MeshData): [number, number, number][] {
+    const { triVerts, numTri } = base;
+    const tv = (vi: number): [number, number, number] => [
+      base.vertProperties[vi * 3], base.vertProperties[vi * 3 + 1], base.vertProperties[vi * 3 + 2],
+    ];
+    return samples.map((s) => {
+      let best = Infinity; let bn: [number, number, number] = [0, 0, 1];
+      for (let t = 0; t < numTri; t++) {
+        const a = tv(triVerts[t * 3]), b = tv(triVerts[t * 3 + 1]), c = tv(triVerts[t * 3 + 2]);
+        const cp = closestPointOnTriangle(s[0], s[1], s[2], a[0], a[1], a[2], b[0], b[1], b[2], c[0], c[1], c[2]);
+        const d2 = (cp[0] - s[0]) ** 2 + (cp[1] - s[1]) ** 2 + (cp[2] - s[2]) ** 2;
+        if (d2 < best) {
+          best = d2;
+          const ux = b[0] - a[0], uy = b[1] - a[1], uz = b[2] - a[2];
+          const vx = c[0] - a[0], vy = c[1] - a[1], vz = c[2] - a[2];
+          const nx = uy * vz - uz * vy, ny = uz * vx - ux * vz, nz = ux * vy - uy * vx;
+          const len = Math.hypot(nx, ny, nz) || 1;
+          bn = [nx / len, ny / len, nz / len];
+        }
+      }
+      return bn;
+    });
+  }
+
+  test('grid result matches the brute-force scan for on-surface samples', () => {
+    const base = wrinkledGrid(12, 0.5); // 288 tris
+    const { triVerts } = base;
+    const tv = (vi: number): [number, number, number] => [
+      base.vertProperties[vi * 3], base.vertProperties[vi * 3 + 1], base.vertProperties[vi * 3 + 2],
+    ];
+    // Sample at every triangle centroid (unambiguously on that triangle).
+    const samples: [number, number, number][] = [];
+    for (let t = 0; t < base.numTri; t++) {
+      const a = tv(triVerts[t * 3]), b = tv(triVerts[t * 3 + 1]), c = tv(triVerts[t * 3 + 2]);
+      samples.push([(a[0] + b[0] + c[0]) / 3, (a[1] + b[1] + c[1]) / 3, (a[2] + b[2] + c[2]) / 3]);
+    }
+    const got = deriveSampleNormals(samples, base);
+    const ref = brute(samples, base);
+    expect(got.length).toBe(samples.length);
+    for (let i = 0; i < samples.length; i++) {
+      expect(got[i][0]).toBeCloseTo(ref[i][0], 6);
+      expect(got[i][1]).toBeCloseTo(ref[i][1], 6);
+      expect(got[i][2]).toBeCloseTo(ref[i][2], 6);
+    }
+  });
+
+  test('matches brute force for slightly off-surface samples and falls back when far', () => {
+    const base = wrinkledGrid(10, 0.4);
+    // A near-surface point (nudged off a centroid) and a far one (well outside
+    // the grid, exercising the full-scan fallback).
+    const samples: [number, number, number][] = [
+      [3.4, 4.7, 0.05], [7.1, 2.2, -0.1], [5.5, 5.5, 0.2], [100, 100, 100],
+    ];
+    const got = deriveSampleNormals(samples, base);
+    const ref = brute(samples, base);
+    for (let i = 0; i < samples.length; i++) {
+      expect(got[i][0]).toBeCloseTo(ref[i][0], 6);
+      expect(got[i][1]).toBeCloseTo(ref[i][1], 6);
+      expect(got[i][2]).toBeCloseTo(ref[i][2], 6);
+    }
   });
 });
 


### PR DESCRIPTION
Track 1 of #405 — the recommended-first, cheap, deterministic paint-perf win.

## Problem

`deriveSampleNormals` (`src/color/subdivide.ts`) finds each stroke sample's nearest base triangle with a full **O(samples × numTri)** scan. It's used to attach per-sample surface normals for **slab** strokes — which #394 made the **default** surface mode — so it's now on the hot path for ordinary painting, and it runs on every smooth/spray commit (main thread *and* the subdivision worker).

## Change

Samples lie on the surface, so the closest base triangle sits in the sample's own grid cell. Reuse the **cached per-mesh triangle grid** (`triGridFor`, already warm from the footprint/geodesic passes — no new dependency, worker-safe) to test only that cell neighbourhood instead of every triangle. Turns the scan into O(samples × triangles-near-the-sample).

**Behaviour-identical**, by construction:
- Lowest triangle index wins ties (a sample exactly on a shared edge), matching the old `0..numTri` linear scan's first-min.
- A full scan still backs up the rare empty-neighbourhood case (a sample off the surface), so the normal is always the globally-closest triangle's.

Chose the grid over reusing `baseRemap`'s `three-mesh-bvh` deliberately: the worker doesn't currently bundle `three-mesh-bvh`, and the grid is already cached for this mesh — so this adds zero deps and near-zero setup, and stays deterministic (no CPU/GPU or cross-device float drift).

## Measurements

| | brute (old) | grid (new) | |
|---|---|---|---|
| 200 samples, 28.8k-tri mesh | 334 ms | 53 ms | **~6.3×**, max normal error **0.0** |

The speedup is capped by the shared grid's coarse cell sizing (tuned for AABB-superset queries, not nearest-neighbour); finer-grained gains are possible but out of scope here. For typical base meshes / sample counts the call was already fast — this is a heavy-tail (large + dense + long-stroke) improvement, matching how #405 framed it.

## Test plan

- **New unit tests** (`tests/unit/subdivide.test.ts`): grid result matches a brute-force scan for every triangle centroid on a 288-tri wrinkled surface (each triangle distinctly oriented, so a wrong nearest pick → wrong normal), plus off-/near-surface samples exercising the full-scan fallback.
- Full unit tier green (**574**); `npm run build` (tsc) clean.
- Slab e2e (`paint-smooth-brush.spec.ts --grep slab`, 9/9) green — slab is the default path that consumes these normals, incl. no-bleed + save/reload determinism.

## Scope / follow-ups

This PR is **track 1 only**. Per #405's own ordering, tracks **2** (spatial-index the *samples* inside `strokeSignedDist`) and **3** (WebGPU/WebGL spike) are gated on a **full-stroke profile** — confirming whether per-point signed-distance or the subdivision/allocation now dominates — which is best run in the browser pipeline as part of the spike rather than guessed at here. Issue #405 stays open for those.

Refs #405.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCzTrs4L2rVUZ9VX1SqGuy)_