### PR TITLE
chore: add gitleaks CI secret scan and gitignore .env

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,49 @@
+name: Secret scan
+
+# Server-side secret detection — a backstop independent of the local
+# gitleaks pre-commit hook (lefthook.yml). That hook only fires on a machine
+# where `lefthook install` has run AND the gitleaks binary is on PATH, so it
+# silently does nothing in web/remote sessions (empty .git/hooks) or on a
+# fresh clone. This job runs gitleaks in CI so every PR is scanned regardless
+# of who or where committed. A non-zero exit (leak found) fails the job.
+#
+# Uses a pinned gitleaks release binary rather than gitleaks-action to avoid
+# the action's license-server round-trip. The repo has no .gitleaks.toml, so
+# gitleaks uses its built-in default ruleset (sk-ant-*, sk-*, AIza*, etc.) —
+# matching what the pre-commit hook enforces.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+concurrency:
+  group: secret-scan-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  GITLEAKS_VERSION: 8.21.2
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the scan covers every commit on the PR/branch,
+          # not just the tip. fetch-depth: 0 disables the shallow clone.
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Scan git history for secrets
+        run: gitleaks git --redact --verbose --exit-code 1 .

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ playwright/.cache/
 # Interstitial planning files
 .plans/
 
+# Environment files — may contain API keys; never commit
+.env
+.env.*
+!.env.example
+
 # Top-level screenshots/images from testing
 /*.png
 /*.jpg

--- a/prompts/secret-scan-hardening.md
+++ b/prompts/secret-scan-hardening.md
@@ -1,0 +1,55 @@
+---
+session: "kindmax"
+timestamp: "2026-06-04T16:00:00Z"
+model: claude-opus-4-8
+tools: [explore, Bash]
+---
+
+## Human
+
+Review the catalog and published app to be sure API keys can't accidentally
+leak when publishing catalog entries (sessions export AI chat history — is the
+export safe, and did any keys leak into the catalog?). Also confirm no keys
+leaked into git history — a gitleaks pre-commit hook should have protected me;
+is it still working?
+
+## Assistant
+
+## Key decisions
+
+**Audit conclusion (no code change needed for the leak itself):** API keys live
+only in IndexedDB's `aiKeys` store (`src/ai/db.ts`, `KeyRecord.apiKey`). No
+export path reads it — `exportSession()` serializes session/parts/versions/
+notes/chat, and the chat transcript (`ChatBlock`) holds only text, images,
+thinking, tool-call inputs, and tool results. Provider error strings that could
+appear in an `errored` message are in-memory only (never `putMessages`'d) and
+the diagnostics ring buffer is memory-only too. Catalog files carry only 5
+top-level keys, no chat/keys. Full git-history scan (492 commits) found no real
+key material. So keys are safe by construction; history is clean.
+
+**Why the hook is fragile (the real gap):** the gitleaks pre-commit hook in
+`lefthook.yml` only fires where `lefthook install` ran *and* the gitleaks binary
+is present. In web/remote sessions `.git/hooks/` is empty (no `npm install` → no
+`lefthook install`) — the exact trap `CLAUDE.md` documents for the prompt-log
+hook, which got a `PreToolUse` backstop while gitleaks did not. There is also no
+server-side secret scan in CI, and `.env` is not gitignored.
+
+**Changes made (user picked 3 of 4 hardening options):**
+
+1. **`.github/workflows/secret-scan.yml`** — new gitleaks CI job on PRs into
+   `main` and pushes to `main`. Runs a pinned gitleaks release binary (not
+   gitleaks-action, to avoid the license-server round-trip) with
+   `fetch-depth: 0` so it scans full history, and `gitleaks git --exit-code 1`
+   so a leak fails the job. No `.gitleaks.toml` exists, so it uses the built-in
+   default ruleset — same coverage as the pre-commit hook. This closes the
+   web-session bypass server-side.
+
+2. **`.gitignore`** — added `.env`, `.env.*` (with a `!.env.example` allow) so
+   stray local key files can't be committed.
+
+3. **GitHub push protection** — repo setting, not togglable via available
+   tools; handed back to the user as manual steps.
+
+The user declined the 4th option (defaulting "Chat history" off for catalog
+exports); noted as a future consideration since it risks transcript (not key)
+exposure only.


### PR DESCRIPTION
## Summary

Hardening following a security review of API-key leakage in session exports and the catalog. **The audit found no leaks** — keys live only in IndexedDB's `aiKeys` store and no export path reads it; the catalog files and the full 492-commit git history are clean. The real exposure was *process fragility*, which this PR addresses.

The gitleaks pre-commit hook (`lefthook.yml`) only fires where `lefthook install` has run **and** the gitleaks binary is on PATH — so it silently no-ops in web/remote sessions (empty `.git/hooks`) and on fresh clones, with no server-side net behind it.

### Changes
- **`.github/workflows/secret-scan.yml`** — new gitleaks CI job on PRs into `main` and pushes to `main`. Pinned release binary (avoids the gitleaks-action license round-trip), `fetch-depth: 0` to scan full history, `gitleaks git --exit-code 1` so a leak fails the job. Uses the built-in default ruleset (no `.gitleaks.toml`), matching the pre-commit hook.
- **`.gitignore`** — excludes `.env` / `.env.*` (keeps `.env.example`) so stray local key files can't be committed.

### Follow-up (manual, not in this PR)
- **Enable GitHub secret scanning + push protection** in repo Settings → Code security (free for public repos) for a third, push-time net.

## Test plan
- `secret-scan.yml` is valid YAML and runs on this PR — the gitleaks job should appear green (no secrets in history).
- No app/runtime code changed; build/unit/e2e behavior is unaffected.

https://claude.ai/code/session_01MUvJL1MzRgmr9nLaXuJvVJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUvJL1MzRgmr9nLaXuJvVJ)_