### PR TITLE
feat: preserve interactive camera angle across version switches and code edits

### DIFF
--- a/prompts/20260607-144949-camera-angle-version-persistence.md
+++ b/prompts/20260607-144949-camera-angle-version-persistence.md
@@ -1,0 +1,65 @@
+---
+session: "fvIqe7"
+timestamp: "2026-06-07T14:49:49Z"
+model: claude-opus-4-8
+tools: [explore, playwright]
+---
+
+## Human
+
+When I've changed the angle in the interactive view, and then when I switch
+versions, the angle of the next version in the interactive view flips back to
+some default angle. I don't want it to do that. When I'm changing between
+versions within a session, whatever my most recent interactive view angle was,
+I want it to be remembered — and as I switch versions, keep using that exact
+same perspective (angle and distance) I previously picked. Implement this and
+make it a PR.
+
+## Assistant
+
+## Key decisions
+
+**Root cause**: Loading a version re-renders its geometry through
+`updateMesh`, whose auto-frame calls `frameModel()` — which unconditionally
+snaps `camera.position` + `controls.target` to the default 3/4 view. There was
+no camera-state write-back path (`getCameraState` existed, but read-only).
+
+**Approach**: Snapshot the live camera pose before the re-render and restore it
+after, rather than skipping the auto-frame. `frameModel()` also recomputes
+bounds-derived state (clip-slider range, grid height, near/far planes,
+`maxDistance`) which *must* adapt to the new version's geometry — so we let it
+run and only put the camera back.
+
+- Added `getCameraPose()` / `setCameraPose()` to `src/renderer/viewport.ts`.
+  These work in exact world-space (position + target) rather than the rounded
+  azimuth/elevation/distance of the API-facing `getCameraState`, so the restore
+  is lossless.
+- Added `captureCameraToPreserve()` + a `lastFramedSessionId` tracker in
+  `main.ts`. It returns the live pose **only** when a model is already on screen
+  *and* we're staying in the same session — so the first render of a
+  freshly-opened session still auto-frames, and opening a different session
+  doesn't inherit the previous session's odd angle. This same-session gate is
+  the safety net.
+
+**Scoping — why an explicit `preserveCamera` opt on `runCodeSync`**: The naive
+fix (preserve on every same-session re-render) broke genuine new-code runs:
+`partwright.run(cube)` after a default-code session kept the stale (larger)
+framing distance, leaving the new model mis-framed (caught by
+`viewport-reset-view.spec.ts`). Version switches and plain re-runs both flow
+through `runCodeSync`, so they're indistinguishable there. Resolution: gate the
+preserve behind an explicit `opts.preserveCamera`, passed **only** by the
+version-switch call sites — `loadVersionIntoEditor` (cache-miss),
+`partwright.loadVersion`, `partwright.navigateVersion`, and the post-merge
+active-version re-render. The cache-hit branch of `loadVersionIntoEditor`
+(direct `updateMesh`, no `runCodeSync`) is covered by a capture/restore around
+the function body. Genuine runs keep auto-framing.
+
+**Note**: `setValue` already cancels the debounced auto-run on programmatic
+value-sets, so there's no 300ms reframe echo to fight after a version load.
+
+**Verification**: New `tests/viewport-camera-persistence.spec.ts` — one test
+asserts angle+distance survive a version switch (via both console API and the
+UI prev-arrow during dev), another asserts a freshly-opened session still
+auto-frames (doesn't inherit the prior angle). Re-ran the camera-adjacent specs
+(`viewport-reset-view`, `version-nav-language`, `thumbnail-camera`,
+`paint-camera-passthrough`) — all green.

--- a/prompts/20260607-150345-camera-persist-on-code-edits.md
+++ b/prompts/20260607-150345-camera-persist-on-code-edits.md
@@ -1,0 +1,49 @@
+---
+session: "fvIqe7"
+timestamp: "2026-06-07T15:03:45Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 2
+---
+
+## Human
+
+I also notice that whenever I make changes to the code, the interactive pane
+re-renders and I lose my angle/perspective in that case too. If your change
+already fixes that, fantastic. If not, please ensure that when I'm editing the
+code, whatever perspective/angle I've set in the interactive view doesn't reset.
+
+## Assistant
+
+## Key decisions
+
+The first commit deliberately scoped the live-edit case *out* — genuine
+new-code runs kept auto-framing — so this wasn't fixed yet. Extended
+preservation to the interactive editing path.
+
+**Change**: `runCode` (the RAF wrapper that every interactive entry point routes
+through — editor debounced auto-run, the Run button, the command-palette "Run"
+action, Customizer param change/reset, voxel-paint deactivate, diff "use this
+code") now defaults to `preserveCamera: true` when calling `runCodeSync`. A
+caller can still opt out with `preserveCamera: false`.
+
+**Why this is the right seam**: Programmatic runs — `partwright.run` /
+`runAndSave` (console + AI agent), import/merge flows, `openSession` — call
+`runCodeSync` *directly*, not through `runCode`, so they keep auto-framing. That
+preserves the framing behavior the AI/agent and the viewport-reset-view +
+thumbnail-camera specs depend on, while interactive human edits keep the angle.
+
+**Safety net unchanged**: `captureCameraToPreserve`'s same-session +
+model-already-shown gate still auto-frames the *first* render of a session even
+when it comes via `runCode(defaultCode)` (e.g. opening from the landing page or
+creating a session). So "don't reset my angle" applies to re-renders within a
+session; opening a fresh session still frames its model. "Reset View" remains
+the explicit re-frame escape hatch.
+
+**Verification**: Added a third case to
+`tests/viewport-camera-persistence.spec.ts` — orbit, then physically edit the
+code in the CodeMirror editor (Ctrl/Cmd-A + type a smaller cube), and assert the
+camera angle/distance survive the debounced auto-run. Confirmed visually with
+before/after screenshots (model shrank, perspective identical). Re-ran all
+camera-adjacent specs (viewport-reset-view, version-nav-language,
+thumbnail-camera, paint-camera-passthrough) — all green.

--- a/prompts/20260607-1530-closesession-frame-reset.md
+++ b/prompts/20260607-1530-closesession-frame-reset.md
@@ -1,0 +1,28 @@
+---
+session: "fvIqe7"
+timestamp: "2026-06-07T15:30:00Z"
+model: claude-opus-4-8
+sequence: 3
+---
+
+## Human
+
+(work-reviewer follow-up) Review of the camera-persistence branch flagged that
+closeSession leaves lastFramedSessionId stale, so re-opening a just-closed
+session would preserve the prior angle instead of auto-framing — a deviation
+from the "opening a session always frames" contract.
+
+## Assistant
+
+## Key decisions
+
+Applied the reviewer's suggested fix: reset `lastFramedSessionId = null` in the
+`partwright.closeSession` wrapper (the only main.ts path that reaches the
+session-manager `closeSession`). After close, the next render — whether a new
+session or a re-open of the just-closed one — sees `sid !== lastFramedSessionId`
+and auto-frames, restoring strict adherence to the contract.
+
+Left the other two review notes as-is (deliberate, non-blocking): an
+empty-output run not refreshing the tracker (geometry unchanged, self-heals on
+next real render), and `frameModel` clamping the restored zoom to the new
+model's `maxDistance` on large size changes (correct anti-speck behavior).

--- a/src/main.ts
+++ b/src/main.ts
@@ -12757,7 +12757,7 @@ async function main() {
     });
   }
 
