### PR TITLE
feat: per-part mesh cache + preserve all state on part switch

### DIFF
--- a/prompts/20260604-010000-part-mesh-cache.md
+++ b/prompts/20260604-010000-part-mesh-cache.md
@@ -1,0 +1,37 @@
+---
+date: 2026-06-04
+branch: claude/part-mesh-cache
+files_changed:
+  - src/main.ts
+---
+
+## Human
+
+When I switch from one part to another and no changes have happened, SCAD parts
+always rerender. Can this be fixed?
+
+## Assistant
+
+Every `loadVersionIntoEditor` call unconditionally ran `runCodeSync`, which
+recompiles the whole SCAD model — even when you switch back to a part you
+visited moments ago and nothing changed.
+
+Fix: per-version mesh cache keyed by `version.id`.
+
+- `PartMeshCacheEntry` stores the full result state needed to skip the compile:
+  `meshData`, `labelMap`, `lostLabels`, `modelColorDecls`, and `paramsSchema`.
+  LRU map (`Map` preserves insertion order), evicts at 8 entries.
+- `loadPartIntoEditor` checks the cache before `clearMesh()`. On a hit it
+  skips the `clearMesh()` call entirely (no blank-viewport flash) and passes the
+  entry to `loadVersionIntoEditor`.
+- `loadVersionIntoEditor` gains an optional `cachedEntry` parameter. On a hit it
+  restores mesh, Manifold, label map, model colors, params panel, geometry data
+  element, and clip slider bounds — then lets `rehydrateColorRegions` and
+  `applyVersionAnnotations` run as normal (they read `currentMeshData` and
+  `version.geometryData` which are both set). No `runCodeSync` call.
+- On a miss, after a successful `runCodeSync`, the result is cached. Only
+  mesh-producing runs are cached (compile errors leave `currentMeshData`
+  unchanged so `currentMeshData !== meshBeforeRun` is false).
+
+The cache key is `versionId`, not `partId`: navigating to a different version
+of the same part is a cache miss and correctly recompiles.

--- a/prompts/20260604-020000-preserve-state-and-save-cache.md
+++ b/prompts/20260604-020000-preserve-state-and-save-cache.md
@@ -1,0 +1,36 @@
+---
+date: 2026-06-04
+branch: claude/part-mesh-cache
+files_changed:
+  - src/main.ts
+---
+
+## Human
+
+When I paint a model and switch from one part to another, the color is lost.
+Once I do save, that causes a rerender which takes a while — all I did was
+colour. What's the simple and holistic fix that best solves all the problems
+(annotations, params, companion files, etc.)?
+
+## Assistant
+
+Two independent bugs, both in `src/main.ts`, one fix each:
+
+**Bug 1 — unsaved state (paint, annotations, params, companions) silently
+discarded on part switch.**
+`preserveCurrentEditsIfNeeded` had an early-return when the code text was
+unchanged: `if (code === s.currentVersion.code) return;`. This bypassed the
+`saveVersion` call entirely, so any state that lives *outside* the code string
+— color regions, annotations, param values, companion files — was never
+persisted before the switch. Fix: remove the early-return. The `saveVersion`
+dedup logic in `sessionManager.ts` is already authoritative: it compares code +
+annotations + colorRegions + paramValues + companions and returns `{skipped}`
+when truly nothing changed, so there is no double-save problem.
+
+**Bug 2 — saving a painted model triggers a recompile on switch-back.**
+After Mod+S, `saveCurrentVersion` creates a new `version.id`. The per-version
+mesh cache (`partMeshCache`) was keyed by the *old* `version.id`, so the new
+id was always a cache miss and `loadVersionIntoEditor` re-ran `runCodeSync`.
+Fix: after a successful `saveVersion` call in `saveCurrentVersion`, populate
+`partMeshCache` with the new `version.id` using the current `currentMeshData`
+and friends — same LRU eviction logic as the cache-miss path.

