### PR TITLE
feat: add print-tested status badge to catalog tiles

### DIFF
--- a/prompts/20260607-catalog-print-tested-status.md
+++ b/prompts/20260607-catalog-print-tested-status.md
@@ -60,3 +60,17 @@ fit for a no-backend SPA — the "upload" is a git commit, photos added via a
 GitHub PR / web drag-drop or locally), or (B) host photos externally
 (Cloudflare Images/R2, etc.) and store URLs in the manifest. Recommended (A)
 and asked the user to choose before building the photo-display side.
+
+### Follow-up: work-reviewer fixes
+
+A review pass on the green PR surfaced two should-fixes, both applied:
+
+1. The in-app meta row lacked `flex-wrap` (the static renderer had it). With a
+   third chip now on the row and `overflow-hidden` on the tile, chips could clip
+   on narrow widths instead of wrapping. Added `flex-wrap` so both renderers
+   match.
+2. Search-token collision: the untested token `not-print-tested` *contains* the
+   substring `print-tested`, and the filter matches substrings — so searching
+   "print-tested" matched every tile, not just verified ones. Dropped it to just
+   `untested`, and added a unit case asserting untested tokens never contain
+   `print-tested`.

--- a/prompts/20260607-catalog-print-tested-status.md
+++ b/prompts/20260607-catalog-print-tested-status.md
@@ -1,0 +1,62 @@
+---
+date: 2026-06-07
+branch: claude/catalog-print-tested-status-Lvt9F
+files_changed:
+  - src/content/data/catalogCategories.ts
+  - src/content/build/render.ts
+  - src/ui/catalog.ts
+  - tests/unit/catalogCategories.test.ts
+  - tests/catalog.spec.ts
+---
+
+## Human
+
+Add a print-tested status to catalog items so people can have confidence a
+model is actually printable. Default every model to "not print-tested yet".
+Create a PR for that work. Separately, consult me on the best way to upload
+photos of my prints and associate them to catalog items, given this is a
+stateless single-page app.
+
+## Assistant
+
+Two deliverables: ship the print-tested badge (this PR) and open a design
+discussion about print photos (chat, no code yet).
+
+**Why a manifest field, not a payload trait.** The other tile badges split two
+ways: language comes from the entry/payload, while the Parametric chip is
+*derived* from session code (`deriveCharacteristics`). Print-tested can't be
+derived — it's an editorial fact about the physical world — so it has to be
+declared. The manifest entry (`CatalogManifestEntry`) is the right home: it's
+already fetched by both render paths and is where the curator edits metadata.
+Added `printTested?: boolean`.
+
+**Default = absent.** The user wants every model "not print-tested yet" by
+default. Rather than stamp `"printTested": false` onto all ~80 entries (noisy
+diff, and absent already means the same thing for every other optional field
+here), absence is treated as untested. The badge still renders on every tile so
+the status is always explicit; flipping one to verified is a one-line
+`"printTested": true` edit.
+
+**One pure helper, two renderers.** Both the static pre-renderer
+(`render.ts`) and the in-app overlay (`catalog.ts`) must render an identical
+chip, so I put `printTestedBadge()` in the shared dependency-free
+`catalogCategories.ts` (same place `categorizeOf`/`deriveCharacteristics`
+live). It returns label + Tailwind classes + tooltip + searchable tokens.
+Verified → green `✓ Print-tested`; untested → muted `Untested`. Distinct search
+tokens (`verified` vs `untested`) fold into each tile's `data-search` haystack
+so the shared filter can find either state.
+
+Tests: unit coverage for the helper's two branches + that absent ≡ false; an
+e2e assertion that every static tile carries exactly one status chip, all read
+"Untested" by default, and the status is searchable. Verified both states in a
+real browser (temporarily flipped one entry to confirm the green chip, then
+reverted).
+
+**Print-photo upload (consult, not built).** Flagged that I can *see* a photo
+pasted in chat but can't faithfully reproduce its bytes as a committed binary,
+so the realistic options are: (A) commit photo files as static assets under
+`public/catalog/prints/<id>/` and reference them from the manifest (the natural
+fit for a no-backend SPA — the "upload" is a git commit, photos added via a
+GitHub PR / web drag-drop or locally), or (B) host photos externally
+(Cloudflare Images/R2, etc.) and store URLs in the manifest. Recommended (A)
+and asked the user to choose before building the photo-display side.

