### PR TITLE
feat: live bucket flood-fill preview that tracks the tolerance setting

### DIFF
--- a/prompts/20260604-143000-bucket-tolerance-live-preview.md
+++ b/prompts/20260604-143000-bucket-tolerance-live-preview.md
@@ -1,0 +1,50 @@
+---
+session: "01Q5PMQ8Lfu2dPbrdSAWsAko"
+timestamp: "2026-06-04T14:30:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+The bucket paint with color tolerance highlights the triangle instead of
+walking the region that would actually be painted based on the tolerance
+setting. I would like to preview the actual paint region that would be
+painted based on the tolerance setting.
+
+## Assistant
+
+## Key decisions
+
+**Diagnosis (empirical, not assumed).** The hover handler in
+`processMouseMove` already calls `findColorRegion`/`findCoplanarRegion` and
+passes the *whole* flood-fill region to `showHighlight`, so on hover the
+region preview already works. Reproduced in a browser spec: hovering a
+painted hemisphere highlighted 1024 triangles (the whole region), not one.
+The real gap surfaced when changing the tolerance slider **without moving the
+mouse** — the highlight stayed frozen (1024 tris) at the old tolerance
+instead of growing/shrinking. The preview only ever recomputed on a
+`pointermove`, so it never tracked the tolerance setting the user was
+dialling in. That stale, setting-detached preview is what reads as
+"highlights the [wrong] region instead of the region the tolerance would
+paint."
+
+**Fix.** Remember the triangle the bucket cursor last hovered
+(`lastBucketSeed` in `paintMode.ts`) and expose `refreshBucketPreview()` that
+re-runs the same flood-fill from that seed at the *current* tolerance/mode
+and redraws the highlight. The paint UI calls it from the color/geometry
+tolerance slider + number input and the color/geometry mode toggle, so the
+previewed region updates live as the setting changes.
+
+**Seed lifecycle.** `lastBucketSeed` defaults to null at the top of
+`processMouseMove` and is only set in the bucket branch, so every hover-off /
+other-tool path leaves it null and a later tolerance tweak can't redraw a
+stale region. It's also cleared on mesh change (`updatePaintMesh`, where the
+old triangle indices no longer apply) and bounds-checked in
+`refreshBucketPreview`. `refreshBucketPreview` reuses the existing
+`showHighlight` primitive, so commit-time and preview-time regions stay
+computed by the identical code path.
+
+**Test.** Added a permanent golden-path e2e in
+`paint-controls-extended.spec.ts`: paint a hemisphere, hover the bucket at 5 %
+tolerance, then crank to 100 % with no mouse move and assert the previewed
+triangle count grows.

--- a/prompts/20260604-153500-bucket-color-flood-fix.md
+++ b/prompts/20260604-153500-bucket-color-flood-fix.md
@@ -1,0 +1,59 @@
+---
+session: "01Q5PMQ8Lfu2dPbrdSAWsAko"
+timestamp: "2026-06-04T15:35:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+I just tested your PR and I'm still seeing the triangles being previewed
+when I have Bucket tolerance set to "Color" no matter how I change the
+tolerance slider. Additionally, now I don't see the bucket fill actually
+painting. I first paint a large red circle (on the starter manifold-js
+model) then I tried to bucket fill yellow in the circle (which I expect to
+change the red circle to a yellow circle). Investigate and fix.
+
+## Assistant
+
+## Key decisions
+
+Reproduced the exact flow (brush-paint a red blob on a cube, then color-bucket
+over it) in a browser spec and instrumented it. Found **two** distinct,
+pre-existing bugs the live-preview work had merely surfaced:
+
+**Bug 1 — fragmented adjacency (preview stuck on a few triangles).** The brush's
+adaptive subdivision leaves **T-junctions** (a neighbour's edge is split at its
+midpoint while the other side stays whole). `buildAdjacency` matched only full
+edges by vertex pair, so the painted region shattered into ~6-triangle islands
+(measured: index-adjacency component = 7 of 9655; position-welding didn't help —
+7). The flood-fill could only ever reach a handful of triangles, and at 100%
+tolerance the "whole connected component" fast path was still just those 7 — so
+the slider looked dead. Fix: build adjacency by **shared vertex (corner)**, not
+shared edge. At a T-junction the split edge's two endpoints are still shared
+corners, so corner adjacency reconnects across it (measured component = 9655,
+the whole mesh). Every flood-fill caller gates each step by color or normal, so
+the looser adjacency can't over-select. This also fixes the geometry bucket and
+`paintNear` on refined meshes.
+
+**Bug 2 — bucket commit collapsed to zero after reconcile.** The color bucket
+stored `{kind:'triangles', ids}` in the *current working* (subdivided) mesh's
+index space, but a `triangles` descriptor must hold *base*-tessellation ids
+(`resolveDescriptorTriangles` carries them across subdivision via
+parentToChildren). So the reconcile that fires after every paint dropped them →
+0 triangles. Base-mapping the ids (what projection paint does) over-painted to
+whole base faces (9648), because that collapses sub-face resolution. The right
+fix mirrors the geometry bucket's `coplanar` descriptor: a new **`colorFlood`**
+descriptor storing a stable world-space seed point + the matched color +
+tolerance, re-flooded by color on every reconcile/reload. To stop the region's
+own freshly-stamped color from masking the source color it follows,
+`buildTriColors` gained an `excludeRegionId` param, and `findColorRegion` an
+optional seed-color anchor. Result: the bucket fill now resolves to exactly the
+4799-triangle blob and survives reconcile (verified: red blob → yellow).
+
+User chose the full re-resolvable fix over a base-id snapshot (asked via
+AskUserQuestion, since it adds a serialized descriptor kind).
+
+Tests: unit coverage for T-junction bridging + the seed-color override; a
+permanent e2e that brush-paints a blob, color-buckets over it, and asserts the
+new region survives reconcile with the new color. Ran the paint/region/reconcile
+e2e specs (57 tests) — all green.