--- a/prompts/20260604-030000-cache-review-fixes.md
+++ b/prompts/20260604-030000-cache-review-fixes.md
@@ -1,0 +1,38 @@
+---
+date: 2026-06-04
+branch: claude/part-mesh-cache
+files_changed:
+  - src/main.ts
+---
+
+## Human
+
+Code review before testing — run work-reviewer and code-review subagents.
+
+## Assistant
+
+Three correctness bugs surfaced by the work-reviewer, fixed in this commit:
+
+**Double-refinement on cache hit after save.**
+`saveCurrentVersion` was caching `currentMeshData`, which for a painted+refined
+version is the post-subdivision mesh. On cache hit, `loadVersionIntoEditor`
+restored `paintBaseMesh = cachedEntry.meshData` (the refined mesh), then
+`rehydrateColorRegions` called `refineMeshForRegions(refinedMesh, ...)` — a
+second pass over already-subdivided geometry, misaligning triangle indices.
+Fix: cache `paintBaseMesh ?? currentMeshData` (the coarse pre-paint base) so
+`rehydrateColorRegions` always gets the right starting point.
+
+**Stale mesh cached under new version id in `confirmRemoveCompanion`.**
+`confirmRemoveCompanion` fired `runCode()` (async, no-await) then immediately
+`void saveCurrentVersion()`. The save completed before the recompile, so the
+new version's id was cached against the old (pre-removal) mesh. Fix: replaced
+`runCode` with `await runCodeSync` so the mesh is correct before saving.
+
+**Printability pill stale after cache hit.**
+The cache-hit branch set `geometryDataEl.textContent` directly but never called
+`computePrintability` / updated `printabilityIndicatorEl`. The previous part's
+pill persisted. Fix: after setting `geometryDataEl.textContent`, read the
+same `version.geometryData` through `computePrintability` and update the pill.
+
+Also: snap `new Set(r.triangles)` at both cache-population sites to avoid
+aliasing into the live region store.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1464,12 +1464,16 @@ async function saveCurrentVersion(label?: string): Promise<
     // away and back doesn't trigger a recompile. The code/geometry didn't
     // change (only paint or annotations may have), so the current in-memory
     // mesh is still correct for the new version id.
