### PR TITLE
feat: surface disconnected-components warning as a transient toast

### DIFF
--- a/prompts/20260604-162644-disconnected-components-toast.md
+++ b/prompts/20260604-162644-disconnected-components-toast.md
@@ -1,0 +1,46 @@
+---
+session: "vibrant-goodall"
+timestamp: "2026-06-04T16:26:44Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+When the "X disconnected components" warning shows I want it to be a toast that
+goes away and is recorded in the diagnostic menu like other toasts. I also want
+it to render wherever other toasts render.
+
+## Assistant
+
+## Key decisions
+
+**Where it lived before**: `computePrintability` returns a list of issues, and
+`updateGeometryData` (`src/main.ts`) joined them into the persistent viewport
+**printability pill** (`printabilityIndicatorEl`, top-left overlay). The
+disconnected-components warning was one of those issues; it stayed up as
+standing status and was never recorded in the Diagnostic Log.
+
+**Change**: In `updateGeometryData` I split the `${n} disconnected components`
+issue out of the pill. The pill now renders only the remaining issues (e.g.
+"non-manifold mesh (not watertight)"), which are genuine standing status. The
+disconnected-components warning is emitted via `showToast(..., { variant:
+'warn', source: 'engine' })` — bottom-center where every other toast renders,
+fading after the standard duration, and (because `showToast` mirrors warns to
+`errorLog`) automatically recorded in the Diagnostic Log.
+
+**De-dup**: `updateGeometryData` fires on every run / simplify / paint-apply, so
+toasting unconditionally would spam an unchanged broken model. A module-level
+`lastDisconnectedWarning` tracks the last text toasted; we only toast when it
+changes, and reset it to `null` when the warning clears (including on the run
+error path) so the next occurrence toasts again.
+
+**Scope**: Kept narrow to exactly the disconnected-components case the user
+named. The non-manifold warning stays on the pill as standing status, matching
+the "persistent status ≠ transient notification" guidance in CLAUDE.md (the
+pill principle still holds for the issues that remain on it).
+
+**Verification**: Added `tests/printability-toast.spec.ts` — runs two
+non-overlapping cubes, asserts the bottom-center `role=status` toast carries the
+warning, the pill does not, and the Diagnostic Log captured it as a WARN row.
+Manually confirmed in the browser via screenshot (toast bottom-center, amber
+warn style, Diagnostics badge incremented).

--- a/src/main.ts
+++ b/src/main.ts
@@ -386,6 +386,11 @@ let currentLostLabels: string[] | null = null;
 let geometryDataEl: HTMLElement;
 // Viewport overlay pill — shows printability issues after each successful run.
 let printabilityIndicatorEl: HTMLElement | null = null;
+// The disconnected-components warning is surfaced as a transient toast (recorded
+// in the Diagnostic Log) rather than the persistent pill. Track the last one we
+// toasted so re-runs of an unchanged broken model don't re-spam the same toast;
+// reset to null whenever the warning clears so its next occurrence toasts again.
+let lastDisconnectedWarning: string | null = null;
 
 // === Shared-link preview mode ===
 //
@@ -568,13 +573,23 @@ function updateGeometryData(executionTimeMs?: number, sourceCode?: string) {
   const data = withSessionContext(computeGeometryStats(currentManifold, currentMeshData, executionTimeMs, sourceCode));
   geometryDataEl.textContent = JSON.stringify(data, null, 2);
   if (printabilityIndicatorEl) {
-    const { printable, issues } = computePrintability(data);
-    if (printable) {
+    const { issues } = computePrintability(data);
+    // The disconnected-components warning surfaces as a transient toast (which
+    // also records it in the Diagnostic Log) rather than the persistent pill;
+    // every other issue (e.g. non-manifold) stays on the pill as standing status.
+    const disconnected = issues.find((i) => i.includes('disconnected component')) ?? null;
+    const pillIssues = issues.filter((i) => i !== disconnected);
+    if (pillIssues.length === 0) {
       printabilityIndicatorEl.style.display = 'none';
     } else {
-      printabilityIndicatorEl.textContent = '⚠ ' + issues.join(' · ');
+      printabilityIndicatorEl.textContent = '⚠ ' + pillIssues.join(' · ');
       printabilityIndicatorEl.style.display = '';
     }
+    // Toast once per change so re-running an unchanged broken model isn't spammy.
+    if (disconnected && disconnected !== lastDisconnectedWarning) {
+      showToast('⚠ ' + disconnected, { variant: 'warn', source: 'engine' });
+    }
+    lastDisconnectedWarning = disconnected;
   }
 }
 
@@ -3875,8 +3890,10 @@ async function main() {
   });
 
   // Printability indicator pill — shown in the viewport overlay when the model
