### PR TITLE
fix: source generateId from crypto.getRandomValues instead of Math.random

### DIFF
--- a/prompts/20260604-230000-secure-generateid.md
+++ b/prompts/20260604-230000-secure-generateid.md
@@ -1,0 +1,48 @@
+---
+session: "ZvDxi"
+timestamp: "2026-06-04T23:00:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 2
+---
+
+## Human
+
+On the June 4 release PR (#438), CodeQL flagged "cryptographically insecure
+random number generated at Math.random() in a security context" in
+sessionManager.ts. After I investigated and reported it was a pre-existing
+false positive (local IndexedDB keys, no auth boundary), the user chose to
+"harden anyway for cleanliness."
+
+## Assistant
+
+## Key decisions
+
+**Fixed the real source, not the reported file.** The alert pointed at
+`sessionManager.ts` but the `Math.random()` lives in `generateId()` in
+`src/storage/db.ts:296` — CodeQL's dataflow follows the generated id to where
+it's stored as `session.id`. Swapped the entropy source there.
+
+**Kept the ID format byte-identical (12-char base62).** generateId mints local
+IndexedDB record keys (sessions, parts, versions, images, chat messages) that
+also appear in URLs (`?session=<id>`). Preserving the 12-char base62 shape means
+zero back-compat risk (existing stored IDs untouched, new ones look the same)
+while sourcing bytes from `crypto.getRandomValues`. Used rejection sampling
+(drop bytes ≥ 248 = 4×62) to keep the distribution uniform instead of a biased
+`byte % 62`. Partwright already requires a modern browser (SharedArrayBuffer /
+WASM threads), so `crypto` is always present — no Math.random fallback needed.
+
+**Left `sessionLock.ts` alone, deliberately.** Its tab id (line 24) *already*
+prefers `crypto.randomUUID()` with Math.random only as a legacy fallback that
+never runs in supported browsers, and line 104 is a backoff *jitter delay*, not
+an identifier — converting a sleep timer to crypto is noise, not hardening.
+Neither was in the CodeQL alert. Scoped the change to the one real finding.
+
+**Release hygiene.** This is a `fix:` PR into `main` (never onto a release
+branch) so it flows main → gate → a future release, keeping production
+promotions pure. Branch reset to the just-merged `origin/main` so the push
+fast-forwards (no force).
+
+**Verification.** build clean; a throwaway Playwright probe generated 200 ids
+(all valid 12-char base62, all unique) and confirmed a real session saves a
+version through the generateId hot path. Scratch spec deleted.

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -295,9 +295,18 @@ function openDB(): Promise<IDBDatabase> {
 
 export function generateId(): string {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  // 12-char base62 IDs for local IndexedDB record keys (sessions, parts,
+  // versions, images, chat messages). Sourced from crypto.getRandomValues
+  // rather than Math.random — these aren't security tokens, but a secure
+  // source keeps the entropy unimpeachable and clears static-analysis flags.
+  // Rejection sampling (drop bytes ≥ 248 = 4×62) keeps the distribution
+  // uniform, avoiding the modulo bias of a raw `byte % 62`.
   let id = '';
-  for (let i = 0; i < 12; i++) {
-    id += chars[Math.floor(Math.random() * chars.length)];
+  while (id.length < 12) {
+    const bytes = crypto.getRandomValues(new Uint8Array(12 - id.length));
+    for (const b of bytes) {
+      if (b < 248) id += chars[b % 62];
+    }
   }
   return id;
 }


### PR DESCRIPTION
## Summary

Resolves the CodeQL **"This uses a cryptographically insecure random number generated at `Math.random()` in a security context"** alert (code-scanning #5) surfaced on release PR #438.

The alert pointed at `sessionManager.ts`, but the `Math.random()` actually lives in **`generateId()` (`src/storage/db.ts`)** — CodeQL's dataflow follows the generated id to where it's stored as `session.id`. This swaps the entropy source at the real origin.

### Context — it was a pre-existing false positive
`generateId()` mints **local IndexedDB record keys** (sessions, parts, versions, attached images, chat messages). Partwright is fully client-side — no backend, no accounts, no server-issued sessions, no auth tokens — so these IDs are never a security boundary (share links encode the whole model in the URL; they don't rely on an unguessable id). The code was byte-identical on the prior `production`. We're hardening it anyway for a clean security dashboard and unimpeachable entropy.

### The change
```js
// before: id += chars[Math.floor(Math.random() * chars.length)]
// after:  bytes from crypto.getRandomValues, rejection-sampled into base62
```
- **ID format unchanged** — still 12-char base62, so existing stored IDs and `?session=<id>` URLs are unaffected and there's zero back-compat risk.
- **Uniform distribution** — rejection sampling (drop bytes ≥ 248 = 4×62) avoids the modulo bias of a raw `byte % 62`.
- **No fallback needed** — Partwright already requires a modern browser (SharedArrayBuffer / WASM threads), so `crypto` is always present.

### Deliberately out of scope
`src/storage/sessionLock.ts` already prefers `crypto.randomUUID()` for its tab id (Math.random is only a legacy fallback that never runs in supported browsers), and its other `Math.random` is a backoff *jitter delay*, not an identifier. Neither was in the alert; left untouched.

## Test plan
- `npm run build` — clean (type-check passes).
- Browser probe: generated 200 IDs (all valid 12-char base62, all unique) and confirmed a real session saves a version through the `generateId` hot path. The e2e suite (which creates sessions/versions) exercises this path on CI.

## Release sequencing
A `fix:` into `main` — flows `main` → staging gate → a future `staging → production` release. Intentionally **not** placed on any release branch, keeping production promotions pure.

https://claude.ai/code/session_01PfWJ4vXhLdaRXuhHDF7stm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfWJ4vXhLdaRXuhHDF7stm)_