### PR TITLE
fix: refresh models catalog via PR instead of pushing to protected main

### DIFF
--- a/.github/workflows/refresh-models-catalog.yml
+++ b/.github/workflows/refresh-models-catalog.yml
@@ -1,0 +1,90 @@
+name: Refresh models catalog
+
+# Keeps src/ai/generated/modelsCatalog.json current with models.dev.
+#
+# `main` is a protected branch — changes must go through a pull request — so a
+# bot CANNOT push the refreshed snapshot to main directly (that's the GH006
+# "protected branch hook declined" failure the staging gate used to hit). This
+# workflow instead refreshes the snapshot, validates it (build + unit), and
+# opens/updates a PR into main. The normal main → staging gate then promotes it
+# to staging once it merges.
+#
+# The release_date filter in the refresh script uses a moving "last 365 days"
+# window keyed on the run date, so the snapshot can change even when models.dev
+# itself hasn't — running weekly keeps it current without churning a PR daily.
+
+on:
+  schedule:
+    # Mondays 07:00 UTC.
+    - cron: '0 7 * * 1'
+  workflow_dispatch: {}
+
+# One refresh PR at a time; a manual run shouldn't race the scheduled one.
+concurrency:
+  group: refresh-models-catalog
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: chore/refresh-models-catalog
+      SNAPSHOT: src/ai/generated/modelsCatalog.json
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Refresh snapshot
+        id: refresh
+        run: |
+          node scripts/refreshModelsSnapshot.mjs
+          if git diff --quiet "$SNAPSHOT"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "[catalog] snapshot already up to date — nothing to open a PR for"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Validate the refreshed snapshot before opening a PR. The PR's own
+      # pr-checks may not fire (PRs created with the default GITHUB_TOKEN don't
+      # trigger workflows), so prove build + unit here.
+      - name: Build (type-check + vite build)
+        if: steps.refresh.outputs.changed == 'true'
+        run: npm run build
+      - name: Unit tests
+        if: steps.refresh.outputs.changed == 'true'
+        run: npm run test:unit
+
+      - name: Open or update refresh PR
+        if: steps.refresh.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add "$SNAPSHOT"
+          git commit -m "chore: refresh models catalog snapshot"
+          # Force-push the single-commit branch; it's a bot-owned scratch branch
+          # whose only content is the latest snapshot.
+          git push -f origin "$BRANCH"
+          if [ -z "$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: refresh models catalog snapshot" \
+              --body "Automated refresh of \`$SNAPSHOT\` from models.dev. Build + unit validated in the refresh workflow. Merging triggers the main → staging gate to promote it." \
+              --label ignore-for-release
+          else
+            echo "Refresh PR already open for $BRANCH — force-push updated it."
+          fi

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -27,8 +27,6 @@ permissions:
 jobs:
   build-unit:
     runs-on: ubuntu-latest
-    outputs:
-      promote-sha: ${{ steps.commit-catalog.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -36,20 +34,6 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - name: Refresh models catalog snapshot
-        id: commit-catalog
-        run: |
-          node scripts/refreshModelsSnapshot.mjs
-          if ! git diff --quiet src/ai/generated/modelsCatalog.json; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add src/ai/generated/modelsCatalog.json
-            git commit -m "chore: refresh models catalog snapshot"
-            git push origin HEAD:main
-            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          else
-            echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
-          fi
       - name: Build (type-check + vite build)
         run: npm run build
       - name: Unit tests
@@ -94,15 +78,13 @@ jobs:
         with:
           fetch-depth: 0
       # Reached only when build + unit + every e2e shard pass. Promotes the
-      # green commit to staging, which Cloudflare deploys to the known-good
-      # staging preview. Uses the SHA from build-unit, which may be one commit
-      # ahead of GITHUB_SHA if the catalog snapshot was refreshed.
+      # green commit (the one this run was triggered on) to staging, which
+      # Cloudflare deploys to the known-good staging preview.
       - name: Promote to staging
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin staging main
           git checkout -B staging origin/staging
-          PROMOTE_SHA="${{ needs.build-unit.outputs.promote-sha }}"
-          git merge --ff-only "$PROMOTE_SHA" || git merge --no-edit "$PROMOTE_SHA"
+          git merge --ff-only "$GITHUB_SHA" || git merge --no-edit "$GITHUB_SHA"
           git push origin staging

--- a/prompts/20260603-032100-models-catalog-pipeline-fix.md
+++ b/prompts/20260603-032100-models-catalog-pipeline-fix.md
@@ -1,0 +1,70 @@
+---
+session: "treoA1"
+timestamp: "2026-06-03T03:21:00Z"
+model: claude-opus-4-8
+tools: [github-mcp]
+---
+
+## Human
+
+Failure with main and the pipeline to staging. The staging gate's "Refresh
+models catalog snapshot" step runs `node scripts/refreshModelsSnapshot.mjs`,
+then commits the changed snapshot and `git push origin HEAD:main`. The push is
+rejected:
+
+```
+remote: error: GH006: Protected branch update failed for refs/heads/main.
+remote: - Changes must be made through a pull request.
+ ! [remote rejected] HEAD -> main (protected branch hook declined)
+Process completed with exit code 1.
+```
+
+Please fix or resolve.
+
+## Assistant
+
+## Key decisions
+
+**Root cause**: commit `99bcd8d` moved the catalog refresh out of the Vite
+build (to stop idempotency-breaking build-time churn) into the staging gate's
+`build-unit` job, where it committed the snapshot and pushed *directly to
+`main`*. `main` is a protected branch that requires PRs, so the bot push is
+rejected with GH006 — the gate has never been able to succeed when the
+snapshot changed. The gate is also the *only* refresh mechanism now (the old
+Vite `catalogSnapshot` plugin was removed), so the snapshot can't just be
+dropped.
+
+**Fix shape**: writes to `main` must go through a PR — that's the branch model
+the repo deliberately set up (`main` PR-only, `staging` written only by the
+gate, `production` by manual release PR). So:
+
+1. **New `.github/workflows/refresh-models-catalog.yml`** — scheduled weekly
+   (+ `workflow_dispatch`). Runs the refresh script, and if the snapshot
+   changed, validates it with `npm run build` + `npm run test:unit`, then
+   force-pushes a bot-owned `chore/refresh-models-catalog` branch and opens (or
+   leaves updated) a PR into `main` via `gh`. Merging that PR triggers the
+   existing main → staging gate, which promotes the fresh snapshot to staging.
+   Chose the weekly cadence because the script's `release_date` filter uses a
+   moving "last 365 days" window keyed on run date, so the snapshot drifts even
+   when models.dev doesn't — daily would churn a PR for no real change.
+   Validated build+unit *inside* this workflow because PRs opened with the
+   default `GITHUB_TOKEN` don't trigger `pr-checks`.
+
+2. **`staging-gate.yml`** — removed the broken refresh/commit/push step and the
+   `promote-sha` job output that threaded the post-refresh SHA through; the
+   promote step now fast-forwards staging to `$GITHUB_SHA` (the commit the run
+   was triggered on) directly. The gate is back to its single job: build, test,
+   promote the pushed commit.
+
+3. Used only first-party tooling (`actions/*` + pre-installed `gh`), no
+   third-party PR-creating actions, to keep the supply-chain surface unchanged.
+   Dropped the non-existent `chore` label from `gh pr create` (verified via the
+   labels API — only `ignore-for-release` exists) so the command can't fail.
+
+4. Fixed now-stale comments in `scripts/refreshModelsSnapshot.mjs` and
+   `src/ai/catalog.ts` that still claimed the snapshot is refreshed "at build
+   start" via a Vite plugin.
+
+Verified: both workflow YAMLs parse; `npm run test:unit` passes (582 tests).
+The refresh script soft-fails gracefully here (sandbox network returns 403),
+preserving the committed snapshot — the intended resilience.

--- a/scripts/refreshModelsSnapshot.mjs
+++ b/scripts/refreshModelsSnapshot.mjs
@@ -6,10 +6,13 @@
 // parse them inline — used when models.dev is unreachable (sandboxed CI,
 // restrictive corporate proxy) so the bootstrap and refresh still works.
 //
-// Wired into Vite via the catalogSnapshot plugin in vite.config.ts:
-// `buildStart` runs this so every build/dev start tries to refresh. On any
-// failure (network down, schema drift, parse error) the committed snapshot is
-// preserved and the build proceeds, so the catalog can never break the build.
+// Run by the `Refresh models catalog` GitHub workflow
+// (.github/workflows/refresh-models-catalog.yml), which opens a PR into main
+// with any changes — main is protected, so the snapshot reaches it through a
+// PR, never a direct bot push. Also runnable locally via `npm run
+// refresh-models`. On any failure (network down, schema drift, parse error)
+// the committed snapshot is preserved and the script soft-exits, so a flaky
+// upstream can never produce a broken snapshot.
 //
 // Filter: only providers we wire up (anthropic / openai / google) and only
 // models whose release_date is within the last MAX_AGE_DAYS days. Filtering

--- a/src/ai/catalog.ts
+++ b/src/ai/catalog.ts
@@ -1,7 +1,8 @@
 // Static model catalog backed by a build-time snapshot of models.dev data.
 //
-// The snapshot at src/ai/generated/modelsCatalog.json is refreshed at build
-// start by `scripts/refreshModelsSnapshot.mjs`, filtered to providers we wire
+// The snapshot at src/ai/generated/modelsCatalog.json is refreshed by
+// `scripts/refreshModelsSnapshot.mjs` (run weekly by the refresh-models-catalog
+// workflow, which opens a PR into main), filtered to providers we wire
 // up (anthropic / openai / google) and to models whose `release_date` is
 // within the last year. That keeps the bundle small and the picker focused on
 // current models without us hand-maintaining the list.


### PR DESCRIPTION
## Summary

The `Gate main → staging` workflow failed (and blocked promotion to staging) because its **Refresh models catalog snapshot** step pushed the regenerated `src/ai/generated/modelsCatalog.json` **directly to `main`**:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
Process completed with exit code 1.
```

`main` is a protected branch that requires PRs, so a bot can never push to it directly. Commit `99bcd8d` had moved the catalog refresh out of the Vite build into the gate precisely to commit-and-push it — but that fights the branch-protection model the repo deliberately set up (`main` PR-only, `staging` written only by the gate, `production` by manual release PR).

### What changed

- **New `.github/workflows/refresh-models-catalog.yml`** — scheduled weekly (+ manual `workflow_dispatch`). Runs `scripts/refreshModelsSnapshot.mjs`, and when the snapshot changes, validates it (`npm run build` + `npm run test:unit`), force-pushes a bot-owned `chore/refresh-models-catalog` branch, and opens/updates a **PR into `main`**. Merging that PR triggers the existing main → staging gate, which promotes the fresh snapshot to staging.
  - Weekly, not daily: the script's `release_date` filter uses a moving "last 365 days" window keyed on run date, so the snapshot drifts even when models.dev doesn't — daily would churn a PR for no real change.
  - Build + unit run *inside* this workflow because PRs opened with the default `GITHUB_TOKEN` don't trigger `pr-checks`.
  - First-party tooling only (`actions/*` + pre-installed `gh`); no third-party PR-creating action.
- **`.github/workflows/staging-gate.yml`** — removed the broken refresh/commit/push step and the `promote-sha` job output; the promote step now fast-forwards `staging` to `$GITHUB_SHA` (the commit the run was triggered on) directly. The gate is back to: build → test → promote the pushed commit.
- Fixed now-stale comments in `scripts/refreshModelsSnapshot.mjs` and `src/ai/catalog.ts` that still claimed the snapshot is refreshed "at build start" via a Vite plugin.

## Test plan

- [x] Both workflow YAMLs parse (`yaml.safe_load`).
- [x] `npm run test:unit` — 582 tests pass.
- [x] `node scripts/refreshModelsSnapshot.mjs` soft-fails gracefully when models.dev is unreachable, preserving the committed snapshot (verified in the sandbox where the API returns 403).
- [ ] PR-checks shards (build + unit + 3× e2e) green on this PR.

No app-visible behavior changes — CI configuration + comments only.

https://claude.ai/code/session_01ChJ6Ax1suRGis7HSUrd4m2

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChJ6Ax1suRGis7HSUrd4m2)_