### PR TITLE
feat: add rolling "Did you know?" hints ticker to the editor

### DIFF
--- a/prompts/20260606-131922-editor-hints-ticker.md
+++ b/prompts/20260606-131922-editor-hints-ticker.md
@@ -1,0 +1,71 @@
+---
+session: "noethr"
+timestamp: "2026-06-06T13:00:00Z"
+model: claude-opus-4-8
+tools: [subagent, playwright]
+---
+
+## Human
+
+Add a feature at the top of the editor: a rolling/recurring series of "Did you
+know?" hints that tell the user about app capabilities they might not discover
+organically (⌘K command palette, the texture tool in the interactive view,
+etc.). Each hint should have a call-to-action: clicking it navigates to the
+relevant place — the catalog/ideas page if it's about those, or, if it's an
+in-editor menu, switch to the interactive view and automatically open the menu
+with an arrow pointing at the option. Research and create a plan, then report
+back.
+
+Follow-up decisions (via AskUserQuestion):
+- Look & feel: slim rolling ticker between toolbar and session bar.
+- In-editor CTA behavior: auto-open the menu/modal AND pulse a spotlight arrow.
+- Persistence: shown by default; ✕ hides for the session; a permanent toggle in
+  Advanced Settings.
+
+## Assistant
+
+## Key decisions
+
+**Reuse over rebuild.** Two existing systems carried most of the weight:
+the command registry (`src/ui/commandPalette.ts`, ~40 actions keyed by id) and
+the guided-tour coachmark (`src/ui/tour.ts`, spotlight + directional arrows).
+So the CTA layer is mostly *dispatch into existing actions* plus a lightweight
+extracted coachmark, not new navigation plumbing.
+
+**Data-driven hints.** `src/ui/hints/hintsData.ts` mirrors the `ideas.ts`
+pattern: a flat dataset of `Hint`s, each with a discriminated-union `HintCta`:
+`command` (run a registered palette action by id), `open` (the two global
+overlays that aren't palette commands — command palette, shortcuts), and
+`coach` (run prep commands, optionally click a popover trigger to reveal a
+nested button, then pulse an arrow at a target selector). Kept dependency-free
+(type-only import) so it unit-tests in the node tier.
+
+**New reusable coachmark** (`src/ui/coachmark.ts`) instead of overloading the
+tour: a non-modal pulse ring + arrow bubble that is `pointer-events:none`, so
+the user can click the highlighted control *through* it. Auto-dismisses on a
+timer or the first real interaction; bails (returns false) if the target is
+missing or zero-size (e.g. inside a collapsed popover).
+
+**The popover-close gotcha.** A `coach` CTA that opens the Tools popover and
+arrows the Surface/Paint button inside it initially failed: opening the popover
+during the CTA click let that same click keep bubbling to `document`, tripping
+the popover's own click-outside handler and closing it again. Fix: defer the
+whole coach sequence with `setTimeout(0)` so it runs after the click finishes
+propagating. Verified in the browser (screenshot) that the Tools menu now opens
+and the ✦ Surface button gets a ringed, labeled arrow.
+
+**Visibility model.** `config.ui.editorHintsEnabled` (permanent, Advanced
+Settings + `toggle-hints` command) gates mounting; a per-tab `sessionStorage`
+flag (`partwright-hints-hidden`) is the ✕ "hide this session" — so a fresh tab
+shows it again, honoring cross-tab isolation. Unseen hints rotate first
+(`localStorage` seen-set), then cycle. Added `onConfigChange` to appConfig so
+the settings toggle takes effect live, and `runCommandById` to the palette so
+CTAs reuse registered actions without duplicating wiring.
+
+**Mount point.** A stable host `#editor-hints-host` is appended to `#editor-ui`
+right after the toolbar (before the session bar), so the strip sits between
+them and the ticker can mount/unmount in place without disturbing layout.
+
+Tests: `tests/unit/hintsData.test.ts` (dataset integrity + CTA ids resolve
+against a mirror of the registered command set) and `tests/editor-hints.spec.ts`
+(renders, rotates, ✕-dismisses, and a coach CTA pulses an arrow).

--- a/prompts/20260606-140100-hints-into-toolbar.md
+++ b/prompts/20260606-140100-hints-into-toolbar.md
@@ -1,0 +1,49 @@
+---
+session: "noethr"
+timestamp: "2026-06-06T13:55:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 2
+---
+
+## Human
+
+Move the hints into the top toolbar — to the right of the language selection
+and the left of the "Use AI" button. Make it clear the previous/next/close
+buttons pertain to the hints (keep them close, and maybe a visual separator
+between the left and right side of the toolbar — whatever you think is best).
+
+## Assistant
+
+## Key decisions
+
+**Placement.** Replaced the toolbar's single `flex-1` spacer (between the
+language help "?" and the "Use AI" button) with a `#editor-hints-host` that is
+itself `flex-1` — so it fills the middle *and* still right-aligns the
+AI/Import/Export cluster when the ticker is hidden. The ticker mounts into this
+host instead of a separate full-width strip below the toolbar.
+
+**Framing the controls.** The inline strip is wrapped by a thin vertical
+divider on each side (`makeDivider`), so the hint text + CTA + its `‹ › ✕`
+controls read as one delimited region distinct from the toolbar's left and
+right button clusters. The controls sit just inside the trailing divider,
+adjacent to "Use AI" but clearly separated from it.
+
+**The hard part — the toolbar runs out of room.** The AI panel is open by
+default (`drawerOpen: true`), which compresses the editor toolbar to ~840px on
+a 1280 laptop, leaving ~45px in the middle. A naive `flex-1` strip overflowed
+and its controls overlapped the Import/Export buttons (confirmed with
+`elementFromPoint`). Fix: a `ResizeObserver` on the host degrades the strip by
+available width — drop the "💡 Did you know?" badge below 360px, hide the whole
+strip below 200px — so it never overflows. Verified three states by screenshot:
+panel-closed (full ticker), 1280+panel-open (cleanly hidden), 1728+panel-open
+(full ticker).
+
+**Trade-off flagged to the user.** On a narrow screen with the AI panel open
+(the default), there is genuinely no room, so the ticker auto-hides until the
+panel is closed or the window is wider. Surfaced this so they can decide whether
+the responsive-hide is acceptable or they'd prefer another home for it.
+
+**Test updates.** The e2e spec now seeds `drawerOpen: false` so the toolbar has
+room, and targets the hint text via a stable `#editor-hints-text` id (the DOM
+order changed once dividers — also `<span>`s — were added).

--- a/prompts/20260606-142800-hints-restore-on-new-session.md
+++ b/prompts/20260606-142800-hints-restore-on-new-session.md
@@ -1,0 +1,40 @@
+---
+session: "noethr"
+timestamp: "2026-06-06T14:20:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 3
+---
+
+## Human
+
+I started a new session and the hints didn't come back. [Clarified: had
+dismissed them with ✕; wants starting/opening a different session to restore
+them — ✕ should mean "not now, this session".]
+
+## Assistant
+
+## Key decisions
+
+**Root cause.** The ✕ dismiss writes a per-tab `sessionStorage` flag
+(`partwright-hints-hidden`) that survives reloads *and* new design sessions in
+the same tab, so creating a new Partwright session left the hints hidden. The
+user's mental model is that ✕ is scoped to the *design session*, not the
+browser tab.
+
+**Fix.** The ticker now listens for the app's `session-changed` event and calls
+`showHintsTicker()` (which clears the per-tab dismiss + re-mounts) when the
+session **id** transitions to a different non-null value. It seeds
+`lastSessionId` from `getState()` at mount so the initial session load on page
+open is *not* treated as a transition — a plain reload keeps a same-session
+dismiss in place, only a genuinely new/opened session restores.
+
+**Guarding against over-firing.** `session-changed` fires on every state change
+(version navigation, save, part switches), so gating on an id change is
+essential — otherwise navigating versions would immediately un-dismiss the
+hints the user just closed. The permanent Settings off-switch still wins:
+`showHintsTicker` → `refreshHintsTicker` re-checks `editorHintsEnabled`, so a
+session change never overrides a permanent disable.
+
+**Verified** by Playwright: dismiss with ✕ → `partwright.createSession()` →
+the `#editor-hints` strip reappears. Added as a permanent e2e case.

