### PR TITLE
feat: wrap editor hints multiline when cramped, hide on mobile

### DIFF
--- a/prompts/20260606-hints-multiline.md
+++ b/prompts/20260606-hints-multiline.md
@@ -1,0 +1,50 @@
+---
+date: 2026-06-06
+branch: claude/awesome-lamport-MnWRP
+files_changed:
+  - src/ui/hints/hintsTicker.ts
+---
+
+## Human
+
+When the AI pane is open the hint box shows messages with an ellipsis. Can we
+make it where if the AI pane is open (or otherwise the horizontal space is
+cramped) that we multiline it and expand it vertically? On mobile when it's very
+small we should probably just not bother showing it.
+
+## Assistant
+
+The "Did you know?" hints strip lives in the toolbar's flex-1 middle host
+(`src/ui/hints/hintsTicker.ts`). Its text span carried Tailwind `truncate`
+(`white-space: nowrap; overflow: hidden; text-overflow: ellipsis`), so whenever
+the AI panel opened — which shrinks the toolbar middle, since the panel is a real
+flex column eating layout width — the hint collapsed to one ellipsised line.
+
+Two changes:
+
+- **Wrap instead of truncate.** Swapped `truncate` for
+  `break-words line-clamp-3` on the text span. Natural wrapping means the hint
+  stays on one line when there's room and only expands vertically when cramped
+  (AI panel open or a narrow window) — which is exactly the "if cramped, go
+  multiline" ask, with no need to explicitly watch the panel toggle since the
+  existing `ResizeObserver` on the host already reacts to the width change.
+  `line-clamp-3` caps growth at three lines so a very long hint on a very narrow
+  strip can't balloon the toolbar; the flex siblings (icon, badge, CTA, ‹›✕
+  controls) stay vertically centered via the strip's `items-center`.
+- **Hide on mobile.** The strip previously only hid below a 200px host width,
+  which doesn't reliably trigger on mobile (the wrapped toolbar can still give
+  the host a wide row). Added a `matchMedia('(min-width: 768px)')` gate to the
+  `applyWidth` check so the strip is hidden outright below the app's md
+  breakpoint — the toolbar is already cramped and wrapping on phones, so the
+  discovery strip isn't worth the space there. Re-evaluated on breakpoint
+  `change` too (a window resize across 768px may not shift the host's own width
+  enough to trip the ResizeObserver) and cleaned the listener up in
+  `teardownStrip` alongside the existing observer disconnect.
+
+Used the md (768px) convention the rest of the app uses (`layout.ts`,
+`aiPanel.ts`) for "mobile" rather than inventing a new cutoff.
+
+Verified with a throwaway Playwright probe at three viewports: AI closed/wide →
+visible, single line; AI open (host ~388px) → wraps to multiple lines, strip
+grows vertically; mobile (390px) → strip hidden. `npm run build` and
+`npm run test:unit` (718) green.

--- a/src/ui/hints/hintsTicker.ts
+++ b/src/ui/hints/hintsTicker.ts
@@ -38,6 +38,7 @@ let paused = false;
 let configUnsub: (() => void) | null = null;
 let sessionUnsub: (() => void) | null = null;
 let resizeObs: ResizeObserver | null = null;
+let desktopMqCleanup: (() => void) | null = null;
 /** Last session id seen, so we only restore hints on a real session transition
  *  (new / opened / switched session) — not on intra-session changes like
  *  version navigation, which also fire 'session-changed'. */