--- a/src/color/adjacency.ts
+++ b/src/color/adjacency.ts
@@ -12,41 +12,56 @@ export interface AdjacencyGraph {
   centroids: Float32Array;
 }
 
-/** Create a canonical edge key from two vertex indices (order-independent). */
-function edgeKey(a: number, b: number): string {
-  return a < b ? `${a},${b}` : `${b},${a}`;
-}
-
 /** Build a triangle adjacency graph from mesh data.
- *  O(numTri) with Map-based edge lookup. */
+ *  O(Σ valence²) with Map-based vertex lookup — effectively O(numTri) for the
+ *  bounded-valence meshes we deal with. */
 export function buildAdjacency(mesh: MeshData): AdjacencyGraph {
-  const { triVerts, numTri, vertProperties, numProp } = mesh;
+  const { triVerts, numTri, numVert, vertProperties, numProp } = mesh;
 
-  // Build edge → triangle list map
-  const edgeToTris = new Map<string, number[]>();
+  // Canonicalise vertices by exact position, then connect triangles that share a
+  // *vertex* (corner), not just a full edge. Two reasons:
+  //
+  //  1. **Coincident-but-split vertices.** A render mesh can carry per-triangle
+  //     vertex copies at the same position; matching by raw index would miss the
+  //     shared corner. Welding by position fixes that.
+  //  2. **T-junctions.** The brush's adaptive subdivision leaves hanging nodes —
+  //     one triangle's edge is split into two while the neighbour's stays whole,
+  //     so the full edge (vertex pair) no longer matches and edge-only adjacency
+  //     shatters the mesh into tiny islands (a bucket flood-fill grabs ~6
+  //     triangles instead of the whole region). The split edge's two *endpoints*
+  //     are still shared corners, so corner adjacency keeps both sides connected.
+  //
+  // The flood-fill callers (`findColorRegion`, `findCoplanarRegion`,
+  // `findConnectedFromSeed`) gate every step by color or normal, so the looser
+  // corner adjacency can't over-select beyond what those thresholds allow.
+  const posId = new Map<string, number>();
+  const vertCanon = new Int32Array(numVert);
+  for (let v = 0; v < numVert; v++) {
+    const key = `${vertProperties[v * numProp]},${vertProperties[v * numProp + 1]},${vertProperties[v * numProp + 2]}`;
+    let id = posId.get(key);
+    if (id === undefined) { id = posId.size; posId.set(key, id); }
+    vertCanon[v] = id;
+  }
 
+  // Vertex (canonical position) → triangles touching it.
+  const vertToTris = new Map<number, number[]>();
   for (let t = 0; t < numTri; t++) {
-    const v0 = triVerts[t * 3];
-    const v1 = triVerts[t * 3 + 1];
-    const v2 = triVerts[t * 3 + 2];
-
-    for (const key of [edgeKey(v0, v1), edgeKey(v1, v2), edgeKey(v2, v0)]) {
-      let list = edgeToTris.get(key);
-      if (!list) {
-        list = [];
-        edgeToTris.set(key, list);
-      }
+    for (let k = 0; k < 3; k++) {
+      const pid = vertCanon[triVerts[t * 3 + k]];
+      let list = vertToTris.get(pid);
+      if (!list) { list = []; vertToTris.set(pid, list); }
       list.push(t);
     }
   }
 
-  // Build neighbor lists
+  // Build neighbor lists: every pair of triangles sharing a vertex is adjacent.
   const neighbors: Set<number>[] = new Array(numTri);
   for (let i = 0; i < numTri; i++) neighbors[i] = new Set();
 
-  for (const tris of edgeToTris.values()) {
+  for (const tris of vertToTris.values()) {
     for (let i = 0; i < tris.length; i++) {
       for (let j = i + 1; j < tris.length; j++) {
+        if (tris[i] === tris[j]) continue;
         neighbors[tris[i]].add(tris[j]);
         neighbors[tris[j]].add(tris[i]);
       }
@@ -241,6 +256,10 @@ export function findColorRegion(
   adjacency: AdjacencyGraph,
   triColors: Uint8Array | null,
   colorTolerance = 0.05,
+  /** Optional anchor color (R,G,B 0–255) the flood matches against, instead of
+   *  the seed triangle's own color in `triColors`. Lets a re-resolve follow the
+   *  *original* matched color even after the seed triangle has been recolored. */
+  seedColorOverride?: readonly [number, number, number],
 ): Set<number> {
   const { neighbors } = adjacency;
   const result = new Set<number>();
@@ -260,9 +279,9 @@ export function findColorRegion(
     return result;
   }
 
-  const sr = triColors[seedTri * 3];
-  const sg = triColors[seedTri * 3 + 1];
-  const sb = triColors[seedTri * 3 + 2];
+  const sr = seedColorOverride ? seedColorOverride[0] : triColors[seedTri * 3];
+  const sg = seedColorOverride ? seedColorOverride[1] : triColors[seedTri * 3 + 1];
+  const sb = seedColorOverride ? seedColorOverride[2] : triColors[seedTri * 3 + 2];
 
   // Max squared distance in normalised [0,1]³ space is 3.
   const maxDistSq = colorTolerance * colorTolerance * 3;

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -93,6 +93,11 @@ export function setTriangleToBaseMapper(fn: ((id: number) => number) | null): vo
 // Hover highlight state
 let highlightMesh: THREE.Mesh | null = null;
 let hoveredTriangles: Set<number> | null = null;
+// Triangle the bucket cursor last hovered, so the flood-fill preview can be
+// recomputed at a new tolerance/mode without waiting for a mouse move (driven by
+// `refreshBucketPreview`). null whenever the cursor isn't over the model with the
+// bucket tool active.
+let lastBucketSeed: number | null = null;
 
 // Brush ring indicator — outline showing the brush footprint in world space
 let brushRingMesh: THREE.LineLoop | null = null;
@@ -313,6 +318,7 @@ setPaintAccessors({ getColor, getCurrentMesh, shapeSmoothDescriptorFields });
 export function updatePaintMesh(mesh: MeshData): void {
   currentMesh = mesh;
   adjacency = null; // invalidate — mesh changed
+  lastBucketSeed = null; // the remembered seed indexes the old tessellation
   invalidateProjection(); // the id-buffer geometry is rebuilt against the new mesh
   if (active) {
     adjacency = buildAdjacency(mesh);
@@ -425,6 +431,11 @@ function cancelPendingMove(): void {
 function processMouseMove(event: MouseEvent): void {
   if (!adjacency || !currentMesh) return;
 
+  // Default to "no bucket seed"; only the bucket branch below re-establishes it.
+  // Every other path (hover-off, other tools) leaves it null so a later tolerance
+  // tweak doesn't redraw a stale flood-fill region.
+  lastBucketSeed = null;
+
   // Slab and box tools own their own gizmo / drag interactions; the
   // bucket-vs-brush hover preview gets out of the way.
   if (currentTool === 'slab' || currentTool === 'box') {
@@ -503,6 +514,7 @@ function processMouseMove(event: MouseEvent): void {
   } else {
     // bucket
     clearBrushRing();
+    lastBucketSeed = result.triangleIndex;
     if (bucketMode === 'geometry') {
       region = findCoplanarRegion(result.triangleIndex, adjacency, bucketTolerance);
     } else {
@@ -894,6 +906,23 @@ function onPointerCancel(event: PointerEvent): void {
 export function previewTriangles(triangles: Set<number>, color?: [number, number, number]): () => void {
   showHighlight(triangles, color);
   return () => clearHighlight();
+}
+
+/** Recompute and redraw the bucket hover preview for the triangle the cursor is
+ *  currently over, using the *current* tolerance and mode. The paint UI calls
+ *  this from the bucket tolerance slider/input and the color/geometry mode toggle
+ *  so the previewed flood-fill region grows and shrinks live as the setting is
+ *  dialled in, instead of staying frozen until the next mouse move. No-op unless
+ *  the bucket tool is active and the cursor last hovered a triangle. */
+export function refreshBucketPreview(): void {
+  if (!active || currentTool !== 'bucket') return;
+  if (!adjacency || !currentMesh || lastBucketSeed === null) return;
+  if (lastBucketSeed >= currentMesh.numTri) { lastBucketSeed = null; return; }
+  const region = bucketMode === 'geometry'
+    ? findCoplanarRegion(lastBucketSeed, adjacency, bucketTolerance)
+    : findColorRegion(lastBucketSeed, adjacency, buildTriColors(currentMesh.numTri), bucketColorTolerance);
+  hoveredTriangles = region;
+  showHighlight(region);
 }
 
 function showHighlight(triangles: Set<number>, colorOverride?: [number, number, number]): void {

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -867,14 +867,23 @@ function onPointerUp(event: PointerEvent): void {
       region,
     );
   } else {
+    const seedTri = result.triangleIndex;
     const triColors = buildTriColors(currentMesh.numTri);
-    region = findColorRegion(result.triangleIndex, adjacency, triColors, bucketColorTolerance);
+    region = findColorRegion(seedTri, adjacency, triColors, bucketColorTolerance);
+    const normal = getTriangleNormal(seedTri, adjacency);
+    // The color we matched (the surface under the cursor *before* this fill
+    // recolors it). Stored on the descriptor so the region re-floods the same
+    // color on every reconcile — a `triangles` snapshot can't survive a
+    // brush-refined mesh, where the fill lives at sub-base-triangle resolution.
+    const seedColor: [number, number, number] = triColors
+      ? [triColors[seedTri * 3] / 255, triColors[seedTri * 3 + 1] / 255, triColors[seedTri * 3 + 2] / 255]
+      : [0, 0, 0];
     const existingCount = getRegions().length;
     addRegion(
       `Region ${existingCount + 1}`,
       [...currentColor] as [number, number, number],
       'face-pick',
-      { kind: 'triangles', ids: [...region] },
+      { kind: 'colorFlood', seedPoint: result.point, seedNormal: normal, seedColor, colorTolerance: bucketColorTolerance },
       region,
     );
   }

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -45,6 +45,7 @@ import {
   setSlabAxis,
   getSlabAxis,
   previewTriangles,
+  refreshBucketPreview,
   getCurrentMesh as getPaintMesh,
   type PaintTool,
   type BrushShape,
@@ -472,8 +473,8 @@ function createBucketControls(): HTMLElement {
     geomPanel.classList.toggle('hidden', m !== 'geometry');
   };
 
-  colorModeBtn.addEventListener('click', () => { setBucketMode('color'); syncModeBtns(); });
-  geomModeBtn.addEventListener('click', () => { setBucketMode('geometry'); syncModeBtns(); });
+  colorModeBtn.addEventListener('click', () => { setBucketMode('color'); syncModeBtns(); refreshBucketPreview(); });
+  geomModeBtn.addEventListener('click', () => { setBucketMode('geometry'); syncModeBtns(); refreshBucketPreview(); });
   modeRow.appendChild(colorModeBtn);
   modeRow.appendChild(geomModeBtn);
   headerRow.appendChild(modeRow);
@@ -511,6 +512,7 @@ function createBucketControls(): HTMLElement {
     const tol = parseInt(colorSlider.value, 10) / 100;
     setBucketColorTolerance(tol);
     colorInput.value = String(Math.round(tol * 100));
+    refreshBucketPreview();
   });
   const applyColorPct = (): void => {
     const raw = parseFloat(colorInput.value);
@@ -519,6 +521,7 @@ function createBucketControls(): HTMLElement {
     setBucketColorTolerance(pct / 100);
     colorSlider.value = String(pct);
     colorInput.value = String(pct);
+    refreshBucketPreview();
   };
   colorInput.addEventListener('change', applyColorPct);
   colorInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') { applyColorPct(); colorInput.blur(); } });
@@ -566,6 +569,7 @@ function createBucketControls(): HTMLElement {
     const tol = sliderPctToTolerance(parseInt(geomSlider.value, 10));
     setBucketTolerance(tol);
     geomInput.value = toleranceToAngleDeg(tol).toFixed(1);
+    refreshBucketPreview();
   });
   const applyAngle = (): void => {
     const raw = parseFloat(geomInput.value);
@@ -575,6 +579,7 @@ function createBucketControls(): HTMLElement {
     setBucketTolerance(tol);
     geomSlider.value = String(toleranceToSliderPct(tol));
     geomInput.value = angle.toFixed(1);
+    refreshBucketPreview();
   };
   geomInput.addEventListener('change', applyAngle);
   geomInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') { applyAngle(); geomInput.blur(); } });

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -40,6 +40,16 @@ export type RegionDescriptor =
       smooth?: boolean; maxEdge?: number }
   | { kind: 'triangles'; ids: number[] }
   | { kind: 'byLabel'; label: string }
+  // Color magic-wand (the bucket tool's Color mode). Stores a stable world-space
+  // seed plus the matched color and tolerance, so it re-floods by color on every
+  // re-resolve — surviving subdivision/re-runs the way `coplanar` does for the
+  // geometry bucket. A raw `triangles` snapshot can't: a fill over a brush-refined
+  // mesh lives at sub-base-triangle resolution that base-indexed ids can't carry.
+  // `seedColor` (0–1 RGB) is the color under the cursor at paint time, used as the
+  // flood anchor so the match survives even after this region recolors those
+  // triangles (the re-resolve excludes this region's own color from the lookup).
+  | { kind: 'colorFlood'; seedPoint: [number, number, number]; seedNormal: [number, number, number];
+      seedColor: [number, number, number]; colorTolerance: number }
   | { kind: 'connectedFromSeed'; seedPoint: [number, number, number]; seedNormal: [number, number, number]; maxDeviationDeg: number;
       // Optional AABB clamp — flood-fill won't walk into triangles whose
       // centroid falls outside this box. Used to constrain `paintConnected`
@@ -382,8 +392,13 @@ export function clearModelColorRegions(): void {
  *
  *  `respectPerRegionVisibility` (default false) skips regions with `visible:false`
  *  so the viewport reflects per-region eye-toggle state. Exports leave it false
- *  so a hidden-in-UI region still ships in the GLB/3MF. */
-export function buildTriColors(numTri: number, respectPerRegionVisibility = false): Uint8Array | null {
+ *  so a hidden-in-UI region still ships in the GLB/3MF.
+ *
+ *  `excludeRegionId` omits one user region from the composite. A `colorFlood`
+ *  region re-resolves by matching colors, so it must read the surface color
+ *  *underneath* itself — without this, its own freshly-stamped color would mask
+ *  the source color it's meant to follow and the flood would collapse to the seed. */
+export function buildTriColors(numTri: number, respectPerRegionVisibility = false, excludeRegionId?: number): Uint8Array | null {
   if (regions.length === 0 && modelRegions.length === 0) return null;
 
   const buf = new Uint8Array(numTri * 3); // default 0,0,0 — ignored for un-colored tris
@@ -396,7 +411,8 @@ export function buildTriColors(numTri: number, respectPerRegionVisibility = fals
   // layer. Layers are applied in call order, so a later layer overwrites an
   // earlier one wherever they overlap.
   const stampLayer = (layer: ColorRegion[]) => {
-    const eligible = respectPerRegionVisibility ? layer.filter(r => r.visible) : layer;
+    let eligible = respectPerRegionVisibility ? layer.filter(r => r.visible) : layer;
+    if (excludeRegionId !== undefined) eligible = eligible.filter(r => r.id !== excludeRegionId);
     const sorted = [...eligible].sort((a, b) => a.order - b.order);
     const layerOrder = new Int32Array(numTri).fill(-1); // -1 = untouched in this layer
     for (const region of sorted) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -180,7 +180,7 @@ import { setReadOnlyReason } from './editor/editorAccess';
 import { asLanguage } from './storage/languageFallback';
 import { encodeShare, decodeShare, validateSharePayloadShape, ShareUnsupportedError } from './share/shareLink';
 import { openShareModal, renderSharedBanner, renderSharedOverlay } from './share/shareUI';
-import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, resolveSeed, findNearestTriangle, type AdjacencyGraph } from './color/adjacency';
+import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, findColorRegion, resolveSeed, findNearestTriangle, type AdjacencyGraph } from './color/adjacency';
 import { findSlabTriangles, slabRefineRegion, smoothEdgeForResolution } from './color/slabPaint';
 import { findBoxTriangles, findShapeTriangles, shapeRefineRegion } from './color/boxPaint';
 import { cylinderRefineRegion, findCylinderTriangles } from './color/cylinderPaint';
@@ -737,6 +737,9 @@ function resolveDescriptorTriangles(
   mesh: MeshData,
   adjacency: AdjacencyGraph | null,
   parentToChildren: Map<number, number[]> | null,
+  /** Id of the region being resolved, when known. Used by `colorFlood` to read
+   *  the surface color *beneath* itself (excluding its own stamp). */
+  selfRegionId?: number,
 ): Set<number> {
   switch (descriptor.kind) {
     case 'coplanar': {
@@ -744,6 +747,21 @@ function resolveDescriptorTriangles(
       const { seedPoint, seedNormal, normalTolerance } = descriptor;
       const seedTri = resolveSeed(seedPoint, seedNormal, mesh, adjacency, normalTolerance);
       return seedTri >= 0 ? findCoplanarRegion(seedTri, adjacency, normalTolerance) : new Set<number>();
+    }
+    case 'colorFlood': {
+      if (!adjacency) return new Set<number>();
+      const { seedPoint, seedColor, colorTolerance } = descriptor;
+      // Triangle indices are unstable across re-tessellation; the world-space
+      // seed point is not. Find the triangle under it, then magic-wand by color.
+      const nearest = findNearestTriangle(seedPoint, mesh, adjacency);
+      if (nearest.triIndex < 0) return new Set<number>();
+      // Read colors with this region excluded, and anchor on the stored matched
+      // color, so the flood follows the *source* color this fill sits on top of.
+      const triColors = buildTriColors(mesh.numTri, false, selfRegionId);
+      const anchor: [number, number, number] = [
+        Math.round(seedColor[0] * 255), Math.round(seedColor[1] * 255), Math.round(seedColor[2] * 255),
+      ];
+      return findColorRegion(nearest.triIndex, adjacency, triColors, colorTolerance, anchor);
     }
     case 'triangles':
       // Raw ids index the base tessellation; carry them across any subdivision.
@@ -905,7 +923,7 @@ function rehydrateColorRegions(geometryData: Record<string, unknown> | null): { 
   // reconcile (we've already built the mesh here).
   suspendReconcile = true;
   for (const region of regions) {
-    const triangles = resolveDescriptorTriangles(region.descriptor, mesh, adjacency, parentToChildren);
+    const triangles = resolveDescriptorTriangles(region.descriptor, mesh, adjacency, parentToChildren, region.id);
     if (triangles.size > 0) {
       addRegion(region.name, region.color, region.source, region.descriptor, triangles, region.visible !== false);
       report.carried.push(region.name);
@@ -957,7 +975,7 @@ function rebuildPaintedGeometry(): void {
   updatePaintMesh(mesh);
   const adjacency = buildAdjacency(mesh);
   for (const region of getRegions()) {
-    setRegionTriangles(region.id, resolveDescriptorTriangles(region.descriptor, mesh, adjacency, parentToChildren));
+    setRegionTriangles(region.id, resolveDescriptorTriangles(region.descriptor, mesh, adjacency, parentToChildren, region.id));
   }
   paintedColorRefresh();
   syncLockState();
@@ -999,8 +1017,8 @@ function appendStrokeRefine(descriptor: Extract<RegionDescriptor, { kind: 'brush
     if (d.kind === 'triangles' || d.kind === 'byLabel' || !overlapsSplit(region)) {
       setRegionTriangles(region.id, remapTriangleIds(region.triangles, parentToChildren));
     } else {
-      if (!adjacency && (d.kind === 'coplanar' || d.kind === 'connectedFromSeed')) adjacency = buildAdjacency(mesh);
-      setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, parentToChildren));
+      if (!adjacency && (d.kind === 'coplanar' || d.kind === 'connectedFromSeed' || d.kind === 'colorFlood')) adjacency = buildAdjacency(mesh);
+      setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, parentToChildren, region.id));
     }
   }
   paintedColorRefresh();
@@ -1241,8 +1259,8 @@ async function appendStrokeRefineAsync(
       } else if (d.kind === 'triangles' || d.kind === 'byLabel' || !overlapsSplit(region)) {
         setRegionTriangles(region.id, remapTriangleIds(region.triangles, parentToChildren));
       } else {
-        if (!adjacency && (d.kind === 'coplanar' || d.kind === 'connectedFromSeed')) adjacency = buildAdjacency(mesh);
-        setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, parentToChildren));
+        if (!adjacency && (d.kind === 'coplanar' || d.kind === 'connectedFromSeed' || d.kind === 'colorFlood')) adjacency = buildAdjacency(mesh);
+        setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, parentToChildren, region.id));
       }
     }
     paintedColorRefresh();
@@ -1302,7 +1320,7 @@ async function rebuildPaintedGeometryAsync(): Promise<void> {
       if (workerTris) {
         setRegionTriangles(region.id, new Set(workerTris));
       } else {
-        setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, parentToChildren));
+        setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, parentToChildren, region.id));
       }
     }
     paintedColorRefresh();
@@ -11662,10 +11680,10 @@ async function main() {
         let adjacency: AdjacencyGraph | null = null;
         for (const region of getRegions()) {
           const d = region.descriptor;
-          if (!adjacency && (d.kind === 'coplanar' || d.kind === 'connectedFromSeed')) {
+          if (!adjacency && (d.kind === 'coplanar' || d.kind === 'connectedFromSeed' || d.kind === 'colorFlood')) {
             adjacency = buildAdjacency(mesh);
           }
-          setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, null));
+          setRegionTriangles(region.id, resolveDescriptorTriangles(d, mesh, adjacency, null, region.id));
         }
         const displayMesh = applyTriColorsIfVisible(mesh);
         updateMesh(displayMesh);

--- a/tests/paint-controls-extended.spec.ts
+++ b/tests/paint-controls-extended.spec.ts
@@ -253,4 +253,57 @@ test.describe('extended paint controls', () => {
     expect(result.hidden).toBe(false);
     expect(result.shown).toBe(true);
   });
+
+  test('bucket flood-fill preview tracks the tolerance slider live (no mouse move)', async ({ page }) => {
+    await openEditor(page);
+    // Replace the cube with a higher-tri sphere and paint its top hemisphere so
+    // the bucket has a real two-color region to flood-fill.
+    await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run(`const { Manifold } = api; return Manifold.sphere(8, 64);`);
+      pw.paintInBox({ box: { min: [-8, -8, 0], max: [8, 8, 8] }, color: [1, 0.2, 0.2] });
+    });
+
+    // Dismiss the onboarding tour so its backdrop doesn't eat the hover pointer.
+    const skip = page.locator('button:has-text("Skip")');
+    if (await skip.count()) await skip.first().click().catch(() => {});
+
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+    await page.locator('#paint-picker-panel button:has-text("Bucket")').dispatchEvent('click');
+
+    // Hover the painted (upper) hemisphere at a tight tolerance.
+    const tolInput = page.locator('#paint-picker-panel input[type="number"][title*="Color tolerance"]');
+    await tolInput.fill('5');
+    await tolInput.press('Enter');
+    const box = await page.locator('canvas').first().boundingBox();
+    if (!box) throw new Error('no canvas');
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height * 0.35;
+    await page.mouse.move(cx - 20, cy - 20);
+    await page.mouse.move(cx, cy);
+    await page.waitForTimeout(300);
+
+    const hoverTris = async () => page.evaluate(async () => {
+      const vp = await import('/src/renderer/viewport.ts');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let found: any = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vp.getMeshGroup().traverse((o: any) => { if (o.name === 'paint-hover') found = o; });
+      const pos = found?.geometry?.attributes?.position;
+      return pos ? pos.count / 3 : 0;
+    });
+
+    const tight = await hoverTris();
+    expect(tight).toBeGreaterThan(0); // the red hemisphere region is previewed
+
+    // Crank tolerance to 100 % WITHOUT moving the mouse — the preview must grow
+    // to the whole connected sphere, proving it tracks the setting live.
+    await tolInput.fill('100');
+    await tolInput.press('Enter');
+    await page.waitForTimeout(300);
+    const loose = await hoverTris();
+    expect(loose).toBeGreaterThan(tight);
+  });
 });

--- a/tests/paint-controls-extended.spec.ts
+++ b/tests/paint-controls-extended.spec.ts
@@ -306,4 +306,66 @@ test.describe('extended paint controls', () => {
     const loose = await hoverTris();
     expect(loose).toBeGreaterThan(tight);
   });
+
+  test('color bucket fill over a brush-painted blob commits and survives reconcile', async ({ page }) => {
+    await openEditor(page);
+    await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.run(`const { Manifold } = api; return Manifold.cube([20, 20, 20], true);`);
+    });
+
+    const skip = page.locator('button:has-text("Skip")');
+    if (await skip.count()) await skip.first().click().catch(() => {});
+
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+    // Brush is the default tool — paint a red blob (the brush adaptively
+    // subdivides the face, leaving the T-junctions the adjacency fix bridges).
+    await page.evaluate(async () => {
+      const pm = await import('/src/color/paintMode.ts');
+      pm.setColor([1, 0.15, 0.15]);
+    });
+    const box = await page.locator('canvas').first().boundingBox();
+    if (!box) throw new Error('no canvas');
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await page.mouse.move(cx - 40, cy);
+    await page.mouse.down();
+    for (let i = -40; i <= 40; i += 8) await page.mouse.move(cx + i, cy + Math.sin(i / 10) * 8);
+    await page.mouse.up();
+    await page.waitForTimeout(700);
+
+    const afterBrush = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (window as any).partwright.listRegions().map((r: any) => r.triangles);
+    });
+    expect(afterBrush.length).toBe(1);
+    expect(afterBrush[0]).toBeGreaterThan(50); // the refined red blob
+
+    // Switch to bucket / Color, pick a new color, and fill inside the blob.
+    await page.locator('#paint-picker-panel button:has-text("Bucket")').dispatchEvent('click');
+    await page.locator('#paint-picker-panel button:has-text("Color")').dispatchEvent('click');
+    await page.evaluate(async () => {
+      const pm = await import('/src/color/paintMode.ts');
+      pm.setColor([1, 0.85, 0.1]); // yellow
+    });
+    const tolInput = page.locator('#paint-picker-panel input[type="number"][title*="Color tolerance"]');
+    await tolInput.fill('20'); await tolInput.press('Enter');
+    await page.mouse.move(cx - 100, cy - 100);
+    await page.mouse.move(cx - 4, cy); await page.mouse.move(cx, cy);
+    await page.waitForTimeout(250);
+    await page.mouse.down(); await page.waitForTimeout(40); await page.mouse.up();
+    await page.waitForTimeout(700); // let the async reconcile re-resolve regions
+
+    const afterBucket = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (window as any).partwright.listRegions().map((r: any) => ({ tris: r.triangles, color: r.color }));
+    });
+    // Two regions; the bucket region must NOT collapse to zero after reconcile,
+    // and it carries the new (yellow) color over the blob it matched.
+    expect(afterBucket.length).toBe(2);
+    expect(afterBucket[1].tris).toBeGreaterThan(50);
+    expect(afterBucket[1].color[2]).toBeLessThan(0.5); // yellow, not the red it replaced
+  });
 });

--- a/tests/unit/colorRegion.test.ts
+++ b/tests/unit/colorRegion.test.ts
@@ -78,4 +78,41 @@ describe('findColorRegion', () => {
     // Seed is blue → exact-match tolerance keeps only the blue quad.
     expect([...region].sort((a, b) => a - b)).toEqual([2, 3]);
   });
+
+  it('bridges a T-junction (corner adjacency) the brush leaves behind', () => {
+    // Triangle A spans edge P0–P1. On the far side that edge is split at its
+    // midpoint M into B1 and B2 — a T-junction: A shares NO full edge with B1/B2
+    // (so pure edge-pair adjacency would strand A alone), but it still shares the
+    // corners P0 and P1. Corner adjacency must keep all three connected so the
+    // bucket walks across the subdivision boundary instead of grabbing one face.
+    const vertProperties = new Float32Array([
+      0, 0, 0, // 0 P0
+      2, 0, 0, // 1 P1
+      1, 1, 0, // 2 P2
+      1, 0, 0, // 3 M (midpoint of P0–P1)
+      1, -1, 0, // 4 X
+    ]);
+    const triVerts = new Uint32Array([
+      0, 1, 2, // A
+      0, 3, 4, // B1
+      3, 1, 4, // B2
+    ]);
+    const mesh: MeshData = { vertProperties, triVerts, numVert: 5, numTri: 3, numProp: 3 };
+    const adjacency = buildAdjacency(mesh);
+    // All one color → a tight tolerance still fills all three across the T-junction.
+    const sameColor = new Uint8Array([10, 20, 30, 10, 20, 30, 10, 20, 30]);
+    const region = findColorRegion(0, adjacency, sameColor, 0);
+    expect([...region].sort((a, b) => a - b)).toEqual([0, 1, 2]);
+  });
+
+  it('anchors on the seed-color override instead of the seed triangle color', () => {
+    const { adjacency } = buildStrip();
+    // Seed the red quad but tell the flood to match BLUE: the seed is always
+    // included, and the walk then collects only the blue-matching neighbours.
+    const region = findColorRegion(0, adjacency, RED_BLUE, 0, [0, 0, 255]);
+    expect(region.has(0)).toBe(true); // seed always kept
+    expect(region.has(2)).toBe(true); // blue
+    expect(region.has(3)).toBe(true); // blue
+    expect(region.has(1)).toBe(false); // red, not the matched color
+  });
 });