-  function runCode(code?: string, opts: { surfaceErrors?: boolean } = {}) {
+  function runCode(code?: string, opts: { surfaceErrors?: boolean; preserveCamera?: boolean } = {}) {
     // Never execute the sharer's untrusted code in a read-only preview. Fork first.
     if (isSharedPreview()) return;
     const src = code ?? getValue();
@@ -12782,7 +12782,15 @@ async function main() {
       // cancel only this specific run (not an explicit run that superseded it).
       const myRafGen = _runGeneration + 1;
       _rafOwnedGeneration = myRafGen;
-      await runCodeSync(src, opts);
+      // runCode is the interactive entry point (editor auto-run, Run button,
+      // command palette, quality/param changes), so it preserves the user's
+      // current camera angle by default — re-rendering edited code shouldn't
+      // snap the view back to the default 3/4 framing. The same-session gate in
+      // captureCameraToPreserve still auto-frames the first render of a session
+      // (e.g. runCode(defaultCode) on a freshly-created session). Programmatic
+      // runs (partwright.run/runAndSave) call runCodeSync directly and keep
+      // auto-framing. A caller can opt out with preserveCamera: false.
+      await runCodeSync(src, { preserveCamera: true, ...opts });
       // If we still own the generation slot and the run is done, clear it.
       if (_rafOwnedGeneration === myRafGen) _rafOwnedGeneration = -1;
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { resolveParamValues, pruneParamValues, type ParamSpec, type ParamValue } from './geometry/params';
 import { createParamsPanel, type ParamsPanelController } from './ui/paramsPanel';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
-import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange, resetView } from './renderer/viewport';
+import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCameraPose, setCameraPose, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange, resetView } from './renderer/viewport';
 // Side-effect import: registers the phantom/annotation/session-plane viewport
 // hooks. Must load before initViewport runs (below). See viewportSubsystems.ts.
 import './renderer/viewportSubsystems';
@@ -414,6 +414,24 @@ function syncParamsPanel(schema: ParamSpec[] | undefined): void {
 }
 
 let currentMeshData: MeshData | null = null;
+/** Session id whose geometry the viewport last framed. Lets the render paths
+ *  tell a *re-render within the active session* (version switch or re-run —
+ *  preserve the user's current interactive camera angle) apart from the first
+ *  render of a freshly-opened session (let the camera auto-frame the new model). */
+let lastFramedSessionId: string | null = null;
+type CameraPose = { position: [number, number, number]; target: [number, number, number] };
+/** Snapshot the live camera pose to restore after a re-render, but only when the
+ *  active session's geometry is already on screen — i.e. the impending render is
+ *  a version switch or re-run within the session, where the user's interactive
+ *  angle/zoom should be kept instead of snapping back to the default 3/4 framing.
+ *  Returns null for the first render of a freshly-opened session (let it
+ *  auto-frame). Restore with `if (pose) setCameraPose(pose)` after the render. */
+function captureCameraToPreserve(): CameraPose | null {
+  const sid = getState().session?.id ?? null;
+  return currentMeshData !== null && sid !== null && sid === lastFramedSessionId
+    ? getCameraPose()
+    : null;
+}
 /** WASM heap high-water (bytes) reported by the geometry Worker for the most
  *  recent manifold-js run. Surfaced in the geometry-data stats and engine-error
  *  log so users can see how close a run came to the ~4 GB ceiling. Undefined
@@ -2678,7 +2696,7 @@ async function main() {
         // shows the active version's code. Re-render the active version so the
         // editor text and viewport agree again.
         const st = getState();
-        if (st.currentVersion) await runCodeSync(st.currentVersion.code);
+        if (st.currentVersion) await runCodeSync(st.currentVersion.code, { preserveCamera: true });
         const partWord = result.addedParts.length === 1 ? 'part' : 'parts';
         showToast(`Merged ${result.addedParts.length} ${partWord} into this session.`, { variant: 'success' });
         return true;
@@ -4574,6 +4592,15 @@ async function main() {
     // after navigation would write the wrong session's voxels into the new
     // editor. Also unlocks the editor and clears the floating panel.
     cancelVoxelPaintIfActive();
+    // Preserve the user's interactive camera angle across version switches
+    // *within* a session. Loading a version re-renders the geometry, whose
+    // updateMesh auto-frames the camera back to the default 3/4 view — undoing
+    // any orbit/zoom the user set. We snapshot the live pose here and restore it
+    // after the new geometry is in (frameModel still runs, so clip range / grid /
+    // near-far adapt to the new model's bounds — only the camera is put back).
+    // runCodeSync applies the same preserve on the cache-miss compile and on the
+    // debounced auto-run that re-renders ~300ms after a version load.
+    const preservedCameraPose = captureCameraToPreserve();
     // Each version remembers the language it was authored in (per-version
     // since schema 1.8); fall back to the session-level hint, then to the
     // engine default. Lets a single session hold mixed JS + SCAD versions
@@ -4650,8 +4677,11 @@ async function main() {
       setStatus(statusBar, 'ready', 'Ready');
     } else {
       // Cache miss: compile the code and, on success, populate the cache.
+      // preserveCamera keeps the user's interactive angle across the switch
+      // (see captureCameraToPreserve); the cache-hit branch above relies on the
+      // preservedCameraPose restore at the end of this function instead.
       const meshBeforeRun = currentMeshData;
-      const applied = await runCodeSync(version.code);
+      const applied = await runCodeSync(version.code, { preserveCamera: true });
       // If a newer version-switch arrived while we were compiling, our result
       // was discarded — don't rehydrate colours or annotations for the wrong version.
       if (!applied) return;
@@ -4675,6 +4705,13 @@ async function main() {
         }
       }
     }
+
+    // Restore the pre-switch camera angle (see capture above), or record this
+    // session as framed so the *next* switch within it preserves the angle.
+    if (preservedCameraPose) {
+      setCameraPose(preservedCameraPose);
+    }
+    lastFramedSessionId = getState().session?.id ?? null;
 
     await rehydrateColorRegions(version.geometryData);
     applyVersionAnnotations(version);
@@ -8704,7 +8741,7 @@ async function main() {
       // Restore this version's Customizer overrides before the re-run so it
       // renders with the values it was saved at (matches loadVersionIntoEditor).
       currentParamValues = { ...(version.paramValues ?? {}) };
-      await runCodeSync(version.code);
+      await runCodeSync(version.code, { preserveCamera: true });
       await rehydrateColorRegions(version.geometryData);
       applyVersionAnnotations(version);
       // Labels are runtime state from the just-executed code. Surface
@@ -8744,7 +8781,7 @@ async function main() {
         // Restore this version's Customizer overrides before the re-run so it
         // renders with the values it was saved at (matches loadVersion).
         currentParamValues = { ...(version.paramValues ?? {}) };
-        await runCodeSync(version.code);
+        await runCodeSync(version.code, { preserveCamera: true });
         await rehydrateColorRegions(version.geometryData);
         applyVersionAnnotations(version);
       }
@@ -12780,7 +12817,7 @@ async function main() {
     cancelInlineBtn.classList.add('hidden');
   }
 
-  async function runCodeSync(src: string, opts: { surfaceErrors?: boolean } = {}): Promise<boolean> {
+  async function runCodeSync(src: string, opts: { surfaceErrors?: boolean; preserveCamera?: boolean } = {}): Promise<boolean> {
     // Hard refusal in shared-preview mode: this is the single execution
     // chokepoint that the console API (partwright.run / runAndSave) also routes
     // through, so guarding it here keeps the sharer's untrusted code from ever
@@ -12965,6 +13002,13 @@ async function main() {
       // "shattered shards" bug. Gate on hasRefineDescriptors() (not just brush
       // strokes) so slab/box smooth regions rebuild too, exactly as the
       // visibility-toggle path does via reconcilePaintedGeometry.
+      //
+      // Snapshot the camera before the auto-framing updateMesh runs when this
+      // run is a version switch (opts.preserveCamera) within an already-framed
+      // session: keep the user's interactive angle instead of snapping to the
+      // default 3/4 view. Genuine new-code runs (pw.run, live edits) leave this
+      // null so the new model auto-frames as before.
+      const preservedCameraPose = opts.preserveCamera ? captureCameraToPreserve() : null;
       if (hasColorRegions() && hasRefineDescriptors()) {
         rebuildPaintedGeometry();
         lastStrokeList = strokeDescriptors();
@@ -12994,6 +13038,9 @@ async function main() {
         updateMesh(result.mesh);
         updatePaintMesh(result.mesh); // always pass uncolored mesh for adjacency
       }
+      // Put the camera back where the user had it (no-op on a session's first
+      // render, where captureCameraToPreserve returned null and we auto-frame).
+      if (preservedCameraPose) setCameraPose(preservedCameraPose);
 
       updateGeometryData(elapsed, src);
       syncClipSliderBounds();
@@ -13005,6 +13052,11 @@ async function main() {
       simplifyBaselineModelRegions = null;
       refreshSimplifyIfOpen();
       setStatus(statusBar, 'ready', 'Ready');
+      // Record the session this freshly-framed geometry belongs to, so the next
+      // version switch within it preserves the user's camera angle (see
+      // loadVersionIntoEditor). A fresh compile auto-frames, which is the
+      // baseline we want each new session to start from.
+      lastFramedSessionId = getState().session?.id ?? null;
     }
     return true;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8581,6 +8581,10 @@ async function main() {
     /** Close the current session */
     async closeSession() {
       await closeSession();
+      // Forget the framed session so re-opening it (or any session) auto-frames
+      // its model rather than preserving the angle from before it was closed —
+      // matches the "opening a session always frames" contract.
+      lastFramedSessionId = null;
     },
 
     /** Delete a session and all its versions */

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -681,6 +681,29 @@ export function getCameraState(): { azimuth: number; elevation: number; distance
   };
 }
 