@@ -159,6 +160,8 @@ function teardownStrip(): void {
   rotateTimer = 0;
   resizeObs?.disconnect();
   resizeObs = null;
+  desktopMqCleanup?.();
+  desktopMqCleanup = null;
   dismissCoachmark();
   if (host) host.replaceChildren();
   strip = null;
@@ -197,7 +200,12 @@ function renderStrip(): void {
 
   textEl = document.createElement('span');
   textEl.id = 'editor-hints-text';
-  textEl.className = 'min-w-0 truncate text-zinc-300';
+  // Wrap onto multiple lines when horizontal room is tight (e.g. the AI panel
+  // is open) instead of truncating to a single ellipsised line — the strip
+  // grows vertically and the toolbar row grows with it. A long hint still fits
+  // on one line when there's room; line-clamp-3 caps the growth at three lines
+  // so a very long hint on a very narrow strip can't balloon the toolbar.
+  textEl.className = 'min-w-0 text-zinc-300 break-words line-clamp-3';
 
   ctaEl = document.createElement('button');
   ctaEl.type = 'button';
@@ -217,19 +225,28 @@ function renderStrip(): void {
   host.appendChild(strip);
 
   // Degrade gracefully as the toolbar's middle shrinks (e.g. the AI panel opens
-  // or on a narrow screen): drop the "💡 Did you know?" badge first, then hide
-  // the whole strip when there's no room — so it never overflows into the
-  // adjacent toolbar buttons. The host stays flex-1, so it keeps right-aligning
-  // the AI/Import/Export cluster even when the strip is hidden.
+  // or on a narrow screen). On mobile the toolbar already wraps and is cramped,
+  // so the discovery strip isn't worth the space — hide it outright below the
+  // md (768px) breakpoint. On desktop, drop the "💡 Did you know?" badge first
+  // as room tightens, let the hint text wrap to multiple lines (see textEl
+  // above), and finally hide the whole strip when there's genuinely no room —
+  // so it never overflows into the adjacent toolbar buttons. The host stays
+  // flex-1, so it keeps right-aligning the AI/Import/Export cluster even when
+  // the strip is hidden.
+  const desktopMq = window.matchMedia('(min-width: 768px)');
   const applyWidth = () => {
     if (!strip) return;
     const w = host!.clientWidth;
-    strip.style.display = w >= 200 ? '' : 'none';
+    strip.style.display = desktopMq.matches && w >= 200 ? '' : 'none';
     badge.style.display = w >= 360 ? '' : 'none';
   };
   resizeObs?.disconnect();
   resizeObs = new ResizeObserver(applyWidth);
   resizeObs.observe(host);
+  // Re-evaluate on breakpoint crossings: resizing the window across 768px may
+  // not shift the host's own width enough to trip the ResizeObserver.
+  desktopMq.addEventListener('change', applyWidth);
+  desktopMqCleanup = () => desktopMq.removeEventListener('change', applyWidth);
   applyWidth();
 
   // Pause rotation while the user is reading (hover) or interacting (focus).


### PR DESCRIPTION
## Summary

When the AI panel is open (or the window is otherwise narrow) the "Did you know?" hints strip in the toolbar truncated its message to a single ellipsised line. This makes the hint **wrap onto multiple lines and expand vertically** when horizontal room is tight, and **hides the strip entirely on mobile**.

The hints strip lives in the toolbar's `flex-1` middle host (`src/ui/hints/hintsTicker.ts`). The AI panel is a real flex column, so opening it shrinks that host — which the existing `ResizeObserver` already reacts to.

- **Wrap instead of truncate.** Swapped the text span's Tailwind `truncate` (`white-space: nowrap` + ellipsis) for `break-words line-clamp-3`. Natural wrapping keeps the hint on one line when there's room and only grows vertically when cramped (AI panel open / narrow window) — so no need to explicitly listen for the panel toggle. `line-clamp-3` caps growth at three lines so a very long hint on a very narrow strip can't balloon the toolbar; the icon/badge/CTA/`‹ › ✕` controls stay vertically centered.
- **Hide on mobile.** The strip previously only hid below a 200px host width, which doesn't reliably trigger on phones (the wrapped toolbar can still give the host a wide row). Added a `matchMedia('(min-width: 768px)')` gate so the strip is hidden below the app's md breakpoint — the toolbar is already cramped/wrapping on phones, so the discovery strip isn't worth the space there. The breakpoint `change` is also wired up (a resize across 768px may not move the host's own width enough to trip the ResizeObserver) and the listener is cleaned up in `teardownStrip`.

Used the md (768px) cutoff the rest of the app uses (`layout.ts`, `aiPanel.ts`) for "mobile."

## Test plan

Verified with a throwaway Playwright probe at three viewports (screenshots posted in the session):

- AI closed, wide window → strip visible, single line for normal hints
- AI open (host ~388px) → text wraps to multiple lines, strip expands vertically, CTA/controls centered
- Mobile (390px) → strip hidden entirely

`npm run build` ✅ · `npm run test:unit` (718) ✅

https://claude.ai/code/session_01BCQcRK6isXqAh5nnr3ios7

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQcRK6isXqAh5nnr3ios7)_