### PR TITLE
feat: link landing New bubble to What's-new and fix anchor Back-scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,11 +186,11 @@
         <div id="li-hero" style="position:relative;z-index:1;max-width:72rem;margin:0 auto;padding:32px 24px 64px;box-sizing:border-box">
           <!-- Left -->
           <div>
-            <div style="display:inline-flex;align-items:center;gap:8px;font-size:12px;color:#d4d4d8;background:rgba(255,255,255,0.05);border:1px solid #3f3f46;border-radius:999px;padding:6px 14px;margin-bottom:24px">
+            <a href="/whats-new" style="display:inline-flex;align-items:center;gap:8px;font-size:12px;color:#d4d4d8;background:rgba(255,255,255,0.05);border:1px solid #3f3f46;border-radius:999px;padding:6px 14px;margin-bottom:24px;text-decoration:none">
               <span style="font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;color:#fbbf24">New</span>
               <span>Voxels, BREP solids &amp; image relief</span>
               <span style="color:#71717a">&#8594;</span>
-            </div>
+            </a>
             <h1 id="li-h1" style="font-weight:800;line-height:1.03;letter-spacing:-0.025em;margin:0 0 20px;color:#fafafa;font-family:'Sora',system-ui,sans-serif">
               Describe a part.<br>Get a <span style="background:linear-gradient(115deg,#fcd34d 8%,#2dd4bf 92%);-webkit-background-clip:text;background-clip:text;color:transparent">printable model.</span>
             </h1>

