### PR TITLE
feat: slot-aware multi-color 3MF export + over-budget warning (Phase 2)

### DIFF
--- a/prompts/20260605-slot-aware-3mf-export.md
+++ b/prompts/20260605-slot-aware-3mf-export.md
@@ -1,0 +1,44 @@
+---
+session: "stylized-paint-effects"
+timestamp: "2026-06-05T13:50:00Z"
+---
+
+## Human
+
+Move onto the next phase (Phase 2: slot-aware multi-color 3MF export for
+multi-color FDM / Bambu Studio AMS).
+
+## Assistant
+
+## Key decisions
+
+**Slot-ordered 3MF materials.** `build3MF` previously built the `m:colorgroup`
+in triangle-encounter order with the viewport default pinned at index 0. Replaced
+that: emit the colours of the *used* filament-palette slots first, in slot order
+(so the 3MF material index follows the user's AMS slot order), then any remaining
+painted colours (custom + the unpainted default) in first-encounter order — and
+only colours that actually appear in the mesh (no phantom default filament for a
+fully-painted model). The exporter has only baked `triColors` (no slotId on the
+mesh), and slot painting bakes the slot's exact hex, so an exact hex match against
+`listFilaments()` recovers the slot order losslessly (hex→rgb→×255→hex is
+identity). Unit-tested by painting two slot colours in non-slot order and
+asserting the colorgroup emits them in slot order.
+
+**Over-budget + format-honesty warnings (UI path only).** Extended
+`ExportWarningInfo` with `colorOverBudget` (distinct region colours vs
+`getPaletteCapacity()`, for 3MF/GLB/OBJ) and `colorDropped` (STL on a painted
+model). Computed in `exportWarningInfo()` (the UI-only `confirmExportOrProceed`
+path) so the console/AI `export3MF*` APIs stay unblocked. Advisory only.
+
+**Bambu-native `paint_color` deferred — deliberately.** The user wanted faces
+auto-assigned to filaments in Bambu Studio. That needs Bambu/Orca's per-triangle
+`paint_color` segmentation, which is an *undocumented* bitstream (a recursive
+TriangleSelector serialization). Web research surfaced the gotchas (uppercase-only
+hex, 16-filament cap) but not a verifiable encoding, and a wrong encoding fails
+*silently* in Bambu — worse than none. So Phase 2 ships the documented, portable
+standard `m:colorgroup` (which Bambu imports as a multi-colour object, now in
+slot order), and the native segmentation is held for a follow-up that can be
+validated against a real Bambu Studio. Flagged to the user.
+
+Layering: `src/export/threemf.ts` → `src/color/palette` (leaf) is a clean new
+edge; `lint:deps` stays acyclic.

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -3,7 +3,8 @@ import { get3MFUnitString } from '../geometry/units';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
 import type { BuiltExport } from './gltf';
 import { buildZip } from './zip';
-import { assertFiniteMesh, cleanMeshForExport, DEFAULT_COLOR_HEX, triColorHex, hasAnyPainted } from './meshClean';
+import { assertFiniteMesh, cleanMeshForExport, triColorHex, hasAnyPainted } from './meshClean';
+import { listFilaments } from '../color/palette';
 
 /** Build a 3MF export blob without triggering a download. */
 export function build3MF(meshData: MeshData, customName?: string): BuiltExport {
@@ -22,22 +23,37 @@ export function build3MF(meshData: MeshData, customName?: string): BuiltExport {
     vertices.push(`          <vertex x="${x}" y="${y}" z="${z}" />`);
   }
 
-  // Collect distinct colors for m:colorgroup
+  // Collect distinct colors for m:colorgroup. Order matters: a slicer (Bambu
+  // Studio / Orca) maps each m:color to a filament in declaration order, so we
+  // emit the colours of the *filament-palette slots that are actually used*
+  // first, in slot order — making the 3MF material index follow the user's
+  // AMS slot order. Any remaining painted colours (custom/ad-hoc, plus the
+  // default colour of unpainted faces) follow in first-encounter order. Only
+  // colours that actually appear in the mesh are emitted (no phantom filaments).
   const hasColors = triColors != null && hasAnyPainted(triColors, validTris);
   const colorMap = new Map<string, number>(); // hex -> material index
   const materialColors: string[] = [];
 
   if (hasColors && triColors) {
-    colorMap.set(DEFAULT_COLOR_HEX, 0);
-    materialColors.push(DEFAULT_COLOR_HEX);
-
-    for (const t of validTris) {
-      const hex = triColorHex(triColors, t);
-      if (hex !== DEFAULT_COLOR_HEX && !colorMap.has(hex)) {
+    const pushMaterial = (hex: string) => {
+      if (!colorMap.has(hex)) {
         colorMap.set(hex, materialColors.length);
         materialColors.push(hex);
       }
+    };
+
+    // Which painted colours actually appear in the mesh.
+    const usedHexes = new Set<string>();
+    for (const t of validTris) usedHexes.add(triColorHex(triColors, t));
+
+    // 1) Used palette slots, in slot order → material index follows AMS order.
+    for (const slot of listFilaments()) {
+      const hex = slot.hex.toLowerCase();
+      if (usedHexes.has(hex)) pushMaterial(hex);
     }
+    // 2) Everything else (custom colours + the unpainted default), in
+    //    first-encounter order.
+    for (const t of validTris) pushMaterial(triColorHex(triColors, t));
   }
 
   // Build triangles XML (remapped vertex indices, filtered for degenerates)

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,7 +124,7 @@ import { DEFAULT_RELIEF_OPTIONS, type ReliefOptions, type ReliefImportMode, type
 import { computeReliefTriColors, getSwapGuideFor, setPreviewMode as ctlSetReliefPreviewMode, getPreviewMode as ctlGetReliefPreviewMode, isPreviewActive as isReliefPreviewActive } from './relief/reliefController';
 import { setReliefSettings, getReliefSettings, updateReliefSettings, isReliefSession, getPreviewModeFor } from './relief/reliefSettings';
 import { saveReliefSource, getReliefSource } from './relief/reliefSource';
-import { listFilaments, hexToRgb } from './relief/filaments';
+import { listFilaments, hexToRgb, getPaletteCapacity } from './relief/filaments';
 import { meshBounds } from './color/slabPaint';
 import { openReliefImportModal } from './ui/reliefImportModal';
 import { mountReliefStudio, type ReliefStudioHandle } from './ui/reliefStudio';
@@ -172,7 +172,7 @@ import {
 import { setColor as setAnnotateColor, setWidth as setAnnotateWidth, getWidth as getAnnotateWidth } from './annotations/annotateMode';
 import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontSize as getAnnotateFontSize } from './annotations/textMode';
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
-import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, setRegionTriangles, buildTriColors, createEmptyTriColors, overlayPainted, setModelColorRegions, hasModelColorRegions, clearModelColorRegions, getModelRegions, type SerializedColorRegion, type RegionDescriptor } from './color/regions';
+import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, setRegionTriangles, buildTriColors, createEmptyTriColors, overlayPainted, setModelColorRegions, hasModelColorRegions, clearModelColorRegions, getModelRegions, getDistinctRegionColors, type SerializedColorRegion, type RegionDescriptor } from './color/regions';
 import { setPaintLabels } from './color/labels';
 import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as getPaintBucketTolerance, setBucketColorTolerance as setPaintBucketColorTolerance, getBucketColorTolerance as getPaintBucketColorTolerance, setBucketMode as setPaintBucketMode, getBucketMode as getPaintBucketMode, setBrushRadius as setPaintBrushRadius, getBrushRadius as getPaintBrushRadius, setBrushSmooth as setPaintBrushSmooth, isBrushSmooth as isPaintBrushSmooth, setBrushSmoothDivisor as setPaintBrushSmoothDivisor, getBrushSmoothDivisor as getPaintBrushSmoothDivisor, setBrushSurface as setPaintBrushSurface, getBrushSurface as getPaintBrushSurface, setBrushPaintDepth as setPaintBrushDepth, getBrushPaintDepth as getPaintBrushDepth, SMOOTH_DIVISOR_MIN, SMOOTH_DIVISOR_MAX } from './color/paintMode';
 import { buildStrokeMesh, buildRefinedMesh, buildRefinedMeshFromSet, brushRefineRegion, strokeFootprintTriangles, deriveSampleNormals, buildGeodesicField, tangentBasis, childrenByParent, type BrushStroke, type BrushShape, type RefineRegion } from './color/subdivide';
@@ -3639,12 +3639,25 @@ async function main() {
     const dimensions = Array.isArray(rawDims) && rawDims.length === 3 && rawDims.every(n => typeof n === 'number')
       ? (rawDims as [number, number, number])
       : null;
+    // Colour-aware warnings. Colour-carrying formats (3MF/GLB/OBJ) warn when the
+    // model needs more filament colours than the palette's slot capacity; STL
+    // can't carry colour at all, so a painted model warns that colours drop.
+    const colorCarrying = format === '3MF' || format === 'GLB' || format === 'OBJ';
+    let colorOverBudget: { used: number; capacity: number } | undefined;
+    if (colorCarrying && hasColorRegions()) {
+      const used = getDistinctRegionColors().length;
+      const capacity = getPaletteCapacity();
+      if (used > capacity) colorOverBudget = { used, capacity };
+    }
+    const colorDropped = format === 'STL' && (hasColorRegions() || hasModelColorRegions());
     return {
       unitless: _getUnits() === 'unitless',
       dimensions,
       isManifold: gd?.isManifold !== false, // treat unknown as manifold (no false alarm)
       componentCount: typeof gd?.componentCount === 'number' ? gd.componentCount : 1,
       format,
+      colorOverBudget,
+      colorDropped,
     };
   }
 

--- a/src/ui/exportConfirmModal.ts
+++ b/src/ui/exportConfirmModal.ts
@@ -25,11 +25,18 @@ export interface ExportWarningInfo {
   componentCount: number;
   /** Format label shown in the confirm button, e.g. 'STL'. */
   format: string;
+  /** Set when the painted model needs more filament colours than the palette's
+   *  printer-slot capacity (advisory — never blocks). */
+  colorOverBudget?: { used: number; capacity: number };
+  /** True when the chosen format can't carry colour (STL) but the model is
+   *  painted, so the colours will be dropped. */
+  colorDropped?: boolean;
 }
 
 /** Whether any warning is worth interrupting the export for. */
 export function hasExportWarning(info: ExportWarningInfo): boolean {
-  return info.unitless || !info.isManifold || info.componentCount > 1;
+  return info.unitless || !info.isManifold || info.componentCount > 1
+    || info.colorOverBudget != null || info.colorDropped === true;
 }
 
 /**
@@ -76,6 +83,25 @@ export function showExportConfirm(info: ExportWarningInfo): Promise<boolean> {
       block.innerHTML =
         '<strong>Printability warning:</strong> ' + lines.join(' and ') +
         '. Many slicers may fail or produce a bad print. Consider fixing the model before exporting.';
+      shell.body.appendChild(block);
+    }
+
+    if (info.colorOverBudget) {
+      const block = document.createElement('div');
+      block.className = 'rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 leading-snug';
+      const { used, capacity } = info.colorOverBudget;
+      block.innerHTML =
+        `<strong>More colours than slots.</strong> This model uses <strong>${used}</strong> filament colours but your palette capacity is <strong>${capacity}</strong>. ` +
+        'Your printer may not have enough filament slots. Adjust capacity in the palette manager (🧵 Palette).';
+      shell.body.appendChild(block);
+    }
+
+    if (info.colorDropped) {
+      const block = document.createElement('div');
+      block.className = 'rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 leading-snug';
+      block.innerHTML =
+        `<strong>${info.format} can't carry colour.</strong> Your painted colours will be dropped — the exported model is geometry only. ` +
+        'Export <strong>3MF</strong> (or GLB) to keep colours.';
       shell.body.appendChild(block);
     }
 

--- a/tests/paint-palette.spec.ts
+++ b/tests/paint-palette.spec.ts
@@ -137,4 +137,38 @@ test.describe('filament palette + slot painting', () => {
     expect(await dialog.locator('input[type="text"]').count()).toBeGreaterThan(6); // 6 defaults + imports
     await expect(dialog).toContainText('Recent colours');
   });
+
+  test('over-budget export shows a colour warning in the confirm modal', async ({ page }) => {
+    // Real .click() on the toolbar needs the first-run tour backdrop gone.
+    await page.addInitScript(() => {
+      try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+    });
+    await openEditorWithSlab(page);
+
+    // Paint two distinct palette slots.
+    await page.locator('#paint-picker-panel button[title^="Slot 3:"]').dispatchEvent('click');
+    await bucketPaintCentre(page);
+    await page.locator('#paint-picker-panel button[title^="Slot 5:"]').dispatchEvent('click');
+    await bucketPaintCentre(page);
+
+    // Capacity → 1 via the manager (2 colours used now exceeds it).
+    await page.locator('#palette-manager-toggle').dispatchEvent('click');
+    const cap = page.locator('[role="dialog"] input[type="number"]');
+    await cap.fill('1');
+    await cap.dispatchEvent('change');
+    await page.locator('[role="dialog"] button:has-text("Done")').dispatchEvent('click');
+    await page.waitForSelector('[role="dialog"]', { state: 'detached' });
+    // Close the paint panel so it can't intercept the toolbar click.
+    await page.locator('#paint-toggle').dispatchEvent('click');
+
+    // Trigger 3MF export from the toolbar Export menu (the 3MF item is unique by
+    // its Bambu description).
+    await page.locator('#btn-export').click();
+    await page.getByText('Native format for Bambu Studio multi-color prints.').click();
+
+    const confirm = page.locator('[role="dialog"]:has-text("Export 3MF?")');
+    await expect(confirm).toBeVisible();
+    await expect(confirm).toContainText('More colours than slots');
+    await expect(confirm).toContainText('uses 2 filament colours');
+  });
 });

--- a/tests/unit/export.test.ts
+++ b/tests/unit/export.test.ts
@@ -15,6 +15,20 @@ function tri(): MeshData {
   } as unknown as MeshData;
 }
 
+// Two separate triangles painted with palette-slot colours, in NON-slot order:
+// triangle 0 is red (default slot 3), triangle 1 is black (default slot 2). A
+// slot-ordered exporter must emit black before red regardless of triangle order.
+function paintedTwoTri(): MeshData {
+  return {
+    numProp: 3,
+    numVert: 6,
+    numTri: 2,
+    vertProperties: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0, 0, 3, 0, 0, 2, 1, 0]),
+    triVerts: new Uint32Array([0, 1, 2, 3, 4, 5]),
+    triColors: new Uint8Array([0xc0, 0x25, 0x25, 0x18, 0x18, 0x18]), // red, black
+  } as unknown as MeshData;
+}
+
 async function blobBytes(blob: Blob): Promise<Uint8Array> {
   return new Uint8Array(await blob.arrayBuffer());
 }
@@ -66,5 +80,23 @@ describe('export attribution + STL header safety', () => {
     const text = asLatin1(await blobBytes(buildOBJ(tri()).blob));
     expect(text).toContain('# Partwright');
     expect(text).toContain('https://www.partwrightstudio.com');
+  });
+});
+
+describe('3MF slot-ordered colour materials', () => {
+  it('emits m:colorgroup materials in filament-palette slot order, not encounter order', async () => {
+    const text = asLatin1(await blobBytes(build3MF(paintedTwoTri()).blob));
+    // Default palette: White(0) Black(1) Red(2) … — so black precedes red.
+    const black = text.indexOf('181818FF');
+    const red = text.indexOf('C02525FF');
+    expect(black).toBeGreaterThan(-1);
+    expect(red).toBeGreaterThan(-1);
+    // Triangle 0 is red, but black is the earlier slot → black material first.
+    expect(black).toBeLessThan(red);
+    // Exactly two materials (no phantom default filament for a fully-painted mesh).
+    expect(text.match(/<m:color /g)?.length).toBe(2);
+    // Material indices line up: black = 0 (p1="0"), red = 1 (p1="1").
+    expect(text).toContain('pid="2" p1="0"');
+    expect(text).toContain('pid="2" p1="1"');
   });
 });


### PR DESCRIPTION
Phase 2 of the multi-color-FDM (AMS/MMU) initiative — addresses #413. Builds on the Phase 1 palette/`slotId` foundation (merged in #415). Makes 3MF export reflect the filament palette so a painted model maps onto a printer's AMS slots.

## What's in this PR
- **Slot-ordered 3MF materials** (`src/export/threemf.ts`) — the `m:colorgroup` was built in triangle-encounter order with the viewport default pinned at index 0. Now it emits the colours of the **used palette slots first, in slot order** (so the 3MF material index follows AMS slot order), then any remaining painted colours (custom + unpainted default) in first-encounter order — and only colours that actually appear in the mesh (no phantom default filament on a fully-painted model). The exporter has only baked `triColors`, but slot painting bakes the slot's exact hex, so an exact match against `listFilaments()` recovers slot order losslessly.
- **Over-budget warning at export** (UI path only) — `ExportWarningInfo.colorOverBudget`: distinct painted colours vs. palette capacity. Surfaces "uses N colours but your palette capacity is M" in the export-confirm modal. Computed in the UI-only `confirmExportOrProceed` path, so the `window.partwright.export3MF*` console/AI APIs stay unblocked.
- **Format honesty** — `ExportWarningInfo.colorDropped`: exporting a painted model to **STL** warns that colours will be dropped (export 3MF/GLB to keep them).

## Deferred (deliberately): Bambu-native `paint_color`
The user uses **Bambu Studio** and wanted faces auto-assigned to filaments. That requires Bambu/Orca's per-triangle `paint_color` segmentation — an **undocumented** recursive bitstream. Research surfaced the gotchas (uppercase-only hex, 16-filament cap) but not a verifiable encoding, and a wrong encoding fails **silently** in Bambu (worse than none). So this PR ships the documented, portable standard `m:colorgroup` — which Bambu imports as a multi-colour object, now in slot order — and the native segmentation is held for a follow-up that can be validated against a real Bambu Studio. (Sources: [OrcaSlicer wiki](https://github.com/OrcaSlicer/OrcaSlicer/wiki/prepare_color_painting), [Bambu forum](https://forum.bambulab.com/t/import-with-color/230485).)

## Test plan
- `npm run build` ✅ (type-check clean), `npm run lint:deps` ✅ (acyclic)
- `npm run test:unit` ✅ (670) — adds a 3MF slot-ordering test (paints two slot colours in non-slot order; asserts the colorgroup emits them in slot order, exactly two materials, correct `p1` indices).
- e2e `tests/paint-palette.spec.ts` ✅ — over-budget export surfaces the colour warning in the confirm modal.
- Manual browser verification ✅ — export-confirm modal showing "More colours than slots — uses 2 filament colours but your palette capacity is 1."

## Back-compat / risk
- `build3MF` output is unchanged for unpainted meshes and for painted meshes whose colours don't match any palette slot (falls back to encounter order). Only the material *ordering* changes for slot-matched colours.
- New `src/export/threemf.ts` → `src/color/palette` import is a clean edge (palette is a leaf); graph stays acyclic.
- Warnings are advisory and UI-only; never block export.

https://claude.ai/code/session_01CUt3ZS6Xr4fX5LEbNnMpNJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUt3ZS6Xr4fX5LEbNnMpNJ)_