### PR TITLE
test: scope diagnostic-log assertion to the log, not run history

### DIFF
--- a/prompts/20260604-174311-fix-diagnostic-log-test.md
+++ b/prompts/20260604-174311-fix-diagnostic-log-test.md
@@ -1,0 +1,40 @@
+---
+session: "fix-diagnostic-log-test-nbjcu"
+timestamp: "2026-06-04T17:43:11Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 1
+---
+
+## Human
+
+A failed main→staging gate build needs fixing. The e2e test
+`editor live errors › transient typing errors stay out of the diagnostic log`
+fails: after typing bad code, the `#diagnostics-panel` contains
+`zzznotdefined123` (surfaced via "Recent geometry runs ... error · zzznotdefined123 is not defined").
+
+## Assistant
+
+## Key decisions
+
+Root cause: the recent `refactor: fold worker health into the diagnostics panel`
+(bfd25d2) merged the worker-telemetry view (incl. the "Recent geometry runs"
+ring buffer) into the same `#diagnostics-panel` surface as the diagnostic log.
+The run-history legitimately records *every* geometry run, failed auto-runs
+included — that's telemetry, distinct from the user-facing error log the test
+guards. The test's own header comment scopes its intent to "the diagnostic
+log," but its assertion checked the whole panel, so it became over-broad after
+the refactor.
+
+Decided this is a stale test, not a behavior regression: keeping failed runs in
+the run-history is desired (it's debugging telemetry). Fix is to scope the
+assertion to the log half.
+
+- Gave the log list element a stable id `diagnostics-log-list` in
+  `diagnosticsPanel.ts`.
+- Pointed the test's `not.toContainText` assertion at `#diagnostics-log-list`
+  instead of the whole panel, with a comment explaining the upper/lower split.
+
+Verified: build + unit (640) green, all 3 `editor-live-errors` specs pass, and
+a scratch screenshot confirmed the LOG section stays clean while the error
+appears only in the inline editor panel / run history.

--- a/src/ui/diagnosticsPanel.ts
+++ b/src/ui/diagnosticsPanel.ts
@@ -429,6 +429,7 @@ function buildPanel(): HTMLElement {
   logSection.appendChild(lSub);
 
   _listEl = document.createElement('div');
+  _listEl.id = 'diagnostics-log-list';
   _listEl.className = 'flex-1 overflow-y-auto';
   logSection.appendChild(_listEl);
 

--- a/tests/editor-live-errors.spec.ts
+++ b/tests/editor-live-errors.spec.ts
@@ -62,6 +62,11 @@ test.describe('editor live errors', () => {
     await page.click('#btn-diagnostics');
     const diag = page.locator('#diagnostics-panel');
     await expect(diag).toBeVisible();
-    await expect(diag).not.toContainText('zzznotdefined123');
+    // Scope to the diagnostic log (lower half). The panel's upper half is
+    // worker telemetry — its "Recent geometry runs" ring buffer legitimately
+    // records every auto-run, failures included; that's run history, not the
+    // user-facing error log this test guards.
+    const log = page.locator('#diagnostics-log-list');
+    await expect(log).not.toContainText('zzznotdefined123');
   });
 });


### PR DESCRIPTION
## Summary

Fixes the red `main → staging` gate. The e2e test `editor live errors › transient typing errors stay out of the diagnostic log` was failing because it checked the **whole** `#diagnostics-panel` for the absence of the bad-code error text (`zzznotdefined123`).

The recent `refactor: fold worker health into the diagnostics panel` (`bfd25d2`) merged the worker-telemetry view — including the **"Recent geometry runs"** ring buffer — into that same panel. That run-history legitimately records *every* geometry run, failed auto-runs included; it's debugging telemetry, distinct from the user-facing **diagnostic log** the test actually guards (and which its own header comment scopes it to).

So this is a stale, over-broad test rather than a behavior regression — keeping failed runs in the run-history is desired. The fix:

- Give the log list element a stable id `#diagnostics-log-list` in `src/ui/diagnosticsPanel.ts`.
- Scope the test's `not.toContainText('zzznotdefined123')` assertion to `#diagnostics-log-list` instead of the whole panel.

## Test plan

- `npm run build` — green
- `npm run test:unit` — 640 passing
- `npx playwright test tests/editor-live-errors.spec.ts` — all 3 specs pass
- Manual browser check: typed the bad code, opened the panel, confirmed the LOG section stays clean while the error appears only in the inline editor panel / Workers run-history (screenshot posted in session).

https://claude.ai/code/session_01Sd2qdnEkCPFEQ5WZXPJatG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd2qdnEkCPFEQ5WZXPJatG)_