### PR TITLE
fix: overlay clicks paint the model behind them and stick the brush "on"

### DIFF
--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -388,6 +388,18 @@ function processMouseMove(event: MouseEvent): void {
 
   // Brush drag: collect triangles into the active brush session.
   if (currentTool === 'brush' && brushPainting && brushSession) {
+    // Safety net: if we think we're painting but no button is held, a pointerup
+    // was missed (e.g. it landed on an overlay that captured the pointer). Treat
+    // the button-less move as the release — commit and stop — instead of
+    // painting a runaway stroke that only a page refresh would clear.
+    if (event.buttons === 0) {
+      if (hasActiveStroke()) commitBrushStroke();
+      brushPainting = false;
+      brushSession = null;
+      strokeSamples = [];
+      clearHighlight();
+      return;
+    }
     const result = pickFace(event);
     if (result) {
       const added = recordStrokeSample(result.point);
@@ -455,6 +467,15 @@ function onPointerDown(event: PointerEvent): void {
   if (!adjacency || !currentMesh) return;
   if (event.button !== 0) return;
   if (currentTool === 'slab' || currentTool === 'box') return;
+
+  // This listener is registered on the container in the CAPTURE phase, so it
+  // also sees pointerdowns on overlay panels (paint picker, AI drawer, modals)
+  // that sit in front of the 3D view. Only start a stroke when the press landed
+  // on the canvas itself — otherwise a click on a panel raycasts a hit on the
+  // model *behind* it and paints, and setPointerCapture binds the pointer to the
+  // panel, so the matching pointerup never reaches our canvas handler and
+  // `brushPainting` stays stuck on (every later move then paints with no button).
+  if (event.target !== getRenderer().domElement) return;
 
   // Off-model click → OrbitControls is rotating; remember so pointerup doesn't
   // paint if the user happens to release over the model after a rotation.

--- a/tests/paint-pointer-isolation.spec.ts
+++ b/tests/paint-pointer-isolation.spec.ts
@@ -1,0 +1,76 @@
+// Regression: a pointerdown on an overlay panel that sits in front of the 3D
+// view must NOT paint the model behind it, and must not leave the brush stuck
+// "painting" so later moves keep applying paint with no button held. Both stem
+// from the capture-phase pointerdown listener firing for non-canvas targets.
+
+import { test, expect } from 'playwright/test';
+
+async function setup(page: import('playwright/test').Page) {
+  await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', new Date().toISOString()));
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.run(`const { Manifold } = api; return Manifold.sphere(20, 64);`);
+  });
+  await page.locator('#paint-toggle').dispatchEvent('click');
+  await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+  await page.locator('#paint-picker-panel button:has-text("Brush")').dispatchEvent('click');
+  await page.waitForTimeout(150);
+}
+
+test.describe('paint pointer-target isolation', () => {
+  test('a press on an overlay in front of the model does not paint or stick', async ({ page }) => {
+    await setup(page);
+    const regions = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const canvas = document.querySelector('canvas')!;
+      const container = canvas.parentElement!;
+      const r = canvas.getBoundingClientRect();
+      const cx = r.left + r.width / 2, cy = r.top + r.height / 2; // over the sphere
+
+      // An overlay panel covering the model, like the paint picker / AI drawer.
+      const overlay = document.createElement('div');
+      overlay.style.cssText = `position:absolute;left:${r.left}px;top:${r.top}px;width:${r.width}px;height:${r.height}px;z-index:9999`;
+      container.appendChild(overlay);
+
+      const fire = (el: Element, type: string, x: number, y: number, buttons: number) =>
+        el.dispatchEvent(new PointerEvent(type, { bubbles: true, clientX: x, clientY: y, button: 0, buttons, pointerId: 1, pointerType: 'mouse', isPrimary: true }));
+
+      // 1) Press on the overlay (target = overlay, not the canvas), over the model.
+      fire(overlay, 'pointerdown', cx, cy, 1);
+      // 2) Move over the canvas — if the brush got stuck on, this paints.
+      fire(canvas, 'pointermove', cx + 10, cy, 1);
+      fire(canvas, 'pointermove', cx + 20, cy + 10, 1);
+      // 3) Release over the canvas — a stuck stroke would commit a region here.
+      fire(canvas, 'pointerup', cx + 20, cy + 10, 0);
+      await pw.waitForPaint();
+
+      overlay.remove();
+      return pw.listRegions().length;
+    });
+    expect(regions).toBe(0); // nothing painted from the overlay press
+  });
+
+  test('a genuine press on the canvas still paints (fix does not over-block)', async ({ page }) => {
+    await setup(page);
+    const regions = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const canvas = document.querySelector('canvas')!;
+      const r = canvas.getBoundingClientRect();
+      const cx = r.left + r.width / 2, cy = r.top + r.height / 2;
+      const fire = (type: string, x: number, y: number, buttons: number) =>
+        canvas.dispatchEvent(new PointerEvent(type, { bubbles: true, clientX: x, clientY: y, button: 0, buttons, pointerId: 1, pointerType: 'mouse', isPrimary: true }));
+      fire('pointermove', cx, cy, 0);
+      fire('pointerdown', cx, cy, 1);
+      fire('pointermove', cx + 8, cy, 1);
+      fire('pointerup', cx + 8, cy, 0);
+      await pw.waitForPaint();
+      return pw.listRegions().length;
+    });
+    expect(regions).toBe(1); // normal canvas painting unaffected
+  });
+});


