### PR TITLE
fix: clear autosaved draft on save and warn when saving error-state code

### DIFF
--- a/prompts/20260604-151533-save-clears-draft-and-error-toast.md
+++ b/prompts/20260604-151533-save-clears-draft-and-error-toast.md
@@ -1,0 +1,73 @@
+---
+session: "brave-hawking"
+timestamp: "2026-06-04T15:15:33Z"
+model: claude-opus-4-8
+tools: [explore-subagent, playwright]
+---
+
+## Human
+
+Reported a bug from a session with the in-app AI. Two issues:
+
+1. After saving a new version and refreshing the page, the editor showed
+   stale draft code instead of the just-saved version. The user expected
+   that clicking Save (or saving via the API) clears the draft history so a
+   refresh loads the saved version — but the draft "survived and got used on
+   refresh." (The in-app AI had earlier claimed the Save button is "disabled
+   whenever the active model has an error" — that explanation turned out to be
+   a hallucination; no such logic exists.)
+
+2. The user wants Save to work even when the code has a validation error, but
+   to show a warning toast that the saved version contains errors.
+
+## Assistant
+
+## Key decisions
+
+**Root cause of the refresh bug (issue 1).** Drafts are autosaved per
+`(session, part, language)` and restored on load by `restoreDraftIfNewer`,
+which restores the draft whenever it differs from the loaded version's code.
+Nothing ever deleted the draft after a version was saved. The failure mode:
+when a *non-editor* path commits a new version — e.g. the AI tools load fixed
+code via a programmatic `setValue` (which doesn't trigger the input-driven
+autosave) and then call `saveVersion` — the IndexedDB draft still holds the
+OLD code. On reload, draft ≠ saved version, so the stale draft shadows the
+fresh save. Confirmed this is the exact mechanism via an explore subagent.
+
+**Fix: clear the draft inside `saveVersion`, not at the call sites.** Every
+save path (UI button, ⌘S, `window.partwright.saveVersion`, `runAndSave`,
+`forkVersion`, AI tools) funnels through `saveVersion` in `sessionManager.ts`,
+so deleting the now-superseded draft there fixes all of them at once. Added a
+single-key `deleteDraft(sessionId, language, partId)` to `db.ts` (the existing
+`deletePartDrafts` deletes *all* languages for a part, which would discard
+unsaved work in a language the user merely switched away from — too broad).
+Delete only the active-language draft, keyed by `version.language ??
+getActiveLanguage()` so it matches the key the autosave/restore path uses.
+Best-effort with try/catch: the version is already committed, so a draft-delete
+failure must not fail the save. Captured `sessionId`/`partId` before the
+`currentState` reassignment because that reassignment resets TS null-narrowing.
+
+**Issue 2: saving is already allowed with errors — the missing piece was the
+warning.** There was never any error-gating on Save (the AI's claim was
+wrong); a broken model already saves with `geometryData.status === 'error'`.
+So the only real change needed was feedback. Kept the toast in the UI layer
+(`sessionBar.ts` button handler + `saveVersionWithToast` for ⌘S/command
+palette) rather than in `saveVersion` — `sessionManager.ts` is storage-layer
+and has no UI imports; routing toasts through it would break that layering.
+Added three outcomes so a Save click is never a silent no-op: neutral "No
+changes to save" when `saveVersion` returns null (the dedup case, which
+previously looked like a dead button and is the likely real cause of the
+user's "I can't click Save"), amber warn when the saved model has errors, and
+green success otherwise.
+
+**What I skipped.** Did not add an error-status warning to every internal
+`saveVersion` caller (import/merge/relief flows) — those are not the
+user-driven "Save" surfaces the request was about, and they have their own
+established toasts.
+
+**Verification.** Added an e2e regression test in `autosave.spec.ts` that
+autosaves a stale draft, commits a different version via the API, reloads, and
+asserts the editor shows the saved code (not the stale draft). Confirmed it
+genuinely fails when the `deleteDraft` line is removed. Manually exercised the
+warning toast in a real browser (scratch spec + screenshot) and posted it.
+Build + unit (598) + the autosave e2e all green.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3984,6 +3984,10 @@ async function main() {
       showToast(result.error, { variant: 'warn' });
     } else if ('skipped' in result) {
       showToast('No changes to save', { variant: 'neutral' });
+    } else if (getGeometryDataObj()?.status === 'error') {
+      // Checkpointing a broken model is allowed, but warn that this version
+      // won't render correctly so the save isn't mistaken for a clean one.
+      showToast(`Saved v${result.index}${result.label ? ` — ${result.label}` : ''}, but the model has errors and won't render correctly`, { variant: 'warn' });
     } else {
       showToast(`Saved v${result.index}${result.label ? ` — ${result.label}` : ''}`, { variant: 'success' });
     }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1027,6 +1027,15 @@ export async function listDrafts(sessionId: string): Promise<SessionDraft[]> {
   return reqToPromise(index.getAll(IDBKeyRange.only(sessionId))) as Promise<SessionDraft[]>;
 }
 
