### PR TITLE
feat: let Customizer number fields exceed declared min/max

### DIFF
--- a/prompts/20260604-020000-customizer-exceed-min-max.md
+++ b/prompts/20260604-020000-customizer-exceed-min-max.md
@@ -1,0 +1,47 @@
+---
+date: 2026-06-04
+branch: claude/dreamy-euler-HvCh2
+files_changed:
+  - src/geometry/params.ts
+  - src/ui/paramsPanel.ts
+  - tests/customizer.spec.ts
+  - tests/unit/params.test.ts
+  - tests/unit/scadParams.test.ts
+---
+
+## Human
+
+In the customize menu, I'd like to be able to exceed the min or max value by
+typing in a custom value into the text input part of each parameter.
+
+## Assistant
+
+The Customizer's number field already forwarded the raw typed value, but the
+authoritative clamp in `coerceParamValue` (params.ts) snapped any override back
+inside `spec.min`/`spec.max`, and `setValue` then reconciled the UI to the
+clamped result — so typing past a bound was silently undone. That clamp is the
+single chokepoint every engine shares (manifold-js/voxel via `createParamCapture`,
+and SCAD via `scadParams.ts`'s `buildScadDefines`), so relaxing it there fixes
+all paths at once.
+
+Decisions:
+
+- **Stop clamping numeric *overrides*** in `coerceParamValue` — honor any finite
+  value (still reject non-finite, still round ints). The min/max bounds remain
+  meaningful as the *slider's* convenient range; the number field is the escape
+  hatch. Default normalization in `normalizeParamSchema` still clamps the
+  author-declared `default` so a sloppy default stays coherent.
+- **Dropped the `min`/`max` HTML attributes on the number `<input>`** so the
+  field (and its spinner arrows) isn't capped or marked `:invalid` when the user
+  exceeds a bound.
+- **Grow the slider's range to contain an out-of-range value** (new `reflect()`
+  helper used by commit, slider-change, and the post-run `setValue`). Without
+  this the thumb would pin misleadingly at an edge while the field showed e.g.
+  250; now the thumb tracks the true value, and dragging back into the declared
+  range restores the original scale.
+
+Updated the two unit tests that asserted override-clamping (params + scadParams)
+to assert the value is now honored, added a `resolveParamValues` test for values
+beyond both min and max, and added a customizer e2e test that types 250 into a
+max:100 field and asserts the model re-runs to 250 with a grown slider. Verified
+in-browser with a throwaway spec: a cube re-rendered at 250 from a max:100 Width.

--- a/prompts/20260604-020000-customizer-exceed-min-max.md
+++ b/prompts/20260604-020000-customizer-exceed-min-max.md
@@ -4,6 +4,9 @@ branch: claude/dreamy-euler-HvCh2
 files_changed:
   - src/geometry/params.ts
   - src/ui/paramsPanel.ts
+  - src/ai/tools.ts
+  - src/main.ts
+  - src/storage/sessionManager.ts
   - tests/customizer.spec.ts
   - tests/unit/params.test.ts
   - tests/unit/scadParams.test.ts
@@ -45,3 +48,8 @@ to assert the value is now honored, added a `resolveParamValues` test for values
 beyond both min and max, and added a customizer e2e test that types 250 into a
 max:100 field and asserts the model re-runs to 250 with a grown slider. Verified
 in-browser with a throwaway spec: a cube re-rendered at 250 from a max:100 Width.