-    if (currentMeshData) {
+    // Cache the coarse pre-refinement base mesh (paintBaseMesh) so that
+    // rehydrateColorRegions can re-apply paint correctly on switch-back
+    // rather than re-refining an already-refined mesh.
+    const meshToCache = paintBaseMesh ?? currentMeshData;
+    if (meshToCache) {
       const entry: PartMeshCacheEntry = {
-        meshData: currentMeshData,
+        meshData: meshToCache,
         labelMap: currentLabelMap,
         lostLabels: currentLostLabels,
-        modelColorDecls: getModelRegions().map(r => ({ name: r.name, color: r.color, triangles: r.triangles })),
+        modelColorDecls: getModelRegions().map(r => ({ name: r.name, color: r.color, triangles: new Set(r.triangles) })),
         paramsSchema: currentParamSchema ?? undefined,
       };
       partMeshCache.delete(version.id);
@@ -4293,6 +4297,16 @@ async function main() {
       geometryDataEl.textContent = version.geometryData
         ? JSON.stringify(version.geometryData, null, 2)
         : JSON.stringify({ status: 'ready' });
+      if (printabilityIndicatorEl) {
+        const geoData = version.geometryData ?? {};
+        const { printable, issues } = computePrintability(geoData);
+        if (printable) {
+          printabilityIndicatorEl.style.display = 'none';
+        } else {
+          printabilityIndicatorEl.textContent = '⚠ ' + issues.join(' · ');
+          printabilityIndicatorEl.style.display = '';
+        }
+      }
       syncClipSliderBounds();
       simplifyBaselineMesh = null;
       simplifyBaselineColoredMesh = null;
@@ -4315,7 +4329,7 @@ async function main() {
           meshData: currentMeshData,
           labelMap: currentLabelMap,
           lostLabels: currentLostLabels,
-          modelColorDecls: getModelRegions().map(r => ({ name: r.name, color: r.color, triangles: r.triangles })),
+          modelColorDecls: getModelRegions().map(r => ({ name: r.name, color: r.color, triangles: new Set(r.triangles) })),
           paramsSchema: currentParamSchema ?? undefined,
         };
         partMeshCache.delete(version.id);
@@ -5354,9 +5368,9 @@ async function main() {
     removeCompanionFileFromRegistry(path);
     if (_companionActiveTab === path) switchToMainTab();
     else renderCompanionFilesBar();
-    // Re-run main code without this companion, then persist the removal so
-    // it survives a page reload (registry-only removal is lost on refresh).
-    runCode(getValue(), { surfaceErrors: false });
+    // Re-run synchronously so the cache and saved geometry data reflect the
+    // post-removal mesh (fire-and-forget runCode races with saveCurrentVersion).
+    await runCodeSync(getValue());
     void saveCurrentVersion();
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1459,7 +1459,28 @@ async function saveCurrentVersion(label?: string): Promise<
   }
   const thumbnail = await captureThumbnail();
   const version = await saveVersion(getValue(), enrichGeometryDataWithColors(getGeometryDataObj()), thumbnail, label, undefined, { paramValues: currentParamValues, companionFiles: getCompanionFiles() });
-  if (version) return { id: version.id, index: version.index, label: version.label };
+  if (version) {
+    // Keep the mesh cache valid for the newly-saved version so that switching
+    // away and back doesn't trigger a recompile. The code/geometry didn't
+    // change (only paint or annotations may have), so the current in-memory
+    // mesh is still correct for the new version id.
+    if (currentMeshData) {
+      const entry: PartMeshCacheEntry = {
+        meshData: currentMeshData,
+        labelMap: currentLabelMap,
+        lostLabels: currentLostLabels,
+        modelColorDecls: getModelRegions().map(r => ({ name: r.name, color: r.color, triangles: r.triangles })),
+        paramsSchema: currentParamSchema ?? undefined,
+      };
+      partMeshCache.delete(version.id);
+      partMeshCache.set(version.id, entry);
+      if (partMeshCache.size > PART_MESH_CACHE_SIZE) {
+        const oldest = partMeshCache.keys().next().value;
+        if (oldest) partMeshCache.delete(oldest);
+      }
+    }
+    return { id: version.id, index: version.index, label: version.label };
+  }
   return {
     skipped: true as const,
     reason: 'No changes since the current version (code, annotations, and color regions all match). Add a new region, edit code, or pass a different label to force a save.',
@@ -2906,7 +2927,13 @@ async function main() {
     if (!s.session || !s.currentPart) return;
     const code = getValue();
     if (isStarterCode(code)) return;
-    if (s.currentVersion && !editorContentDiffersFrom(s.currentVersion.code)) return;
+    // Previously bailed here when code was unchanged, silently discarding
+    // unsaved paint, annotations, param overrides, and companion-file edits.
+    // saveVersion already deduplicates on all five axes (code + annotations +
+    // paint + params + companions), so letting it run is the holistic fix: no
+    // DB write when truly nothing changed, one write when any tracked state
+    // differs. The only extra cost is the captureThumbnail() call (~30–80 ms
+    // canvas readback, not a recompile).
     const thumbnail = await captureThumbnail();
     const geometryData = enrichGeometryDataWithColors(getGeometryDataObj());
     // Include companions so the dedup check in saveVersion works when a

--- a/src/main.ts
+++ b/src/main.ts
@@ -376,6 +376,19 @@ let currentLabelMap: Map<string, Set<number>> | null = null;
  *  `listLabels().lostLabels` so they don't have to diff by hand. */
 let currentLostLabels: string[] | null = null;
 
+// Per-version mesh cache: avoids recompiling SCAD (or any engine) when
+// switching between parts whose last-loaded version is unchanged. Keyed by
+// version id; LRU eviction keeps memory bounded.
+type PartMeshCacheEntry = {
+  meshData: MeshData;
+  labelMap: Map<string, Set<number>> | null;
+  lostLabels: string[] | null;
+  modelColorDecls: Array<{ name: string; color: [number, number, number]; triangles: Set<number> }>;
+  paramsSchema: ParamSpec[] | undefined;
+};
+const PART_MESH_CACHE_SIZE = 8;
+const partMeshCache = new Map<string, PartMeshCacheEntry>();
+
 // #geometry-data element — always-updated machine-readable state
 let geometryDataEl: HTMLElement;
 // Viewport overlay pill — shows printability issues after each successful run.
@@ -3805,9 +3818,12 @@ async function main() {
   // where `api.Manifold` is undefined). This is the mixed-language case a JSON
   // merge creates: a voxel Part 2 alongside an unsaved manifold-js Part 1.
   async function loadPartIntoEditor(version: Version | null, opts: { skipDraftSave?: boolean } = {}) {
-    clearMesh();
+    const cached = version ? partMeshCache.get(version.id) : undefined;
+    // Only clear the viewport when there is no cached mesh to restore — avoids
+    // a blank-viewport flash during the recompile that cache hits skip entirely.
+    if (!cached) clearMesh();
     if (version) {
-      await loadVersionIntoEditor(version, opts);
+      await loadVersionIntoEditor(version, opts, cached);
     } else {
       if (getActiveLanguage() !== 'manifold-js') await switchLanguage('manifold-js');
       startNewPartInEditor();
@@ -4187,7 +4203,7 @@ async function main() {
     void ensureEngineStarted();
   }
 
-  async function loadVersionIntoEditor(version: Version, opts: { skipDraftSave?: boolean } = {}) {
+  async function loadVersionIntoEditor(version: Version, opts: { skipDraftSave?: boolean } = {}, cachedEntry?: PartMeshCacheEntry) {
     // Cancel any active voxel paint before loading a different version — its
     // live grid and provenance map are bound to the OUTGOING code, so a Bake
     // after navigation would write the wrong session's voxels into the new
@@ -4222,10 +4238,69 @@ async function main() {
     // saved thumbnail/stats. runCodeSync prunes these against the model's
     // declared schema, so stale keys from a previous model fall away.
     currentParamValues = { ...(version.paramValues ?? {}) };
-    const applied = await runCodeSync(version.code);
-    // If a newer version-switch arrived while we were compiling, our result
-    // was discarded — don't rehydrate colours or annotations for the wrong version.
-    if (!applied) return;
+
+    if (cachedEntry) {
+      // Cache hit: restore previously computed mesh without recompiling.
+      // Bump to MRU position in the LRU map.
+      partMeshCache.delete(version.id);
+      partMeshCache.set(version.id, cachedEntry);
+
+      currentMeshData = cachedEntry.meshData;
+      paintBaseMesh = cachedEntry.meshData;
+      if (currentManifold && typeof currentManifold.delete === 'function') {
+        try { currentManifold.delete(); } catch { /* already deleted */ }
+      }
+      const mod = getModule();
+      try {
+        currentManifold = (mod && cachedEntry.meshData) ? mod.Manifold.ofMesh(cachedEntry.meshData) : null;
+      } catch {
+        currentManifold = null;
+      }
+      currentLabelMap = cachedEntry.labelMap;
+      currentLostLabels = cachedEntry.lostLabels;
+      setPaintLabels(currentLabelMap);
+      setModelColorRegions(cachedEntry.modelColorDecls);
+      syncParamsPanel(cachedEntry.paramsSchema);
+      updateMesh(cachedEntry.meshData);
+      updatePaintMesh(cachedEntry.meshData);
+      geometryDataEl.textContent = version.geometryData
+        ? JSON.stringify(version.geometryData, null, 2)
+        : JSON.stringify({ status: 'ready' });
+      syncClipSliderBounds();
+      simplifyBaselineMesh = null;
+      simplifyBaselineColoredMesh = null;
+      simplifyBaselineRegions = null;
+      simplifyBaselineModelRegions = null;
+      refreshSimplifyIfOpen();
+      setStatus(statusBar, 'ready', 'Ready');
+    } else {
+      // Cache miss: compile the code and, on success, populate the cache.
+      const meshBeforeRun = currentMeshData;
+      const applied = await runCodeSync(version.code);
+      // If a newer version-switch arrived while we were compiling, our result
+      // was discarded — don't rehydrate colours or annotations for the wrong version.
+      if (!applied) return;
+      // Store the freshly compiled result so the next switch back is instant.
+      // Only cache on a successful mesh-producing run (compile errors leave
+      // currentMeshData as the previous part's mesh, i.e. unchanged).
+      if (currentMeshData !== null && currentMeshData !== meshBeforeRun) {
+        const entry: PartMeshCacheEntry = {
+          meshData: currentMeshData,
+          labelMap: currentLabelMap,
+          lostLabels: currentLostLabels,
+          modelColorDecls: getModelRegions().map(r => ({ name: r.name, color: r.color, triangles: r.triangles })),
+          paramsSchema: currentParamSchema ?? undefined,
+        };
+        partMeshCache.delete(version.id);
+        partMeshCache.set(version.id, entry);
+        if (partMeshCache.size > PART_MESH_CACHE_SIZE) {
+          // Evict the least-recently-used entry (first key in insertion-order map).
+          const oldest = partMeshCache.keys().next().value;
+          if (oldest) partMeshCache.delete(oldest);
+        }
+      }
+    }
+
     rehydrateColorRegions(version.geometryData);
     applyVersionAnnotations(version);
     const sessionImages = await getImagesFromSession();


### PR DESCRIPTION
## Summary

- **Per-part mesh cache** — switching back to a previously-visited part no longer triggers a recompile. Cache keyed by `version.id`, LRU max 8 entries. Cache hit restores mesh/Manifold/labels/model-colors/params without calling `runCodeSync`, eliminating the blank-viewport flash too.
- **Paint, annotations, params, and companions preserved on part switch** — `preserveCurrentEditsIfNeeded` had an early-return when code was unchanged, silently discarding all non-code state. Removed the early-return; `saveVersion`'s 5-axis dedup (code + annotations + colorRegions + paramValues + companions) is the authoritative "nothing changed" gate.
- **No rerender after saving a painted model** — after Mod+S, the new `version.id` was never in `partMeshCache`, so switching away and back always forced a full recompile. `saveCurrentVersion` now populates the cache with the new version id after a successful save.

## Test plan

- [ ] Switch between two SCAD/JS parts — second switch-back should load instantly with no recompile
- [ ] Paint a model, switch to another part and back — paint should be preserved (auto-saved on switch)
- [ ] Add annotations or change param values, switch parts and back — all state preserved
- [ ] Mod+S on a painted model, switch away and back — no recompile (cache hit on new version id)
- [ ] Mod+S with no changes — still returns `{ skipped }` (dedup still works)

https://claude.ai/code/session_016ERzP1fyesqT3aQtiYyY51