### PR TITLE
feat: consolidate quality panel to a single Apply button

### DIFF
--- a/prompts/20260605-224159-unify-quality-apply.md
+++ b/prompts/20260605-224159-unify-quality-apply.md
@@ -1,0 +1,61 @@
+---
+session: "exbellnkv"
+timestamp: "2026-06-05T22:41:59Z"
+model: claude-opus-4-8
+tools: [explore, playwright]
+sequence: 2
+---
+
+## Human
+
+I merged that PR [the curvature-quality Apply button], but I was thinking
+people could use any combination of curvature quality and simplify/enhance and
+just click a single apply button (or save as new version). Not a huge deal, but
+I thought you were going to get rid of the save as new version button and have
+just one apply at the bottom of the menu (which would be more consistent with
+other menus). If you agree and make that change, create a new PR.
+
+## Assistant
+
+## Key decisions
+
+**Agreed and consolidated to a single bottom Apply.** The Quality panel had
+grown three action buttons (Apply quality, the simplify/enhance Apply, and Save
+as version). Collapsed them into one shared **Apply** at the bottom of the
+menu, with Reset beside it.
+
+**Behavior model** (confirmed the "Single Apply only" option with the user, who
+accepted that every simplify/enhance Apply now saves a version and there's no
+preview-without-saving):
+- The single Apply commits any combination of pending changes. It persists the
+  previewed curvature quality and, when a simplify/enhance target is set, runs
+  that mesh op and bakes the result into a new saved version — the old separate
+  "Save as version" step is gone (Apply *is* the commit).
+- Quality-only Apply just commits the setting (status "Quality applied."). It
+  deliberately does NOT spawn a version: quality is a session setting that isn't
+  captured in a saved version, so a version there would be a misleading snapshot
+  of unchanged code. (Noted this nuance to the user — a slight, sensible
+  deviation from the literal "saves every time.")
+- Picking a quality preset still previews live and reverts on close if not
+  applied (carried over from the prior PR). Reset now also reverts the quality
+  preview in addition to restoring the baseline mesh.
+
+**Implementation** (`src/ui/simplifyUI.ts`):
+- Removed the `qualityApplyBtn` and `saveBtn` (and the `appliedCount` /
+  `updateSaveEnabled` plumbing that only the Save button used).
+- Added `qualityPending()` / `meshPending()` predicates; `updateApplyEnabled()`
+  enables the shared Apply when either is pending.
+- Rewrote the action into one `runApply()`: commit quality → if a mesh op is
+  pending, re-snapshot the baseline (a quality re-render nulls the cached
+  baseline via main.ts), run the op through the existing worker handlers, then
+  `handlers.save()` to bake the version. Final status is restored after the
+  closing `refresh()` (which would otherwise clear it).
+- Moved the Reset/Apply row outside `controlsEl` so quality stays applyable even
+  before a model exists.
+
+**Tests.** Updated the three quality/simplify specs for the new model: quality
+specs click the shared `#simplify-apply` (was `#quality-apply`); simplify specs
+no longer click a separate `#simplify-save` — Apply both reduces/enhances and
+saves. Split the old "Apply reduces and Reset restores" into "Reset clears the
+pending target" + "Apply reduces and bakes a version in one step", and dropped
+the now-invalid Reset-restores-to-baseline assertions (Apply commits/saves).

