### PR TITLE
feat: agent-grade CLI commands + Homebrew tap-ready skeleton

### DIFF
--- a/Formula/partwright.rb
+++ b/Formula/partwright.rb
@@ -1,0 +1,45 @@
+require "language/node"
+
+# Homebrew formula for the `partwright` headless CLI.
+#
+# STATUS: tap-ready SKELETON, not yet published. The repo is set up so a future
+# `brew tap` + `brew install partwright` is a one-step change — fill in `url` and
+# `sha256` from a tagged release tarball and move this file into a tap repo
+# (e.g. homebrew-partwright/Formula/). Nothing here is distributed today.
+#
+# Local install without a tap (works now):
+#   npm ci && npm link        # exposes `partwright` on PATH
+#   # or run ad hoc:  node bin/partwright.mjs --help
+class Partwright < Formula
+  desc "Headless CLI to drive the Partwright CAD engine + app for AI agents"
+  homepage "https://www.partwrightstudio.com"
+  # TODO(release): point at a tagged tarball and fill in the checksum.
+  url "https://github.com/kemper/mainifold/archive/refs/tags/v0.0.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "LicenseRef-PolyForm-Noncommercial-1.0.0"
+  version "0.0.0"
+
+  depends_on "node"
+
+  def install
+    # Installs the package + its runtime `dependencies` (vite/playwright/sharp
+    # were promoted out of devDependencies for exactly this) into libexec and
+    # creates the `partwright` bin shim from package.json `bin`.
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  def caveats
+    <<~EOS
+      Phase 1 (`partwright preview` / `run`) works out of the box.
+
+      Phase 2 (the headless-browser daemon — `iterate`, `render`, `call`,
+      `methods`, `bake`) needs a Chromium build. Install it once:
+        npx playwright install chromium
+    EOS
+  end
+
+  test do
+    assert_match "headless Partwright CLI", shell_output("#{bin}/partwright --help")
+  end
+end

--- a/docs/headless-cli.md
+++ b/docs/headless-cli.md
@@ -46,14 +46,37 @@ partwright daemon start [--app-port N] [--control-port N]
 partwright daemon stop
 partwright daemon status
 
+partwright iterate <file.js> [--out png] [--views all] [--lang L] [-p k=v]  # run → stats+warnings+real render
 partwright call <method> [argsJSON] [--out file.png] # any window.partwright method
+partwright methods [filter]                          # list callable methods
 partwright render [--code file.js] [--out file.png] [--views auto|tri|all|box] [-p k=v]
 partwright bake <fixtureDir> [--catalog public/catalog]