### PR DESCRIPTION
## Summary

Makes the **color bucket** tool's tolerance actually usable: the hover preview now tracks the setting live, and a fill walks — and persists — the real region. Three pre-existing bugs, found by reproducing the reported flow (brush-paint a blob, then color-bucket over it):

### 1. Live preview (commit 1)
The hover preview already flood-filled on hover, but only recomputed on a `pointermove` — so dragging the tolerance slider left the highlight frozen at the old tolerance. Added `refreshBucketPreview()` (recomputes from the last hovered seed at the current tolerance/mode) and wired it to the tolerance sliders/inputs and the color/geometry toggle. The region now grows/shrinks in real time.

### 2. Fragmented adjacency (commit 2)
The brush's adaptive subdivision leaves **T-junctions** (a neighbour's edge split at its midpoint). `buildAdjacency` matched only full edges by vertex pair, so the flood-fill shattered into ~6-triangle islands — the tolerance slider looked dead and a fill grabbed almost nothing. Now adjacency connects by **shared vertex (corner)**: the split edge's endpoints stay shared corners, reconnecting across the T-junction (measured: 7 → 9655 triangles in the connected component). Every flood-fill caller gates each step by color/normal, so the looser adjacency can't over-select. Also fixes the geometry bucket and `paintNear` on refined meshes.

