### PR TITLE
feat: add reset-view button and zoom-out limit to the viewport

### DIFF
--- a/prompts/20260604-154358-reset-view-and-zoom-out-limit.md
+++ b/prompts/20260604-154358-reset-view-and-zoom-out-limit.md
@@ -1,0 +1,48 @@
+---
+session: "zen-cori"
+timestamp: "2026-06-04T15:43:58Z"
+model: claude-opus-4-8
+tools: [claude-code]
+---
+
+## Human
+
+I'd like a reset view button in the interactive view and a limit on how far
+away I can zoom out.
+
+## Assistant
+
+## Key decisions
+
+**Single framing path, reused.** The camera auto-frame logic was inline inside
+`updateMesh`. Rather than copy it into a new reset handler (which would drift
+out of sync the way the project's "duplicated logic" guidance warns against), I
+extracted it into a private `frameModel()` in `viewport.ts` and exported a thin
+`resetView()` that calls it. `updateMesh`'s auto-frame and the new button now go
+through the exact same code, so "reset" provably matches the framing applied
+after a fresh run.
+
+**Zoom-out limit via OrbitControls `maxDistance`, scaled to the model.** A fixed
+world-unit cap would be wrong across the app's arbitrary-scale models (a 5mm
+keychain vs an 890mm panel). I set `controls.maxDistance = maxDim *
+maxZoomOutFactor` inside `frameModel()`, re-derived every time the model is
+framed. The default framing sits at ~2.1×maxDim, so the factor (default 12)
+leaves ~6× of pull-back room before clamping — generous but bounded. It stays
+comfortably inside the existing `camera.far = maxDim * 50`, so the model never
+clips out at the limit.
+
+**Tunable, not hardcoded.** Per the repo's "no hardcoded numeric constants"
+rule, `maxZoomOutFactor` is a new `renderer` field in `appConfig.ts` with a
+default and a JSDoc, read via `getConfig()` at frame time (so a user override
+applies on the next frame), and surfaced as a `<Field>` in the advanced
+settings modal.
+
+**Discoverability.** Added a "↻ Reset View" button to the clip-controls overlay
+next to the existing view toggles, and exposed `partwright.resetView()` on the
+console API (plus its signature entry and ai.md docs) so AI agents can re-frame
+too.
+
+**Verification.** Confirmed in a real browser via a Playwright spec: a 10-unit
+cube frames at distance 20.78; wheeling out hard clamps exactly at 120
+(= 10 × 12) instead of running away; clicking Reset View returns to 20.78. Kept
+the spec as a permanent golden-path test (`tests/viewport-reset-view.spec.ts`).

--- a/public/ai.md
+++ b/public/ai.md
@@ -222,6 +222,7 @@ partwright.setDimensionsVisible(on?) // Show/hide bounding box dimensions (omit 
 partwright.areDimensionsVisible()    // Whether dimensions overlay is visible
 partwright.setOrbitLock(on?)         // Lock/unlock camera rotation (omit to toggle) -> boolean
 partwright.isOrbitLocked()           // Whether camera orbit is locked
+partwright.resetView()               // Reset camera to the default framing of the current model
 partwright.setTheme('dark'|'light')  // Set color theme
 partwright.getTheme()                // -> 'dark' or 'light'
 partwright.setAutoRun(enabled)       // Enable/disable auto-render on code edit

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -90,6 +90,10 @@ export interface AppConfig {
     gizmoSnapDurationSec: number;
     /** OrbitControls damping factor — lower is snappier, higher is smoother. */
     orbitDampingFactor: number;
+    /** Zoom-out limit as a multiple of the model's largest dimension. Caps how
+     *  far the camera can dolly back (OrbitControls maxDistance) so the model
+     *  can't shrink to a speck. Re-derived from the model size on each frame. */
+    maxZoomOutFactor: number;
     /** Ambient light intensity in the 3D viewport (0–2 range). */
     ambientLightIntensity: number;
     /** Primary directional light intensity (0–2 range). */
@@ -190,6 +194,7 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     gizmoHitRadius: 0.4,
     gizmoSnapDurationSec: 0.4,
     orbitDampingFactor: 0.1,
+    maxZoomOutFactor: 12,
     ambientLightIntensity: 0.6,
     primaryLightIntensity: 0.8,
     secondaryLightIntensity: 0.3,

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { resolveParamValues, pruneParamValues, type ParamSpec, type ParamValue } from './geometry/params';
 import { createParamsPanel, type ParamsPanelController } from './ui/paramsPanel';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
-import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange } from './renderer/viewport';
+import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange, resetView } from './renderer/viewport';
 // Side-effect import: registers the phantom/annotation/session-plane viewport
 // hooks. Must load before initViewport runs (below). See viewportSubsystems.ts.
 import './renderer/viewportSubsystems';
