### PR TITLE
feat: add Apply button for curvature quality preview

### DIFF
--- a/prompts/20260605-202302-quality-apply-button.md
+++ b/prompts/20260605-202302-quality-apply-button.md
@@ -1,0 +1,49 @@
+---
+session: "exbellnkv"
+timestamp: "2026-06-05T20:23:02Z"
+model: claude-opus-4-8
+tools: [explore, playwright]
+---
+
+## Human
+
+When curvature quality is selected from the quality menu it takes effect
+instantly. I'm ok with that as an auto-preview operation but I want there to
+be an apply button for those changes. That could be awkward with that sharing
+the menu with simplify/enhance as it says "Save as version." Maybe I should
+have an apply for both operations and also have a save as new version for both.
+What do you think?
+
+## Assistant
+
+## Key decisions
+
+**Pushed back on full symmetry.** Curvature quality and simplify/enhance are
+different *kinds* of operation: quality is a non-destructive render *setting*
+(it just re-tessellates and is already persisted as a setting), whereas
+simplify/enhance produces an *ephemeral* baked mesh that only "Save as version"
+can persist. Putting both buttons on both sections would make the same two
+labels mean four different things. "Save as version" earns its place for
+simplify/enhance because there's an ephemeral result to rescue; quality has
+nothing ephemeral, so a Save-as-version there would be redundant and confusing.
+
+Confirmed direction with the user via two questions: (1) quality gets **Apply
+only**, not Save-as-version; (2) an un-applied quality change is a true preview
+that **reverts on cancel/close**.
+
+**Implementation** (`src/ui/simplifyUI.ts`, localized):
+- Picking a quality radio now only *previews* — it still calls
+  `saveQualityForLang` to re-render live, but no longer counts as committed.
+- Added an **Apply quality** button under the radios. Enabled only while the
+  previewed quality differs from the committed one (mirrors the simplify Apply's
+  "no-op stays disabled" rule via `updateQualityApplyEnabled`).
+- `committedQuality` is snapshotted on panel open and on each Apply. Closing the
+  panel (any path — ×, Escape, toggle, forceDeactivate all route through
+  `closePanel`) calls `revertQualityPreview`, which restores the committed
+  quality if the live preview drifted. Language switches re-baseline the
+  committed snapshot since the engine silently swaps in that language's default.
+
+**Tests.** The existing quality specs encoded the old instant-persist behavior
+(pick a preset, close without Apply, expect it to stick), so they were updated
+to click Apply quality before closing. Added a new test asserting that closing
+without Apply reverts the preview to the committed Highest default.

--- a/src/ui/simplifyUI.ts
+++ b/src/ui/simplifyUI.ts
@@ -19,7 +19,7 @@ import { showToast } from './toast';
 import { isWireframeVisible, setWireframeVisible } from '../renderer/viewport';
 import { openViewportPanel, closeViewportPanel } from './viewportPanelRegistry';
 import { attachViewportPanelDrag, setInitialPanelPosition } from './viewportPanelDrag';
-import { QUALITY_OPTIONS, QUALITY_SEGMENTS, loadQualitySettings } from '../geometry/qualitySettings';
+import { QUALITY_OPTIONS, QUALITY_SEGMENTS, loadQualitySettings, type QualitySettings } from '../geometry/qualitySettings';
 import { saveQualityForLang, initQualityLogic, notifyLanguageChange as notifyQualityLangChange } from './curvatureQualityPanel';
 import type { Language } from '../geometry/engine';
 
@@ -115,6 +115,13 @@ const MODE_INACTIVE = 'flex-1 px-2 py-1 rounded text-xs text-zinc-400 bg-zinc-70
 const MODE_ACTIVE = 'flex-1 px-2 py-1 rounded text-xs text-blue-300 bg-blue-500/20 transition-colors border border-blue-500/40';
 
 let qualityRadios: HTMLInputElement[] = [];
+let qualityApplyBtn: HTMLButtonElement | null = null;
+// The committed (applied) curvature quality to revert to when the panel closes
+// without an explicit Apply. Captured on open and updated each time the user
+// clicks Apply quality. Picking a radio only *previews* (re-renders live); it's
+// not persisted until Apply, and closing the panel reverts an un-applied
+// preview so a heavy quality the user was just trying out doesn't stick.
+let committedQuality: QualitySettings | null = null;
 let stopRenderBtn: HTMLButtonElement | null = null;
 let isScadLang = false;
 let onCancelRender: (() => void) | null = null;
@@ -220,6 +227,10 @@ export function notifyQualityLangChanged(lang: Language): void {
   notifyQualityLangChange(lang);
   isScadLang = lang === 'scad';
   syncQualityRadios();
+  // The language switch silently swaps in that language's quality default, so
+  // re-baseline the commit/preview against it.
+  committedQuality = { ...loadQualitySettings() };
+  updateQualityApplyEnabled();
   if (stopRenderBtn && !isScadLang) stopRenderBtn.classList.add('hidden');
 }
 
