### PR TITLE
fix: scope image-paint Clear to stamps and keep stamps working after brush paint

### DIFF
--- a/prompts/20260605-stamp-clear-scoping-brush-coexist.md
+++ b/prompts/20260605-stamp-clear-scoping-brush-coexist.md
@@ -1,0 +1,58 @@
+---
+session: "b7e3f1"
+timestamp: "2026-06-05T19:10:00Z"
+model: claude-opus-4-8
+tools: [explore, playwright]
+---
+
+## Human
+
+I merged a picture stamp feature recently but the clear button clears all
+painting rather than dropping just the stamps. So, previous painting (like with
+a paint brush) is lost when clearing. Please fix.
+
+Also, once I've painted on a model using the brush, the stamping of an image
+doesn't seem to work. Also fix.
+
+## Assistant
+
+## Key decisions
+
+Both bugs came from the image-paint stamp path not being isolated from the rest
+of the colour-region store / paint-reconcile pipeline. They live in the same
+`regions` array, keyed only by `source`.
+
+**Bug 1 — image-paint "Clear" wiped everything.** The Image Paint panel's Clear
+called the global `clearRegions()`, which empties the entire `regions` array
+(brush strokes included). Fix: added `clearRegionsBySource(source)` in
+`regions.ts` that removes only regions of one source and saves a *partial* clear
+snapshot. `undoClear` now branches on a `clearSnapshotPartial` flag so restoring
+a scoped clear merges the removed regions back into the survivors instead of
+replacing the whole array. Wired the panel's Clear button to
+`clearRegionsBySource('imagePaint')`. Render priority keys on each region's
+`order` field (not array position), so a plain append on undo restores layering.
+The main Paint panel's Clear keeps its full-clear semantics.
+
+**Bug 2 — stamping after brush paint produced an empty stamp.** Committing a
+stamp region fires the colour-region change listener, which runs
+`reconcilePaintedGeometryAsync`. With a brush stroke present,
+`hasRefineDescriptors()` is true, so the reconciler took the full
+`rebuildPaintedGeometryAsync` path: it rebuilds the mesh from base and
+re-resolves every region. A smooth stamp's descriptor carries **empty** entries
+(its colours live in runtime `perTriColors`, replayed from `imageDataUrl` only
+on reload), so the rebuild re-resolved it to zero triangles — the stamp
+vanished, and brush paint was collateral. The stamp flow already builds the
+final mesh and resolves every region itself, so the reconcile is pure harm here.
+Fix: added a `setStampCommitHook` registration to `imagePaintUI`; `main.ts`
+provides a hook that runs the stamp's `addRegion` with `suspendReconcile` set,
+then calls `paintedColorRefresh()` to composite directly — same pattern
+rehydration already uses for bulk region adds. `executeStamp` now commits
+through that hook.
+
+**Verification.** Added `tests/image-paint-stamp-with-brush.spec.ts`, which
+drives the real UI (loads an image into the panel's file input via an in-page
+DataTransfer, then dispatches pointer events to stamp). It asserts that after
+stamping over brush paint both regions are populated, and that the panel's Clear
+removes only the stamp while the brush survives. Confirmed the spec fails on the
+pre-fix tree (stamp resolves to 0 triangles; Clear nukes the brush) and passes
+after. Posted before/after screenshots in the chat.

