### PR TITLE
feat: add data-usage, share, inspect, export & tour hints

### DIFF
--- a/prompts/20260606-hints-data-usage.md
+++ b/prompts/20260606-hints-data-usage.md
@@ -1,0 +1,42 @@
+---
+session: "serene-cray"
+timestamp: "2026-06-06T22:40:00Z"
+model: claude-opus-4-8
+tools: [explore, Bash, Edit, Write, Read, AskUserQuestion]
+---
+
+## Human
+
+Added a hint feature recently. Realized it'd be good to tell people they can
+view and control all browser data usage and wipe all local data like API keys.
+Update the hint list — and think of more things to add.
+
+## Assistant
+
+## Key decisions
+
+**The Data tab is the honest hub for the requested ask.** `tab-data`
+(`switchTab('data')`, `src/ui/dataExplorer.ts`) browses every IndexedDB store +
+localStorage with a "Total browser storage used" readout and a "Manage / delete
+data…" link to the Uninstall modal (`showUninstallModal`, which wipes selectable
+categories incl. `aiKeys`). So one hint with a `command` CTA to `tab-data`
+covers both "view all browser data usage" and "wipe local data incl. API keys"
+— rather than splitting across the Settings → Uninstall button (which has no
+direct open command). Copy: "See exactly what Partwright stores in your browser
+— and wipe it all, including AI API keys, anytime."
+
+**Added four more underused-feature hints** (user selected all four from a
+multi-select): `share-link` (read-only share link, `command` CTA), `inspect-tools`
+(measure + cross-section — `coach` pointing at `#measure-toggle` inside the
+`#viewport-inspect-group-btn` popover, mirroring the paint/surface coach
+pattern), `export-formats` (`coach` at `#export-wrapper`, mirroring the import
+hint), and `guided-tour` (`command` → `retake-tour`).
+
+**Verification:** all CTA command ids (`tab-data`, `share-link`, `retake-tour`)
+are in the unit test's `REGISTERED_COMMAND_IDS` mirror, and all coach selectors
+were confirmed against the live DOM (popover button id convention is
+`${id}-group-btn` from `createPopoverGroup` in `popoverMenu.ts`). Updated the
+verified-targets comment block at the top of `hintsData.ts`. Ran the hints unit
+test (7 passing), `npm run build`, and a throwaway Playwright spec that rotated
+the ticker to the data-usage hint and confirmed its CTA opens the Data tab
+(screenshots posted in chat, scratch spec deleted).

--- a/src/ui/hints/hintsData.ts
+++ b/src/ui/hints/hintsData.ts
@@ -50,11 +50,14 @@ export const DEFAULT_CTA_LABEL = 'Check it out →';
 
 // Order here is the rotation order for a fresh user; the ticker prioritizes
 // unseen hints and then cycles. Targets/ids are verified against the live DOM:
-//   #viewport-tools-group-btn  — the "Tools ▾" popover trigger (clip-controls)
-//   #paint-toggle              — Paint button (inside the Tools popover)
-//   #surface-viewport-toggle   — ✦ Surface button (inside the Tools popover)
-//   #lang-toggle               — JS/SCAD/BREP/VOXEL engine switch (toolbar)
-//   #import-wrapper            — Import dropdown (toolbar)
+//   #viewport-tools-group-btn   — the "Tools ▾" popover trigger (clip-controls)
+//   #paint-toggle               — Paint button (inside the Tools popover)
+//   #surface-viewport-toggle    — ✦ Surface button (inside the Tools popover)
+//   #viewport-inspect-group-btn — the "Inspect ▾" popover trigger (toolbar)
+//   #measure-toggle             — 📏 Measure button (inside the Inspect popover)
+//   #lang-toggle                — JS/SCAD/BREP/VOXEL engine switch (toolbar)
+//   #import-wrapper             — Import dropdown (toolbar)
+//   #export-wrapper             — Export dropdown (toolbar)
 export const HINTS: Hint[] = [
   {
     id: 'command-palette',
@@ -139,5 +142,46 @@ export const HINTS: Hint[] = [
       placement: 'bottom',
       label: 'Import meshes, source files, or whole sessions here.',
     },
+  },
+  {
+    id: 'export-formats',
+    text: 'Export your model to STL, OBJ, 3MF, GLB, STEP, or VOX for printing or other CAD tools.',
+    ctaLabel: 'Show export →',
+    cta: {
+      kind: 'coach',
+      target: '#export-wrapper',
+      placement: 'bottom',
+      label: 'Export to STL, OBJ, 3MF, GLB, STEP & more here.',
+    },
+  },
+  {
+    id: 'inspect-tools',
+    text: 'Measure distances between points and slice the model with a cross-section plane.',
+    ctaLabel: 'Find the tools →',
+    cta: {
+      kind: 'coach',
+      openSelector: '#viewport-inspect-group-btn',
+      target: '#measure-toggle',
+      placement: 'bottom',
+      label: 'Measure & cross-section the model from here.',
+    },
+  },
+  {
+    id: 'share-link',
+    text: 'Share a read-only link to your design — anyone can open it and fork their own copy.',
+    ctaLabel: 'Copy a link →',
+    cta: { kind: 'command', id: 'share-link' },
+  },
+  {
+    id: 'data-usage',
+    text: 'See exactly what Partwright stores in your browser — and wipe it all, including AI API keys, anytime.',
+    ctaLabel: 'Open Data tab →',
+    cta: { kind: 'command', id: 'tab-data' },
+  },
+  {
+    id: 'guided-tour',
+    text: 'New here? Take the guided tour for a quick walkthrough of the editor.',
+    ctaLabel: 'Start the tour →',
+    cta: { kind: 'command', id: 'retake-tour' },
   },
 ];


### PR DESCRIPTION
## Summary

Expands the editor "Did you know?" hints ticker (`src/ui/hints/hintsData.ts`) with five new hints, headlined by the one requested: surfacing that users can **view all browser data usage and wipe local data including AI API keys**.

- **`data-usage`** — "See exactly what Partwright stores in your browser — and wipe it all, including AI API keys, anytime." CTA opens the **Data tab** (`tab-data`), which lists every IndexedDB store + localStorage, shows total browser storage used, and links to the Uninstall modal for wiping. This is the honest hub for both viewing usage *and* wiping (incl. the `aiKeys` store).
- **`share-link`** — share a read-only link to a design (`share-link` command).
- **`inspect-tools`** — measure distances + cross-section the model (coach mark at `#measure-toggle` inside the Inspect popover).
- **`export-formats`** — STL / OBJ / 3MF / GLB / STEP / VOX (coach mark at `#export-wrapper`).
- **`guided-tour`** — take the guided tour (`retake-tour` command).

Also updated the verified-targets comment block at the top of `hintsData.ts` to cover the two new DOM selectors.

## Test plan

- [x] `npx vitest run tests/unit/hintsData.test.ts` — 7 passing (ids unique, all CTA command ids registered, coach selectors valid)
- [x] `npm run build` — type-check + production build green
- [x] Manual browser check (throwaway Playwright spec, since deleted): rotated the ticker to the `data-usage` hint and confirmed its CTA opens the Data tab showing AI API keys + total storage + "Manage / delete data…". Screenshots posted in the session.

https://claude.ai/code/session_01PVTtaoXr9ZXmRxA9WRnFic

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVTtaoXr9ZXmRxA9WRnFic)_