-  // has structural issues that would prevent 3D printing (non-manifold or
-  // disconnected components). Hidden when the model is printable.
+  // has standing structural issues that would prevent 3D printing (e.g.
+  // non-manifold mesh). The disconnected-components warning is split off into a
+  // transient toast (see updateGeometryData); the pill is hidden when no
+  // pill-level issue remains.
   printabilityIndicatorEl = document.createElement('span');
   printabilityIndicatorEl.className = 'absolute top-8 left-2 z-20 text-xs text-amber-300 font-mono bg-zinc-900/80 px-2 py-0.5 rounded border border-amber-700/60 cursor-help';
   // A persistent status indicator, not a transient toast: it stays up while the
@@ -11619,6 +11636,7 @@ async function main() {
       const diagnostics = result.diagnostics ?? [];
       setStatus(statusBar, 'error', summarizeDiagnostics(result.error, diagnostics));
       if (printabilityIndicatorEl) printabilityIndicatorEl.style.display = 'none';
+      lastDisconnectedWarning = null;
       geometryDataEl.textContent = JSON.stringify({
         status: 'error',
         error: result.error,

--- a/tests/printability-toast.spec.ts
+++ b/tests/printability-toast.spec.ts
@@ -1,0 +1,62 @@
+// The disconnected-components printability warning surfaces as a transient
+// toast (recorded in the Diagnostic Log) rather than the persistent viewport
+// pill. This covers the golden path: run a multi-component model, see the
+// bottom-center toast, confirm it landed in the Diagnostic Log, and confirm the
+// pill does NOT carry the disconnected-components text.
+
+import { test, expect, type Page } from 'playwright/test';
+
+type PW = {
+  createSession: (n?: string) => Promise<unknown>;
+  run: (code: string) => Promise<unknown>;
+};
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+// Two non-overlapping cubes → 2 disconnected components.
+const TWO_COMPONENTS =
+  'const { Manifold } = api; return Manifold.cube([5,5,5], true).add(Manifold.cube([5,5,5], true).translate([40,0,0]));';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+  });
+});
+
+test.describe('Disconnected-components toast', () => {
+  test('multi-component run toasts the warning and records it; pill stays clear', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    await page.evaluate(async (c) => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('disconnected-toast');
+      await pw.run(c);
+    }, TWO_COMPONENTS);
+
+    // Transient toast (bottom-center role=status) carries the warning.
+    const toast = page.locator('[role="status"]', { hasText: 'disconnected components' });
+    await expect(toast).toBeVisible({ timeout: 5000 });
+
+    // The persistent printability pill must NOT show the disconnected text.
+    const pillText = await page.evaluate(() => {
+      const el = document.querySelector('span.cursor-help') as HTMLElement | null;
+      return el && el.style.display !== 'none' ? (el.textContent ?? '') : '';
+    });
+    expect(pillText).not.toContain('disconnected');
+
+    // It was mirrored into the Diagnostic Log like every other toast.
+    await page.click('#btn-diagnostics');
+    const panel = page.locator('#diagnostics-panel');
+    await expect(panel).toBeVisible();
+    const row = panel.locator('div.border-b', { hasText: 'disconnected components' }).first();
+    await expect(row).toBeVisible();
+    await expect(row.getByText('● WARN')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

The "X disconnected components" printability warning previously lived on the persistent viewport **printability pill** (top-left overlay) and was never recorded in the Diagnostic Log. Per the request, it now behaves like every other toast:

- **Transient toast** — emitted via `showToast(..., { variant: 'warn', source: 'engine' })`, so it renders bottom-center wherever other toasts render and fades after the standard duration.
- **Recorded in the Diagnostic menu** — `showToast` automatically mirrors `warn` toasts into the central Diagnostic Log (toolbar ⚠), so there's a durable record.
- **Off the pill** — `updateGeometryData` (`src/main.ts`) now splits the disconnected-components issue out of the pill. The pill keeps showing the remaining genuine standing-status issues (e.g. "non-manifold mesh (not watertight)").

A module-level `lastDisconnectedWarning` tracker de-dupes the toast: it only fires when the warning text changes, and resets when the warning clears (including on the run error path), so re-running an unchanged broken model doesn't re-spam it.

## Test plan

- `npm run build` ✅ (type-check + bundle)
- `npm run test:unit` ✅ (614 passed)
- New e2e spec `tests/printability-toast.spec.ts` ✅ — runs two non-overlapping cubes, asserts the bottom-center `role=status` toast carries the warning, the pill does not, and the Diagnostic Log captured it as a WARN row.
- Manual browser check: the toast "⚠ 2 disconnected components" renders bottom-center in amber warn style and the Diagnostics badge increments (screenshot posted in the session chat).

https://claude.ai/code/session_01HeNmi6UMkyVauGW9aAs6Pq