### PR TITLE
docs: add print-in-place mechanisms subdoc for the in-app AI

### DIFF
--- a/prompts/20260605-184000-ai-mechanisms-subdoc.md
+++ b/prompts/20260605-184000-ai-mechanisms-subdoc.md
@@ -1,0 +1,36 @@
+---
+session: "trusting-dirac"
+timestamp: "2026-06-05T18:40:00Z"
+---
+
+## Human
+
+Create a new PR for the doc changes.
+
+## Assistant
+
+## Key decisions
+
+**Separate PR, separate branch.** The in-app print-in-place mechanism guidance had
+been held out of the catalog/tooling PR (#447). On request, I moved the three
+files — `public/ai/mechanisms.md` (new subdoc), plus its wiring in `public/ai.md`
+(topic index + verb-tree rows) and `src/ai/tools.ts` (`SUBDOC_NAMES` +
+`readDoc` description) — onto a fresh branch cut from `origin/main` (via stash →
+checkout → pop, after confirming the files matched `main` so nothing from #447
+leaked in). This keeps the docs PR an independent, clean diff and unblocks #447.
+
+**Audience-correct content.** This subdoc targets the *in-app / chrome-extension*
+AI, so it speaks only the in-browser vocabulary — `renderViews()`, sandbox
+`decompose()`, `runAndSave(..., {maxComponents})`, `componentCount` from
+`geometry-data` — and deliberately contains **no** `model:preview`/CLI references
+(those live in `CLAUDE.md` for repo agents). Same technique, different tool surface.
+
+**Corrected before shipping.** The subdoc leads with the verified recipe — split a
+solid with a clearance-thick cutter (e.g. a full-diameter helical slab), then
+`decompose()` and color each component — replacing an earlier *false* claim
+(that a helical cut can't split a solid of revolution) that I'd caught and proven
+wrong with the engine. Doc claims about geometry are stated only after testing.
+
+**Also fixed a pre-existing drift:** `textures` was missing from the `readDoc`
+name list though the subdoc + `SUBDOC_NAMES` already had it — added it alongside
+`mechanisms`.

--- a/public/ai.md
+++ b/public/ai.md
@@ -97,6 +97,8 @@ Reach for the right tool the first time. If the table sends you to a subdoc, fet
 | Cross-section image (any axis, for debugging cavities) | `partwright.renderSection({axis, offset?, size?})` | `partwright.renderSection(...)` — same window API | `partwright.renderSection(...)` — same window API |
 | Threaded rod / bolt / nut | (write a helix manually) | BOSL2 `threaded_rod()`, `screw()`, `nut()` | (coming; today use OpenSCAD/BOSL2) |
 | Spur / bevel / worm gear | (sample involute manually) | BOSL2 `spur_gear()`, `bevel_gear()`, `worm_gear()` | (coming; today use OpenSCAD/BOSL2) |
+| Print-in-place mechanism (screw, spinner, hinge, captive ball, slider) | Separate parts via `labeledUnion`, separated by a ~0.3–0.5 mm clearance gap; assert `componentCount` -> `/ai/mechanisms.md` | (model parts + clearance manually) | (model parts + clearance manually) |
+| Helical thread / auger / spiral flute | `cs.extrude(h, nDiv, 360*turns, scaleTop)` on a bumped/fluted profile -> `/ai/mechanisms.md` | `linear_extrude(twist=)`, or BOSL2 `threaded_rod()` | (use manifold-js) |
 | Smooth fillet / blend between two shapes (no edge-picking) | `a.smoothUnion(b, k)` via `api.sdf` -> `/ai/sdf.md` | (not available) | (mesh-only; not in BREP) |
 | Lattice / gyroid / periodic infill | `api.sdf.gyroid(cell, thickness)` -> `/ai/sdf.md` | (not available) | (mesh-only; not in BREP) |
 | Twisted / bent body (one expression) | `api.sdf.<shape>(...).twist(deg)` -> `/ai/sdf.md` | (`linear_extrude(twist=)` for the extrusion case only) | (mesh-only; not in BREP) |
@@ -132,6 +134,7 @@ The main reference splits into focused subdocs. **Fetch each by calling `readDoc
 | `bosl2` | Before writing SCAD code that needs edge rounding (`cuboid(rounding=)`), threads (`screw`), gears (`spur_gear`), path-following (`path_sweep`), or attachables. |
 | `replicad` | Before using `api.BREP.*` inside a manifold-js session, or before switching to the replicad/BREP language. Covers exact fillets/chamfers, STEP export, and the manifold-js ↔ BREP boundary. |
 | `voxel` | Before writing voxel-language code or importing an image as voxels. Covers the `api.voxels()` grid API, colors, coordinate system, and image import. |
+| `mechanisms` | Before modeling a print-in-place / multi-part assembly that **moves** — a screw, spinner, hinge, captive ball, or slider. Covers clearance gaps, `componentCount` verification, twist-extrude threads/spirals, matched-taper nesting, and cutaway checks. |
 | `print-safety` | Before exporting STL/3MF for FDM printing — minimum wall thickness, taper traps, sub-extrusion-width layer detection. |
 | `colors` | Before any paint operation — the picker decision tree, labelled construction, vision-driven painting, export behavior. |
 | `reference-images` | When the user attaches a photo or asks you to model from one — `setImages` shape, label conventions, the five-step photo-to-model loop. |

--- a/public/ai/mechanisms.md
+++ b/public/ai/mechanisms.md
@@ -1,0 +1,150 @@
+# Print-in-place mechanisms & multi-part assemblies
+
+How to model a **single object that contains multiple separate, moving parts** —
+a screw that twists, a spinner that spins, a hinge that folds, a captive ball,
+a slider — all printed together in one job (FDM "print-in-place"). The trick is
+geometric: the parts share one model but are separated by a **clearance gap** so
+the slicer/printer (and the engine) treats them as distinct bodies that move
+relative to each other instead of one fused lump.
+
+Treat **1 unit ≈ 1 mm** throughout (FDM tolerances are quoted in mm).
+
+## The golden rule: `componentCount` == number of parts
+
+`componentCount` in `geometry-data` is your primary instrument for these
+builds. A 2-part mechanism **must** report `componentCount === 2`. If it reports
+`1`, your parts are **fused** — the gap is too small, two surfaces collide, or
+there's a topology mistake — and it will print as a single immovable blob.
+
+- Build the parts with `api.labeledUnion([{name, shape, color}, ...])`. The
+  union keeps them as separate, individually-colored bodies **as long as a gap
+  separates them** — it does not weld parts that don't touch.
+- **Always check `componentCount` after building**, before declaring success.
+  It's the cheapest possible proof that the mechanism is actually separate.
+
+## Clearance gaps — the number that makes it move
+
+FDM print-in-place needs roughly **0.3–0.5 mm** between moving surfaces:
+
+- **< ~0.3 mm** → the surfaces fuse on the print (and often in the mesh too).
+- **0.3–0.5 mm** → moves freely after a gentle first twist/break-in.
+- **> ~0.8 mm** → loose and rattly.
+
+Create the gap by sizing one part = the other ± clearance:
+
+- 2D profiles: `crossSection.offset(clearance)` grows a profile uniformly, or
+  just add the clearance to radii directly.
+- Then **verify the gap survives meshing**: `componentCount` must be `2`. A gap
+  that's correct in the math but smaller than the local mesh resolution can
+  bridge into one component.
+
+## Helical / spiral / threaded geometry — twist-extrude
+
+`crossSection.extrude(height, nDivisions, twistDegrees, scaleTop)` rotates the
+cross-section as it rises. This is the workhorse for threads, augers, spiral
+flutes, and twist vases. `twistDegrees = 360 * turns`.
+
+- **Circle + a bump → a single-start thread.** The bump traces a helix as it
+  twists, producing a continuous screw thread:
+  ```js
+  const core = CrossSection.circle(6, 64)
+    .add(CrossSection.circle(2, 28).translate([6, 0]));   // shaft + thread bump
+  const screw = core.extrude(40, 300, 360 * 4, 0.4);      // 4 turns, tapered
+  ```
+- **Fluted profile → spiral flutes.** A circle whose radius dips `lobes` times,
+  extruded with twist, gives `lobes` helical ridges. **Fewer lobes + more turns
+  = bold, clearly-helical ridges; many lobes reads as horizontal rings.**
+- Use a high `nDivisions` (200–300) so threads/flutes stay smooth.
+
+## Nesting tapered parts — MATCH THE TAPER RATE (sharp edge)
+
+When nesting a tapered (coned) part inside a tapered bore, **`scaleTop` alone is
+not enough.** The inner part and the bore must share the same **taper *rate***
+(radius lost per unit height) — otherwise a slower-tapering inner exceeds the
+bore partway up, punches through the wall, and fuses the two parts
+(`componentCount` drops to `1`). This is the single most common failure here.
+
+Taper rate `k = (1 - taper) / H`. If the bore tapers by ratio `taper` over its
+height `Ho`, then `k = (1 - taper) / Ho`, and an inner of height `Hi` must use:
+
+```js
+const k = (1 - taper) / Ho;          // shared taper RATE per unit height
+const innerScaleTop = 1 - k * Hi;    // NOT `taper`, and NOT `taper * Hi/Ho`
+```
+
+so the inner shrinks at exactly the bore's rate and stays strictly inside it
+over the whole engaged height (only poking out past `Ho`).
+
+## A taper shrinks the gap toward the tip
+
+A radial clearance offset **scales down** along a cone: `gap(z) = clearance *
+scaleFactor(z)`. A generous 1.5 mm gap at the base can fall below printable near
+the narrow top. **Size the base clearance so the *narrowest* point (the top)
+stays ≥ ~0.35 mm.** Example: taper 0.4, base clearance 1.5 → top gap ≈ 0.6 mm. ✅
+
+## Splitting one solid into interleaved moving parts — slab cut + `decompose()`
+
+To turn a single solid into two (or more) interleaved, separately-colored parts
+that move relative to each other — e.g. a two-tone spiral cone whose halves twist
+apart — **subtract a thin cutter, then `decompose()`**:
+
+1. Build the whole solid.
+2. Subtract a cutter that is the *gap* you want — for a spiral, a **full-diameter
+   helical slab** (a thin rectangle, thickness = clearance, extruded with twist).
+   A full-diameter helical slab **does** split a solid of revolution into two
+   separate components (verify with `componentCount`).
+3. `solid.decompose()` returns one `Manifold` per connected component. Color each
+   and `labeledUnion` them.
+
+```js
+const cone = Manifold.cylinder(46, 15, 2.5, 160);
+const cut  = CrossSection.square([1.0, 60], true)     // thickness = clearance
+  .extrude(48, 320, 360 * 2.5, 1).translate([0, 0, -1]); // helical, 2.5 turns
+const parts = cone.subtract(cut).decompose();          // → 2 components
+return api.labeledUnion(parts.map((s, i) => ({
+  name: 'p' + i, shape: s, color: ['#f5b324', '#7c3aed'][i % 2],
+})));
+```
+
+`decompose()` is the clean primitive for coloring the separate pieces of a split
+— far simpler than hand-building rotating half-spaces or nested-taper math. If
+the split reports **1** component, the cutter is too thin (raise the clearance)
+or doesn't fully span the body.
+
+## Verify with a CUTAWAY render
+
+`componentCount` proves separation but not *where* the gap is or whether parts
+collide internally. To inspect internal clearances, intersect each labeled part
+with a half-space and render — empty colored space between the two parts = a
+printable gap:
+
+```js
+const half = Manifold.cube([300, 300, 300], false).translate([-300, -150, -60]);
+return api.labeledUnion([
+  { name: 'a', shape: partA.intersect(half), color: '#7c3aed' },
+  { name: 'b', shape: partB.intersect(half), color: '#f5b324' },
+]);
+```
+
+Then call `renderViews()` and look at the cut faces. (Restore the un-cut
+`labeledUnion` for the saved version.)
+
+## Give the moving part an affordance
+
+Add an intentional grip — a knob, wings, a textured cap, finger scallops — so the
+user knows what to twist/slide and the protruding part reads as design, not a
+stray spike.
+
+## Common captive patterns (starting points)
+
+| Mechanism | How it's captive |
+|---|---|
+| **Screw / twist** | Inner threaded shaft in a bored socket; match taper if conical. |
+| **Spinner / bearing** | A core trapped by an overhanging lip on the surrounding body, separated by an annular gap (~0.35 mm). |
+| **Captive ball / bead** | A ball larger than every cage opening, built as `ball.subtract` clearance, trapped inside a cage or track. |
+| **Hinge / pivot** | A pin captured in a barrel (or two knuckles) with radial clearance; the pin can't pull out sideways. |
+| **Compliant flex** | One solid body whose thin members bend elastically (no gap needed — it's `componentCount === 1` *by design*; the motion is material flex, not a sliding joint). |
+
+For each: build it, check `componentCount`, then cutaway-render to confirm the
+gap. Always save the final version with `runAndSave(code, label, {maxComponents:
+<expected>})` so the component count is asserted on every rerun.

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -426,7 +426,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'readDoc',
-    description: 'Fetch one of the topic-specific docs from /ai/<name>.md. Use this when the core ai.md points you at a subdoc and you need its full content before writing code. Names: curves, bosl2, replicad, sdf, voxel, colors, print-safety, reference-images, file-io, annotations, relief, iteration-workflow, gotchas, visual-verification, spending, manifold-api.',
+    description: 'Fetch one of the topic-specific docs from /ai/<name>.md. Use this when the core ai.md points you at a subdoc and you need its full content before writing code. Names: curves, bosl2, replicad, sdf, voxel, colors, print-safety, reference-images, file-io, annotations, relief, textures, mechanisms, iteration-workflow, gotchas, visual-verification, spending, manifold-api.',
     input_schema: {
       type: 'object',
       properties: {
@@ -1634,7 +1634,7 @@ function detectLanguageMismatch(code: string): string | null {
  *  `tools.ts` to import the engine module statically. The function lives
  *  in `src/geometry/engine.ts` and is already loaded by the app shell at
  *  startup, so a require-style lookup via `window.partwright` is safe. */
-const SUBDOC_NAMES = new Set(['curves', 'bosl2', 'replicad', 'sdf', 'voxel', 'colors', 'print-safety', 'reference-images', 'file-io', 'annotations', 'relief', 'textures', 'iteration-workflow', 'gotchas', 'visual-verification', 'spending', 'manifold-api']);
+const SUBDOC_NAMES = new Set(['curves', 'bosl2', 'replicad', 'sdf', 'voxel', 'colors', 'print-safety', 'reference-images', 'file-io', 'annotations', 'relief', 'textures', 'mechanisms', 'iteration-workflow', 'gotchas', 'visual-verification', 'spending', 'manifold-api']);
 
 /** Fetch a topic subdoc by short name. Same fetch path for Anthropic and
  *  local providers — both run inside the user's browser tab, so this is


### PR DESCRIPTION
## Summary

Adds a new on-demand AI subdoc, **`public/ai/mechanisms.md`**, teaching the in-app / chrome-extension AI how to model **print-in-place mechanisms** — objects with separate, captive, *moving* parts (screws, spinners, hinges, captive balls, two-tone spirals) printed in one piece.

It captures the technique, distilled from building a print-in-place spiral fidget cone:

- **`componentCount` is the instrument** — a mechanism with N moving parts must report `componentCount === N`; if it fuses to 1 the clearance gap is too small or parts collide.
- **Clearance gaps** — the ~0.3–0.5 mm rule, how to build them, and verifying they survive meshing.
- **Twist-extrude** for threads / augers / spiral flutes (fewer lobes + more turns = bold helix).
- **Matched-taper nesting** — when nesting cones, share the taper *rate*, not just `scaleTop`, or the inner punches through the bore.
- **Split-with-a-slab + `decompose()`** — the reliable recipe for cutting one solid into interleaved, separately-colored parts (a full-diameter helical slab *does* split a solid of revolution; verify with `componentCount`).
- **Cutaway verification** + a captive-pattern cookbook (screw / bearing / captive ball / hinge / compliant flex).

Wired in so the AI is routed to it: registered in the `readDoc` tool (`src/ai/tools.ts` `SUBDOC_NAMES` + description) and surfaced in `public/ai.md` (topic index + two verb-tree rows). Also fixes a small pre-existing drift — `textures` was missing from the `readDoc` name list though the subdoc already existed.

**Audience scope:** this is the *in-browser* counterpart to the CLI-only `model:preview` tool (which is documented in `CLAUDE.md`). The subdoc deliberately uses only in-app vocabulary — `renderViews()`, sandbox `decompose()`, `runAndSave(..., {maxComponents})`, `componentCount` from `geometry-data` — and contains no CLI references.

## Test plan

- `npm run build` (tsc) clean; `npm run test:unit` (670) green.
- Pure docs + a string-list addition to the `readDoc` registry; no behavior change. PR-checks (build + unit + e2e shards) will confirm `readDoc` still resolves every name (the new `mechanisms.md` and existing `textures.md` both exist).

https://claude.ai/code/session_018KRzurBd2pU8UEP3448xpt

---
_Generated by [Claude Code](https://claude.ai/code/session_018KRzurBd2pU8UEP3448xpt)_