@@ -239,6 +250,34 @@ function syncQualityRadios(): void {
   for (const radio of qualityRadios) {
     radio.checked = radio.value === current.quality;
   }
+}
+
+function qualityMatches(a: QualitySettings, b: QualitySettings): boolean {
+  return a.quality === b.quality && a.customSegments === b.customSegments;
+}
+
+/** Enable "Apply quality" only while a previewed quality differs from the
+ *  committed one (mirrors the simplify Apply's "no-op stays disabled" rule). */
+function updateQualityApplyEnabled(): void {
+  if (!qualityApplyBtn) return;
+  qualityApplyBtn.disabled = !committedQuality || qualityMatches(loadQualitySettings(), committedQuality);
+}
+
+/** Commit the currently-previewed quality so it survives the panel closing. */
+function applyQualityPreview(): void {
+  committedQuality = { ...loadQualitySettings() };
+  updateQualityApplyEnabled();
+}
+
+/** Revert an un-applied quality preview back to the committed setting. Called
+ *  when the panel closes so a live preview the user didn't Apply doesn't stick. */
+function revertQualityPreview(): void {
+  if (committedQuality && !qualityMatches(loadQualitySettings(), committedQuality)) {
+    onCancelRender?.();
+    saveQualityForLang({ ...committedQuality });
+  }
+  syncQualityRadios();
+  updateQualityApplyEnabled();
 }
 
 function toggle(): void {
@@ -268,6 +307,11 @@ function openPanel(): void {
     prevWireframeVisible = isWireframeVisible();
     if (!prevWireframeVisible) setWireframeVisible(true);
   }
+  // Snapshot the live quality so radio changes preview against it and an
+  // un-applied preview reverts here on close.
+  committedQuality = { ...loadQualitySettings() };
+  syncQualityRadios();
+  updateQualityApplyEnabled();
   refresh(true);
 }
 
