### PR TITLE
feat: palette colour reconciliation + named collections (Phase 3)

### DIFF
--- a/prompts/20260605-palette-reconciliation-collections.md
+++ b/prompts/20260605-palette-reconciliation-collections.md
@@ -1,0 +1,51 @@
+---
+session: "stylized-paint-effects"
+timestamp: "2026-06-05T17:20:00Z"
+---
+
+## Human
+
+Phase 3 (one PR): reconcile a model's off-palette colours (replace a colour with
+a palette/history colour, merge two colours keeping one), an auto-matcher that
+snaps colours to the nearest palette slot, named saved palettes you can switch
+between, and — for image imports — just a toast nudge to the palette tool rather
+than constraining the importers. History should only hold deliberately-chosen
+palette colours (not colours pulled in when a model opens).
+
+## Assistant
+
+## Key decisions
+
+**Never mutate a model on open; reconcile on demand.** Opening a model keeps its
+exact colours. The palette manager grew a "Colours in this model" section that
+lists the distinct used colours tagged in/off-palette, with per-colour **Replace**
+(swap to a palette/recent colour) and **Merge** (collapse one model colour into
+another, target = the kept colour), plus **Apply palette** (auto-match every
+colour to the nearest slot). All are explicit, user-driven edits.
+
+**Reconciliation primitives live in `regions.ts`, palette-independent.**
+`reassignRegionColor(from, to, slotId?)` (recolour + re-attribute matching
+regions) and `applyPaletteAutoMatch(slots)` (nearest-slot snap by RGB Euclidean)
+are pure and take the palette as an argument — so `regions` never imports
+`palette` (no layering edge). Reused the existing `getDistinctRegionColors`.
+Replace/Merge set `slotId` correctly (a swap to a slot attributes the regions;
+a merge into an ad-hoc colour clears it).
+
+**Named collections via a storage generalisation that preserves the whole slot
+API.** `palette.ts` now stores `{ palettes: NamedPalette[]; activeId }`; `load()`
+/`save()` operate on the *active* palette, so every existing slot function works
+unchanged. First access migrates the pre-collections single palette into one
+"Default". New/duplicated palettes get **fresh slot ids** — so a region's
+`slotId` stays bound to the palette it was painted under; switching palettes
+surfaces the model's colours as off-palette, which the reconciliation tools then
+resolve (the two features compose). Capacity stays global (a printer trait).
+
+**Imports: toast, not coupling.** After a colour-bearing import (voxel art,
+colour relief) a neutral toast points to the palette tool — no palette logic
+wired into the relief/voxel pipelines. Opt-in "quantize to palette" in those
+modals is a clean later follow-on.
+
+**History semantics confirmed.** `recordColor` already fires only on a
+slot-colour commit and on photo import — opening a model never records — so
+history holds only deliberately-chosen colours, matching the ask. No change
+needed.

--- a/src/color/palette.ts
+++ b/src/color/palette.ts
@@ -38,9 +38,15 @@ export const DEFAULT_FILAMENTS: Filament[] = [
   { id: 'def-gray', name: 'Gray', hex: '#808080', td: 0.8 },
 ];
 
+// Named palette collections. A user can keep several named palettes (e.g. one
+// per spool set) and switch the active one; the active palette's slots are what
+// every other API returns. Stored as one blob so switching is atomic.
+const COLLECTIONS_KEY = 'partwright.palette.collections';
+interface NamedPalette { id: string; name: string; slots: Filament[] }
+interface Collections { palettes: NamedPalette[]; activeId: string }
 // In-memory mirror — the live copy when localStorage is unavailable (SSR /
 // private mode / tests), and a cache otherwise so reads don't re-parse JSON.
-let slotsMem: Filament[] | null = null;
+let collectionsMem: Collections | null = null;
 
 type Listener = () => void;
 const listeners: Listener[] = [];
@@ -87,29 +93,60 @@ function legacyEffective(): Filament[] {
   ];
 }
 
