### PR TITLE
feat: add voice-to-text microphone button to AI panel

### DIFF
--- a/prompts/20260607-voice-input-microphone.md
+++ b/prompts/20260607-voice-input-microphone.md
@@ -1,0 +1,66 @@
+---
+date: 2026-06-07
+branch: claude/voice-input-microphone-0uTvd
+files_changed:
+  - src/ui/voiceInput.ts
+  - src/ui/aiPanel.ts
+  - tests/ai-voice-input.spec.ts
+---
+
+## Human
+
+Add a microphone button to the AI pane so people can click it and do voice-to-text
+input for their instructions to the AI. Investigate first: if there's a really
+straightforward way for web apps to do this, implement it and open a PR. If it's
+tricky — needs a library selection or design decisions — report back and ask
+questions instead.
+
+## Assistant
+
+There *is* a straightforward, no-decision path: the browser-native **Web Speech
+API** (`SpeechRecognition` / `webkitSpeechRecognition`). No library, no backend,
+no API key — the browser captures audio and returns the transcript. It's
+supported in Chrome, Edge, and Safari (the Chromium the e2e suite runs on), and
+absent in Firefox. Because nothing about it required a library choice or
+architectural decision, I implemented it directly per the "go ahead" branch of
+the request rather than asking.
+
+Key decisions:
+
+- **New leaf module `src/ui/voiceInput.ts`** owns the recognition lifecycle and
+  exposes `isVoiceInputSupported()` + `createVoiceController()`. Keeping it
+  separate from `aiPanel.ts` isolates the one place that needs ambient type
+  declarations (the Web Speech API isn't in TypeScript's DOM lib) and keeps the
+  panel wiring thin. The controller emits plain callbacks
+  (`onTranscript`/`onStateChange`/`onError`) so the panel decides where text
+  lands.
+
+- **Feature-gated UI.** The mic button (`#btn-ai-mic`, 🎤) only renders when
+  `isVoiceInputSupported()` is true, so Firefox users never see a dead button.
+  It sits in the input button row beside the existing 📎 attachment button and
+  reuses that button's exact Tailwind class for visual consistency; the
+  listening state swaps to a red `animate-pulse` variant.
+
+- **Append, don't replace.** On start it anchors the text already in the box and
+  appends dictated words to it (with a separator), then dispatches a synthetic
+  `input` event so the slash-command menu and other downstream listeners behave
+  exactly as for typed text. `continuous` + `interimResults` give live partial
+  text; an `onend` auto-restart keeps the session open through Chrome's
+  mid-pause stops until the user clicks to stop.
+
+- **Stop on send.** `voiceController?.stop()` runs at the top of both
+  `sendMessage` and `queueCurrentInput` so dictation doesn't keep appending to a
+  box that's about to be cleared.
+
+- **Errors → `showToast({ variant: 'warn' })`** (auto-mirrored to the Diagnostic
+  Log), with spec error codes mapped to actionable messages (blocked mic, no
+  speech, no device, network).
+
+- **Language** defaults to `navigator.language`. I deliberately did *not* add an
+  appConfig knob: the advanced-settings Field component is numeric-only, and a
+  string language picker would be scope creep for a sensible auto-default.
+
+Verified in the browser with a Playwright spec that stubs the Web Speech API
+(headless Chromium has no real engine): the mic button renders, dictated text
+lands in the textarea appended to existing input, the button reflects the
+listening state, and it's hidden entirely when the API is absent.

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -34,6 +34,8 @@ import { ensureModelLoaded, effectiveContextCeiling, interruptLocal, isModelLoad
 import { activeModel, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type ImageSource, type PersistedToolResult, type Preset, type Provider, type TurnOutcomeReason } from '../ai/types';
 import { matchSlashCommands, parseSlashCommand, slashMenuPrefix, type SlashCommandName, type SlashCommandSpec } from '../ai/slashCommands';
 import { errorLog } from '../diagnostics/errorLog';
+import { showToast } from './toast';
+import { createVoiceController, isVoiceInputSupported, type VoiceController } from './voiceInput';
 
 interface PanelState {
   open: boolean;
@@ -160,6 +162,7 @@ let forwardBtnRef: HTMLButtonElement | null = null;
 let drawerEl: HTMLElement | null = null;
 let transcriptEl: HTMLElement | null = null;
 let inputEl: HTMLTextAreaElement | null = null;
+let voiceController: VoiceController | null = null;
 let planApprovalBarEl: HTMLElement | null = null;
 
 // The docked panel is an editor tool: it only takes layout space on the editor
@@ -880,6 +883,45 @@ function buildDrawer(): void {
     });
   });
   inputBtnRow.appendChild(fileBtn);