@@ -428,6 +472,7 @@ function requestKey(r: MeshOpRequest): string {
 }
 
 function closePanel(): void {
+  revertQualityPreview();
   panel?.classList.add('hidden');
   document.removeEventListener('keydown', onSimplifyEscape);
   closeViewportPanel(registryEntry);
@@ -637,9 +682,12 @@ function buildPanel(): HTMLElement {
     radio.className = 'accent-blue-400 cursor-pointer flex-shrink-0';
     radio.addEventListener('change', () => {
       if (!radio.checked) return;
+      // Live preview only — re-render at the new quality but don't commit it.
+      // Apply quality persists it; closing the panel reverts it.
       onCancelRender?.();
       const { customSegments } = loadQualitySettings();
       saveQualityForLang({ quality: opt.id, customSegments });
+      updateQualityApplyEnabled();
     });
     qualityRadios.push(radio);
 
@@ -656,6 +704,15 @@ function buildPanel(): HTMLElement {
   }
   qualitySection.appendChild(radiosWrap);
   syncQualityRadios();
+
+  qualityApplyBtn = document.createElement('button');
+  qualityApplyBtn.id = 'quality-apply';
+  qualityApplyBtn.className = 'w-full mt-2 px-2 py-1.5 rounded text-xs font-medium bg-blue-500/30 text-blue-200 [@media(hover:hover)]:hover:bg-blue-500/40 transition-colors border border-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed';
+  qualityApplyBtn.textContent = 'Apply quality';
+  qualityApplyBtn.title = 'Commit the previewed curvature quality. Closing the panel without applying reverts it.';
+  qualityApplyBtn.disabled = true;
+  qualityApplyBtn.addEventListener('click', applyQualityPreview);
+  qualitySection.appendChild(qualityApplyBtn);
 
   stopRenderBtn = document.createElement('button');
   stopRenderBtn.className = 'hidden w-full mt-2 px-2 py-1 rounded text-xs bg-red-500/20 text-red-300 [@media(hover:hover)]:hover:bg-red-500/30 transition-colors border border-red-500/40';

--- a/tests/quality-scad.spec.ts
+++ b/tests/quality-scad.spec.ts
@@ -47,9 +47,11 @@ test('SCAD engine applies the chosen $fn from quality preset', async ({ page }) 
   expect(high.error).toBeFalsy();
   expect(high.triangleCount ?? 0).toBeGreaterThan(100);
 
-  // Drop to Low via the curvature quality panel.
+  // Drop to Low via the curvature quality panel, then Apply to commit it
+  // (picking a preset only previews; closing without Apply would revert).
   await page.locator('#simplify-toggle').click();
   await page.locator('#simplify-panel input[type=radio][value=low]').check();
+  await page.locator('#quality-apply').click();
   await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
 
   // Re-run — fewer triangles.

--- a/tests/quality-settings.spec.ts
+++ b/tests/quality-settings.spec.ts
@@ -30,20 +30,44 @@ test.describe('Modeling quality settings', () => {
     await expect(page.locator('#simplify-panel')).not.toBeVisible();
   });
 
-  test('picking Low is reflected in panel and in-memory', async ({ page }) => {
+  test('applying Low is reflected in panel and in-memory', async ({ page }) => {
     await page.goto('/editor');
     await page.waitForSelector('#simplify-toggle');
 
     await page.locator('#simplify-toggle').click();
     await page.locator('#simplify-panel input[type=radio][value=low]').check();
 
-    // Radio should be checked immediately.
+    // Radio should be checked immediately (live preview).
     await expect(page.locator('#simplify-panel input[type=radio][value=low]')).toBeChecked();
 
-    // Close + reopen panel — Low should still be selected (in-memory cache).
+    // Apply quality becomes enabled once the preview differs; click to commit.
+    const applyBtn = page.locator('#quality-apply');
+    await expect(applyBtn).toBeEnabled();
+    await applyBtn.click();
+    await expect(applyBtn).toBeDisabled(); // committed → no-op again
+
+    // Close + reopen panel — Low should still be selected (committed in-memory).
     await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
     await page.locator('#simplify-toggle').click();
     await expect(page.locator('#simplify-panel input[type=radio][value=low]')).toBeChecked();
+  });
+
+  test('closing without Apply reverts the quality preview', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#simplify-toggle');
+
+    await page.locator('#simplify-toggle').click();
+    // Default is Highest; preview Low without applying.
+    await expect(page.locator('#simplify-panel input[type=radio][value=highest]')).toBeChecked();
+    await page.locator('#simplify-panel input[type=radio][value=low]').check();
+    await expect(page.locator('#simplify-panel input[type=radio][value=low]')).toBeChecked();
+
+    // Close without Apply — the preview should snap back to the committed Highest.
+    await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
+    await page.locator('#simplify-toggle').click();
+    await expect(page.locator('#simplify-panel input[type=radio][value=highest]')).toBeChecked();
+    // Apply is disabled again because nothing is pending after the revert.
+    await expect(page.locator('#quality-apply')).toBeDisabled();
   });
 
   test('manifold-js engine applies the chosen segment count', async ({ page }) => {
@@ -65,9 +89,10 @@ test.describe('Modeling quality settings', () => {
     }, sphereCode);
     expect(high.triangleCount ?? 0).toBeGreaterThan(2000);
 
-    // Drop to Low via the panel.
+    // Drop to Low via the panel and Apply to commit it.
     await page.locator('#simplify-toggle').click();
     await page.locator('#simplify-panel input[type=radio][value=low]').check();
+    await page.locator('#quality-apply').click();
     await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
 
     // Re-run the same code — should produce far fewer triangles.
@@ -97,10 +122,11 @@ test.describe('Modeling quality settings', () => {
       return api.run(code);
     }, cylinderCode);
 
-    // Switch to Ultra (1024 segments).
+    // Switch to Ultra (1024 segments) and Apply to commit it.
     await page.locator('#simplify-toggle').click();
     await page.locator('#simplify-panel input[type=radio][value=ultra]').check();
     await expect(page.locator('#simplify-panel input[type=radio][value=ultra]')).toBeChecked();
+    await page.locator('#quality-apply').click();
     await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
 
     const ultra = await page.evaluate(async (code) => {


### PR DESCRIPTION
## Summary

Selecting a curvature-quality preset in the Quality panel used to take effect **instantly and permanently**. This keeps the instant effect as a *live preview* but adds an explicit **Apply quality** button to commit it — closing the panel without applying reverts to the last-committed quality.

This addresses the awkwardness of the quality section sharing the panel with Simplify/Enhance (whose action is "Save as version"). Rather than forcing both buttons onto both sections, the change respects that they're different *kinds* of operation:

- **Curvature quality** is a non-destructive *render setting* (it just re-tessellates and is already persisted as a setting) → gets **Apply** only.
- **Simplify/Enhance** produces an *ephemeral baked mesh* that only **Save as version** can persist → left untouched.

Putting "Save as version" on quality too would be redundant and make the same label mean two different things, so it was deliberately left out (confirmed with the user).

## Behavior

- Picking a quality radio re-renders live (preview) but no longer commits.
- **Apply quality** (new button, under the radios) commits the previewed setting. It's enabled only while the preview differs from the committed value — mirroring the Simplify Apply's "no-op stays disabled" rule.
- Closing the panel via any path (×, Escape, tool-toggle, mode-exclusion) reverts an un-applied preview to the committed quality.
- Language switches re-baseline the committed snapshot, since the engine silently swaps in that language's quality default.

## Implementation

Localized to `src/ui/simplifyUI.ts`: a `committedQuality` snapshot captured on open/Apply, plus `updateQualityApplyEnabled` / `applyQualityPreview` / `revertQualityPreview` helpers wired into the radio change handler and `closePanel`.

## Test plan

- `npm run build` ✅ (type-check)
- `npm run test:unit` ✅ (678 passed)
- `npx playwright test quality-settings.spec.ts quality-scad.spec.ts simplify.spec.ts` ✅
  - Existing quality specs updated to **Apply** before closing (they previously relied on instant-persist).
  - New test: closing without Apply reverts the preview to the committed Highest default.
- Manual browser check: previewed Low, confirmed **Apply quality** lights up and sits distinctly above the Simplify/Enhance section (screenshot posted in session).

https://claude.ai/code/session_012ZsMuWDH8LgKHAeLbfxP8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZsMuWDH8LgKHAeLbfxP8Q)_