### PR DESCRIPTION
Found while investigating reported paint quirks: **clicking a menu/panel over the 3D view paints the model**, and a **stuck "painting" state where the mouse keeps applying paint with no button held** (only a page refresh clears it). Both are one root cause.

## Root cause

The paint `pointerdown` handler is registered on the viewport **container in the CAPTURE phase** (intentionally — a bubble-phase canvas listener gets killed by the canvas's own capture-phase OrbitControls suppressor, which calls `stopImmediatePropagation`). The side effect: it also fires for pointerdowns on **overlay panels** (paint picker, AI drawer, modals) that sit in front of the canvas. It started a stroke based only on `pickFace(event)` raycasting a hit — never checking the press actually landed on the canvas. So:

1. **Menu clicks bleed into the canvas** — a click on a panel over the model raycasts a hit on the model *behind* the panel and paints it.
2. **Stuck brush** — `setPointerCapture(event.pointerId)` is called on `event.target`, which for a panel click is the **panel**, not the canvas. The pointer is captured to the panel, so the matching `pointerup` never reaches the canvas's `onPointerUp` → `brushPainting` stays `true`. Every subsequent move then paints with no button held.
3. **Over-painting** — that stuck brush accumulates triangles as the cursor moves, producing a runaway region (likely what looked like a jagged/filled mess).

## Fix

- **`onPointerDown` bails unless `event.target` is the canvas** (`getRenderer().domElement`). A press on an overlay no longer starts a stroke or mis-captures the pointer. This is the root-cause fix for all three symptoms.
- **Defense-in-depth in `processMouseMove`:** if a paint move arrives with `event.buttons === 0` (no button held), treat it as a missed `pointerup` — commit and end the stroke instead of painting. Any future desync now self-heals without a refresh.

Both are minimal and don't touch the slab/geodesic resolve math or the smooth/projection commit paths.

## Test plan

- **New regression e2e** `tests/paint-pointer-isolation.spec.ts`:
  - A press on an overlay positioned in front of the sphere paints **nothing** and leaves no stuck stroke (a follow-up canvas move + release commits no region).
  - A genuine canvas press still paints exactly one region (the guard doesn't over-block).
  - Verified the overlay test **fails** with the guard removed (press → 1 region), so it actually pins the bug.
- Interactive paint suites green locally: `paint-projection-brush` + `paint-smooth-brush` + `paint-airbrush` + the new spec (**34 passed**).
- Full unit tier (**580**) green; `npm run build` (tsc) clean.

## Notes

This is unrelated to #407 (the `deriveSampleNormals` perf change) and to the slab-on-curvature discussion — it's a pointer-event isolation bug on `main`. Separately investigated and could not reproduce a slab-specific jagged regression (the slab resolve math is byte-identical between staging and main); the jaggedness reproduces only with a thin slab depth on high curvature, which is the inherent slab trade-off, not a code regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCzTrs4L2rVUZ9VX1SqGuy)_