@@ -5668,6 +5668,7 @@ async function main() {
   });
   initMeasureToggle(clipControls);
   initOrbitLockToggle(clipControls);
+  initResetViewButton(clipControls);
 
   // Relief / Edit colors toggle in the viewport overlay — paint/simplify are
   // alongside this button so the colour palette is discoverable from the
@@ -6854,6 +6855,12 @@ async function main() {
     /** Whether camera orbit is currently locked */
     isOrbitLocked(): boolean {
       return isUserOrbitLocked();
+    },
+
+    /** Reset the camera to the default framing of the current model (same view
+     *  applied after a fresh run). */
+    resetView(): void {
+      resetView();
     },
 
     // === Theme API ===
@@ -10626,6 +10633,7 @@ async function main() {
         'areDimensionsVisible': { signature: 'areDimensionsVisible() -- Whether dimensions overlay is visible', docs: '/ai.md#viewport-controls' },
         'setOrbitLock':         { signature: 'setOrbitLock(on?) -- Lock/unlock camera rotation (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
         'isOrbitLocked':        { signature: 'isOrbitLocked() -- Whether camera orbit is locked', docs: '/ai.md#viewport-controls' },
+        'resetView':            { signature: 'resetView() -- Reset the camera to the default framing of the current model', docs: '/ai.md#viewport-controls' },
         'setTheme':             { signature: 'setTheme("dark"|"light") -- Set color theme', docs: '/ai.md#viewport-controls' },
         'getTheme':             { signature: 'getTheme() -- Current color theme', docs: '/ai.md#viewport-controls' },
         'setAutoRun':           { signature: 'setAutoRun(enabled) -- Enable/disable auto-render on edit', docs: '/ai.md#viewport-controls' },
@@ -11879,6 +11887,12 @@ async function main() {
     // (e.g. pen/text/select activate, programmatic API).
     onUserOrbitLockChange(reflect);
     reflect(isUserOrbitLocked());
+  }
+
+  function initResetViewButton(container: HTMLElement) {
+    const resetBtn = container.querySelector('#reset-view') as HTMLButtonElement;
+    if (!resetBtn) return;
+    resetBtn.addEventListener('click', () => { resetView(); });
   }
 }
 

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -393,38 +393,8 @@ export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boole
   }
 
   // Auto-frame the camera (skip when only colors changed)
-  const box = new THREE.Box3().setFromObject(meshGroup);
-
   if (!options?.skipAutoFrame) {
-    const center = box.getCenter(new THREE.Vector3());
-    const size = box.getSize(new THREE.Vector3());
-    const maxDim = Math.max(size.x, size.y, size.z);
-
-    // Update model bounds for clip slider
-    modelBounds = { min: box.min.z, max: box.max.z };
-
-    // Position grid at the bottom of the model
-    grid.position.z = box.min.z;
-
-    // Update bounding box dimension annotations
-    updateDimensionLines(box);
-
-    controls.target.copy(center);
-    camera.position.set(
-      center.x + maxDim * 1.2,
-      center.y - maxDim * 1.2,
-      center.z + maxDim * 1.2,
-    );
-    // Adapt the clip planes to the model size. With a fixed far plane a large
-    // model (e.g. scaled to ~890mm) auto-frames the camera far enough away that
-    // the geometry falls beyond the frustum and disappears; a fixed near plane
-    // would z-fight on tiny models. Scale both with the model's largest dim.
-    if (maxDim > 0) {
-      camera.near = Math.max(0.05, maxDim * 0.005);
-      camera.far = Math.max(1000, maxDim * 50);
-      camera.updateProjectionMatrix();
-    }
-    controls.update();
+    frameModel();
 
     // Update clip plane position if clipping
     if (clippingEnabled) {
@@ -434,6 +404,59 @@ export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boole
 
   needsRender = true;
   onMeshUpdate?.(meshData);
+}
+
+/** Frame the camera to the default 3/4 view of the current model and refresh
+ *  everything derived from its bounds: clip-slider range, grid height, dimension
+ *  annotations, near/far planes, and the zoom-out (maxDistance) limit. Shared by
+ *  updateMesh's auto-frame and the viewport "Reset view" button. No-op when the
+ *  mesh group is empty. */
+function frameModel(): void {
+  const box = new THREE.Box3().setFromObject(meshGroup);
+  if (box.isEmpty()) return;
+
+  const center = box.getCenter(new THREE.Vector3());
+  const size = box.getSize(new THREE.Vector3());
+  const maxDim = Math.max(size.x, size.y, size.z);
+
+  // Update model bounds for clip slider
+  modelBounds = { min: box.min.z, max: box.max.z };
+
+  // Position grid at the bottom of the model
+  grid.position.z = box.min.z;
+
+  // Update bounding box dimension annotations
+  updateDimensionLines(box);
+
+  controls.target.copy(center);
+  camera.position.set(
+    center.x + maxDim * 1.2,
+    center.y - maxDim * 1.2,
+    center.z + maxDim * 1.2,
+  );
+  // Adapt the clip planes to the model size. With a fixed far plane a large
+  // model (e.g. scaled to ~890mm) auto-frames the camera far enough away that
+  // the geometry falls beyond the frustum and disappears; a fixed near plane
+  // would z-fight on tiny models. Scale both with the model's largest dim.
+  if (maxDim > 0) {
+    camera.near = Math.max(0.05, maxDim * 0.005);
+    camera.far = Math.max(1000, maxDim * 50);
+    camera.updateProjectionMatrix();
+    // Bound how far the user can dolly out so the model can't shrink to a
+    // speck (and drift toward the far plane). The default framing distance is
+    // ~maxDim*2.1, so a multiple well above that still leaves generous room.
+    controls.maxDistance = maxDim * getConfig().renderer.maxZoomOutFactor;
+  }
+  controls.update();
+}
+
+/** Re-frame the camera to the default view of the current model — the same
+ *  framing applied after a fresh run. Bound to the viewport "Reset view" button
+ *  and exposed on the partwright API. */
+export function resetView(): void {
+  frameModel();
+  if (clippingEnabled) updateClipPlaneVisual();
+  needsRender = true;
 }
 
 // === Clipping API ===

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -492,6 +492,14 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           onChange={v => set('renderer', 'orbitDampingFactor', v)}
         />
         <Field
+          label="Max zoom-out factor"
+          tooltip="How far you can zoom the camera out, as a multiple of the model's largest dimension. The default framing sits at roughly 2× that dimension, so a value of 12 lets you pull back about 6× from the default before hitting the limit. Lower it to keep the model filling more of the view; raise it for more room. Re-applied each time the model is framed."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.maxZoomOutFactor}
+          value={c.renderer.maxZoomOutFactor}
+          min={3} max={100} step={1}
+          onChange={v => set('renderer', 'maxZoomOutFactor', v)}
+        />
+        <Field
           label="Orientation gizmo size"
           unit="px"
           tooltip="The canvas size in CSS pixels of the orientation gizmo (the XYZ cube in the viewport corner). Larger makes the axis labels easier to read; smaller keeps it out of the way. Takes effect after a page reload."

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -749,6 +749,14 @@ function createClipControls(): HTMLElement {
   lockBtn.title = 'Lock camera rotation';
   container.appendChild(lockBtn);
 
+  // Reset view \u2014 re-frames the camera to the default 3/4 angle of the model.
+  const resetBtn = document.createElement('button');
+  resetBtn.id = 'reset-view';
+  resetBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  resetBtn.textContent = '\u21BB Reset View';
+  resetBtn.title = 'Reset camera to the default view';
+  container.appendChild(resetBtn);
+
   // Visual separator between the view toggles (above) and the tools that follow
   // (Measure, Cross Section, plus the injected Paint/Annotate/Simplify buttons).
   const divider = document.createElement('div');

--- a/tests/viewport-reset-view.spec.ts
+++ b/tests/viewport-reset-view.spec.ts
@@ -1,0 +1,86 @@
+// Golden-path tests for the viewport "Reset View" button and the zoom-out limit:
+//  - the Reset View button lives in the clip-controls overlay
+//  - zooming out past the limit clamps the camera distance (it can't shrink the
+//    model to a speck) — maxDistance = model's largest dim × maxZoomOutFactor
+//  - clicking Reset View re-frames the camera to the default 3/4 view
+//
+// Uses dispatchEvent('click') instead of .click() to dodge the onboarding tour
+// backdrop that can intercept pointer events on first load of the editor.
+
+import { test, expect, type Page } from 'playwright/test';
+
+// A 10×10×10 cube → largest dimension 10, so with the default maxZoomOutFactor
+// of 12 the camera can dolly out to at most distance 120.
+const CUBE = 'const { Manifold } = api; return Manifold.cube([10, 10, 10], true);';
+
+function cameraDistance(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const pw = (window as unknown as { partwright: { getViewState(): { camera: { distance: number } } } }).partwright;
+    return pw.getViewState().camera.distance;
+  });
+}
+
+async function openEditorWithCube(page: Page): Promise<void> {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  await page.evaluate(async (code) => {
+    const pw = (window as unknown as { partwright: { run(code: string): Promise<unknown> } }).partwright;
+    await pw.run(code);
+  }, CUBE);
+  await page.waitForTimeout(1000); // let the viewport auto-frame the new mesh
+}
+
+test('zoom-out is clamped to the max-distance limit', async ({ page }) => {
+  await openEditorWithCube(page);
+
+  const framed = await cameraDistance(page);
+  expect(framed).toBeGreaterThan(0);
+
+  // Wheel out hard — without the limit this would push the camera arbitrarily
+  // far back. Dispatch real wheel events on the canvas (OrbitControls' input).
+  await page.evaluate(async () => {
+    const canvas = document.querySelector('#viewport') as HTMLCanvasElement;
+    const r = canvas.getBoundingClientRect();
+    const cx = r.left + r.width / 2, cy = r.top + r.height / 2;
+    for (let i = 0; i < 80; i++) {
+      canvas.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: 400, clientX: cx, clientY: cy, bubbles: true, cancelable: true,
+      }));
+      await new Promise(res => requestAnimationFrame(() => res(null)));
+    }
+  });
+  await page.waitForTimeout(600);
+
+  const zoomedOut = await cameraDistance(page);
+  expect(zoomedOut).toBeGreaterThan(framed);   // it did zoom out
+  expect(zoomedOut).toBeLessThanOrEqual(121);   // ...but no further than the cap
+});
+
+test('Reset View re-frames the camera to the default view', async ({ page }) => {
+  await openEditorWithCube(page);
+
+  const resetBtn = page.locator('#reset-view');
+  await expect(resetBtn).toBeVisible();
+
+  const framed = await cameraDistance(page);
+
+  // Zoom out so the view is no longer at the default framing.
+  await page.evaluate(async () => {
+    const canvas = document.querySelector('#viewport') as HTMLCanvasElement;
+    const r = canvas.getBoundingClientRect();
+    const cx = r.left + r.width / 2, cy = r.top + r.height / 2;
+    for (let i = 0; i < 40; i++) {
+      canvas.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: 400, clientX: cx, clientY: cy, bubbles: true, cancelable: true,
+      }));
+      await new Promise(res => requestAnimationFrame(() => res(null)));
+    }
+  });
+  await page.waitForTimeout(400);
+  expect(await cameraDistance(page)).toBeGreaterThan(framed + 1);
+
+  // Reset returns to the default framing distance.
+  await resetBtn.dispatchEvent('click');
+  await page.waitForTimeout(600);
+  expect(Math.abs(await cameraDistance(page) - framed)).toBeLessThan(1);
+});