+/** Snapshot the exact live camera pose (world-space position + orbit target).
+ *  Unlike getCameraState (rounded azimuth/elevation/distance for the API), this
+ *  keeps full precision so it can be restored losslessly — used to preserve the
+ *  user's interactive view across version switches within a session. */
+export function getCameraPose(): { position: [number, number, number]; target: [number, number, number] } {
+  return {
+    position: [camera.position.x, camera.position.y, camera.position.z],
+    target: [controls.target.x, controls.target.y, controls.target.z],
+  };
+}
+
+/** Restore a pose captured with getCameraPose. The companion to frameModel's
+ *  auto-frame: callers let updateMesh reframe (so clip range / grid / near-far
+ *  adapt to the new geometry's bounds) and then call this to put the camera
+ *  back where the user had it. */
+export function setCameraPose(pose: { position: [number, number, number]; target: [number, number, number] }): void {
+  camera.position.set(pose.position[0], pose.position[1], pose.position[2]);
+  controls.target.set(pose.target[0], pose.target[1], pose.target[2]);
+  controls.update();
+  if (clippingEnabled) updateClipPlaneVisual();
+  needsRender = true;
+}
+
 export function getCanvas(): HTMLCanvasElement {
   return renderer.domElement;
 }

--- a/tests/viewport-camera-persistence.spec.ts
+++ b/tests/viewport-camera-persistence.spec.ts
@@ -77,6 +77,35 @@ test.describe('viewport camera persistence', () => {
     expect(Math.abs(after.distance - before.distance)).toBeLessThan(2);
   });
 
