### PR TITLE
fix: keep AI input textarea at a 3-row minimum height

### DIFF
--- a/prompts/20260605-ai-input-3row-floor.md
+++ b/prompts/20260605-ai-input-3row-floor.md
@@ -1,0 +1,42 @@
+---
+session: "happy-einstein"
+timestamp: "2026-06-05T00:00:00Z"
+model: claude-opus-4-8
+tools: [explore, Bash, Edit, Write]
+---
+
+## Human
+
+I've had some situation where the AI pane text box gets squished and it's hard
+to read or type into. I never want it to have a height less than maybe 3 rows
+of text.
+
+## Assistant
+
+## Key decisions
+
+**Root cause.** The AI drawer's textarea (`src/ui/aiPanel.ts`) had `min-h-0`
+and lived inside `bottomSection`, a *fixed* 220px box with `overflow-hidden`.
+The textarea was `flex-1`, so it only got whatever height the fixed budget had
+left after its `shrink-0` siblings (toggle strip, cost meter, pending-images
+row, in-progress indicator, queued-message badge). When several of those rows
+appeared at once — or the toggle strip wrapped — they ate the 220px and the
+`min-h-0` textarea collapsed toward 0px. There was no programmatic floor.
+
+**Fix — a real 3-row floor that's actually honored, not clipped.**
+- Textarea: dropped `min-h-0`, kept `flex-1` (still grows to fill the pane),
+  and added `style.minHeight = '74px'` ≈ 3 rows of `text-sm` (20px
+  line-height) + `py-1.5` padding + border. Bumped `rows` 2 → 3 as the
+  non-flex fallback.
+- `bottomSection`: switched from a fixed `height` to `minHeight` and removed
+  `overflow-hidden`, so when sibling rows appear the whole section *grows* to
+  preserve the textarea floor instead of clipping it. The section is `shrink-0`
+  in the panel column, so growth pushes the transcript (which scrolls) rather
+  than squishing the input.
+- Resizer (`initInputResizer`): now sets `style.minHeight` to match, so the
+  drag-handle's 100–520px range still works with the growable model.
+
+**Verification.** `npm run build` (type-check) clean. A throwaway Playwright
+spec opened the panel, force-revealed every space-claiming sibling row at once,
+and measured the textarea: baseline 87px, worst-case 74px — the floor holds
+where it previously collapsed. Scratch spec/screenshots deleted before commit.

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -752,8 +752,12 @@ function buildDrawer(): void {
 
   // Bottom section — rewind, toggles, cost, input
   const bottomSection = document.createElement('div');
-  bottomSection.className = 'flex flex-col shrink-0 overflow-hidden';
-  bottomSection.style.height = '220px';
+  // min-height (not a fixed height) so the section can grow to keep the input
+  // readable: when sibling rows below appear (progress, pending images, queued
+  // badge, a wrapped toggle strip) they no longer compress the textarea — the
+  // whole section expands instead, preserving the textarea's 3-row floor.
+  bottomSection.className = 'flex flex-col shrink-0';
+  bottomSection.style.minHeight = '220px';
   initInputResizer(inputResizeHandle, bottomSection);
 
 
@@ -795,8 +799,14 @@ function buildDrawer(): void {
 
   const ta = document.createElement('textarea');
   ta.placeholder = 'Ask the AI to model something…  (type / for commands)';
-  ta.rows = 2;
-  ta.className = 'w-full flex-1 min-h-0 px-2 py-1.5 rounded bg-zinc-800 border border-zinc-600 text-zinc-100 text-sm placeholder:text-zinc-500 focus:outline-none focus:border-blue-500 resize-none';
+  ta.rows = 3;
+  // Hard 3-row floor: `flex-1` still lets the textarea grow to fill the pane,
+  // but min-height keeps it readable/typeable no matter what siblings claim
+  // space below. 3 rows of text-sm (20px line-height) + py-1.5 padding +
+  // border ≈ 74px. Replaces the old `min-h-0`, which let flexbox squish it
+  // all the way to 0.
+  ta.className = 'w-full flex-1 px-2 py-1.5 rounded bg-zinc-800 border border-zinc-600 text-zinc-100 text-sm placeholder:text-zinc-500 focus:outline-none focus:border-blue-500 resize-none';
+  ta.style.minHeight = '74px';
   ta.addEventListener('keydown', e => {
     // When the slash-command menu is open it owns the arrow/Tab/Enter/Escape
     // keys so the user can navigate and run a command without it being sent
@@ -1023,7 +1033,7 @@ function initInputResizer(handle: HTMLElement, bottomSection: HTMLElement): void
     const delta = startY - e.clientY;
     const minH = 100;
     const maxH = 520;
-    bottomSection.style.height = `${Math.max(minH, Math.min(maxH, startHeight + delta))}px`;
+    bottomSection.style.minHeight = `${Math.max(minH, Math.min(maxH, startHeight + delta))}px`;
   });
 
   const onInputResizeEnd = (e: PointerEvent) => {


### PR DESCRIPTION
## Summary

The AI drawer's prompt textarea could get "squished" to an unreadable/untypeable
height. Root cause: the textarea had `min-h-0` and lived inside `bottomSection`,
a **fixed** 220px box with `overflow-hidden`. Because the textarea is `flex-1`,
it only got whatever vertical space was left after its `shrink-0` siblings —
the toggle strip, cost meter, pending-images row, in-progress indicator, and
queued-message badge. When several of those appeared at once (or the toggle
strip wrapped), they consumed the fixed 220px and the `min-h-0` textarea
collapsed toward 0px. Nothing enforced a floor.

## Changes (`src/ui/aiPanel.ts`)

- **Textarea floor:** removed `min-h-0`, kept `flex-1` (it still grows to fill
  the pane), and added `min-height: 74px` ≈ 3 rows of `text-sm` (20px
  line-height) + `py-1.5` padding + border. Bumped `rows` 2 → 3 as the non-flex
  fallback.
- **Growable bottom section:** `bottomSection` now uses `min-height` instead of
  a fixed `height`, and `overflow-hidden` is removed — so when sibling rows
  appear the section *grows* to preserve the textarea floor rather than clipping
  it. The section is `shrink-0` in the panel column, so growth pushes the
  scrollable transcript, not the input.
- **Resizer:** `initInputResizer` now sets `style.minHeight` to stay consistent
  with the growable model; the drag handle's 100–520px range is unchanged.

## Test plan

- `npm run build` (type-check) — clean.
- Manual browser check via a throwaway Playwright spec: opened the AI panel,
  force-revealed every space-claiming sibling row at once (the worst-case squish),
  and measured the textarea — baseline **87px**, worst-case **74px** (the 3-row
  floor holds where it previously collapsed). Scratch spec/screenshots removed
  before commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8Z3ubSAoqAuk3CguN2cKb)_