+
+Follow-up after a `work-reviewer` pass (no blocking issues): synced three stale
+"out-of-range values are clamped" docs to the new behavior — the `setParams` AI
+tool description (`src/ai/tools.ts`), the `setParams` JSDoc (`src/main.ts`), and
+the version-load comment in `src/storage/sessionManager.ts`.

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -81,7 +81,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'setParams',
-    description: 'Tweak one or more Customizer parameters and re-run the model — the same effect as the user dragging the Parameters panel\'s sliders, but driven from code. Pass an object of `{ paramKey: value }`. Out-of-range or wrong-type values are clamped / fall back to the default (never errors on a bad value); unknown keys are ignored. Returns the updated geometry stats and resolved parameter values. Prefer this over rewriting the code when you only need to change a declared dimension/option — it\'s cheaper and preserves the model. Errors only if the model declares no parameters.',
+    description: 'Tweak one or more Customizer parameters and re-run the model — the same effect as the user dragging the Parameters panel\'s sliders, but driven from code. Pass an object of `{ paramKey: value }`. A numeric value beyond the declared min/max is honored as typed (the bounds only size the slider — they don\'t clamp); only wrong-type/unparseable values fall back to the default (never errors on a bad value); unknown keys are ignored. Returns the updated geometry stats and resolved parameter values. Prefer this over rewriting the code when you only need to change a declared dimension/option — it\'s cheaper and preserves the model. Errors only if the model declares no parameters.',
     input_schema: {
       type: 'object',
       properties: {

--- a/src/geometry/params.ts
+++ b/src/geometry/params.ts
@@ -190,17 +190,21 @@ function clamp(v: number, min?: number, max?: number): number {
 
 /** Coerce one override value against its spec, or return undefined if the value
  *  can't be made valid (caller falls back to the default). Lenient by design:
- *  overrides come from persisted UI state / tool calls, not author code, so a
- *  stale or out-of-range value should degrade to the default, never throw. */
+ *  overrides come from persisted UI state / tool calls, not author code, so an
+ *  unparseable value degrades to the default rather than throwing. Numeric
+ *  overrides are honored as-is even outside spec.min/max — the slider bounds are
+ *  a convenience, and the number field intentionally allows exceeding them. */
 export function coerceParamValue(spec: ParamSpec, value: unknown): ParamValue | undefined {
   switch (spec.type) {
     case 'number':
     case 'int': {
       const n = typeof value === 'number' ? value : (typeof value === 'string' ? Number(value) : NaN);
       if (!Number.isFinite(n)) return undefined;
-      let c = clamp(n, spec.min, spec.max);
-      if (spec.type === 'int') c = Math.round(c);
-      return c;
+      // Deliberately *not* clamped to spec.min/max: those bounds size the
+      // Customizer slider's convenient range, but the paired number field lets
+      // the user type an exact value beyond them (e.g. a thickness past the
+      // slider max). We only reject non-finite input and round ints here.
+      return spec.type === 'int' ? Math.round(n) : n;
     }
     case 'boolean':
       return typeof value === 'boolean' ? value : undefined;

--- a/src/main.ts
+++ b/src/main.ts
@@ -6352,7 +6352,8 @@ async function main() {
 
     /** Set one or more Customizer parameter overrides and re-run the model —
      *  the language-based equivalent of dragging the panel's sliders. Unknown
-     *  keys are ignored and out-of-range / wrong-type values are clamped or
+     *  keys are ignored; a numeric value beyond the declared min/max is honored
+     *  as typed (the bounds only size the slider), and only wrong-type values
      *  fall back to the declared default (never throws on a bad value). Returns
      *  the updated geometry data plus the resolved parameter values, or
      *  `{ error }` if the model declares no parameters. */

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -1747,8 +1747,9 @@ export async function importSession(
         asLanguage(v.language),
         // Customizer parameter overrides (schema 1.9+). Pre-1.9 files omit it;
         // the version then runs at the model's declared defaults. Validation of
-        // the values against the model's schema happens at run time (coerced /
-        // clamped in resolveParamValues), so a stale value can't break a load.
+        // the values against the model's schema happens at run time (coerced in
+        // resolveParamValues — numerics honored as-is, non-numerics validated),
+        // so a stale value can't break a load.
         v.paramValues && typeof v.paramValues === 'object' ? v.paramValues : undefined,
         // Companion SCAD files (schema 1.10+). Pre-1.10 files omit this field;
         // those versions import with no companions, which is correct for all

--- a/src/ui/paramsPanel.ts
+++ b/src/ui/paramsPanel.ts
@@ -239,11 +239,10 @@ function buildWidget(spec: ParamSpec, onChange: (key: string, value: ParamValue)
     numInput.type = 'number';
     // Narrow, mono, right-aligned — reads like the old readout but is editable.
     numInput.className = 'w-16 text-[11px] font-mono tabular-nums text-right text-zinc-200 bg-zinc-800 border border-zinc-600 rounded px-1 py-0.5 focus:border-blue-400 focus:outline-none';
-    // Only constrain the field by limits the author declared, so an undeclared
-    // bound doesn't silently clamp a typed value (the slider keeps its own
-    // synthesized range for the thumb).
-    if (spec.min !== undefined) numInput.min = String(spec.min);
-    if (spec.max !== undefined) numInput.max = String(spec.max);
+    // The field is intentionally *unconstrained* — no min/max attributes — so
+    // the user can type (and spinner-step) a value beyond the author's declared
+    // bounds. min/max only size the slider's convenient range; params.ts honors
+    // an out-of-range typed value rather than clamping it.
     numInput.step = String(step);
     labelRow.appendChild(numInput);
     row.appendChild(labelRow);
@@ -254,10 +253,22 @@ function buildWidget(spec: ParamSpec, onChange: (key: string, value: ParamValue)
     slider.min = String(min);
     slider.max = String(max);
     slider.step = String(step);
+
+    // Push a value into both controls. When it falls outside the declared
+    // [min, max] (a typed/persisted override that exceeds the slider's range),
+    // grow the slider's bounds to include it so the thumb tracks the true value
+    // instead of pinning at an edge; values inside the range restore it.
+    const reflect = (n: number) => {
+      slider.min = String(Math.min(min, n));
+      slider.max = String(Math.max(max, n));
+      slider.value = String(n);
+      numInput.value = String(n);
+    };
+
     slider.addEventListener('input', () => { numInput.value = slider.value; });
     slider.addEventListener('change', () => {
       const n = isInt ? Math.round(Number(slider.value)) : Number(slider.value);
-      numInput.value = String(n);
+      reflect(n);
       onChange(spec.key, n);
     });
     row.appendChild(slider);
@@ -270,11 +281,7 @@ function buildWidget(spec: ParamSpec, onChange: (key: string, value: ParamValue)
         return;
       }
       const n = isInt ? Math.round(raw) : raw;
-      // Reflect the typed value on the slider thumb (the browser clamps it into
-      // the slider's range; the field keeps the true value). The post-run
-      // sync via setValue will reconcile both to params.ts's coerced result.
-      slider.value = String(n);
-      if (isInt) numInput.value = String(n);
+      reflect(n);
       onChange(spec.key, n);
     };
     numInput.addEventListener('change', commitField);
@@ -283,8 +290,7 @@ function buildWidget(spec: ParamSpec, onChange: (key: string, value: ParamValue)
 
     setValue = (v) => {
       const n = typeof v === 'number' ? v : Number(v);
-      slider.value = String(n);
-      numInput.value = String(n);
+      reflect(n);
     };
   } else if (spec.type === 'boolean') {
     const wrap = document.createElement('div');

--- a/tests/customizer.spec.ts
+++ b/tests/customizer.spec.ts
@@ -125,6 +125,33 @@ test.describe('Customizer parameters', () => {
     expect(Number(sliderVal)).toBeCloseTo(47, 0);
   });
 
+  test('typing past the declared max keeps the exact value and grows the slider', async ({ page }) => {
+    await page.evaluate((code) => (window as unknown as { partwright: PW }).partwright.run(code), PARAM_MODEL);
+    await expect(page.locator('#params-panel')).toBeVisible();
+
+    // Width is declared max:100 — type 250 and commit. The model must re-run to
+    // the exact typed dimension rather than clamping back to 100.
+    await page.evaluate(() => {
+      const panel = document.getElementById('params-panel')!;
+      const field = panel.querySelector('input[type="number"]') as HTMLInputElement; // first = width
+      field.value = '250';
+      field.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await expect.poll(() => currentXDim(page)).toBeCloseTo(250, 0);
+
+    // Both controls reflect the out-of-range value: the field shows 250 and the
+    // slider grew its range so the thumb tracks it instead of pinning at 100.
+    const state = await page.evaluate(() => {
+      const panel = document.getElementById('params-panel')!;
+      const field = panel.querySelector('input[type="number"]') as HTMLInputElement;
+      const slider = panel.querySelector('input[type="range"]') as HTMLInputElement;
+      return { field: field.value, sliderVal: slider.value, sliderMax: slider.max };
+    });
+    expect(Number(state.field)).toBeCloseTo(250, 0);
+    expect(Number(state.sliderVal)).toBeCloseTo(250, 0);
+    expect(Number(state.sliderMax)).toBeGreaterThanOrEqual(250);
+  });
+
   test('parameters work in a voxel session (engine-agnostic)', async ({ page }) => {
     const VOXEL_PARAM_MODEL = `
 const p = api.params({ size: { type: 'int', default: 4, min: 1, max: 20, label: 'Size' } });

--- a/tests/unit/params.test.ts
+++ b/tests/unit/params.test.ts
@@ -77,12 +77,21 @@ describe('resolveParamValues', () => {
     });
   });
 
-  it('applies valid overrides and clamps/rounds/truncates as needed', () => {
+  it('applies valid overrides, rounding ints and truncating text (numbers are not clamped)', () => {
     expect(resolveParamValues(schema, {
       width: 999, rows: 3.6, rounded: false, style: 'beveled', title: 'ABCDEFG', accent: '#ABCDEF',
     })).toEqual({
-      width: 120, rows: 4, rounded: false, style: 'beveled', title: 'ABCD', accent: '#abcdef',
+      // width keeps the typed value past its max — the field lets you exceed the
+      // slider's range; only ints round and text truncates.
+      width: 999, rows: 4, rounded: false, style: 'beveled', title: 'ABCD', accent: '#abcdef',
     });
+  });
+
+  it('honors a number/int override beyond the declared min or max', () => {
+    expect(resolveParamValues(schema, { width: 999 }).width).toBe(999);
+    expect(resolveParamValues(schema, { width: -50 }).width).toBe(-50);
+    // ints past max are still rounded but not clamped.
+    expect(resolveParamValues(schema, { rows: 12.6 }).rows).toBe(13);
   });
 
   it('falls back to the default for invalid overrides and ignores unknown keys', () => {
@@ -179,10 +188,10 @@ describe('createParamCapture', () => {
     expect(() => (p as Record<string, unknown>).widht).toThrow(/no parameter "widht"/);
   });
 
-  it('clamps an out-of-range override to the declared limits', () => {
+  it('honors an out-of-range override beyond the declared limits', () => {
     const capture = createParamCapture({ width: 999 });
     const p = capture.params({ width: { type: 'number', default: 20, min: 10, max: 100 } });
-    expect(p.width).toBe(100);
+    expect(p.width).toBe(999);
   });
 
   it('merges schemas across multiple api.params calls (last def wins, order kept)', () => {

--- a/tests/unit/scadParams.test.ts
+++ b/tests/unit/scadParams.test.ts
@@ -129,8 +129,8 @@ describe('buildScadDefines — override flags', () => {
     expect(args).toEqual([]);
   });
 
-  it('clamps out-of-range numeric overrides before emitting', () => {
-    expect(buildScadDefines(SRC, { width: 999 })).toEqual(['-D', 'width=100']);
+  it('emits out-of-range numeric overrides as-is (the field can exceed the slider range)', () => {
+    expect(buildScadDefines(SRC, { width: 999 })).toEqual(['-D', 'width=999']);
   });
 
   it('escapes quotes/backslashes in string overrides', () => {


### PR DESCRIPTION
## Summary

In the **Customize** panel, you can now type a value into a parameter's number field that **exceeds the declared `min`/`max`**. Those bounds still size the slider's convenient range, but the text field is an escape hatch for an exact value beyond it (e.g. a thickness past the slider max).

Previously the field forwarded the typed value, but the authoritative clamp in `coerceParamValue` (the single chokepoint every engine shares — manifold-js/voxel via `createParamCapture`, SCAD via `buildScadDefines`) snapped the override back inside the bounds, and the post-run UI sync then reconciled the field to the clamped result — so typing past a bound was silently undone.

## Changes

- **`src/geometry/params.ts`** — `coerceParamValue` no longer clamps numeric *overrides* to `spec.min`/`max`; it honors any finite value (still rejects non-finite, still rounds ints). Default normalization in `normalizeParamSchema` still clamps the author-declared `default` so a sloppy default stays coherent.
- **`src/ui/paramsPanel.ts`** — dropped the `min`/`max` HTML attributes on the number `<input>` so the field (and spinner arrows) isn't capped or flagged `:invalid` when exceeding a bound. Added a `reflect()` helper that **grows the slider's range** to contain an out-of-range value so the thumb tracks the true value instead of pinning at an edge; dragging back into the declared range restores the original scale.

## Test plan

- Updated the two unit tests that asserted override-clamping (`params.test.ts`, `scadParams.test.ts`) to assert the value is now honored; added a `resolveParamValues` test for values beyond both min and max.
- Added a customizer e2e test: typing `250` into a `max:100` Width field re-runs the model to 250 and grows the slider.
- `npm run build` ✅ · `npm run test:unit` ✅ (599 passing)
- Manually verified in the browser: a cube re-rendered at **250** from a `max:100` Width field, with the slider thumb tracking the out-of-range value.

https://claude.ai/code/session_019xG5MGSvvtqpnkoDDSvqDP

---
_Generated by [Claude Code](https://claude.ai/code/session_019xG5MGSvvtqpnkoDDSvqDP)_