+
+  // Microphone — voice-to-text dictation via the browser-native Web Speech API.
+  // Only shown where the browser supports it (Chrome/Edge/Safari, not Firefox).
+  if (isVoiceInputSupported()) {
+    const micBtn = document.createElement('button');
+    micBtn.id = 'btn-ai-mic';
+    const micIdleClass = 'shrink-0 px-2 py-1 rounded text-[11px] text-zinc-300 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700';
+    const micActiveClass = 'shrink-0 px-2 py-1 rounded text-[11px] text-white bg-red-600 hover:bg-red-500 border border-red-500 animate-pulse';
+    micBtn.className = micIdleClass;
+    micBtn.textContent = '🎤';
+    micBtn.title = 'Dictate your message (voice to text). Click again to stop.';
+    micBtn.setAttribute('aria-label', 'Dictate message with voice input');
+
+    // Text already in the box when dictation starts; spoken words append to it.
+    let micBaseText = '';
+    voiceController = createVoiceController({
+      onTranscript: (transcript, _isFinal) => {
+        if (!inputEl) return;
+        const sep = micBaseText && !/\s$/.test(micBaseText) ? ' ' : '';
+        inputEl.value = transcript ? micBaseText + sep + transcript : micBaseText;
+        // Drive the same downstream behaviour as manual typing (slash menu, etc).
+        inputEl.dispatchEvent(new Event('input'));
+      },
+      onStateChange: listening => {
+        micBtn.className = listening ? micActiveClass : micIdleClass;
+        micBtn.title = listening
+          ? 'Listening… click to stop dictation.'
+          : 'Dictate your message (voice to text). Click again to stop.';
+        micBtn.setAttribute('aria-pressed', String(listening));
+        if (listening && inputEl) {
+          micBaseText = inputEl.value;
+          inputEl.focus();
+        }
+      },
+      onError: message => showToast(message, { variant: 'warn', source: 'ai' }),
+    });
+    micBtn.addEventListener('click', () => { voiceController?.toggle(); });
+    inputBtnRow.appendChild(micBtn);
+  }
 
   const inputBtnSpacer = document.createElement('div');
   inputBtnSpacer.className = 'flex-1';
