### PR TITLE
fix: warn instead of crashing when simplify/enhance output is non-manifold

### DIFF
--- a/prompts/20260604-120000-simplify-not-manifold-guard.md
+++ b/prompts/20260604-120000-simplify-not-manifold-guard.md
@@ -1,0 +1,47 @@
+---
+session: "fervkel"
+timestamp: "2026-06-04T12:00:00Z"
+model: claude-opus-4-8
+tools: [explore]
+---
+
+## Human
+
+Sometimes after I've painted, then enhanced a model, then painted it again, I go
+to the simplify menu to simplify it and I get an error "model is not manifold"
+but I've done nothing that would make it non-manifold. I also don't see any
+warning that I have a non manifold model. Can you investigate? I'm using the
+starter manifold-js model to test.
+
+## Assistant
+
+## Key decisions
+
+**Root cause**: `applyLiveGeometry()` in `src/main.ts` (the helper that swaps in
+new geometry after a simplify/enhance) rebuilt the queryable Manifold with
+`mod.Manifold.ofMesh(mesh)` **without a try/catch**. The normal post-code-run
+path (`runCodeSync`, ~line 11610) does the identical call but wraps it and falls
+back to `currentManifold = null` on failure. A simplify/enhance result — or a
+paint-subdivided mesh fed into it — can come back not-quite-manifold (degenerate
+tris, non-2-manifold edges), so `ofMesh` throws "Not manifold". Because
+`applyLiveGeometry` was unguarded, that exception escaped: the simplify UI's
+catch surfaced a raw `Simplify failed: Not manifold` (the user's "model is not
+manifold"), AND the exception aborted the helper *before* `updateGeometryData()`
+and `syncClipSliderBounds()` ran — so the stats/printability surfaces never
+refreshed and the user got no warning (their second complaint).
+
+**Fix**: Mirror the proven post-run guard inside `applyLiveGeometry` — wrap
+`ofMesh` in try/catch, fall back to `currentManifold = null`, and additionally
+emit a `showToast(..., { variant: 'warn', source: 'engine' })`. The toast (a)
+only fires when `ofMesh` genuinely throws, i.e. the mesh really is non-manifold,
+so it's correct for every caller of the helper; (b) gives the honest warning the
+user was missing — a bare `null` manifold otherwise produces the misleading
+"render-only import — unverified" stats message (meant for never-measured
+imports, not a failed measurement); and (c) auto-logs to the Diagnostic Log per
+the single-messaging-system rule. Chose the in-helper guard over fixing each
+simplify/enhance call site so restore and any future caller are covered too.
+
+**Verification**: `npm run build` (type-check) clean; existing `simplify.spec.ts`
+(7 tests) still green — no happy-path regression; a scratch repro of the
+paint→simplify flow confirmed the reduction applies (4,608 → 768 tris) with a
+`pageerror` listener asserting no uncaught "Not manifold" error escapes.

--- a/src/main.ts
+++ b/src/main.ts
@@ -5391,7 +5391,23 @@ async function main() {
       try { currentManifold.delete(); } catch { /* already deleted */ }
     }
     const mod = getModule();
-    currentManifold = mod && mesh ? mod.Manifold.ofMesh(mesh) : null;
+    // Mirror the post-run path (see runCodeSync's ofMesh reconstruction): a
+    // simplify / enhance / paint-refine result can come back not-quite-manifold
+    // (degenerate tris, non-2-manifold edges), and Manifold.ofMesh throws
+    // "Not manifold" on those. Without this guard the exception escapes the
+    // helper, the simplify/enhance handler surfaces a raw "Not manifold" error,
+    // AND the stats / printability refresh below is skipped — so the user gets
+    // no warning that the model went non-manifold (the exact bug reported for
+    // paint → enhance → paint → simplify). Fall back to render-only and warn.
+    try {
+      currentManifold = mod && mesh ? mod.Manifold.ofMesh(mesh) : null;
+    } catch {
+      currentManifold = null;
+      showToast(
+        "The resulting mesh isn’t a watertight solid (non-manifold) — it still renders, but won’t slice or boolean cleanly. Try a higher triangle target, or re-run the code to rebuild a clean solid.",
+        { variant: 'warn', source: 'engine', durationMs: 6000 },
+      );
+    }
     updateMesh(mesh);
     updatePaintMesh(mesh);
     updateGeometryData();


### PR DESCRIPTION
## Summary

Fixes the reported bug: **paint → enhance → paint → simplify** sometimes throws `Simplify failed: Not manifold` with **no warning** that the model went non-manifold.

**Root cause** — `applyLiveGeometry()` (`src/main.ts`), the helper that swaps in new geometry after a simplify/enhance/restore, rebuilt the queryable Manifold with `Manifold.ofMesh(mesh)` **without a try/catch**. The normal post-code-run path (`runCodeSync`) does the *identical* call but guards it and falls back to `currentManifold = null`. A simplify/enhance result — or a paint-subdivided mesh fed into it — can come back not-quite-manifold (degenerate tris, non-2-manifold edges), so `ofMesh` throws `"Not manifold"`. Because the helper was unguarded:

1. The exception escaped to the simplify UI's catch → raw `Simplify failed: Not manifold` (the user's *"model is not manifold"*).
2. It aborted the helper **before** `updateGeometryData()` / `syncClipSliderBounds()` ran → the stats/printability surfaces never refreshed, so the user got **no warning** (their second complaint).

**Fix** — mirror the proven post-run guard inside `applyLiveGeometry`: wrap `ofMesh` in try/catch, fall back to `currentManifold = null`, and emit a `showToast(..., { variant: 'warn', source: 'engine' })`. The toast only fires when `ofMesh` genuinely throws (i.e. the mesh really is non-manifold), gives the honest warning the user was missing — a bare `null` manifold otherwise yields the misleading "render-only import — unverified" stats message — and auto-logs to the Diagnostic Log per the single-messaging-system rule. Guarding in the helper (rather than each call site) covers restore and any future caller too.

## Test plan

- [x] `npm run build` (type-check) — clean
- [x] Existing `tests/simplify.spec.ts` (7 tests) — all green, no happy-path regression
- [x] Scratch repro of the paint→simplify flow — reduction applies (4,608 → 768 tris) with a `pageerror` listener asserting no uncaught "Not manifold" error escapes (scratch spec removed before commit)
- [ ] PR-checks shards (build + unit + 3 e2e) green

https://claude.ai/code/session_01VxMmrAAywfqWbaAYttL7VH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxMmrAAywfqWbaAYttL7VH)_