### PR TITLE
feat: engine-aware headless preview + photo→voxel CLI

### DIFF
--- a/docs/headless-cli.md
+++ b/docs/headless-cli.md
@@ -42,6 +42,9 @@ subsequent call.
 partwright preview <file.js> [--png out.png] [--json] [--size N] [-p k=v ...]
 partwright run     <file.js> [-p k=v ...]            # stats JSON only, no PNG
 
+partwright preview <file.js> [--lang manifold-js|voxel|scad] [--png out] [--json] [--size N] [-p k=v]
+partwright photo <image> [--palette p.json] [--max N] [--mode billboard|heightmap] [--depth N] [--bg] [--crop x,y,w,h] [--out model.js] [--png out]
+
 partwright daemon start [--app-port N] [--control-port N]
 partwright daemon stop
 partwright daemon status
@@ -84,8 +87,27 @@ the CLI itself failed, while `ok:false` is a tractable in-model error.
 here). It loads the file against the real engine via Vite SSR and prints the rich
 stat block (`isManifold`, `componentCount`, per-component volumes/bboxes, genus,
 edge stats, declared labels, `warnings[]`). Unless `--json` is passed it also
-writes a 4-view PNG (front/right/top/iso), software-rasterized — flat shading,
-model-declared label colors only. `run` is `preview --json` (stats, no PNG).
+writes a 4-view PNG (front/right/top/iso), software-rasterized — flat shading.
+
+**Multi-engine (`--lang`).** `preview`/`run` dispatch across the engines that
+run without a browser: `manifold-js` (default), `voxel` (pure-JS grid mesher),
+and `scad` (OpenSCAD's Emscripten WASM loads cleanly under Node). For these the
+rasterizer uses the mesh's own per-triangle colors, so voxel/painted models show
+their real colors — not just label colors. `replicad` is **not** stateless: its
+OpenCASCADE WASM resolves its `.wasm` to a server-style path that doesn't exist
+on Node's filesystem, so preview it through the Phase-2 daemon
+(`partwright iterate --lang replicad <file>`), which drives the real app.
+
+**`photo`** turns a raster image into a palette-constrained voxel model — the CLI
+front door to the same image→voxel pipeline the in-app import modal uses
+(`src/import/imageToVoxel.ts`): decode + EXIF-orient + high-quality downsample
+(sharp) → snap every pixel to the nearest palette colour (perceptual LAB
+distance) → optional background removal → emit runnable `voxels.decode(…)` editor
+code, mesh it, and write a 4-view preview PNG + stats (voxel count, dims, and a
+per-slot palette-usage histogram) in one shot. `--palette p.json` takes a JSON
+array of `"#rrggbb"` strings or `{name,hex}` objects; omit it for the app's
+default 6-slot palette. `--mode heightmap` makes brightness drive per-column
+depth (a bas-relief sculpt) instead of a flat `--depth` billboard.
 
 What Phase 1 **cannot** show: brush-painted vertex colors, annotations, edge
 overlays, surface modifiers, anything stateful (sessions/versions). Those live in

--- a/prompts/20260607-headless-multi-engine-preview-and-photo.md
+++ b/prompts/20260607-headless-multi-engine-preview-and-photo.md
@@ -1,0 +1,63 @@
+---
+session: "01CZby"
+timestamp: "2026-06-07T14:20:00Z"
+---
+
+## Human
+
+I want to create highly detailed voxel versions of my photos, constrained to a
+fixed colour palette I own (15 colours), and iterate quickly by having previews
+generated from the CLI. Also: I want to be able to generate previews for all 4
+engines I have, even if that requires CLI updates — do that first so the voxel
+preview comes out correctly.
+
+(Scope narrowed during the session to one photo — a wide-eyed gray tabby,
+supplied via a Google Photos share link.)
+
+## Assistant
+
+## Key decisions
+
+**Made the stateless preview tier engine-aware instead of writing a one-off
+photo script.** `src/tools/previewModel.ts` (behind `model:preview` and
+`partwright preview/run`) only ran `manifold-js`. The voxel `voxels.decode(…)`
+code the app's image import emits runs in a *separate* engine (`api.voxels` is
+not in the manifold-js sandbox), so it could never preview through that path.
+Rather than bridge photos→PNG in isolation, `previewModel` now takes a `lang`
+and dispatches to the right engine — the same dogfooding the app does — so any
+voxel/SCAD model previews through the standard tool. `--lang` threads through
+`scripts/cli/preview.mjs`, `scripts/cli/main.mjs`, and `scripts/model-preview.mjs`.
+
+**Three of four engines run in the fast (no-browser) tier; replicad stays
+Phase-2.** Spiked each under Vite SSR in Node: `voxel` is pure JS (trivial),
+`scad`'s OpenSCAD WASM initialises cleanly (~600 ms), but `replicad`'s
+OpenCASCADE glue resolves its `.wasm` to a server-style `/node_modules/…` path
+that doesn't exist on Node's filesystem (`__dirname` shim gets past the first
+error, then the binary 404s). Fixing that is fragile WASM-path plumbing, and the
+Phase-2 daemon already drives replicad via the real app, so `STATELESS_ENGINES`
+is `['manifold-js','voxel','scad']` and replicad is documented as
+`iterate --lang replicad`.
+
+**Reconstruct a Manifold from the mesh for non-manifold-js stats.** The voxel
+and SCAD paths hand back `manifold: null` (voxel never builds one; the worker
+frees SCAD's). `previewModel` now round-trips `Manifold.ofMesh(mesh)` to compute
+volume/genus/components — voxel meshes are welded + watertight so this is exact —
+and frees the reconstructed handle. The rasterizer also prefers the mesh's own
+`triColors` (per-triangle, the layout `composePng` already wants) over
+label-derived colours, so per-voxel palette colours render faithfully.
+
+**`partwright photo` is the CLI front door to the existing image→voxel
+pipeline, not a reimplementation.** `scripts/cli/photo.mjs` does file IO on the
+main thread (sharp: decode + EXIF-orient + Lanczos downsample, optional crop)
+and loads `src/import/imageToVoxel.ts` + the voxel mesher via SSR, so the codegen
+matches the in-app import exactly (one source of truth, no drift). It resizes to
+the target longest-side with sharp first so the pipeline's own nearest-neighbour
+downsample is a no-op — area averaging beats point-sampling a 12 MP photo to
+64 px. One command emits the `voxels.decode(…)` model, a 4-view PNG, and stats
+(voxel count, dims, per-slot palette histogram). Palette via `--palette` (JSON
+of `"#rrggbb"` or `{name,hex}`); the user's 15-colour palette lives under
+`.plans/` (gitignored, personal), and the CLI default is the app's 6-slot
+palette.
+
+This is the prototype for a possible in-app "photo → voxel" feature; keeping the
+conversion in the shared TS module means the CLI and a future UI stay in sync.

--- a/scripts/cli/main.mjs
+++ b/scripts/cli/main.mjs
@@ -4,6 +4,7 @@
 import { resolve, dirname, basename, join } from 'node:path';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { runPreview, composePng } from './preview.mjs';
+import { runPhoto, meshToPng, loadPalette } from './photo.mjs';
 import { runDaemon } from './daemon.mjs';
 import { startDaemon, stopDaemon, statusDaemon, rpc, evalInPage, resetPage } from './client.mjs';
 
@@ -33,9 +34,9 @@ const json = (v) => JSON.stringify(v, (_k, val) => (ArrayBuffer.isView(val) ? un
 async function cmdPreview(argv, { pngDefault }) {
   const a = parse(argv, ['json']);
   const file = a._[0];
-  if (!file) { console.error('usage: partwright preview <file.js> [--png out] [--json] [--size N] [-p k=v]'); process.exit(2); }
+  if (!file) { console.error('usage: partwright preview <file.js> [--lang manifold-js|voxel] [--png out] [--json] [--size N] [-p k=v]'); process.exit(2); }
   const abs = resolve(file);
-  const result = await runPreview(abs, { params: a.params });
+  const result = await runPreview(abs, { params: a.params, lang: a.lang || 'manifold-js' });
   if (!result.ok) { console.log(json({ ok: false, error: result.error, diagnostics: result.diagnostics })); process.exit(1); }
 
   let pngPath = null;
@@ -45,6 +46,44 @@ async function cmdPreview(argv, { pngDefault }) {
     await img.toFile(pngPath);
   }
   console.log(json({ ok: true, png: pngPath, stats: result.stats }));
+}
+
+// Photo → palette-constrained voxel model. Stateless (no daemon): decode +
+// snap + emit `voxels.decode(…)` code, write a 4-view preview PNG, print stats.
+async function cmdPhoto(argv) {
+  const a = parse(argv, ['bg', 'invert', 'json', 'calls']);
+  const file = a._[0];
+  if (!file) { console.error('usage: partwright photo <image> [--out model.js] [--png out.png] [--palette p.json] [--max N] [--mode billboard|heightmap] [--depth N] [--bg] [--crop x,y,w,h] [--brightness n] [--contrast n] [--saturation n] [--size N] [--calls] [--json]'); process.exit(2); }
+  const abs = resolve(file);
+  const stem = basename(abs).replace(/\.[^.]+$/, '');
+  const crop = a.crop ? a.crop.split(',').map((n) => parseInt(n, 10)) : null;
+  const palette = a.palette ? loadPalette(resolve(a.palette)) : undefined;
+  const num = (v, d) => (v === undefined ? d : Number(v));
+
+  const r = await runPhoto(abs, {
+    palette,
+    max: num(a.max, 64),
+    mode: a.mode || 'billboard',
+    depth: num(a.depth, 1),
+    maxHeight: num(a['max-height'], 16),
+    baseThickness: num(a['base'], 1),
+    invert: !!a.invert,
+    removeBackground: !!a.bg,
+    brightness: num(a.brightness, 0),
+    contrast: num(a.contrast, 0),
+    saturation: num(a.saturation, 0),
+    crop,
+    codeStyle: a.calls ? 'calls' : 'decode',
+  });
+
+  const outJs = resolve(a.out || stem + '.voxel.js');
+  writeFileSync(outJs, r.code);
+  let png = null;
+  if (!a.json) {
+    png = resolve(a.png || stem + '.voxel.png');
+    await meshToPng(r.mesh, Number(a.size) || 480).toFile(png);
+  }
+  console.log(json({ ok: true, model: outJs, png, stats: r.stats }));
 }
 
 async function cmdDaemon(argv) {
@@ -179,8 +218,11 @@ async function cmdMethods(argv) {
 const USAGE = `partwright — headless Partwright CLI for driving model creation + feedback
 
 Phase 1 (stateless, no browser — fast inner loop):
-  partwright preview <file.js> [--png out] [--json] [--size N] [-p k=v]
-  partwright run     <file.js> [-p k=v]                  stats JSON only
+  partwright preview <file.js> [--lang manifold-js|voxel] [--png out] [--json] [--size N] [-p k=v]
+  partwright run     <file.js> [--lang …] [-p k=v]       stats JSON only
+  partwright photo   <image>   [--palette p.json] [--max N] [--mode billboard|heightmap]
+                               [--depth N] [--bg] [--crop x,y,w,h] [--out model.js] [--png out]
+                               photo → palette-snapped voxel model + preview
 
 Phase 2 (headless-browser daemon — full fidelity + state):
   partwright iterate <file.js> [--out png] [--views all] [-p k=v]
@@ -198,6 +240,7 @@ export async function main(argv) {
   switch (cmd) {
     case 'preview': return cmdPreview(rest, { pngDefault: true });
     case 'run': return cmdPreview(rest, { pngDefault: false });
+    case 'photo': return cmdPhoto(rest);
     case 'iterate': return cmdIterate(rest);
     case 'daemon': return cmdDaemon(rest);
     case 'call': return cmdCall(rest);

--- a/scripts/cli/photo.mjs
+++ b/scripts/cli/photo.mjs
@@ -1,0 +1,136 @@
+// `partwright photo` — turn a raster photo into a palette-constrained voxel
+// model, headless and fast. It is the CLI front door to the SAME image→voxel
+// pipeline the in-app import modal uses (src/import/imageToVoxel.ts): downsample
+// → tonal adjust → snap every pixel to the nearest palette colour (perceptual
+// LAB distance) → optional background removal → emit runnable `voxels.decode(…)`
+// editor code. We also mesh the grid here (src/geometry/voxel/mesher.ts) and
+// hand it to the shared 4-view rasterizer so one command gives you the model
+// code, a preview PNG, and stats — the inner loop for iterating on a photo.
+//
+// sharp does the file decode + EXIF auto-orient + high-quality resize on the
+// main thread; the TS pipeline modules load via Vite SSR (same trick as
+// scripts/cli/preview.mjs), so there is one source of truth and no drift.
+import { createServer } from 'vite';
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import sharp from 'sharp';
+import { composePng } from './preview.mjs';
+
+// The app's out-of-the-box palette (mirrors DEFAULT_FILAMENTS in
+// src/color/palette.ts) — used when no --palette file is given.
+const DEFAULT_PALETTE = [
+  { name: 'White', hex: '#f5f5f0' }, { name: 'Black', hex: '#181818' },
+  { name: 'Red', hex: '#c02525' }, { name: 'Yellow', hex: '#e8c024' },
+  { name: 'Blue', hex: '#2452c0' }, { name: 'Gray', hex: '#808080' },
+];
+
+function hexToRgb(hex) {
+  let h = String(hex).trim().replace(/^#/, '');
+  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  const n = parseInt(h, 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+
+/** Load a palette JSON file: accepts `["#rrggbb", …]` or `[{name,hex}, …]`.
+ *  Returns `{ rgb: [[r,g,b],…], names: [name|null,…] }`. */
+export function loadPalette(file) {
+  const raw = JSON.parse(readFileSync(file, 'utf8'));
+  if (!Array.isArray(raw)) throw new Error(`palette file ${file} must be a JSON array`);
+  const rgb = [], names = [];
+  for (const entry of raw) {
+    const hex = typeof entry === 'string' ? entry : entry?.hex;
+    if (!hex) continue;
+    rgb.push(hexToRgb(hex));
+    names.push(typeof entry === 'object' ? (entry.name ?? null) : null);
+  }
+  if (!rgb.length) throw new Error(`palette file ${file} had no usable colours`);
+  return { rgb, names };
+}
+
+/** Decode + orient + (optionally crop) + downsample a photo to an RGBA
+ *  ImageData-like the voxel pipeline consumes. We resize with a quality kernel
+ *  HERE so the pipeline's own nearest-neighbour downsample is a no-op — area
+ *  averaging beats point-sampling a 12-megapixel photo down to 64px. */
+async function loadImageData(file, { max, crop }) {
+  let img = sharp(file).rotate(); // EXIF auto-orient
+  if (crop) {
+    const [left, top, width, height] = crop;
+    img = img.extract({ left, top, width, height });
+  }
+  img = img.resize(max, max, { fit: 'inside', kernel: 'lanczos3', withoutEnlargement: true });
+  const { data, info } = await img.ensureAlpha().raw().toBuffer({ resolveWithObject: true });
+  return { width: info.width, height: info.height, data: new Uint8ClampedArray(data.buffer, data.byteOffset, data.length) };
+}
+
+/** Tally palette usage so the CLI can report which slots a photo actually used. */
+function paletteHistogram(grid, palette, names) {
+  const key = (r, g, b) => (r << 16) | (g << 8) | b;
+  const want = new Map(palette.map(([r, g, b], i) => [key(r, g, b), i]));
+  const counts = new Array(palette.length).fill(0);
+  grid.forEach((_x, _y, _z, rgb) => {
+    const i = want.get(rgb & 0xffffff);
+    if (i !== undefined) counts[i]++;
+  });
+  return counts
+    .map((count, i) => ({ slot: i + 1, name: names[i], hex: '#' + ((palette[i][0] << 16) | (palette[i][1] << 8) | palette[i][2]).toString(16).padStart(6, '0'), voxels: count }))
+    .filter((e) => e.voxels > 0)
+    .sort((a, b) => b.voxels - a.voxels);
+}
+
+/** Core: photo file + options → { code, mesh, grid, stats }. Loads the TS
+ *  pipeline via SSR so the codegen matches the app exactly. */
+export async function runPhoto(file, opts = {}) {
+  const max = opts.max ?? 64;
+  const { rgb: palette, names } = opts.palette ?? { rgb: DEFAULT_PALETTE.map((p) => hexToRgb(p.hex)), names: DEFAULT_PALETTE.map((p) => p.name) };
+  const image = await loadImageData(file, { max, crop: opts.crop });
+
+  const server = await createServer({ configFile: false, server: { middlewareMode: true }, appType: 'custom', logLevel: 'silent', optimizeDeps: { noDiscovery: true } });
+  try {
+    const i2v = await server.ssrLoadModule('/src/import/imageToVoxel.ts');
+    const mesher = await server.ssrLoadModule('/src/geometry/voxel/mesher.ts');
+
+    const grid = i2v.imageDataToVoxelGrid(image, {
+      // The image is already sized to `max`; cap downsample at its longest side
+      // so the pipeline keeps every pixel we handed it (scale = 1).
+      maxSize: Math.max(image.width, image.height),
+      mode: opts.mode ?? 'billboard',
+      depth: opts.depth ?? 1,
+      maxHeight: opts.maxHeight ?? 16,
+      baseThickness: opts.baseThickness ?? 1,
+      invert: opts.invert ?? false,
+      palette,
+      removeBackground: opts.removeBackground ?? false,
+      ...(opts.backgroundColor ? { backgroundColor: opts.backgroundColor } : {}),
+      brightness: opts.brightness ?? 0,
+      contrast: opts.contrast ?? 0,
+      saturation: opts.saturation ?? 0,
+    });
+
+    const code = i2v.generateVoxelImportCode(grid, basename(file), { style: opts.codeStyle ?? 'decode' });
+    const mesh = mesher.meshGrid(grid);
+    const b = grid.bounds();
+    const dims = b ? { x: b.max[0] - b.min[0] + 1, y: b.max[1] - b.min[1] + 1, z: b.max[2] - b.min[2] + 1 } : { x: 0, y: 0, z: 0 };
+    const stats = {
+      voxelCount: grid.size,
+      dims,
+      sampled: { width: image.width, height: image.height },
+      paletteUsed: paletteHistogram(grid, palette, names),
+    };
+    return { code, mesh, grid, stats };
+  } finally {
+    await server.close();
+  }
+}
+
+/** Compose a 4-view PNG from a voxel mesh (per-triangle colours). */
+export function meshToPng(mesh, size = 480) {
+  const p = mesh.vertProperties;
+  let minX = Infinity, minY = Infinity, minZ = Infinity, maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  for (let i = 0; i < p.length; i += 3) {
+    if (p[i] < minX) minX = p[i]; if (p[i] > maxX) maxX = p[i];
+    if (p[i + 1] < minY) minY = p[i + 1]; if (p[i + 1] > maxY) maxY = p[i + 1];
+    if (p[i + 2] < minZ) minZ = p[i + 2]; if (p[i + 2] > maxZ) maxZ = p[i + 2];
+  }
+  const bbox = { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+  return composePng(mesh.vertProperties, mesh.triVerts, mesh.triColors, bbox, size);
+}

--- a/scripts/cli/preview.mjs
+++ b/scripts/cli/preview.mjs
@@ -98,12 +98,12 @@ export function composePng(positions, triVerts, triColors, bbox, size) {
 
 // Run a model file through the real engine via a throwaway in-process Vite SSR
 // server. Returns the PreviewResult from src/tools/previewModel.ts.
-export async function runPreview(file, { params = {} } = {}) {
+export async function runPreview(file, { params = {}, lang = 'manifold-js' } = {}) {
   const code = readFileSync(file, 'utf8');
   const server = await createServer({ configFile: false, server: { middlewareMode: true }, appType: 'custom', logLevel: 'silent', optimizeDeps: { noDiscovery: true } });
   try {
     const mod = await server.ssrLoadModule('/src/tools/previewModel.ts');
-    return await mod.previewModel(code, { params });
+    return await mod.previewModel(code, { params, lang });
   } finally {
     await server.close();
   }

--- a/scripts/model-preview.mjs
+++ b/scripts/model-preview.mjs
@@ -15,12 +15,13 @@ import { resolve, dirname, basename, join } from 'node:path';
 import { runPreview, composePng } from './cli/preview.mjs';
 
 function parseArgs(argv) {
-  const a = { params: {}, size: 480, json: false, png: null, file: null };
+  const a = { params: {}, size: 480, json: false, png: null, file: null, lang: 'manifold-js' };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
     if (t === '--json') a.json = true;
     else if (t === '--size') a.size = parseInt(argv[++i], 10);
     else if (t === '--png') a.png = argv[++i];
+    else if (t === '--lang') a.lang = argv[++i];
     else if (t === '-p' || t === '--param') { const [k, ...v] = argv[++i].split('='); a.params[k] = coerce(v.join('=')); }
     else if (!a.file && !t.startsWith('-')) a.file = t;
   }
@@ -32,7 +33,7 @@ async function main() {
   const a = parseArgs(process.argv.slice(2));
   if (!a.file) { console.error('Usage: npm run model:preview -- <file.js> [--png out.png] [--json] [--size N] [-p k=v]'); process.exit(2); }
   const file = resolve(a.file);
-  const result = await runPreview(file, { params: a.params });
+  const result = await runPreview(file, { params: a.params, lang: a.lang });
 
   if (!result.ok) {
     console.log(JSON.stringify({ ok: false, error: result.error, diagnostics: result.diagnostics }, null, 2));

--- a/src/tools/previewModel.ts
+++ b/src/tools/previewModel.ts
@@ -3,7 +3,11 @@
 // block + render data an AI needs to self-correct. Loaded via vite SSR by
 // scripts/model-preview.mjs (`npm run model:preview`). The execution path is the
 // exact same `manifoldJsEngine` the app uses, so results are faithful.
-import { manifoldJsEngine } from '../geometry/engines/manifoldJs';
+import { manifoldJsEngine, getManifoldModule } from '../geometry/engines/manifoldJs';
+import { voxelEngine } from '../geometry/engines/voxel';
+import { openscadEngine, runScadAsync } from '../geometry/engines/openscad';
+import type { Language } from '../geometry/engines/types';
+import type { MeshResult } from '../geometry/engines/types';
 
 export interface PreviewComponent {
   index: number;
@@ -30,6 +34,10 @@ export interface PreviewStats {
   warnings: string[];         // actionable heuristics (fused parts, tri budget, …)
   paramsSchema: unknown;
   renderOnly: boolean;
+  /** Which engine produced this preview (so the caller can label output). */
+  engine: Language;
+  /** Occupied-voxel count — only set for the `voxel` engine. */
+  voxelCount?: number;
 }
 
 export interface PreviewRender {
@@ -61,21 +69,45 @@ function toBox(raw: { min: unknown; max: unknown }) {
   return { min: vec(raw.min), max: vec(raw.max) };
 }
 
+/** Engines runnable in the stateless (no-browser) preview tier:
+ *  - `manifold-js` — owns the WASM kernel (loaded once via init).
+ *  - `voxel` — plain JS that meshes a grid (no WASM).
+ *  - `scad` — OpenSCAD's Emscripten WASM, which loads cleanly under Node.
+ *  `replicad` is omitted: its OpenCASCADE WASM resolves its `.wasm` to a
+ *  server-style path that doesn't exist on Node's filesystem, so it runs
+ *  through the Phase-2 daemon (`partwright iterate --lang replicad`) instead. */
+const STATELESS_ENGINES: Language[] = ['manifold-js', 'voxel', 'scad'];
+
 export async function previewModel(
   code: string,
-  opts: { params?: Record<string, unknown>; maxComponents?: number } = {},
+  opts: { params?: Record<string, unknown>; maxComponents?: number; lang?: Language } = {},
 ): Promise<PreviewResult> {
+  const engine: Language = opts.lang ?? 'manifold-js';
+  // manifold-3d is always needed: the kernel for manifold-js runs, and the
+  // mesh→Manifold round-trip we use to compute stats for the voxel engine.
   await manifoldJsEngine.init();
-  const r = manifoldJsEngine.run(code, opts.params) as {
-    mesh: { vertProperties: Float32Array; triVerts: Uint32Array; numVert: number; numTri: number; numProp: number } | null;
+  if (!STATELESS_ENGINES.includes(engine)) {
+    return {
+      ok: false,
+      error: `Headless preview for the '${engine}' engine isn't supported in the stateless tier (it needs its own WASM). Use the daemon: \`partwright iterate --lang ${engine} <file>\`.`,
+      stats: null,
+      render: null,
+    };
+  }
+
+  let raw: MeshResult;
+  if (engine === 'voxel') {
+    raw = voxelEngine.run(code, opts.params);
+  } else if (engine === 'scad') {
+    if (!openscadEngine.isReady()) await openscadEngine.init();
+    raw = await runScadAsync(code, opts.params);
+  } else {
+    raw = manifoldJsEngine.run(code, opts.params);
+  }
+  const r = raw as MeshResult & {
+    mesh: { vertProperties: Float32Array; triVerts: Uint32Array; numVert: number; numTri: number; numProp: number; triColors?: Uint8Array } | null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     manifold: any;
-    error: string | null;
-    diagnostics?: unknown;
-    labelMap?: Map<string, Set<number>>;
-    labelColors?: Map<string, [number, number, number]>;
-    paramsSchema?: unknown;
-    renderOnly?: boolean;
   };
 
   if (r.error || !r.mesh) {
@@ -83,13 +115,27 @@ export async function previewModel(
   }
 
   const mesh = r.mesh;
-  const man = r.manifold;
   const renderOnly = r.renderOnly === true;
+  // The voxel engine returns mesh data with `manifold: null` (the grid mesher
+  // never builds a live Manifold). Reconstruct one via ofMesh so volume / genus
+  // / component stats come out the same as a manifold-js model — voxel meshes
+  // are welded + watertight, so this round-trips cleanly. Free it at the end.
+  let man = r.manifold;
+  let reconstructed = false;
+  if (!man && !renderOnly) {
+    try { man = getManifoldModule().Manifold.ofMesh(mesh); reconstructed = true; } catch { /* leave man null → render-only stats */ }
+  }
 
-  // --- per-triangle colors from model-declared labels ---
+  // --- per-triangle colors ---
+  // The voxel engine (and any painted mesh) carries authored per-triangle RGB
+  // directly on the mesh — one rgb triple per triangle, exactly the layout the
+  // rasterizer wants — so prefer it. Otherwise fall back to deriving colors
+  // from model-declared labels (the manifold-js path).
   const numTri = mesh.numTri;
   let triColors: Uint8Array | null = null;
-  if (r.labelMap && r.labelColors && r.labelColors.size > 0) {
+  if (mesh.triColors && mesh.triColors.length >= numTri * 3) {
+    triColors = new Uint8Array(mesh.triColors.subarray(0, numTri * 3));
+  } else if (r.labelMap && r.labelColors && r.labelColors.size > 0) {
     triColors = new Uint8Array(numTri * 3).fill(170); // neutral default
     for (const [name, ids] of r.labelMap) {
       const c = r.labelColors.get(name);
@@ -135,6 +181,7 @@ export async function previewModel(
       vertexCount: mesh.numVert, volume: 0, surfaceArea: 0, genus: 0,
       bbox: null, aspectRatio: 0, minEdgeLength: edge.min, meanEdgeLength: edge.mean,
       components: [], labels, warnings: [], paramsSchema: r.paramsSchema, renderOnly: true,
+      engine, voxelCount: r.voxelCount,
     };
     stats.warnings = buildWarnings(stats);
   } else {
@@ -177,8 +224,16 @@ export async function previewModel(
       warnings: [],
       paramsSchema: r.paramsSchema,
       renderOnly: false,
+      engine, voxelCount: r.voxelCount,
     };
     stats.warnings = buildWarnings(stats);
+  }
+
+  // Free the Manifold we built solely to compute stats (the live WASM object
+  // isn't returned). manifold-js models hand back their own Manifold, which
+  // the short-lived SSR process reclaims on exit, so only free ours.
+  if (reconstructed && man && typeof man.delete === 'function') {
+    try { man.delete(); } catch { /* exit cleans up */ }
   }
 
   return {


### PR DESCRIPTION
## Summary

Extends the headless CLI so previews work across multiple engines, and adds a `photo → palette-constrained voxel` command. Motivated by iterating on voxel versions of a photo, snapped to a fixed colour palette, entirely from the CLI.

### Engine-aware stateless preview (`--lang`)
- `src/tools/previewModel.ts` (behind `model:preview` and `partwright preview/run`) used to run **manifold-js only**. It now takes a `lang` and dispatches across the engines that run without a browser:
  - **manifold-js** (default), **voxel** (pure-JS grid mesher), **scad** (OpenSCAD Emscripten WASM — inits cleanly under Node SSR, ~600 ms).
  - **replicad** stays Phase-2: its OpenCASCADE WASM resolves its `.wasm` to a server-style `/node_modules/…` path that doesn't exist on Node's filesystem. Preview it via the daemon: `partwright iterate --lang replicad <file>`.
- The software rasterizer now prefers the mesh's own **per-triangle colours** (`triColors`) over label-derived colours, so voxel and painted models preview in their real colours.
- Non-manifold-js engines get volume/genus/component stats via a `Manifold.ofMesh(mesh)` round-trip (voxel/SCAD meshes are welded + watertight), and the reconstructed handle is freed.
- `--lang` threads through `scripts/cli/preview.mjs`, `scripts/cli/main.mjs`, and `scripts/model-preview.mjs`.

### `partwright photo <image>`
The CLI front door to the existing `src/import/imageToVoxel.ts` pipeline — **not** a reimplementation:
- sharp handles decode + EXIF auto-orient + Lanczos downsample + optional `--crop`; the TS pipeline + voxel mesher load via Vite SSR, so codegen matches the in-app import exactly (one source of truth).
- Snaps each pixel to the nearest palette colour (perceptual LAB distance), emits runnable `voxels.decode(…)` editor code, meshes it, and writes a 4-view preview PNG + stats (voxel count, dims, per-slot palette-usage histogram) in one shot.
- `--palette p.json` (JSON of `"#rrggbb"` strings or `{name,hex}` objects); `--mode heightmap` makes brightness drive per-column depth (bas-relief) instead of a flat `--depth` billboard. Default palette = the app's 6-slot default.

This doubles as a prototype for a possible in-app "photo → voxel" feature; keeping conversion in the shared TS module means CLI and any future UI stay in sync.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:unit` — 718 passing
- [x] Manual: voxel snippet, SCAD (cube−sphere), and a photo (cropped billboard + heightmap) all preview correctly with real colours (screenshots posted in the working session)
- [ ] PR-checks e2e shards (run on this draft)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZby4SCbdFedT5UtihwMou)_