### PR TITLE
feat: group viewport overlay controls into View/Inspect/Tools popovers

### DIFF
--- a/prompts/20260606-viewport-toolbar-groups.md
+++ b/prompts/20260606-viewport-toolbar-groups.md
@@ -1,0 +1,64 @@
+---
+date: 2026-06-06
+branch: claude/busy-faraday-dY8jN
+files_changed:
+  - src/ui/popoverMenu.ts
+  - src/ui/layout.ts
+  - src/ui/toolbar.ts
+  - src/main.ts
+  - src/annotations/annotateUI.ts
+  - src/color/paintUI.ts
+  - src/color/imagePaintUI.ts
+  - src/color/voxelPaintUI.ts
+  - src/ui/simplifyUI.ts
+  - src/ui/surfaceModal.ts
+  - src/ui/resizeModal.ts
+  - tests/viewport-toolbar-groups.spec.ts
+  - tests/paint-controls-extended.spec.ts
+---
+
+## Human
+
+The interactive view has grown to many buttons/features. Should they be grouped
+so people open a group and pick a sub-item, keeping few buttons visible while
+keeping usability/discoverability high? Wanted recommendations, then: "implement
+what you proposed and I'll test the experience. Make a PR."
+
+## Assistant
+
+Inventoried the live UI first (~130–140 controls). The crowding was concentrated
+in the **viewport overlay bar**: a flat row of ~16 buttons that grew every time a
+feature module injected its own toggle. Recommended a three-tier model rather than
+"nest everything": a few always-visible primaries, labelled group popovers (named,
+not a generic "⋯ More", so contents are predictable), and the command palette as
+the flat searchable safety net that makes hiding things cheap.
+
+Implemented exactly that for the viewport bar:
+
+- **`popoverMenu.ts`** — promoted the Import/Export dropdown helpers
+  (`createMenuSectionHeader`/`createMenuDivider`) out of `toolbar.ts` into a shared
+  module, and added `createPopoverGroup` (a labelled flyout with single-open
+  coordination, click-outside, Escape) plus `viewportToolsMount`.
+- **View / Inspect / Tools** popovers in `createClipControls`. View = display
+  prefs (edges/grid/dims/lock, closeOnSelect off so you can flip several);
+  Inspect = measure + cross-section; Tools = the mutate/decorate tools.
+- **Injection contract:** the tool modules already received a `controlsContainer`
+  and derived their floating-panel host from `controlsContainer.parentElement`, so
+  I kept passing `clipControls` (host stays correct) but redirected just the
+  *button* into `#viewport-tools-menu` via `viewportToolsMount`. Surface/Resize
+  self-mount, so they target the tools menu directly now.
+
+Key decision: **Customize and Relief stay top-level**, not in Tools. They're
+contextual *primaries* — hidden until relevant (params declared / relief session),
+and when shown they're a strong discoverability signal. Burying them also broke
+their visibility-asserting tests, which confirmed the call.
+
+Tests were safe because the suite drives these buttons with `dispatchEvent('click')`
+(ignores visibility), so nesting in collapsed popovers didn't break them. Only one
+visibility assertion needed updating (edges/grid now open the View popover first),
+plus a new golden-path spec. Registered the previously palette-less viewport tools
+(Measure, Cross Section, Paint, Palette, Image, Annotate, Quality, Customize) as
+⌘K commands so the grouping stays discoverable.
+
+This is an evaluation build — left per-tool "active" indication on the group
+buttons as a noted follow-up; the group highlights its open state for now.

--- a/src/annotations/annotateUI.ts
+++ b/src/annotations/annotateUI.ts
@@ -42,6 +42,7 @@ import { setAnnotationsVisible, isAnnotationsVisible } from './annotationOverlay
 import { endSession as endSessionPlane, hidePlaneOutline } from './sessionPlane';
 import { openViewportPanel, closeViewportPanel } from '../ui/viewportPanelRegistry';
 import { attachViewportPanelDrag, setInitialPanelPosition } from '../ui/viewportPanelDrag';