--- a/prompts/20260606-145200-hints-pill-restyle.md
+++ b/prompts/20260606-145200-hints-pill-restyle.md
@@ -1,0 +1,36 @@
+---
+session: "noethr"
+timestamp: "2026-06-06T14:50:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 4
+---
+
+## Human
+
+Centrally align the section and have the previous/next/close buttons inside the
+"Did you know" section. Also use a cooler icon than the lightbulb. I trust you.
+
+## Assistant
+
+## Key decisions
+
+**Self-contained centered pill.** Replaced the full-width framed strip with a
+bordered, rounded pill (`bg-zinc-800/60 border border-zinc-700/70`) that holds
+everything — icon, "Did you know?" label, rotating hint, CTA, and the ‹ › ✕
+controls — as one section. The toolbar host went from left-aligned to
+`justify-center`, and the pill is `inline-flex max-w-full` rather than `flex-1`,
+so it centers in the gap between the language "?" and "Use AI" while the host
+stays flex-1 to keep right-aligning the AI/Import/Export cluster.
+
+**Controls inside the section.** The ‹ › ✕ group now lives inside the pill, set
+off by a thin internal `border-l` divider instead of the old external dividers —
+so they read unambiguously as the hints' own controls.
+
+**Icon.** Swapped the 💡 emoji for the Lucide "sparkles" glyph as an inline SVG
+(`currentColor`, amber-300), matching the codebase's existing inline-SVG idiom
+(layout.ts) and reading as tips/discovery rather than a plain lightbulb.
+
+The responsive `ResizeObserver` behavior is unchanged (drop the label below
+360px of host width, hide the whole pill below 200px). All three e2e cases still
+pass; verified the centered pill by screenshot.

--- a/prompts/20260606-150400-hints-random-start.md
+++ b/prompts/20260606-150400-hints-random-start.md
@@ -1,0 +1,28 @@
+---
+session: "noethr"
+timestamp: "2026-06-06T15:02:00Z"
+model: claude-opus-4-8
+sequence: 5
+---
+
+## Human
+
+Does the first hint get picked randomly and then rotate? I feel like I'm seeing
+the same initial hint every time.
+
+## Assistant
+
+## Key decisions
+
+**Confirmed the cause.** `buildOrder()` returned unseen hints in *dataset order*
+and started at index 0, so the first hint was always the next-unseen one — and
+once every hint had been marked seen, it reset to `HINTS[0]` (the ⌘K hint) on
+every load. Deterministic, hence the "same initial hint" feeling.
+
+**Fix.** Shuffle each group (unseen, then seen) with Fisher–Yates in
+`buildOrder`, which runs on every mount and session change. The first hint shown
+is now random — a fresh unseen one while any remain (preserving the discovery
+bias), then any once all are seen — and the whole rotation sequence varies too.
+
+No test changes needed; the existing e2e (rotate, restore, coach) still passes
+since hints remain distinct and the full set is still present in the order.

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -174,6 +174,13 @@ export interface AppConfig {
     /** Live-refresh interval (ms) for the worker health panel — how often it
      *  re-polls in-flight counts and liveness while open. */
     workerPanelRefreshMs: number;
+    /** Whether the "Did you know?" rolling hints strip shows at the top of the
+     *  editor. Users can turn it off permanently here; the strip's ✕ only hides
+     *  it for the current tab/session. */
+    editorHintsEnabled: boolean;
+    /** How long each "Did you know?" hint stays before the strip rotates to the
+     *  next one (ms). */
+    hintRotationMs: number;
   };
 }
 
@@ -252,6 +259,8 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     paletteHistoryMax: 48,
     workerRunHistorySize: 50,
     workerPanelRefreshMs: 1000,
+    editorHintsEnabled: true,
+    hintRotationMs: 12_000,
   },
 };
 
@@ -316,6 +325,13 @@ export function loadAppConfig(): AppConfig {
 /** Return the current config (cached after first load). */
 export function getConfig(): AppConfig {
   return loadAppConfig();
+}
+
+/** Subscribe to config changes (saved overrides or a reset). Returns an
+ *  unsubscribe function. Fires with the new config after every persist. */
+export function onConfigChange(fn: (cfg: AppConfig) => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
 }
 
 /** Persist the given config snapshot and notify listeners. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -4068,15 +4068,14 @@ async function main() {
     },
   });
 
-  // "Did you know?" hints ticker — a stable host slotted between the toolbar and
-  // the session bar (both append to editorUI, so appending now lands it second).
-  // The ticker mounts/unmounts inside this host as it's toggled, so layout stays
-  // put. Shown by default; hidden per-session via its ✕ or permanently in
-  // Advanced Settings (config.ui.editorHintsEnabled).
-  const hintsHost = document.createElement('div');
-  hintsHost.id = 'editor-hints-host';
-  editorUI.appendChild(hintsHost);
-  mountHintsTicker(hintsHost);
+  // "Did you know?" hints ticker — mounts into the toolbar's middle host
+  // (#editor-hints-host, created by createToolbar between the language "?" and
+  // the "Use AI" button). The ticker mounts/unmounts inside it as it's toggled.
+  // Shown by default; hidden per-session via its ✕ or permanently in Advanced
+  // Settings (config.ui.editorHintsEnabled).
+  // Query within editorUI (not document) — it isn't attached to the page yet.
+  const hintsHost = editorUI.querySelector<HTMLElement>('#editor-hints-host');
+  if (hintsHost) mountHintsTicker(hintsHost);
 
   // Init diagnostic panel — attaches to document.body, registers badge subscriber.
   initDiagnosticsPanel();

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ import { createLayout, type TabName } from './ui/layout';
 import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState, setRunState } from './ui/toolbar';
 import { installKeyboardShortcuts } from './ui/keyboardShortcuts';
 import { registerCommands } from './ui/commandPalette';
+import { mountHintsTicker, showHintsTicker } from './ui/hints/hintsTicker';
 import { showAdvancedSettingsModal } from './ui/advancedSettingsModal';
 import { combo, MOD_LABEL, SHIFT_LABEL, ALT_LABEL } from './ui/shortcutDefs';
 import { showToast } from './ui/toast';
@@ -265,7 +266,7 @@ import {
   checkAssertions,
   type GeometryAssertions,
 } from './geometry/statsComputation';
-import { getConfig } from './config/appConfig';
+import { getConfig, saveAppConfig } from './config/appConfig';
 import { extractPositions, maxEdgeLength, minEdgeLength, estimateRefineTriangles } from './surface/meshSubdivide';
 
 // Load examples as raw text — JS and SCAD
@@ -4067,6 +4068,16 @@ async function main() {
     },
   });
 
+  // "Did you know?" hints ticker — a stable host slotted between the toolbar and
+  // the session bar (both append to editorUI, so appending now lands it second).
+  // The ticker mounts/unmounts inside this host as it's toggled, so layout stays
+  // put. Shown by default; hidden per-session via its ✕ or permanently in
+  // Advanced Settings (config.ui.editorHintsEnabled).
+  const hintsHost = document.createElement('div');
+  hintsHost.id = 'editor-hints-host';
+  editorUI.appendChild(hintsHost);
+  mountHintsTicker(hintsHost);
+
   // Init diagnostic panel — attaches to document.body, registers badge subscriber.
   initDiagnosticsPanel();
 
@@ -4301,6 +4312,16 @@ async function main() {
   // Viewport tools need the editor active and a model on screen to act on.
   const viewportToolEnabled = () => isEditorActive() && currentMeshData !== null;
 
+  // Flip the permanent on/off for the hints ticker (also exposed in Advanced
+  // Settings). Turning it on clears any per-session ✕-dismiss so it reappears.
+  function toggleEditorHints(): void {
+    const cfg = getConfig();
+    const next = !cfg.ui.editorHintsEnabled;
+    saveAppConfig({ ...cfg, ui: { ...cfg.ui, editorHintsEnabled: next } });
+    if (next) showHintsTicker();
+    showToast(next ? 'Editor hints shown' : 'Editor hints hidden', { variant: 'neutral' });
+  }
+
   // Register command-palette actions (⌘K). Reuses the same handlers the
   // toolbar/session bar/layout already wire up so behavior can't drift.
   registerCommands([
@@ -4349,6 +4370,7 @@ async function main() {
     { id: 'open-whats-new', title: "Open what's new", hint: 'Navigate', keywords: 'changelog recent features updates release notes', run: () => showWhatsNewPage() },
     { id: 'open-quality', title: 'Settings', hint: 'Settings', keywords: 'resolution curve segments smoothness advanced', run: () => showAdvancedSettingsModal() },
     { id: 'retake-tour', title: 'Take the guided tour', hint: 'Help', keywords: 'onboarding walkthrough intro tutorial', run: () => { resetTour(); startTour(); }, enabled: isEditorActive },
+    { id: 'toggle-hints', title: 'Toggle "Did you know?" hints', hint: 'View', keywords: 'did you know tips ticker discovery hints banner strip', run: () => toggleEditorHints() },
   ]);
 
   // Init gallery — `loadVersion` (in gallery.ts) has already updated state to

--- a/src/style.css
+++ b/src/style.css
@@ -162,6 +162,54 @@
   border-left: 8px solid var(--color-zinc-600);
 }
 
+/* Lightweight coachmark (src/ui/coachmark.ts) — a non-modal pulse + arrow that
+   points at a control. The root stays pointer-events:none so clicks pass through
+   to the highlighted button beneath it. */
+.pw-coachmark-root {
+  position: fixed;
+  inset: 0;
+  z-index: 9996;
+  pointer-events: none;
+}
+
+.pw-coachmark-ring {
+  position: fixed;
+  border-radius: 8px;
+  border: 2px solid var(--color-blue-400, #60a5fa);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25);
+  opacity: 0;
+  transition: opacity 0.2s ease, top 0.15s ease, left 0.15s ease, width 0.15s ease, height 0.15s ease;
+}
+
+.pw-coachmark-ring.visible {
+  opacity: 1;
+  animation: pw-coachmark-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pw-coachmark-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25); }
+  50% { box-shadow: 0 0 0 7px rgba(96, 165, 250, 0.05); }
+}
+
+.pw-coachmark-bubble {
+  position: fixed;
+  z-index: 9997;
+  background: var(--color-zinc-800);
+  border: 1px solid var(--color-zinc-600);
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--color-zinc-100);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.pw-coachmark-bubble.visible {
+  opacity: 1;
+}
+
 /* Fast hover tooltips (replaces the slow native title delay) */
 .pw-tooltip {
   position: fixed;

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -104,6 +104,38 @@ function Field(props: FieldProps) {
   );
 }
 
+interface ToggleFieldProps {
+  label: string;
+  hint?: string;
+  defaultValue: boolean;
+  value: boolean;
+  onChange: (v: boolean) => void;
+}
+
+function ToggleField(props: ToggleFieldProps) {
+  const { label, hint, defaultValue, value, onChange } = props;
+  const changed = value !== defaultValue;
+  return (
+    <div class="flex flex-col gap-1">
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={value}
+          class="w-4 h-4 accent-blue-500"
+          onChange={e => onChange((e.currentTarget as HTMLInputElement).checked)}
+        />
+        <span class="text-xs font-medium text-zinc-300 flex-1">{label}</span>
+        {changed && (
+          <span class="text-[9px] text-amber-400 border border-amber-400/30 rounded px-1 py-px uppercase tracking-wide">
+            modified
+          </span>
+        )}
+      </label>
+      {hint && <p class="text-[10px] text-zinc-500 leading-snug pl-6">{hint}</p>}
+    </div>
+  );
+}
+
 interface SectionProps {
   title: string;
   children: ComponentChildren;
@@ -136,7 +168,7 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
     );
   });
 
-  function set<S extends keyof AppConfig>(section: S, key: keyof AppConfig[S], value: number): void {
+  function set<S extends keyof AppConfig>(section: S, key: keyof AppConfig[S], value: number | boolean): void {
     const next = cloneConfig(cfg.value);
     (next[section] as Record<string, unknown>)[key as string] = value;
     cfg.value = next;
@@ -644,6 +676,23 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
       </Section>
 
       <Section title="UI">
+        <ToggleField
+          label="Show editor hints"
+          hint={'The "Did you know?" strip at the top of the editor that rotates through tips. Off hides it everywhere; the strip’s ✕ only hides it for the current tab.'}
+          defaultValue={APP_CONFIG_DEFAULTS.ui.editorHintsEnabled}
+          value={c.ui.editorHintsEnabled}
+          onChange={v => set('ui', 'editorHintsEnabled', v)}
+        />
+        <Field
+          label="Hint rotation interval"
+          unit="ms"
+          hint="How long each editor hint shows before the strip rotates to the next."
+          tooltip="The 'Did you know?' strip auto-advances to the next tip after this long. Hovering the strip pauses rotation; the ‹ › arrows step manually. Raise it to read each tip longer; lower it to cycle faster."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.hintRotationMs}
+          value={c.ui.hintRotationMs}
+          min={3_000} max={60_000} integer
+          onChange={v => set('ui', 'hintRotationMs', v)}
+        />
         <Field
           label="Toast duration"
           unit="ms"

--- a/src/ui/coachmark.ts
+++ b/src/ui/coachmark.ts
@@ -1,0 +1,154 @@
+// Lightweight, non-modal coachmark: pulses a ring + arrow + label at a target
+// element to draw the eye to it, then auto-fades. Unlike the guided tour
+// (src/ui/tour.ts), it does NOT dim the screen or trap focus — the whole
+// overlay is pointer-events:none so the user can still click the highlighted
+// control through it (e.g. the button an arrow is pointing at). Used by the
+// "Did you know?" hints ticker to reveal where a feature lives after its CTA
+// switches views / opens a menu.
+
+export type CoachPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export interface CoachmarkOptions {
+  /** Short label shown in the arrow bubble (e.g. "Texture & paint live here"). */
+  text?: string;
+  /** Which side of the target the bubble sits on. Default 'bottom'. */
+  placement?: CoachPlacement;
+  /** Auto-dismiss after this long (ms). Default 4000. */
+  durationMs?: number;
+}
+
+// One coachmark at a time — a new one supersedes the old.
+let active: { root: HTMLElement; cleanup: () => void } | null = null;
+
+/** Tear down any visible coachmark immediately. */
+export function dismissCoachmark(): void {
+  active?.cleanup();
+  active = null;
+}
+
+/**
+ * Pulse a ring + arrow at the element matching `selector`. Returns false (and
+ * does nothing) when the target is missing or not visible — callers can treat
+ * that as "nothing to point at". The overlay is pointer-events:none, so the
+ * first real interaction the user makes (click/scroll/keydown) passes through
+ * to the page and also dismisses the coachmark.
+ */
+export function spotlightElement(selector: string, opts: CoachmarkOptions = {}): boolean {
+  const target = document.querySelector<HTMLElement>(selector);
+  if (!target) return false;
+  const rect = target.getBoundingClientRect();
+  // Hidden / zero-size element (e.g. inside a collapsed popover) — nothing to show.
+  if (rect.width === 0 || rect.height === 0) return false;
+
+  dismissCoachmark();
+
+  const placement = opts.placement ?? 'bottom';
+  const durationMs = opts.durationMs ?? 4000;
+  const pad = 6;
+
+  const root = document.createElement('div');
+  root.className = 'pw-coachmark-root';
+
+  // Pulsing ring hugging the target.
+  const ring = document.createElement('div');
+  ring.className = 'pw-coachmark-ring';
+  ring.style.top = `${rect.top - pad}px`;
+  ring.style.left = `${rect.left - pad}px`;
+  ring.style.width = `${rect.width + pad * 2}px`;
+  ring.style.height = `${rect.height + pad * 2}px`;
+  root.appendChild(ring);
+
+  // Optional label bubble with a directional arrow.
+  let bubble: HTMLElement | null = null;
+  if (opts.text) {
+    bubble = document.createElement('div');
+    bubble.className = 'pw-coachmark-bubble';
+    bubble.textContent = opts.text;
+    const arrow = document.createElement('div');
+    arrow.className = `tour-arrow tour-arrow-${placement}`;
+    bubble.appendChild(arrow);
+    root.appendChild(bubble);
+  }
+
+  document.body.appendChild(root);
+
+  // Position the bubble relative to the target now that it's measurable.
+  if (bubble) positionBubble(bubble, rect, placement);
+
+  // Fade in.
+  requestAnimationFrame(() => {
+    ring.classList.add('visible');
+    bubble?.classList.add('visible');
+  });
+
+  // Teardown wiring.
+  let timer = window.setTimeout(dismissCoachmark, durationMs);
+  const onInteract = () => dismissCoachmark();
+  // Re-measure on layout shifts; if the target vanishes, dismiss.
+  const onReflow = () => {
+    const r = target.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) { dismissCoachmark(); return; }
+    ring.style.top = `${r.top - pad}px`;
+    ring.style.left = `${r.left - pad}px`;
+    ring.style.width = `${r.width + pad * 2}px`;
+    ring.style.height = `${r.height + pad * 2}px`;
+    if (bubble) positionBubble(bubble, r, placement);
+  };
+  // Capture-phase so we see the interaction even though the overlay can't.
+  document.addEventListener('pointerdown', onInteract, { capture: true });
+  document.addEventListener('keydown', onInteract, { capture: true });
+  window.addEventListener('scroll', onReflow, { capture: true, passive: true });
+  window.addEventListener('resize', onReflow, { passive: true });
+
+  const cleanup = () => {
+    window.clearTimeout(timer);
+    timer = 0;
+    document.removeEventListener('pointerdown', onInteract, { capture: true } as EventListenerOptions);
+    document.removeEventListener('keydown', onInteract, { capture: true } as EventListenerOptions);
+    window.removeEventListener('scroll', onReflow, { capture: true } as EventListenerOptions);
+    window.removeEventListener('resize', onReflow);
+    root.remove();
+  };
+
+  active = { root, cleanup };
+  return true;
+}
+
+const BUBBLE_W = 240;
+
+function positionBubble(bubble: HTMLElement, targetRect: DOMRect, placement: CoachPlacement): void {
+  const gap = 14;
+  const margin = 12;
+  bubble.style.width = `${BUBBLE_W}px`;
+
+  // Force a measure for the height.
+  const h = bubble.offsetHeight;
+
+  let top = 0;
+  let left = 0;
+  switch (placement) {
+    case 'bottom':
+      top = targetRect.bottom + gap;
+      left = targetRect.left + targetRect.width / 2 - BUBBLE_W / 2;
+      break;
+    case 'top':
+      top = targetRect.top - h - gap;
+      left = targetRect.left + targetRect.width / 2 - BUBBLE_W / 2;
+      break;
+    case 'right':
+      top = targetRect.top + targetRect.height / 2 - h / 2;
+      left = targetRect.right + gap;
+      break;
+    case 'left':
+      top = targetRect.top + targetRect.height / 2 - h / 2;
+      left = targetRect.left - BUBBLE_W - gap;
+      break;
+  }
+
+  // Clamp to the viewport.
+  left = Math.max(margin, Math.min(window.innerWidth - BUBBLE_W - margin, left));
+  top = Math.max(margin, Math.min(window.innerHeight - h - margin, top));
+
+  bubble.style.top = `${top}px`;
+  bubble.style.left = `${left}px`;
+}