+  test('preserves the camera angle when editing code (live re-run)', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+    await page.evaluate(async (box) => {
+      await (window as unknown as { partwright: PW }).partwright.run(box);
+    }, BOX);
+    await page.waitForTimeout(800);
+
+    await orbitAndZoom(page);
+    const before = await camera(page);
+    expect(Math.abs(before.azimuth - 45) > 5 || Math.abs(before.elevation - 35) > 5).toBe(true);
+
+    // Edit the code for real — replace it via the editor so the debounced
+    // auto-run fires through the same runCode path a user hits while typing.
+    const showCode = page.getByText('Show code', { exact: false });
+    if (await showCode.count()) await showCode.first().click().catch(() => {});
+    const editor = page.locator('.cm-content').first();
+    await editor.click();
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.type('const { Manifold } = api; return Manifold.cube([6, 6, 6], true);');
+    await page.waitForTimeout(2000); // past the 300ms auto-run debounce + render
+
+    const after = await camera(page);
+    // The model shrank, but the camera angle/distance must be unchanged.
+    expect(Math.abs(after.azimuth - before.azimuth)).toBeLessThan(2);
+    expect(Math.abs(after.elevation - before.elevation)).toBeLessThan(2);
+    expect(Math.abs(after.distance - before.distance)).toBeLessThan(2);
+  });
+
   test('still auto-frames on the first render of a freshly-opened session', async ({ page }) => {
     await page.goto('/editor');
     await page.waitForSelector('text=Ready', { timeout: 15000 });

--- a/tests/viewport-camera-persistence.spec.ts
+++ b/tests/viewport-camera-persistence.spec.ts
@@ -1,0 +1,107 @@
+// Golden-path tests for interactive camera-angle persistence across version
+// switches within a session. Switching versions re-renders the geometry; that
+// re-render used to auto-frame the camera back to the default 3/4 view, throwing
+// away whatever angle/zoom the user had orbited to. The fix snapshots the live
+// camera pose and restores it after the new geometry is in — but only within the
+// same session (the first render of a freshly-opened session still auto-frames).
+//
+// See src/main.ts captureCameraToPreserve / setCameraPose (src/renderer/viewport.ts).
+
+import { test, expect, type Page } from 'playwright/test';
+
+type PW = {
+  run: (code: string) => Promise<unknown>;
+  runAndSave: (code: string, label?: string) => Promise<unknown>;
+  listVersions: () => Promise<Array<{ index: number; id: string }>>;
+  loadVersion: (t: { index?: number; id?: string }) => Promise<unknown>;
+  getViewState: () => { camera: { azimuth: number; elevation: number; distance: number; target: [number, number, number] } };
+};
+
+const BOX = 'const { Manifold } = api; return Manifold.cube([10, 10, 10], true);';
+const SPHERE = 'const { Manifold } = api; return Manifold.sphere(8, 32);';
+
+function camera(page: Page) {
+  return page.evaluate(() => (window as unknown as { partwright: PW }).partwright.getViewState().camera);
+}
+
+// Orbit + zoom the viewport away from its default framing via a real mouse drag
+// + wheel on the canvas (OrbitControls' own input path).
+async function orbitAndZoom(page: Page): Promise<void> {
+  const canvas = page.locator('#viewport');
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error('no #viewport canvas');
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  await page.mouse.move(cx, cy);
+  await page.mouse.down();
+  await page.mouse.move(cx + 140, cy - 90, { steps: 12 });
+  await page.mouse.up();
+  await page.mouse.move(cx, cy);
+  await page.mouse.wheel(0, -300);
+  await page.waitForTimeout(600);
+}
+
+test.describe('viewport camera persistence', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('preserves the camera angle when switching versions in a session', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    await page.evaluate(async ([box, sphere]) => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.runAndSave(box, 'box');
+      await pw.runAndSave(sphere, 'sphere');
+    }, [BOX, SPHERE]);
+    await page.waitForTimeout(800);
+
+    await orbitAndZoom(page);
+    const before = await camera(page);
+    // Sanity: we actually moved off the default ~45°/35° framing.
+    expect(Math.abs(before.azimuth - 45) > 5 || Math.abs(before.elevation - 35) > 5).toBe(true);
+
+    // Switch to the earlier version. The debounced auto-run also re-renders
+    // ~300ms later, so wait long enough to catch a late reframe.
+    await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      const versions = await pw.listVersions();
+      await pw.loadVersion({ index: versions[0].index });
+    });
+    await page.waitForTimeout(1200);
+
+    const after = await camera(page);
+    expect(Math.abs(after.azimuth - before.azimuth)).toBeLessThan(2);
+    expect(Math.abs(after.elevation - before.elevation)).toBeLessThan(2);
+    expect(Math.abs(after.distance - before.distance)).toBeLessThan(2);
+  });
+
+  test('still auto-frames on the first render of a freshly-opened session', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // Frame + orbit session A.
+    await page.evaluate(async (box) => {
+      await (window as unknown as { partwright: PW }).partwright.run(box);
+    }, BOX);
+    await page.waitForTimeout(600);
+    await orbitAndZoom(page);
+    const orbited = await camera(page);
+
+    // Open a brand-new session — its first render must auto-frame to the default
+    // view, NOT inherit the orbited angle from the previous session.
+    await page.evaluate(async (sphere) => {
+      const pw = (window as unknown as { partwright: { createSession(): Promise<unknown> } & PW }).partwright;
+      await pw.createSession();
+      await pw.run(sphere);
+    }, SPHERE);
+    await page.waitForTimeout(1000);
+
+    const fresh = await camera(page);
+    // Default framing is ~azimuth 45 / elevation 35; assert we snapped there and
+    // did not carry over the orbited angle.
+    expect(Math.abs(fresh.azimuth - orbited.azimuth)).toBeGreaterThan(5);
+    expect(Math.abs(fresh.elevation - 35)).toBeLessThan(5);
+  });
+});