### PR DESCRIPTION
## Summary

Two small viewport-navigation quality-of-life improvements requested by the user:

1. **"↻ Reset View" button** — added to the viewport overlay (the clip-controls bar, next to Edges/Grid/Dims/Lock). Clicking it re-frames the camera to the default 3/4 view of the current model — the same framing applied after a fresh run.
2. **Zoom-out limit** — the camera can no longer dolly back arbitrarily far. `OrbitControls.maxDistance` is now set to `maxDim × maxZoomOutFactor` (re-derived every time the model is framed), so the model can't shrink to an unrecoverable speck.

### How it works
- The camera auto-frame logic in `updateMesh` was extracted into a shared private `frameModel()` so the button and the post-run auto-frame go through the **exact same path** (no drift). `resetView()` is a thin export over it.
- The zoom-out cap scales with the model's largest dimension, so it's correct across the app's arbitrary-scale models. Default framing sits at ~2.1×maxDim, so the default factor of **12** leaves ~6× of pull-back room before clamping, and stays well inside `camera.far` (50×maxDim) so nothing clips at the limit.
- `maxZoomOutFactor` is a new tunable `renderer` field in `appConfig.ts` (default 12), exposed in the advanced settings modal.
- Also exposed `partwright.resetView()` on the console/AI API (signature entry + ai.md docs).

## Test plan
- `npm run build` ✅ · `npm run test:unit` ✅ · `npm run lint:deps` ✅ (graph still acyclic)
- New golden-path e2e spec `tests/viewport-reset-view.spec.ts` (2 tests, both green locally):
  - a 10-unit cube frames at distance ~20.78; wheeling out hard clamps **exactly at 120** (= 10 × 12) instead of running away
  - clicking **Reset View** returns the camera from 120 back to ~20.78
- Manual browser verification: screenshots posted in the session showing the clamped zoom-out and the post-reset default framing.

🤖 https://claude.ai/code/session_017ch81CBBR8w48PhvFmmiuz

---
_Generated by [Claude Code](https://claude.ai/code/session_017ch81CBBR8w48PhvFmmiuz)_