### PR TITLE
fix: recover from fatal WASM faults + surface engine heap usage in diagnostics

### DIFF
--- a/prompts/20260604-150313-wasm-fault-worker-recycle.md
+++ b/prompts/20260604-150313-wasm-fault-worker-recycle.md
@@ -1,0 +1,50 @@
+---
+session: "ecstatic-sagan"
+timestamp: "2026-06-04T15:03:13Z"
+model: claude-opus-4-8
+tools: [Read, Grep, Bash, Edit, Write, Playwright]
+---
+
+## Human
+
+Testing a PR branch; AI built a parameterized chain and scaling it to 100
+links produced an error: "memory access out of bounds … source: engine … No
+stack trace or origin captured for this entry." Suspected to also exist on
+main/staging. Wants to understand it and prevent it. Attached the session
+JSON (3 versions; v3 = the failing 100-link run, `executionTimeMs: 1`).
+
+## Assistant
+
+## Key decisions
+
+**Root cause** — "memory access out of bounds" is a `WebAssembly.RuntimeError`
+trap from the manifold-3d kernel: the model is too large for the WASM linear
+heap (which only ever grows, never shrinks). The deeper, reproducible defect is
+that the long-lived geometry Worker is **not recycled** after such a trap. A
+trap can leave the kernel's C++ state half-mutated, so every *subsequent* run —
+even a trivial cube — faults instantly with the same error (the `executionTimeMs:
+1` tell) until the page is reloaded. `engine.ts` only restarted the Worker on
+timeout / crash / messageerror, never on a fault returned as a normal result.
+Confirmed empirically in a real browser: with recycle disabled, run-3 (a cube)
+fails with the same OOM; with it, run-3 succeeds.
+
+**Fix scope** — chose graceful recovery + clearer messaging over trying to
+pre-empt heavy models (can't predict the heap ceiling reliably):
+
+- `src/geometry/workerFaults.ts` (new, dependency-free → unit tier): classifies
+  fatal WASM traps (`isFatalWasmFault`) and produces an actionable, memory-aware
+  hint (`wasmFaultHint`). Shared by the engine client and the sandbox engine.
+- `src/geometry/engine.ts`: after delivering a result whose error is a fatal WASM
+  fault, recycle the Worker (`recycleEngineWorker`) so the next run boots a clean
+  module — the actual cascade fix. `console.warn` (recovery, not a second crash).
+- `src/geometry/engines/manifoldJs.ts`: the OOM message previously matched none
+  of the existing hint patterns (`RuntimeError`/`unreachable`), so it passed
+  through raw; now it gets the memory-aware hint.
+- `src/main.ts`: engine errors carry no JS stack (fault is off-thread, in WASM),
+  which is why the diagnostic log read "No stack trace or origin captured."
+  Attach diagnostics + language + executionTimeMs as the log `detail`.
+
+**Verification** — `tests/unit/workerFaults.test.ts` (classifier) and
+`tests/engine-wasm-fault-recovery.spec.ts` (e2e: fault → graceful error with
+hint → next run recovers). The e2e fails on pre-fix code (proven by temporarily
+disabling the recycle), so it's a real regression guard, not a no-op.

--- a/prompts/20260604-151825-wasm-fault-e2e-deterministic.md
+++ b/prompts/20260604-151825-wasm-fault-e2e-deterministic.md
@@ -1,0 +1,34 @@
+---
+session: "ecstatic-sagan"
+timestamp: "2026-06-04T15:18:25Z"
+model: claude-opus-4-8
+tools: [Bash, Playwright, Edit, Write]
+sequence: 2
+---
+
+## Human
+
+(PR #423 CI) The e2e shard failed: tests/engine-wasm-fault-recovery.spec.ts
+timed out at 30 s on the CI runner — both the original and the retry.
+
+## Assistant
+
+## Key decisions
+
+**Why it failed** — the spec forced a *real* OOM via `Manifold.sphere(10, 100000)`.
+That's a CPU grind whose timing depends on the host memory ceiling: it trapped in
+~0.1 s on the constrained sandbox but ran past Playwright's 30 s timeout on the
+roomier CI runner (it was still building the giant sphere, not yet trapping).
+Probed other triggers — manifold-3d *gracefully* rejects malformed input
+("Not manifold", 1–4 ms); only genuine heap exhaustion traps, and that is always
+a slow, machine-timing-dependent grind. So a real-OOM e2e can't be a reliable gate.
+
+**Redesign** — simulate the kernel's exact trap message instead of exhausting the
+heap: sandbox code `throw new Error('memory access out of bounds')` flows through
+the *identical* recovery path — caught in the engine's `run()` try/catch, returned
+as an `execute_result` error, classified by `isFatalWasmFault`, and recycled — so
+it deterministically exercises the wiring in ~6 s. Assertions: (1) the actionable
+"ran out of memory" hint surfaces, (2) the "Recycling geometry Worker after fatal
+WASM fault" log fires — the regression guard for the recycle, **verified to fail
+on pre-fix code**, and (3) the next run recovers. No production test seam added;
+the simulation rides the real code path.

--- a/prompts/20260604-154816-engine-wasm-heap-diagnostics.md
+++ b/prompts/20260604-154816-engine-wasm-heap-diagnostics.md
@@ -1,0 +1,46 @@
+---
+session: "ecstatic-sagan"
+timestamp: "2026-06-04T15:48:16Z"
+model: claude-opus-4-8
+tools: [Bash, Read, Edit, Write, Playwright]
+sequence: 3
+---
+
+## Human
+
+Dubious that the chain actually reached 4 GB of memory. Could I track the
+real WASM heap usage via the diagnostics menu somehow?
+
+## Assistant
+
+## Key decisions
+
+**Context** — the doubt is well-founded: "memory access out of bounds" often
+trips *below* 4 GB because growing the heap needs a single contiguous
+ArrayBuffer, which fragmentation / per-tab limits can block at ~1–2 GB. So
+showing the actual heap high-water mark is genuinely informative.
+
+**Feasibility** — confirmed the prebuilt manifold-3d@3.3.2 exposes `Module["HEAPU8"]`,
+so the worker can read `HEAPU8.byteLength` (the grown heap size; WASM memory
+never shrinks, so post-run it's the high-water mark).
+
+**Implementation** — report the manifold-js heap high-water in the diagnostics:
+- `src/geometry/engineMemory.ts` (new, pure → unit tier): `WASM_HEAP_MAX_BYTES`
+  (= manifold's compiled `getHeapMax()`, 4 GiB − 64 KiB) and `formatEngineMemory`
+  → e.g. `"1850 MB / 4096 MB (45%)"`. The percentage of the 4 GB ceiling is the
+  tell — a low % at fault time means a fragmentation failure, not true exhaustion.
+- `engineWorker.ts`: read the manifold heap after each manifold-js run (only —
+  other engines own separate heaps) and post `engineHeapBytes` on both the
+  success and error `execute_result`.
+- `engine.ts` / `types.ts`: thread `engineHeapBytes` through `MeshResult`.
+- `main.ts`: surface it in the **Data panel** for every run (via
+  `withSessionContext` → `engineMemory`) so users can watch it climb, in the
+  **engine-error diagnostic-log detail** (so an OOM shows how far memory really
+  grew), and in `executeIsolated` stats (so the AI agent's `runIsolated` sees it
+  too). Mutated the `Record<string,unknown>` stats rather than spreading it —
+  spreading drops the index signature and broke `.status` access downstream.
+
+**Verification** — browser-checked end to end: heap reads 16 MB at boot, climbs
+to 144 MB after a multi-sphere union, and the fault path carries the high-water
+too. Unit test for the formatter/constant; the e2e recovery spec now also asserts
+the `"N MB / 4096 MB (P%)"` readout on both a normal run and the fault.

--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -9,6 +9,7 @@ import { getActiveImports } from '../import/importedMesh';
 import { getCompanionFiles } from '../import/companionFiles';
 import { getDefaultCircularSegments } from './qualitySettings';
 import { getConfig } from '../config/appConfig';
+import { isFatalWasmFault } from './workerFaults';
 
 export type { Language };
 export { isLanguage, DEFAULT_LANGUAGE };
@@ -170,6 +171,25 @@ export function cancelCurrentExecution(): void {
   restartEngineWorker('Execution cancelled');
 }
 
+/** Discard the Worker after a *handled* fatal WASM fault. Unlike
+ *  restartEngineWorker, the current call's result has already been delivered —
+ *  we tear the Worker down only so the *next* run boots a clean WASM module.
+ *  A WASM trap (e.g. "memory access out of bounds") can leave the kernel's C++
+ *  state half-mutated, after which every subsequent call into the same instance
+ *  faults instantly; recycling here is the only reliable recovery short of a
+ *  page reload. Any *other* in-flight calls are rejected so they reboot too. */
+function recycleEngineWorker(reason: string): void {
+  rejectAllPending(new Error(reason));
+  workerReadyReject?.(new Error(reason));
+  workerReadyReject = null;
+  engineWorker?.terminate();
+  engineWorker = null;
+  // Recovery, not a crash — warn (still recorded in the diagnostic log) rather
+  // than error, so it doesn't read as a second hard failure to the user.
+  // eslint-disable-next-line no-console
+  console.warn('[EngineWorker]', reason);
+}
+
 function initEngineWorker(): void {
   if (engineWorker) return;
   // Fresh ready-gate so the restarted Worker's 'ready' message resolves it,
@@ -248,6 +268,12 @@ function handleEngineWorkerMessage(event: MessageEvent): void {
       paramsSchema: (msg.paramsSchema as MeshResult['paramsSchema']) ?? undefined,
     };
     pending.resolve(result);
+    // A WASM trap (OOM / abort) reported as a *result* leaves the Worker's
+    // kernel poisoned — without this, the next run could fault instantly with
+    // the same error until the page is reloaded. Recycle so it boots fresh.
+    if (result.error && isFatalWasmFault(result.error)) {
+      recycleEngineWorker(`Recycling geometry Worker after fatal WASM fault: ${result.error}`);
+    }
     return;
   }
 

--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -266,6 +266,7 @@ function handleEngineWorkerMessage(event: MessageEvent): void {
       renderOnly: !!msg.renderOnly,
       lostLabels: lostLabels && lostLabels.length > 0 ? lostLabels : undefined,
       paramsSchema: (msg.paramsSchema as MeshResult['paramsSchema']) ?? undefined,
+      engineHeapBytes: msg.engineHeapBytes as number | undefined,
     };
     pending.resolve(result);
     // A WASM trap (OOM / abort) reported as a *result* leaves the Worker's

--- a/src/geometry/engineMemory.ts
+++ b/src/geometry/engineMemory.ts
@@ -1,0 +1,27 @@
+// Engine WASM heap reporting helpers.
+//
+// "memory access out of bounds" is what a user sees when the manifold-3d kernel
+// can't grow its heap any further. The nominal ceiling is the 32-bit WASM limit,
+// but in practice a grow can fail well below it (the browser must hand back a
+// single *contiguous* ArrayBuffer, which address-space fragmentation or per-tab
+// limits can block at ~1–2 GB). Surfacing the heap high-water mark in the
+// diagnostics therefore answers the real question — "did I actually hit the
+// ceiling, or fail far below it?" — instead of leaving users to guess.
+
+/** Hard ceiling of a 32-bit WASM linear memory, matching manifold-3d's compiled
+ *  `getHeapMax()` (`4294901760` = 4 GiB − one 64 KiB page). The kernel's heap
+ *  grows up to here and no further; a 32-bit address space cannot address more.
+ *  A structural constant (the wasm32 limit), not a tunable knob. */
+export const WASM_HEAP_MAX_BYTES = 4294901760;
+
+const BYTES_PER_MB = 1024 * 1024;
+
+/** Human-readable heap usage, e.g. `"1850 MB / 4096 MB (45%)"`. The percentage
+ *  is of the 4 GiB wasm32 ceiling, so a fault at a low percentage is the signal
+ *  that the grow failed on fragmentation rather than truly exhausting 4 GB. */
+export function formatEngineMemory(bytes: number): string {
+  const mb = Math.round(bytes / BYTES_PER_MB);
+  const maxMb = Math.round(WASM_HEAP_MAX_BYTES / BYTES_PER_MB);
+  const pct = Math.round((bytes / WASM_HEAP_MAX_BYTES) * 100);
+  return `${mb} MB / ${maxMb} MB (${pct}%)`;
+}

--- a/src/geometry/engineWorker.ts
+++ b/src/geometry/engineWorker.ts
@@ -59,6 +59,20 @@ const enhanceCancelFlags = new Map<string, boolean>();
 
 let manifoldReady = false;
 
+/** Current size (bytes) of the manifold-3d WASM linear heap — its grown
+ *  high-water mark, since WASM memory never shrinks. Reported back to the main
+ *  thread so the diagnostics can show how close a run came to the 4 GB ceiling
+ *  (and, on an OOM, whether it truly hit it or failed far below). Only
+ *  meaningful for manifold-js runs; the other engines own separate WASM heaps. */
+function manifoldHeapBytes(): number | undefined {
+  try {
+    const heap = (getManifoldModule() as { HEAPU8?: { byteLength?: number } } | null)?.HEAPU8;
+    return typeof heap?.byteLength === 'number' ? heap.byteLength : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // Catch unhandled promise rejections inside the Worker (e.g. WASM panics that
 // escape an inner try-catch) and forward them as 'error' messages so the main
 // thread's pendingExecutions promises are rejected rather than hanging forever.
@@ -177,6 +191,8 @@ self.onmessage = async (event: MessageEvent) => {
         : null;
       const lostLabels = result.lostLabels ?? null;
       const paramsSchema = result.paramsSchema ?? null;
+      // Heap high-water for manifold-js runs (other engines own separate heaps).
+      const engineHeapBytes = effectiveLang === 'manifold-js' ? manifoldHeapBytes() : undefined;
 
       const mesh = result.mesh;
       if (mesh) {
@@ -195,7 +211,7 @@ self.onmessage = async (event: MessageEvent) => {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (self as any).postMessage(
-          { type: 'execute_result', callId, mesh, error: null, diagnostics: [], labelMapEntries, labelColorEntries, lostLabels, paramsSchema, renderOnly: !!result.renderOnly },
+          { type: 'execute_result', callId, mesh, error: null, diagnostics: [], labelMapEntries, labelColorEntries, lostLabels, paramsSchema, renderOnly: !!result.renderOnly, engineHeapBytes },
           transfer,
         );
       } else {
@@ -208,6 +224,7 @@ self.onmessage = async (event: MessageEvent) => {
           labelMapEntries: null,
           lostLabels: null,
           paramsSchema,
+          engineHeapBytes,
         });
       }
 

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -9,6 +9,7 @@ import { getActiveImports } from '../../import/importedMesh';
 import { createSdfNamespace, SdfNode } from '../sdf';
 import { getBrepNamespace, consumeBrepAllocations, disposeBrepAllocationsExcept, consumeBrepToManifoldLabels } from '../brepRuntime';
 import { parseLabelColor } from '../../color/labelColor';
+import { wasmFaultHint } from '../workerFaults';
 
 /** Marker the sandbox attaches to render-only proxies (see `renderMesh` below).
  *  The engine looks for it on the user-returned object to decide whether the
@@ -412,8 +413,11 @@ export const manifoldJsEngine: Engine = {
         hint = 'Manifold.cube([x, y, z], center?) — first arg must be an array of 3 numbers.';
       } else if (msg.includes('Missing field')) {
         hint = 'You may have passed an array where an object was expected, or vice versa. Check the API signature.';
-      } else if (msg.includes('unreachable') || msg.includes('RuntimeError')) {
-        hint = 'WASM runtime error — likely caused by degenerate geometry, a self-intersection, or an invalid boolean. Try simplifying the operation or checking input dimensions.';
+      } else if (wasmFaultHint(msg)) {
+        // Fatal WASM trap — memory exhaustion ("memory access out of bounds") or
+        // an abort. Give the memory-aware mitigation; the engine client recycles
+        // the Worker so the next run starts from a clean module.
+        hint = wasmFaultHint(msg);
       }
 
       if (hint) msg += `\nHint: ${hint}`;

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -67,6 +67,12 @@ export interface MeshResult {
    *  and tells callers which knobs (and value ranges) the model exposes. Absent
    *  when the model declared no parameters. */
   paramsSchema?: ParamSpec[];
+  /** Size (bytes) of the manifold-3d WASM heap after this run — its grown
+   *  high-water mark (WASM memory never shrinks). Surfaced in the diagnostics so
+   *  users can see how close a run came to the ~4 GB ceiling, and on an OOM
+   *  whether it truly hit it or failed far below. Only set for manifold-js runs;
+   *  absent for the other engines (which own separate heaps). */
+  engineHeapBytes?: number;
 }
 
 export interface CrossSectionResult {

--- a/src/geometry/workerFaults.ts
+++ b/src/geometry/workerFaults.ts
@@ -1,0 +1,73 @@
+// Classification of fatal WASM-kernel faults.
+//
+// The geometry engines run inside a long-lived Web Worker that owns a single
+// manifold-3d (and, lazily, OpenSCAD / OpenCASCADE) WASM instance. WebAssembly
+// linear memory only ever *grows* — it is never returned to the OS — so a heavy
+// run can push the heap to its ceiling. When a later allocation or access then
+// traps, the kernel raises a `WebAssembly.RuntimeError` such as
+// "memory access out of bounds". Critically, such a trap can leave the module's
+// C++ state half-mutated: every *subsequent* call into the same instance can
+// fault instantly (we have seen ~1 ms "executionTimeMs" failures), so the only
+// reliable recovery is to discard the Worker and boot a fresh module.
+//
+// This module is intentionally dependency-free (pure string matching) so it can
+// be imported from both the main-thread engine client and the sandbox engine,
+// and exercised in the fast unit tier.
+
+/** Substrings that mark a WASM trap which poisons the kernel instance. Matched
+ *  case-insensitively against an error message. These are emitted by Emscripten
+ *  builds (manifold-3d / OpenSCAD / OpenCASCADE) when memory is exhausted or the
+ *  module aborts; once seen, the Worker must be recycled rather than reused. */
+const FATAL_WASM_PATTERNS: readonly string[] = [
+  'memory access out of bounds',
+  'out of bounds memory access',
+  'cannot enlarge memory',
+  'out of memory',
+  'table index is out of bounds',
+  'null function or function signature mismatch',
+  'unreachable', // wasm `unreachable` trap (Emscripten abort)
+  'aborted',
+  'runtimeerror',
+];
+
+/** True when `message` indicates a WASM trap that corrupts the kernel instance,
+ *  meaning the owning Worker should be recycled so the next run starts clean. */
+export function isFatalWasmFault(message: string | null | undefined): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  return FATAL_WASM_PATTERNS.some((p) => m.includes(p));
+}
+
+/** Whether the fault is specifically a memory-exhaustion trap (vs. a generic
+ *  abort), so callers can offer the "reduce complexity" mitigation. */
+export function isWasmMemoryFault(message: string | null | undefined): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  return (
+    m.includes('memory access out of bounds') ||
+    m.includes('out of bounds memory access') ||
+    m.includes('cannot enlarge memory') ||
+    m.includes('out of memory')
+  );
+}
+
+/** Actionable hint for a fatal WASM fault, or undefined if the message isn't
+ *  one. Surfaced to the user in place of the raw, opaque trap text. */
+export function wasmFaultHint(message: string | null | undefined): string | undefined {
+  if (isWasmMemoryFault(message)) {
+    return (
+      'The geometry kernel ran out of memory. This model is too large or complex for the ' +
+      'available WebAssembly heap — try fewer parts/links, a lower circular-segment quality ' +
+      '(Quality setting / setCircularSegments), or simplifying the geometry. The engine is ' +
+      'reset automatically, so your next run starts from a clean state.'
+    );
+  }
+  if (isFatalWasmFault(message)) {
+    return (
+      'The geometry kernel hit a fatal WASM error and has been reset. This is usually caused by ' +
+      'degenerate geometry, a self-intersection, or an invalid boolean — try simplifying the ' +
+      'operation or checking input dimensions. Your next run starts from a clean state.'
+    );
+  }
+  return undefined;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11558,7 +11558,16 @@ async function main() {
       if (surfaceErrors) {
         // Explicit run: record + show + log + jump to the first diagnostic now.
         recordError(result.error);
-        errorLog.capture({ level: 'error', source: 'engine', message: result.error });
+        // Engine errors carry no JS stack (the fault is inside the WASM kernel,
+        // off-thread), so attach the diagnostics + run metadata as the log detail
+        // — otherwise the diagnostics panel shows "No stack trace or origin
+        // captured" for what is often a memory/complexity fault worth context.
+        const engineDetail = [
+          `language: ${getActiveLanguage()}`,
+          `executionTimeMs: ${elapsed}`,
+          ...diagnostics.map(d => `${d.severity ?? 'error'} (${d.source ?? 'engine'}): ${d.message}`),
+        ].join('\n');
+        errorLog.capture({ level: 'error', source: 'engine', message: result.error, detail: engineDetail });
         setEditorDiagnostics(diagnostics);
         renderEditorError(editorErrorPanel, result.error, diagnostics);
         revealFirstDiagnostic();

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import './style.css';
 import { errorLog } from './diagnostics/errorLog';
 import { initDiagnosticsPanel, toggleDiagnosticsPanel } from './ui/diagnosticsPanel';
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, detectScadIncludesAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, exportLastBrepAsSTEP, importSTEPToBrep, importSTEPToMesh, clearBrepImports, clearBrepShape, simplifyInWorker, enhanceInWorker, cancelCurrentExecution, type Language } from './geometry/engine';
+import { formatEngineMemory } from './geometry/engineMemory';
 import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { resolveParamValues, pruneParamValues, type ParamSpec, type ParamValue } from './geometry/params';
 import { createParamsPanel, type ParamsPanelController } from './ui/paramsPanel';
@@ -300,6 +301,11 @@ function syncParamsPanel(schema: ParamSpec[] | undefined): void {
 }
 
 let currentMeshData: MeshData | null = null;
+/** WASM heap high-water (bytes) reported by the geometry Worker for the most
+ *  recent manifold-js run. Surfaced in the geometry-data stats and engine-error
+ *  log so users can see how close a run came to the ~4 GB ceiling. Undefined
+ *  for non-manifold-js engines (separate heaps) or before the first run. */
+let lastEngineHeapBytes: number | undefined;
 /** The pristine mesh produced by the authored code, before any smooth brush
  *  subdivision. `currentMeshData` equals this until a `brushStroke` region
  *  exists, at which point it becomes the refined (subdivided) mesh rebuilt by
@@ -542,6 +548,11 @@ function withSessionContext(data: Record<string, unknown>): Record<string, unkno
     data.sessionId = state.session.id;
     data.sessionUrl = getSessionUrl();
     data.galleryUrl = getGalleryUrl();
+  }
+  // Engine WASM heap high-water for the last run, so the Data panel doubles as a
+  // memory readout — watch it climb as a model scales up toward the ceiling.
+  if (lastEngineHeapBytes !== undefined) {
+    data.engineMemory = formatEngineMemory(lastEngineHeapBytes);
   }
   return data;
 }
@@ -6033,6 +6044,12 @@ async function main() {
     const result = await executeCodeAsync(code, lang);
     const elapsed = Math.round(performance.now() - t0);
 
+    // Engine WASM heap high-water for this run (manifold-js only) so isolated
+    // runs report memory in their stats just like the editor's Data panel.
+    const engineMemory = result.engineHeapBytes !== undefined
+      ? formatEngineMemory(result.engineHeapBytes)
+      : undefined;
+
     if (result.error) {
       recordError(result.error);
       return {
@@ -6042,6 +6059,7 @@ async function main() {
           diagnostics: result.diagnostics ?? [],
           executionTimeMs: elapsed,
           codeHash: simpleHash(code),
+          ...(engineMemory !== undefined ? { engineMemory } : {}),
         },
         meshData: null as MeshData | null,
         manifold: null as unknown,
@@ -6052,6 +6070,7 @@ async function main() {
     const mod = getModule();
     const manifold = result.manifold ?? (mod && result.mesh ? mod.Manifold.ofMesh(result.mesh) : null);
     const stats = computeGeometryStats(manifold, result.mesh!, elapsed, code);
+    if (engineMemory !== undefined) stats.engineMemory = engineMemory;
     return {
       geometryData: stats,
       meshData: result.mesh,
@@ -11537,6 +11556,11 @@ async function main() {
     _running = false;
     stopRunTimer();
 
+    // Record the engine WASM heap high-water for this run (undefined for non
+    // manifold-js engines, which own separate heaps). Surfaced in the Data panel
+    // and engine-error log so users can see how close a run came to the ceiling.
+    lastEngineHeapBytes = result.engineHeapBytes;
+
     // Reconcile the Customizer with what the model declared this run. The
     // schema rides on the result for both success and error, so the panel
     // stays visible (and editable) even while the model is mid-error. Prune
@@ -11554,6 +11578,7 @@ async function main() {
         diagnostics,
         executionTimeMs: elapsed,
         codeHash: simpleHash(src),
+        ...(lastEngineHeapBytes !== undefined ? { engineMemory: formatEngineMemory(lastEngineHeapBytes) } : {}),
       });
       if (surfaceErrors) {
         // Explicit run: record + show + log + jump to the first diagnostic now.
@@ -11565,6 +11590,7 @@ async function main() {
         const engineDetail = [
           `language: ${getActiveLanguage()}`,
           `executionTimeMs: ${elapsed}`,
+          ...(lastEngineHeapBytes !== undefined ? [`WASM heap: ${formatEngineMemory(lastEngineHeapBytes)}`] : []),
           ...diagnostics.map(d => `${d.severity ?? 'error'} (${d.source ?? 'engine'}): ${d.message}`),
         ].join('\n');
         errorLog.capture({ level: 'error', source: 'engine', message: result.error, detail: engineDetail });

--- a/tests/engine-wasm-fault-recovery.spec.ts
+++ b/tests/engine-wasm-fault-recovery.spec.ts
@@ -39,14 +39,21 @@ test.describe('engine WASM fault recovery', () => {
 
     const cube = 'return api.Manifold.cube([10,10,10], true);';
 
-    // 1) Baseline: a normal model runs fine.
-    expect((await run(cube)).status).toBe('ok');
+    // 1) Baseline: a normal model runs fine, and its stats report the engine's
+    //    WASM heap high-water (the diagnostics memory readout) as "N MB / 4096
+    //    MB (P%)" — so users can see how close a run is to the ~4 GB ceiling.
+    const baseline = await run(cube);
+    expect(baseline.status).toBe('ok');
+    expect(baseline.engineMemory).toMatch(/^\d+ MB \/ 4096 MB \(\d+%\)$/);
 
     // 2) A fatal WASM-memory fault surfaces as an error with the actionable,
     //    memory-aware hint (instead of the raw, opaque trap text).
     const fault = await run("throw new Error('memory access out of bounds');");
     expect(fault.status).toBe('error');
     expect(fault.error).toMatch(/ran out of memory/i);
+    // The fault stats still carry the heap high-water, so an OOM report shows
+    // how far memory actually grew (often well below the ceiling).
+    expect(fault.engineMemory).toMatch(/^\d+ MB \/ 4096 MB \(\d+%\)$/);
 
     // 3) The engine must have recycled the poisoned Worker. This log fires only
     //    when the recovery wiring runs — it is absent on pre-fix code.

--- a/tests/engine-wasm-fault-recovery.spec.ts
+++ b/tests/engine-wasm-fault-recovery.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from 'playwright/test';
+
+// Regression: a fatal WASM kernel fault (e.g. "memory access out of bounds" from
+// a model too large for the heap) must NOT poison the geometry Worker. Before the
+// fix, the trap left the manifold-3d module in a half-mutated state and every
+// subsequent run — even a trivial cube — failed instantly with the same error
+// until the page was reloaded. The engine now recycles the Worker after such a
+// fault, so the next run boots a clean module and succeeds.
+test.describe('engine WASM fault recovery', () => {
+  test('fatal memory fault recovers on the next run', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForFunction(
+      () => !!(window as unknown as { partwright?: { runIsolated?: unknown } }).partwright?.runIsolated,
+      null,
+      { timeout: 30000 },
+    );
+    await page.waitForTimeout(3000); // let WASM boot
+
+    const run = (code: string) =>
+      page.evaluate(
+        async (c) => (await (window as any).partwright.runIsolated(c)).geometryData, // eslint-disable-line @typescript-eslint/no-explicit-any
+        code,
+      );
+
+    const cube = 'return api.Manifold.cube([10,10,10], true);';
+
+    // 1) Baseline: a normal model runs fine.
+    expect((await run(cube)).status).toBe('ok');
+
+    // 2) Force a WASM memory fault: an absurd circular-segment count makes the
+    //    kernel try to allocate billions of vertices, tripping the heap ceiling.
+    const fault = await run('return api.Manifold.sphere(10, 100000);');
+    expect(fault.status).toBe('error');
+    // The opaque trap text is replaced with an actionable, memory-aware hint.
+    expect(fault.error).toMatch(/ran out of memory/i);
+
+    // 3) Recovery: the same baseline model must run again. Pre-fix this failed
+    //    instantly with the same memory error (the poisoned-worker cascade).
+    expect((await run(cube)).status).toBe('ok');
+  });
+});

--- a/tests/engine-wasm-fault-recovery.spec.ts
+++ b/tests/engine-wasm-fault-recovery.spec.ts
@@ -1,13 +1,28 @@
 import { test, expect } from 'playwright/test';
 
-// Regression: a fatal WASM kernel fault (e.g. "memory access out of bounds" from
-// a model too large for the heap) must NOT poison the geometry Worker. Before the
-// fix, the trap left the manifold-3d module in a half-mutated state and every
-// subsequent run — even a trivial cube — failed instantly with the same error
-// until the page was reloaded. The engine now recycles the Worker after such a
-// fault, so the next run boots a clean module and succeeds.
+// Regression: a fatal WASM kernel fault (e.g. "memory access out of bounds" when
+// a model exceeds the manifold-3d heap, which only grows) must NOT poison the
+// long-lived geometry Worker. Before the fix the trap left the kernel's C++
+// state half-mutated, so every subsequent run — even a trivial cube — failed
+// instantly with the same error until the page was reloaded. The engine now
+// recognises the fatal fault and recycles the Worker so the next run boots a
+// clean module.
+//
+// Why we *simulate* the trap rather than really exhausting the heap: a genuine
+// OOM is a CPU grind whose timing depends on the host's memory ceiling (it
+// trapped in ~0.1 s on a constrained sandbox but ran past 30 s on a roomier CI
+// runner). Throwing the kernel's exact message string from sandbox code flows
+// through the identical path — caught in the engine's run() try/catch, returned
+// as an `execute_result` error, classified by isFatalWasmFault, and recycled —
+// so this faithfully and deterministically exercises the recovery wiring.
 test.describe('engine WASM fault recovery', () => {
-  test('fatal memory fault recovers on the next run', async ({ page }) => {
+  test('a fatal WASM fault is classified, recycles the Worker, and recovers', async ({ page }) => {
+    const recycleLogs: string[] = [];
+    page.on('console', (m) => {
+      const t = m.text();
+      if (/Recycling geometry Worker after fatal WASM fault/i.test(t)) recycleLogs.push(t);
+    });
+
     await page.goto('/editor');
     await page.waitForFunction(
       () => !!(window as unknown as { partwright?: { runIsolated?: unknown } }).partwright?.runIsolated,
@@ -27,15 +42,17 @@ test.describe('engine WASM fault recovery', () => {
     // 1) Baseline: a normal model runs fine.
     expect((await run(cube)).status).toBe('ok');
 
-    // 2) Force a WASM memory fault: an absurd circular-segment count makes the
-    //    kernel try to allocate billions of vertices, tripping the heap ceiling.
-    const fault = await run('return api.Manifold.sphere(10, 100000);');
+    // 2) A fatal WASM-memory fault surfaces as an error with the actionable,
+    //    memory-aware hint (instead of the raw, opaque trap text).
+    const fault = await run("throw new Error('memory access out of bounds');");
     expect(fault.status).toBe('error');
-    // The opaque trap text is replaced with an actionable, memory-aware hint.
     expect(fault.error).toMatch(/ran out of memory/i);
 
-    // 3) Recovery: the same baseline model must run again. Pre-fix this failed
-    //    instantly with the same memory error (the poisoned-worker cascade).
+    // 3) The engine must have recycled the poisoned Worker. This log fires only
+    //    when the recovery wiring runs — it is absent on pre-fix code.
+    await expect.poll(() => recycleLogs.length, { timeout: 5000 }).toBeGreaterThan(0);
+
+    // 4) Recovery: the same baseline model runs again on the fresh module.
     expect((await run(cube)).status).toBe('ok');
   });
 });

--- a/tests/unit/engineMemory.test.ts
+++ b/tests/unit/engineMemory.test.ts
@@ -1,0 +1,33 @@
+// Unit tests for the engine WASM heap formatting helpers. Pure logic → fast
+// Node tier.
+
+import { describe, test, expect } from 'vitest';
+import { WASM_HEAP_MAX_BYTES, formatEngineMemory } from '../../src/geometry/engineMemory';
+
+describe('WASM_HEAP_MAX_BYTES', () => {
+  test('matches manifold-3d\'s compiled getHeapMax() (4 GiB − 64 KiB page)', () => {
+    expect(WASM_HEAP_MAX_BYTES).toBe(4294901760);
+    // ~4096 MB.
+    expect(Math.round(WASM_HEAP_MAX_BYTES / (1024 * 1024))).toBe(4096);
+  });
+});
+
+describe('formatEngineMemory', () => {
+  test('reports MB used, the ceiling, and a percentage', () => {
+    expect(formatEngineMemory(1850 * 1024 * 1024)).toBe('1850 MB / 4096 MB (45%)');
+  });
+
+  test('a fault far below the ceiling reads as a low percentage', () => {
+    // The fragmentation case: only ~1.2 GB in use when the grow failed.
+    const s = formatEngineMemory(1200 * 1024 * 1024);
+    expect(s).toMatch(/^1200 MB \/ 4096 MB \(29%\)$/);
+  });
+
+  test('the boot heap (16 MB) is ~0%', () => {
+    expect(formatEngineMemory(16 * 1024 * 1024)).toBe('16 MB / 4096 MB (0%)');
+  });
+
+  test('full ceiling reads as 100%', () => {
+    expect(formatEngineMemory(WASM_HEAP_MAX_BYTES)).toBe('4096 MB / 4096 MB (100%)');
+  });
+});

--- a/tests/unit/workerFaults.test.ts
+++ b/tests/unit/workerFaults.test.ts
@@ -1,0 +1,66 @@
+// Unit tests for the fatal-WASM-fault classifier. The module is intentionally
+// dependency-free (pure string matching) so it runs in the fast Node tier and
+// can be shared by the main-thread engine client and the sandbox engine.
+
+import { describe, test, expect } from 'vitest';
+import { isFatalWasmFault, isWasmMemoryFault, wasmFaultHint } from '../../src/geometry/workerFaults';
+
+describe('isFatalWasmFault', () => {
+  test('flags the manifold-3d OOM trap', () => {
+    // The exact message from the chain-at-100-links session.
+    expect(isFatalWasmFault('memory access out of bounds')).toBe(true);
+  });
+
+  test('flags other Emscripten heap/abort traps', () => {
+    expect(isFatalWasmFault('Cannot enlarge memory arrays')).toBe(true);
+    expect(isFatalWasmFault('out of memory')).toBe(true);
+    expect(isFatalWasmFault('table index is out of bounds')).toBe(true);
+    expect(isFatalWasmFault('null function or function signature mismatch')).toBe(true);
+    expect(isFatalWasmFault('unreachable')).toBe(true);
+    expect(isFatalWasmFault('Aborted(OOM)')).toBe(true);
+  });
+
+  test('is case-insensitive', () => {
+    expect(isFatalWasmFault('Memory Access Out Of Bounds')).toBe(true);
+  });
+
+  test('does NOT flag ordinary user errors that leave the kernel healthy', () => {
+    expect(isFatalWasmFault('Code must return a Manifold object.')).toBe(false);
+    expect(isFatalWasmFault('function _Cylinder called with 2 arguments, expected 3')).toBe(false);
+    expect(isFatalWasmFault('Missing field: "x"')).toBe(false);
+    expect(isFatalWasmFault('sweep requires a path with at least 2 points')).toBe(false);
+    expect(isFatalWasmFault('')).toBe(false);
+    expect(isFatalWasmFault(null)).toBe(false);
+    expect(isFatalWasmFault(undefined)).toBe(false);
+  });
+});
+
+describe('isWasmMemoryFault', () => {
+  test('distinguishes memory exhaustion from a generic abort', () => {
+    expect(isWasmMemoryFault('memory access out of bounds')).toBe(true);
+    expect(isWasmMemoryFault('out of memory')).toBe(true);
+    // A bare `unreachable` abort is fatal but not specifically a memory fault.
+    expect(isWasmMemoryFault('unreachable')).toBe(false);
+    expect(isWasmMemoryFault('Code must return a Manifold object.')).toBe(false);
+  });
+});
+
+describe('wasmFaultHint', () => {
+  test('memory faults get the "reduce complexity" mitigation', () => {
+    const hint = wasmFaultHint('memory access out of bounds');
+    expect(hint).toBeDefined();
+    expect(hint).toMatch(/ran out of memory/i);
+    expect(hint).toMatch(/circular-segment|fewer parts|simplif/i);
+  });
+
+  test('non-memory fatal faults get the generic reset hint', () => {
+    const hint = wasmFaultHint('unreachable');
+    expect(hint).toBeDefined();
+    expect(hint).toMatch(/reset/i);
+  });
+
+  test('returns undefined for ordinary user errors', () => {
+    expect(wasmFaultHint('Code must return a Manifold object.')).toBeUndefined();
+    expect(wasmFaultHint(null)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Investigated a user report: an AI-built parameterized chain failed with **`memory access out of bounds` · source: engine · No stack trace or origin captured** when scaled to 100 links (the session JSON's v3 showed `executionTimeMs: 1`). The bug is pre-existing on `main`/`staging`. This PR makes the engine recover gracefully **and** adds a memory readout so users can see how close a run came to the ceiling.

### Root cause
`memory access out of bounds` is a `WebAssembly.RuntimeError` trap from the manifold-3d kernel — the model exceeding the WASM linear heap (which only ever grows). The deeper, reproducible defect: the long-lived geometry Worker was **never recycled** after such a trap. A trap can leave the kernel's C++ state half-mutated, so every *subsequent* run — even a trivial cube — faulted instantly with the same error (the `executionTimeMs: 1` tell) until the page was reloaded. Proven in a browser: with the recycle disabled, run-3 (a cube) fails with the same OOM; with it, run-3 succeeds.

### Changes

**Recovery + messaging**
- **`src/geometry/workerFaults.ts`** (new, pure → unit tier): `isFatalWasmFault()` classifier + `wasmFaultHint()` actionable, memory-aware message.
- **`src/geometry/engine.ts`**: recycle the Worker after a fatal-WASM-fault result so the next run boots a clean module — the cascade fix.
- **`src/geometry/engines/manifoldJs.ts`**: the OOM message matched none of the existing hint patterns and passed through raw; now it gets the memory-aware hint.
- **`src/main.ts`**: attach diagnostics/language/timing as the engine error-log detail (was "No stack trace or origin captured").

**Engine memory diagnostics** (answering "did I *really* hit 4 GB?")
- "memory access out of bounds" frequently trips **below** 4 GB — growing the heap needs a single contiguous `ArrayBuffer`, which address-space fragmentation / per-tab limits can block at ~1–2 GB.
- **`src/geometry/engineMemory.ts`** (new, pure → unit tier): `WASM_HEAP_MAX_BYTES` (= manifold's compiled `getHeapMax()`, 4 GiB − 64 KiB) + `formatEngineMemory` → `"1850 MB / 4096 MB (45%)"`. The % of the ceiling is the tell: a fault at a low % means a fragmentation failure, not true exhaustion.
- **`engineWorker.ts`**: reads the manifold-js heap high-water (`HEAPU8.byteLength`, monotonic) and reports `engineHeapBytes` on success and error.
- **`main.ts`**: surfaces it in the **Data panel** every run (watch it climb), in the **engine-error diagnostic-log detail** (how far memory grew on an OOM), and in `executeIsolated` stats (so the AI agent's `runIsolated` sees it too).

### Why no "just raise the limit"
Confirmed from the prebuilt `manifold-3d@3.3.2`: it already ships at the **wasm32 hard maximum** — `getHeapMax() = 4294901760` (~4 GB), memory section max `65536 pages`, growth already enabled, and the memory is module-internal so there's no factory flag to override. Past 4 GB needs a wasm64 rebuild of manifold (not a config change). So graceful handling + a memory readout is the correct response.

### Test plan
- `npm run test:unit` — green (new `workerFaults.test.ts`, `engineMemory.test.ts`).
- `npm run build`, `lint:deps`, `lint:deadcode` — green.
- `tests/engine-wasm-fault-recovery.spec.ts` (e2e): simulates the kernel's exact trap message (deterministic, ~6 s — a real OOM is a CPU grind whose timing depends on host memory) → asserts the hint, that the Worker recycle fires (**verified to fail on pre-fix code**), the `"N MB / 4096 MB (P%)"` readout, and that the next run recovers.

### For the user's chain
100 links is genuinely near the ceiling, so it may still OOM on a memory-constrained machine — but now it fails with an actionable message, the session stays usable, and the Data panel shows the actual heap high-water. Mitigations: fewer links, lower Quality / `setCircularSegments`, or simplifying the link sweep.

https://claude.ai/code/session_012vu4fb8vrZQGo3UAcydimQ