+
+partwright help                                      # usage (also --help / -h)
 ```
 
 - `preview` / `run` are **Phase 1** — stateless, no daemon, no browser.
-- `call` / `render` / `bake` are **Phase 2** — they auto-start the daemon if it
-  isn't already up, then reuse the warm page.
+- `iterate` / `call` / `methods` / `render` / `bake` are **Phase 2** — they
+  auto-start the daemon if it isn't already up, then reuse the warm page.
+
+### Agent quickstart
+
+The fastest agent loop is **draft a snippet → `iterate` → read stats+image →
+fix → repeat**:
+
+```
+partwright iterate part.js            # writes part.iterate.png, prints {stats, png}
+```
+
+`stats` carries `isManifold`, `componentCount`, `volume`, `bbox`, `printability`,
+and a `warnings[]` array of actionable hints (fused parts, sub-extrusion detail,
+extreme aspect ratio, …) — everything needed to self-correct — and the PNG is a
+real multi-view WebGL render. For a sub-second check with no browser, use
+`preview` (software render) instead. Discover the rest of the surface with
+`partwright methods paint` (or any filter) and reach for `call <method>` for
+anything `iterate`/`render` don't wrap. Every command prints a single JSON object
+to stdout (`{ ok: true, … }` or `{ ok: false, error }`); a non-zero exit means
+the CLI itself failed, while `ok:false` is a tractable in-model error.
 
 ### Phase 1 commands
 
@@ -86,8 +109,15 @@ and writes it to a file. The same persistent IndexedDB user-data-dir backs every
 call, so sessions/versions/notes persist across invocations exactly as they would
 in a real browser tab.
 
-`render` is a convenience wrapper: optionally `setActiveLanguage` + run a code
-file, then `renderViews` → PNG. `bake` drives the full catalog-entry flow
+`iterate` is the high-level feedback command: it `setActiveLanguage` + `run`s the
+file in the warm page, then returns `getGeometryData` (stats + warnings +
+printability) **and** a real `renderViews` PNG in one call — the inner loop for
+"is this good? show me," at full WebGL fidelity. `methods [filter]` enumerates
+the callable `window.partwright` methods for discovery.
+
+`render` is a thinner convenience wrapper: optionally `setActiveLanguage` + run a
+code file, then `renderViews` → PNG (image only). `bake` drives the full
+catalog-entry flow
 (createSession → runAndSave → optional paint-by-label → save → exportSessionData
 → write `<id>.partwright.json` + manifest row), replacing the `BAKE_CATALOG=1`
 Playwright spec for CLI users — same fixture format (`<id>.js` + `<id>.meta.json`).
@@ -164,18 +194,31 @@ healthy daemon is found.
 The daemon gets full parity for free because the tools **already exist and run**
 in the page it drives.
 
-## Phase 3 — packaging (not yet built)
+## Phase 3 — Homebrew-ready (tap-ready skeleton; distribution deferred)
 
-- **Homebrew tap.** The CLI is plain Node ESM; a formula can install it and a
-  thin `partwright` shim. The weight is Chromium — the formula should make the
-  `npx playwright install chromium` step (or system-Chrome reuse) explicit, not
-  silent.
-- **Dependency move.** Phase 1/2 currently lean on `vite`, `playwright`, and
-  `sharp` from `devDependencies` (fine while the repo is `private`). A published
-  CLI must promote the runtime-needed ones to `dependencies` or bundle them.
-- **Bundle hosting.** The daemon needs the built app. Ship a versioned `dist/`
-  inside the package (simplest, version-locked) rather than pointing at a
-  deployed URL (drift + network dependency).
+The repo is now structured so a tap is a one-step flip whenever distribution is
+wanted — **nothing is published today**:
+
+- **Local install (works now).** `npm ci && npm link` exposes `partwright` on
+  PATH (or run `node bin/partwright.mjs` / `npm run cli` directly). The `bin`
+  field in `package.json` maps `partwright` → `bin/partwright.mjs`.
+- **Formula skeleton.** `Formula/partwright.rb` is a complete node-CLI formula
+  with placeholder `url`/`sha256` and a Chromium caveat. To distribute: tag a
+  release, fill the tarball URL + checksum, and move the file into a tap repo
+  (`homebrew-partwright/Formula/`).
+- **Dependency move (done).** `vite`, `playwright`, and `sharp` were promoted
+  from `devDependencies` to `dependencies` so a production install (what
+  `brew install` runs, `--omit=dev`) has the CLI's runtime needs. The app build
+  is unaffected (`npm ci` installs both sections regardless).
+
+Still open for a real release (when you choose to distribute):
+
+- **Chromium provisioning.** The formula's caveat tells the user to run
+  `npx playwright install chromium`; a polished release could auto-provision it
+  in a post-install step or detect a system Chrome.
+- **Bundle hosting.** The daemon serves the app from the repo's source via Vite.
+  A distributed CLI should ship a versioned built `dist/` (or vendor the source)
+  rather than assume the repo is present.
 - **Optional: expose the AI chat loop.** The `executeToolFn` seam in
   `src/ai/chatLoop.ts` means the daemon could also run the in-app provider chat
   loop, letting a CLI agent delegate to it. Near-free to add; probably not what a

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,22 +28,25 @@
         "manifold-3d": "^3.3.2",
         "openscad-wasm-prebuilt": "^1.2.0",
         "opentype.js": "^2.0.0",
+        "playwright": "^1.58.2",
         "preact": "^10.29.2",
         "replicad": "^0.23.1",
         "replicad-opencascadejs": "^0.23.0",
+        "sharp": "^0.34.5",
         "tailwindcss": "^4.2.1",
         "three": "^0.183.2",
-        "three-mesh-bvh": "^0.9.10"
+        "three-mesh-bvh": "^0.9.10",
+        "vite": "^6.3.5"
+      },
+      "bin": {
+        "partwright": "bin/partwright.mjs"
       },
       "devDependencies": {
         "@ast-grep/cli": "^0.43.0",
         "@types/three": "^0.183.1",
         "knip": "^6.15.0",
         "madge": "^8.0.0",
-        "playwright": "^1.58.2",
-        "sharp": "^0.34.5",
         "typescript": "~5.8.3",
-        "vite": "^6.3.5",
         "vitest": "^4.1.8"
       }
     },
@@ -3125,7 +3128,6 @@
     },
     "node_modules/playwright": {
       "version": "1.58.2",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -3142,7 +3144,6 @@
     },
     "node_modules/playwright-core": {
       "version": "1.58.2",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -28,10 +28,7 @@
     "@types/three": "^0.183.1",
     "knip": "^6.15.0",
     "madge": "^8.0.0",
-    "playwright": "^1.58.2",
-    "sharp": "^0.34.5",
     "typescript": "~5.8.3",
-    "vite": "^6.3.5",
     "vitest": "^4.1.8"
   },
   "dependencies": {
@@ -54,11 +51,14 @@
     "manifold-3d": "^3.3.2",
     "openscad-wasm-prebuilt": "^1.2.0",
     "opentype.js": "^2.0.0",
+    "playwright": "^1.58.2",
     "preact": "^10.29.2",
     "replicad": "^0.23.1",
     "replicad-opencascadejs": "^0.23.0",
+    "sharp": "^0.34.5",
     "tailwindcss": "^4.2.1",
     "three": "^0.183.2",
-    "three-mesh-bvh": "^0.9.10"
+    "three-mesh-bvh": "^0.9.10",
+    "vite": "^6.3.5"
   }
 }

--- a/prompts/20260605-cli-agent-ergonomics-homebrew.md
+++ b/prompts/20260605-cli-agent-ergonomics-homebrew.md
@@ -1,0 +1,46 @@
+---
+session: "c7e1a9"
+timestamp: "2026-06-05T20:05:00Z"
+sequence: 3
+---
+
+## Human
+
+Move onto phase 3 — but I don't want to distribute yet. I love the idea of a CLI
+that agents can use to drive model creation and get feedback, and I want to keep
+it Homebrew-compliant. (Chosen: both, ergonomics first; tap-ready skeleton.)
+
+## Assistant
+
+## Key decisions
+
+**Reframed Phase 3 from "distribute" to "agent-grade CLI + tap-ready scaffolding."**
+The user isn't shipping yet, so publishing is deferred; the leverage is in agent
+ergonomics + keeping a one-step path to a tap.
+
+**Agent ergonomics (Track A).**
+- `iterate <file>` — the high-level one-shot feedback loop: `setActiveLanguage` +
+  `run` in the warm daemon page, then return `getGeometryData` (which already
+  carries stats + `warnings[]` + `printability`) **and** a real `renderViews`
+  PNG, in a single call. `preview` stays as the fast stateless/software variant.
+- `methods [filter]` — discovery over `Object.keys(window.partwright)` so an agent
+  can find callable methods without reading source.
+- `help` / `--help` / `-h` now print usage and exit 0 (needed for the Homebrew
+  formula's `test do` block; previously unknown-command exited 1).
+- Documented an "Agent quickstart" in docs/headless-cli.md: draft → iterate →
+  read stats+image → fix; every command emits one JSON object, `ok:false` is a
+  tractable in-model error vs a non-zero exit = CLI failure.
+
+**Homebrew tap-ready (Track B), nothing published.**
+- `Formula/partwright.rb` — a complete node-CLI formula skeleton (placeholder
+  url/sha256, Chromium caveat for Phase 2, `--help` smoke test).
+- Promoted `vite`/`playwright`/`sharp` from devDependencies to dependencies so a
+  `--omit=dev` production install (what `brew install` runs) has the CLI's
+  runtime needs; regenerated package-lock. App build unaffected (`npm ci`
+  installs both sections). Verified knip stays green (they're used by the `bin`
+  production entry, so the categorisation is correct).
+- Local install path: `npm ci && npm link`.
+
+Verified: build + 670 unit tests, the full static-analysis trio
+(consistency/deadcode/deps), and a daemon smoke test of `iterate` (real
+multi-view render + stats) and `methods`.

--- a/scripts/cli/main.mjs
+++ b/scripts/cli/main.mjs
@@ -145,30 +145,69 @@ async function cmdBake(argv) {
   console.log(`BAKED ${baked.length}/${metas.length}`);
 }
 
+// High-level one-shot agent feedback: run a model in the daemon and return the
+// stat block (with warnings + printability) AND a real WebGL render in a single
+// call — the inner loop for "I wrote this, is it good? show me." Use `preview`
+// for the faster stateless/software-rendered variant.
+async function cmdIterate(argv) {
+  const a = parse(argv);
+  const file = a._[0];
+  if (!file) { console.error('usage: partwright iterate <file.js> [--out png] [--views all] [--lang manifold-js] [-p k=v]'); process.exit(2); }
+  const code = readFileSync(resolve(file), 'utf8');
+  await rpc('setActiveLanguage', [a.lang || 'manifold-js']);
+  const runRes = await rpc('run', [code]);
+  if (!runRes.ok) { console.log(json(runRes)); process.exit(1); }
+  if (runRes.result?.status === 'error') { console.log(json({ ok: false, error: runRes.result.error, stats: runRes.result })); process.exit(1); }
+  if (Object.keys(a.params).length) await rpc('setParams', [a.params]); // re-runs with overrides
+  const stats = (await rpc('getGeometryData', [])).result;
+  const img = await rpc('renderViews', [{ views: a.views || 'all', size: Number(a.size) || 420 }]);
+  let png = null;
+  if (img.ok && typeof img.result === 'string') { png = resolve(a.out || basename(file).replace(/\.[^.]+$/, '') + '.iterate.png'); writeDataUrl(img.result, png); }
+  console.log(json({ ok: true, png, stats }));
+}
+
+// Discovery — list the window.partwright methods reachable via `call`.
+async function cmdMethods(argv) {
+  const a = parse(argv);
+  const filter = (a._[0] || '').toLowerCase();
+  const r = await evalInPage('const pw = window.partwright; return Object.keys(pw).filter((k) => typeof pw[k] === "function").sort();', {});
+  if (!r.ok) { console.log(json(r)); process.exit(1); }
+  const names = (r.result || []).filter((n) => !filter || n.toLowerCase().includes(filter));
+  console.log(json({ ok: true, count: names.length, methods: names }));
+}
+
+const USAGE = `partwright — headless Partwright CLI for driving model creation + feedback
+
+Phase 1 (stateless, no browser — fast inner loop):
+  partwright preview <file.js> [--png out] [--json] [--size N] [-p k=v]
+  partwright run     <file.js> [-p k=v]                  stats JSON only
+
+Phase 2 (headless-browser daemon — full fidelity + state):
+  partwright iterate <file.js> [--out png] [--views all] [-p k=v]
+                                                         run → stats+warnings+real render
+  partwright render  [--code file.js] [--out png] [--views all] [--size N]
+  partwright call    <method> [argsJSON] [--out png]     any window.partwright method
+  partwright methods [filter]                            list callable methods
+  partwright bake    <fixtureDir> [--catalog public/catalog]
+  partwright daemon  start|stop|status
+
+See docs/headless-cli.md.`;
+
 export async function main(argv) {
   const [cmd, ...rest] = argv;
   switch (cmd) {
     case 'preview': return cmdPreview(rest, { pngDefault: true });
     case 'run': return cmdPreview(rest, { pngDefault: false });
+    case 'iterate': return cmdIterate(rest);
     case 'daemon': return cmdDaemon(rest);
     case 'call': return cmdCall(rest);
     case 'render': return cmdRender(rest);
+    case 'methods': return cmdMethods(rest);
     case 'bake': return cmdBake(rest);
     case '__daemon-run': { const a = parse(rest); return runDaemon({ appPort: Number(a['app-port']), controlPort: Number(a['control-port']) }); }
+    case 'help': case '--help': case '-h': console.log(USAGE); return;
     default:
-      console.error(`partwright — headless Partwright CLI
-
-Phase 1 (stateless, no browser):
-  partwright preview <file.js> [--png out] [--json] [--size N] [-p k=v]
-  partwright run     <file.js> [-p k=v]
-
-Phase 2 (headless-browser daemon):
-  partwright daemon start|stop|status
-  partwright call <method> [argsJSON] [--out file.png]
-  partwright render [--code file.js] [--out file.png] [--views all] [--size N]
-  partwright bake <fixtureDir> [--catalog public/catalog]
-
-See docs/headless-cli.md.`);
+      console.error(USAGE);
       process.exit(cmd ? 1 : 0);
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to the headless CLI (#451), reframing "Phase 3" per the goals: make the
CLI genuinely good for **agents driving model creation + feedback**, and keep it
**Homebrew-compliant** — without distributing anything yet.

### Agent ergonomics
- **`partwright iterate <file.js>`** — the one-shot feedback loop: `setActiveLanguage`
  + `run` the model in the warm daemon page, then return `getGeometryData` (stats
  + `warnings[]` + `printability`) **and** a real multi-view WebGL render in a
  single call. `preview` remains the fast stateless/software variant.
- **`partwright methods [filter]`** — discover the callable `window.partwright`
  methods (e.g. `methods paint` → 23 results) so an agent can introspect the
  surface without reading source.
- **`help` / `--help` / `-h`** now print usage and exit 0.
- **Agent quickstart** added to `docs/headless-cli.md` (draft → iterate → read
  stats+image → fix; JSON-per-command contract, `ok:false` = tractable in-model
  error vs non-zero exit = CLI failure).

### Homebrew tap-ready (nothing published)
- **`Formula/partwright.rb`** — a complete node-CLI formula skeleton: placeholder
  release `url`/`sha256`, a Chromium caveat for Phase 2, and a `--help` smoke
  test. To ship later: tag a release, fill the tarball + checksum, move into a tap.
- **Dependency move** — promoted `vite`/`playwright`/`sharp` from
  `devDependencies` to `dependencies` so a `--omit=dev` production install (what
  `brew install` runs) has the CLI's runtime needs; `package-lock.json`
  regenerated. The app build is unaffected (`npm ci` installs both sections).
- **Local install today:** `npm ci && npm link`.

## Test plan
- ✅ `npm run build` (tsc + vite) and `npm run test:unit` (670 passing).
- ✅ Full static-analysis trio: `lint:consistency`, `lint:deadcode` (knip green
  after the dep move), `lint:deps` (madge, no cycles).
- ✅ `partwright --help` exits 0 (the formula's test).
- ✅ Daemon smoke test: `iterate examples/dna_helix.js` returns stats +
  printability + a real 4-view render; `methods paint` lists 23 methods.

Distribution itself (publishing the tap, Chromium auto-provisioning, shipping a
built `dist/`) remains deferred and is documented as the remaining open items in
`docs/headless-cli.md`.

https://claude.ai/code/session_01USvpqcztUVyeUMxFXQedw4

---
_Generated by [Claude Code](https://claude.ai/code/session_01USvpqcztUVyeUMxFXQedw4)_