### PR TITLE
feat: remove misleading "✕" close button from session bar

### DIFF
--- a/prompts/20260606-remove-session-bar-close-button.md
+++ b/prompts/20260606-remove-session-bar-close-button.md
@@ -1,0 +1,44 @@
+---
+session: "3Fprq"
+timestamp: "2026-06-06T00:00:00Z"
+model: claude-opus-4-8
+tools: [explore]
+---
+
+## Human
+
+There's an "✕" on the session bar that I think was originally meant to close a
+session. But sessions are now automatically created and mandatory, and every
+time I touch the "✕" the session ID changes, which doesn't really make sense on
+its own. Maybe we just need a "new session" button — or maybe I don't need this
+at all and people should create a new session explicitly. I'm thinking of at
+least getting rid of the "✕". What do you think? — then: I agree, do it and make
+a PR.
+
+## Assistant
+
+## Key decisions
+
+**Diagnosed the mismatch, then removed rather than relabeled.** The "✕"
+(`sessionBar.ts`, titled "Close & start a new session") didn't close anything —
+clicking it called `createSession()` directly, which deletes the current session
+if empty, mints a brand-new session with a new id, rewrites the URL via
+`history.replaceState`, and resets the editor. A session always exists while the
+editor is open (there is no session-less state to return to), so the glyph
+promised dismissal and delivered replacement — the source of the "my session id
+changed" papercut.
+
+**Chose removal over relabel-to-"+".** Confirmed via an explore pass that
+starting a fresh session has several other, correctly-labeled in-editor paths:
+the Sessions modal's "+ New Session" button, the command palette's "New session"
+command, plus implicit creation via catalog tiles and language switching. So the
+"✕" was redundant, not load-bearing. A persistent "make another one" button
+doesn't belong on the bar that represents the *current, mandatory* session,
+especially when the bar already uses "+ New Session" (not "✕") in its
+no-session state — the "✕" was the odd one out within its own file. Explicit
+creation is the cleaner mental model and what the user was already inclined
+toward.
+
+**No orphaned wiring.** `createSession` and the `onNewSession` callback are
+still used by the no-session "+ New Session" button, so removing the close
+button left no dead imports.

--- a/src/ui/sessionBar.ts
+++ b/src/ui/sessionBar.ts
@@ -223,15 +223,12 @@ function render(state: SessionState) {
   barEl.appendChild(el('div', 'flex-1', ''));
 
   // (Session switcher moved to the activity rail header — see createLayout.)
-
-  // "Close" starts a fresh blank session rather than dropping to a
-  // session-less editor — a session always exists while the editor is open.
-  const closeBtn = btn('✕', async () => {
-    await createSession();
-    callbacks.onNewSession();
-  });
-  closeBtn.title = 'Close & start a new session';
-  barEl.appendChild(closeBtn);
+  //
+  // No "close" button here: a session always exists while the editor is open,
+  // so there's nothing to close. Starting a fresh session is an explicit action
+  // via the Sessions modal ("+ New Session") or the command palette ("New
+  // session") — the old "✕" mislabeled "make a new session" as "close" and
+  // silently swapped the session id when touched.
 }
 
 function el(tag: string, className: string, text: string): HTMLElement {


### PR DESCRIPTION
## Summary

Removes the "✕" button from the session bar (`src/ui/sessionBar.ts`).

The button was titled **"Close & start a new session"** but didn't close anything — clicking it called `createSession()` directly, which deletes the current session (if empty), mints a **brand-new session with a new id**, rewrites the URL via `history.replaceState`, and resets the editor to starter code. Because a session always exists while the editor is open (there's no session-less state to return to), the "✕" glyph promised *dismissal* but delivered *replacement* — silently swapping the session id on every touch. That mismatch was the papercut.

It was also redundant. Starting a fresh session already has correctly-labeled, well-scoped paths:

- **Sessions modal** (toolbar) → "+ New Session" — `src/ui/sessionList.ts`
- **Command palette** (⌘K/Ctrl+K → "new session") — `src/main.ts`
- Implicit creation via catalog tiles, language switching, and `window.partwright.createSession()`

The session bar even uses **"+ New Session"** (not "✕") in its own no-session state, so the "✕" was the odd one out within its own file. Removal leans on explicit session creation, which is the cleaner mental model.

No orphaned wiring: `createSession` and the `onNewSession` callback are still used by the no-session "+ New Session" button.

## Test plan

- [x] `npm run build` (type-check) passes
- [x] Manual browser check: loaded `/editor`, confirmed the active session bar now ends at "Save" with no "✕" (the "✕" at the top-right is the AI panel's own close button, a separate component)
- [ ] PR-checks shards (build + unit + e2e) green

## Screenshot

Session bar after the change — ends cleanly at "Save", no "✕":

`Session 6/6/2026 · JS · no versions · 💾 Save`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BdvKSShNsvKsMFAWQ57o9B)_