### PR DESCRIPTION
## Summary

Switching versions within a session — and re-rendering edited code — used to snap the interactive 3D viewport camera back to its default 3/4 framing, discarding whatever angle/zoom the user had orbited to. Now the viewport keeps the user's perspective across both: version switches **and** live code edits within a session.

**How it works:** loading a version / re-running edited code still lets the auto-frame run (so clip-slider range, grid height, and near/far planes adapt to the new geometry's bounds) — but the camera position + target are snapshotted before and restored after, so only the bounds-derived state updates, not the viewing angle.

### What changed
- **`src/renderer/viewport.ts`** — new `getCameraPose()` / `setCameraPose()` that capture & restore the exact world-space camera pose (position + orbit target), losslessly (unlike the rounded, read-only `getCameraState`).
- **`src/main.ts`**
  - `captureCameraToPreserve()` + a `lastFramedSessionId` tracker. It returns the live pose **only** when a model is already on screen *and* we're staying in the same session — the same-session gate.
  - An explicit `preserveCamera` option on `runCodeSync`, passed by the version-switch call sites (`loadVersionIntoEditor`, `partwright.loadVersion`/`navigateVersion`, post-merge re-render).
  - `runCode` (the interactive entry point — editor auto-run, Run button, command palette, Customizer param changes, voxel-paint deactivate, diff "use this code") now defaults to `preserveCamera: true`.

### Scope / safety
- The **first render of a freshly-opened session still auto-frames** (the same-session gate returns no pose), and opening a *different* session frames its model rather than inheriting the previous angle.
- **Programmatic runs** — `partwright.run` / `runAndSave` (console + AI agent), import/merge flows, `openSession` — call `runCodeSync` directly and keep auto-framing, so AI iteration and the existing framing-dependent specs are unaffected.
- **Reset View** remains the explicit re-frame escape hatch.

## Test plan
- New `tests/viewport-camera-persistence.spec.ts` (3 cases):
  - camera angle/distance survive a version switch within a session
  - camera angle/distance survive a real in-editor code edit (debounced auto-run)
  - a freshly-opened session still auto-frames (does not inherit the prior angle)
- Re-ran the camera-adjacent specs — all green: `viewport-reset-view`, `version-nav-language`, `thumbnail-camera`, `paint-camera-passthrough`.
- `npm run build` (tsc) + `npm run test:unit` (718 passing) clean.
- Manually verified in the browser (version-switch via UI prev-arrow and console API; live code edit) with before/after screenshots — model changes, perspective stays.

https://claude.ai/code/session_01VqvJEGcQhXi7wvNg7qKcpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqvJEGcQhXi7wvNg7qKcpm)_