--- a/prompts/20260605-231820-enhance-guard-and-reset.md
+++ b/prompts/20260605-231820-enhance-guard-and-reset.md
@@ -1,0 +1,69 @@
+---
+session: "exbellnkv"
+timestamp: "2026-06-05T23:18:20Z"
+model: claude-opus-4-8
+tools: [explore, playwright]
+sequence: 3
+---
+
+## Human
+
+I used an enhance mesh value way too large and couldn't click cancel. I
+eventually got a warning that the model was over 10 million triangles. Then I
+got multiple browser popups asking if I should wait for the page or kill the
+tab. I'd like this calculation to happen in wasm or a web worker, whatever
+makes the most sense. Just so long as we don't hang the main thread. But also,
+we should probably warn people when they click apply and the triangle count is
+over whatever our current warn limit is and have them click proceed or cancel.
+Also, once I did apply the "reset" button is still enabled which no longer does
+anything. If it can only reset before the apply, it should be disabled until a
+change has happened and then become enabled, but disabled again right after
+apply is clicked.
+
+## Assistant
+
+## Key decisions
+
+Investigated first (explore agent over the worker path). Findings that shaped
+the fix:
+- The refine compute **already runs in the geometry Web Worker** — the freeze
+  was NOT the search. The direct edge-length enhance (`refineToEdgeLength`) is
+  **uncapped**: a tiny edge length produces a 10M+ triangle mesh, and the
+  **main-thread commit** of that result (`Manifold.ofMesh` + a 10M-iteration
+  `meshGLToBufferGeometry` + `computeVertexNormals`) is what froze the page and
+  blocked the Cancel button. The "10M" warning the user recalled doesn't exist;
+  the only threshold was a hardcoded `HIGH_COMPLEXITY_TRIANGLES = 1_000_000`.
+
+So moving the calc to a worker wasn't the real fix (it's already there). The fix
+is to **never hand a giant mesh to the main thread**, plus a pre-apply confirm.
+
+**Issue 1 + 2 — don't freeze; warn before applying (two layers):**
+1. **Pre-apply guard (front line, `simplifyUI.runApply`).** Before an enhance
+   runs, project the triangle count — exact for the count knob, estimated for
+   edge length via a new pure `estimateRefineTriangles` (Σ k² over triangles,
+   k = ceil(longestEdge/length)). Over `enhanceMaxTriangles` → refuse outright
+   (toast, never runs). Over `enhanceWarnTriangles` → a Proceed/Cancel modal
+   (`heavyMeshConfirmModal.ts`, mirrors `exportConfirmModal`). Only enhance is
+   gated; simplify only reduces.
+2. **Worker hard cap (backstop, `simplify.refineToEdgeLength` +
+   `enhanceToTriangleBudget`).** After the WASM refine, if the result exceeds
+   the cap, the Worker discards it and returns `{ exceeded, triangleCount }`
+   with **no mesh** — so even when the estimate undershoots, the giant mesh
+   never reaches the main thread. The cap is read on the main thread (where
+   getConfig sees the user override) and threaded through the `enhance` message,
+   since the Worker's own getConfig only sees static defaults.
+
+   Thresholds are new `renderer.enhanceWarnTriangles` (1M) /
+   `enhanceMaxTriangles` (5M) config fields (not hardcoded), exposed in Advanced
+   Settings.
+
+**Issue 3 — Reset enable/disable.** Reset now mirrors Apply: `updateApplyEnabled`
+disables both when nothing is pending, so Reset is idle on open, enables when a
+quality preview or simplify/enhance target is set, and goes disabled again the
+instant Apply commits (appliedKey updates, quality becomes committed).
+
+**Tests.** New unit test for `estimateRefineTriangles`; e2e tests for the
+Proceed/Cancel confirm (cancel leaves the mesh, proceed grows it) and the
+hard-cap refusal; tightened the Reset test to assert the disabled→enabled→
+disabled lifecycle. All on the existing PR #456 branch (these are follow-ups to
+that unmerged feature).

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -108,6 +108,15 @@ export interface AppConfig {
     pointerGraceMs: number;
     /** Max time (ms) to wait for thumbnail generation before giving up. */
     thumbnailTimeoutMs: number;
+    /** Projected triangle count above which the Quality panel's Apply asks for
+     *  a Proceed/Cancel confirmation before running an enhance (the result is
+     *  heavy and slow to display). */
+    enhanceWarnTriangles: number;
+    /** Hard ceiling on an enhance result. The geometry Worker refuses to return
+     *  a refined mesh larger than this, and Apply won't run a target above it —
+     *  prevents a runaway refine from freezing the main thread when the giant
+     *  result is committed to the viewport. */
+    enhanceMaxTriangles: number;
   };
   import: {
     /** Vertex-weld tolerance for STL imports (world units). */
@@ -214,6 +223,8 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     offscreenIdleDisposeMs: 10_000,
     pointerGraceMs: 350,
     thumbnailTimeoutMs: 4000,
+    enhanceWarnTriangles: 1_000_000,
+    enhanceMaxTriangles: 5_000_000,
   },
   import: {
     stlWeldTolerance: 1e-5,

--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -489,6 +489,10 @@ function handleEngineWorkerMessage(event: MessageEvent): void {
       pending.reject(new Error(error));
       return;
     }
+    if (msg.exceeded) {
+      pending.resolve({ mesh: null, triangleCount: msg.triangleCount as number, exceeded: true });
+      return;
+    }
     if (msg.cancelled || !msg.mesh) {
       pending.resolve(null);
       return;
@@ -865,8 +869,13 @@ export async function simplifyInWorker(
 // ── Enhance Worker client ───────────────────────────────────────────────────
 
 export interface EnhanceWorkerResult {
-  mesh: MeshData;
+  /** The refined mesh, or null when the result was refused for exceeding the
+   *  hard triangle cap (see `exceeded`). */
+  mesh: MeshData | null;
   triangleCount: number;
+  /** True when the refine would have exceeded `maxTriangles`; the mesh was
+   *  discarded in the Worker and never committed. */
+  exceeded?: boolean;
 }
 
 export class EnhanceAbortError extends Error {
@@ -929,8 +938,12 @@ export async function enhanceInWorker(
       numProp: mesh.numProp,
     };
     const transfer: Transferable[] = [meshCopy.vertProperties.buffer, meshCopy.triVerts.buffer];
+    // Read the hard cap on the main thread (where getConfig sees the user's
+    // override) and pass it through — the Worker's own getConfig only sees
+    // static defaults.
+    const maxTriangles = getConfig().renderer.enhanceMaxTriangles;
     engineWorker!.postMessage(
-      { type: 'enhance', callId, mesh: meshCopy, targetTriangles, maxEdgeLength,
+      { type: 'enhance', callId, mesh: meshCopy, targetTriangles, maxEdgeLength, maxTriangles,
         ...(directEdgeLength && directEdgeLength > 0 ? { edgeLength: directEdgeLength } : {}) },
       transfer,
     );

--- a/src/geometry/engineWorker.ts
+++ b/src/geometry/engineWorker.ts
@@ -47,7 +47,7 @@ import { sourceUsesManifoldText, preloadTextFonts } from './textGlyphs';
 import { setActiveImports, type ImportedMesh } from '../import/importedMesh';
 import { setCircularSegmentsOverride } from './qualitySettings';
 import type { Language } from './engines/types';
-import { simplifyToTriangleBudget, enhanceToTriangleBudget, simplifyToTolerance, refineToEdgeLength, type SimplifyResult, type EnhanceResult } from './simplify';
+import { simplifyToTriangleBudget, enhanceToTriangleBudget, simplifyToTolerance, refineToEdgeLength, isEnhanceExceeded, type SimplifyResult, type EnhanceResult, type EnhanceExceeded } from './simplify';
 import type { MeshData } from './types';
 
 /** Per-callId cancel flags for in-flight simplify jobs. The simplify loop
@@ -362,7 +362,7 @@ self.onmessage = async (event: MessageEvent) => {
 
   // ── enhance ────────────────────────────────────────────────────────────
   if (msg.type === 'enhance') {
-    const { callId, mesh, targetTriangles, maxEdgeLength, edgeLength } = msg as unknown as {
+    const { callId, mesh, targetTriangles, maxEdgeLength, edgeLength, maxTriangles } = msg as unknown as {
       callId: string;
       mesh: MeshData;
       targetTriangles: number;
@@ -372,6 +372,10 @@ self.onmessage = async (event: MessageEvent) => {
       // size" knob. Splits only edges longer than this, so the larger triangles
       // densify first.
       edgeLength?: number;
+      // Hard ceiling on the refined triangle count — the Worker refuses to
+      // return a mesh larger than this so a runaway refine can't freeze the
+      // main thread when the result is committed.
+      maxTriangles?: number;
     };
     if (!manifoldReady) {
       self.postMessage({
@@ -386,12 +390,13 @@ self.onmessage = async (event: MessageEvent) => {
     try {
       baseManifold = mod.Manifold.ofMesh(mesh);
       const direct = typeof edgeLength === 'number' && edgeLength > 0;
-      let result: EnhanceResult | null;
+      let result: EnhanceResult | EnhanceExceeded | null;
       if (direct) {
         self.postMessage({ type: 'enhance_progress', callId, fraction: 0 });
         result = refineToEdgeLength(
           baseManifold as unknown as Parameters<typeof refineToEdgeLength>[0],
           edgeLength,
+          maxTriangles,
         );
         self.postMessage({ type: 'enhance_progress', callId, fraction: 1 });
       } else {
@@ -404,6 +409,7 @@ self.onmessage = async (event: MessageEvent) => {
             return new Promise<void>(r => setTimeout(r, 0));
           },
           () => enhanceCancelFlags.get(callId) === true,
+          maxTriangles,
         );
       }
       const cancelled = enhanceCancelFlags.get(callId) === true;
@@ -412,6 +418,13 @@ self.onmessage = async (event: MessageEvent) => {
         self.postMessage({
           type: 'enhance_result', callId, mesh: null, triangleCount: 0,
           cancelled: true, error: null,
+        });
+      } else if (result && isEnhanceExceeded(result)) {
+        // Refused: the refine would exceed the hard cap. Report the count with
+        // no mesh so the main thread can warn without ever committing it.
+        self.postMessage({
+          type: 'enhance_result', callId, mesh: null, triangleCount: result.triangleCount,
+          cancelled: false, exceeded: true, error: null,
         });
       } else if (result) {
         const transfer: Transferable[] = [

--- a/src/geometry/simplify.ts
+++ b/src/geometry/simplify.ts
@@ -199,6 +199,20 @@ export function simplifyToTolerance(
 
 export type EnhanceResult = SimplifyResult;
 
+/** Returned in place of an EnhanceResult when a refine would exceed the hard
+ *  triangle cap. The mesh is discarded (never materialised on the JS heap or
+ *  handed to the main thread) so a runaway refine can't freeze the UI — the
+ *  caller surfaces this as a "too large, not applied" warning. */
+export interface EnhanceExceeded {
+  exceeded: true;
+  /** The triangle count the refine would have produced. */
+  triangleCount: number;
+}
+
+export function isEnhanceExceeded(r: unknown): r is EnhanceExceeded {
+  return typeof r === 'object' && r !== null && (r as EnhanceExceeded).exceeded === true;
+}
+
 /** Single-pass refine so no edge exceeds `length` — subdivides every edge
  *  longer than `length`, which inherently densifies the LARGER triangles first
  *  and leaves already-fine ones untouched (the "by edge length / triangle size"
@@ -210,7 +224,8 @@ export type EnhanceResult = SimplifyResult;
 export function refineToEdgeLength(
   manifold: SimplifiableManifold,
   length: number,
-): EnhanceResult | null {
+  maxTriangles?: number,
+): EnhanceResult | EnhanceExceeded | null {
   if (typeof manifold.refineToLength !== 'function') return null;
   if (!(length > 0)) return null;
   const baseTri = manifold.numTri();
@@ -224,6 +239,14 @@ export function refineToEdgeLength(
   if (n <= baseTri) {
     release(candidate);
     return null;
+  }
+  // Hard cap: never copy a mesh this large to the JS heap / main thread. The
+  // WASM call already ran (on the Worker thread, so the UI stayed responsive),
+  // but materialising and committing a multi-million-triangle mesh is what
+  // freezes the page — so we discard it and report the count instead.
+  if (maxTriangles && maxTriangles > 0 && n > maxTriangles) {
+    release(candidate);
+    return { exceeded: true, triangleCount: n };
   }
   const result: EnhanceResult = { mesh: toMeshData(candidate), triangleCount: n, tolerance: length };
   release(candidate);
@@ -243,10 +266,14 @@ export async function enhanceToTriangleBudget(
   maxEdgeLength: number,
   onProgress?: SimplifyProgress,
   shouldCancel?: () => boolean,
+  maxTriangles?: number,
 ): Promise<EnhanceResult | null> {
   if (typeof manifold.refineToLength !== 'function') return null;
   const baseTri = manifold.numTri();
-  const target = Math.floor(targetTriangles);
+  // The search aims for at most `target` triangles; clamp it to the hard cap so
+  // the count knob can never request a main-thread-freezing result.
+  const cap = maxTriangles && maxTriangles > 0 ? maxTriangles : Infinity;
+  const target = Math.min(Math.floor(targetTriangles), cap);
   if (!Number.isFinite(target) || target <= baseTri) return null;
   if (!(maxEdgeLength > 0)) return null;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -266,7 +266,7 @@ import {
   type GeometryAssertions,
 } from './geometry/statsComputation';
 import { getConfig } from './config/appConfig';
-import { extractPositions, maxEdgeLength, minEdgeLength } from './surface/meshSubdivide';
+import { extractPositions, maxEdgeLength, minEdgeLength, estimateRefineTriangles } from './surface/meshSubdivide';
 
 // Load examples as raw text — JS and SCAD
 const jsExampleModules = import.meta.glob('../examples/*.js', { query: '?raw', import: 'default' });
@@ -5939,7 +5939,9 @@ async function main() {
         (fraction) => { void onProgress(fraction); },
         signal,
       );
-      return commitMeshOpResult(result, baseline, coloredBaseline);
+      if (result?.exceeded) return { exceeded: true, triangleCount: result.triangleCount };
+      const meshResult = result && result.mesh ? { mesh: result.mesh, triangleCount: result.triangleCount } : null;
+      return commitMeshOpResult(meshResult, baseline, coloredBaseline);
     },
 
     async simplifyByTolerance(tolerance, preserveColor, onProgress, signal) {
@@ -5973,7 +5975,16 @@ async function main() {
         signal,
         edgeLength,
       );
-      return commitMeshOpResult(result, baseline, coloredBaseline);
+      if (result?.exceeded) return { exceeded: true, triangleCount: result.triangleCount };
+      const meshResult = result && result.mesh ? { mesh: result.mesh, triangleCount: result.triangleCount } : null;
+      return commitMeshOpResult(meshResult, baseline, coloredBaseline);
+    },
+
+    estimateRefine(edgeLength) {
+      const baseline = simplifyBaselineMesh;
+      if (!baseline || !(edgeLength > 0)) return baseline?.numTri ?? 0;
+      const positions = extractPositions(baseline);
+      return estimateRefineTriangles(positions, baseline.triVerts, edgeLength);
     },
 
     reset() {

--- a/src/surface/meshSubdivide.ts
+++ b/src/surface/meshSubdivide.ts
@@ -49,6 +49,29 @@ export function minEdgeLength(positions: Float32Array, triVerts: Uint32Array): n
   return Number.isFinite(min) ? min : 0;
 }
 
+/** Estimate the triangle count a `refineToLength(length)` pass would produce.
+ *  manifold subdivides each triangle into ~k² sub-triangles, where k is how
+ *  many `length`-sized pieces its longest edge splits into. Summing k² over all
+ *  triangles gives a fast, allocation-free projection used to warn/guard before
+ *  running a potentially runaway enhance. Approximate (uses the longest edge per
+ *  triangle); the Worker enforces the real hard cap as a backstop. */
+export function estimateRefineTriangles(
+  positions: Float32Array,
+  triVerts: Uint32Array,
+  length: number,
+): number {
+  const triCount = triVerts.length / 3;
+  if (!(length > 0)) return triCount;
+  let total = 0;
+  for (let t = 0; t < triVerts.length; t += 3) {
+    const a = triVerts[t], b = triVerts[t + 1], c = triVerts[t + 2];
+    const longest = Math.max(edgeLen(positions, a, b), edgeLen(positions, b, c), edgeLen(positions, c, a));
+    const k = Math.max(1, Math.ceil(longest / length));
+    total += k * k;
+  }
+  return total;
+}
+
 function edgeLen(p: Float32Array, i: number, j: number): number {
   const dx = p[i * 3] - p[j * 3];
   const dy = p[i * 3 + 1] - p[j * 3 + 1];

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -552,6 +552,24 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           min={500} max={30_000} integer
           onChange={v => set('renderer', 'thumbnailTimeoutMs', v)}
         />
+        <Field
+          label="Enhance warn triangles"
+          unit="tris"
+          tooltip="When the Quality panel's Apply projects an enhance result above this triangle count, it asks for a Proceed/Cancel confirmation first — a model this dense is slow to display and edit."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.enhanceWarnTriangles}
+          value={c.renderer.enhanceWarnTriangles}
+          min={10_000} max={50_000_000} integer
+          onChange={v => set('renderer', 'enhanceWarnTriangles', v)}
+        />
+        <Field
+          label="Enhance max triangles"
+          unit="tris"
+          tooltip="Hard ceiling on an enhance result. The geometry worker refuses to return a refined mesh larger than this, and Apply won't run a target above it — prevents a runaway refine from freezing the page when the giant result is committed to the viewport."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.enhanceMaxTriangles}
+          value={c.renderer.enhanceMaxTriangles}
+          min={100_000} max={100_000_000} integer
+          onChange={v => set('renderer', 'enhanceMaxTriangles', v)}
+        />
       </Section>
 
       <Section title="Import">

--- a/src/ui/heavyMeshConfirmModal.ts
+++ b/src/ui/heavyMeshConfirmModal.ts
@@ -1,0 +1,60 @@
+// Pre-apply confirmation for a heavy enhance (mesh refine) whose projected
+// triangle count crosses the warn threshold. A model this dense is slow to
+// display and edit, and committing it can briefly stutter the page — so the
+// Quality panel asks before running. Resolves true to proceed, false to cancel.
+//
+// This is distinct from the Worker's hard cap: above the *max* the Worker
+// refuses outright; between *warn* and *max* we ask the user. The projected
+// count is exact for the count knob and approximate (`approx`) for the
+// edge-length knob.
+
+import { createModalShell } from './modalShell';
+import { BUTTON_PRIMARY, BUTTON_CANCEL } from './styleConstants';
+
+export function showHeavyEnhanceConfirm(opts: {
+  projected: number;
+  warnLimit: number;
+  approx: boolean;
+}): Promise<boolean> {
+  const { projected, warnLimit, approx } = opts;
+  return new Promise((resolve) => {
+    let result = false;
+    const shell = createModalShell({
+      title: 'Apply this heavy enhance?',
+      onClose: () => {
+        document.removeEventListener('keydown', onEnter);
+        resolve(result);
+      },
+    });
+
+    const block = document.createElement('div');
+    block.className = 'rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 leading-snug';
+    block.innerHTML =
+      `This enhance will produce ${approx ? 'about ' : ''}<strong>${projected.toLocaleString()}</strong> triangles ` +
+      `(over the ${warnLimit.toLocaleString()} heads-up threshold). ` +
+      'A model this dense is slower to display and edit, and applying it may briefly stutter the page. ' +
+      'You can lower the target or pick a larger edge length to keep it lighter.';
+    shell.body.appendChild(block);
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = BUTTON_CANCEL;
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.setAttribute('data-testid', 'heavy-enhance-cancel');
+    cancelBtn.addEventListener('click', () => { result = false; shell.close(); });
+    shell.footer.appendChild(cancelBtn);
+
+    const proceedBtn = document.createElement('button');
+    proceedBtn.className = BUTTON_PRIMARY;
+    proceedBtn.textContent = 'Apply anyway';
+    proceedBtn.setAttribute('data-testid', 'heavy-enhance-proceed');
+    proceedBtn.addEventListener('click', () => { result = true; shell.close(); });
+    shell.footer.appendChild(proceedBtn);
+
+    function onEnter(e: KeyboardEvent): void {
+      if (e.key === 'Enter') { e.preventDefault(); result = true; shell.close(); }
+    }
+    document.addEventListener('keydown', onEnter);
+
+    proceedBtn.focus();
+  });
+}

--- a/src/ui/simplifyUI.ts
+++ b/src/ui/simplifyUI.ts
@@ -32,6 +32,8 @@ import { openViewportPanel, closeViewportPanel } from './viewportPanelRegistry';
 import { attachViewportPanelDrag, setInitialPanelPosition } from './viewportPanelDrag';
 import { QUALITY_OPTIONS, QUALITY_SEGMENTS, loadQualitySettings, type QualitySettings } from '../geometry/qualitySettings';
 import { saveQualityForLang, initQualityLogic, notifyLanguageChange as notifyQualityLangChange } from './curvatureQualityPanel';
+import { showHeavyEnhanceConfirm } from './heavyMeshConfirmModal';
+import { getConfig } from '../config/appConfig';
 import type { Language } from '../geometry/engine';
 
 export interface SimplifyOpenInfo {
@@ -69,6 +71,17 @@ export type SimplifyMode = 'simplify' | 'enhance';
  *              collapses features smaller than it. */
 export type KnobMode = 'count' | 'edge' | 'size';
 
+/** Outcome of a simplify/enhance op:
+ *  - `{ triangleCount }` — applied; this is the new live triangle count.
+ *  - `{ exceeded, triangleCount }` — refused because the (enhance) result would
+ *    exceed the hard cap; nothing was committed. `triangleCount` is what it
+ *    would have produced.
+ *  - `null` — nothing changed at that setting (or cancelled). */
+export type MeshOpOutcome =
+  | { triangleCount: number }
+  | { exceeded: true; triangleCount: number }
+  | null;
+
 export interface SimplifyHandlers {
   /** Snapshot the current model as the baseline. Returns its triangle count
    *  (and the count currently on screen), or a reason when the model can't be
@@ -84,7 +97,7 @@ export interface SimplifyHandlers {
     preserveColor: boolean,
     onProgress: SimplifyProgress,
     signal?: AbortSignal,
-  ): Promise<{ triangleCount: number } | null>;
+  ): Promise<MeshOpOutcome>;
   /** Enhance the baseline up toward `targetTriangles` and show it live.
    *  `preserveColor` carries paint through the topology change. */
   enhance(
@@ -92,7 +105,7 @@ export interface SimplifyHandlers {
     preserveColor: boolean,
     onProgress: SimplifyProgress,
     signal?: AbortSignal,
-  ): Promise<{ triangleCount: number } | null>;
+  ): Promise<MeshOpOutcome>;
   /** Simplify the baseline with a single direct `simplify(tolerance)` pass
    *  (the "by edge length / feature size" knob) and show it live. Returns the
    *  achieved triangle count, or null when nothing fell below the tolerance
@@ -102,7 +115,7 @@ export interface SimplifyHandlers {
     preserveColor: boolean,
     onProgress: SimplifyProgress,
     signal?: AbortSignal,
-  ): Promise<{ triangleCount: number } | null>;
+  ): Promise<MeshOpOutcome>;
   /** Enhance the baseline with a single direct `refineToLength(edgeLength)`
    *  pass (the "by edge length / triangle size" knob) and show it live. Splits
    *  only edges longer than `edgeLength`, so the larger triangles densify
@@ -113,7 +126,12 @@ export interface SimplifyHandlers {
     preserveColor: boolean,
     onProgress: SimplifyProgress,
     signal?: AbortSignal,
-  ): Promise<{ triangleCount: number } | null>;
+  ): Promise<MeshOpOutcome>;
+  /** Estimate the triangle count a direct `refineToLength(edgeLength)` pass
+   *  would produce on the current baseline — used to warn/guard before running
+   *  a potentially runaway enhance. Approximate; the Worker enforces the real
+   *  hard cap as a backstop. */
+  estimateRefine(edgeLength: number): number;
   /** Restore the baseline mesh to the viewport (with original colors). */
   reset(): void;
   /** Bake the mesh currently on screen into a new saved version. */
@@ -530,11 +548,14 @@ function currentTarget(): number {
   return clampTarget(Number(numberInput?.value ?? slider?.value ?? info?.currentTriangles ?? 0));
 }
 
-/** Enable the shared Apply whenever there's something pending to commit — a
- *  curvature-quality preview, a simplify/enhance op, or both. */
+/** Enable the shared Apply (and Reset) whenever there's something pending to
+ *  commit — a curvature-quality preview, a simplify/enhance op, or both. Reset
+ *  only undoes *pending* (un-applied) changes, so it mirrors Apply: idle until
+ *  the user changes something, and disabled again the moment Apply commits. */
 function updateApplyEnabled(): void {
-  if (!applyBtn) return;
-  applyBtn.disabled = applying || (!qualityPending() && !meshPending());
+  const idle = applying || (!qualityPending() && !meshPending());
+  if (applyBtn) applyBtn.disabled = idle;
+  if (resetBtn) resetBtn.disabled = idle;
 }
 
 function setControlsDisabled(disabled: boolean): void {
@@ -597,6 +618,31 @@ async function runApply(): Promise<void> {
   const isDirect = req.kind !== 'count';
   const doPreserveColor = preserveColor && baseline.hasColor;
 
+  // Guard a runaway enhance before it ever runs: estimate the projected
+  // triangle count (exact for the count knob, approximate for edge length) and
+  // refuse / confirm over the configured thresholds. Committing a multi-million
+  // triangle mesh freezes the main thread, so this is the front-line defense
+  // (the Worker hard cap backs it up if the estimate undershoots). Only an
+  // enhance can explode the count — simplify only ever reduces it.
+  if (currentMode === 'enhance') {
+    const { enhanceWarnTriangles: warn, enhanceMaxTriangles: max } = getConfig().renderer;
+    const approx = req.kind !== 'count';
+    const projected = req.kind === 'count' ? req.value : handlers.estimateRefine(req.value);
+    if (projected >= max) {
+      const msg = `That setting would produce ${approx ? '~' : ''}${Math.round(projected).toLocaleString()} triangles, over the ${max.toLocaleString()} limit. Not applied — try a larger edge length or a lower target.`;
+      if (statusEl) statusEl.textContent = msg;
+      showToast(msg, { variant: 'warn', source: 'engine' });
+      return;
+    }
+    if (projected >= warn) {
+      const proceed = await showHeavyEnhanceConfirm({ projected: Math.round(projected), warnLimit: warn, approx });
+      if (!proceed) {
+        if (statusEl) statusEl.textContent = 'Cancelled.';
+        return;
+      }
+    }
+  }
+
   applying = true;
   applyAbort = new AbortController();
   const abort = applyAbort;
@@ -624,7 +670,7 @@ async function runApply(): Promise<void> {
   // otherwise clear it).
   let finalStatus = '';
   try {
-    let r: { triangleCount: number } | null;
+    let r: MeshOpOutcome;
     if (req.kind === 'count') {
       const handler = currentMode === 'simplify' ? handlers.apply : handlers.enhance;
       r = await handler.call(handlers, req.value, doPreserveColor, onProgress, abort.signal);
@@ -634,23 +680,33 @@ async function runApply(): Promise<void> {
       r = await handlers.enhanceByEdgeLength(req.value, doPreserveColor, onProgress, abort.signal);
     }
     appliedKey = requestKey(req);
-    const changed = !!r && r.triangleCount !== baseline.baseTriangles;
-    showResult(r ? r.triangleCount : baseline.baseTriangles);
-    if (!r && isDirect) {
-      // A direct pass that changed nothing means the threshold matched no
-      // edges / triangles — warn so the user knows to adjust the knob.
-      finalStatus = currentMode === 'simplify'
-        ? 'Nothing to simplify at that setting — no detail was below the tolerance. Try a larger value.'
-        : 'Nothing to enhance at that setting — no edge was longer than that. Try a smaller value.';
+    if (r && 'exceeded' in r) {
+      // The Worker refused: the refine would exceed the hard cap, so nothing
+      // was committed (the giant mesh never reached the main thread). This is
+      // the backstop for an estimate that undershot the real count.
+      const max = getConfig().renderer.enhanceMaxTriangles;
+      showResult(baseline.baseTriangles);
+      finalStatus = `That produced ~${r.triangleCount.toLocaleString()} triangles, over the ${max.toLocaleString()} limit — not applied. Try a larger edge length.`;
       showToast(finalStatus, { variant: 'warn', source: 'engine' });
-    } else if (!changed) {
-      finalStatus = 'No change at that setting.';
     } else {
-      // 3. Bake the applied result into a new saved version (Apply is the
-      //    commit — there's no separate Save button).
-      if (statusEl) statusEl.textContent = 'Saving…';
-      const saveRes = await handlers.save();
-      finalStatus = saveRes.message;
+      const changed = !!r && r.triangleCount !== baseline.baseTriangles;
+      showResult(r ? r.triangleCount : baseline.baseTriangles);
+      if (!r && isDirect) {
+        // A direct pass that changed nothing means the threshold matched no
+        // edges / triangles — warn so the user knows to adjust the knob.
+        finalStatus = currentMode === 'simplify'
+          ? 'Nothing to simplify at that setting — no detail was below the tolerance. Try a larger value.'
+          : 'Nothing to enhance at that setting — no edge was longer than that. Try a smaller value.';
+        showToast(finalStatus, { variant: 'warn', source: 'engine' });
+      } else if (!changed) {
+        finalStatus = 'No change at that setting.';
+      } else {
+        // 3. Bake the applied result into a new saved version (Apply is the
+        //    commit — there's no separate Save button).
+        if (statusEl) statusEl.textContent = 'Saving…';
+        const saveRes = await handlers.save();
+        finalStatus = saveRes.message;
+      }
     }
   } catch (e) {
     const err = e as Error;
@@ -982,6 +1038,7 @@ function buildPanel(): HTMLElement {
   resetBtn.className = 'px-2 py-1.5 rounded text-xs bg-zinc-700/70 text-zinc-300 [@media(hover:hover)]:hover:bg-zinc-600/70 transition-colors border border-zinc-600/50 disabled:opacity-40 disabled:cursor-not-allowed';
   resetBtn.textContent = 'Reset';
   resetBtn.title = 'Discard pending changes: revert the quality preview and restore the original mesh';
+  resetBtn.disabled = true; // nothing to reset until the user changes something
   resetBtn.addEventListener('click', () => {
     if (applying) return;
     revertQualityPreview();

--- a/src/ui/simplifyUI.ts
+++ b/src/ui/simplifyUI.ts
@@ -1,9 +1,20 @@
-// Simplify/Enhance mode UI — a viewport-overlay button that opens a popup panel
-// for either reducing (simplify) or increasing (enhance) the model's triangle
-// count. A mode toggle switches between the two operations; a "Preserve colors
-// (best-effort)" checkbox carries paint through the topology change via
-// nearest-triangle centroid transfer. The shared progress modal (with a Cancel
-// button) tracks the worker search on heavy models.
+// Quality panel — a viewport-overlay button that opens a popup panel combining
+// two related model-quality controls:
+//   • Curvature quality — the circular-segment count used when the code runs.
+//     Picking a preset previews live (re-renders); it isn't committed until the
+//     single bottom Apply, and closing the panel reverts an un-applied preview.
+//   • Simplify / Enhance — reduce or increase the model's triangle count. A mode
+//     toggle switches between the two; knob pills pick how the target is
+//     expressed (count / edge length / size); a "Preserve colors (best-effort)"
+//     checkbox carries paint through the topology change.
+//
+// There is one shared Apply button at the bottom of the menu. Clicking it
+// commits any combination of pending changes: it persists the previewed
+// curvature quality and, when a simplify/enhance target is set, runs that mesh
+// op and bakes the result into a new saved session version in a single step.
+// (There is intentionally no separate "Save as version" button — Apply is the
+// commit.) The shared progress modal (with a Cancel button) tracks the worker
+// search on heavy models.
 //
 // Opening the panel auto-enables the viewport's mesh-edges (wireframe) overlay
 // so the user can see what they're changing, and restores the previous setting
@@ -115,11 +126,10 @@ const MODE_INACTIVE = 'flex-1 px-2 py-1 rounded text-xs text-zinc-400 bg-zinc-70
 const MODE_ACTIVE = 'flex-1 px-2 py-1 rounded text-xs text-blue-300 bg-blue-500/20 transition-colors border border-blue-500/40';
 
 let qualityRadios: HTMLInputElement[] = [];
-let qualityApplyBtn: HTMLButtonElement | null = null;
 // The committed (applied) curvature quality to revert to when the panel closes
 // without an explicit Apply. Captured on open and updated each time the user
-// clicks Apply quality. Picking a radio only *previews* (re-renders live); it's
-// not persisted until Apply, and closing the panel reverts an un-applied
+// clicks the shared Apply. Picking a radio only *previews* (re-renders live);
+// it's not persisted until Apply, and closing the panel reverts an un-applied
 // preview so a heavy quality the user was just trying out doesn't stick.
 let committedQuality: QualitySettings | null = null;
 let stopRenderBtn: HTMLButtonElement | null = null;
@@ -137,7 +147,6 @@ let statusEl: HTMLElement | null = null;
 let controlsEl: HTMLElement | null = null;
 let applyBtn: HTMLButtonElement | null = null;
 let resetBtn: HTMLButtonElement | null = null;
-let saveBtn: HTMLButtonElement | null = null;
 let colorCheckbox: HTMLInputElement | null = null;
 let colorRow: HTMLElement | null = null;
 let simplifyModeBtn: HTMLButtonElement | null = null;
@@ -162,9 +171,6 @@ let knobMode: KnobMode = 'count';
 // no-op until the user changes mode / knob / value. Set after each apply,
 // refresh, and reset.
 let appliedKey = '';
-// The triangle count currently on screen (drives the Save button's enabled
-// state) — set every time the applied result changes.
-let appliedCount = 0;
 let applying = false;
 /** AbortController for the in-flight apply/enhance. Lives across panel
  *  close/reopen so the modal's Cancel button reaches the right worker job. */
@@ -230,7 +236,7 @@ export function notifyQualityLangChanged(lang: Language): void {
   // The language switch silently swaps in that language's quality default, so
   // re-baseline the commit/preview against it.
   committedQuality = { ...loadQualitySettings() };
-  updateQualityApplyEnabled();
+  updateApplyEnabled();
   if (stopRenderBtn && !isScadLang) stopRenderBtn.classList.add('hidden');
 }
 
@@ -256,28 +262,21 @@ function qualityMatches(a: QualitySettings, b: QualitySettings): boolean {
   return a.quality === b.quality && a.customSegments === b.customSegments;
 }
 
-/** Enable "Apply quality" only while a previewed quality differs from the
- *  committed one (mirrors the simplify Apply's "no-op stays disabled" rule). */
-function updateQualityApplyEnabled(): void {
-  if (!qualityApplyBtn) return;
-  qualityApplyBtn.disabled = !committedQuality || qualityMatches(loadQualitySettings(), committedQuality);
-}
-
-/** Commit the currently-previewed quality so it survives the panel closing. */
-function applyQualityPreview(): void {
-  committedQuality = { ...loadQualitySettings() };
-  updateQualityApplyEnabled();
+/** Whether the previewed curvature quality differs from the committed one. */
+function qualityPending(): boolean {
+  return !!committedQuality && !qualityMatches(loadQualitySettings(), committedQuality);
 }
 
 /** Revert an un-applied quality preview back to the committed setting. Called
- *  when the panel closes so a live preview the user didn't Apply doesn't stick. */
+ *  when the panel closes (or Reset) so a live preview the user didn't Apply
+ *  doesn't stick. */
 function revertQualityPreview(): void {
   if (committedQuality && !qualityMatches(loadQualitySettings(), committedQuality)) {
     onCancelRender?.();
     saveQualityForLang({ ...committedQuality });
   }
   syncQualityRadios();
-  updateQualityApplyEnabled();
+  updateApplyEnabled();
 }
 
 function toggle(): void {
@@ -311,7 +310,6 @@ function openPanel(): void {
   // un-applied preview reverts here on close.
   committedQuality = { ...loadQualitySettings() };
   syncQualityRadios();
-  updateQualityApplyEnabled();
   refresh(true);
 }
 
@@ -471,6 +469,13 @@ function requestKey(r: MeshOpRequest): string {
   return `${knobMode}:${r.kind}:${r.value > 0 ? String(r.value) : '0'}`;
 }
 
+/** Whether a simplify/enhance op is pending (target differs from what's live). */
+function meshPending(): boolean {
+  if (!info) return false;
+  const r = currentRequest();
+  return r.kind !== 'noop' && requestKey(r) !== appliedKey;
+}
+
 function closePanel(): void {
   revertQualityPreview();
   panel?.classList.add('hidden');
@@ -489,6 +494,7 @@ function showUnavailable(reason: string): void {
     statusEl.classList.remove('hidden');
     statusEl.textContent = reason;
   }
+  updateApplyEnabled();
 }
 
 function showControls(): void {
@@ -498,7 +504,6 @@ function showControls(): void {
 
 function showResult(count: number): void {
   if (!info || !resultEl) return;
-  appliedCount = count;
   const base = info.baseTriangles;
   if (count < base) {
     const pct = base > 0 ? Math.round((1 - count / base) * 100) : 0;
@@ -509,7 +514,6 @@ function showResult(count: number): void {
   } else {
     resultEl.textContent = `Result: ${count.toLocaleString()} triangles`;
   }
-  updateSaveEnabled();
 }
 
 function clampTarget(raw: number): number {
@@ -526,15 +530,11 @@ function currentTarget(): number {
   return clampTarget(Number(numberInput?.value ?? slider?.value ?? info?.currentTriangles ?? 0));
 }
 
+/** Enable the shared Apply whenever there's something pending to commit — a
+ *  curvature-quality preview, a simplify/enhance op, or both. */
 function updateApplyEnabled(): void {
   if (!applyBtn) return;
-  const r = currentRequest();
-  applyBtn.disabled = applying || !info || r.kind === 'noop' || requestKey(r) === appliedKey;
-}
-
-function updateSaveEnabled(): void {
-  if (!saveBtn) return;
-  saveBtn.disabled = applying || !info || appliedCount === info.baseTriangles;
+  applyBtn.disabled = applying || (!qualityPending() && !meshPending());
 }
 
 function setControlsDisabled(disabled: boolean): void {
@@ -550,23 +550,52 @@ function setControlsDisabled(disabled: boolean): void {
   if (knobEdgeBtn) knobEdgeBtn.disabled = disabled;
   if (knobSizeBtn) knobSizeBtn.disabled = disabled;
   if (colorCheckbox) colorCheckbox.disabled = disabled;
+  for (const radio of qualityRadios) radio.disabled = disabled;
   if (disabled) {
     if (applyBtn) applyBtn.disabled = true;
-    if (saveBtn) saveBtn.disabled = true;
   } else {
     updateApplyEnabled();
-    updateSaveEnabled();
   }
 }
 
+/** The shared bottom Apply. Commits any combination of pending changes: it
+ *  persists the previewed curvature quality and, when a simplify/enhance target
+ *  is set, runs that mesh op and bakes the result into a new saved version. */
 async function runApply(): Promise<void> {
-  if (!handlers || !info || applying) return;
+  if (!handlers || applying) return;
+  const wantQuality = qualityPending();
+  const wantMesh = meshPending();
+  if (!wantQuality && !wantMesh) return;
+
+  // 1. Commit the curvature-quality preview. Selecting a preset already
+  //    re-rendered the model live, so committing just means it survives close.
+  if (wantQuality) committedQuality = { ...loadQualitySettings() };
+
+  if (!wantMesh) {
+    // Quality-only apply — nothing to bake. (Quality is a session setting, not
+    // captured in a saved version, so a version here would be a misleading
+    // snapshot of unchanged code.)
+    if (statusEl) statusEl.textContent = 'Quality applied.';
+    updateApplyEnabled();
+    return;
+  }
+
+  // 2. A simplify/enhance op is pending. If quality also changed, its live
+  //    re-render dropped the cached baseline (a fresh run invalidates it), so
+  //    re-snapshot from the freshly-rendered mesh before operating.
+  if (wantQuality) {
+    const res = handlers.open(false);
+    if (!res.ok) { showUnavailable(res.reason); return; }
+    info = res.info;
+    if (originalEl) originalEl.textContent = `Original: ${info.baseTriangles.toLocaleString()} triangles`;
+  }
+  if (!info) return;
+
   const req = currentRequest();
-  if (req.kind === 'noop' || requestKey(req) === appliedKey) return;
   const baseline = info;
   const currentMode = mode;
   const isDirect = req.kind !== 'count';
-  const doPreserveColor = preserveColor && info.hasColor;
+  const doPreserveColor = preserveColor && baseline.hasColor;
 
   applying = true;
   applyAbort = new AbortController();
@@ -591,6 +620,9 @@ async function runApply(): Promise<void> {
     updateProgress(progressId, fraction, `${currentMode === 'simplify' ? 'Simplifying' : 'Enhancing'}… ${pct}%`);
   };
 
+  // The final status line, applied after the closing refresh (which would
+  // otherwise clear it).
+  let finalStatus = '';
   try {
     let r: { triangleCount: number } | null;
     if (req.kind === 'count') {
@@ -602,31 +634,39 @@ async function runApply(): Promise<void> {
       r = await handlers.enhanceByEdgeLength(req.value, doPreserveColor, onProgress, abort.signal);
     }
     appliedKey = requestKey(req);
+    const changed = !!r && r.triangleCount !== baseline.baseTriangles;
     showResult(r ? r.triangleCount : baseline.baseTriangles);
     if (!r && isDirect) {
       // A direct pass that changed nothing means the threshold matched no
       // edges / triangles — warn so the user knows to adjust the knob.
-      const warn = currentMode === 'simplify'
+      finalStatus = currentMode === 'simplify'
         ? 'Nothing to simplify at that setting — no detail was below the tolerance. Try a larger value.'
         : 'Nothing to enhance at that setting — no edge was longer than that. Try a smaller value.';
-      if (statusEl) statusEl.textContent = warn;
-      showToast(warn, { variant: 'warn', source: 'engine' });
-    } else if (statusEl) {
-      statusEl.textContent = '';
+      showToast(finalStatus, { variant: 'warn', source: 'engine' });
+    } else if (!changed) {
+      finalStatus = 'No change at that setting.';
+    } else {
+      // 3. Bake the applied result into a new saved version (Apply is the
+      //    commit — there's no separate Save button).
+      if (statusEl) statusEl.textContent = 'Saving…';
+      const saveRes = await handlers.save();
+      finalStatus = saveRes.message;
     }
   } catch (e) {
     const err = e as Error;
-    if (err?.name === 'AbortError') {
-      if (statusEl) statusEl.textContent = 'Cancelled.';
-    } else {
-      if (statusEl) statusEl.textContent = `${currentMode === 'simplify' ? 'Simplify' : 'Enhance'} failed: ${err.message}`;
-    }
+    finalStatus = err?.name === 'AbortError'
+      ? 'Cancelled.'
+      : `${currentMode === 'simplify' ? 'Simplify' : 'Enhance'} failed: ${err.message}`;
   } finally {
     applying = false;
     applyAbort = null;
     endProgress(progressId);
     setControlsDisabled(false);
   }
+  // Re-read the (possibly baked) geometry so the controls reset to the new
+  // baseline, then restore the status line the refresh cleared.
+  if (handlers) refresh(false);
+  if (statusEl) statusEl.textContent = finalStatus;
 }
 
 function buildPanel(): HTMLElement {
@@ -683,11 +723,11 @@ function buildPanel(): HTMLElement {
     radio.addEventListener('change', () => {
       if (!radio.checked) return;
       // Live preview only — re-render at the new quality but don't commit it.
-      // Apply quality persists it; closing the panel reverts it.
+      // The shared Apply persists it; closing the panel reverts it.
       onCancelRender?.();
       const { customSegments } = loadQualitySettings();
       saveQualityForLang({ quality: opt.id, customSegments });
-      updateQualityApplyEnabled();
+      updateApplyEnabled();
     });
     qualityRadios.push(radio);
 
@@ -704,15 +744,6 @@ function buildPanel(): HTMLElement {
   }
   qualitySection.appendChild(radiosWrap);
   syncQualityRadios();
-
-  qualityApplyBtn = document.createElement('button');
-  qualityApplyBtn.id = 'quality-apply';
-  qualityApplyBtn.className = 'w-full mt-2 px-2 py-1.5 rounded text-xs font-medium bg-blue-500/30 text-blue-200 [@media(hover:hover)]:hover:bg-blue-500/40 transition-colors border border-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed';
-  qualityApplyBtn.textContent = 'Apply quality';
-  qualityApplyBtn.title = 'Commit the previewed curvature quality. Closing the panel without applying reverts it.';
-  qualityApplyBtn.disabled = true;
-  qualityApplyBtn.addEventListener('click', applyQualityPreview);
-  qualitySection.appendChild(qualityApplyBtn);
 
   stopRenderBtn = document.createElement('button');
   stopRenderBtn.className = 'hidden w-full mt-2 px-2 py-1 rounded text-xs bg-red-500/20 text-red-300 [@media(hover:hover)]:hover:bg-red-500/30 transition-colors border border-red-500/40';
@@ -934,31 +965,26 @@ function buildPanel(): HTMLElement {
   colorRow.append(colorCheckbox, colorLabel);
   controlsEl.appendChild(colorRow);
 
-  applyBtn = document.createElement('button');
-  applyBtn.id = 'simplify-apply';
-  applyBtn.className = 'w-full px-2 py-1.5 rounded text-xs font-medium bg-blue-500/30 text-blue-200 [@media(hover:hover)]:hover:bg-blue-500/40 transition-colors border border-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed mb-2';
-  applyBtn.textContent = 'Apply';
-  applyBtn.title = 'Apply the target triangle count';
-  applyBtn.disabled = true;
-  applyBtn.addEventListener('click', () => { void runApply(); });
-  controlsEl.appendChild(applyBtn);
-
   resultEl = document.createElement('div');
   resultEl.id = 'simplify-result';
-  resultEl.className = 'text-xs text-blue-300 mb-2.5';
+  resultEl.className = 'text-xs text-blue-300 mb-2';
   resultEl.textContent = 'Result: —';
   controlsEl.appendChild(resultEl);
 
+  c.appendChild(controlsEl);
+
+  // --- Shared bottom action row: Reset + one Apply for everything ---
   const actions = document.createElement('div');
-  actions.className = 'flex items-center gap-2';
+  actions.className = 'flex items-center gap-2 mt-1';
 
   resetBtn = document.createElement('button');
   resetBtn.id = 'simplify-reset';
-  resetBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-700/70 text-zinc-300 [@media(hover:hover)]:hover:bg-zinc-600/70 transition-colors border border-zinc-600/50';
+  resetBtn.className = 'px-2 py-1.5 rounded text-xs bg-zinc-700/70 text-zinc-300 [@media(hover:hover)]:hover:bg-zinc-600/70 transition-colors border border-zinc-600/50 disabled:opacity-40 disabled:cursor-not-allowed';
   resetBtn.textContent = 'Reset';
-  resetBtn.title = 'Restore the original mesh';
+  resetBtn.title = 'Discard pending changes: revert the quality preview and restore the original mesh';
   resetBtn.addEventListener('click', () => {
-    if (!info || applying) return;
+    if (applying) return;
+    revertQualityPreview();
     handlers?.reset();
     // Re-read the (now restored) baseline so every control returns to its
     // default and Apply goes idle until the user changes something.
@@ -967,24 +993,15 @@ function buildPanel(): HTMLElement {
   });
   actions.appendChild(resetBtn);
 
-  saveBtn = document.createElement('button');
-  saveBtn.id = 'simplify-save';
-  saveBtn.className = 'px-2 py-1 rounded text-xs bg-blue-500/30 text-blue-200 [@media(hover:hover)]:hover:bg-blue-500/40 transition-colors border border-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed';
-  saveBtn.textContent = 'Save as version';
-  saveBtn.title = 'Bake the current mesh into a new saved version';
-  saveBtn.disabled = true;
-  saveBtn.addEventListener('click', async () => {
-    if (!handlers || !saveBtn || applying) return;
-    saveBtn.disabled = true;
-    if (statusEl) statusEl.textContent = 'Saving…';
-    const res = await handlers.save();
-    if (res.ok) refresh(false);
-    if (statusEl) statusEl.textContent = res.message;
-  });
-  actions.appendChild(saveBtn);
-  controlsEl.appendChild(actions);
-
-  c.appendChild(controlsEl);
+  applyBtn = document.createElement('button');
+  applyBtn.id = 'simplify-apply';
+  applyBtn.className = 'flex-1 px-2 py-1.5 rounded text-xs font-medium bg-blue-500/30 text-blue-200 [@media(hover:hover)]:hover:bg-blue-500/40 transition-colors border border-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed';
+  applyBtn.textContent = 'Apply';
+  applyBtn.title = 'Apply pending quality and simplify/enhance changes. A simplify/enhance applies and saves a new version.';
+  applyBtn.disabled = true;
+  applyBtn.addEventListener('click', () => { void runApply(); });
+  actions.appendChild(applyBtn);
+  c.appendChild(actions);
 
   statusEl = document.createElement('div');
   statusEl.id = 'simplify-status';

--- a/tests/quality-scad.spec.ts
+++ b/tests/quality-scad.spec.ts
@@ -51,7 +51,7 @@ test('SCAD engine applies the chosen $fn from quality preset', async ({ page }) 
   // (picking a preset only previews; closing without Apply would revert).
   await page.locator('#simplify-toggle').click();
   await page.locator('#simplify-panel input[type=radio][value=low]').check();
-  await page.locator('#quality-apply').click();
+  await page.locator('#simplify-apply').click();
   await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
 
   // Re-run — fewer triangles.

--- a/tests/quality-settings.spec.ts
+++ b/tests/quality-settings.spec.ts
@@ -40,8 +40,8 @@ test.describe('Modeling quality settings', () => {
     // Radio should be checked immediately (live preview).
     await expect(page.locator('#simplify-panel input[type=radio][value=low]')).toBeChecked();
 
-    // Apply quality becomes enabled once the preview differs; click to commit.
-    const applyBtn = page.locator('#quality-apply');
+    // The shared Apply becomes enabled once the preview differs; click to commit.
+    const applyBtn = page.locator('#simplify-apply');
     await expect(applyBtn).toBeEnabled();
     await applyBtn.click();
     await expect(applyBtn).toBeDisabled(); // committed → no-op again
@@ -67,7 +67,7 @@ test.describe('Modeling quality settings', () => {
     await page.locator('#simplify-toggle').click();
     await expect(page.locator('#simplify-panel input[type=radio][value=highest]')).toBeChecked();
     // Apply is disabled again because nothing is pending after the revert.
-    await expect(page.locator('#quality-apply')).toBeDisabled();
+    await expect(page.locator('#simplify-apply')).toBeDisabled();
   });
 
   test('manifold-js engine applies the chosen segment count', async ({ page }) => {
@@ -92,7 +92,7 @@ test.describe('Modeling quality settings', () => {
     // Drop to Low via the panel and Apply to commit it.
     await page.locator('#simplify-toggle').click();
     await page.locator('#simplify-panel input[type=radio][value=low]').check();
-    await page.locator('#quality-apply').click();
+    await page.locator('#simplify-apply').click();
     await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
 
     // Re-run the same code — should produce far fewer triangles.
@@ -126,7 +126,7 @@ test.describe('Modeling quality settings', () => {
     await page.locator('#simplify-toggle').click();
     await page.locator('#simplify-panel input[type=radio][value=ultra]').check();
     await expect(page.locator('#simplify-panel input[type=radio][value=ultra]')).toBeChecked();
-    await page.locator('#quality-apply').click();
+    await page.locator('#simplify-apply').click();
     await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
 
     const ultra = await page.evaluate(async (code) => {

--- a/tests/simplify.spec.ts
+++ b/tests/simplify.spec.ts
@@ -1,9 +1,9 @@
 // Smoke tests for the Simplify overlay tool:
 //  - the panel opens from the viewport overlay and shows a slider + a typeable
 //    "max triangles" input bounded by the model's current triangle count
-//  - setting a target alone does nothing; clicking Apply reduces the live
-//    model; Reset restores it
-//  - "Save as version" bakes the reduced mesh into a new saved version
+//  - setting a target alone does nothing; Reset clears the pending target
+//  - the single shared Apply reduces the live model AND bakes the result into a
+//    new saved version in one step (there is no separate "Save as version")
 //
 // Uses dispatchEvent('click') instead of .click() to dodge the onboarding tour
 // backdrop that can intercept pointer events on first load of the editor.
@@ -49,7 +49,7 @@ test.describe('Simplify tool', () => {
     await expect(page.locator('#simplify-original')).toContainText(base.toLocaleString());
   });
 
-  test('setting a target does nothing until Apply; Apply reduces and Reset restores', async ({ page }) => {
+  test('setting a target does nothing until Apply; Reset clears the pending target', async ({ page }) => {
     const base = await openEditorWithSphere(page);
 
     await page.locator('#simplify-toggle').dispatchEvent('click');
@@ -58,41 +58,20 @@ test.describe('Simplify tool', () => {
     const target = Math.max(50, Math.round(base / 4));
     await page.locator('#simplify-input').fill(String(target));
 
-    // Setting the target no longer touches the live model — that's Apply's job.
+    // Setting the target doesn't touch the live model — that's Apply's job.
     // Apply becomes enabled, but the mesh stays at full detail until clicked.
     await expect(page.locator('#simplify-apply')).toBeEnabled();
     expect(await triangleCount(page)).toBe(base);
 
-    // Apply runs the reduction; wait for the model to actually shrink.
-    await page.locator('#simplify-apply').dispatchEvent('click');
-    await page.waitForFunction(
-      (b) => {
-        const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
-        return (pw.getGeometryData().triangleCount ?? b) < b;
-      },
-      base,
-      { timeout: 10000 },
-    );
-
-    const reduced = await triangleCount(page);
-    expect(reduced).toBeLessThan(base);
-    expect(reduced).toBeLessThanOrEqual(target);
-    expect(reduced).toBeGreaterThanOrEqual(4);
-
-    // Reset puts the full-detail mesh back on screen.
+    // Reset clears the pending target without ever running the op, so Apply
+    // goes idle again and the model is untouched.
     await page.locator('#simplify-reset').dispatchEvent('click');
-    await page.waitForFunction(
-      (b) => {
-        const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
-        return (pw.getGeometryData().triangleCount ?? 0) === b;
-      },
-      base,
-      { timeout: 10000 },
-    );
+    await expect(page.locator('#simplify-apply')).toBeDisabled();
+    await expect(page.locator('#simplify-input')).toHaveValue(String(base));
     expect(await triangleCount(page)).toBe(base);
   });
 
-  test('Save as version bakes the reduced mesh into a new version', async ({ page }) => {
+  test('Apply reduces the mesh and bakes a new saved version in one step', async ({ page }) => {
     const base = await openEditorWithSphere(page);
     // Commit the parametric sphere as v1 so we can see the count grow.
     await page.evaluate(async () => {
@@ -109,18 +88,16 @@ test.describe('Simplify tool', () => {
 
     const target = Math.max(50, Math.round(base / 4));
     await page.locator('#simplify-input').fill(String(target));
-    await page.locator('#simplify-apply').dispatchEvent('click');
-    await page.waitForFunction(
-      (b) => {
-        const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
-        return (pw.getGeometryData().triangleCount ?? b) < b;
-      },
-      base,
-      { timeout: 10000 },
-    );
 
-    await page.locator('#simplify-save').dispatchEvent('click');
-    await expect(page.locator('#simplify-status')).toContainText('Saved', { timeout: 10000 });
+    // The single Apply both reduces the live mesh and saves a version — there
+    // is no separate "Save as version" step.
+    await page.locator('#simplify-apply').dispatchEvent('click');
+    await expect(page.locator('#simplify-status')).toContainText('Saved', { timeout: 15000 });
+
+    const reduced = await triangleCount(page);
+    expect(reduced).toBeLessThan(base);
+    expect(reduced).toBeLessThanOrEqual(target);
+    expect(reduced).toBeGreaterThanOrEqual(4);
 
     const versions = await page.evaluate(async () => {
       const pw = (window as unknown as { partwright: { listVersions(): Promise<{ label: string | null }[]> } }).partwright;
@@ -130,7 +107,7 @@ test.describe('Simplify tool', () => {
     expect(versions[versions.length - 1].label).toBe('simplified');
   });
 
-  test('Save as version preserves an unsaved edited original as its own version', async ({ page }) => {
+  test('Apply preserves an unsaved edited original as its own version', async ({ page }) => {
     const base = await openEditorWithSphere(page);
 
     // Commit a baseline sphere as a saved version.
@@ -157,19 +134,10 @@ test.describe('Simplify tool', () => {
 
     const target = Math.max(50, Math.round(base / 4));
     await page.locator('#simplify-input').fill(String(target));
+    // Apply reduces and bakes in one step; the status line calls out that the
+    // unsaved original was preserved as its own version, not just saved.
     await page.locator('#simplify-apply').dispatchEvent('click');
-    await page.waitForFunction(
-      (b) => {
-        const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
-        return (pw.getGeometryData().triangleCount ?? b) < b;
-      },
-      base,
-      { timeout: 10000 },
-    );
-
-    await page.locator('#simplify-save').dispatchEvent('click');
-    // The status line calls out that the original was preserved, not just saved.
-    await expect(page.locator('#simplify-status')).toContainText('original', { timeout: 10000 });
+    await expect(page.locator('#simplify-status')).toContainText('original', { timeout: 15000 });
 
     const indices = await page.evaluate(async () => {
       const pw = (window as unknown as { partwright: { listVersions(): Promise<{ index: number; label: string | null }[]> } }).partwright;
@@ -309,7 +277,7 @@ test.describe('Quality panel — edge-length & size knobs', () => {
     }, MIXED);
   }
 
-  test('Enhance + Edge knob refines the large triangles; Reset restores', async ({ page }) => {
+  test('Enhance + Edge knob refines the large triangles', async ({ page }) => {
     const base = await openEditorWithMixed(page);
     expect(base).toBeGreaterThan(100);
 
@@ -324,6 +292,7 @@ test.describe('Quality panel — edge-length & size knobs', () => {
     await expect(page.locator('#simplify-slider')).toBeHidden();
 
     // A small target edge length splits the big box faces → more triangles.
+    // The single Apply refines and bakes the result in one step.
     await page.locator('#simplify-length-input').fill('3');
     await page.locator('#simplify-length-input').dispatchEvent('change');
     await page.locator('#simplify-apply').dispatchEvent('click');
@@ -336,16 +305,6 @@ test.describe('Quality panel — edge-length & size knobs', () => {
       { timeout: 15000 },
     );
     expect(await triangleCount(page)).toBeGreaterThan(base);
-
-    await page.locator('#simplify-reset').dispatchEvent('click');
-    await page.waitForFunction(
-      (b) => {
-        const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
-        return (pw.getGeometryData().triangleCount ?? 0) === b;
-      },
-      base,
-      { timeout: 10000 },
-    );
   });
 
   test('an edge length longer than every edge warns and leaves the mesh unchanged', async ({ page }) => {

--- a/tests/simplify.spec.ts
+++ b/tests/simplify.spec.ts
@@ -55,18 +55,24 @@ test.describe('Simplify tool', () => {
     await page.locator('#simplify-toggle').dispatchEvent('click');
     await page.waitForSelector('#simplify-panel:not(.hidden)');
 
+    // Nothing pending yet → both Reset and Apply start disabled.
+    await expect(page.locator('#simplify-reset')).toBeDisabled();
+    await expect(page.locator('#simplify-apply')).toBeDisabled();
+
     const target = Math.max(50, Math.round(base / 4));
     await page.locator('#simplify-input').fill(String(target));
 
     // Setting the target doesn't touch the live model — that's Apply's job.
-    // Apply becomes enabled, but the mesh stays at full detail until clicked.
+    // Apply (and Reset) become enabled, but the mesh stays at full detail.
     await expect(page.locator('#simplify-apply')).toBeEnabled();
+    await expect(page.locator('#simplify-reset')).toBeEnabled();
     expect(await triangleCount(page)).toBe(base);
 
-    // Reset clears the pending target without ever running the op, so Apply
-    // goes idle again and the model is untouched.
+    // Reset clears the pending target without ever running the op, so both go
+    // idle again and the model is untouched.
     await page.locator('#simplify-reset').dispatchEvent('click');
     await expect(page.locator('#simplify-apply')).toBeDisabled();
+    await expect(page.locator('#simplify-reset')).toBeDisabled();
     await expect(page.locator('#simplify-input')).toHaveValue(String(base));
     expect(await triangleCount(page)).toBe(base);
   });
@@ -105,6 +111,10 @@ test.describe('Simplify tool', () => {
     });
     expect(versions.length).toBe(before + 1);
     expect(versions[versions.length - 1].label).toBe('simplified');
+
+    // Apply committed everything, so both Reset and Apply are idle again.
+    await expect(page.locator('#simplify-apply')).toBeDisabled();
+    await expect(page.locator('#simplify-reset')).toBeDisabled();
   });
 
   test('Apply preserves an unsaved edited original as its own version', async ({ page }) => {
@@ -346,5 +356,93 @@ test.describe('Quality panel — edge-length & size knobs', () => {
       { timeout: 15000 },
     );
     expect(await triangleCount(page)).toBeLessThan(base);
+  });
+});
+
+test.describe('Quality panel — heavy-enhance guard', () => {
+  // Inject a low warn threshold (and a high hard cap) so an ordinary enhance
+  // trips the Proceed/Cancel confirmation without needing a 10M-triangle model.
+  async function openWithLowWarn(page: Page): Promise<number> {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('partwright-tour-completed', '1');
+        localStorage.setItem('partwright-app-config-v1', JSON.stringify({
+          renderer: { enhanceWarnTriangles: 100, enhanceMaxTriangles: 100_000_000 },
+        }));
+      } catch { /* ignore */ }
+    });
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+    return page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: { createSession(n?: string): Promise<unknown>; run(c: string): Promise<unknown>; getGeometryData(): { triangleCount?: number } } }).partwright;
+      await pw.createSession('heavy-enhance');
+      await pw.run('const { Manifold } = api; return Manifold.sphere(10, 48);');
+      return pw.getGeometryData().triangleCount ?? 0;
+    });
+  }
+
+  test('an enhance over the warn limit asks before applying; Cancel leaves the mesh', async ({ page }) => {
+    const base = await openWithLowWarn(page);
+    expect(base).toBeGreaterThan(100);
+
+    await page.locator('#simplify-toggle').dispatchEvent('click');
+    await page.waitForSelector('#simplify-panel:not(.hidden)');
+    // Enhance mode (count knob default target is base×2 → well over the warn=100).
+    await page.getByRole('button', { name: 'Enhance', exact: true }).dispatchEvent('click');
+
+    await page.locator('#simplify-apply').dispatchEvent('click');
+    // The confirmation modal appears instead of immediately running.
+    const proceed = page.locator('[data-testid="heavy-enhance-proceed"]');
+    await expect(proceed).toBeVisible({ timeout: 5000 });
+
+    // Cancel → nothing runs, the mesh stays at its original count.
+    await page.locator('[data-testid="heavy-enhance-cancel"]').click();
+    await expect(proceed).toBeHidden();
+    expect(await triangleCount(page)).toBe(base);
+
+    // Apply again and proceed → the enhance runs and the mesh grows.
+    await page.locator('#simplify-apply').dispatchEvent('click');
+    await expect(proceed).toBeVisible({ timeout: 5000 });
+    await proceed.click();
+    await page.waitForFunction(
+      (b) => {
+        const pw = (window as unknown as { partwright: { getGeometryData(): { triangleCount?: number } } }).partwright;
+        return (pw.getGeometryData().triangleCount ?? 0) > b;
+      },
+      base,
+      { timeout: 15000 },
+    );
+    expect(await triangleCount(page)).toBeGreaterThan(base);
+  });
+
+  test('an enhance over the hard cap is refused, not applied', async ({ page }) => {
+    // Tiny cap so even a modest enhance is refused outright (no confirm, no commit).
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('partwright-tour-completed', '1');
+        localStorage.setItem('partwright-app-config-v1', JSON.stringify({
+          renderer: { enhanceWarnTriangles: 10, enhanceMaxTriangles: 100 },
+        }));
+      } catch { /* ignore */ }
+    });
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+    const base = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: { createSession(n?: string): Promise<unknown>; run(c: string): Promise<unknown>; getGeometryData(): { triangleCount?: number } } }).partwright;
+      await pw.createSession('enhance-cap');
+      await pw.run('const { Manifold } = api; return Manifold.sphere(10, 48);');
+      return pw.getGeometryData().triangleCount ?? 0;
+    });
+    expect(base).toBeGreaterThan(100); // already above the tiny cap
+
+    await page.locator('#simplify-toggle').dispatchEvent('click');
+    await page.waitForSelector('#simplify-panel:not(.hidden)');
+    await page.getByRole('button', { name: 'Enhance', exact: true }).dispatchEvent('click');
+    await page.locator('#simplify-apply').dispatchEvent('click');
+
+    // Refused before running — status calls out the limit and the mesh is untouched.
+    await expect(page.locator('#simplify-status')).toContainText('over the', { timeout: 5000 });
+    await expect(page.locator('[data-testid="heavy-enhance-proceed"]')).toHaveCount(0);
+    expect(await triangleCount(page)).toBe(base);
   });
 });

--- a/tests/unit/surface.test.ts
+++ b/tests/unit/surface.test.ts
@@ -5,6 +5,7 @@ import {
   computeVertexNormals,
   maxEdgeLength,
   extractPositions,
+  estimateRefineTriangles,
   bboxOf,
 } from '../../src/surface/meshSubdivide';
 import { fuzzySkin } from '../../src/surface/fuzzySkin';
@@ -39,6 +40,20 @@ describe('meshSubdivide', () => {
     expect(out.numTri).toBeGreaterThan(c.numTri);
     expect(out.numProp).toBe(3);
     expect(maxEdgeLength(out.vertProperties, out.triVerts)).toBeLessThanOrEqual(before / 3 + 1e-6);
+  });
+
+  it('estimateRefineTriangles grows ~quadratically as the target length shrinks', () => {
+    const c = cube(10); // longest edge is a face diagonal ≈ 14.14
+    // A length >= the longest edge means no split: ~1 sub-triangle each.
+    expect(estimateRefineTriangles(extractPositions(c), c.triVerts, 100)).toBe(c.numTri);
+    // Halving the length roughly quadruples each triangle's k² contribution, so
+    // a much smaller length yields a far larger estimate.
+    const coarse = estimateRefineTriangles(extractPositions(c), c.triVerts, 5);
+    const fine = estimateRefineTriangles(extractPositions(c), c.triVerts, 1);
+    expect(fine).toBeGreaterThan(coarse);
+    expect(coarse).toBeGreaterThan(c.numTri);
+    // Non-positive length is a no-op estimate (the base count).
+    expect(estimateRefineTriangles(extractPositions(c), c.triVerts, 0)).toBe(c.numTri);
   });
 
   it('dedupes shared edge midpoints (stays watertight, no vertex explosion)', () => {


### PR DESCRIPTION
## Summary

Follow-up to #454. Consolidates the Quality panel and hardens the enhance path.

### 1. Single Apply (consolidation)
The panel's three action buttons (Apply quality, the simplify/enhance Apply, Save as version) collapse into **one shared Apply at the bottom**, with Reset beside it. Apply commits any combination of pending changes: it persists the previewed curvature quality, and when a simplify/enhance target is set, runs that op **and bakes the result into a new version** — in one step. A quality-only Apply just persists the setting (no version — quality isn't captured in a version). Picking a preset still previews live and reverts on close if unapplied.

### 2. Runaway-enhance guard (no more frozen page)
A too-large enhance could freeze the tab. The compute already runs in the geometry **Worker** — the freeze was the **main-thread commit** of a multi-million-triangle result (`Manifold.ofMesh` + a 10M-iteration BufferGeometry build), which also blocked the Cancel button. Fixed in two layers:

- **Pre-apply guard:** project the enhance triangle count (exact for the count knob, estimated for edge length via a new pure `estimateRefineTriangles`). Over the **hard cap** → refuse before running; over the **warn threshold** → a Proceed/Cancel confirm modal. Only enhance is gated (simplify only reduces).
- **Worker hard cap:** the worker now discards and refuses to return a refined mesh larger than the cap, so a giant result never reaches the main thread even if the estimate undershoots. The cap is read on the main thread (user override visible) and threaded through the `enhance` worker message.

New `renderer.enhanceWarnTriangles` (1M) / `enhanceMaxTriangles` (5M) config fields, exposed in Advanced Settings.

### 3. Reset enable/disable
Reset now mirrors Apply — disabled until there's a pending change, enabled while pending, and disabled again the instant Apply commits (it only ever undoes un-applied changes).

## Implementation

- `src/ui/simplifyUI.ts` — single Apply + Reset row; `qualityPending()`/`meshPending()` drive both buttons' enabled state; `runApply()` commits quality, runs the op, gates on the projected count, bakes the version, and handles the worker's "exceeded" outcome.
- `src/ui/heavyMeshConfirmModal.ts` — new Proceed/Cancel modal (mirrors `exportConfirmModal`).
- `src/surface/meshSubdivide.ts` — pure `estimateRefineTriangles`.
- `src/geometry/simplify.ts` / `engineWorker.ts` / `engine.ts` — `maxTriangles` cap threaded through the enhance worker RPC; `EnhanceExceeded` sentinel.
- `src/config/appConfig.ts` + `advancedSettingsModal.tsx` — two new config fields.
- `src/main.ts` — `estimateRefine` handler; enhance handlers surface the exceeded result.

## Test plan

- `npm run build` ✅ · `npm run test:unit` ✅ (687, incl. new `estimateRefineTriangles` test)
- `npm run lint:deps` ✅ · `lint:deadcode` ✅ (no new dead code)
- `npx playwright test simplify.spec.ts quality-settings.spec.ts quality-scad.spec.ts` ✅ (18 passed), including:
  - new heavy-enhance guard tests: confirm appears over the warn limit (Cancel leaves the mesh, Proceed grows it); over the hard cap it's refused outright.
  - Reset lifecycle: disabled → enabled on change → disabled after Apply.
  - quality/simplify specs updated for the single-Apply model.
- Manual browser check: screenshots of the consolidated layout and the confirm dialog posted in the session.

https://claude.ai/code/session_012ZsMuWDH8LgKHAeLbfxP8Q