--- a/src/ui/commandPalette.ts
+++ b/src/ui/commandPalette.ts
@@ -32,6 +32,19 @@ function getCommands(): Command[] {
   return [...registry.values()];
 }
 
+/**
+ * Run a registered command by id, honoring its `enabled` gate. Returns false
+ * when the id is unknown or the command is currently disabled (so callers can
+ * fall back). Lets non-palette UI (e.g. the hints ticker) reuse the same
+ * actions the palette exposes without duplicating their wiring.
+ */
+export function runCommandById(id: string): boolean {
+  const cmd = registry.get(id);
+  if (!cmd || (cmd.enabled && !cmd.enabled())) return false;
+  cmd.run();
+  return true;
+}
+
 // --- Palette UI ---
 
 let overlayEl: HTMLElement | null = null;

--- a/src/ui/hints/hintsData.ts
+++ b/src/ui/hints/hintsData.ts
@@ -1,0 +1,143 @@
+// The "Did you know?" hints dataset — the single source of truth for the
+// rolling editor hints ticker (src/ui/hints/hintsTicker.ts).
+//
+// Each hint is one capability a new user is likely to miss, plus a call-to-
+// action that takes them straight to it. The CTA is a small discriminated
+// union so the ticker stays dumb: it just dispatches by `kind`.
+//
+//   - `command`: run a registered command-palette action by id (navigation,
+//     tab switches, open-modal actions, …). The id must exist in the registry
+//     wired up in main.ts.
+//   - `open`: open one of the two global overlays that aren't palette commands.
+//   - `coach`: the star case — run any prep commands (switch view, open a
+//     menu), optionally click a menu trigger to reveal nested buttons, then
+//     pulse an arrow at the target control so the user learns where it lives.
+//
+// Kept dependency-free (no imports) so it can be unit-tested in the node tier.
+
+import type { CoachPlacement } from '../coachmark';
+
+export type HintCta =
+  | { kind: 'command'; id: string }
+  | { kind: 'open'; what: 'commandPalette' | 'shortcuts' }
+  | {
+      kind: 'coach';
+      /** Command ids run in order before pointing (e.g. switch to a view). */
+      prep?: string[];
+      /** Selector clicked to open a popover so the `target` becomes visible. */
+      openSelector?: string;
+      /** Selector the arrow points at. */
+      target: string;
+      /** Side of the target the bubble sits on. */
+      placement?: CoachPlacement;
+      /** Bubble label. */
+      label?: string;
+    };
+
+export interface Hint {
+  /** Stable id (also used to remember which hints have been seen). */
+  id: string;
+  /** The "Did you know?" line. Keep it to one sentence. */
+  text: string;
+  /** CTA link label. Defaults to "Check it out →". */
+  ctaLabel?: string;
+  /** What clicking the CTA does. */
+  cta: HintCta;
+}
+
+/** Default CTA link text when a hint doesn't override it. */
+export const DEFAULT_CTA_LABEL = 'Check it out →';
+
+// Order here is the rotation order for a fresh user; the ticker prioritizes
+// unseen hints and then cycles. Targets/ids are verified against the live DOM:
+//   #viewport-tools-group-btn  — the "Tools ▾" popover trigger (clip-controls)
+//   #paint-toggle              — Paint button (inside the Tools popover)
+//   #surface-viewport-toggle   — ✦ Surface button (inside the Tools popover)
+//   #lang-toggle               — JS/SCAD/BREP/VOXEL engine switch (toolbar)
+//   #import-wrapper            — Import dropdown (toolbar)
+export const HINTS: Hint[] = [
+  {
+    id: 'command-palette',
+    text: 'Press ⌘K (Ctrl+K) to open the command palette and run any action by name.',
+    ctaLabel: 'Open it →',
+    cta: { kind: 'open', what: 'commandPalette' },
+  },
+  {
+    id: 'shortcuts',
+    text: 'Press ? anywhere to see the full keyboard-shortcut cheat sheet.',
+    ctaLabel: 'Show shortcuts →',
+    cta: { kind: 'open', what: 'shortcuts' },
+  },
+  {
+    id: 'surface-texture',
+    text: 'Add knurling, fuzzy skin, woven, or fur textures to any model with the Surface tool.',
+    ctaLabel: 'Try it →',
+    cta: {
+      kind: 'coach',
+      prep: ['tab-interactive'],
+      openSelector: '#viewport-tools-group-btn',
+      target: '#surface-viewport-toggle',
+      placement: 'left',
+      label: 'Surface textures live here — fuzzy, knit, woven, fur & more.',
+    },
+  },
+  {
+    id: 'paint-colors',
+    text: 'Paint regions of your model for multi-color 3D prints, exported as 3MF or OBJ.',
+    ctaLabel: 'Show me →',
+    cta: {
+      kind: 'coach',
+      prep: ['tab-interactive'],
+      openSelector: '#viewport-tools-group-btn',
+      target: '#paint-toggle',
+      placement: 'left',
+      label: 'Paint coplanar regions and label them by name.',
+    },
+  },
+  {
+    id: 'photo-to-model',
+    text: 'Turn any photo into a printable relief, lithophane, or colored voxel model.',
+    ctaLabel: 'Open Ideas →',
+    cta: { kind: 'command', id: 'open-ideas' },
+  },
+  {
+    id: 'brep-engine',
+    text: 'Switch to the BREP engine for true rounded fillets, chamfers, and STEP export.',
+    ctaLabel: 'Find the switch →',
+    cta: {
+      kind: 'coach',
+      target: '#lang-toggle',
+      placement: 'bottom',
+      label: 'Pick an engine here: JS, SCAD, BREP, or VOXEL.',
+    },
+  },
+  {
+    id: 'diff-versions',
+    text: 'Compare any two versions side by side — code and geometry stats — in the Diff tab.',
+    ctaLabel: 'Open Diff →',
+    cta: { kind: 'command', id: 'tab-diff' },
+  },
+  {
+    id: 'catalog',
+    text: 'Browse a catalog of ready-made models you can open, tweak, or hand to the AI.',
+    ctaLabel: 'Browse catalog →',
+    cta: { kind: 'command', id: 'open-catalog' },
+  },
+  {
+    id: 'ai-review',
+    text: 'Get a second opinion: have a different AI provider review your current model.',
+    ctaLabel: 'Open the AI panel →',
+    cta: { kind: 'command', id: 'toggle-ai' },
+  },
+  {
+    id: 'import',
+    text: 'Import STL or STEP meshes, .scad / .js source, .vox models, or a full session file.',
+    ctaLabel: 'Show import →',
+    cta: {
+      kind: 'coach',
+      target: '#import-wrapper',
+      placement: 'bottom',
+      label: 'Import meshes, source files, or whole sessions here.',
+    },
+  },
+];

