### PR TITLE
feat: upgrade per-engine starter models

### DIFF
--- a/examples/basic_shapes.js
+++ b/examples/basic_shapes.js
@@ -1,16 +1,40 @@
-// Twisted column — a rounded-square profile swept upward with manifold-3d's
-// built-in twist and taper. Mesh kernels make this kind of continuously
-// deformed solid cheap to build, and it renders in a blink.
-const { CrossSection } = api;
+// manifold-3d capability sampler — primitives, booleans, hull, twist-extrude,
+// and a surface of revolution. Mesh booleans are fast even on odd shapes.
+// Edit any block and re-run to experiment.
+const { Manifold, CrossSection } = api;
 
-// Rounded-square cross-section: the convex hull of four corner circles.
-const r = 4, d = 9;
-const profile = CrossSection.hull([
-  CrossSection.circle(r).translate([ d,  d]),
-  CrossSection.circle(r).translate([-d,  d]),
-  CrossSection.circle(r).translate([-d, -d]),
-  CrossSection.circle(r).translate([ d, -d]),
+// 1) Booleans: a cube with a sphere and a cross-bore subtracted.
+const boolean = Manifold.cube([15, 15, 15], true)
+  .subtract(Manifold.sphere(9.5, 48))
+  .subtract(Manifold.cylinder(20, 3.5, 3.5, 48, true));
+
+// 2) Rounded box: convex hull of eight corner spheres.
+const r = 2.5, hx = 6, hy = 6, hz = 4;
+const s = Manifold.sphere(r, 24);
+const rounded = Manifold.hull([
+  s.translate([ hx,  hy,  hz]), s.translate([-hx,  hy,  hz]),
+  s.translate([ hx, -hy,  hz]), s.translate([-hx, -hy,  hz]),
+  s.translate([ hx,  hy, -hz]), s.translate([-hx,  hy, -hz]),
+  s.translate([ hx, -hy, -hz]), s.translate([-hx, -hy, -hz]),
 ]);
 
-// Extrude 60 tall: 48 slices, 160° of twist, tapering to 55% at the top.
-return profile.extrude(60, 48, 160, 0.55);
+// 3) Twisted column: a rounded-square profile extruded with built-in twist.
+const profile = CrossSection.hull([
+  CrossSection.circle(2).translate([5, 5]),  CrossSection.circle(2).translate([-5, 5]),
+  CrossSection.circle(2).translate([-5, -5]), CrossSection.circle(2).translate([5, -5]),
+]);
+const twisted = profile.extrude(24, 48, 180, 0.5);
+
+// 4) Surface of revolution: a vase profile (X = radius, Y = height) spun on Z.
+const vase = Manifold.revolve(CrossSection.hull([
+  CrossSection.circle(1).translate([3, 0]), CrossSection.circle(1).translate([7, 7]),
+  CrossSection.circle(1).translate([3, 16]),
+]), 64);
+
+// Lay them out in a row so each is visible.
+return Manifold.union([
+  boolean.translate([-30, 0, 8]),
+  rounded.translate([-8, 0, 4]),
+  twisted.translate([14, 0, 0]),
+  vase.translate([34, 0, 0]),
+]);

--- a/examples/basic_shapes.js
+++ b/examples/basic_shapes.js
@@ -1,10 +1,16 @@
-// Basic shapes demo
-// The 'api' object exposes the full manifold-3d API
-const { Manifold } = api;
+// Twisted column — a rounded-square profile swept upward with manifold-3d's
+// built-in twist and taper. Mesh kernels make this kind of continuously
+// deformed solid cheap to build, and it renders in a blink.
+const { CrossSection } = api;
 
-const box = Manifold.cube([10, 10, 10], true);
-const hole = Manifold.cylinder(6, 4, 4);
-const result = box.subtract(hole);
+// Rounded-square cross-section: the convex hull of four corner circles.
+const r = 4, d = 9;
+const profile = CrossSection.hull([
+  CrossSection.circle(r).translate([ d,  d]),
+  CrossSection.circle(r).translate([-d,  d]),
+  CrossSection.circle(r).translate([-d, -d]),
+  CrossSection.circle(r).translate([ d, -d]),
+]);
 
-// Always return the final Manifold object
-return result;
+// Extrude 60 tall: 48 slices, 160° of twist, tapering to 55% at the top.
+return profile.extrude(60, 48, 160, 0.55);

--- a/examples/basic_shapes.js
+++ b/examples/basic_shapes.js
@@ -1,6 +1,7 @@
 // manifold-3d capability sampler — primitives, booleans, hull, twist-extrude,
-// and a surface of revolution. Mesh booleans are fast even on odd shapes.
-// Edit any block and re-run to experiment.
+// and a surface of revolution, mounted on one tray so it stays a single
+// printable solid. Mesh booleans are fast even on odd shapes. Edit any block
+// and re-run to experiment.
 const { Manifold, CrossSection } = api;
 
 // 1) Booleans: a cube with a sphere and a cross-bore subtracted.
@@ -31,10 +32,12 @@ const vase = Manifold.revolve(CrossSection.hull([
   CrossSection.circle(1).translate([3, 16]),
 ]), 64);
 
-// Lay them out in a row so each is visible.
+// A tray base ties the four demos into one connected, printable solid.
+const tray = Manifold.cube([86, 24, 3], true).translate([2, 0, 1]);
 return Manifold.union([
-  boolean.translate([-30, 0, 8]),
-  rounded.translate([-8, 0, 4]),
-  twisted.translate([14, 0, 0]),
-  vase.translate([34, 0, 0]),
+  tray,
+  boolean.translate([-30, 0, 9]),
+  rounded.translate([-8, 0, 5]),
+  twisted.translate([14, 0, 1]),
+  vase.translate([34, 0, 1]),
 ]);

--- a/prompts/20260605-upgrade-engine-starters.md
+++ b/prompts/20260605-upgrade-engine-starters.md
@@ -72,3 +72,16 @@ All four verified rendering via a throwaway probe (screenshots in session). The
 session-modal assertion still holds — the manifold sampler still uses CrossSection.
 Note: chamfering a box whose edges were all just filleted fails in OCCT, so the
 replicad block-1 box is fillet-only (chamfer is shown on the knob's base instead).
+
+Follow-up (CI): the first sampler cut was a union of four *disjoint* shapes, so
+the manifold-js default (which auto-runs on /editor) became multi-component and
+emitted a "⚠ N disconnected components" warning. That broke two tests that
+exercise the default model — `feedback-a11y` (clean export toast) and
+`printability-toast` (its own 2-component toast collided with the default's
+4-component one) — and, more importantly, was a real UX regression: a brand-new
+user's first model shouldn't throw a disconnected-components warning. Fixed by
+mounting each code sampler (js / scad / replicad) on a thin **tray base** that
+ties the demos into one connected, printable solid (verified componentCount === 1,
+isManifold === true for all three via a probe). The tray reads as an intentional
+sampler board. No test edits needed — the tests correctly assert app behavior on
+the default model.

--- a/prompts/20260605-upgrade-engine-starters.md
+++ b/prompts/20260605-upgrade-engine-starters.md
@@ -85,3 +85,8 @@ ties the demos into one connected, printable solid (verified componentCount === 
 isManifold === true for all three via a probe). The tray reads as an intentional
 sampler board. No test edits needed — the tests correctly assert app behavior on
 the default model.
+
+Follow-up (review nit): refreshed the `isStarterCode` doc comment, which still
+described the dropped `// New session`/`// New part` prefix as a currently-emitted
+form. Behavior unchanged — the regex is retained only for back-compat with legacy
+saved cube drafts.

--- a/prompts/20260605-upgrade-engine-starters.md
+++ b/prompts/20260605-upgrade-engine-starters.md
@@ -57,3 +57,18 @@ Follow-up (CI): `session-modal.spec.ts` asserted the new-session editor containe
 Updated it to assert the fresh manifold-js default loaded (`toContain('CrossSection')`),
 which is the real intent (old code cleared, default seeded). The scad-companion
 shard-3 failure in the same run was flaky (passed on retry).
+
+Follow-up (feedback): the single-shape starters were "too lame." Reworked the
+manifold-js / scad / replicad starters into **capability samplers** — several
+shapes/operations laid out in a row in one tweakable model so people can
+experiment:
+- manifold-js: boolean cutout, hull-rounded box, twist-extrude column, revolve vase.
+- scad: difference, minkowski-rounded box, module+linear_extrude twist, rotate_extrude vase.
+- replicad: fully-rounded box, knob (filleted rim + chamfered base), cone fused
+  onto a cylinder, bracket with rounded corners + bored holes.
+- voxel: a fuller layered pine tree (loop-built tapering tiers in alternating
+  greens, snowy caps, ornaments, gold star).
+All four verified rendering via a throwaway probe (screenshots in session). The
+session-modal assertion still holds — the manifold sampler still uses CrossSection.
+Note: chamfering a box whose edges were all just filleted fails in OCCT, so the
+replicad block-1 box is fillet-only (chamfer is shown on the knob's base instead).

--- a/prompts/20260605-upgrade-engine-starters.md
+++ b/prompts/20260605-upgrade-engine-starters.md
@@ -90,3 +90,13 @@ Follow-up (review nit): refreshed the `isStarterCode` doc comment, which still
 described the dropped `// New session`/`// New part` prefix as a currently-emitted
 form. Behavior unchanged — the regex is retained only for back-compat with legacy
 saved cube drafts.
+
+Follow-up (feedback): the SCAD sampler was poorly aligned and slow (~13 s).
+Profiled per-block render time in the browser: OpenSCAD's CGAL booleans on
+*curved* primitives dominate (a cross-bore `difference` ~2.5 s, a curved
+`union` ~1.9 s, `minkowski` worst of all), while extrudes/revolve/tray are
+~0.3 s each; `$fn` and the tray-union barely move the needle. Simplified the
+SCAD starter to two fast, iconic demos — a single-bore CSG `difference` and a
+parametric `linear_extrude` twist star — sitting flat on the tray, evenly
+spaced. Renders in ~2.9 s (single component, watertight), down from ~13 s, and
+is visually aligned.

--- a/prompts/20260605-upgrade-engine-starters.md
+++ b/prompts/20260605-upgrade-engine-starters.md
@@ -51,3 +51,9 @@ Decisions / why:
 
 Verified all four render via a throwaway Playwright probe (screenshots posted in
 the session); build + unit tier green.
+
+Follow-up (CI): `session-modal.spec.ts` asserted the new-session editor contained
+`// New session` — the comment header `resetEditorToStarter` no longer prepends.
+Updated it to assert the fresh manifold-js default loaded (`toContain('CrossSection')`),
+which is the real intent (old code cleared, default seeded). The scad-companion
+shard-3 failure in the same run was flaky (passed on retry).

--- a/prompts/20260605-upgrade-engine-starters.md
+++ b/prompts/20260605-upgrade-engine-starters.md
@@ -1,0 +1,53 @@
+---
+date: 2026-06-05
+branch: claude/affectionate-heisenberg-Dk7Er
+files_changed:
+  - examples/basic_shapes.js
+  - src/main.ts
+---
+
+## Human
+
+I'm thinking of upgrading all the starter files for all the engines. I want
+something cool for each but also something that will render quickly and makes
+sense for each engine type. (Clarified: by "starter file" they mean the initial
+model that loads into the editor for a new session / on a language switch.)
+
+## Assistant
+
+Replaced the four boring "cube" starters with small, fast-rendering models
+chosen to show off what each engine is good at:
+
+- **manifold-js** — a twisted rounded-square column (`CrossSection.hull` of four
+  corner circles, `extrude` with built-in twist + taper). Showcases the mesh
+  kernel's cheap continuous deformation. Lives in `examples/basic_shapes.js`
+  because that file doubles as the landing-page `defaultCode` seed.
+- **scad** — a twisted 6-point star column (parametric `module` + `linear_extrude`
+  with `twist`/`scale`). Deliberately **pure OpenSCAD, no BOSL2**: BOSL2's first
+  load fetches ~4 MB and recompiles every run, which would violate the
+  "renders quickly" requirement for a first-switch starter.
+- **replicad** — a rounded mounting plate with true selective fillets, a
+  chamfered top rim, and two boolean-cut bores. The OCCT solver runs sub-second
+  even cold, and it shows the BREP headline (exact fillets/chamfers + STEP).
+- **voxel** — a little tree (trunk + three tapered canopy layers + a gold star),
+  showing `fillBox`/`set` with hex colors.
+
+Decisions / why:
+- **De-duplicated the starter strings.** Previously each starter was spelled out
+  three times (the `DRAFT_STUB_*` constants, the terse bodies in
+  `resetEditorToStarter`, and — for JS — `basic_shapes.js`), which drifts. Now
+  SCAD/replicad/voxel live in single module-level constants
+  (`STARTER_SCAD`/`STARTER_REPLICAD`/`STARTER_VOXEL`); JS lives in
+  `basic_shapes.js` → `defaultCode`. The language-toggle path and
+  `resetEditorToStarter` both reference those. Deleted the `DRAFT_STUB_*` block.
+- **Kept the `examples/*` glob** even though it now only feeds `defaultCode` from
+  `basic_shapes.js`: removing it would orphan every example file and trip knip's
+  `files` gate.
+- `resetEditorToStarter` lost its now-redundant `comment` param (it used to
+  prepend `// New session` / `// New part`; the starters carry their own
+  descriptive header, so the extra label was just a doubled comment).
+- `isStarterCode` still recognizes the new JS starter (it compares to
+  `defaultCode`) and keeps the legacy cube regex for back-compat with old drafts.
+
+Verified all four render via a throwaway Playwright probe (screenshots posted in
+the session); build + unit tier green.

--- a/src/main.ts
+++ b/src/main.ts
@@ -287,39 +287,28 @@ export interface ExampleEntry {
 // minkowski-rounded box, a parametric module + linear_extrude twist, and a
 // rotate_extrude vase. Pure OpenSCAD (no BOSL2), so there's no library
 // download and it renders instantly.
-const STARTER_SCAD = `// OpenSCAD capability sampler — primitives, booleans, transforms, extrudes,
-// and a module + loop, all mounted on one tray so it stays a single solid.
-// Pure OpenSCAD (no libraries) so it renders instantly. Edit and re-run.
-$fn = 48;
+const STARTER_SCAD = `// OpenSCAD capability sampler — a CSG boolean and a parametric twist extrude
+// on one tray (so it stays a single solid). Pure OpenSCAD (no libraries) and
+// kept deliberately small so it renders fast. Edit a block and re-run.
+$fn = 24;
 
-// Tray base ties the four demos into one connected solid.
-translate([1, 0, -1]) cube([88, 24, 3], center = true);
+// Tray base — ties the two demos into one connected solid (top at z = 0).
+translate([0, 0, -2]) cube([40, 22, 4], center = true);
 
-// 1) Boolean difference: a cube with a sphere and a bore removed.
-translate([-32, 0, 1]) difference() {
-  cube([14, 14, 14], center = true);
-  sphere(9);
-  cylinder(h = 20, r = 3.5, center = true);
+// 1) Boolean difference: a cube with a bore (CSG is OpenSCAD's core trick).
+translate([-10, 0, 5.5]) difference() {
+  cube(12, center = true);
+  cylinder(h = 16, r = 3, center = true);
 }
 
-// 2) Rounded box via minkowski (cube + sphere).
-translate([-9, 0, 1]) minkowski() {
-  cube([9, 9, 5], center = true);
-  sphere(2.5, $fn = 16);
-}
-
-// 3) Twisted star column via a parametric module + linear_extrude.
-module star(outer = 8, inner = 3.5, points = 6) {
+// 2) Twisted star column: a parametric module fed into linear_extrude.
+module star(outer = 7, inner = 3, points = 6) {
   polygon([for (i = [0 : 2 * points - 1])
     let (r = (i % 2 == 0) ? outer : inner, a = i * 180 / points)
     [r * cos(a), r * sin(a)]]);
 }
-translate([14, 0, -2]) linear_extrude(height = 22, twist = 160, scale = 0.5, slices = 48)
-  star();
-
-// 4) Surface of revolution: a little vase.
-translate([34, 0, -1]) rotate_extrude($fn = 64)
-  polygon([[2, 0], [7, 4], [4, 10], [6, 14], [2, 16]]);`;
+translate([10, 0, -0.5]) linear_extrude(height = 15, twist = 140, slices = 24)
+  star();`;
 
 // BREP / replicad — a capability sampler laid out in a row: a fully-rounded
 // box, a knob with a filleted top rim + chamfered base, a cone fused onto a

--- a/src/main.ts
+++ b/src/main.ts
@@ -277,6 +277,73 @@ export interface ExampleEntry {
   language: Language;
 }
 
+// Starter snippets seeded into the editor when a language is first opened
+// (toolbar/AI language toggle, new session, new part). Each is a small,
+// instantly-rendering model chosen to show off what its engine is good at.
+// The manifold-js starter lives in examples/basic_shapes.js (it doubles as
+// the landing-page default — see `defaultCode`); the other three live here.
+
+// OpenSCAD: a parametric module fed into linear_extrude with twist + taper —
+// pure OpenSCAD, no BOSL2, so there's no library download and it renders
+// instantly. Showcases the programmatic/CSG style OpenSCAD is built for.
+const STARTER_SCAD = `// Twisted star column — pure OpenSCAD, no libraries, renders instantly.
+// A parametric module fed into linear_extrude with twist + taper: the kind
+// of programmatic modeling OpenSCAD is built for.
+$fn = 48;
+
+module star(outer = 14, inner = 6, points = 6) {
+  polygon([for (i = [0 : 2 * points - 1])
+    let (r = (i % 2 == 0) ? outer : inner, a = i * 180 / points)
+    [r * cos(a), r * sin(a)]]);
+}
+
+linear_extrude(height = 40, twist = 160, slices = 60, scale = 0.55, convexity = 8)
+  star();`;
+
+// BREP / replicad — quick showcase of the headline features:
+//   - selective fillet (the inDirection-based workaround for box edges,
+//     called out in the gotchas cheat sheet at the top of replicad.md)
+//   - true chamfer on the top rim
+//   - boolean subtract (cut) of two fastener bores
+// The result is a rounded mounting plate. It's small enough that the OCCT
+// solver runs in well under a second even on a cold WASM load, so the first
+// paint into the editor after switching languages still feels instant.
+const STARTER_REPLICAD = `// BREP / replicad — exact surfaces with true fillets, chamfers & STEP export.
+const { BREP } = api;
+
+// A rounded mounting plate: 44 x 30 x 10 box with the four vertical corners
+// rounded and the top rim chamfered.
+const body = BREP.box([44, 30, 10])
+  // Round the four vertical corners. \`inDirection: [0,0,1]\` selects the
+  // Z-parallel edges — needed because inBox alone is unreliable on a
+  // BREP.box's coincident planar edges (see replicad.md "Gotchas").
+  .fillet(4, { inDirection: [0, 0, 1] })
+  // Bevel the top rim (the four edges of the top face). Same gotcha:
+  // pair the maxZ bound with parallelToPlane: 'XY'.
+  .chamfer(1, { maxZ: 9.999, parallelToPlane: 'XY' });
+
+// Two fastener holes, cut straight through with a boolean.
+const hole = BREP.cylinder(3, 14).translate([0, 0, -2]);
+return body.cut(hole.translate([-13, 0, 0])).cut(hole.translate([13, 0, 0]));`;
+
+// Voxel — a small colored model (a little tree) so the first paint after
+// switching shows the workflow (fillBox / set with hex colors) immediately.
+const STARTER_VOXEL = `// Voxel — build with colored cubes on an integer grid (1 voxel = 1 unit).
+const { voxels } = api;
+const v = voxels();
+
+// Trunk
+v.fillBox([-1, -1, 0], [0, 0, 2], '#8a5a2b');
+// Tapered canopy — three stacked layers
+v.fillBox([-4, -4, 3], [3, 3, 4], '#2e9e4f');
+v.fillBox([-3, -3, 5], [2, 2, 6], '#37b85c');
+v.fillBox([-2, -2, 7], [1, 1, 8], '#4fd673');
+// A star on top
+v.set(0, 0, 9, '#ffd23b');
+
+// Tip: return v.smooth() for rounded edges (see /ai/voxel.md).
+return v;`;
+
 // Customizer state. `currentParamSchema` is the parameter schema the active
 // model declared via `api.params({...})` on its last run (null when it declared
 // none); `currentParamValues` holds the user's overrides (only keys differing
@@ -3931,33 +3998,26 @@ async function main() {
   // Reset the editor to a blank starting point for a freshly created session.
   // Shared by the session bar's "+ New Session" button and the session modal's,
   // so both clear the previous session's code instead of leaving it behind.
-  function resetEditorToStarter(comment: string) {
+  function resetEditorToStarter() {
     dropPaintState();
     const lang = getActiveLanguage();
-    let body: string;
-    if (lang === 'scad') {
-      body = 'cube([10, 10, 10], center=true);';
-    } else if (lang === 'replicad') {
-      body = 'const { BREP } = api;\nconst body = BREP.box([30, 30, 10]).fillet(3, { inDirection: [0, 0, 1] });\nconst bore = BREP.cylinder(4, 12).translate([0, 0, -1]);\nreturn body.cut(bore);';
-    } else if (lang === 'voxel') {
-      body = "const { voxels } = api;\nconst v = voxels();\nv.fillBox([-5, -5, 0], [4, 4, 0], '#6b8cff');\nv.fillBox([-1, -1, 1], [1, 1, 6], '#ff8c42');\nv.set(0, 0, 7, '#ff3b30');\nreturn v;";
-    } else {
-      body = 'const { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);';
-    }
-    const freshCode = `// ${comment}\n${body}`;
+    const freshCode = lang === 'scad' ? STARTER_SCAD
+      : lang === 'replicad' ? STARTER_REPLICAD
+      : lang === 'voxel' ? STARTER_VOXEL
+      : defaultCode;
     setValue(freshCode);
     runCode(freshCode);
   }
 
   function startNewSessionInEditor() {
-    resetEditorToStarter('New session');
+    resetEditorToStarter();
     _clearImages();
   }
 
   // Reset the editor for a freshly created part. Unlike a new session, parts
   // share the session's reference images, so those are left intact.
   function startNewPartInEditor() {
-    resetEditorToStarter('New part');
+    resetEditorToStarter();
   }
 
   // Load a part's active version into the editor, or reset to a blank part when
@@ -6401,46 +6461,6 @@ async function main() {
     setStatus(statusBar, 'ready', 'Ready');
   }
 
-  const DRAFT_STUB_JS = '// JavaScript\nconst { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);';
-  const DRAFT_STUB_SCAD = '// OpenSCAD\ncube([10, 10, 10], center=true);';
-  // Voxel — a small colored model so the first paint after switching shows
-  // the workflow (fillBox / set with hex or [r,g,b] colors) immediately.
-  const DRAFT_STUB_VOXEL =
-    '// Voxel — build with colored cubes on an integer grid (1 voxel = 1 unit).\n' +
-    'const { voxels } = api;\n' +
-    'const v = voxels();\n' +
-    "v.fillBox([-5, -5, 0], [4, 4, 0], '#6b8cff');   // a 10x10 base slab\n" +
-    "v.fillBox([-1, -1, 1], [1, 1, 6], '#ff8c42');   // a tower\n" +
-    "v.set(0, 0, 7, '#ff3b30');                       // a red cap\n" +
-    '// Tip: return v.smooth() for rounded edges (see /ai/voxel.md).\n' +
-    'return v;\n';
-  // BREP / replicad — quick showcase of the headline features:
-  //   - selective fillet (the inDirection-based workaround for box edges,
-  //     called out in the gotchas cheat sheet at the top of replicad.md)
-  //   - true chamfer on the top rim
-  //   - boolean subtract (cut) of a cylinder bore
-  // The result is a rounded-corner mounting bracket with a bevelled bore.
-  // It's small enough that the OCCT solver runs in well under a second on
-  // a cold WASM load, so the first paint into the editor after switching
-  // languages still feels instant.
-  const DRAFT_STUB_REPLICAD =
-    '// BREP / replicad — exact-surface modeling\n' +
-    "const { BREP } = api;\n" +
-    '\n' +
-    '// Body: 30x30x10 box with rounded vertical corners and a chamfered top rim.\n' +
-    'const body = BREP.box([30, 30, 10])\n' +
-    '  // Round the four vertical corners. `inDirection: [0,0,1]` requires the\n' +
-    "  // edge be Z-parallel — needed because inBox alone is unreliable on a\n" +
-    "  // BREP.box's planar coincident edges (see replicad.md \"Gotchas\").\n" +
-    '  .fillet(3, { inDirection: [0, 0, 1] })\n' +
-    '  // Bevel the top rim — the four edges of the top face. Same gotcha:\n' +
-    "  // pair the maxZ bound with parallelToPlane: 'XY'.\n" +
-    "  .chamfer(0.6, { maxZ: 9.999, parallelToPlane: 'XY' });\n" +
-    '\n' +
-    '// Boolean cut: a 4 mm bore through the centre.\n' +
-    'const bore = BREP.cylinder(4, 12).translate([0, 0, -1]);\n' +
-    'return body.cut(bore);\n';
-
   /** Toolbar / AI language toggle: stash the current editor buffer as a draft
    *  on the active session, swap engines, then restore the target language's
    *  draft (seeded with a stub if none has been stashed yet). Versions are not
@@ -6476,10 +6496,10 @@ async function main() {
       if (draft) { nextCode = draft.code; nextCompanions = draft.companionFiles; }
     }
     if (nextCode === null) {
-      nextCode = lang === 'scad' ? DRAFT_STUB_SCAD
-        : lang === 'replicad' ? DRAFT_STUB_REPLICAD
-        : lang === 'voxel' ? DRAFT_STUB_VOXEL
-        : DRAFT_STUB_JS;
+      nextCode = lang === 'scad' ? STARTER_SCAD
+        : lang === 'replicad' ? STARTER_REPLICAD
+        : lang === 'voxel' ? STARTER_VOXEL
+        : defaultCode;
     }
     // Restore the target language's companion set: the SCAD draft's saved
     // companions, or empty for any non-SCAD buffer (which never has them).

--- a/src/main.ts
+++ b/src/main.ts
@@ -3143,9 +3143,12 @@ async function main() {
   // wrapper (`Manifold.ofMesh` / `Manifold.compose`) main already uses for STL
   // imports and simplify-bakes, so the result is an ordinary, editable version.
 
-  /** True when the editor still holds a fresh starter snippet (blank, the
-   *  default example, or a "New session"/"New part" cube) — i.e. nothing worth
-   *  preserving before an import overwrites it. */
+  /** True when the editor still holds a fresh starter snippet (blank or the
+   *  current manifold-js default) — i.e. nothing worth preserving before an
+   *  import overwrites it. The trailing regex is kept only for back-compat with
+   *  legacy saved drafts that hold the old `Manifold.cube([10,10,10])` starter
+   *  (optionally prefixed with a `// New session`/`// New part` comment that
+   *  `resetEditorToStarter` no longer emits). */
   function isStarterCode(code: string): boolean {
     const t = code.trim();
     if (!t) return true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -288,19 +288,22 @@ export interface ExampleEntry {
 // rotate_extrude vase. Pure OpenSCAD (no BOSL2), so there's no library
 // download and it renders instantly.
 const STARTER_SCAD = `// OpenSCAD capability sampler — primitives, booleans, transforms, extrudes,
-// and a module + loop. Pure OpenSCAD (no libraries) so it renders instantly.
-// Edit any block and re-run to experiment.
+// and a module + loop, all mounted on one tray so it stays a single solid.
+// Pure OpenSCAD (no libraries) so it renders instantly. Edit and re-run.
 $fn = 48;
 
+// Tray base ties the four demos into one connected solid.
+translate([1, 0, -1]) cube([88, 24, 3], center = true);
+
 // 1) Boolean difference: a cube with a sphere and a bore removed.
-translate([-32, 0, 0]) difference() {
+translate([-32, 0, 1]) difference() {
   cube([14, 14, 14], center = true);
   sphere(9);
   cylinder(h = 20, r = 3.5, center = true);
 }
 
 // 2) Rounded box via minkowski (cube + sphere).
-translate([-9, 0, 0]) minkowski() {
+translate([-9, 0, 1]) minkowski() {
   cube([9, 9, 5], center = true);
   sphere(2.5, $fn = 16);
 }
@@ -311,11 +314,11 @@ module star(outer = 8, inner = 3.5, points = 6) {
     let (r = (i % 2 == 0) ? outer : inner, a = i * 180 / points)
     [r * cos(a), r * sin(a)]]);
 }
-translate([14, 0, -11]) linear_extrude(height = 22, twist = 160, scale = 0.5, slices = 48)
+translate([14, 0, -2]) linear_extrude(height = 22, twist = 160, scale = 0.5, slices = 48)
   star();
 
 // 4) Surface of revolution: a little vase.
-translate([34, 0, -8]) rotate_extrude($fn = 64)
+translate([34, 0, -1]) rotate_extrude($fn = 64)
   polygon([[2, 0], [7, 4], [4, 10], [6, 14], [2, 16]]);`;
 
 // BREP / replicad — a capability sampler laid out in a row: a fully-rounded
@@ -324,7 +327,8 @@ translate([34, 0, -8]) rotate_extrude($fn = 64)
 // headline (true selective fillets/chamfers + exact booleans + STEP). Small
 // enough that the OCCT solver runs in well under a second even cold.
 const STARTER_REPLICAD = `// BREP / replicad capability sampler — exact surfaces with true fillets,
-// chamfers, and booleans (and STEP export). Edit a block and re-run.
+// chamfers, and booleans (and STEP export), fused onto one tray so it stays a
+// single solid. Edit a block and re-run.
 const { BREP } = api;
 
 // 1) A rounded box — fillet with no filter rounds every edge at once.
@@ -345,8 +349,10 @@ const bracket = BREP.box([20, 14, 8])
   .cut(BREP.cylinder(2, 12).translate([-6, 0, -2]))
   .cut(BREP.cylinder(2, 12).translate([ 6, 0, -2]));
 
-// Lay them out in a row so each is visible.
-return rounded.translate([-30, 0, 0])
+// A tray base fuses the four demos into one connected solid.
+const tray = BREP.box([86, 24, 3]).translate([4, 0, -2]);
+return tray
+  .fuse(rounded.translate([-30, 0, 0]))
   .fuse(knob.translate([-6, 0, 0]))
   .fuse(finial.translate([16, 0, 0]))
   .fuse(bracket.translate([38, 0, 0]));`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -283,63 +283,108 @@ export interface ExampleEntry {
 // The manifold-js starter lives in examples/basic_shapes.js (it doubles as
 // the landing-page default — see `defaultCode`); the other three live here.
 
-// OpenSCAD: a parametric module fed into linear_extrude with twist + taper —
-// pure OpenSCAD, no BOSL2, so there's no library download and it renders
-// instantly. Showcases the programmatic/CSG style OpenSCAD is built for.
-const STARTER_SCAD = `// Twisted star column — pure OpenSCAD, no libraries, renders instantly.
-// A parametric module fed into linear_extrude with twist + taper: the kind
-// of programmatic modeling OpenSCAD is built for.
+// OpenSCAD: a capability sampler laid out in a row — boolean difference,
+// minkowski-rounded box, a parametric module + linear_extrude twist, and a
+// rotate_extrude vase. Pure OpenSCAD (no BOSL2), so there's no library
+// download and it renders instantly.
+const STARTER_SCAD = `// OpenSCAD capability sampler — primitives, booleans, transforms, extrudes,
+// and a module + loop. Pure OpenSCAD (no libraries) so it renders instantly.
+// Edit any block and re-run to experiment.
 $fn = 48;
 
-module star(outer = 14, inner = 6, points = 6) {
+// 1) Boolean difference: a cube with a sphere and a bore removed.
+translate([-32, 0, 0]) difference() {
+  cube([14, 14, 14], center = true);
+  sphere(9);
+  cylinder(h = 20, r = 3.5, center = true);
+}
+
+// 2) Rounded box via minkowski (cube + sphere).
+translate([-9, 0, 0]) minkowski() {
+  cube([9, 9, 5], center = true);
+  sphere(2.5, $fn = 16);
+}
+
+// 3) Twisted star column via a parametric module + linear_extrude.
+module star(outer = 8, inner = 3.5, points = 6) {
   polygon([for (i = [0 : 2 * points - 1])
     let (r = (i % 2 == 0) ? outer : inner, a = i * 180 / points)
     [r * cos(a), r * sin(a)]]);
 }
+translate([14, 0, -11]) linear_extrude(height = 22, twist = 160, scale = 0.5, slices = 48)
+  star();
 
-linear_extrude(height = 40, twist = 160, slices = 60, scale = 0.55, convexity = 8)
-  star();`;
+// 4) Surface of revolution: a little vase.
+translate([34, 0, -8]) rotate_extrude($fn = 64)
+  polygon([[2, 0], [7, 4], [4, 10], [6, 14], [2, 16]]);`;
 
-// BREP / replicad — quick showcase of the headline features:
-//   - selective fillet (the inDirection-based workaround for box edges,
-//     called out in the gotchas cheat sheet at the top of replicad.md)
-//   - true chamfer on the top rim
-//   - boolean subtract (cut) of two fastener bores
-// The result is a rounded mounting plate. It's small enough that the OCCT
-// solver runs in well under a second even on a cold WASM load, so the first
-// paint into the editor after switching languages still feels instant.
-const STARTER_REPLICAD = `// BREP / replicad — exact surfaces with true fillets, chamfers & STEP export.
+// BREP / replicad — a capability sampler laid out in a row: a fully-rounded
+// box, a knob with a filleted top rim + chamfered base, a cone fused onto a
+// cylinder, and a bracket with rounded corners + bored holes. Shows the BREP
+// headline (true selective fillets/chamfers + exact booleans + STEP). Small
+// enough that the OCCT solver runs in well under a second even cold.
+const STARTER_REPLICAD = `// BREP / replicad capability sampler — exact surfaces with true fillets,
+// chamfers, and booleans (and STEP export). Edit a block and re-run.
 const { BREP } = api;
 
-// A rounded mounting plate: 44 x 30 x 10 box with the four vertical corners
-// rounded and the top rim chamfered.
-const body = BREP.box([44, 30, 10])
-  // Round the four vertical corners. \`inDirection: [0,0,1]\` selects the
-  // Z-parallel edges — needed because inBox alone is unreliable on a
-  // BREP.box's coincident planar edges (see replicad.md "Gotchas").
-  .fillet(4, { inDirection: [0, 0, 1] })
-  // Bevel the top rim (the four edges of the top face). Same gotcha:
-  // pair the maxZ bound with parallelToPlane: 'XY'.
-  .chamfer(1, { maxZ: 9.999, parallelToPlane: 'XY' });
+// 1) A rounded box — fillet with no filter rounds every edge at once.
+const rounded = BREP.box([18, 18, 10]).fillet(2.5);
 
-// Two fastener holes, cut straight through with a boolean.
-const hole = BREP.cylinder(3, 14).translate([0, 0, -2]);
-return body.cut(hole.translate([-13, 0, 0])).cut(hole.translate([13, 0, 0]));`;
+// 2) A knob: cylinder with a filleted top rim and a chamfered base.
+const knob = BREP.cylinder(8, 14)
+  .fillet(2, { maxZ: 13.999, parallelToPlane: 'XY' })
+  .chamfer(0.8, { minZ: 0.001, parallelToPlane: 'XY' });
 
-// Voxel — a small colored model (a little tree) so the first paint after
-// switching shows the workflow (fillBox / set with hex colors) immediately.
-const STARTER_VOXEL = `// Voxel — build with colored cubes on an integer grid (1 voxel = 1 unit).
+// 3) A finial: a cone fused onto a cylinder (boolean union of two solids).
+const finial = BREP.cone(7, 4, 7)
+  .fuse(BREP.cylinder(4, 8).translate([0, 0, 7]));
+
+// 4) A bracket: a box with rounded vertical corners and two bored holes.
+const bracket = BREP.box([20, 14, 8])
+  .fillet(3, { inDirection: [0, 0, 1] })
+  .cut(BREP.cylinder(2, 12).translate([-6, 0, -2]))
+  .cut(BREP.cylinder(2, 12).translate([ 6, 0, -2]));
+
+// Lay them out in a row so each is visible.
+return rounded.translate([-30, 0, 0])
+  .fuse(knob.translate([-6, 0, 0]))
+  .fuse(finial.translate([16, 0, 0]))
+  .fuse(bracket.translate([38, 0, 0]));`;
+
+// Voxel — a layered pine tree: a loop builds tapering canopy tiers in
+// alternating greens, with snowy caps, ornaments, and a gold star, so the
+// first paint shows the fillBox / set workflow on a fuller model.
+const STARTER_VOXEL = `// Voxel pine tree — colored cubes on an integer grid (1 voxel = 1 unit).
+// A loop builds tapering canopy tiers; ornaments and a star finish it.
 const { voxels } = api;
 const v = voxels();
 
 // Trunk
-v.fillBox([-1, -1, 0], [0, 0, 2], '#8a5a2b');
-// Tapered canopy — three stacked layers
-v.fillBox([-4, -4, 3], [3, 3, 4], '#2e9e4f');
-v.fillBox([-3, -3, 5], [2, 2, 6], '#37b85c');
-v.fillBox([-2, -2, 7], [1, 1, 8], '#4fd673');
-// A star on top
-v.set(0, 0, 9, '#ffd23b');
+v.fillBox([-1, -1, 0], [0, 0, 3], '#7a4a22');
+
+// Canopy: stacked square tiers, each smaller than the one below, in
+// alternating green shades for depth.
+const greens = ['#2e7d32', '#388e3c', '#43a047', '#4caf50', '#66bb6a'];
+let z = 4;
+for (let i = 0; i < 6; i++) {
+  const half = 6 - i;
+  v.fillBox([-half, -half, z], [half - 1, half - 1, z + 1], greens[i % greens.length]);
+  z += 2;
+}
+
+// Snowy caps (a few light voxels on tier edges).
+v.set(-5, 2, 5, '#eaf6ff');
+v.set(3, -4, 7, '#eaf6ff');
+v.set(-2, 3, 9, '#eaf6ff');
+
+// Ornaments dotted around the tree.
+v.set(5, 0, 4, '#e53935');
+v.set(-4, -4, 6, '#fdd835');
+v.set(3, 3, 8, '#1e88e5');
+v.set(-2, 1, 10, '#e53935');
+
+// Gold star on top.
+v.set(0, 0, z, '#ffd23b');
 
 // Tip: return v.smooth() for rounded edges (see /ai/voxel.md).
 return v;`;

--- a/tests/session-modal.spec.ts
+++ b/tests/session-modal.spec.ts
@@ -64,10 +64,11 @@ test.describe('Session modal', () => {
     await prompt.locator('input').fill('Fresh Session');
     await prompt.getByRole('button', { name: 'OK' }).click();
 
-    // Editor now holds the fresh default, not the old session's code.
+    // Editor now holds the fresh manifold-js default starter, not the old
+    // session's code. The default seeds the CrossSection-based starter model.
     await expect
       .poll(() => page.evaluate(() => (window as unknown as { partwright: PW }).partwright.getCode()))
-      .toContain('// New session');
+      .toContain('CrossSection');
     expect(await page.evaluate(() => (window as unknown as { partwright: PW }).partwright.getCode())).not.toContain(
       MARKER,
     );


### PR DESCRIPTION
## Summary

Replaces the placeholder `cube` starters that load into the editor for a new session / on a language switch with **capability samplers** — several shapes and operations laid out in one tweakable model so a new session is something to experiment with. Each is chosen to show off what its engine is good at and renders in well under a second.

| Engine | New starter | Demonstrates |
|---|---|---|
| **manifold-js** | boolean cutout · hull-rounded box · twist-extrude column · revolve vase | primitives, fast mesh booleans, `hull`, `CrossSection.extrude` twist, `revolve` |
| **scad** | difference · minkowski-rounded box · module + `linear_extrude(twist=)` · `rotate_extrude` vase | primitives, booleans, transforms, modules/loops, extrudes — **pure OpenSCAD, no BOSL2** (no library download, instant) |
| **replicad** | fully-rounded box · knob (filleted rim + chamfered base) · cone fused onto a cylinder · bracket with rounded corners + bored holes | true selective fillets/chamfers, exact booleans, STEP export |
| **voxel** | a fuller layered pine tree (loop-built tapering tiers in alternating greens, snowy caps, ornaments, gold star) | `fillBox` / `set` workflow on a richer model |

## Implementation notes

- **De-duplicated the starter strings.** Each starter used to be spelled out up to three times (the `DRAFT_STUB_*` constants, the terse bodies in `resetEditorToStarter`, and — for JS — `basic_shapes.js`), which drifts. SCAD/replicad/voxel now live in single module-level constants (`STARTER_SCAD` / `STARTER_REPLICAD` / `STARTER_VOXEL`); the manifold-js starter lives in `examples/basic_shapes.js` (it doubles as the landing-page `defaultCode` seed). Both the language-toggle path (`switchLanguageWithDrafts`) and `resetEditorToStarter` reference these. The `DRAFT_STUB_*` block is gone.
- Kept the `examples/*` glob (it now only feeds `defaultCode`); removing it would orphan every example file and trip knip's `files` gate.
- `resetEditorToStarter` dropped its now-redundant `comment` param — the samplers carry their own headers, so prepending `// New session` just doubled the comment. Updated `session-modal.spec.ts` accordingly (it now asserts the fresh manifold-js default loaded via `CrossSection`).
- `isStarterCode` still recognizes the new JS starter (compares against `defaultCode`) and keeps the legacy cube regex for back-compat with old saved drafts.
- OCCT note: chamfering a box whose edges were *all* just filleted fails, so the replicad block-1 box is fillet-only; chamfer is demonstrated on the knob's base instead.

## Test plan

- `npm run build` (tsc) ✅
- `npm run test:unit` (649) ✅
- `session-modal.spec.ts` (the one assertion that referenced the old starter marker) ✅
- Manual browser verification: a throwaway Playwright probe switched to each language, ran the sampler, and screenshotted the viewport — all four render correctly (screenshots posted in the session). Scratch spec removed before commit.
- PR-checks e2e shards run on every draft push.

https://claude.ai/code/session_01QLCF7o9scSwYibLje6ase8