--- a/src/color/imagePaintUI.ts
+++ b/src/color/imagePaintUI.ts
@@ -19,7 +19,7 @@ import {
   getRegions,
   onChange as onRegionsChange,
   removeLastRegion,
-  clearRegions,
+  clearRegionsBySource,
   isVisible as isPaintVisible,
   setVisible as setPaintVisible,
   canUndoClear,
@@ -105,6 +105,21 @@ let smoothStampCb: SmoothStampCallback | null = null;
 
 export function setSmoothStampCallback(cb: SmoothStampCallback): void {
   smoothStampCb = cb;
+}
+
+// The stamp flow (smooth or flat) already produces the final mesh and resolves
+// every region's triangles itself, so committing the new stamp region must NOT
+// kick off the paint reconciler — when brush strokes (or other refine regions)
+// are present the reconciler would rebuild the mesh from base and wipe both the
+// just-placed stamp (its colours live in runtime perTriColors, not the
+// descriptor) and the existing brush paint. main.ts registers a hook that wraps
+// the region commit so it runs with the reconciler suspended, then refreshes the
+// composited colours directly. Falls back to running the commit as-is.
+type StampCommitHook = (commit: () => void) => void;
+let stampCommitHook: StampCommitHook | null = null;
+
+export function setStampCommitHook(hook: StampCommitHook): void {
+  stampCommitHook = hook;
 }
 
 // Hint element for stamp instructions
@@ -345,7 +360,7 @@ function executeStamp(hitPoint: [number, number, number], hitNormal: [number, nu
 
   stampCounter++;
   const triangles = new Set(result.perTriColors.keys());
-  addRegion(
+  const commit = () => addRegion(
     `Stamp ${stampCounter}`,
     result.avgColor,
     'imagePaint',
@@ -367,6 +382,10 @@ function executeStamp(hitPoint: [number, number, number], hitNormal: [number, nu
     undefined, // unslotted — image-paint carries per-triangle colours, not a palette slot
     result.perTriColors,
   );
+  // Commit through the reconcile-suspending hook when wired (see setStampCommitHook),
+  // so adding the stamp can't trigger a mesh rebuild that drops it or existing paint.
+  if (stampCommitHook) stampCommitHook(commit);
+  else commit();
 }
 
 // ─── Panel construction ───────────────────────────────────────────────────────
@@ -495,8 +514,8 @@ function buildPanel(): HTMLElement {
   const clearBtn = document.createElement('button');
   clearBtn.className = 'px-2 py-1 rounded text-[10px] bg-red-700/60 text-red-200 hover:bg-red-600/60 transition-colors';
   clearBtn.textContent = 'Clear';
-  clearBtn.title = 'Remove all paint regions';
-  clearBtn.addEventListener('click', clearRegions);
+  clearBtn.title = 'Remove all image stamps (keeps brush paint and other regions)';
+  clearBtn.addEventListener('click', () => clearRegionsBySource('imagePaint'));
   footer.appendChild(clearBtn);
 
   el.appendChild(footer);

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -137,6 +137,11 @@ let regionRedoStack: ColorRegion[] = [];
 // Clear snapshot — saved when clearRegions() is called. Nulled when a new
 // region is added so undo-clear is only valid until the next paint operation.
 let clearSnapshot: ColorRegion[] | null = null;
+// True when the snapshot came from a *scoped* clear (clearRegionsBySource) that
+// removed only some regions and left the rest in place. undoClear then merges
+// the snapshot back into the surviving regions instead of replacing the whole
+// array, so a scoped clear doesn't resurrect regions the user never cleared.
+let clearSnapshotPartial = false;
 
 function notify(): void {
   for (const fn of listeners) fn();
@@ -195,9 +200,14 @@ export function canUndoClear(): boolean {
 
 export function undoClear(): void {
   if (!clearSnapshot) return;
-  regions = [...clearSnapshot];
-  nextOrder = regions.reduce((max, r) => Math.max(max, r.order + 1), 1);
+  // A scoped clear (clearRegionsBySource) left other regions in place, so merge
+  // the removed ones back in. A full clear replaces the (now-empty) array. Render
+  // priority keys on each region's `order` field, not array position, so a plain
+  // append restores the original layering. `nextOrder` only ever grows.
+  regions = clearSnapshotPartial ? [...regions, ...clearSnapshot] : [...clearSnapshot];
+  nextOrder = regions.reduce((max, r) => Math.max(max, r.order + 1), clearSnapshotPartial ? nextOrder : 1);
   clearSnapshot = null;
+  clearSnapshotPartial = false;
   clearRedoStack();
   notify();
   notifyClearSnapshot();
@@ -405,8 +415,24 @@ export function setRegionTriangles(
 export function clearRegions(): void {
   if (regions.length === 0) return;
   clearSnapshot = [...regions];
+  clearSnapshotPartial = false;
   regions = [];
   nextOrder = 1;
+  clearRedoStack();
+  notify();
+  notifyClearSnapshot();
+}
+
+/** Clear only the regions with the given `source` (e.g. `'imagePaint'` stamps),
+ *  leaving every other region (brush strokes, face picks, …) untouched. Saves a
+ *  partial snapshot so "Undo clear" restores exactly the removed regions back
+ *  into the surviving list. No-op when nothing matches. */
+export function clearRegionsBySource(source: ColorRegion['source']): void {
+  const removed = regions.filter(r => r.source === source);
+  if (removed.length === 0) return;
+  clearSnapshot = removed;
+  clearSnapshotPartial = true;
+  regions = regions.filter(r => r.source !== source);
   clearRedoStack();
   notify();
   notifyClearSnapshot();

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,7 +145,7 @@ import { initTooltips } from './ui/tooltip';
 import { initTheme, getTheme, setTheme } from './ui/theme';
 import type { Theme } from './ui/theme';
 import { initPaintUI, isPaintOpen, forceDeactivate as closePaintMenu } from './color/paintUI';
-import { initImagePaintUI, setSmoothStampCallback } from './color/imagePaintUI';
+import { initImagePaintUI, setSmoothStampCallback, setStampCommitHook } from './color/imagePaintUI';
 import { stampImageOntoMesh, buildTangentFrame, entriesToPerTriColors, remapPerTriColors, loadImageDataFromUrl } from './color/imagePaint';
 import { initVoxelPaintUI, setVoxelPaintAvailable, syncActiveState as syncVoxelPaintUI } from './color/voxelPaintUI';
 import { initSimplifyUI, isSimplifyOpen, refreshSimplifyIfOpen, forceDeactivate as closeSimplifyMenu, notifyQualityLangChanged, setQualityRenderState, type SimplifyHandlers } from './ui/simplifyUI';
@@ -6113,6 +6113,22 @@ async function main() {
     // Step 5: Stamp on the now-fine mesh for crisp image edges.
     const finalResult = stampImageOntoMesh(mesh, imageData, stampOpts);
     return { result: finalResult, parentToChildren };
+  });
+  // Commit a freshly-placed stamp region with the paint reconciler suspended.
+  // The stamp flow already built the final mesh and resolved every region's
+  // triangles/colours, so a reconcile here would only ever do harm: with brush
+  // strokes (or smooth slabs/etc.) present it rebuilds the mesh from base and
+  // re-resolves regions, wiping the stamp (whose colours live in runtime
+  // perTriColors, not its descriptor) and any pre-existing paint. Suspend it,
+  // run the addRegion, then re-composite colours directly.
+  setStampCommitHook((commit) => {
+    suspendReconcile = true;
+    try {
+      commit();
+    } finally {
+      suspendReconcile = false;
+    }
+    paintedColorRefresh();
   });
   initVoxelPaintUI(clipControls, {
     activate: async () => {

--- a/tests/image-paint-stamp-with-brush.spec.ts
+++ b/tests/image-paint-stamp-with-brush.spec.ts
@@ -1,0 +1,161 @@
+// Image-paint stamps must coexist with brush paint. Two regressions are covered:
+//
+//   1. Stamping onto a model that already has brush paint must NOT wipe the
+//      brush strokes (and the stamp itself must land). The stamp flow builds the
+//      final mesh + resolves every region itself, so committing the stamp runs
+//      with the paint reconciler suspended — otherwise the reconciler rebuilds
+//      from base and drops the stamp (its colours live in runtime perTriColors,
+//      not its descriptor) plus the existing paint.
+//
+//   2. The image-paint panel's "Clear" removes only the stamps, leaving brush
+//      paint (and any other region) intact.
+//
+// The stamp has no console API, so this drives the real UI: load an image into
+// the panel's file input (via a DataTransfer built in-page), then dispatch
+// pointer events on the viewport to stamp.
+
+import { test, expect } from 'playwright/test';
+import type { Page } from 'playwright/test';
+
+async function openEditor(page: Page) {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  // Dismiss the first-run onboarding tour so it doesn't dim the viewport.
+  const skip = page.locator('button:has-text("Skip")');
+  if (await skip.count()) await skip.first().dispatchEvent('click').catch(() => {});
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    // A wide, flat slab fills the viewport so the centre ray reliably hits the
+    // top face for both the brush stroke and the stamp click.
+    await pw.run(`const { Manifold } = api; return Manifold.cube([40, 40, 3], true);`);
+  });
+  await page.waitForTimeout(200); // let the viewport auto-frame settle
+}
+
+// Load a two-colour PNG into the image-paint panel and wait until it's ready to
+// stamp. Background removal is turned off so the whole image stamps (a solid
+// region we can assert on).
+async function loadStampImage(page: Page) {
+  await page.evaluate(async () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64; canvas.height = 64;
+    const ctx = canvas.getContext('2d')!;
+    ctx.fillStyle = '#ff3030'; ctx.fillRect(0, 0, 64, 64);
+    ctx.fillStyle = '#3030ff'; ctx.fillRect(16, 16, 32, 32);
+    const blob: Blob = await new Promise((res) => canvas.toBlob((b) => res(b!), 'image/png'));
+    const file = new File([blob], 'stamp.png', { type: 'image/png' });
+    const input = document.querySelector('#image-paint-panel input[type="file"]') as HTMLInputElement;
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    input.files = dt.files;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  // Wait until the panel reports it's ready to stamp (pickedImageData decoded).
+  await expect(page.locator('#image-paint-panel [data-stamp-hint]')).toHaveText('Click on model to stamp', { timeout: 10000 });
+
+  // Turn off auto background removal so the solid image stamps in full.
+  await page.evaluate(() => {
+    const panel = document.querySelector('#image-paint-panel')!;
+    const box = panel.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+    if (box && box.checked) { box.checked = false; box.dispatchEvent(new Event('change', { bubbles: true })); }
+  });
+}
+
+// Click the centre of the viewport to drop a stamp there.
+async function stampAtCentre(page: Page) {
+  await page.evaluate(() => {
+    const canvas = document.querySelector('canvas')!;
+    const r = canvas.getBoundingClientRect();
+    const cx = r.left + r.width / 2, cy = r.top + r.height / 2;
+    const fire = (t: string) => canvas.dispatchEvent(new PointerEvent(t, {
+      bubbles: true, clientX: cx, clientY: cy, button: 0, buttons: 1,
+      pointerId: 1, pointerType: 'mouse', isPrimary: true,
+    }));
+    fire('pointermove'); // hover preview
+    fire('pointerdown'); // commits the stamp
+    fire('pointerup');
+  });
+  // Drain any paint-reconcile work the stamp may have kicked off. Pre-fix, this
+  // is exactly where the destructive rebuild ran and wiped the stamp/brush, so
+  // waiting for it to settle makes the regression deterministic.
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    if (pw.waitForPaint) await pw.waitForPaint();
+  });
+  await page.waitForTimeout(200);
+}
+
+test.describe('image-paint stamps coexist with brush paint', () => {
+  test('stamping after brush paint keeps the brush, and Clear drops only stamps', async ({ page }) => {
+    await openEditor(page);
+
+    // 1. Brush a stroke (same code path as the UI smooth brush).
+    const brushTris = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const r = pw.paintStroke({ points: [[-12, 0, 1.5]], radius: 5, maxEdge: 0.5, color: [0.1, 0.8, 0.2] });
+      return r.triangles as number;
+    });
+    expect(brushTris).toBeGreaterThan(0);
+
+    // 2. Open the image-paint panel and load an image.
+    await page.locator('#image-paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#image-paint-panel:not(.hidden)');
+    await loadStampImage(page);
+
+    // 3. Stamp on the model.
+    await stampAtCentre(page);
+
+    // 4. Both regions must be present and populated: the stamp landed AND the
+    //    brush survived (the bug wiped one or the other).
+    const afterStamp = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const regions = pw.listRegions() as Array<{ source: string; triangles: number }>;
+      const brush = regions.filter(r => r.source !== 'imagePaint');
+      const stamps = regions.filter(r => r.source === 'imagePaint');
+      return {
+        stampCount: stamps.length,
+        stampTris: stamps.reduce((n, r) => n + r.triangles, 0),
+        brushCount: brush.length,
+        brushTris: brush.reduce((n, r) => n + r.triangles, 0),
+      };
+    });
+    expect(afterStamp.stampCount).toBe(1);
+    expect(afterStamp.stampTris).toBeGreaterThan(0);   // the stamp actually landed
+    expect(afterStamp.brushCount).toBe(1);
+    expect(afterStamp.brushTris).toBeGreaterThan(0);   // brush paint was NOT wiped
+
+    // Close the panel for a clean eyes-on shot: green brush dab on the left,
+    // red/blue stamp in the centre, both on the slab.
+    await page.locator('#image-paint-panel button[title*="Close"]').dispatchEvent('click');
+    await page.waitForTimeout(300);
+    await page.screenshot({ path: 'test-results/stamp-with-brush.png' });
+
+    // 5. Reopen the panel and Clear — removes only the stamp.
+    await page.locator('#image-paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#image-paint-panel:not(.hidden)');
+    await page.locator('#image-paint-panel').getByRole('button', { name: 'Clear', exact: true }).dispatchEvent('click');
+    await page.waitForTimeout(300);
+
+    const afterClear = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const regions = pw.listRegions() as Array<{ source: string; triangles: number }>;
+      return {
+        stampCount: regions.filter(r => r.source === 'imagePaint').length,
+        brushCount: regions.filter(r => r.source !== 'imagePaint').length,
+        brushTris: regions.filter(r => r.source !== 'imagePaint').reduce((n, r) => n + r.triangles, 0),
+      };
+    });
+    expect(afterClear.stampCount).toBe(0);             // stamps cleared
+    expect(afterClear.brushCount).toBe(1);             // brush paint preserved
+    expect(afterClear.brushTris).toBeGreaterThan(0);
+
+    await page.locator('#image-paint-panel button[title*="Close"]').dispatchEvent('click');
+    await page.waitForTimeout(300);
+    await page.screenshot({ path: 'test-results/stamp-cleared-brush-kept.png' });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two image-paint (picture stamp) regressions reported by the user:

1. **The image-paint panel's "Clear" wiped all painting, not just stamps.** It called the global `clearRegions()`, which empties the entire `regions` array — so brush-painted strokes (and any other region) were lost when clearing stamps.
2. **Stamping onto a model that already had brush paint produced an empty stamp.** Committing the stamp fired the paint reconciler; with a refine descriptor (the brush stroke) present, the reconciler took the full `rebuildPaintedGeometryAsync` path, rebuilt the mesh from base, and re-resolved every region. A smooth stamp's descriptor carries **empty** entries (its colours live in runtime `perTriColors`, replayed from `imageDataUrl` only on reload), so the rebuild re-resolved it to zero triangles — the stamp vanished.

## What changed

- **`src/color/regions.ts`** — add `clearRegionsBySource(source)` that removes only one source's regions and saves a *partial* clear snapshot; `undoClear` now branches on `clearSnapshotPartial` so restoring a scoped clear merges the removed regions back into the survivors instead of replacing the whole array. Full `clearRegions()` semantics are unchanged (the main Paint panel still clears everything).
- **`src/color/imagePaintUI.ts`** — wire the panel's Clear to `clearRegionsBySource('imagePaint')`; add `setStampCommitHook` so the stamp's `addRegion` can run with the reconciler suspended.
- **`src/main.ts`** — register the hook: commit a stamp with `suspendReconcile` set, then `paintedColorRefresh()` to composite directly. The stamp flow already builds the final mesh and resolves every region, so the reconcile was pure harm.

## Test plan

- New `tests/image-paint-stamp-with-brush.spec.ts` drives the real UI (loads an image into the panel's file input via an in-page `DataTransfer`, then dispatches pointer events to stamp). It asserts that after stamping over brush paint **both** regions are populated, and that Clear removes **only** the stamp while the brush survives. Confirmed it **fails on the pre-fix tree** (stamp → 0 triangles; Clear nukes the brush) and **passes** after.
- `npm run build` ✓, `npm run test:unit` (670) ✓, related paint e2e suite (`paint-smooth-brush`, `save-after-paint`, `paint-batch-and-lifecycle`, `import-paint-reset`, `paint-cancel`, 34 tests) ✓, `lint:deps` (no new cycles) ✓.

### Eyes-on

After stamping over a brush dab: green brush + red/blue stamp both render. After Clear: stamp gone, brush preserved (`Paint 1` badge). Screenshots posted in the session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H81wQrxCy5LnFqPRgPg6S3)_