-/** Load the ordered slot list, migrating legacy relief data on first access. */
-function load(): Filament[] {
-  if (slotsMem) return slotsMem;
+/** The slot list for a brand-new "Default" palette — the single-palette source
+ *  (PALETTE_KEY from before collections), else migrated legacy relief data,
+ *  else the built-in defaults. */
+function seedSlots(): Filament[] {
   const stored = readJSON<unknown[]>(PALETTE_KEY);
   if (stored && Array.isArray(stored)) {
-    slotsMem = stored.filter(isValidFilament);
-    return slotsMem;
+    const s = stored.filter(isValidFilament);
+    if (s.length) return s;
   }
-  // First run (or unavailable storage): seed from legacy relief data, else
-  // the built-in defaults, and persist so order is stable from here on.
-  const seed = legacyEffective();
-  slotsMem = seed.length > 0 ? seed : DEFAULT_FILAMENTS.map(f => ({ ...f }));
-  save(slotsMem);
-  return slotsMem;
+  const legacy = legacyEffective();
+  return legacy.length > 0 ? legacy : DEFAULT_FILAMENTS.map(f => ({ ...f }));
 }
 
-function save(list: Filament[]): void {
-  slotsMem = list;
+/** Load the palette collections, migrating the pre-collections single palette
+ *  into one "Default" palette on first access. */
+function loadCollections(): Collections {
+  if (collectionsMem) return collectionsMem;
+  const stored = readJSON<Collections>(COLLECTIONS_KEY);
+  if (stored && Array.isArray(stored.palettes) && stored.palettes.length > 0 && typeof stored.activeId === 'string') {
+    const palettes = stored.palettes
+      .filter(p => p && typeof p.id === 'string' && typeof p.name === 'string' && Array.isArray(p.slots))
+      .map(p => ({ id: p.id, name: p.name, slots: p.slots.filter(isValidFilament) }));
+    if (palettes.length > 0) {
+      const activeId = palettes.some(p => p.id === stored.activeId) ? stored.activeId : palettes[0].id;
+      collectionsMem = { palettes, activeId };
+      return collectionsMem;
+    }
+  }
+  collectionsMem = { palettes: [{ id: 'default', name: 'Default', slots: seedSlots() }], activeId: 'default' };
+  saveCollections();
+  return collectionsMem;
+}
+
+function saveCollections(): void {
   try {
-    localStorage.setItem(PALETTE_KEY, JSON.stringify(list));
+    localStorage.setItem(COLLECTIONS_KEY, JSON.stringify(collectionsMem));
   } catch {
     /* keep the in-memory copy as the live source */
   }
+}
+
+function activePalette(): NamedPalette {
+  const c = loadCollections();
+  return c.palettes.find(p => p.id === c.activeId) ?? c.palettes[0];
+}
+
+/** The active palette's ordered slot list. All other slot APIs read this. */
+function load(): Filament[] {
+  return activePalette().slots;
+}
+
+function save(list: Filament[]): void {
+  activePalette().slots = list;
+  saveCollections();
 }
 
 /** The ordered palette slots. Slot index == intended filament/AMS slot. */
@@ -267,10 +304,74 @@ export interface Palette {
   slots: Filament[];
 }
 
-/** The active palette. PR 1 ships exactly one ("Default"); the indirection lets
- *  Phase 3 add named collections without touching callers or region data. */
+/** The active palette (slots + capacity), via the collections layer. */
 export function getActivePalette(): Palette {
-  return { id: 'default', name: 'Default', capacity: getPaletteCapacity(), slots: listFilaments() };
+  const p = activePalette();
+  return { id: p.id, name: p.name, capacity: getPaletteCapacity(), slots: listFilaments() };
+}
+
+// ── Named collections ────────────────────────────────────────────────────────
+
+export interface PaletteSummary { id: string; name: string; active: boolean }
+
+/** Give each slot a fresh id — used when creating/duplicating a palette so a
+ *  region's `slotId` stays bound to the one palette it was painted under
+ *  (switching palettes then surfaces the model's colours as off-palette, which
+ *  the reconciliation tools resolve). */
+function withFreshSlotIds(slots: Filament[]): Filament[] {
+  return slots.map(s => ({ ...s, id: genId() }));
+}
+
+/** All palettes, with which one is active. */
+export function listPalettes(): PaletteSummary[] {
+  const c = loadCollections();
+  return c.palettes.map(p => ({ id: p.id, name: p.name, active: p.id === c.activeId }));
+}
+
+export function getActivePaletteId(): string { return loadCollections().activeId; }
+export function getActivePaletteName(): string { return activePalette().name; }
+
+/** Switch the active palette. Fires a change so the paint swatches rebuild. */
+export function setActivePalette(id: string): void {
+  const c = loadCollections();
+  if (c.activeId === id || !c.palettes.some(p => p.id === id)) return;
+  c.activeId = id;
+  saveCollections();
+  notify();
+}
+
+/** Create a new palette and make it active. `slots` defaults to a copy of the
+ *  current active palette's slots (a "Save as…"); pass `[]`-free defaults via
+ *  the built-ins by passing `DEFAULT_FILAMENTS`. Slot ids are regenerated.
+ *  Returns the new palette id. */
+export function createPalette(name: string, slots?: Filament[]): string {
+  const c = loadCollections();
+  const id = `pal-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const src = slots ?? activePalette().slots;
+  c.palettes.push({ id, name: name.trim() || 'Palette', slots: withFreshSlotIds(src) });
+  c.activeId = id;
+  saveCollections();
+  notify();
+  return id;
+}
+
+export function renamePalette(id: string, name: string): void {
+  const p = loadCollections().palettes.find(q => q.id === id);
+  if (!p) return;
+  p.name = name.trim() || p.name;
+  saveCollections();
+  notify();
+}
+
+/** Delete a palette. Refuses to delete the last one; if the active palette is
+ *  deleted, the first remaining one becomes active. */
+export function deletePalette(id: string): void {
+  const c = loadCollections();
+  if (c.palettes.length <= 1) return;
+  c.palettes = c.palettes.filter(p => p.id !== id);
+  if (!c.palettes.some(p => p.id === c.activeId)) c.activeId = c.palettes[0].id;
+  saveCollections();
+  notify();
 }
 
 // ── Colour helpers ──────────────────────────────────────────────────────────
@@ -291,5 +392,5 @@ export function rgbToHex([r, g, b]: [number, number, number]): string {
 
 /** @internal Reset the in-memory cache so tests can re-read storage. */
 export function __resetPaletteCacheForTests(): void {
-  slotsMem = null;
+  collectionsMem = null;
 }

--- a/src/color/paletteManager.ts
+++ b/src/color/paletteManager.ts
@@ -98,8 +98,14 @@ export function openPaletteManager(): void {
   delPalBtn.className = 'shrink-0 px-2 py-1 rounded text-[10px] text-zinc-400 hover:text-red-300 hover:bg-zinc-700/60 transition-colors disabled:opacity-30 disabled:cursor-default';
   delPalBtn.textContent = 'Delete';
   delPalBtn.addEventListener('click', async () => {
-    if (await confirmDialog(`Delete the palette "${getActivePaletteName()}"?`, { confirmLabel: 'Delete', danger: true })) {
-      deletePalette(getActivePaletteId());
+    // Deleting the active palette hands control to the top palette in the list.
+    const activeId = getActivePaletteId();
+    const nextActive = listPalettes().find(p => p.id !== activeId);
+    const detail = nextActive
+      ? ` "${nextActive.name}" (the top palette) will become the active palette. Painted models keep their colours — any that no longer match a slot show as off-palette and can be reconciled.`
+      : '';
+    if (await confirmDialog(`Delete the palette "${getActivePaletteName()}"?${detail}`, { confirmLabel: 'Delete', danger: true })) {
+      deletePalette(activeId);
       refreshAll();
     }
   });

--- a/src/color/paletteManager.ts
+++ b/src/color/paletteManager.ts
@@ -7,7 +7,17 @@
 
 import { createModalShell } from '../ui/modalShell';
 import { BUTTON_PRIMARY } from '../ui/styleConstants';
+import { showToast } from '../ui/toast';
+import { promptDialog, confirmDialog } from '../ui/dialogs';
 import {
+  listPalettes,
+  setActivePalette,
+  createPalette,
+  renamePalette,
+  deletePalette,
+  getActivePaletteId,
+  getActivePaletteName,
+  DEFAULT_FILAMENTS,
   listFilaments,
   addFilament,
   updateFilament,
@@ -22,9 +32,15 @@ import {
   recordColor,
   removeColorHistory,
   hexToRgb,
+  rgbToHex,
   type Filament,
 } from './palette';
-import { recolorRegionsForSlot } from './regions';
+import {
+  recolorRegionsForSlot,
+  getDistinctRegionColors,
+  reassignRegionColor,
+  applyPaletteAutoMatch,
+} from './regions';
 import { getSlotId, setSlot } from './paintMode';
 import { openPhotoColorPicker } from './photoColorPicker';
 
@@ -46,6 +62,71 @@ export function openPaletteManager(): void {
   intro.className = 'text-xs text-zinc-400 leading-snug';
   intro.textContent = 'Each slot maps to a filament on your printer. Painting with a slot lets a multi-colour model load straight into your slicer. Edits here update the paint swatches and the relief tools.';
   shell.body.appendChild(intro);
+
+  // Collections: switch the active palette, or save the current one under a new
+  // name. The active palette is the one used everywhere (paint, relief, export).
+  const palRow = document.createElement('div');
+  palRow.className = 'flex items-center gap-1.5 mt-2 flex-wrap';
+  const palSelect = document.createElement('select');
+  palSelect.className = 'flex-1 min-w-0 px-2 py-1 rounded text-xs bg-zinc-900/60 text-zinc-200 border border-zinc-700';
+  palSelect.title = 'Active palette';
+  palSelect.addEventListener('change', () => { setActivePalette(palSelect.value); refreshAll(); });
+  const saveAsBtn = document.createElement('button');
+  saveAsBtn.className = 'shrink-0 px-2 py-1 rounded text-[10px] bg-zinc-700/60 text-zinc-200 hover:bg-zinc-600/60 transition-colors';
+  saveAsBtn.textContent = 'Save as…';
+  saveAsBtn.title = 'Save the current slots as a new named palette';
+  saveAsBtn.addEventListener('click', async () => {
+    const name = await promptDialog('Name this palette', { initialValue: `${getActivePaletteName()} copy`, confirmLabel: 'Save' });
+    if (name) { createPalette(name); refreshAll(); }
+  });
+  const newBtn = document.createElement('button');
+  newBtn.className = saveAsBtn.className;
+  newBtn.textContent = 'New';
+  newBtn.title = 'Create a new palette from the built-in defaults';
+  newBtn.addEventListener('click', async () => {
+    const name = await promptDialog('Name the new palette', { initialValue: 'Palette', confirmLabel: 'Create' });
+    if (name) { createPalette(name, DEFAULT_FILAMENTS.map(f => ({ ...f }))); refreshAll(); }
+  });
+  const renameBtn = document.createElement('button');
+  renameBtn.className = saveAsBtn.className;
+  renameBtn.textContent = 'Rename';
+  renameBtn.addEventListener('click', async () => {
+    const name = await promptDialog('Rename palette', { initialValue: getActivePaletteName(), confirmLabel: 'Rename' });
+    if (name) { renamePalette(getActivePaletteId(), name); refreshAll(); }
+  });
+  const delPalBtn = document.createElement('button');
+  delPalBtn.className = 'shrink-0 px-2 py-1 rounded text-[10px] text-zinc-400 hover:text-red-300 hover:bg-zinc-700/60 transition-colors disabled:opacity-30 disabled:cursor-default';
+  delPalBtn.textContent = 'Delete';
+  delPalBtn.addEventListener('click', async () => {
+    if (await confirmDialog(`Delete the palette "${getActivePaletteName()}"?`, { confirmLabel: 'Delete', danger: true })) {
+      deletePalette(getActivePaletteId());
+      refreshAll();
+    }
+  });
+  palRow.append(palSelect, saveAsBtn, newBtn, renameBtn, delPalBtn);
+  shell.body.appendChild(palRow);
+
+  function renderCollections(): void {
+    const pals = listPalettes();
+    palSelect.replaceChildren();
+    for (const p of pals) {
+      const opt = document.createElement('option');
+      opt.value = p.id;
+      opt.textContent = p.name;
+      opt.selected = p.active;
+      palSelect.appendChild(opt);
+    }
+    delPalBtn.disabled = pals.length <= 1;
+  }
+
+  // "Colours in this model" — reconciliation. Shows the distinct colours the
+  // current model actually paints with, tagged in/off-palette, with per-colour
+  // Replace (swap to a palette/recent colour) and Merge (collapse into another
+  // model colour), plus a one-click Apply-palette auto-match. Only shown when
+  // the model has painted regions.
+  const modelWrap = document.createElement('div');
+  modelWrap.className = 'hidden flex-col gap-1.5 mt-2 p-2 rounded border border-zinc-700/70 bg-zinc-900/30';
+  shell.body.appendChild(modelWrap);
 
   const rows = document.createElement('div');
   rows.className = 'flex flex-col gap-1.5 mt-1';
@@ -221,6 +302,158 @@ export function openPaletteManager(): void {
   constrainRow.append(constrainBox, constrainText);
   shell.body.appendChild(constrainRow);
 
+  // ── Model-colour reconciliation ────────────────────────────────────────────
+
+  /** The palette slot whose colour exactly matches `rgb`, if any. */
+  function slotForColor(rgb: [number, number, number]): Filament | undefined {
+    const hex = rgbToHex(rgb).toLowerCase();
+    return listFilaments().find(s => s.hex.toLowerCase() === hex);
+  }
+
+  /** A small swatch button used in the Replace/Merge target picker. */
+  function targetSwatch(rgb: [number, number, number], title: string, onPick: () => void): HTMLElement {
+    const b = document.createElement('button');
+    b.className = 'w-6 h-6 rounded border border-zinc-600/60 hover:border-white/70 transition-colors';
+    b.style.backgroundColor = rgbToHex(rgb);
+    b.title = title;
+    b.addEventListener('click', onPick);
+    return b;
+  }
+
+  function buildModelColorRow(rgb: [number, number, number], allUsed: [number, number, number][]): HTMLElement {
+    const wrap = document.createElement('div');
+    wrap.className = 'flex flex-col gap-1';
+
+    const row = document.createElement('div');
+    row.className = 'flex items-center gap-2';
+    const sw = document.createElement('span');
+    sw.className = 'w-6 h-6 rounded border border-zinc-600/60 shrink-0';
+    sw.style.backgroundColor = rgbToHex(rgb);
+    const label = document.createElement('span');
+    label.className = 'text-[11px] flex-1 min-w-0 truncate';
+    const slot = slotForColor(rgb);
+    if (slot) {
+      label.innerHTML = `<span class="font-mono text-zinc-400">${rgbToHex(rgb)}</span> <span class="text-emerald-400">✓ ${slot.name}</span>`;
+    } else {
+      label.innerHTML = `<span class="font-mono text-zinc-300">${rgbToHex(rgb)}</span> <span class="text-amber-400">off-palette</span>`;
+    }
+
+    const replaceBtn = document.createElement('button');
+    replaceBtn.className = 'shrink-0 px-2 py-0.5 rounded text-[10px] bg-zinc-700/60 text-zinc-200 hover:bg-zinc-600/60 transition-colors';
+    replaceBtn.textContent = 'Replace…';
+    replaceBtn.title = 'Swap this colour for a palette/recent colour, or merge it into another model colour';
+
+    const addBtn = document.createElement('button');
+    addBtn.className = 'shrink-0 px-2 py-0.5 rounded text-[10px] bg-zinc-700/60 text-zinc-200 hover:bg-zinc-600/60 transition-colors';
+    addBtn.textContent = '+ Slot';
+    addBtn.title = 'Add this colour to the palette and attribute these regions to it';
+    addBtn.addEventListener('click', () => {
+      const hex = rgbToHex(rgb);
+      const f = addFilament({ name: hex, hex, td: 1 });
+      recordColor(hex);
+      reassignRegionColor(rgb, rgb, f.id); // attribute the regions to the new slot
+      refreshAll();
+    });
+
+    row.append(sw, label);
+    if (!slot) row.append(addBtn);
+    row.append(replaceBtn);
+    wrap.append(row);
+
+    // Inline target picker, toggled by Replace.
+    const picker = document.createElement('div');
+    picker.className = 'hidden flex-wrap items-center gap-1 pl-8';
+    replaceBtn.addEventListener('click', () => {
+      picker.classList.toggle('hidden');
+      picker.classList.toggle('flex');
+      if (!picker.classList.contains('hidden')) buildPicker();
+    });
+
+    function buildPicker(): void {
+      picker.replaceChildren();
+      const tag = (t: string) => {
+        const s = document.createElement('span');
+        s.className = 'text-[9px] text-zinc-500 uppercase tracking-wider w-full';
+        s.textContent = t;
+        return s;
+      };
+      // Palette slots.
+      const slots = listFilaments();
+      if (slots.length) {
+        picker.append(tag('Palette'));
+        for (const s of slots) {
+          picker.append(targetSwatch(hexToRgb(s.hex), `→ ${s.name}`, () => {
+            reassignRegionColor(rgb, hexToRgb(s.hex), s.id);
+            refreshAll();
+          }));
+        }
+      }
+      // Recent colours.
+      const hist = getColorHistory();
+      if (hist.length) {
+        picker.append(tag('Recent'));
+        for (const h of hist) {
+          const hr = hexToRgb(h);
+          picker.append(targetSwatch(hr, `→ ${h}`, () => {
+            reassignRegionColor(rgb, hr, slotForColor(hr)?.id);
+            refreshAll();
+          }));
+        }
+      }
+      // Other model colours → merge.
+      const others = allUsed.filter(c => rgbToHex(c) !== rgbToHex(rgb));
+      if (others.length) {
+        picker.append(tag('Merge into'));
+        for (const c of others) {
+          picker.append(targetSwatch(c, `Merge into ${rgbToHex(c)}`, () => {
+            reassignRegionColor(rgb, c, slotForColor(c)?.id);
+            refreshAll();
+          }));
+        }
+      }
+    }
+
+    wrap.append(picker);
+    return wrap;
+  }
+
+  function renderModelColors(): void {
+    modelWrap.replaceChildren();
+    const used = getDistinctRegionColors();
+    modelWrap.classList.toggle('hidden', used.length === 0);
+    modelWrap.classList.toggle('flex', used.length > 0);
+    if (used.length === 0) return;
+
+    const head = document.createElement('div');
+    head.className = 'flex items-center justify-between gap-2';
+    const title = document.createElement('div');
+    title.className = 'text-[10px] text-zinc-400 uppercase tracking-wider font-medium';
+    const off = used.filter(c => !slotForColor(c)).length;
+    title.textContent = off > 0 ? `Colours in this model · ${off} off-palette` : 'Colours in this model';
+    const apply = document.createElement('button');
+    apply.className = 'shrink-0 px-2 py-0.5 rounded text-[10px] bg-blue-600/80 text-white hover:bg-blue-500 transition-colors';
+    apply.textContent = 'Apply palette';
+    apply.title = 'Snap every colour to the nearest palette slot';
+    apply.addEventListener('click', () => {
+      const n = applyPaletteAutoMatch(listFilaments().map(s => ({ id: s.id, color: hexToRgb(s.hex) })));
+      showToast(n > 0 ? `Matched ${n} region${n === 1 ? '' : 's'} to the palette` : 'Already matched the palette', { variant: n > 0 ? 'success' : 'neutral' });
+      refreshAll();
+    });
+    head.append(title, apply);
+    modelWrap.append(head);
+
+    for (const rgb of used) modelWrap.append(buildModelColorRow(rgb, used));
+  }
+
+  /** Re-render every section after a reconciliation edit (slot list may gain a
+   *  slot, swatches/history may change, model colours re-tag). */
+  function refreshAll(): void {
+    renderCollections();
+    render();
+    renderHistory();
+    renderModelColors();
+  }
+
   // Footer: a single Done button.
   const done = document.createElement('button');
   done.className = BUTTON_PRIMARY;
@@ -228,6 +461,8 @@ export function openPaletteManager(): void {
   done.addEventListener('click', () => shell.close());
   shell.footer.appendChild(done);
 
+  renderCollections();
   render();
   renderHistory();
+  renderModelColors();
 }

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -330,6 +330,60 @@ export function usedSlotIds(): Set<string> {
   return ids;
 }
 
+const colorDist = (a: readonly number[], b: readonly number[]) =>
+  Math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2);
+
+/** Reconcile a model colour: recolour every region within `tolerance` of
+ *  `fromColor` to `toColor`, and set their palette attribution to `toSlotId`
+ *  (pass `undefined` to clear it — the colour is now ad-hoc). This is the
+ *  primitive behind the palette tool's Replace (swap to a palette/history
+ *  colour) and Merge (collapse one model colour into another). Returns the
+ *  number of regions changed. */
+export function reassignRegionColor(
+  fromColor: [number, number, number],
+  toColor: [number, number, number],
+  toSlotId: string | undefined,
+  tolerance = 0.02,
+): number {
+  let count = 0;
+  for (const r of regions) {
+    if (colorDist(r.color, fromColor) <= tolerance) {
+      r.color = [...toColor] as [number, number, number];
+      r.slotId = toSlotId;
+      count++;
+    }
+  }
+  if (count > 0) notify();
+  return count;
+}
+
+/** Auto-match every user region to the nearest palette slot (Euclidean RGB),
+ *  recolouring it to that slot's colour and stamping its `slotId`. Used by the
+ *  palette tool's "Apply palette" to reconcile an off-palette or freshly
+ *  imported model in one step. `slots` is the ordered palette. Returns the
+ *  number of regions changed. */
+export function applyPaletteAutoMatch(
+  slots: ReadonlyArray<{ id: string; color: [number, number, number] }>,
+): number {
+  if (slots.length === 0) return 0;
+  let count = 0;
+  for (const r of regions) {
+    let best = slots[0];
+    let bestD = Infinity;
+    for (const s of slots) {
+      const d = colorDist(r.color, s.color);
+      if (d < bestD) { bestD = d; best = s; }
+    }
+    // Skip a no-op (already exactly this slot's colour and attribution).
+    if (r.slotId === best.id && colorDist(r.color, best.color) === 0) continue;
+    r.color = [...best.color] as [number, number, number];
+    r.slotId = best.id;
+    count++;
+  }
+  if (count > 0) notify();
+  return count;
+}
+
 /** Batch-replace the color of every user region whose color is within
  *  `tolerance` (Euclidean distance in normalised [0,1]³ RGB) of `sourceColor`.
  *  Returns the number of regions changed. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -2309,6 +2309,9 @@ async function main() {
         // interactive: true → the wizard is the only entry point that may show
         // the import-target modal (console/AI imports stay modal-free).
         await createReliefFromImageData(image, opts, name || 'relief', sourceFile, true);
+        // Colour reliefs bring their own palette of cluster colours — nudge the
+        // user to reconcile them. Tonal (luminance) reliefs have no colours.
+        if (opts.mode === 'quantized') nudgePaletteAfterColorImport();
       },
       onCreateSvg: async (svgText, opts, name, sourceFile) => {
         await createReliefFromSvgText(svgText, opts, name || 'relief', sourceFile, true);
@@ -2731,7 +2734,15 @@ async function main() {
       // the ImageDataLike→ImageData narrowing is safe here.
       await registerImportSnapshot(sourceFile, chosenName, 'IMAGE', meta, createThumbnailFromImageData(chosenImage as ImageData));
     }
+    nudgePaletteAfterColorImport();
     return true;
+  }
+
+  /** After an import that brings in its own colours (voxel art, colour relief),
+   *  nudge the user toward the palette tool to match those colours to their
+   *  filaments — rather than constraining the importers to the palette. */
+  function nudgePaletteAfterColorImport(): void {
+    showToast('Imported with colours — open 🧵 Palette to match them to your filaments.', { variant: 'neutral', source: 'import' });
   }
 
   /** Import an image as a colored voxel billboard in a new voxel session.

--- a/tests/paint-palette.spec.ts
+++ b/tests/paint-palette.spec.ts
@@ -171,4 +171,56 @@ test.describe('filament palette + slot painting', () => {
     await expect(confirm).toContainText('More colours than slots');
     await expect(confirm).toContainText('uses 2 filament colours');
   });
+
+  test('palette manager reconciles off-palette model colours (auto-match)', async ({ page }) => {
+    await page.addInitScript(() => {
+      try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+    });
+    await openEditorWithSlab(page);
+
+    // Paint an in-palette slot colour, then an off-palette custom colour.
+    await page.locator('#paint-picker-panel button[title^="Slot 3:"]').dispatchEvent('click');
+    await bucketPaintCentre(page);
+    await page.locator('#paint-picker-panel input[title*="Custom color"]').evaluate((el) => {
+      (el as HTMLInputElement).value = '#aa33cc';
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await bucketPaintCentre(page);
+
+    // The manager's reconciliation section flags the off-palette colour.
+    await page.locator('#palette-manager-toggle').dispatchEvent('click');
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toContainText('Colours in this model');
+    await expect(dialog).toContainText('off-palette');
+
+    // Apply palette → every colour snaps to the nearest slot, none off-palette.
+    await dialog.getByRole('button', { name: 'Apply palette' }).click();
+    await expect(dialog).not.toContainText('off-palette');
+  });
+
+  test('named palette collections: create and switch', async ({ page }) => {
+    await page.addInitScript(() => {
+      try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+    });
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 20000 });
+
+    await page.locator('#palette-manager-toggle').dispatchEvent('click');
+    const select = page.locator('[role="dialog"] select[title="Active palette"]');
+    await expect(select.locator('option')).toHaveCount(1); // Default
+
+    // Create a new named palette.
+    await page.locator('[role="dialog"] button:has-text("New")').click();
+    const prompt = page.locator('[role="dialog"]:has-text("Name the new palette")');
+    await prompt.locator('input[type="text"]').fill('Minis');
+    await prompt.locator('button:has-text("Create")').click();
+
+    await expect(select.locator('option')).toHaveCount(2);
+    await expect(select).toHaveValue(/.+/); // active = the new palette
+    await expect(select.locator('option:checked')).toHaveText('Minis');
+
+    // Switch back to Default.
+    await select.selectOption({ label: 'Default' });
+    await expect(select.locator('option:checked')).toHaveText('Default');
+  });
 });

--- a/tests/unit/palette.test.ts
+++ b/tests/unit/palette.test.ts
@@ -14,6 +14,13 @@ import {
   isPaletteConstrained,
   setPaletteConstrained,
   getActivePalette,
+  listPalettes,
+  setActivePalette,
+  createPalette,
+  renamePalette,
+  deletePalette,
+  getActivePaletteId,
+  getActivePaletteName,
   getColorHistory,
   recordColor,
   removeColorHistory,
@@ -124,6 +131,52 @@ describe('palette: active-palette indirection', () => {
     expect(p.id).toBe('default');
     expect(p.capacity).toBe(3);
     expect(p.slots.length).toBe(DEFAULT_FILAMENTS.length);
+  });
+});
+
+describe('palette: named collections', () => {
+  it('starts with a single active Default palette', () => {
+    const pals = listPalettes();
+    expect(pals).toHaveLength(1);
+    expect(pals[0]).toMatchObject({ name: 'Default', active: true });
+    expect(getActivePaletteName()).toBe('Default');
+  });
+
+  it('creates a palette (active) with fresh slot ids and isolated edits', () => {
+    const defaultIds = listFilaments().map(s => s.id);
+    const id = createPalette('Minis', DEFAULT_FILAMENTS.map(f => ({ ...f })));
+    expect(getActivePaletteId()).toBe(id);
+    expect(listPalettes()).toHaveLength(2);
+    // Fresh slot ids — not shared with the Default palette.
+    const newIds = listFilaments().map(s => s.id);
+    expect(newIds.some(x => defaultIds.includes(x))).toBe(false);
+    // Editing the active palette doesn't touch the other.
+    addFilament({ name: 'Extra', hex: '#010203', td: 1 });
+    expect(listFilaments()).toHaveLength(DEFAULT_FILAMENTS.length + 1);
+  });
+
+  it('switches the active palette', () => {
+    const first = getActivePaletteId();
+    const id = createPalette('Other');
+    setActivePalette(first);
+    expect(getActivePaletteId()).toBe(first);
+    setActivePalette(id);
+    expect(getActivePaletteId()).toBe(id);
+  });
+
+  it('renames a palette', () => {
+    renamePalette(getActivePaletteId(), 'Renamed');
+    expect(getActivePaletteName()).toBe('Renamed');
+  });
+
+  it('deletes a palette but refuses the last one', () => {
+    const id = createPalette('Throwaway');
+    deletePalette(id);
+    expect(listPalettes().some(p => p.id === id)).toBe(false);
+    // Now down to one — deleting it is a no-op.
+    const lone = getActivePaletteId();
+    deletePalette(lone);
+    expect(listPalettes()).toHaveLength(1);
   });
 });
 

--- a/tests/unit/regionsSlot.test.ts
+++ b/tests/unit/regionsSlot.test.ts
@@ -6,6 +6,8 @@ import {
   getRegions,
   recolorRegionsForSlot,
   usedSlotIds,
+  reassignRegionColor,
+  applyPaletteAutoMatch,
 } from '../../src/color/regions';
 
 // Phase 1: per-region palette-slot attribution. regions.ts is a dependency-free
@@ -47,5 +49,47 @@ describe('region slotId attribution', () => {
     addRegion('C', [0, 0, 1], 'face-pick', { kind: 'triangles', ids: [2] }, new Set([2]), true, 'slot-1');
     addRegion('D', [1, 1, 1], 'face-pick', { kind: 'triangles', ids: [3] }, new Set([3])); // unslotted
     expect(usedSlotIds()).toEqual(new Set(['slot-1', 'slot-2']));
+  });
+});
+
+describe('palette reconciliation (reassign + auto-match)', () => {
+  beforeEach(() => clearRegions());
+
+  it('reassignRegionColor swaps colour + slot for matching regions only', () => {
+    addRegion('A', [1, 0, 0], 'face-pick', { kind: 'triangles', ids: [0] }, new Set([0])); // off-palette red
+    addRegion('B', [0, 1, 0], 'face-pick', { kind: 'triangles', ids: [1] }, new Set([1])); // green
+    const n = reassignRegionColor([1, 0, 0], [0.2, 0.2, 0.8], 'slot-blue');
+    expect(n).toBe(1);
+    const a = getRegions().find(r => r.name === 'A')!;
+    expect(a.color).toEqual([0.2, 0.2, 0.8]);
+    expect(a.slotId).toBe('slot-blue');
+    expect(getRegions().find(r => r.name === 'B')!.color).toEqual([0, 1, 0]); // untouched
+  });
+
+  it('reassignRegionColor merges one model colour into another (keep target)', () => {
+    addRegion('A', [1, 0, 0], 'face-pick', { kind: 'triangles', ids: [0] }, new Set([0])); // red
+    addRegion('B', [0, 0, 1], 'face-pick', { kind: 'triangles', ids: [1] }, new Set([1])); // blue (kept)
+    // Merge A into B: only A (the source colour) is recoloured to B's colour.
+    const n = reassignRegionColor([1, 0, 0], [0, 0, 1], undefined);
+    expect(n).toBe(1);
+    expect(getRegions().find(r => r.name === 'A')!.color).toEqual([0, 0, 1]);
+    expect(getRegions().find(r => r.name === 'B')!.color).toEqual([0, 0, 1]);
+  });
+
+  it('applyPaletteAutoMatch snaps each region to the nearest slot', () => {
+    addRegion('A', [0.9, 0.1, 0.1], 'face-pick', { kind: 'triangles', ids: [0] }, new Set([0]));
+    addRegion('B', [0.1, 0.1, 0.9], 'face-pick', { kind: 'triangles', ids: [1] }, new Set([1]));
+    const slots = [
+      { id: 'red', color: [1, 0, 0] as [number, number, number] },
+      { id: 'blue', color: [0, 0, 1] as [number, number, number] },
+    ];
+    const n = applyPaletteAutoMatch(slots);
+    expect(n).toBe(2);
+    const a = getRegions().find(r => r.name === 'A')!;
+    const b = getRegions().find(r => r.name === 'B')!;
+    expect(a.slotId).toBe('red');
+    expect(a.color).toEqual([1, 0, 0]);
+    expect(b.slotId).toBe('blue');
+    expect(b.color).toEqual([0, 0, 1]);
   });
 });


### PR DESCRIPTION
Phase 3 of the multi-color-FDM palette initiative — addresses #414, all in one PR per request. Builds on Phase 1/2 (merged).

## What's in this PR

### Model-colour reconciliation (the palette manager's new "Colours in this model" section)
Opening a model never changes its colours; reconciliation is always user-driven.
- Lists the distinct colours the model paints with, each tagged **✓ in-palette** (slot name) or **off-palette**.
- Per colour: **+ Slot** (add an off-palette colour to the palette and attribute its regions), **Replace…** (swap to a palette slot, a recent colour, or — to **merge** — another model colour; the target is the kept colour).
- **Apply palette** — auto-match every colour to the nearest slot (RGB Euclidean) and stamp its `slotId`.
- Primitives live in `regions.ts` (`reassignRegionColor`, `applyPaletteAutoMatch`) — pure, palette-independent (no layering edge).

### Named palette collections
- Save the current slots as a new named palette, **switch** the active palette, **rename**, **delete** (refuses the last). The active palette is what's used everywhere (paint, relief, export).
- Storage generalised to `{ palettes[], activeId }` while keeping the **entire existing slot API intact** (`load`/`save` operate on the active palette); first access migrates the old single palette into "Default". New/duplicated palettes get **fresh slot ids**, so switching palettes surfaces a model's colours as off-palette — which the reconciliation tools then resolve (the two features compose).

### Image-import nudge (not coupling)
After a colour-bearing import (voxel art, colour relief), a neutral toast points to the palette tool — no palette logic wired into the importers. Opt-in "quantize to palette" in those modals is a clean later follow-on.

### History semantics (confirmed, no change)
`recordColor` already fires only on a slot-colour commit and on photo import — opening a model never records — so history holds only deliberately-chosen colours, as requested.

## Test plan
- `npm run build` ✅, `npm run lint:deps` ✅ (acyclic)
- `npm run test:unit` ✅ (678) — adds collections CRUD/switch tests + reconciliation (`reassignRegionColor`, `applyPaletteAutoMatch`) tests.
- e2e `tests/paint-palette.spec.ts` ✅ (6 tests) — adds reconciliation auto-match and collections create/switch.
- Manual browser verification ✅ — reconciliation before/after auto-match + collections selector screenshots.

## Back-compat / risk
- Palette storage migrates the pre-collections single palette into a "Default" collection on first read; all existing slot APIs unchanged.
- Region `color` is always the render source of truth; `slotId` is attribution only — an unresolved slot (after a palette switch) just shows as off-palette, never breaks rendering.
- Module graph stays acyclic.

https://claude.ai/code/session_01CUt3ZS6Xr4fX5LEbNnMpNJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUt3ZS6Xr4fX5LEbNnMpNJ)_