--- a/prompts/20260605-landing-bubble-link-anchor-back.md
+++ b/prompts/20260605-landing-bubble-link-anchor-back.md
@@ -1,0 +1,49 @@
+---
+date: 2026-06-05
+branch: claude/practical-hypatia-ORMxl
+files_changed:
+  - index.html
+  - src/landing/landingEntry.ts
+  - tests/landing-static.spec.ts
+---
+
+## Human
+
+I want the "New: Voxels, BREP solids & image relief" bubble on the landing page
+to be a button to the "What's new" page linked from the top menu. Currently it's
+not clickable. In addition, when I click "Try with an AI agent →" the back button
+doesn't take me back to that link in the page — I'd like it to. Same thing when
+someone clicks "For AI agents" from the top menu: the back button should return
+to the top of the page when that link was clicked.
+
+## Assistant
+
+Two changes, plus a regression spec.
+
+**1. New hero bubble → /whats-new.** The bubble was a static decorative `<div>`.
+Turned it into an `<a href="/whats-new">` (same pill styling + `text-decoration:
+none`), matching where the header's "What's new" link points. It's a plain
+hard-navigation link, so Back from the What's-new page returns to the landing
+page natively.
+
+**2. Back button after in-page anchor jumps.** Root cause: the landing page
+scrolls *inside* `#landing-inline` (`position:fixed; overflow-y:auto`) because
+`<body>` is `overflow-hidden` — the document itself never scrolls. Browsers only
+restore scroll position on Back/Forward for the *document* scroller, never an
+inner container, so a native `#li-agent-section` jump (from "Try with an AI
+agent →" or the header's "For AI agents") left `#landing-inline` stuck
+scrolled-down on Back.
+
+Fixed by taking over same-page anchor navigation in `landingEntry.ts`
+(`initAnchorScroll`): a delegated click handler on `#landing-inline` intercepts
+`a[href^="#"]`, pushes a history entry, and smooth-scrolls the target into view;
+a `popstate` handler re-syncs the inner scroll to the current URL hash (empty
+hash → scroll to top), so Back returns to the top and Forward returns to the
+section. Also handles deep links arriving with a hash (e.g. `/#li-agent-section`
+from another page's header) by scrolling once on load. Left modified-click /
+middle-click untouched so open-in-new-tab still works.
+
+Kept the module's tiny import graph intact (no new imports) per the landing
+split contract. Verified in a real browser via a throwaway spec (bubble links +
+scroll-down + Back-to-top for both entry points), then folded permanent
+assertions into `tests/landing-static.spec.ts`.

--- a/src/landing/landingEntry.ts
+++ b/src/landing/landingEntry.ts
@@ -39,6 +39,7 @@ const FEATURED_CATALOG_COUNT = 8;
 function init(): void {
   enhanceCopyPrompt();
   rewritePromptOrigin();
+  initAnchorScroll();
   void fillCatalog();
   void fillRecentSessions();
 
@@ -48,6 +49,54 @@ function init(): void {
   window.addEventListener('pageshow', (e) => {
     if ((e as PageTransitionEvent).persisted) void fillRecentSessions();
   });
+}
+
+// ---------- In-page anchor scroll + Back-button support ----------
+
+// The landing page scrolls inside #landing-inline (position:fixed; overflow-y:
+// auto) because <body> is overflow-hidden — the document itself never scrolls.
+// Browsers only restore scroll position on Back/Forward for the *document*
+// scroller, not an inner container, so a native `#hash` jump (e.g. "Try with an
+// AI agent →", or "For AI agents" in the header) leaves #landing-inline stuck
+// scrolled-down when you press Back. We take over same-page anchor navigation:
+// push a history entry on click, then re-sync the inner scroll to the URL hash
+// on click *and* on popstate, so Back returns to the top (or wherever the
+// previous hash pointed) and Forward returns to the section.
+function initAnchorScroll(): void {
+  const scroller = document.getElementById('landing-inline');
+  if (!scroller) return;
+
+  const scrollToHash = (hash: string, smooth: boolean): void => {
+    const behavior: ScrollBehavior = smooth ? 'smooth' : 'auto';
+    if (!hash || hash === '#') {
+      scroller.scrollTo({ top: 0, behavior });
+      return;
+    }
+    const target = document.getElementById(decodeURIComponent(hash.slice(1)));
+    if (target) target.scrollIntoView({ behavior, block: 'start' });
+  };
+
+  // Intercept clicks on same-page anchors so we own history + scrolling.
+  scroller.addEventListener('click', (e) => {
+    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    const anchor = (e.target as Element | null)?.closest('a[href^="#"]') as HTMLAnchorElement | null;
+    if (!anchor) return;
+    const hash = anchor.getAttribute('href') ?? '';
+    if (hash.length < 2) return; // ignore bare "#"
+    e.preventDefault();
+    if (hash !== window.location.hash) window.history.pushState(null, '', hash);
+    scrollToHash(hash, true);
+  });
+
+  // Back/Forward within the landing page only changes the hash (same document),
+  // so re-sync the inner scroll to whatever the URL now points at.
+  window.addEventListener('popstate', () => scrollToHash(window.location.hash, true));
+
+  // Deep link that arrives with a hash (e.g. "/#li-agent-section" from another
+  // page's header): jump to it once layout has settled.
+  if (window.location.hash.length > 1) {
+    requestAnimationFrame(() => scrollToHash(window.location.hash, false));
+  }
 }
 
 // ---------- Copy prompt ----------

--- a/tests/landing-static.spec.ts
+++ b/tests/landing-static.spec.ts
@@ -28,6 +28,31 @@ test.describe('Static, app-free landing route', () => {
     await expect(page.locator('#li-sessions-grid > *').first()).toBeVisible({ timeout: 15000 });
   });
 
+  test('the "New" hero bubble links to the What\'s-new page', async ({ page }) => {
+    await page.goto('/');
+    const bubble = page.locator('#li-hero a[href="/whats-new"]');
+    await expect(bubble).toBeVisible();
+    await expect(bubble).toContainText('Voxels, BREP solids');
+    await bubble.click();
+    await expect(page).toHaveURL(/\/whats-new$/, { timeout: 30000 });
+    await expect(page.getByRole('heading', { name: /What.s new/i })).toBeVisible({ timeout: 30000 });
+  });
+
+  test('in-page anchors scroll #landing-inline and Back returns to the top', async ({ page }) => {
+    // The landing scrolls inside #landing-inline (body is overflow-hidden), so
+    // Back-button scroll must be restored by landingEntry, not the browser.
+    const scrollTop = () => page.evaluate(() => document.getElementById('landing-inline')!.scrollTop);
+    await page.goto('/');
+    expect(await scrollTop()).toBeLessThan(50);
+
+    await page.locator('#li-hero a[href="#li-agent-section"]').click();
+    await expect(page).toHaveURL(/#li-agent-section$/);
+    await expect.poll(scrollTop).toBeGreaterThan(200);
+
+    await page.goBack();
+    await expect.poll(scrollTop).toBeLessThan(50);
+  });
+
   test('a catalog tile loads that entry into the editor via /editor?catalog=', async ({ page }) => {
     await page.goto('/');
     const firstTile = page.locator('#li-catalog-grid a').first();


### PR DESCRIPTION
## Summary

Two landing-page fixes requested by the user:

1. **The hero "New: Voxels, BREP solids & image relief" pill is now a link to `/whats-new`** — the same destination as the header's "What's new" link. It was a static, non-clickable `<div>`; it's now an `<a href="/whats-new">` with identical pill styling. A plain hard-navigation, so Back from the What's-new page returns to the landing page natively.

2. **The Back button now returns to the top of the page after an in-page anchor jump** ("Try with an AI agent →" in the hero, and "For AI agents" in the header).

### Why the Back button was broken

The landing page scrolls *inside* `#landing-inline` (`position:fixed; overflow-y:auto`) because `<body>` is `overflow-hidden` — the document itself never scrolls. Browsers only restore scroll position on Back/Forward for the **document** scroller, never an inner container, so a native `#li-agent-section` jump left `#landing-inline` stuck scrolled-down on Back.

`landingEntry.ts` now owns same-page anchor navigation (`initAnchorScroll`): a delegated click handler on `#landing-inline` intercepts `a[href^="#"]`, pushes a history entry, and smooth-scrolls the target in; a `popstate` handler re-syncs the inner scroll to the current URL hash (empty hash → top). Deep links arriving with a hash (e.g. `/#li-agent-section` from another page's header) are scrolled once on load. Modified/middle clicks are left untouched so open-in-new-tab still works. No new imports — the landing split contract (tiny import graph) is preserved.

## Test plan

- `npm run build` — passes (type-check clean)
- `npm run test:unit` — 686 passed
- `tests/landing-static.spec.ts` — added two permanent specs (bubble → /whats-new navigation; in-page anchor scrolls `#landing-inline` and Back returns to top). All 4 in the file pass.
- Manual browser verification (Playwright screenshots): bubble visible, anchor scrolls to the "Built for AI agents" section, Back returns to top, bubble navigates to the rendered What's-new page.

https://claude.ai/code/session_013q3DbpJnozfvkRg8cwtEGN

---
_Generated by [Claude Code](https://claude.ai/code/session_013q3DbpJnozfvkRg8cwtEGN)_