--- a/src/ui/hints/hintsTicker.ts
+++ b/src/ui/hints/hintsTicker.ts
@@ -108,12 +108,24 @@ function runCta(cta: HintCta): void {
 
 // ─── rotation ──────────────────────────────────────────────────────────────────
 
-/** Build the rotation order: unseen hints first (in dataset order), then seen. */
+/** Fisher–Yates shuffle (in place), returning the same array. */
+function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/** Build the rotation order: unseen hints first, then seen — but each group is
+ *  shuffled, so the *first* hint shown is random (a fresh one you haven't seen
+ *  yet while any remain, then any once you've seen them all) rather than always
+ *  the same dataset-order hint. Rebuilt on every mount / session change. */
 function buildOrder(): Hint[] {
   const seen = readSeen();
-  const unseen = HINTS.filter(h => !seen.has(h.id));
-  const rest = HINTS.filter(h => seen.has(h.id));
-  return unseen.length ? [...unseen, ...rest] : [...HINTS];
+  const unseen = shuffle(HINTS.filter(h => !seen.has(h.id)));
+  const rest = shuffle(HINTS.filter(h => seen.has(h.id)));
+  return [...unseen, ...rest];
 }
 
 function showCurrent(): void {

--- a/src/ui/hints/hintsTicker.ts
+++ b/src/ui/hints/hintsTicker.ts
@@ -1,0 +1,249 @@
+// The "Did you know?" rolling hints strip at the top of the editor.
+//
+// A slim, single-line ticker that rotates through HINTS (src/ui/hints/hintsData.ts),
+// each with a CTA that navigates to / reveals the feature it describes. Designed
+// to be the lowest-footprint discovery surface: it sits between the toolbar and
+// the session bar and never steals focus.
+//
+// Visibility rules (matching the product decision):
+//   - Shown by default. A permanent on/off lives in Advanced Settings
+//     (config.ui.editorHintsEnabled) — also flipped by the `toggle-hints`
+//     command in main.ts.
+//   - The ✕ hides it for the current TAB/SESSION only (sessionStorage), so a
+//     fresh tab shows it again. Re-enabling via settings/command clears that.
+//
+// The ticker mounts into a stable host element (created once in main.ts) so it
+// can be torn down and rebuilt in place when toggled without disturbing layout.
+
+import { HINTS, DEFAULT_CTA_LABEL, type Hint, type HintCta } from './hintsData';
+import { runCommandById, openCommandPalette } from '../commandPalette';
+import { openShortcutsOverlay } from '../shortcutsOverlay';
+import { spotlightElement, dismissCoachmark } from '../coachmark';
+import { getConfig, onConfigChange } from '../../config/appConfig';
+
+/** localStorage: ids the user has already been shown (rotate fresh ones first). */
+const SEEN_KEY = 'partwright-hints-seen';
+/** sessionStorage: set when the user ✕-dismisses for this tab. */
+const HIDDEN_KEY = 'partwright-hints-hidden';
+
+let host: HTMLElement | null = null;
+let strip: HTMLElement | null = null;
+let textEl: HTMLElement | null = null;
+let ctaEl: HTMLButtonElement | null = null;
+let rotateTimer = 0;
+let order: Hint[] = [];
+let idx = 0;
+let paused = false;
+let configUnsub: (() => void) | null = null;
+
+// ─── persistence helpers ──────────────────────────────────────────────────────
+
+function readSeen(): Set<string> {
+  try {
+    const raw = localStorage.getItem(SEEN_KEY);
+    if (raw) return new Set(JSON.parse(raw) as string[]);
+  } catch { /* ignore */ }
+  return new Set();
+}
+
+function markSeen(id: string): void {
+  try {
+    const seen = readSeen();
+    if (seen.has(id)) return;
+    seen.add(id);
+    // Only keep ids that still exist, so the list can't grow unbounded.
+    const live = HINTS.map(h => h.id);
+    localStorage.setItem(SEEN_KEY, JSON.stringify([...seen].filter(id => live.includes(id))));
+  } catch { /* ignore */ }
+}
+
+function isSessionHidden(): boolean {
+  try { return sessionStorage.getItem(HIDDEN_KEY) === '1'; } catch { return false; }
+}
+
+function setSessionHidden(hidden: boolean): void {
+  try {
+    if (hidden) sessionStorage.setItem(HIDDEN_KEY, '1');
+    else sessionStorage.removeItem(HIDDEN_KEY);
+  } catch { /* ignore */ }
+}
+
+// ─── CTA dispatch ──────────────────────────────────────────────────────────────
+
+function runCta(cta: HintCta): void {
+  switch (cta.kind) {
+    case 'open':
+      if (cta.what === 'commandPalette') openCommandPalette();
+      else openShortcutsOverlay();
+      return;
+    case 'command':
+      runCommandById(cta.id);
+      return;
+    case 'coach': {
+      // Defer past the current click: opening a popover here, then letting this
+      // very click keep bubbling to document, would trip the popover's own
+      // click-outside handler and close it again. A 0ms timeout runs the whole
+      // sequence after the click finishes propagating.
+      window.setTimeout(() => {
+        for (const id of cta.prep ?? []) runCommandById(id);
+        if (cta.openSelector) {
+          document.querySelector<HTMLElement>(cta.openSelector)?.click();
+        }
+        // Let any view switch / popover open settle before we measure the target.
+        requestAnimationFrame(() => {
+          spotlightElement(cta.target, { text: cta.label, placement: cta.placement });
+        });
+      }, 0);
+      return;
+    }
+  }
+}
+
+// ─── rotation ──────────────────────────────────────────────────────────────────
+
+/** Build the rotation order: unseen hints first (in dataset order), then seen. */
+function buildOrder(): Hint[] {
+  const seen = readSeen();
+  const unseen = HINTS.filter(h => !seen.has(h.id));
+  const rest = HINTS.filter(h => seen.has(h.id));
+  return unseen.length ? [...unseen, ...rest] : [...HINTS];
+}
+
+function showCurrent(): void {
+  if (!textEl || !ctaEl || order.length === 0) return;
+  const hint = order[idx % order.length];
+  textEl.textContent = hint.text;
+  ctaEl.textContent = hint.ctaLabel ?? DEFAULT_CTA_LABEL;
+  ctaEl.onclick = () => runCta(hint.cta);
+  markSeen(hint.id);
+}
+
+function advance(delta: number): void {
+  if (order.length === 0) return;
+  idx = (idx + delta + order.length) % order.length;
+  showCurrent();
+}
+
+function scheduleRotate(): void {
+  window.clearTimeout(rotateTimer);
+  const interval = getConfig().ui.hintRotationMs;
+  rotateTimer = window.setTimeout(() => {
+    if (!paused) advance(1);
+    scheduleRotate();
+  }, interval);
+}
+
+// ─── mount / unmount ─────────────────────────────────────────────────────────
+
+function teardownStrip(): void {
+  window.clearTimeout(rotateTimer);
+  rotateTimer = 0;
+  dismissCoachmark();
+  if (host) host.replaceChildren();
+  strip = null;
+  textEl = null;
+  ctaEl = null;
+}
+
+/** Render the strip into the host (idempotent — rebuilds in place). */
+function renderStrip(): void {
+  if (!host) return;
+  teardownStrip();
+
+  order = buildOrder();
+  idx = 0;
+
+  strip = document.createElement('div');
+  strip.id = 'editor-hints';
+  strip.setAttribute('role', 'note');
+  strip.setAttribute('aria-label', 'Did you know');
+  strip.className =
+    'flex items-center gap-2 px-3 py-1 bg-zinc-900 border-b border-zinc-800 text-xs text-zinc-400 shrink-0 overflow-hidden';
+
+  const badge = document.createElement('span');
+  badge.className = 'shrink-0 text-zinc-500 select-none';
+  badge.textContent = '💡 Did you know?';
+
+  textEl = document.createElement('span');
+  textEl.className = 'min-w-0 truncate text-zinc-300';
+
+  ctaEl = document.createElement('button');
+  ctaEl.type = 'button';
+  ctaEl.className = 'shrink-0 text-blue-400 hover:text-blue-300 hover:underline font-medium transition-colors';
+
+  // ‹ › step + ✕ dismiss, grouped at the right.
+  const controls = document.createElement('div');
+  controls.className = 'shrink-0 flex items-center gap-0.5 ml-auto text-zinc-500';
+
+  const prevBtn = makeIconBtn('‹', 'Previous hint', () => advance(-1));
+  const nextBtn = makeIconBtn('›', 'Next hint', () => advance(1));
+  const closeBtn = makeIconBtn('✕', 'Hide hints for this session', dismissForSession);
+
+  controls.append(prevBtn, nextBtn, closeBtn);
+  strip.append(badge, textEl, ctaEl, controls);
+  host.appendChild(strip);
+
+  // Pause rotation while the user is reading (hover) or interacting (focus).
+  strip.addEventListener('pointerenter', () => { paused = true; });
+  strip.addEventListener('pointerleave', () => { paused = false; });
+  strip.addEventListener('focusin', () => { paused = true; });
+  strip.addEventListener('focusout', () => { paused = false; });
+
+  showCurrent();
+  scheduleRotate();
+}
+
+/** A compact control button with a ≥44px touch target via padding. */
+function makeIconBtn(glyph: string, label: string, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = glyph;
+  btn.setAttribute('aria-label', label);
+  btn.title = label;
+  btn.className =
+    'leading-none px-2 py-2 -my-1 rounded text-zinc-500 hover:text-zinc-200 hover:bg-zinc-800 transition-colors';
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+function dismissForSession(): void {
+  setSessionHidden(true);
+  teardownStrip();
+}
+
+/** Whether the strip should currently be visible. */
+function shouldShow(): boolean {
+  return getConfig().ui.editorHintsEnabled && !isSessionHidden();
+}
+
+/** Re-evaluate visibility and mount/unmount accordingly. */
+function refreshHintsTicker(): void {
+  if (!host) return;
+  if (shouldShow()) {
+    if (!strip) renderStrip();
+  } else {
+    teardownStrip();
+  }
+}
+
+/**
+ * Mount the hints ticker into a stable host element (called once from main.ts,
+ * after the toolbar so the strip sits between toolbar and session bar). Wires a
+ * config subscription so the Advanced Settings toggle takes effect live.
+ */
+export function mountHintsTicker(hostEl: HTMLElement): void {
+  host = hostEl;
+  configUnsub?.();
+  configUnsub = onConfigChange(() => refreshHintsTicker());
+  refreshHintsTicker();
+}
+
+/**
+ * Force the ticker visible: clear this tab's session-dismiss so the strip comes
+ * back even if the user had ✕-ed it. Used by the `toggle-hints` command when
+ * turning hints on. Returns nothing; relies on config already being enabled.
+ */
+export function showHintsTicker(): void {
+  setSessionHidden(false);
+  refreshHintsTicker();
+}

--- a/src/ui/hints/hintsTicker.ts
+++ b/src/ui/hints/hintsTicker.ts
@@ -20,6 +20,7 @@ import { runCommandById, openCommandPalette } from '../commandPalette';
 import { openShortcutsOverlay } from '../shortcutsOverlay';
 import { spotlightElement, dismissCoachmark } from '../coachmark';
 import { getConfig, onConfigChange } from '../../config/appConfig';
+import { getState } from '../../storage/sessionManager';
 
 /** localStorage: ids the user has already been shown (rotate fresh ones first). */
 const SEEN_KEY = 'partwright-hints-seen';
@@ -35,7 +36,12 @@ let order: Hint[] = [];
 let idx = 0;
 let paused = false;
 let configUnsub: (() => void) | null = null;
+let sessionUnsub: (() => void) | null = null;
 let resizeObs: ResizeObserver | null = null;
+/** Last session id seen, so we only restore hints on a real session transition
+ *  (new / opened / switched session) — not on intra-session changes like
+ *  version navigation, which also fire 'session-changed'. */
+let lastSessionId: string | null = null;
 
 // ─── persistence helpers ──────────────────────────────────────────────────────
 
@@ -267,6 +273,25 @@ export function mountHintsTicker(hostEl: HTMLElement): void {
   host = hostEl;
   configUnsub?.();
   configUnsub = onConfigChange(() => refreshHintsTicker());
+
+  // Restore hints when the user starts or opens a *different* session — a ✕
+  // dismiss means "not now, this session", so a new session brings them back.
+  // Seed from the current id so the initial session load isn't seen as a
+  // transition (a reload keeps a same-session dismiss in place).
+  lastSessionId = getState().session?.id ?? null;
+  sessionUnsub?.();
+  const onSessionChanged = () => {
+    const id = getState().session?.id ?? null;
+    if (id && id !== lastSessionId) {
+      lastSessionId = id;
+      showHintsTicker();
+    } else {
+      lastSessionId = id;
+    }
+  };
+  window.addEventListener('session-changed', onSessionChanged);
+  sessionUnsub = () => window.removeEventListener('session-changed', onSessionChanged);
+
   refreshHintsTicker();
 }
 

--- a/src/ui/hints/hintsTicker.ts
+++ b/src/ui/hints/hintsTicker.ts
@@ -35,6 +35,7 @@ let order: Hint[] = [];
 let idx = 0;
 let paused = false;
 let configUnsub: (() => void) | null = null;
+let resizeObs: ResizeObserver | null = null;
 
 // ─── persistence helpers ──────────────────────────────────────────────────────
 
@@ -138,6 +139,8 @@ function scheduleRotate(): void {
 function teardownStrip(): void {
   window.clearTimeout(rotateTimer);
   rotateTimer = 0;
+  resizeObs?.disconnect();
+  resizeObs = null;
   dismissCoachmark();
   if (host) host.replaceChildren();
   strip = null;
@@ -153,35 +156,56 @@ function renderStrip(): void {
   order = buildOrder();
   idx = 0;
 
+  // Inline toolbar variant: lives in the toolbar's flexible middle, framed by a
+  // vertical divider on each side so the hint region (text + CTA + its ‹ › ✕
+  // controls) reads as one unit, distinct from the toolbar's left and right
+  // button clusters.
   strip = document.createElement('div');
   strip.id = 'editor-hints';
   strip.setAttribute('role', 'note');
   strip.setAttribute('aria-label', 'Did you know');
-  strip.className =
-    'flex items-center gap-2 px-3 py-1 bg-zinc-900 border-b border-zinc-800 text-xs text-zinc-400 shrink-0 overflow-hidden';
+  strip.className = 'flex-1 min-w-0 flex items-center gap-2 text-xs text-zinc-400 overflow-hidden';
 
   const badge = document.createElement('span');
   badge.className = 'shrink-0 text-zinc-500 select-none';
   badge.textContent = '💡 Did you know?';
 
   textEl = document.createElement('span');
+  textEl.id = 'editor-hints-text';
   textEl.className = 'min-w-0 truncate text-zinc-300';
 
   ctaEl = document.createElement('button');
   ctaEl.type = 'button';
   ctaEl.className = 'shrink-0 text-blue-400 hover:text-blue-300 hover:underline font-medium transition-colors';
 
-  // ‹ › step + ✕ dismiss, grouped at the right.
+  // ‹ › step + ✕ dismiss, kept tight together and right after a divider so it's
+  // clear they belong to the hints, not the adjacent "Use AI" button.
   const controls = document.createElement('div');
-  controls.className = 'shrink-0 flex items-center gap-0.5 ml-auto text-zinc-500';
+  controls.className = 'shrink-0 flex items-center gap-0.5 text-zinc-500';
 
   const prevBtn = makeIconBtn('‹', 'Previous hint', () => advance(-1));
   const nextBtn = makeIconBtn('›', 'Next hint', () => advance(1));
   const closeBtn = makeIconBtn('✕', 'Hide hints for this session', dismissForSession);
 
   controls.append(prevBtn, nextBtn, closeBtn);
-  strip.append(badge, textEl, ctaEl, controls);
+  strip.append(makeDivider(), badge, textEl, ctaEl, makeDivider(), controls);
   host.appendChild(strip);
+
+  // Degrade gracefully as the toolbar's middle shrinks (e.g. the AI panel opens
+  // or on a narrow screen): drop the "💡 Did you know?" badge first, then hide
+  // the whole strip when there's no room — so it never overflows into the
+  // adjacent toolbar buttons. The host stays flex-1, so it keeps right-aligning
+  // the AI/Import/Export cluster even when the strip is hidden.
+  const applyWidth = () => {
+    if (!strip) return;
+    const w = host!.clientWidth;
+    strip.style.display = w >= 200 ? '' : 'none';
+    badge.style.display = w >= 360 ? '' : 'none';
+  };
+  resizeObs?.disconnect();
+  resizeObs = new ResizeObserver(applyWidth);
+  resizeObs.observe(host);
+  applyWidth();
 
   // Pause rotation while the user is reading (hover) or interacting (focus).
   strip.addEventListener('pointerenter', () => { paused = true; });
@@ -191,6 +215,14 @@ function renderStrip(): void {
 
   showCurrent();
   scheduleRotate();
+}
+
+/** A thin vertical divider used to frame the hint region within the toolbar. */
+function makeDivider(): HTMLElement {
+  const d = document.createElement('span');
+  d.className = 'shrink-0 self-center h-5 w-px bg-zinc-700';
+  d.setAttribute('aria-hidden', 'true');
+  return d;
 }
 
 /** A compact control button with a ≥44px touch target via padding. */

--- a/src/ui/hints/hintsTicker.ts
+++ b/src/ui/hints/hintsTicker.ts
@@ -162,19 +162,26 @@ function renderStrip(): void {
   order = buildOrder();
   idx = 0;
 
-  // Inline toolbar variant: lives in the toolbar's flexible middle, framed by a
-  // vertical divider on each side so the hint region (text + CTA + its ‹ › ✕
-  // controls) reads as one unit, distinct from the toolbar's left and right
-  // button clusters.
+  // Centered, self-contained pill in the toolbar's middle: a subtle bordered
+  // box holding the icon, "Did you know?" label, the rotating hint, its CTA, and
+  // the ‹ › ✕ controls — all one section, distinct from the toolbar's button
+  // clusters. The host centers it (justify-center) and stays flex-1 so it also
+  // right-aligns the AI/Import/Export cluster.
   strip = document.createElement('div');
   strip.id = 'editor-hints';
   strip.setAttribute('role', 'note');
   strip.setAttribute('aria-label', 'Did you know');
-  strip.className = 'flex-1 min-w-0 flex items-center gap-2 text-xs text-zinc-400 overflow-hidden';
+  strip.className =
+    'min-w-0 max-w-full inline-flex items-center gap-2 pl-2.5 pr-1.5 py-1 rounded-md bg-zinc-800/60 border border-zinc-700/70 text-xs text-zinc-400';
+
+  const icon = document.createElement('span');
+  icon.className = 'shrink-0 text-amber-300 flex items-center';
+  icon.setAttribute('aria-hidden', 'true');
+  icon.innerHTML = SPARKLES_SVG;
 
   const badge = document.createElement('span');
   badge.className = 'shrink-0 text-zinc-500 select-none';
-  badge.textContent = '💡 Did you know?';
+  badge.textContent = 'Did you know?';
 
   textEl = document.createElement('span');
   textEl.id = 'editor-hints-text';
@@ -184,17 +191,17 @@ function renderStrip(): void {
   ctaEl.type = 'button';
   ctaEl.className = 'shrink-0 text-blue-400 hover:text-blue-300 hover:underline font-medium transition-colors';
 
-  // ‹ › step + ✕ dismiss, kept tight together and right after a divider so it's
-  // clear they belong to the hints, not the adjacent "Use AI" button.
+  // ‹ › step + ✕ dismiss, kept inside the section, set off by a thin divider so
+  // they read as the hints' own controls.
   const controls = document.createElement('div');
-  controls.className = 'shrink-0 flex items-center gap-0.5 text-zinc-500';
+  controls.className = 'shrink-0 flex items-center gap-0.5 pl-1.5 ml-0.5 border-l border-zinc-700/70 text-zinc-500';
 
   const prevBtn = makeIconBtn('‹', 'Previous hint', () => advance(-1));
   const nextBtn = makeIconBtn('›', 'Next hint', () => advance(1));
   const closeBtn = makeIconBtn('✕', 'Hide hints for this session', dismissForSession);
 
   controls.append(prevBtn, nextBtn, closeBtn);
-  strip.append(makeDivider(), badge, textEl, ctaEl, makeDivider(), controls);
+  strip.append(icon, badge, textEl, ctaEl, controls);
   host.appendChild(strip);
 
   // Degrade gracefully as the toolbar's middle shrinks (e.g. the AI panel opens
@@ -223,13 +230,9 @@ function renderStrip(): void {
   scheduleRotate();
 }
 
-/** A thin vertical divider used to frame the hint region within the toolbar. */
-function makeDivider(): HTMLElement {
-  const d = document.createElement('span');
-  d.className = 'shrink-0 self-center h-5 w-px bg-zinc-700';
-  d.setAttribute('aria-hidden', 'true');
-  return d;
-}
+// Lucide "sparkles" — a cooler stand-in for the old 💡, evoking tips/discovery.
+const SPARKLES_SVG =
+  '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg>';
 
 /** A compact control button with a ≥44px touch target via padding. */
 function makeIconBtn(glyph: string, label: string, onClick: () => void): HTMLButtonElement {

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -296,7 +296,7 @@ export function createToolbar(
   // (src/ui/hints/hintsTicker.ts) into this element by id.
   const hintsHost = document.createElement('div');
   hintsHost.id = 'editor-hints-host';
-  hintsHost.className = 'flex-1 min-w-0 flex items-center mx-2';
+  hintsHost.className = 'flex-1 min-w-0 flex items-center justify-center mx-2';
   toolbar.appendChild(hintsHost);
 
   // Use AI — primary entry point to the chat drawer. The activity rail also

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -289,10 +289,15 @@ export function createToolbar(
   langHelpBtn.addEventListener('click', () => { void callbacks.onLanguageHelp(); });
   toolbar.appendChild(langHelpBtn);
 
-  // Spacer
-  const spacer = document.createElement('div');
-  spacer.className = 'flex-1';
-  toolbar.appendChild(spacer);
+  // Hints ticker host — fills the flexible middle of the toolbar, between the
+  // language help "?" and the "Use AI" button. Kept flex-1 so it also acts as
+  // the spacer that right-aligns the AI/Import/Export group even when the ticker
+  // is dismissed or disabled (the host is then empty). main.ts mounts the ticker
+  // (src/ui/hints/hintsTicker.ts) into this element by id.
+  const hintsHost = document.createElement('div');
+  hintsHost.id = 'editor-hints-host';
+  hintsHost.className = 'flex-1 min-w-0 flex items-center mx-2';
+  toolbar.appendChild(hintsHost);
 
   // Use AI — primary entry point to the chat drawer. The activity rail also
   // has a "✦ AI" item, but on mobile it lives in a horizontally-scrollable

--- a/tests/editor-hints.spec.ts
+++ b/tests/editor-hints.spec.ts
@@ -41,6 +41,22 @@ test.describe('editor hints ticker', () => {
     await expect(strip).toHaveCount(0);
   });
 
+  test('a new session restores hints dismissed with ✕', async ({ page }) => {
+    await page.goto('/editor');
+    const strip = page.locator('#editor-hints');
+    await expect(strip).toBeVisible({ timeout: 15_000 });
+
+    await strip.getByRole('button', { name: /Hide hints/ }).click();
+    await expect(strip).toHaveCount(0);
+
+    // Starting a different session means "✕ was just for that session".
+    await page.evaluate(() =>
+      (window as unknown as { partwright: { createSession: (n?: string) => Promise<unknown> } })
+        .partwright.createSession('hints-test'),
+    );
+    await expect(strip).toBeVisible({ timeout: 8000 });
+  });
+
   test('a coach CTA pulses an arrow at the target control', async ({ page }) => {
     await page.goto('/editor');
     const strip = page.locator('#editor-hints');

--- a/tests/editor-hints.spec.ts
+++ b/tests/editor-hints.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from 'playwright/test';
+
+// Golden path for the "Did you know?" hints ticker (src/ui/hints/*).
+test.describe('editor hints ticker', () => {
+  test.beforeEach(async ({ page }) => {
+    // Suppress the first-run guided tour — its backdrop would intercept clicks.
+    await page.addInitScript(() => {
+      try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+    });
+  });
+
+  test('shows, rotates, coaches, and dismisses', async ({ page }) => {
+    await page.goto('/editor');
+
+    const strip = page.locator('#editor-hints');
+    await expect(strip).toBeVisible({ timeout: 15_000 });
+
+    // Badge + a CTA link are present.
+    await expect(strip).toContainText('Did you know?');
+    const cta = strip.locator('button').filter({ hasText: '→' }).first();
+    await expect(cta).toBeVisible();
+
+    // The hint text is non-empty.
+    const hintText = strip.locator('span').nth(1);
+    const first = (await hintText.textContent())?.trim() ?? '';
+    expect(first.length).toBeGreaterThan(0);
+
+    // The › arrow advances to a different hint.
+    await strip.getByRole('button', { name: 'Next hint' }).click();
+    await expect.poll(async () => (await hintText.textContent())?.trim()).not.toBe(first);
+
+    await page.screenshot({ path: 'test-results/editor-hints.png' });
+
+    // ✕ hides the strip for the session.
+    await strip.getByRole('button', { name: /Hide hints/ }).click();
+    await expect(strip).toHaveCount(0);
+  });
+
+  test('a coach CTA pulses an arrow at the target control', async ({ page }) => {
+    await page.goto('/editor');
+    const strip = page.locator('#editor-hints');
+    await expect(strip).toBeVisible({ timeout: 15_000 });
+
+    // Step to the BREP-engine hint, whose CTA coaches the language toggle.
+    const hintText = strip.locator('span').nth(1);
+    let found = false;
+    for (let i = 0; i < 12; i++) {
+      const t = (await hintText.textContent())?.toLowerCase() ?? '';
+      if (t.includes('brep')) { found = true; break; }
+      await strip.getByRole('button', { name: 'Next hint' }).click();
+    }
+    expect(found).toBe(true);
+
+    await strip.locator('button').filter({ hasText: '→' }).first().click();
+    // The coachmark ring appears and points near the language toggle.
+    await expect(page.locator('.pw-coachmark-ring')).toBeVisible({ timeout: 4000 });
+    await expect(page.locator('.pw-coachmark-bubble')).toContainText('engine');
+    await page.screenshot({ path: 'test-results/editor-hints-coach.png' });
+  });
+});

--- a/tests/editor-hints.spec.ts
+++ b/tests/editor-hints.spec.ts
@@ -3,9 +3,14 @@ import { test, expect } from 'playwright/test';
 // Golden path for the "Did you know?" hints ticker (src/ui/hints/*).
 test.describe('editor hints ticker', () => {
   test.beforeEach(async ({ page }) => {
-    // Suppress the first-run guided tour — its backdrop would intercept clicks.
     await page.addInitScript(() => {
-      try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+      try {
+        // Suppress the first-run guided tour — its backdrop intercepts clicks.
+        localStorage.setItem('partwright-tour-completed', '1');
+        // Start with the AI panel closed so the toolbar's middle has room for
+        // the inline ticker (it collapses responsively when space is tight).
+        localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({ drawerOpen: false }));
+      } catch { /* ignore */ }
     });
   });
 
@@ -21,7 +26,7 @@ test.describe('editor hints ticker', () => {
     await expect(cta).toBeVisible();
 
     // The hint text is non-empty.
-    const hintText = strip.locator('span').nth(1);
+    const hintText = page.locator('#editor-hints-text');
     const first = (await hintText.textContent())?.trim() ?? '';
     expect(first.length).toBeGreaterThan(0);
 
@@ -42,7 +47,7 @@ test.describe('editor hints ticker', () => {
     await expect(strip).toBeVisible({ timeout: 15_000 });
 
     // Step to the BREP-engine hint, whose CTA coaches the language toggle.
-    const hintText = strip.locator('span').nth(1);
+    const hintText = page.locator('#editor-hints-text');
     let found = false;
     for (let i = 0; i < 12; i++) {
       const t = (await hintText.textContent())?.toLowerCase() ?? '';

--- a/tests/unit/hintsData.test.ts
+++ b/tests/unit/hintsData.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { HINTS, DEFAULT_CTA_LABEL, type Hint } from '../../src/ui/hints/hintsData';
+
+// Command ids the hints may reference. Mirrors the registerCommands(...) call in
+// src/main.ts — keep in sync so a typo'd CTA id is caught here rather than
+// silently no-op'ing at runtime (runCommandById returns false for unknown ids).
+const REGISTERED_COMMAND_IDS = new Set([
+  'run', 'save', 'format', 'new-session', 'open-sessions',
+  'tab-interactive', 'tab-gallery', 'tab-versions', 'tab-images', 'tab-diff', 'tab-notes', 'tab-data',
+  'export-glb', 'export-stl', 'export-obj', 'export-3mf', 'export-vox', 'export-step',
+  'share-link',
+  'tool-measure', 'tool-cross-section', 'tool-paint', 'tool-palette', 'tool-image-paint',
+  'tool-annotate', 'tool-quality', 'tool-customize',
+  'toggle-ai', 'toggle-diagnostics',
+  'open-catalog', 'open-ideas', 'open-help', 'open-whats-new',
+  'open-quality', 'retake-tour', 'toggle-hints',
+]);
+
+describe('hints dataset', () => {
+  it('is non-empty', () => {
+    expect(HINTS.length).toBeGreaterThan(0);
+  });
+
+  it('has unique ids', () => {
+    const ids = HINTS.map(h => h.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every hint has text and an id', () => {
+    for (const h of HINTS) {
+      expect(h.id, JSON.stringify(h)).toBeTruthy();
+      expect(h.text.trim().length, h.id).toBeGreaterThan(0);
+    }
+  });
+
+  it('command/coach CTAs reference only registered command ids', () => {
+    const referenced: string[] = [];
+    for (const h of HINTS) {
+      if (h.cta.kind === 'command') referenced.push(h.cta.id);
+      if (h.cta.kind === 'coach') referenced.push(...(h.cta.prep ?? []));
+    }
+    for (const id of referenced) {
+      expect(REGISTERED_COMMAND_IDS.has(id), `unknown command id: ${id}`).toBe(true);
+    }
+  });
+
+  it('coach CTAs have a CSS-selector target and an openSelector that is a selector', () => {
+    for (const h of HINTS) {
+      if (h.cta.kind !== 'coach') continue;
+      expect(h.cta.target.startsWith('#') || h.cta.target.startsWith('['), h.id).toBe(true);
+      if (h.cta.openSelector) {
+        expect(h.cta.openSelector.startsWith('#') || h.cta.openSelector.startsWith('['), h.id).toBe(true);
+      }
+    }
+  });
+
+  it('open CTAs target a known overlay', () => {
+    for (const h of HINTS) {
+      if (h.cta.kind !== 'open') continue;
+      expect(['commandPalette', 'shortcuts']).toContain(h.cta.what);
+    }
+  });
+
+  it('exposes a default CTA label', () => {
+    expect(DEFAULT_CTA_LABEL.length).toBeGreaterThan(0);
+  });
+});
+
+// Type smoke: the exported Hint type is usable.
+const _sample: Hint = HINTS[0];
+void _sample;


### PR DESCRIPTION
## Summary

Adds an always-present **"Did you know?"** hints section in the **top toolbar** — a centered, self-contained pill (between the language toggle's `?` and the "Use AI" button) that rotates through discovery hints. The pill holds a sparkles icon, the label, the rotating hint, a CTA, and its `‹ › ✕` controls all as one section. Hints cover capabilities a new user is unlikely to stumble onto: ⌘K command palette, surface textures, multi-color paint, BREP/STEP, the Diff tab, the catalog, photo→model, and more.

Each hint has a **call-to-action**. CTAs reuse the existing command-palette registry for navigation/tab-switches/open-modal actions, and a new lightweight **coachmark** for in-editor features: clicking the CTA switches to the 3D view, opens the relevant menu, and pulses an arrow at the exact control — so the user learns *where the feature lives*, not just that it exists.

### Behavior
- **Shown by default.** The `✕` hides it for the **current design session**; **starting or opening a different session brings it back** (a reload keeps a same-session dismiss). A permanent on/off lives in **Advanced Settings → "Show editor hints"** (`config.ui.editorHintsEnabled`), also flipped by a new `toggle-hints` command. Rotation interval is configurable (`config.ui.hintRotationMs`, default 12s).
- **Random starting hint:** the order is shuffled each load (biased to unseen hints first for discovery), so you don't see the same hint every time. Rotation **pauses on hover/focus**; `‹ ›` step manually.
- **Responsive:** a `ResizeObserver` drops the "Did you know?" label when the toolbar middle is medium and hides the whole pill when there's no room — so it never overflows into adjacent buttons (e.g. AI panel open on a narrow window). It reappears when the panel closes or the window is wider.

### Implementation
- **`src/ui/hints/hintsData.ts`** — hints dataset + a discriminated-union `HintCta` (`command` / `open` / `coach`). Dependency-free so it unit-tests in the node tier.
- **`src/ui/hints/hintsTicker.ts`** — the pill: shuffled rotation, dismiss, prev/next, CTA dispatch, responsive ResizeObserver, session-change restore, mount/unmount.
- **`src/ui/coachmark.ts`** — a reusable non-modal pulse-ring + arrow that's `pointer-events:none` (so the user can click the highlighted control through it) and bails gracefully on missing/hidden targets.
- **`src/ui/toolbar.ts`** — `#editor-hints-host` (flex-1, `justify-center`) replaces the spacer, so the pill centers and still right-aligns the AI/Import/Export cluster.
- **`src/ui/commandPalette.ts`** — new `runCommandById(id)` so non-palette UI can reuse registered actions (respecting `enabled`).
- **`src/config/appConfig.ts`** — `editorHintsEnabled` + `hintRotationMs`; new `onConfigChange` subscription so the settings toggle takes effect live.
- **`src/ui/advancedSettingsModal.tsx`** — a `ToggleField` + the two fields in the UI section.
- **`src/main.ts`** — mounts the ticker into the toolbar host, and the `toggle-hints` command.

## Test plan
- `npm run build` ✅ · `npm run test:unit` ✅ (694 incl. `tests/unit/hintsData.test.ts`) · `npm run lint:deps` ✅ (no cycles)
- `tests/editor-hints.spec.ts` ✅ — renders/rotates/✕-dismisses, new-session restores a dismissed pill, and a coach CTA pulses an arrow at the target.
- Manual browser verification with screenshots in the session: the centered pill, the toolbar placement across widths (panel closed/open, narrow/wide), and both coachmarks.

https://claude.ai/code/session_01NEoN3u86Y2ajoiGytQv3Ra