+/** Delete the working buffer for a single (session, part, language) triple.
+ *  Called after a version is saved so a now-superseded draft can't shadow the
+ *  freshly-saved code on the next reload. No-ops when no such draft exists. */
+export async function deleteDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', partId?: string): Promise<void> {
+  const store = await tx('drafts', 'readwrite');
+  store.delete(draftId(sessionId, language, partId));
+  await txComplete(store.transaction);
+}
+
 /** Delete all per-part drafts for a given part. Called when a part is removed
  *  so its stashed buffers don't accumulate. */
 export async function deletePartDrafts(sessionId: string, partId: string): Promise<void> {

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -31,6 +31,7 @@ import {
   updateNote as dbUpdateNote,
   getDraft as dbGetDraft,
   setDraft as dbSetDraft,
+  deleteDraft as dbDeleteDraft,
   deletePartDrafts as dbDeletePartDrafts,
   legacyImagesObjectToArray,
   generateId,
@@ -924,6 +925,8 @@ export async function saveVersion(
   },
 ): Promise<Version | null> {
   if (!currentState.session || !currentState.currentPart) return null;
+  const sessionId = currentState.session.id;
+  const partId = currentState.currentPart.id;
 
   const annotationSnapshot = serializeAnnotations();
   const paramValues = options?.paramValues;
@@ -981,6 +984,16 @@ export async function saveVersion(
     currentVersion: version,
     versionCount: currentState.versionCount + 1,
   };
+  // The saved code is now the tip, so any autosaved draft for this
+  // (session, part, language) is superseded. Clear it — otherwise a stale
+  // draft (e.g. one left behind when a *different* code path, like the AI
+  // tools, commits a new version without touching the editor buffer) would
+  // shadow the freshly-saved version on the next reload via
+  // restoreDraftIfNewer. Best-effort: a draft-delete failure must not fail
+  // the save itself, since the version is already committed.
+  try {
+    await dbDeleteDraft(sessionId, version.language ?? getActiveLanguage(), partId);
+  } catch { /* the version saved; a lingering draft is recoverable, not fatal */ }
   setActiveImports((version.importedMeshes ?? []) as ImportedMesh[]);
   setCompanionFiles(version.companionFiles ?? {});
   updateURL();

--- a/src/ui/sessionBar.ts
+++ b/src/ui/sessionBar.ts
@@ -182,7 +182,7 @@ function render(state: SessionState) {
       const data = await callbacks.onSaveVersion();
       const label = `v${state.versionCount + 1}`;
       const force = colorRegionsDiffer(state.currentVersion?.geometryData, data.geometryData);
-      await saveVersion(
+      const version = await saveVersion(
         data.code,
         data.geometryData,
         data.thumbnail,
@@ -190,6 +190,18 @@ function render(state: SessionState) {
         undefined,
         force ? { force: true } : undefined,
       );
+      // Feedback so the click is never a silent no-op. saveVersion returns null
+      // when nothing changed (code + annotations + colors identical to the tip),
+      // which previously looked like a dead button.
+      if (!version) {
+        showToast('No changes to save since the last version.', { variant: 'neutral' });
+      } else if ((data.geometryData as { status?: unknown } | null)?.status === 'error') {
+        // Saving a broken model is allowed — the user may want to checkpoint
+        // work-in-progress — but warn that this version won't render correctly.
+        showToast(`Saved ${version.label || label} — but the model has errors and won't render correctly.`, { variant: 'warn' });
+      } else {
+        showToast(`Saved ${version.label || label}.`, { variant: 'success' });
+      }
     } catch (err) {
       // A failed save must not be silent \u2014 surface it so the user knows their
       // painted/edited state wasn't captured (rather than assume it saved).

--- a/tests/autosave.spec.ts
+++ b/tests/autosave.spec.ts
@@ -32,6 +32,8 @@ async function replaceEditorWith(page: Page, text: string) {
 const SAVED = 'const { Manifold } = api; return Manifold.cube([10, 10, 10], true);';
 // A distinctive draft that is NOT saved as a version.
 const DRAFT = 'const { Manifold } = api; return Manifold.sphere(7, 32); // DRAFT-MARKER-42';
+// A distinctive *saved* version committed after the draft was autosaved.
+const FIXED = 'const { Manifold } = api; return Manifold.cylinder(8, 4); // FIXED-MARKER-99';
 
 test.describe('editor autosave', () => {
   test('restores an autosaved draft after a reload', async ({ page }) => {
@@ -74,5 +76,56 @@ test.describe('editor autosave', () => {
 
     // The editor should show the DRAFT, not the saved v1 code.
     await expect(page.locator('.cm-content')).toContainText('DRAFT-MARKER-42', { timeout: 10_000 });
+  });
+
+  // Regression: saving a new version must clear the now-superseded autosaved
+  // draft. Otherwise a stale draft (e.g. one left behind when the AI tools or
+  // any non-editor path commit a fresh version) shadows the just-saved code on
+  // the next reload — the user saves, refreshes, and sees the OLD code.
+  test('clears the autosaved draft after saving a new version', async ({ page }) => {
+    await openEditor(page);
+
+    const sessionId = await page.evaluate(async (code) => {
+      const pw = (window as unknown as { partwright: {
+        createSession: (n?: string) => Promise<unknown>;
+        runAndSave: (c: string, l?: string) => Promise<unknown>;
+      } }).partwright;
+      await pw.createSession('save-clears-draft-test');
+      await pw.runAndSave(code, 'v1');
+      return new URLSearchParams(window.location.search).get('session');
+    }, SAVED);
+    expect(sessionId).toBeTruthy();
+
+    // Autosave a stale draft (NOT committed as a version) exactly as the first
+    // test does — proving a draft is sitting in IndexedDB that *would* restore.
+    await replaceEditorWith(page, DRAFT);
+    await page.waitForTimeout(1100);
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.waitForTimeout(300);
+
+    // Now commit a *different* corrected version through the API (mirrors the AI
+    // loading fixed code and saving it). This should delete the stale draft.
+    await page.evaluate(async (code) => {
+      const pw = (window as unknown as { partwright: {
+        runAndSave: (c: string, l?: string) => Promise<unknown>;
+      } }).partwright;
+      await pw.runAndSave(code, 'v2-fixed');
+    }, FIXED);
+
+    // Reload WITHOUT a further idle/visibility autosave, so only a surviving
+    // draft could shadow the saved version.
+    await page.reload();
+    await page.waitForSelector('text=Ready', { timeout: 20_000 });
+    await page.waitForFunction(
+      () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+      { timeout: 20_000 },
+    );
+
+    // The editor must show the saved FIXED code — the stale DRAFT must be gone.
+    await expect(page.locator('.cm-content')).toContainText('FIXED-MARKER-99', { timeout: 10_000 });
+    await expect(page.locator('.cm-content')).not.toContainText('DRAFT-MARKER-42');
   });
 });


### PR DESCRIPTION
## Summary

Fixes two issues reported from an in-app AI session:

1. **Stale draft survived a save + refresh.** Editor drafts are autosaved per `(session, part, language)` and restored on load by `restoreDraftIfNewer` whenever the draft differs from the loaded version's code. Nothing ever deleted the draft after a version was saved. The failure mode: when a **non-editor** path commits a new version — e.g. the AI tools load fixed code via a programmatic `setValue` (which doesn't fire the input-driven autosave) and then call `saveVersion` — the IndexedDB draft still holds the **old** code. On reload, draft ≠ saved version, so the stale draft shadows the fresh save. The user saved, refreshed, and saw the old code.

   **Fix:** `saveVersion` now deletes the now-superseded draft for the saved `(session, part, language)`. Every save path (Save button, ⌘S, `window.partwright.saveVersion`, `runAndSave`, `forkVersion`, AI tools) funnels through `saveVersion`, so this covers all of them. Added a single-key `deleteDraft(...)` to `db.ts` (the existing `deletePartDrafts` deletes *all* languages for a part — too broad). Best-effort: a draft-delete failure can't fail an already-committed save.

2. **Save now warns instead of silently saving broken code.** Saving an error-state model was already allowed (there is no error-gating on Save — the AI's earlier claim that the button is "disabled on error" was a hallucination). The missing piece was feedback. The Save button and the ⌘S/command-palette path now show:
   - amber **warning toast** when the saved model has errors ("Saved v_n — but the model has errors and won't render correctly"),
   - neutral "No changes to save" on a code-identical no-op (previously this looked like a dead button — likely the real cause of the reported "I can't click Save"),
   - green success otherwise.

## Test plan

- `npm run build` ✅ (type-check)
- `npm run test:unit` ✅ (598 passing)
- `npm run lint:deps` ✅ (no circular deps)
- New e2e regression in `tests/autosave.spec.ts`: autosaves a stale draft, commits a different version via the API, reloads, and asserts the editor shows the saved code (not the stale draft). **Confirmed it fails when the `deleteDraft` line is removed.** ✅
- Existing autosave restore test still passes ✅
- Manually verified the warning toast in a real browser (screenshot posted in the session) ✅

https://claude.ai/code/session_01EYyEkDyniDYEmTAWSeYzxy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYyEkDyniDYEmTAWSeYzxy)_