+import { viewportToolsMount } from '../ui/popoverMenu';
 
 const PRESET_COLORS: [number, number, number][] = [
   [0.95, 0.20, 0.45], // hot pink (default)
@@ -100,11 +101,9 @@ export function initAnnotateUI(controlsContainer: HTMLElement): void {
 
   annotateBtn.addEventListener('click', toggleAnnotateMode);
 
-  const paintBtn = controlsContainer.querySelector('#paint-toggle');
-  const measureBtn = controlsContainer.querySelector('#measure-toggle');
-  const anchor = paintBtn ?? measureBtn;
-  if (anchor) controlsContainer.insertBefore(annotateBtn, anchor);
-  else controlsContainer.appendChild(annotateBtn);
+  // Mount the button into the Tools popover (falls back to the bar itself).
+  // Order within the popover follows init order; no sibling anchoring needed.
+  viewportToolsMount(controlsContainer).appendChild(annotateBtn);
 
   pickerPanel = createPickerPanel();
   // Parent to the viewport container (same as paint panel) so the panel can be

--- a/src/color/imagePaintUI.ts
+++ b/src/color/imagePaintUI.ts
@@ -33,6 +33,7 @@ import {
 import { getCurrentMesh as getPaintMesh } from './paintMode';
 import { deactivateMode, registerExclusiveMode } from '../ui/modeExclusion';
 import { forceDeactivate as closeSimplifyMenu } from '../ui/simplifyUI';
+import { viewportToolsMount } from '../ui/popoverMenu';
 import { forceDeactivate as closeAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as closeAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as closeAnnotateSelect } from '../annotations/selectMode';
@@ -147,14 +148,15 @@ export function initImagePaintUI(controlsContainer: HTMLElement): void {
 
   imagePaintBtn.addEventListener('click', toggleImagePaint);
 
-  // Insert right after the paint toggle button
-  const paintBtn = controlsContainer.querySelector('#paint-toggle');
+  // Insert right after the paint toggle button, within the Tools popover (or the
+  // bar itself as fallback). insertBefore needs the same parent as the reference
+  // node, so anchor off whichever container actually holds the paint button.
+  const toolsMount = viewportToolsMount(controlsContainer);
+  const paintBtn = toolsMount.querySelector('#paint-toggle');
   if (paintBtn?.nextSibling) {
-    controlsContainer.insertBefore(imagePaintBtn, paintBtn.nextSibling);
-  } else if (paintBtn) {
-    controlsContainer.appendChild(imagePaintBtn);
+    toolsMount.insertBefore(imagePaintBtn, paintBtn.nextSibling);
   } else {
-    controlsContainer.appendChild(imagePaintBtn);
+    toolsMount.appendChild(imagePaintBtn);
   }
 
   panel = buildPanel();

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -94,6 +94,7 @@ import { forceDeactivate as closeSimplifyMenu } from '../ui/simplifyUI';
 import { openViewportPanel, closeViewportPanel } from '../ui/viewportPanelRegistry';
 import { attachViewportPanelDrag, setInitialPanelPosition } from '../ui/viewportPanelDrag';
 import { registerExclusiveMode, deactivateMode } from '../ui/modeExclusion';
+import { viewportToolsMount } from '../ui/popoverMenu';
 
 let paintBtn: HTMLButtonElement | null = null;
 let pickerPanel: HTMLElement | null = null;
@@ -127,12 +128,8 @@ export function initPaintUI(controlsContainer: HTMLElement): void {
 
   paintBtn.addEventListener('click', togglePaintMode);
 
-  const measureBtn = controlsContainer.querySelector('#measure-toggle');
-  if (measureBtn) {
-    controlsContainer.insertBefore(paintBtn, measureBtn);
-  } else {
-    controlsContainer.appendChild(paintBtn);
-  }
+  const toolsMount = viewportToolsMount(controlsContainer);
+  toolsMount.appendChild(paintBtn);
 
   // Standalone palette manager entry point — edit filament slots without
   // entering paint mode. Edits propagate to the paint swatches and relief.
@@ -142,7 +139,7 @@ export function initPaintUI(controlsContainer: HTMLElement): void {
   paletteBtn.textContent = '🧵 Palette';
   paletteBtn.title = 'Manage the filament palette (slots, colours, capacity)';
   paletteBtn.addEventListener('click', () => openPaletteManager());
-  controlsContainer.insertBefore(paletteBtn, paintBtn);
+  toolsMount.insertBefore(paletteBtn, paintBtn);
 
   pickerPanel = createPickerPanel();
   // Anchor the panel to the positioned viewport pane (the toolbar's parent)

--- a/src/color/voxelPaintUI.ts
+++ b/src/color/voxelPaintUI.ts
@@ -5,6 +5,7 @@
 // voxel; the editor locks until "Bake" commits the painted grid back to code.
 
 import * as voxelPaint from './voxelPaint';
+import { viewportToolsMount } from '../ui/popoverMenu';
 
 const SWATCHES: string[] = [
   '#ff3b30', '#ff8c42', '#ffd60a', '#34c759', '#5ac8fa',
@@ -45,10 +46,12 @@ export function initVoxelPaintUI(controlsContainer: HTMLElement, callbacks: Voxe
   paintBtn.title = 'Click a face to set that voxel\'s color. Bake to commit.';
   paintBtn.addEventListener('click', toggle);
 
-  // Slot next to the existing paint button so the two read as related.
-  const sibling = controlsContainer.querySelector('#paint-toggle');
-  if (sibling) controlsContainer.insertBefore(paintBtn, sibling);
-  else controlsContainer.appendChild(paintBtn);
+  // Slot next to the existing paint button so the two read as related. Anchor
+  // within whichever container holds the paint button (the Tools popover).
+  const toolsMount = viewportToolsMount(controlsContainer);
+  const sibling = toolsMount.querySelector('#paint-toggle');
+  if (sibling) toolsMount.insertBefore(paintBtn, sibling);
+  else toolsMount.appendChild(paintBtn);
 
   panel = createPanel();
   // Anchor to the positioned viewport pane (same trick paintUI uses).

--- a/src/main.ts
+++ b/src/main.ts
@@ -4298,6 +4298,9 @@ async function main() {
   };
   installKeyboardShortcuts({ onSave: saveVersionWithToast });
 
+  // Viewport tools need the editor active and a model on screen to act on.
+  const viewportToolEnabled = () => isEditorActive() && currentMeshData !== null;
+
   // Register command-palette actions (⌘K). Reuses the same handlers the
   // toolbar/session bar/layout already wire up so behavior can't drift.
   registerCommands([
@@ -4326,6 +4329,18 @@ async function main() {
     // (mirrors the toolbar's STEP gating); the action toasts if no shape exists.
     { id: 'export-step', title: 'Export STEP', hint: 'Export', keywords: 'download brep cad solidworks fusion freecad', run: () => { void actionExportSTEP(); }, enabled: () => getActiveLanguage() === 'replicad' },
     { id: 'share-link', title: 'Share design (copy link)', hint: 'Share', keywords: 'url public link copy fork readonly', run: () => { void actionShareLink(); }, enabled: canShare },
+    // Viewport tools — now grouped behind the View/Inspect/Tools popovers, so the
+    // palette is the flat, searchable index of everything (keeps grouping cheap
+    // for discoverability). Each fires the existing overlay button by id; click()
+    // works even while the button sits inside a collapsed popover.
+    { id: 'tool-measure', title: 'Measure distance', hint: 'Inspect', keywords: 'distance ruler dimension length point', run: () => document.getElementById('measure-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-cross-section', title: 'Cross section', hint: 'Inspect', keywords: 'clip plane slice cut section interior', run: () => document.getElementById('clip-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-paint', title: 'Paint colors', hint: 'Tools', keywords: 'color region brush bucket filament multicolor airbrush', run: () => document.getElementById('paint-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-palette', title: 'Manage filament palette', hint: 'Tools', keywords: 'palette filament slots colours capacity', run: () => document.getElementById('palette-manager-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-image-paint', title: 'Stamp image onto model', hint: 'Tools', keywords: 'image stamp decal texture paint photo logo', run: () => document.getElementById('image-paint-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-annotate', title: 'Annotate (draw / text)', hint: 'Tools', keywords: 'draw pen text label note markup sketch arrow', run: () => document.getElementById('annotate-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-quality', title: 'Quality: simplify / enhance', hint: 'Tools', keywords: 'simplify enhance decimate reduce triangles quality curvature smoothness', run: () => document.getElementById('simplify-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-customize', title: 'Customize parameters', hint: 'Tools', keywords: 'parameters params sliders tweak knobs', run: () => document.getElementById('customize-toggle')?.click(), enabled: () => isEditorActive() && !document.getElementById('customize-toggle')?.classList.contains('hidden') },
     { id: 'toggle-ai', title: 'Toggle AI panel', hint: 'View', keywords: 'chat assistant drawer', run: () => toggleAiPanel() },
     { id: 'toggle-diagnostics', title: 'Toggle diagnostics', hint: 'View', keywords: 'errors warnings console workers webworkers threads memory wasm performance restarts crash timing health log', run: () => toggleDiagnosticsPanel() },
     { id: 'open-catalog', title: 'Open catalog', hint: 'Navigate', keywords: 'examples premade browse', run: () => { void showCatalogPage(); } },
@@ -5393,12 +5408,11 @@ async function main() {
     onVisibilityChange: syncCustomizeBtn,
   });
   viewportPane.appendChild(paramsPanel.element);
-  // Sit the Customize pill with the other panel-toggling tools (Paint/Measure),
-  // just after the view-toggle divider — same grouping Paint/Annotate use, so it
-  // reads as a tool and stays clear of the top-left "Show code" button that the
-  // wrapping toolbar's leftmost item collides with.
-  const measureToggle = clipControls.querySelector('#measure-toggle');
-  if (measureToggle) clipControls.insertBefore(customizeBtn, measureToggle);
+  // Customize is a contextual primary: hidden until a model declares params,
+  // then surfaced top-level (just before the View group) as a strong "this model
+  // is tweakable" signal — not buried inside the Tools popover.
+  const customizeAnchor = clipControls.querySelector('#viewport-view-group');
+  if (customizeAnchor) clipControls.insertBefore(customizeBtn, customizeAnchor);
   else clipControls.appendChild(customizeBtn);
 
   // Init measure tool
@@ -6327,8 +6341,10 @@ async function main() {
   reliefViewportBtn.textContent = '✦ Relief';
   reliefViewportBtn.title = 'Edit colors for this relief';
   reliefViewportBtn.addEventListener('click', () => toggleReliefStudio());
-  const paintBtnEl = clipControls.querySelector('#paint-toggle');
-  if (paintBtnEl) clipControls.insertBefore(reliefViewportBtn, paintBtnEl);
+  // Relief edit is a contextual primary too (shown only in relief sessions), so
+  // it sits top-level alongside Customize rather than inside the Tools popover.
+  const reliefAnchor = clipControls.querySelector('#viewport-view-group');
+  if (reliefAnchor) clipControls.insertBefore(reliefViewportBtn, reliefAnchor);
   else clipControls.appendChild(reliefViewportBtn);
 
   initEscapeMenuClose();

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -2,6 +2,7 @@ import { getMobilePane, onMobilePaneChange, setMobilePane } from './mobilePane';
 import { showAdvancedSettingsModal } from './advancedSettingsModal';
 import { showAboutModal } from './aboutModal';
 import { loadSettings, saveSettings } from '../ai/settings';
+import { createPopoverGroup } from './popoverMenu';
 
 export type TabName = 'interactive' | 'gallery' | 'versions' | 'images' | 'diff' | 'notes' | 'data';
 
@@ -703,13 +704,33 @@ function createRailItem(canonical: string, display: string, icon: string, active
   return btn;
 }
 
+// Shared pill styling for the toggle buttons that now live inside the View /
+// Inspect popovers. Kept identical to the old inline strings so the toggle-init
+// code (which only ever swaps these classes by id) is unaffected by the move.
+const VIEWPORT_PILL = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50 text-left';
+
+function makeViewportPill(id: string, text: string, title: string, className = VIEWPORT_PILL): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.id = id;
+  btn.className = className;
+  btn.textContent = text;
+  btn.title = title;
+  return btn;
+}
+
+// The viewport overlay bar. Historically a flat row of ~16 buttons that grew with
+// every feature; now collapsed into a couple of always-visible primaries plus
+// three labelled popover groups so the strip stays short while everything is one
+// click (and one ⌘K search) away. Button ids are unchanged — the toggle-wiring
+// in main.ts finds them by id regardless of which popover they now live in, and
+// the injected tool buttons mount into the Tools popover via `viewportToolsMount`.
 function createClipControls(): HTMLElement {
   const container = document.createElement('div');
   container.id = 'clip-controls';
   container.className = 'absolute top-2 right-2 z-10 flex flex-wrap justify-end items-center gap-2 max-w-[calc(100%-1rem)]';
 
-  // Live triangle count of the displayed model — sits at the left of the bar.
-  // Non-interactive readout, updated on every mesh change (run/paint/simplify).
+  // Live triangle count of the displayed model — always-visible readout, updated
+  // on every mesh change (run/paint/simplify).
   const triCount = document.createElement('div');
   triCount.id = 'triangle-count';
   triCount.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 border border-zinc-600/50 tabular-nums select-none';
@@ -717,67 +738,35 @@ function createClipControls(): HTMLElement {
   triCount.textContent = '— tris';
   container.appendChild(triCount);
 
-  // Mesh edge (wireframe) toggle (off by default) — sits left of the grid toggle
-  const wireBtn = document.createElement('button');
-  wireBtn.id = 'wireframe-toggle';
-  wireBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
-  wireBtn.textContent = '△ Edges';
-  wireBtn.title = 'Show mesh edges';
-  container.appendChild(wireBtn);
-
-  // Grid toggle (off by default)
-  const gridBtn = document.createElement('button');
-  gridBtn.id = 'grid-toggle';
-  gridBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
-  gridBtn.textContent = '\u25A6 Grid';
-  gridBtn.title = 'Show grid plane';
-  container.appendChild(gridBtn);
-
-  // Dimensions toggle (on by default)
-  const dimBtn = document.createElement('button');
-  dimBtn.id = 'dimensions-toggle';
-  dimBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-blue-500/20 backdrop-blur text-blue-400 [@media(hover:hover)]:hover:bg-blue-500/30 transition-colors border border-blue-500/30';
-  dimBtn.textContent = '\u2B1A Dims';
-  dimBtn.title = 'Toggle bounding box dimensions';
-  container.appendChild(dimBtn);
-
-  // Orbit lock toggle
-  const lockBtn = document.createElement('button');
-  lockBtn.id = 'orbit-lock-toggle';
-  lockBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
-  lockBtn.textContent = '\uD83D\uDD13 Lock';
-  lockBtn.title = 'Lock camera rotation';
-  container.appendChild(lockBtn);
-
-  // Reset view \u2014 re-frames the camera to the default 3/4 angle of the model.
-  const resetBtn = document.createElement('button');
-  resetBtn.id = 'reset-view';
-  resetBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
-  resetBtn.textContent = '\u21BB Reset View';
-  resetBtn.title = 'Reset camera to the default view';
+  // Reset view — kept as an always-visible primary (frequent, one-shot action).
+  const resetBtn = makeViewportPill('reset-view', '↻ Reset View', 'Reset camera to the default view');
   container.appendChild(resetBtn);
 
-  // Visual separator between the view toggles (above) and the tools that follow
-  // (Measure, Cross Section, plus the injected Paint/Annotate/Simplify buttons).
-  const divider = document.createElement('div');
-  divider.className = 'hidden md:block w-px self-stretch bg-zinc-600/50 mx-0.5';
-  container.appendChild(divider);
+  // View popover — display preferences set once and forgotten. closeOnSelect is
+  // left off so users can flip several toggles without the menu dismissing.
+  const viewGroup = createPopoverGroup({ id: 'viewport-view', label: 'View', title: 'Display options: edges, grid, dimensions, camera lock' });
+  viewGroup.menu.appendChild(makeViewportPill('wireframe-toggle', '△ Edges', 'Show mesh edges'));
+  viewGroup.menu.appendChild(makeViewportPill('grid-toggle', '▦ Grid', 'Show grid plane'));
+  // Dimensions defaults on — give it the active blue styling to match its state.
+  viewGroup.menu.appendChild(makeViewportPill(
+    'dimensions-toggle', '⬚ Dims', 'Toggle bounding box dimensions',
+    'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-blue-500/20 backdrop-blur text-blue-400 [@media(hover:hover)]:hover:bg-blue-500/30 transition-colors border border-blue-500/30 text-left',
+  ));
+  viewGroup.menu.appendChild(makeViewportPill('orbit-lock-toggle', '\uD83D\uDD13 Lock', 'Lock camera rotation'));
+  container.appendChild(viewGroup.wrapper);
 
-  // Measure toggle button
-  const measureBtn = document.createElement('button');
-  measureBtn.id = 'measure-toggle';
-  measureBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
-  measureBtn.textContent = '\uD83D\uDCCF Measure';
-  measureBtn.title = 'Measure distance between two points on your model';
-  container.appendChild(measureBtn);
+  // Inspect popover — read-only analysis tools that never mutate the model.
+  const inspectGroup = createPopoverGroup({ id: 'viewport-inspect', label: 'Inspect', title: 'Measure distances and cross-section the model', closeOnSelect: true });
+  inspectGroup.menu.appendChild(makeViewportPill('measure-toggle', '\uD83D\uDCCF Measure', 'Measure distance between two points on your model'));
+  inspectGroup.menu.appendChild(makeViewportPill('clip-toggle', '✂ Cross Section', 'Toggle cross-section clipping plane'));
+  container.appendChild(inspectGroup.wrapper);
 
-  // Clip toggle button
-  const toggleBtn = document.createElement('button');
-  toggleBtn.id = 'clip-toggle';
-  toggleBtn.className = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
-  toggleBtn.textContent = '\u2702 Cross Section';
-  toggleBtn.title = 'Toggle cross-section clipping plane';
-  container.appendChild(toggleBtn);
+  // Tools popover — the mutate/decorate tools (Paint, Annotate, Surface, Resize,
+  // Quality, ...). Starts empty; each tool module appends its button here at init
+  // via `viewportToolsMount`. closeOnSelect on so picking a tool reveals its
+  // floating panel. Stable id `viewport-tools-menu` is the injection contract.
+  const toolsGroup = createPopoverGroup({ id: 'viewport-tools', label: 'Tools', title: 'Editing tools: paint, annotate, surface modifiers, resize, quality', closeOnSelect: true });
+  container.appendChild(toolsGroup.wrapper);
 
   return container;
 }

--- a/src/ui/popoverMenu.ts
+++ b/src/ui/popoverMenu.ts
@@ -1,0 +1,137 @@
+// Shared popover-menu building blocks.
+//
+// Promoted out of `toolbar.ts` (Import/Export dropdowns) so the viewport overlay
+// bar can reuse the same labelled-section / divider look, plus a self-contained
+// `createPopoverGroup` flyout used to collapse the bar's many buttons into a few
+// labelled groups (View / Inspect / Tools). One source of truth for menu chrome.
+
+/** Small uppercase section label inside a menu (e.g. "From file", "3D model"). */
+export function createMenuSectionHeader(text: string): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'px-3 pt-1 pb-0.5 text-[10px] uppercase tracking-wider text-zinc-500 font-semibold';
+  el.textContent = text;
+  return el;
+}
+
+/** Thin horizontal rule between menu sections. */
+export function createMenuDivider(): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'my-1 border-t border-zinc-700';
+  return el;
+}
+
+// Pill styling for the group buttons — matches the existing viewport bar pills so
+// the groups read as part of the same control strip.
+const GROUP_BTN_BASE =
+  'flex items-center gap-1 px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs backdrop-blur transition-colors border';
+const GROUP_BTN_CLOSED = `${GROUP_BTN_BASE} bg-zinc-800/80 text-zinc-400 border-zinc-600/50 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80`;
+const GROUP_BTN_OPEN = `${GROUP_BTN_BASE} bg-zinc-700/90 text-zinc-100 border-zinc-500/60`;
+
+// All live groups, so opening one closes its siblings (a single popover at a time).
+const liveGroups: PopoverGroup[] = [];
+
+export interface PopoverGroup {
+  /** Relative-positioned flex item — append this to the bar. */
+  wrapper: HTMLElement;
+  /** The clickable group button. */
+  button: HTMLButtonElement;
+  /** Content container — append menu items / sections here. */
+  menu: HTMLElement;
+  open: () => void;
+  close: () => void;
+  isOpen: () => boolean;
+}
+
+export interface PopoverGroupOptions {
+  /** Stable id base; the wrapper gets `${id}-group`, the menu gets `${id}-menu`. */
+  id: string;
+  /** Button label (a ▾ caret is appended automatically). */
+  label: string;
+  /** Button tooltip / aria-label. */
+  title: string;
+  /**
+   * Close the popover when an item button inside it is clicked. True for action
+   * menus (Inspect/Tools — picking a tool should reveal its panel); false for
+   * preference menus (View — users flip several toggles in a row).
+   */
+  closeOnSelect?: boolean;
+}
+
+/**
+ * A labelled flyout group: a pill button that toggles a popover panel beneath it.
+ * Handles single-open coordination, click-outside, and Escape. Append `wrapper`
+ * to the bar and your items to `menu`.
+ */
+export function createPopoverGroup(opts: PopoverGroupOptions): PopoverGroup {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'relative';
+  wrapper.id = `${opts.id}-group`;
+
+  const button = document.createElement('button');
+  button.id = `${opts.id}-group-btn`;
+  button.className = GROUP_BTN_CLOSED;
+  button.title = opts.title;
+  button.setAttribute('aria-haspopup', 'true');
+  button.setAttribute('aria-expanded', 'false');
+  // Label text + a caret. Label comes from a fixed in-source set, never user input.
+  button.innerHTML = `<span>${opts.label}</span><span class="text-[9px] leading-none opacity-70" aria-hidden="true">▾</span>`;
+  wrapper.appendChild(button);
+
+  const menu = document.createElement('div');
+  menu.id = `${opts.id}-menu`;
+  menu.className =
+    'absolute right-0 top-full mt-1 hidden z-20 bg-zinc-800 border border-zinc-600 rounded shadow-lg p-1 flex flex-col gap-1 min-w-[9rem] max-w-[80vw] max-h-[70vh] overflow-y-auto';
+  wrapper.appendChild(menu);
+
+  const isOpen = () => !menu.classList.contains('hidden');
+
+  const close = () => {
+    menu.classList.add('hidden');
+    button.className = GROUP_BTN_CLOSED;
+    button.setAttribute('aria-expanded', 'false');
+  };
+
+  const open = () => {
+    // Single popover at a time — close every sibling first.
+    for (const g of liveGroups) if (g.menu !== menu) g.close();
+    menu.classList.remove('hidden');
+    button.className = GROUP_BTN_OPEN;
+    button.setAttribute('aria-expanded', 'true');
+  };
+
+  button.addEventListener('click', (e) => {
+    e.stopPropagation();
+    isOpen() ? close() : open();
+  });
+
+  if (opts.closeOnSelect) {
+    // Closing on item click reveals the tool's own panel. Skip clicks that aren't
+    // on an actionable button (e.g. a section header) so headers don't dismiss.
+    menu.addEventListener('click', (e) => {
+      if ((e.target as HTMLElement).closest('button')) close();
+    });
+  }
+
+  // Click-outside and Escape close the menu. Singleton bar — listeners persist
+  // for the life of the page, matching the Import/Export dropdown pattern.
+  document.addEventListener('click', (e) => {
+    if (isOpen() && !wrapper.contains(e.target as Node)) close();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && isOpen()) close();
+  });
+
+  const group: PopoverGroup = { wrapper, button, menu, open, close, isOpen };
+  liveGroups.push(group);
+  return group;
+}
+
+/**
+ * The mount point for an injected viewport tool button: the Tools popover's menu
+ * if present, else the given container (graceful fallback before the group exists
+ * or in any non-grouped layout). Tool modules append their button here while
+ * still hosting their floating panel off `controlsContainer.parentElement`.
+ */
+export function viewportToolsMount(controlsContainer: HTMLElement): HTMLElement {
+  return controlsContainer.querySelector<HTMLElement>('#viewport-tools-menu') ?? controlsContainer;
+}

--- a/src/ui/resizeModal.ts
+++ b/src/ui/resizeModal.ts
@@ -380,18 +380,19 @@ export function initResizeUI(api: ResizeApi): void {
 
   const mount = () => {
     if (document.getElementById('resize-viewport-toggle')) return;
-    const anchor = document.getElementById('surface-viewport-toggle')
-      ?? document.getElementById('relief-viewport-toggle')
-      ?? document.getElementById('paint-toggle')
-      ?? document.querySelector<HTMLElement>('[id$="-viewport-toggle"]');
-    if (!anchor || !anchor.parentElement) return;
-    const btnCls = anchor.className.split(' ').filter(c => c !== 'hidden').join(' ') || BTN_BASE;
+    // Land inside the Tools popover (after Surface, if present), matching the
+    // neighbouring tool pill's styling.
+    const styleRef = document.getElementById('surface-viewport-toggle')
+      ?? document.getElementById('paint-toggle');
+    const host = document.getElementById('viewport-tools-menu') ?? styleRef?.parentElement;
+    if (!host) return;
+    const btnCls = (styleRef?.className ?? '').split(' ').filter(c => c !== 'hidden').join(' ') || BTN_BASE;
     const btn = el('button', btnCls);
     btn.id = 'resize-viewport-toggle';
     btn.textContent = '⇲ Resize';
     btn.title = 'Scale the model along X, Y, and Z';
     btn.addEventListener('click', () => openResizeModal(api));
-    anchor.after(btn);
+    host.appendChild(btn);
   };
   let tries = 0;
   const timer = setInterval(() => {

--- a/src/ui/simplifyUI.ts
+++ b/src/ui/simplifyUI.ts
@@ -30,6 +30,7 @@ import { showToast } from './toast';
 import { isWireframeVisible, setWireframeVisible } from '../renderer/viewport';
 import { openViewportPanel, closeViewportPanel } from './viewportPanelRegistry';
 import { attachViewportPanelDrag, setInitialPanelPosition } from './viewportPanelDrag';
+import { viewportToolsMount } from './popoverMenu';
 import { QUALITY_OPTIONS, QUALITY_SEGMENTS, loadQualitySettings, type QualitySettings } from '../geometry/qualitySettings';
 import { saveQualityForLang, initQualityLogic, notifyLanguageChange as notifyQualityLangChange } from './curvatureQualityPanel';
 import { showHeavyEnhanceConfirm } from './heavyMeshConfirmModal';
@@ -215,13 +216,8 @@ export function initSimplifyUI(
   simplifyBtn.title = 'Adjust curvature quality and simplify or enhance triangle count';
   simplifyBtn.addEventListener('click', toggle);
 
-  // Sit immediately before Measure so the overlay reads Paint · Simplify · Measure.
-  const measureBtn = controlsContainer.querySelector('#measure-toggle');
-  if (measureBtn) {
-    controlsContainer.insertBefore(simplifyBtn, measureBtn);
-  } else {
-    controlsContainer.appendChild(simplifyBtn);
-  }
+  // Mount into the Tools popover (falls back to the bar itself).
+  viewportToolsMount(controlsContainer).appendChild(simplifyBtn);
 
   panel = buildPanel();
   const overlayHost = controlsContainer.parentElement ?? controlsContainer;

--- a/src/ui/surfaceModal.ts
+++ b/src/ui/surfaceModal.ts
@@ -657,17 +657,19 @@ export function initSurfaceUI(api: SurfaceApi): void {
   // touching the overlay's creation code. Match the neighbour's styling.
   const mount = () => {
     if (document.getElementById('surface-viewport-toggle')) return;
-    const anchor = document.getElementById('relief-viewport-toggle')
-      ?? document.getElementById('paint-toggle')
-      ?? document.querySelector<HTMLElement>('[id$="-viewport-toggle"]');
-    if (!anchor || !anchor.parentElement) return;
-    const btnCls = anchor.className.split(' ').filter(c => c !== 'hidden').join(' ') || BTN_BASE;
+    // Land inside the Tools popover; borrow the paint button's styling so the
+    // pill matches its neighbours. Falls back to the paint button's parent for
+    // any non-grouped layout.
+    const styleRef = document.getElementById('paint-toggle');
+    const host = document.getElementById('viewport-tools-menu') ?? styleRef?.parentElement;
+    if (!host) return;
+    const btnCls = (styleRef?.className ?? '').split(' ').filter(c => c !== 'hidden').join(' ') || BTN_BASE;
     const btn = el('button', btnCls);
     btn.id = 'surface-viewport-toggle';
     btn.textContent = '✦ Surface';
     btn.title = 'Apply fuzzy skin, smooth/round, or voxelize the current model';
     btn.addEventListener('click', () => openSurfaceModal(api));
-    anchor.after(btn);
+    host.appendChild(btn);
   };
   // The overlay may mount after init; retry a few times then give up (commands
   // still work even if the button never lands).

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -14,6 +14,7 @@ import {
   onImportInboxChange,
   type ImportInboxEntry,
 } from '../import/importInbox';
+import { createMenuSectionHeader, createMenuDivider } from './popoverMenu';
 
 export interface ToolbarCallbacks {
   onRun: () => void;
@@ -345,7 +346,7 @@ export function createToolbar(
   importDropdown.id = 'import-dropdown';
   importDropdown.className = 'fixed left-2 right-2 top-14 bg-zinc-800 border border-zinc-600 rounded shadow-lg py-1 hidden z-20 max-h-[80vh] overflow-y-auto md:absolute md:left-auto md:right-0 md:top-full md:mt-1 md:w-72';
 
-  importDropdown.appendChild(createSectionHeader('From file'));
+  importDropdown.appendChild(createMenuSectionHeader('From file'));
   const chooseFileOpt = createDescribedItem(
     'Choose file\u2026',
     'Open a .partwright.json session, a .js / .scad source file, or an .stl mesh.',
@@ -367,8 +368,8 @@ export function createToolbar(
   });
   importDropdown.appendChild(fromUrlOpt);
 
-  importDropdown.appendChild(createDivider());
-  importDropdown.appendChild(createSectionHeader('Create'));
+  importDropdown.appendChild(createMenuDivider());
+  importDropdown.appendChild(createMenuSectionHeader('Create'));
   const reliefOpt = createDescribedItem(
     'Image → keychain / tile / relief…',
     'Turn an image (or SVG) into a printable colour tile, keychain, sticker, or stepped relief.',
@@ -394,7 +395,7 @@ export function createToolbar(
   importDropdown.appendChild(imageVoxelOpt);
 
   // Recent Imports section — populated from the import inbox.
-  const importRecentDivider = createDivider();
+  const importRecentDivider = createMenuDivider();
   const importRecentHeaderRow = document.createElement('div');
   importRecentHeaderRow.className = 'flex items-center justify-between px-3 pt-1 pb-0.5';
   const importRecentHeader = document.createElement('div');
@@ -515,7 +516,7 @@ export function createToolbar(
   dropdown.className = 'fixed left-2 right-2 top-14 bg-zinc-800 border border-zinc-600 rounded shadow-lg py-1 hidden z-20 max-h-[80vh] overflow-y-auto md:absolute md:left-auto md:right-0 md:top-full md:mt-1 md:w-72';
 
   // Section: 3D model formats
-  dropdown.appendChild(createSectionHeader('3D model'));
+  dropdown.appendChild(createMenuSectionHeader('3D model'));
 
   // Units selector — declares what the model's numbers mean (metadata only,
   // no coordinate transform). Drives export filenames + the 3MF unit
@@ -554,7 +555,7 @@ export function createToolbar(
   unitsRow.appendChild(unitsLabel);
   unitsRow.appendChild(unitsSelect);
   dropdown.appendChild(unitsRow);
-  dropdown.appendChild(createDivider());
+  dropdown.appendChild(createMenuDivider());
 
   const threemfOpt = createDescribedItem(
     '3MF',
@@ -626,8 +627,8 @@ export function createToolbar(
   dropdown.appendChild(voxOpt);
 
   // Section: project / source — for sharing between users or working with the code directly
-  dropdown.appendChild(createDivider());
-  dropdown.appendChild(createSectionHeader('Project'));
+  dropdown.appendChild(createMenuDivider());
+  dropdown.appendChild(createMenuSectionHeader('Project'));
 
   const sessionOpt = createDescribedItem(
     'Session (.partwright.json)',
@@ -661,7 +662,7 @@ export function createToolbar(
   dropdown.appendChild(shareOpt);
 
   // Section: Recent Exports — reuse-anything-you-just-downloaded list. Hidden when empty.
-  const recentDivider = createDivider();
+  const recentDivider = createMenuDivider();
   const recentHeaderRow = document.createElement('div');
   recentHeaderRow.className = 'flex items-center justify-between px-3 pt-1 pb-0.5';
   const recentHeader = document.createElement('div');
@@ -821,19 +822,6 @@ function createDescribedItem(label: string, description: string, badge?: string)
   btn.appendChild(descEl);
 
   return btn;
-}
-
-function createSectionHeader(text: string): HTMLElement {
-  const el = document.createElement('div');
-  el.className = 'px-3 pt-1 pb-0.5 text-[10px] uppercase tracking-wider text-zinc-500 font-semibold';
-  el.textContent = text;
-  return el;
-}
-
-function createDivider(): HTMLElement {
-  const el = document.createElement('div');
-  el.className = 'my-1 border-t border-zinc-700';
-  return el;
 }
 
 function formatSize(bytes: number): string {

--- a/tests/paint-controls-extended.spec.ts
+++ b/tests/paint-controls-extended.spec.ts
@@ -179,14 +179,16 @@ test.describe('extended paint controls', () => {
     expect(result.bad.error).toBeTruthy();
   });
 
-  test('mesh-edge toggle sits left of the grid toggle and defaults off', async ({ page }) => {
+  test('mesh-edge toggle sits above the grid toggle in the View popover and defaults off', async ({ page }) => {
     await openEditor(page);
+    // Edges/Grid now live inside the View popover — open it to reveal them.
+    await page.locator('#viewport-view-group-btn').dispatchEvent('click');
     const wireBtn = page.locator('#wireframe-toggle');
     await expect(wireBtn).toBeVisible();
     await expect(page.locator('#grid-toggle')).toBeVisible();
     // Default: edges hidden, so the button invites showing them.
     await expect(wireBtn).toHaveAttribute('title', 'Show mesh edges');
-    // DOM order places the wireframe button before the grid button (i.e. to its left).
+    // DOM order places the wireframe button before the grid button.
     const wireIsBeforeGrid = await page.evaluate(() => {
       const w = document.querySelector('#wireframe-toggle')!;
       const g = document.querySelector('#grid-toggle')!;

--- a/tests/quality-scad.spec.ts
+++ b/tests/quality-scad.spec.ts
@@ -13,7 +13,7 @@ test.beforeEach(async ({ page }) => {
 
 test('SCAD engine applies the chosen $fn from quality preset', async ({ page }) => {
   await page.goto('/editor');
-  await page.waitForSelector('#simplify-toggle');
+  await page.waitForSelector('#simplify-toggle', { state: 'attached' });
 
   type RunResult = { triangleCount?: number; error?: string };
   type PartwrightApi = {
@@ -48,7 +48,9 @@ test('SCAD engine applies the chosen $fn from quality preset', async ({ page }) 
   expect(high.triangleCount ?? 0).toBeGreaterThan(100);
 
   // Drop to Low via the curvature quality panel, then Apply to commit it
-  // (picking a preset only previews; closing without Apply would revert).
+  // (picking a preset only previews; closing without Apply would revert). The
+  // Quality button now lives in the viewport Tools popover, so open it first.
+  await page.locator('#viewport-tools-group-btn').click();
   await page.locator('#simplify-toggle').click();
   await page.locator('#simplify-panel input[type=radio][value=low]').check();
   await page.locator('#simplify-apply').click();

--- a/tests/quality-settings.spec.ts
+++ b/tests/quality-settings.spec.ts
@@ -13,12 +13,19 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
+// The "○ Quality" button now lives inside the viewport Tools popover, so open
+// the group before clicking it. The popover auto-closes once the panel opens.
+async function openQualityPanel(page: import('playwright/test').Page) {
+  await page.locator('#viewport-tools-group-btn').click();
+  await page.locator('#simplify-toggle').click();
+}
+
 test.describe('Modeling quality settings', () => {
   test('viewport quality button opens panel showing Highest as default', async ({ page }) => {
     await page.goto('/editor');
-    await page.waitForSelector('#simplify-toggle');
+    await page.waitForSelector('#simplify-toggle', { state: 'attached' });
 
-    await page.locator('#simplify-toggle').click();
+    await openQualityPanel(page);
     await expect(page.locator('#simplify-panel')).toBeVisible();
 
     // Highest preset radio should be checked on first load.
@@ -32,9 +39,9 @@ test.describe('Modeling quality settings', () => {
 
   test('applying Low is reflected in panel and in-memory', async ({ page }) => {
     await page.goto('/editor');
-    await page.waitForSelector('#simplify-toggle');
+    await page.waitForSelector('#simplify-toggle', { state: 'attached' });
 
-    await page.locator('#simplify-toggle').click();
+    await openQualityPanel(page);
     await page.locator('#simplify-panel input[type=radio][value=low]').check();
 
     // Radio should be checked immediately (live preview).
@@ -48,15 +55,15 @@ test.describe('Modeling quality settings', () => {
 
     // Close + reopen panel — Low should still be selected (committed in-memory).
     await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
-    await page.locator('#simplify-toggle').click();
+    await openQualityPanel(page);
     await expect(page.locator('#simplify-panel input[type=radio][value=low]')).toBeChecked();
   });
 
   test('closing without Apply reverts the quality preview', async ({ page }) => {
     await page.goto('/editor');
-    await page.waitForSelector('#simplify-toggle');
+    await page.waitForSelector('#simplify-toggle', { state: 'attached' });
 
-    await page.locator('#simplify-toggle').click();
+    await openQualityPanel(page);
     // Default is Highest; preview Low without applying.
     await expect(page.locator('#simplify-panel input[type=radio][value=highest]')).toBeChecked();
     await page.locator('#simplify-panel input[type=radio][value=low]').check();
@@ -64,7 +71,7 @@ test.describe('Modeling quality settings', () => {
 
     // Close without Apply — the preview should snap back to the committed Highest.
     await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
-    await page.locator('#simplify-toggle').click();
+    await openQualityPanel(page);
     await expect(page.locator('#simplify-panel input[type=radio][value=highest]')).toBeChecked();
     // Apply is disabled again because nothing is pending after the revert.
     await expect(page.locator('#simplify-apply')).toBeDisabled();
@@ -72,7 +79,7 @@ test.describe('Modeling quality settings', () => {
 
   test('manifold-js engine applies the chosen segment count', async ({ page }) => {
     await page.goto('/editor');
-    await page.waitForSelector('#simplify-toggle');
+    await page.waitForSelector('#simplify-toggle', { state: 'attached' });
     await page.waitForFunction(
       () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
       { timeout: 20_000 },
@@ -90,7 +97,7 @@ test.describe('Modeling quality settings', () => {
     expect(high.triangleCount ?? 0).toBeGreaterThan(2000);
 
     // Drop to Low via the panel and Apply to commit it.
-    await page.locator('#simplify-toggle').click();
+    await openQualityPanel(page);
     await page.locator('#simplify-panel input[type=radio][value=low]').check();
     await page.locator('#simplify-apply').click();
     await page.locator('#simplify-panel button[aria-label="Close quality panel"]').click();
@@ -106,7 +113,7 @@ test.describe('Modeling quality settings', () => {
 
   test('Ultra preset persists and yields more triangles than the default', async ({ page }) => {
     await page.goto('/editor');
-    await page.waitForSelector('#simplify-toggle');
+    await page.waitForSelector('#simplify-toggle', { state: 'attached' });
     await page.waitForFunction(
       () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
       { timeout: 20_000 },
@@ -123,7 +130,7 @@ test.describe('Modeling quality settings', () => {
     }, cylinderCode);
 
     // Switch to Ultra (1024 segments) and Apply to commit it.
-    await page.locator('#simplify-toggle').click();
+    await openQualityPanel(page);
     await page.locator('#simplify-panel input[type=radio][value=ultra]').check();
     await expect(page.locator('#simplify-panel input[type=radio][value=ultra]')).toBeChecked();
     await page.locator('#simplify-apply').click();

--- a/tests/scad-companion.spec.ts
+++ b/tests/scad-companion.spec.ts
@@ -20,7 +20,7 @@ type Api = {
 
 test('SCAD companion file: add, edit, include, and persist across reload', async ({ page }) => {
   await page.goto('/editor');
-  await page.waitForSelector('#simplify-toggle');
+  await page.waitForSelector('#simplify-toggle', { state: 'attached' });
   await page.waitForFunction(
     () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
     { timeout: 30_000 },
@@ -83,7 +83,7 @@ test('SCAD companion file: add, edit, include, and persist across reload', async
   const url = page.url();
   expect(url).toContain('session=');
   await page.goto(url);
-  await page.waitForSelector('#simplify-toggle');
+  await page.waitForSelector('#simplify-toggle', { state: 'attached' });
   await page.waitForFunction(
     () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
     { timeout: 30_000 },

--- a/tests/viewport-toolbar-groups.spec.ts
+++ b/tests/viewport-toolbar-groups.spec.ts
@@ -1,0 +1,80 @@
+// Golden-path coverage for the grouped viewport overlay bar: the View / Inspect
+// / Tools popovers that collapse the previously-flat strip of ~16 buttons.
+//
+// Uses `dispatchEvent('click')` on the group buttons to dodge the onboarding
+// tour backdrop that intercepts real pointer events on first paint.
+
+import { test, expect } from 'playwright/test';
+
+async function openEditor(page: import('playwright/test').Page) {
+  // Pre-dismiss the first-run tour so its backdrop/keys don't intercept input.
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', new Date().toISOString()); } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.run(`const { Manifold } = api; return Manifold.cube([10, 10, 10], true);`);
+  });
+}
+
+test.describe('viewport toolbar groups', () => {
+  test('the bar collapses to primaries plus three labelled group buttons', async ({ page }) => {
+    await openEditor(page);
+    // Always-visible primaries.
+    await expect(page.locator('#triangle-count')).toBeVisible();
+    await expect(page.locator('#reset-view')).toBeVisible();
+    // The three group buttons.
+    await expect(page.locator('#viewport-view-group-btn')).toBeVisible();
+    await expect(page.locator('#viewport-inspect-group-btn')).toBeVisible();
+    await expect(page.locator('#viewport-tools-group-btn')).toBeVisible();
+  });
+
+  test('View popover holds the display toggles; Inspect holds measure + cross-section', async ({ page }) => {
+    await openEditor(page);
+
+    // Display toggles live inside the View popover and are hidden until opened.
+    await expect(page.locator('#wireframe-toggle')).toBeHidden();
+    await page.locator('#viewport-view-group-btn').dispatchEvent('click');
+    await expect(page.locator('#wireframe-toggle')).toBeVisible();
+    await expect(page.locator('#grid-toggle')).toBeVisible();
+    await expect(page.locator('#dimensions-toggle')).toBeVisible();
+    await expect(page.locator('#orbit-lock-toggle')).toBeVisible();
+
+    // Opening Inspect closes View (single popover at a time) and reveals the
+    // read-only analysis tools.
+    await page.locator('#viewport-inspect-group-btn').dispatchEvent('click');
+    await expect(page.locator('#wireframe-toggle')).toBeHidden();
+    await expect(page.locator('#measure-toggle')).toBeVisible();
+    await expect(page.locator('#clip-toggle')).toBeVisible();
+  });
+
+  test('Tools popover collects the editing tools and a tool opens from it', async ({ page }) => {
+    await openEditor(page);
+    await page.locator('#viewport-tools-group-btn').dispatchEvent('click');
+
+    // The injected editing tools all mounted into the Tools menu.
+    for (const id of ['#paint-toggle', '#palette-manager-toggle', '#annotate-toggle', '#simplify-toggle', '#surface-viewport-toggle', '#resize-viewport-toggle']) {
+      await expect(page.locator(`#viewport-tools-menu ${id}`)).toHaveCount(1);
+    }
+
+    // Selecting a tool from the popover opens its panel.
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+  });
+
+  test('grouped viewport tools are reachable from the command palette', async ({ page }) => {
+    await openEditor(page);
+    // Open the palette and search for the Paint tool command — the palette is the
+    // flat, searchable index that keeps the grouping discoverable.
+    await page.keyboard.press('ControlOrMeta+k');
+    const input = page.locator('input[aria-label="Search commands"]');
+    await expect(input).toBeVisible();
+    await input.fill('Paint colors');
+    await expect(page.locator('[role="option"]').filter({ hasText: 'Paint colors' })).toBeVisible();
+    await page.keyboard.press('Enter');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+  });
+});


### PR DESCRIPTION
## Summary

The viewport overlay bar had grown to ~16 flat buttons (one appended by each feature module as it landed). This collapses it into **a couple of always-visible primaries + three labelled popover groups**, so the strip stays short while everything is one click — or one ⌘K search — away.

This is the **viewport-bar slice** of a broader "is the interactive view too crowded?" discussion. It implements the three-tier model: always-visible primaries → labelled group flyouts → command palette as the flat searchable safety net.

### The bar now reads
`24,084 tris` · `↻ Reset View` · `View ▾` · `Inspect ▾` · `Tools ▾`

| Group | Contains | Rationale |
|---|---|---|
| **View** | Edges, Grid, Dims, Lock | display prefs — set once; menu stays open so you can flip several |
| **Inspect** | Measure, Cross Section | read-only analysis, never mutates the model |
| **Tools** | Paint, Palette, Image, Annotate, Surface, Resize, Quality (+ Voxel paint in voxel sessions) | the mutate/decorate tools; already mutually-exclusive via `viewportPanelRegistry` |

**Customize** and **Relief** stay top-level as *contextual primaries* — they only appear when the model is parametric / a relief session, and that appearance is itself a strong discoverability signal, so they shouldn't be buried.

### What changed
- **New `src/ui/popoverMenu.ts`** — promotes the Import/Export dropdown chrome (`createMenuSectionHeader` / `createMenuDivider`) out of `toolbar.ts`, and adds `createPopoverGroup` (labelled flyout with single-open coordination, click-outside, Escape) + `viewportToolsMount`.
- **`createClipControls`** rebuilt around the three groups. Button **ids are unchanged**, so the toggle-wiring (`querySelector('#…')`, descendant-safe) is untouched.
- **Injection contract preserved**: tool modules still receive `clipControls` (their floating panel still hosts off `controlsContainer.parentElement`); only the *button* is redirected into `#viewport-tools-menu` via `viewportToolsMount`. Surface/Resize self-mount there directly.
- **⌘K**: registered the previously-palette-less viewport tools (Measure, Cross Section, Paint, Palette, Image, Annotate, Quality, Customize).

### Noted follow-up
Group buttons highlight their *open* state but don't yet reflect "a tool inside me is active" — left as a follow-up for this evaluation pass.

## Test plan
- `npm run build` ✓ · `npm run test:unit` (687) ✓ · `lint:deps` (acyclic) ✓ · `lint:deadcode`/`lint:consistency` clean for new files
- New golden-path spec `tests/viewport-toolbar-groups.spec.ts` (4 tests): bar collapses to primaries + 3 groups; View/Inspect contents + single-popover coordination; Tools collects the editing tools and a tool opens from it; a grouped tool is reachable from ⌘K.
- Updated specs that asserted visibility / waited on now-grouped buttons (`paint-controls-extended`, `quality-settings`, `quality-scad`, `scad-companion`) — switched existence waits to `state: 'attached'` and opened the Tools popover before clicking Quality.
- Re-ran all directly-affected e2e specs locally green: customizer, relief, viewport-reset-view, paint-controls-extended, paint-palette, simplify, keyboard-shortcuts, image-paint-stamp, paint-{cancel,smooth,projection,airbrush,camera,pointer,labels}, quality-settings, quality-scad, scad-companion, and the new groups spec.

### Screenshots
Collapsed bar, Tools popover open, View popover open — posted in the session chat.

https://claude.ai/code/session_0114cfr33s7gLV2BQkXYpX7s

---
_Generated by [Claude Code](https://claude.ai/code/session_0114cfr33s7gLV2BQkXYpX7s)_