### 3. Bucket commit collapsed to zero (commit 2)
The color bucket stored working-mesh triangle ids in a `triangles` descriptor, which must hold **base-tessellation** ids — so the reconcile after each paint dropped them (0 triangles). Base-mapping over-painted whole faces. Fix: a new **`colorFlood`** descriptor (stable seed point + matched color + tolerance) that re-floods by color on every reconcile/reload, mirroring the geometry bucket's `coplanar`. `buildTriColors` gained an `excludeRegionId` param and `findColorRegion` a seed-color anchor so the region reads the source color *beneath* its own stamp. The fill now resolves to exactly the matched blob and survives reconcile.

### Before / after
- Preview at 5% tolerance over a painted hemisphere: 1024 tris; cranked to 95–100% with **no mouse move** → grows to the whole sphere (was frozen).
- Brush-paint a red blob, color-bucket yellow inside: the blob recolors red→yellow and stays (was: nothing painted / collapsed to 0).

## Test plan
- New unit tests: T-junction bridging via corner adjacency; the `findColorRegion` seed-color override. (`tests/unit/colorRegion.test.ts`)
- New e2e: live preview tracks the slider; a color bucket over a brush-painted blob commits and survives reconcile. (`tests/paint-controls-extended.spec.ts`)
- `npm run build` ✅ · `npm run test:unit` ✅ 600 passed
- Ran the paint/region/reconcile/brush e2e specs locally (57 + 37 tests) — all green.
- Manual browser verification (Playwright screenshots): preview grows with tolerance; red blob recolors to yellow.

https://claude.ai/code/session_01Q5PMQ8Lfu2dPbrdSAWsAko