@@ -2410,6 +2452,9 @@ function renderPendingImages(): void {
  *  turn with the queued blocks as the new user message. */
 function queueCurrentInput(): void {
   if (!inputEl) return;
+  // Sending commits the text — halt any in-progress dictation so it doesn't
+  // keep appending to a box we're about to clear.
+  voiceController?.stop();
   const text = inputEl.value.trim();
   if (text.length === 0 && state.pendingImages.length === 0) return;
   const blocks: ChatBlock[] = [];
@@ -2774,6 +2819,9 @@ async function sendMessage(): Promise<void> {
   // against the same transcript. The viewer overlay offers "Take control".
   if (!writeOwner) return;
   if (!inputEl) return;
+  // Sending commits the text — halt any in-progress dictation so it doesn't
+  // keep appending to a box we're about to clear.
+  voiceController?.stop();
   const text = inputEl.value.trim();
   if (text.length === 0 && state.pendingImages.length === 0) return;
 

--- a/src/ui/voiceInput.ts
+++ b/src/ui/voiceInput.ts
@@ -1,0 +1,214 @@
+// Voice-to-text input via the browser-native Web Speech API
+// (SpeechRecognition / webkitSpeechRecognition). No library, no backend, no API
+// key: the browser handles capture and transcription. Supported in Chrome,
+// Edge, and Safari; absent in Firefox — callers gate the UI on
+// `isVoiceInputSupported()` so the mic button only appears where it works.
+//
+// This module owns the recognition lifecycle (start/stop/toggle, auto-restart
+// while the user is still holding the mic open) and emits plain callbacks; the
+// consumer (the AI panel) decides where the transcribed text lands.
+
+// The Web Speech API is not in TypeScript's standard DOM lib, so we declare the
+// minimal surface we use. These mirror the WHATWG/Web Speech spec shapes.
+interface SpeechRecognitionAlternative {
+  readonly transcript: string;
+  readonly confidence: number;
+}
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+}
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+}
+interface SpeechRecognitionEventLike extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+interface SpeechRecognitionErrorEventLike extends Event {
+  readonly error: string;
+  readonly message: string;
+}
+interface SpeechRecognitionLike extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  maxAlternatives: number;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
+  onend: ((event: Event) => void) | null;
+  onstart: ((event: Event) => void) | null;
+}
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
+
+function getCtor(): SpeechRecognitionCtor | null {
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionCtor;
+    webkitSpeechRecognition?: SpeechRecognitionCtor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+/** True when the browser exposes the Web Speech recognition API. */
+export function isVoiceInputSupported(): boolean {
+  return getCtor() !== null;
+}
+
+export interface VoiceController {
+  /** Start if idle, stop if listening. */
+  toggle(): void;
+  /** Stop listening (commits whatever was transcribed). No-op if idle. */
+  stop(): void;
+  /** Whether recognition is currently active. */
+  isListening(): boolean;
+  /** Tear down — aborts any active session and drops listeners. */
+  dispose(): void;
+}
+
+export interface VoiceControllerOptions {
+  /**
+   * Fires on every recognition update with the full transcript spoken since
+   * this listening session started (final results plus the live interim tail).
+   * `isFinal` is true once the session ends and the text is committed.
+   */
+  onTranscript(transcript: string, isFinal: boolean): void;
+  /** Fires when listening starts (true) or stops (false). */
+  onStateChange(listening: boolean): void;
+  /** Fires on a recognition error with a human-readable message. */
+  onError(message: string): void;
+  /** BCP-47 language tag. Defaults to the browser locale. */
+  lang?: string;
+}
+
+// Map the spec's error codes to messages a user can act on.
+function errorMessage(code: string): string {
+  switch (code) {
+    case 'not-allowed':
+    case 'service-not-allowed':
+      return 'Microphone access was blocked. Allow it in your browser to use voice input.';
+    case 'no-speech':
+      return 'No speech detected. Try again.';
+    case 'audio-capture':
+      return 'No microphone found.';
+    case 'network':
+      return 'Voice recognition needs a network connection.';
+    case 'aborted':
+      return ''; // user-initiated stop — not surfaced
+    default:
+      return `Voice input error: ${code}`;
+  }
+}
+
+/**
+ * Build a voice-input controller around a single SpeechRecognition instance.
+ * Returns null when the API is unavailable (callers should gate on
+ * `isVoiceInputSupported()` first and hide the UI entirely).
+ */
+export function createVoiceController(opts: VoiceControllerOptions): VoiceController | null {
+  const Ctor = getCtor();
+  if (!Ctor) return null;
+
+  const rec = new Ctor();
+  rec.lang = opts.lang ?? navigator.language ?? 'en-US';
+  rec.continuous = true;
+  rec.interimResults = true;
+  rec.maxAlternatives = 1;
+
+  let listening = false;
+  // `wantListening` distinguishes a user stop from the engine ending a turn on
+  // its own (Chrome stops after a pause even in continuous mode). While the
+  // user still wants to dictate, we restart on `onend`.
+  let wantListening = false;
+  // Final transcript accumulated across auto-restarts within one user session,
+  // so chaining restarts doesn't drop earlier sentences.
+  let committed = '';
+
+  function emit(interim: string, isFinal: boolean): void {
+    const joined = (committed + interim).replace(/\s+/g, ' ').trim();
+    opts.onTranscript(joined, isFinal);
+  }
+
+  rec.onresult = event => {
+    let interim = '';
+    for (let i = event.resultIndex; i < event.results.length; i++) {
+      const result = event.results[i];
+      const text = result[0]?.transcript ?? '';
+      if (result.isFinal) committed += text + ' ';
+      else interim += text;
+    }
+    emit(interim, false);
+  };
+
+  rec.onerror = event => {
+    const msg = errorMessage(event.error);
+    // A blocked/failed permission means we can't recover by restarting.
+    if (event.error === 'not-allowed' || event.error === 'service-not-allowed' || event.error === 'audio-capture') {
+      wantListening = false;
+    }
+    if (msg) opts.onError(msg);
+  };
+
+  rec.onend = () => {
+    if (wantListening) {
+      // Engine ended the turn but the user still holds the mic open — restart.
+      try {
+        rec.start();
+        return;
+      } catch {
+        // Fall through to the stopped state if restart throws (rare).
+      }
+    }
+    listening = false;
+    emit('', true);
+    opts.onStateChange(false);
+  };
+
+  function start(): void {
+    if (listening) return;
+    committed = '';
+    wantListening = true;
+    try {
+      rec.start();
+      listening = true;
+      opts.onStateChange(true);
+    } catch (err) {
+      wantListening = false;
+      listening = false;
+      opts.onError(err instanceof Error ? err.message : 'Could not start voice input.');
+    }
+  }
+
+  function stop(): void {
+    if (!listening) return;
+    wantListening = false;
+    rec.stop();
+  }
+
+  return {
+    toggle() {
+      if (listening) stop();
+      else start();
+    },
+    stop,
+    isListening: () => listening,
+    dispose() {
+      wantListening = false;
+      rec.onresult = null;
+      rec.onerror = null;
+      rec.onend = null;
+      rec.onstart = null;
+      try {
+        rec.abort();
+      } catch {
+        // ignore — already stopped
+      }
+    },
+  };
+}

--- a/tests/ai-voice-input.spec.ts
+++ b/tests/ai-voice-input.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from 'playwright/test';
+import { openAiPanel, waitForEditorReady } from './helpers/aiPanel';
+
+// Voice-to-text dictation in the AI panel rides the browser-native Web Speech
+// API. Headless Chromium has no real speech engine, so we install a minimal
+// stub that emits a transcript on start — enough to exercise the panel wiring
+// (button visibility, listening state, transcript landing in the textarea).
+async function stubSpeechRecognition(page: import('playwright/test').Page): Promise<void> {
+  await page.addInitScript(() => {
+    class FakeRecognition extends EventTarget {
+      lang = '';
+      continuous = false;
+      interimResults = false;
+      maxAlternatives = 1;
+      onresult: ((e: unknown) => void) | null = null;
+      onerror: ((e: unknown) => void) | null = null;
+      onend: ((e: unknown) => void) | null = null;
+      onstart: ((e: unknown) => void) | null = null;
+      start() {
+        this.onstart?.(new Event('start'));
+        setTimeout(() => {
+          this.onresult?.({
+            resultIndex: 0,
+            results: {
+              length: 1,
+              0: { isFinal: true, length: 1, 0: { transcript: 'make a hexagon nut', confidence: 0.9 } },
+            },
+          });
+        }, 50);
+      }
+      stop() { this.onend?.(new Event('end')); }
+      abort() { this.onend?.(new Event('end')); }
+    }
+    (window as unknown as { SpeechRecognition: unknown }).SpeechRecognition = FakeRecognition;
+  });
+  // Suppress the first-run guided tour — its backdrop intercepts clicks.
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+  });
+}
+
+test.describe('AI voice input', () => {
+  test('mic button dictates speech into the input', async ({ page }) => {
+    await stubSpeechRecognition(page);
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    await openAiPanel(page);
+
+    const mic = page.locator('#btn-ai-mic');
+    await expect(mic).toBeVisible();
+
+    // Type some text first — dictation should append to it, not replace it.
+    const ta = page.locator('#ai-panel textarea');
+    await ta.fill('Please');
+
+    await mic.click();
+    await expect(ta).toHaveValue(/Please make a hexagon nut/);
+
+    // Stop dictation; the button returns to its idle (un-pressed) state.
+    await mic.click();
+    await expect(mic).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('mic button is hidden when the browser lacks speech recognition', async ({ page }) => {
+    // No stub: ensure neither vendor-prefixed constructor exists.
+    await page.addInitScript(() => {
+      try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+      delete (window as unknown as Record<string, unknown>).SpeechRecognition;
+      delete (window as unknown as Record<string, unknown>).webkitSpeechRecognition;
+    });
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    await openAiPanel(page);
+
+    await expect(page.locator('#btn-ai-mic')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a 🎤 microphone button to the AI panel's input row so users can dictate their instructions to the AI by voice instead of typing.

This uses the **browser-native Web Speech API** (`SpeechRecognition` / `webkitSpeechRecognition`) — no library, no backend, no API key. The browser captures audio and returns the transcript. It's the straightforward, zero-decision path the request asked for, so it was implemented directly.

### Behaviour

- **Click to dictate, click again to stop.** Spoken words append to whatever is already typed (with a separator), so you can mix typing and dictation.
- **Live transcription** via `continuous` + `interimResults`; an `onend` auto-restart keeps the session open through Chrome's mid-pause stops.
- **Drives the same downstream behaviour as typing** — dispatches a synthetic `input` event so the slash-command menu etc. work normally.
- **Stops automatically on send** so it doesn't keep appending to a box that's about to be cleared.
- **Errors surface as warn toasts** (mirrored to the Diagnostic Log): blocked mic permission, no speech, no device, network.
- **Feature-gated:** the button only renders when the browser supports the API, so Firefox users never see a dead button.
- **Language** defaults to the browser locale (`navigator.language`).

### Files

- `src/ui/voiceInput.ts` — new leaf module owning the recognition lifecycle (`isVoiceInputSupported()`, `createVoiceController()`), including the minimal ambient Web Speech API type declarations (not in TS's DOM lib).
- `src/ui/aiPanel.ts` — renders the mic button (`#btn-ai-mic`) beside the 📎 attachment button, reusing its styling; wires transcript/state/error callbacks; stops dictation on send.
- `tests/ai-voice-input.spec.ts` — e2e golden path (stubs the Web Speech API since headless Chromium has no real engine).

### Browser support note

Web Speech recognition works in **Chrome, Edge, and Safari**; it is **not** available in Firefox (the button is hidden there). In Chrome, transcription is performed via Google's servers — standard for this API. No new dependency, CSP, or COEP/COOP change.

## Test plan

- `npm run build` ✅ (type-check)
- `npm run test:unit` ✅ (718 passed)
- `npm run lint:deadcode` ✅ / `npm run lint:deps` ✅
- `npx playwright test ai-voice-input` ✅ (2 passed) — verified the button renders, dictated text lands in the textarea appended to existing input, the listening state toggles, and the button is hidden when the API is absent. Manually viewed screenshots of idle + listening states.

https://claude.ai/code/session_012ymHzJopFi6hs88gC3rBQm

---
_Generated by [Claude Code](https://claude.ai/code/session_012ymHzJopFi6hs88gC3rBQm)_