--- a/src/content/build/render.ts
+++ b/src/content/build/render.ts
@@ -13,6 +13,7 @@ import {
   CATEGORIES,
   categorizeOf,
   deriveCharacteristics,
+  printTestedBadge,
   CATALOG_LANGUAGE_ORDER,
   type CategoryId,
   type CatalogLanguage,
@@ -188,10 +189,12 @@ function catalogTileHtml(tile: BuiltTile): string {
   const paramChip = tile.hasParams
     ? '<span class="font-semibold border rounded px-1 text-violet-300 border-violet-400/30" title="Exposes adjustable parameters">🎛 Parametric</span>'
     : '';
+  const print = printTestedBadge(tile.entry.printTested);
+  const printChip = `<span class="font-semibold border rounded px-1 ${print.classes}" title="${escAttr(print.title)}">${esc(print.label)}</span>`;
   const versions = tile.versionCount > 0
     ? `<span>${tile.versionCount} version${tile.versionCount !== 1 ? 's' : ''}</span>`
     : '';
-  const haystack = [tile.entry.name, tile.entry.description ?? '', tile.entry.id, badge.label].join(' ').toLowerCase();
+  const haystack = [tile.entry.name, tile.entry.description ?? '', tile.entry.id, badge.label, print.search].join(' ').toLowerCase();
   return `<a href="/editor?catalog=${encodeURIComponent(tile.entry.file)}" data-pw-thumb="${escAttr(tile.entry.file)}" data-catalog-tile data-language="${escAttr(tile.language)}" data-search="${escAttr(haystack)}" class="flex flex-col bg-zinc-800 rounded-lg border border-zinc-700 hover:border-zinc-500 transition-colors overflow-hidden no-underline">
   <div class="relative w-full aspect-square bg-zinc-900 flex items-center justify-center overflow-hidden">
     <span class="text-3xl text-zinc-700">&#11041;</span>
@@ -202,6 +205,7 @@ function catalogTileHtml(tile: BuiltTile): string {
     ${desc}
     <div class="text-[10px] text-zinc-500 mt-1.5 flex items-center gap-2 flex-wrap">
       <span class="font-semibold border rounded px-1 ${badge.classes}">${esc(badge.label)}</span>
+      ${printChip}
       ${paramChip}
       ${versions}
     </div>

--- a/src/content/data/catalogCategories.ts
+++ b/src/content/data/catalogCategories.ts
@@ -64,7 +64,10 @@ export function printTestedBadge(printTested: boolean | undefined): PrintTestedB
         label: 'Untested',
         classes: 'text-zinc-500 border-zinc-600/70',
         title: 'Not print-tested yet — this model has not been verified with a physical print.',
-        search: 'untested not-print-tested',
+        // Just `untested` — avoid any token containing the `print-tested`
+        // substring, so searching "print-tested" surfaces only verified tiles
+        // (the filter matches substrings, see catalogFilter.ts).
+        search: 'untested',
       };
 }
 

--- a/src/content/data/catalogCategories.ts
+++ b/src/content/data/catalogCategories.ts
@@ -26,6 +26,46 @@ export interface CatalogManifestEntry {
   /** Optional curated group. When set, the entry is bucketed into this themed,
    *  language-independent section instead of its engine-derived category. */
   group?: CuratedGroupId;
+  /** Whether this model has been physically 3D-printed and verified printable.
+   *  Absent/false means "not print-tested yet" (the default for every entry) —
+   *  flip to `true` only once a real print exists. Drives the print-tested tile
+   *  badge so users can tell verified-printable models from unproven ones. */
+  printTested?: boolean;
+}
+
+/** Badge describing whether a catalog entry has been verified print-tested.
+ *  Pure (label + Tailwind classes + tooltip + searchable tokens) so both the
+ *  static pre-renderer and the in-app overlay render an identical chip. */
+export interface PrintTestedBadge {
+  /** True once the model has a verified physical print. */
+  tested: boolean;
+  /** Short chip label. */
+  label: string;
+  /** Tailwind text + border colour classes. */
+  classes: string;
+  /** Full-text tooltip. */
+  title: string;
+  /** Tokens folded into the tile's search haystack so the state is findable
+   *  (`verified` for tested, `untested` for not-yet-tested). */
+  search: string;
+}
+
+export function printTestedBadge(printTested: boolean | undefined): PrintTestedBadge {
+  return printTested
+    ? {
+        tested: true,
+        label: '✓ Print-tested',
+        classes: 'text-emerald-300 border-emerald-400/40',
+        title: 'Verified — this model has been physically 3D-printed successfully.',
+        search: 'print-tested verified',
+      }
+    : {
+        tested: false,
+        label: 'Untested',
+        classes: 'text-zinc-500 border-zinc-600/70',
+        title: 'Not print-tested yet — this model has not been verified with a physical print.',
+        search: 'untested not-print-tested',
+      };
 }
 
 /** The catalog is sectioned so each tile's reason for being here is obvious.

--- a/src/ui/catalog.ts
+++ b/src/ui/catalog.ts
@@ -337,7 +337,7 @@ function renderTile(loaded: LoadedEntry, callbacks: CatalogCallbacks): HTMLEleme
   }
 
   const meta = document.createElement('div');
-  meta.className = 'text-[10px] text-zinc-500 mt-1.5 flex items-center gap-2';
+  meta.className = 'text-[10px] text-zinc-500 mt-1.5 flex items-center gap-2 flex-wrap';
   const badge = languageBadge(language);
   const langBadge = document.createElement('span');
   langBadge.className = `font-semibold border rounded px-1 ${badge.classes}`;

--- a/src/ui/catalog.ts
+++ b/src/ui/catalog.ts
@@ -11,6 +11,7 @@ import {
   CATEGORIES,
   categorizeOf,
   deriveCharacteristics as deriveTraits,
+  printTestedBadge,
   CATALOG_LANGUAGE_ORDER,
   type CategoryId,
   type CategoryDef,
@@ -292,11 +293,13 @@ function renderTile(loaded: LoadedEntry, callbacks: CatalogCallbacks): HTMLEleme
   const language = entryLanguage(loaded);
   tile.dataset.catalogTile = '';
   tile.dataset.language = language;
+  const print = printTestedBadge(loaded.manifest.printTested);
   tile.dataset.search = [
     loaded.manifest.name,
     loaded.manifest.description ?? '',
     loaded.manifest.id,
     languageBadge(language).label,
+    print.search,
   ].join(' ').toLowerCase();
 
   // Thumbnail
@@ -340,6 +343,14 @@ function renderTile(loaded: LoadedEntry, callbacks: CatalogCallbacks): HTMLEleme
   langBadge.className = `font-semibold border rounded px-1 ${badge.classes}`;
   langBadge.textContent = badge.label;
   meta.appendChild(langBadge);
+
+  // Print-tested chip — verified-printable vs. not-yet-tested. Always shown so
+  // every tile states its print status (default: "Untested").
+  const printChip = document.createElement('span');
+  printChip.className = `font-semibold border rounded px-1 ${print.classes}`;
+  printChip.textContent = print.label;
+  printChip.title = print.title;
+  meta.appendChild(printChip);
 
   // Parametric chip — the headline "special characteristic": this model exposes
   // tweakable knobs. Reinforces the Customizable section at a per-tile glance.

--- a/tests/catalog.spec.ts
+++ b/tests/catalog.spec.ts
@@ -70,6 +70,29 @@ test.describe('Catalog page (static)', () => {
     await expect(fidget).toContainText('Spiral Fidget Cone');
   });
 
+  test('every tile carries a print-tested status chip (default: Untested)', async ({ page }) => {
+    await gotoCatalog(page);
+
+    const tiles = page.locator('main a[data-catalog-tile]');
+    const tileCount = await tiles.count();
+    expect(tileCount).toBeGreaterThan(0);
+
+    // Each tile shows exactly one print-status chip — verified or untested.
+    for (const tile of await tiles.all()) {
+      const chips = tile.locator('span:has-text("Print-tested"), span:has-text("Untested")');
+      await expect(chips).toHaveCount(1);
+    }
+
+    // With nothing marked print-tested yet, every chip reads "Untested".
+    await expect(page.locator('main a[data-catalog-tile] span:has-text("Untested")')).toHaveCount(tileCount);
+
+    // The status is searchable: filtering on "untested" keeps the untested tiles.
+    const search = page.locator('[data-catalog-search]');
+    await search.fill('untested');
+    expect(await page.locator('main a[data-catalog-tile]:not(.hidden)').count()).toBeGreaterThan(0);
+    await search.fill('');
+  });
+
   test('search narrows tiles, updates section counts, and hides empty sections', async ({ page }) => {
     await gotoCatalog(page);
 

--- a/tests/unit/catalogCategories.test.ts
+++ b/tests/unit/catalogCategories.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { printTestedBadge } from '../../src/content/data/catalogCategories';
+
+describe('printTestedBadge', () => {
+  it('defaults to "Untested" when the flag is absent', () => {
+    const badge = printTestedBadge(undefined);
+    expect(badge.tested).toBe(false);
+    expect(badge.label).toBe('Untested');
+    expect(badge.search).toContain('untested');
+    expect(badge.title).toMatch(/not print-tested/i);
+  });
+
+  it('treats an explicit false the same as absent', () => {
+    expect(printTestedBadge(false)).toEqual(printTestedBadge(undefined));
+  });
+
+  it('reports verified state when the flag is true', () => {
+    const badge = printTestedBadge(true);
+    expect(badge.tested).toBe(true);
+    expect(badge.label).toBe('✓ Print-tested');
+    expect(badge.search).toContain('verified');
+    expect(badge.title).toMatch(/verified/i);
+  });
+
+  it('uses distinct search tokens so each state is independently findable', () => {
+    expect(printTestedBadge(true).search).toContain('verified');
+    expect(printTestedBadge(false).search).not.toContain('verified');
+    expect(printTestedBadge(false).search).toContain('untested');
+    expect(printTestedBadge(true).search).not.toContain('untested');
+  });
+});

--- a/tests/unit/catalogCategories.test.ts
+++ b/tests/unit/catalogCategories.test.ts
@@ -28,4 +28,12 @@ describe('printTestedBadge', () => {
     expect(printTestedBadge(false).search).toContain('untested');
     expect(printTestedBadge(true).search).not.toContain('untested');
   });
+
+  it('untested tokens never contain the "print-tested" substring (filter matches substrings)', () => {
+    // The catalog filter uses haystack.includes(token), so searching
+    // "print-tested" must surface only verified tiles — the untested token
+    // must not collide with it.
+    expect(printTestedBadge(false).search).not.toContain('print-tested');
+    expect(printTestedBadge(true).search).toContain('print-tested');
+  });
 });


### PR DESCRIPTION
## Summary

Catalog tiles now show whether a model has been **verified printable**, so visitors can tell proven models from unproven ones at a glance.

- Adds an optional `printTested?: boolean` to `CatalogManifestEntry`.
- A shared, dependency-free `printTestedBadge()` helper renders an identical chip in **both** catalog surfaces:
  - the static pre-rendered `/catalog` page (`src/content/build/render.ts`)
  - the in-app editor overlay (`src/ui/catalog.ts`)
- **Verified** → green `✓ Print-tested`; **default** → muted `Untested`.
- **Every model defaults to untested** (absence of the flag = untested, matching how the other optional manifest fields behave). To mark a model verified, add `"printTested": true` to its entry in `public/catalog/manifest.json`.
- The status is **searchable** via the existing catalog filter — `verified` / `untested` tokens are folded into each tile's `data-search` haystack.

### Screenshots

| Verified | Untested (default) |
|---|---|
| Green `✓ Print-tested` chip on the Spiral Fidget Cone | Muted `Untested` chip on the Companion Cube |

(Verified locally in a real browser; both states render in the tile meta row alongside the language and parametric chips.)

## Test plan

- `npm run build` — ✅ passes (also the type-check)
- `npm run test:unit` — ✅ 722 passed, incl. new `tests/unit/catalogCategories.test.ts` covering both badge branches + `absent ≡ false`
- `tests/catalog.spec.ts` — added an e2e assertion that every static tile carries exactly one status chip, all read `Untested` by default, and the status is searchable
- Full PR-checks e2e shards run on this draft

## Notes

This PR covers the **status/marking** half of the request. The companion question — how to upload print photos and associate them to catalog items in a stateless SPA — is being discussed with the maintainer separately before any photo-display work is built.

https://claude.ai/code/session_012WyAHWeqpkTVmSivKwjmUx

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyAHWeqpkTVmSivKwjmUx)_