### PR TITLE
feat: guide subscription users to a local Claude/Codex bridge

### DIFF
--- a/prompts/20260607-cli-bridge-api-key-flow.md
+++ b/prompts/20260607-cli-bridge-api-key-flow.md
@@ -1,0 +1,57 @@
+---
+session: "local-cli-endpoint-wrapper"
+timestamp: "2026-06-07T16:50:00Z"
+---
+
+## Human
+
+(Follow-up after trying the bridge.) CLIProxyAPI failed to start — localhost:8317
+showed "Example API key detected … replace template values in
+cliproxyapi.conf, then restart." Requests:
+- Tell users to open localhost:8317 to see/fix errors or confirm it's working.
+- Generate a random API key in the frontend; give a `sed` one-liner that
+  replaces the `your-api-key-N` block with it, then a restart command (and the
+  closest equivalent for other OSes).
+- In the API key field, add a button to use that generated key (warn to only
+  use it if they ran the command with it). Don't mask the key as a password.
+- Next to the Done button add "Done and also enable the selected provider" so
+  users aren't confused that edits don't auto-enable. Rename Done → "Close".
+
+## Assistant
+
+## Key decisions
+
+**API key is now a required setup step, not a nicety.** CLIProxyAPI refuses to
+start while its config holds the template `your-api-key-N` values, so the card
+gained a step 2 "Set an API key (required)" between install and login. It
+surfaces a `localhost:8317` status link in step 1 ("confirm it's running, or see
+errors to fix") since that's where the failure shows.
+
+**Browser-generated key, matched end to end.** `generateApiKey()` (crypto-
+random, `pw-` + 48 hex, no shell metacharacters) is generated once per modal
+open in `CustomTab` and threaded into both (a) the bridge card's setup command
+and (b) the "Use the bridge key" button in the API-key field — so the value the
+proxy is configured with and the value Partwright sends are guaranteed to match.
+The macOS one-liner is a runnable `sed -i '' … "$(brew --prefix)/etc/
+cliproxyapi.conf" && brew services restart cliproxyapi`; Linux gets a `sed`
+template with a path placeholder; Windows falls back to a manual instruction
+(its config path/tooling varies too much to script honestly).
+
+**API-key field is plain text now**, with a note that it's shown unmasked so the
+user can match it against the bridge config. The "Use the bridge key" button
+only fills the field (doesn't auto-save) so the user can eyeball it before
+saving.
+
+**Footer: "Close" + "Done & enable <provider>".** Renamed "Done" → "Close"
+(more accurate) and added a primary "Done & enable <provider>" that switches the
+active provider to the currently-viewed tab and closes — fixing the confusion
+that editing fields doesn't enable the provider. Readiness is shared with the
+top EnableRow via a new `useProviderReady(tab)` hook (extracted from EnableRow's
+old inline logic) so the two enable affordances can't disagree. Updated
+`smoke.spec.ts` which anchored on the AI Settings "Done" string.
+
+**Verification.** Build + unit (718) + deadcode/deps gates green; extended
+`tests/ai-cli-bridge-setup.spec.ts` to assert the required-key step, the
+disabled→enabled footer button, the text-typed key field, and that "Use the
+bridge key" fills a `pw-…` key; re-ran smoke (17 passed). Screenshots of both
+the auto-detected and macOS variants posted in chat.

--- a/prompts/20260607-cli-bridge-ci-selector-fix.md
+++ b/prompts/20260607-cli-bridge-ci-selector-fix.md
@@ -1,0 +1,23 @@
+---
+session: "local-cli-endpoint-wrapper"
+timestamp: "2026-06-07T17:00:00Z"
+---
+
+## Human
+
+(CI follow-up.) e2e shard 1 failed on PR #474.
+
+## Assistant
+
+## Key decisions
+
+**Disambiguated pre-existing selectors broken by the new footer button.** Adding
+the footer's "Done & enable <provider>" button made three `ai-providers.spec.ts`
+assertions hit a Playwright strict-mode violation: `button:has-text("Enable
+OpenAI")` is a case-insensitive *substring* match, so it now also matched "Done
+& enable OpenAI". Fixed by switching those locators (and the Custom / Local /
+Anthropic equivalents) to exact role queries — `getByRole('button', { name:
+'Enable OpenAI', exact: true })` — which target only the EnableRow button. No
+product code changed; the new affordance is legitimate, the selectors just
+needed to be specific. Verified by re-running the full `ai-providers` spec (33
+passed) locally.

--- a/prompts/20260607-local-cli-subscription-bridge.md
+++ b/prompts/20260607-local-cli-subscription-bridge.md
@@ -1,0 +1,60 @@
+---
+session: "local-cli-endpoint-wrapper"
+timestamp: "2026-06-07T15:35:00Z"
+---
+
+## Human
+
+Let people who pay for a Claude Max (or Codex) subscription use the app's AI by
+running the CLI agent locally and connecting to it as if it were an
+OpenAI-compatible endpoint on localhost. Are there existing frameworks/tools
+that do this? Ideally a button in the site that rapidly instructs the user how
+to run whatever component is needed. Focus on Claude Code for now. After
+discussion: don't build/publish a bridge — prefer pointing users at an existing
+tool installable via `brew` (with an `npx`/`winget`-style path for Windows).
+Proceed with the plan and open a PR.
+
+## Assistant
+
+## Key decisions
+
+**Reuse the existing Custom (OpenAI-compatible) provider; add onboarding only.**
+The app's `custom` provider already speaks `/v1/chat/completions` to any base
+URL with optional bearer auth, SSE streaming, a "Test connection"
+(`validateConnection` → `GET /models`) and a "Fetch models" button, and the CSP
+already whitelists `http://localhost:*`. So no new provider, transport, or
+settings were introduced — the only gap was discoverability. The whole feature
+is a guided card that fills the existing Base URL field.
+
+**Recommend CLIProxyAPI as the off-the-shelf bridge.** It is the only surveyed
+wrapper that clears the two bars a *browser* client needs and is also broadly
+distributed: it emits **wildcard CORS** (most IDE-oriented wrappers don't, since
+Cursor/Continue are same-origin native apps and never need it), supports
+**OpenAI function/tool calling** (which Partwright's geometry tools depend on),
+installs via `brew install cliproxyapi` / `winget install LuisPater.CLIProxyAPI`,
+runs as a localhost service on :8317, and covers Claude **and** Codex/Gemini via
+`--claude-login` / `--codex-login`. The decisive CORS/tool-calling facts were
+verified via web research, not memory.
+
+**New component `src/ui/preact/cliBridgeSetup.tsx`** rendered at the top of the
+Custom tab (`settingsModal.tsx` `CustomTab`). It is OS-aware (`navigator`
+sniff with a manual pill override), shows copy-to-clipboard install + login
+commands, and a one-click "Use this endpoint (localhost:8317)" that sets the
+Base URL signal and calls the tab's existing `testConnection()`. Kept it as a
+sibling file rather than inflating the 900-line `settingsModal.tsx`, and reused
+the `Section`/`Pill`/`PrimaryButton` primitives + the existing `navigator.
+clipboard.writeText` copy pattern from `aboutModal.tsx`.
+
+**Security + ToS framing in-UI, not just code.** Wildcard CORS + no auth means
+any site visited while the bridge runs could spend the user's subscription, so
+the card recommends setting an `api-key` in CLIProxyAPI's config and pasting it
+into the existing optional "API key" field (closes the hole with zero new code),
+and notes that subscription use outside the official client is community
+territory — "confirm it's allowed under your plan."
+
+**Verification.** Manual browser screenshot of the card (posted in chat) plus a
+golden-path e2e (`tests/ai-cli-bridge-setup.spec.ts`) that opens AI Settings on
+the Custom tab, asserts the card + steps render, and that "Use this endpoint"
+fills the Base URL with `http://localhost:8317/v1`. The spec dismisses the
+first-run tour via `localStorage 'partwright-tour-completed'` (the established
+pattern) because the tour backdrop intercepts clicks.

--- a/src/ui/aiSettingsModal.tsx
+++ b/src/ui/aiSettingsModal.tsx
@@ -33,7 +33,7 @@ export async function showAiSettingsModal(
     { title: 'AI Settings', scrollable: true, maxWidth: 'lg' },
     close => ({
       body: <SettingsModalBody cb={cb} tab={tab} close={close} />,
-      footer: <SettingsModalFooter close={close} />,
+      footer: <SettingsModalFooter close={close} tab={tab} cb={cb} />,
     }),
     // Match the original modal's body spacing — sections need more
     // breathing room than the default gap-3 the shell hands us.

--- a/src/ui/preact/cliBridgeSetup.tsx
+++ b/src/ui/preact/cliBridgeSetup.tsx
@@ -12,10 +12,15 @@
 //   - it supports OpenAI function/tool calling, which Partwright's geometry
 //     tools depend on.
 //
-// This card is pure onboarding: copy-paste install/login commands plus a
-// one-click "Use this endpoint" that fills the Base URL field below and tests
-// it. The connection itself still flows through the existing Custom provider —
-// no new provider, transport, or settings are introduced.
+// CLIProxyAPI refuses to start while its config still holds the template
+// `your-api-key-N` values, so setting a real key is a *required* step, not a
+// nicety. We generate a strong random key in the browser, hand the user a
+// one-liner that writes it into the config and restarts the bridge, and offer
+// a button to paste that same key into the endpoint's API-key field — so the
+// value the proxy expects and the value Partwright sends always match.
+//
+// This card is pure onboarding: the connection itself still flows through the
+// existing Custom provider — no new provider, transport, or settings.
 
 import type { ComponentChildren } from 'preact';
 import { useSignal } from '@preact/signals';
@@ -24,25 +29,41 @@ import { Section, Pill, PrimaryButton } from './primitives';
 
 /** CLIProxyAPI's default OpenAI-compatible base URL. */
 const CLI_BRIDGE_ENDPOINT = 'http://localhost:8317/v1';
+/** Where CLIProxyAPI serves its status / config-error page. */
+const CLI_BRIDGE_STATUS_URL = 'http://localhost:8317';
 
 const REPO_URL = 'https://github.com/router-for-me/CLIProxyAPI';
 
-type OsKey = 'mac' | 'windows' | 'other';
-
-interface InstallSpec {
-  label: string;
-  /** Steps shown when this OS is selected. The login step is shared and
-   *  appended separately. */
-  install: { cmd: string; note?: string } | { docs: true };
+/** A strong random API key, generated in the browser. Prefixed so it's
+ *  recognizable in a config file; hex body has no shell/sed metacharacters,
+ *  so it drops safely into the generated one-liner. */
+export function generateApiKey(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return 'pw-' + Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
 }
 
-const INSTALL: Record<OsKey, InstallSpec> = {
+type OsKey = 'mac' | 'windows' | 'other';
+
+interface OsSpec {
+  label: string;
+  install: { cmd: string; note?: string } | { docs: true };
+  /** Writes the API key into the config and restarts the bridge. A runnable
+   *  command, or a manual instruction when the path/tooling varies too much
+   *  to script reliably. */
+  fixAndRestart: (key: string) => { cmd: string } | { manual: string };
+}
+
+const OS: Record<OsKey, OsSpec> = {
   mac: {
     label: 'macOS',
     install: {
       cmd: 'brew install cliproxyapi && brew services start cliproxyapi',
       note: 'Installs the bridge and starts it as a background service.',
     },
+    fixAndRestart: key => ({
+      cmd: `sed -i '' -E "s/your-api-key-[0-9]+/${key}/g" "$(brew --prefix)/etc/cliproxyapi.conf" && brew services restart cliproxyapi`,
+    }),
   },
   windows: {
     label: 'Windows',
@@ -50,10 +71,16 @@ const INSTALL: Record<OsKey, InstallSpec> = {
       cmd: 'winget install LuisPater.CLIProxyAPI',
       note: 'Then run cli-proxy-api in a terminal to start the server.',
     },
+    fixAndRestart: () => ({
+      manual: 'Open the config file named on the status page, replace the three your-api-key-N values with the key above, then stop and re-run cli-proxy-api.',
+    }),
   },
   other: {
     label: 'Linux / other',
     install: { docs: true },
+    fixAndRestart: key => ({
+      cmd: `sed -i -E "s/your-api-key-[0-9]+/${key}/g" <config-path-from-the-status-page>`,
+    }),
   },
 };
 
@@ -64,9 +91,13 @@ function detectOs(): OsKey {
   return 'other';
 }
 
-export function CliBridgeSetup(props: { onUseEndpoint: (url: string) => void }) {
+export function CliBridgeSetup(props: {
+  apiKeyExample: string;
+  onUseEndpoint: (url: string) => void;
+}) {
   const os = useSignal<OsKey>(detectOs());
-  const spec = INSTALL[os.value];
+  const spec = OS[os.value];
+  const fix = spec.fixAndRestart(props.apiKeyExample);
 
   return (
     <Section label="Use a Claude or Codex subscription">
@@ -74,12 +105,12 @@ export function CliBridgeSetup(props: { onUseEndpoint: (url: string) => void }) 
         <p
           class="text-[11px] text-zinc-300 leading-snug"
           /* eslint-disable-next-line react/no-danger */
-          dangerouslySetInnerHTML={{ __html: 'Already pay for a <strong>Claude Pro/Max</strong> (or ChatGPT/Codex) plan? Run <strong><a class="text-blue-400 hover:text-blue-300 underline" href="' + REPO_URL + '" target="_blank" rel="noopener noreferrer">CLIProxyAPI</a></strong> — a small local bridge that turns your subscription into an OpenAI-compatible endpoint on <code>localhost</code>. No API key, no per-token billing. Partwright connects to it as a Custom endpoint.' }}
+          dangerouslySetInnerHTML={{ __html: 'Already pay for a <strong>Claude Pro/Max</strong> (or ChatGPT/Codex) plan? Run <strong><a class="text-blue-400 hover:text-blue-300 underline" href="' + REPO_URL + '" target="_blank" rel="noopener noreferrer">CLIProxyAPI</a></strong> — a small local bridge that turns your subscription into an OpenAI-compatible endpoint on <code>localhost</code>. No per-token billing. Partwright connects to it as a Custom endpoint.' }}
         />
 
         <div class="flex flex-wrap gap-1">
-          {(Object.keys(INSTALL) as OsKey[]).map(k => (
-            <Pill key={k} active={os.value === k} label={INSTALL[k].label} onClick={() => { os.value = k; }} />
+          {(Object.keys(OS) as OsKey[]).map(k => (
+            <Pill key={k} active={os.value === k} label={OS[k].label} onClick={() => { os.value = k; }} />
           ))}
         </div>
 
@@ -95,34 +126,48 @@ export function CliBridgeSetup(props: { onUseEndpoint: (url: string) => void }) 
               {spec.install.note && <p class="text-[10px] text-zinc-500">{spec.install.note}</p>}
             </>
           )}
+          <p
+            class="text-[10px] text-zinc-500 leading-snug"
+            /* eslint-disable-next-line react/no-danger */
+            dangerouslySetInnerHTML={{ __html: 'Open <a class="text-blue-400 hover:text-blue-300 underline" href="' + CLI_BRIDGE_STATUS_URL + '" target="_blank" rel="noopener noreferrer">' + CLI_BRIDGE_STATUS_URL + '</a> any time to confirm it\'s running — or to see config errors to fix (e.g. <em>"Example API key detected"</em> → do step 2).' }}
+          />
         </Step>
 
-        <Step n={2} title="Log in with your subscription">
+        <Step n={2} title="Set an API key (required)">
+          <p class="text-[11px] text-zinc-400 leading-snug">
+            CLIProxyAPI won’t start while its config holds the template keys. Here’s a fresh random key — this one-liner writes it in and restarts the bridge:
+          </p>
+          <div class="flex flex-col gap-0.5">
+            <span class="text-[10px] text-zinc-500">Your API key (used below too):</span>
+            <CopyRow cmd={props.apiKeyExample} />
+          </div>
+          {'cmd' in fix ? (
+            <CopyRow cmd={fix.cmd} />
+          ) : (
+            <p class="text-[11px] text-amber-200 leading-snug">{fix.manual}</p>
+          )}
+        </Step>
+
+        <Step n={3} title="Log in with your subscription">
           <CopyRow cmd="cliproxyapi --claude-login" />
           <p class="text-[10px] text-zinc-500">
             Opens a browser to authorize your Claude plan. Use <code>--codex-login</code> instead for a ChatGPT/Codex subscription.
           </p>
         </Step>
 
-        <Step n={3} title="Connect Partwright">
+        <Step n={4} title="Connect Partwright">
           <PrimaryButton
             label="Use this endpoint (localhost:8317)"
             variant="column"
             onClick={() => props.onUseEndpoint(CLI_BRIDGE_ENDPOINT)}
           />
           <p class="text-[10px] text-zinc-500">
-            Fills the <strong>Base URL</strong> below and tests it. Then click <strong>Fetch models</strong> and pick a <code>claude-…</code> model.
+            Fills the <strong>Base URL</strong> below and tests it. Then paste your key with <strong>Use this key</strong> in the API key field, click <strong>Fetch models</strong>, and pick a <code>claude-…</code> model.
           </p>
         </Step>
 
-        <div
-          class="rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-[11px] text-amber-200 leading-snug"
-          /* eslint-disable-next-line react/no-danger */
-          dangerouslySetInnerHTML={{ __html: '<strong>Secure it:</strong> the bridge accepts requests from any origin (wildcard CORS). Set an <code>api-key</code> in its <code>config.yaml</code> and paste it into <strong>API key</strong> below, so only requests bearing that key can spend your subscription. Keep it bound to <code>127.0.0.1</code> (the default) — don\'t expose it on your network.' }}
-        />
-
         <p class="text-[10px] text-zinc-500 leading-snug">
-          Using a subscription outside its official app is community-supported and not endorsed by Anthropic or OpenAI — confirm it’s allowed under your plan before relying on it.
+          Keep the bridge bound to <code>127.0.0.1</code> (the default) — don’t expose it on your network. Using a subscription outside its official app is community-supported and not endorsed by Anthropic or OpenAI; confirm it’s allowed under your plan.
         </p>
       </div>
     </Section>

--- a/src/ui/preact/cliBridgeSetup.tsx
+++ b/src/ui/preact/cliBridgeSetup.tsx
@@ -1,0 +1,160 @@
+// "Use a Claude or Codex subscription" quick-setup card, shown at the top of
+// the Custom (OpenAI-compatible) provider tab.
+//
+// People who already pay for a Claude Pro/Max (or ChatGPT/Codex) subscription
+// can drive Partwright's AI without an API key by running a small, off-the-
+// shelf local bridge — CLIProxyAPI — that exposes the subscription's
+// authenticated CLI as an OpenAI-compatible endpoint on localhost (default
+// :8317). Two properties make it work for a *browser* client where most
+// IDE-oriented wrappers don't:
+//   - it emits wildcard CORS, so a page on https://www.partwrightstudio.com
+//     can fetch it cross-origin (our CSP already allows http://localhost:*);
+//   - it supports OpenAI function/tool calling, which Partwright's geometry
+//     tools depend on.
+//
+// This card is pure onboarding: copy-paste install/login commands plus a
+// one-click "Use this endpoint" that fills the Base URL field below and tests
+// it. The connection itself still flows through the existing Custom provider —
+// no new provider, transport, or settings are introduced.
+
+import type { ComponentChildren } from 'preact';
+import { useSignal } from '@preact/signals';
+
+import { Section, Pill, PrimaryButton } from './primitives';
+
+/** CLIProxyAPI's default OpenAI-compatible base URL. */
+const CLI_BRIDGE_ENDPOINT = 'http://localhost:8317/v1';
+
+const REPO_URL = 'https://github.com/router-for-me/CLIProxyAPI';
+
+type OsKey = 'mac' | 'windows' | 'other';
+
+interface InstallSpec {
+  label: string;
+  /** Steps shown when this OS is selected. The login step is shared and
+   *  appended separately. */
+  install: { cmd: string; note?: string } | { docs: true };
+}
+
+const INSTALL: Record<OsKey, InstallSpec> = {
+  mac: {
+    label: 'macOS',
+    install: {
+      cmd: 'brew install cliproxyapi && brew services start cliproxyapi',
+      note: 'Installs the bridge and starts it as a background service.',
+    },
+  },
+  windows: {
+    label: 'Windows',
+    install: {
+      cmd: 'winget install LuisPater.CLIProxyAPI',
+      note: 'Then run cli-proxy-api in a terminal to start the server.',
+    },
+  },
+  other: {
+    label: 'Linux / other',
+    install: { docs: true },
+  },
+};
+
+function detectOs(): OsKey {
+  const hay = `${navigator.userAgent} ${navigator.platform ?? ''}`.toLowerCase();
+  if (hay.includes('mac')) return 'mac';
+  if (hay.includes('win')) return 'windows';
+  return 'other';
+}
+
+export function CliBridgeSetup(props: { onUseEndpoint: (url: string) => void }) {
+  const os = useSignal<OsKey>(detectOs());
+  const spec = INSTALL[os.value];
+
+  return (
+    <Section label="Use a Claude or Codex subscription">
+      <div class="rounded border border-blue-800/40 bg-blue-950/20 px-3 py-3 flex flex-col gap-3">
+        <p
+          class="text-[11px] text-zinc-300 leading-snug"
+          /* eslint-disable-next-line react/no-danger */
+          dangerouslySetInnerHTML={{ __html: 'Already pay for a <strong>Claude Pro/Max</strong> (or ChatGPT/Codex) plan? Run <strong><a class="text-blue-400 hover:text-blue-300 underline" href="' + REPO_URL + '" target="_blank" rel="noopener noreferrer">CLIProxyAPI</a></strong> — a small local bridge that turns your subscription into an OpenAI-compatible endpoint on <code>localhost</code>. No API key, no per-token billing. Partwright connects to it as a Custom endpoint.' }}
+        />
+
+        <div class="flex flex-wrap gap-1">
+          {(Object.keys(INSTALL) as OsKey[]).map(k => (
+            <Pill key={k} active={os.value === k} label={INSTALL[k].label} onClick={() => { os.value = k; }} />
+          ))}
+        </div>
+
+        <Step n={1} title="Install & start the bridge">
+          {'docs' in spec.install ? (
+            <p class="text-[11px] text-zinc-400 leading-snug">
+              Grab a prebuilt binary or the Docker image from the{' '}
+              <a class="text-blue-400 hover:text-blue-300 underline" href={REPO_URL} target="_blank" rel="noopener noreferrer">CLIProxyAPI releases</a>, then start it so it listens on port 8317.
+            </p>
+          ) : (
+            <>
+              <CopyRow cmd={spec.install.cmd} />
+              {spec.install.note && <p class="text-[10px] text-zinc-500">{spec.install.note}</p>}
+            </>
+          )}
+        </Step>
+
+        <Step n={2} title="Log in with your subscription">
+          <CopyRow cmd="cliproxyapi --claude-login" />
+          <p class="text-[10px] text-zinc-500">
+            Opens a browser to authorize your Claude plan. Use <code>--codex-login</code> instead for a ChatGPT/Codex subscription.
+          </p>
+        </Step>
+
+        <Step n={3} title="Connect Partwright">
+          <PrimaryButton
+            label="Use this endpoint (localhost:8317)"
+            variant="column"
+            onClick={() => props.onUseEndpoint(CLI_BRIDGE_ENDPOINT)}
+          />
+          <p class="text-[10px] text-zinc-500">
+            Fills the <strong>Base URL</strong> below and tests it. Then click <strong>Fetch models</strong> and pick a <code>claude-…</code> model.
+          </p>
+        </Step>
+
+        <div
+          class="rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-[11px] text-amber-200 leading-snug"
+          /* eslint-disable-next-line react/no-danger */
+          dangerouslySetInnerHTML={{ __html: '<strong>Secure it:</strong> the bridge accepts requests from any origin (wildcard CORS). Set an <code>api-key</code> in its <code>config.yaml</code> and paste it into <strong>API key</strong> below, so only requests bearing that key can spend your subscription. Keep it bound to <code>127.0.0.1</code> (the default) — don\'t expose it on your network.' }}
+        />
+
+        <p class="text-[10px] text-zinc-500 leading-snug">
+          Using a subscription outside its official app is community-supported and not endorsed by Anthropic or OpenAI — confirm it’s allowed under your plan before relying on it.
+        </p>
+      </div>
+    </Section>
+  );
+}
+
+function Step(props: { n: number; title: string; children: ComponentChildren }) {
+  return (
+    <div class="flex flex-col gap-1.5">
+      <div class="flex items-center gap-2">
+        <span class="shrink-0 w-4 h-4 rounded-full bg-blue-700 text-white text-[10px] font-medium flex items-center justify-center">{props.n}</span>
+        <span class="text-[11px] font-medium text-zinc-200">{props.title}</span>
+      </div>
+      <div class="flex flex-col gap-1 pl-6">{props.children}</div>
+    </div>
+  );
+}
+
+function CopyRow(props: { cmd: string }) {
+  const label = useSignal('Copy');
+  return (
+    <div class="flex items-stretch gap-1.5">
+      <code class="flex-1 min-w-0 px-2 py-1.5 rounded bg-zinc-950 border border-zinc-700 text-[11px] font-mono text-emerald-200 break-all leading-snug">{props.cmd}</code>
+      <button
+        type="button"
+        class="shrink-0 px-2 py-1 rounded text-[11px] bg-zinc-700 hover:bg-zinc-600 text-zinc-100"
+        onClick={async () => {
+          try { await navigator.clipboard.writeText(props.cmd); label.value = 'Copied!'; }
+          catch { label.value = 'Copy failed'; }
+          setTimeout(() => { label.value = 'Copy'; }, 1600);
+        }}
+      >{label.value}</button>
+    </div>
+  );
+}

--- a/src/ui/preact/settingsModal.tsx
+++ b/src/ui/preact/settingsModal.tsx
@@ -47,7 +47,7 @@ import type { AnthropicModelId, Provider } from '../../ai/types';
 
 import { settingsSignal, setSettings, resyncSettings } from './settingsStore';
 import { Divider, Section, Pill, PrimaryButton, SecondaryButton, TabBar, type TabSpec } from './primitives';
-import { CliBridgeSetup } from './cliBridgeSetup';
+import { CliBridgeSetup, generateApiKey } from './cliBridgeSetup';
 
 export interface AiSettingsCallbacks {
   onChange: () => void;
@@ -104,24 +104,51 @@ export function SettingsModalBody(props: {
   );
 }
 
-export function SettingsModalFooter(props: { close: () => void }) {
-  return <SecondaryButton label="Done" onClick={props.close} />;
+export function SettingsModalFooter(props: {
+  close: () => void;
+  tab: Signal<Provider>;
+  cb: AiSettingsCallbacks;
+}) {
+  const { close, tab, cb } = props;
+  const viewedTab = tab.value;
+  const settings = settingsSignal.value;
+  const isActive = settings.toggles.provider === viewedTab;
+  const ready = useProviderReady(viewedTab);
+  const label = providerLabel(viewedTab);
+
+  return (
+    <>
+      <SecondaryButton label="Close" onClick={close} />
+      {!isActive && (
+        <PrimaryButton
+          label={`Done & enable ${label}`}
+          disabled={!ready}
+          title={ready
+            ? `Make ${label} the active provider and close. Edits above don't switch the active provider on their own.`
+            : `Finish configuring ${label} above before enabling it.`}
+          onClick={() => {
+            setSettings(setProvider(loadSettings(), viewedTab));
+            cb.onChange();
+            close();
+          }}
+        />
+      )}
+    </>
+  );
 }
 
 // === Enable row ===
 
-function EnableRow(props: { viewedTab: Provider; cb: AiSettingsCallbacks }) {
-  const { viewedTab, cb } = props;
-  // null = "haven't checked yet" (e.g. just switched tabs and the
-  // async getKey hasn't resolved). The button stays disabled in that
-  // interim state so we never momentarily render an enabled Enable for
-  // a provider whose key status is unknown.
+/** Whether the viewed provider is configured enough to enable.
+ *  - local: always ready.
+ *  - custom: its endpoint URL is set (the API key is optional).
+ *  - cloud: a key is stored (probed async; `false` until it resolves, so we
+ *    never momentarily offer Enable for a provider whose key status is unknown).
+ *  Shared by EnableRow and the modal footer's "Close & enable" button so the
+ *  two affordances can't disagree. */
+function useProviderReady(viewedTab: Provider): boolean {
   const hasKey = useSignal<boolean | null>(null);
-
   useEffect(() => {
-    // local is always "ready"; custom's readiness is the base URL (a setting,
-    // read synchronously below) not a stored key — skip the getKey probe for
-    // both. Cloud providers gate Enable on a stored key.
     if (viewedTab === 'local') { hasKey.value = true; return; }
     if (viewedTab === 'custom') { hasKey.value = null; return; }
     let cancelled = false;
@@ -131,13 +158,18 @@ function EnableRow(props: { viewedTab: Provider; cb: AiSettingsCallbacks }) {
   }, [viewedTab, keyVersion.value]);
 
   const settings = settingsSignal.value;
-  const isActive = settings.toggles.provider === viewedTab;
-  const label = providerLabel(viewedTab);
-  // Custom is enableable once its endpoint URL is set (the API key is
-  // optional); every cloud provider needs a stored key.
-  const ready = viewedTab === 'custom'
+  return viewedTab === 'custom'
     ? settings.toggles.customBaseUrl.trim().length > 0
     : hasKey.value === true;
+}
+
+function EnableRow(props: { viewedTab: Provider; cb: AiSettingsCallbacks }) {
+  const { viewedTab, cb } = props;
+  const ready = useProviderReady(viewedTab);
+
+  const settings = settingsSignal.value;
+  const isActive = settings.toggles.provider === viewedTab;
+  const label = providerLabel(viewedTab);
 
   // For local, `hasKey` is forced true above, so the "Connect your … key"
   // branch never fires for local; that's why there's no local-specific
@@ -521,6 +553,10 @@ function CustomTab(props: { cb: AiSettingsCallbacks; close: () => void }) {
   const url = useSignal(settings.toggles.customBaseUrl);
   const model = useSignal(settings.toggles.customModel);
   const keyVal = useSignal('');
+  // One example key per modal open — shown in the bridge setup's "set an API
+  // key" command and reusable via the "Use this key" button below, so the value
+  // the proxy is configured with matches the one Partwright sends.
+  const genKey = useSignal(generateApiKey());
   const hasKey = useSignal<boolean | null>(null);
   const models = useSignal<{ id: string; label: string }[]>([]);
   const status = useSignal('');
@@ -605,7 +641,7 @@ function CustomTab(props: { cb: AiSettingsCallbacks; close: () => void }) {
 
   return (
     <>
-      <CliBridgeSetup onUseEndpoint={useEndpoint} />
+      <CliBridgeSetup apiKeyExample={genKey.value} onUseEndpoint={useEndpoint} />
       <Divider />
       <Section label="About">
         {/* eslint-disable-next-line react/no-danger */}
@@ -665,21 +701,27 @@ function CustomTab(props: { cb: AiSettingsCallbacks; close: () => void }) {
             <button type="button" class="text-[11px] text-red-300 hover:text-red-200 underline" onClick={() => { void removeKey(); }}>Remove key</button>
           </div>
         ) : (
-          <div class="flex items-center gap-2">
-            <input
-              type="password"
-              placeholder="leave blank if the endpoint needs no auth"
-              class="flex-1 px-3 py-2 rounded bg-zinc-900 border border-zinc-600 text-zinc-100 text-sm font-mono placeholder:text-zinc-600 focus:outline-none focus:border-blue-500"
-              spellcheck={false}
-              autocomplete="off"
-              value={keyVal.value}
-              onInput={e => { keyVal.value = (e.currentTarget as HTMLInputElement).value; }}
-              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); void saveKey(); } }}
-            />
-            <SecondaryButton label="Save key" size="sm" disabled={!keyVal.value.trim()} onClick={() => { void saveKey(); }} />
+          <div class="flex flex-col gap-1.5">
+            <div class="flex items-center gap-2">
+              <input
+                type="text"
+                placeholder="leave blank if the endpoint needs no auth"
+                class="flex-1 px-3 py-2 rounded bg-zinc-900 border border-zinc-600 text-zinc-100 text-sm font-mono placeholder:text-zinc-600 focus:outline-none focus:border-blue-500"
+                spellcheck={false}
+                autocomplete="off"
+                value={keyVal.value}
+                onInput={e => { keyVal.value = (e.currentTarget as HTMLInputElement).value; }}
+                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); void saveKey(); } }}
+              />
+              <SecondaryButton label="Save key" size="sm" disabled={!keyVal.value.trim()} onClick={() => { void saveKey(); }} />
+            </div>
+            <div class="flex items-center gap-2">
+              <SecondaryButton label="Use the bridge key" size="sm" onClick={() => { keyVal.value = genKey.value; }} />
+              <span class="text-[10px] text-zinc-500">Fills the key from the bridge setup’s step 2 — only if you ran that command with it.</span>
+            </div>
           </div>
         )}
-        <span class="text-[10px] text-zinc-500">Sent as <code>Authorization: Bearer …</code>. Many home servers run with no key — leave this blank then.</span>
+        <span class="text-[10px] text-zinc-500">Sent as <code>Authorization: Bearer …</code>. The key is shown in plain text so you can match it against your bridge config. Other endpoints with no auth can leave this blank.</span>
       </Section>
       <Divider />
       <SystemPromptSection provider="custom" close={close} cb={cb} />

--- a/src/ui/preact/settingsModal.tsx
+++ b/src/ui/preact/settingsModal.tsx
@@ -47,6 +47,7 @@ import type { AnthropicModelId, Provider } from '../../ai/types';
 
 import { settingsSignal, setSettings, resyncSettings } from './settingsStore';
 import { Divider, Section, Pill, PrimaryButton, SecondaryButton, TabBar, type TabSpec } from './primitives';
+import { CliBridgeSetup } from './cliBridgeSetup';
 
 export interface AiSettingsCallbacks {
   onChange: () => void;
@@ -596,11 +597,19 @@ function CustomTab(props: { cb: AiSettingsCallbacks; close: () => void }) {
     cb.onChange();
   }
 
+  // Quick-setup card's "Use this endpoint" → fill the Base URL and test it.
+  function useEndpoint(u: string): void {
+    url.value = u;
+    void testConnection(); // persists the URL itself
+  }
+
   return (
     <>
+      <CliBridgeSetup onUseEndpoint={useEndpoint} />
+      <Divider />
       <Section label="About">
         {/* eslint-disable-next-line react/no-danger */}
-        <p class="text-[11px] text-zinc-300 leading-snug" dangerouslySetInnerHTML={{ __html: 'Point Partwright at any <strong>OpenAI-compatible</strong> chat endpoint — a self-hosted <code>llama.cpp</code> server, vLLM, LM Studio, or similar. Requests use the <code>/v1/chat/completions</code> shape with the full <code>ai.md</code> system prompt; turns are billed at $0 (you run the hardware). The optional API key is stored only in this browser.' }} />
+        <p class="text-[11px] text-zinc-300 leading-snug" dangerouslySetInnerHTML={{ __html: 'Point Partwright at any <strong>OpenAI-compatible</strong> chat endpoint — a local subscription bridge (see above), a self-hosted <code>llama.cpp</code> server, vLLM, LM Studio, or similar. Requests use the <code>/v1/chat/completions</code> shape with the full <code>ai.md</code> system prompt. The optional API key is stored only in this browser.' }} />
         {/* eslint-disable-next-line react/no-danger */}
         <div class="rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-[11px] text-amber-200 leading-snug" dangerouslySetInnerHTML={{ __html: '<strong>Connectivity:</strong> the endpoint must allow this site via <strong>CORS</strong>. When Partwright is served over HTTPS, the endpoint must be HTTPS too (browsers block <code>https→http</code>) — except <code>http://localhost</code>, which is exempt. For llama.cpp, run <code>llama-server</code> and pass <code>--api-key</code> only if you want auth.' }} />
       </Section>

--- a/tests/ai-cli-bridge-setup.spec.ts
+++ b/tests/ai-cli-bridge-setup.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from 'playwright/test';
+import { waitForEditorReady } from './helpers/aiPanel';
+
+// Golden path for the "Use a Claude or Codex subscription" quick-setup card
+// on the AI Settings → Custom tab. We don't run a real bridge here — we assert
+// the onboarding UI renders and that "Use this endpoint" fills the Base URL
+// field with CLIProxyAPI's default localhost endpoint.
+test.describe('AI CLI bridge setup', () => {
+  test('Custom tab shows the subscription bridge card and fills the endpoint', async ({ page }) => {
+    await page.goto('/editor');
+    await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch {} });
+    await page.reload();
+    await waitForEditorReady(page);
+
+    // Open AI Settings straight onto the Custom tab.
+    await page.evaluate(async () => {
+      const m = await import('/src/ui/aiSettingsModal.tsx');
+      await m.showAiSettingsModal({ onChange: () => {} }, { initialTab: 'custom' });
+    });
+
+    await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
+
+    // The quick-setup card and its three steps render.
+    await expect(page.getByText('Use a Claude or Codex subscription')).toBeVisible();
+    await expect(page.getByText('Install & start the bridge')).toBeVisible();
+    await expect(page.getByText('Log in with your subscription')).toBeVisible();
+
+    // The Base URL starts empty; clicking "Use this endpoint" fills it.
+    const baseUrl = page.locator('input[placeholder="http://localhost:8080/v1"]');
+    await expect(baseUrl).toHaveValue('');
+
+    await page.getByRole('button', { name: /Use this endpoint/ }).click();
+    await expect(baseUrl).toHaveValue('http://localhost:8317/v1');
+  });
+});

--- a/tests/ai-cli-bridge-setup.spec.ts
+++ b/tests/ai-cli-bridge-setup.spec.ts
@@ -20,16 +20,31 @@ test.describe('AI CLI bridge setup', () => {
 
     await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
 
-    // The quick-setup card and its three steps render.
+    // The quick-setup card and its steps render — including the required
+    // API-key step CLIProxyAPI needs before it will start.
     await expect(page.getByText('Use a Claude or Codex subscription')).toBeVisible();
     await expect(page.getByText('Install & start the bridge')).toBeVisible();
+    await expect(page.getByText('Set an API key (required)')).toBeVisible();
     await expect(page.getByText('Log in with your subscription')).toBeVisible();
 
-    // The Base URL starts empty; clicking "Use this endpoint" fills it.
+    // Footer shows Close, and a disabled "Done & enable" until the endpoint is set.
+    await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+    const enableBtn = page.getByRole('button', { name: 'Done & enable Custom endpoint' });
+    await expect(enableBtn).toBeDisabled();
+
+    // The Base URL starts empty; clicking "Use this endpoint" fills it and,
+    // in turn, enables the footer's "Done & enable".
     const baseUrl = page.locator('input[placeholder="http://localhost:8080/v1"]');
     await expect(baseUrl).toHaveValue('');
-
     await page.getByRole('button', { name: /Use this endpoint/ }).click();
     await expect(baseUrl).toHaveValue('http://localhost:8317/v1');
+    await expect(enableBtn).toBeEnabled();
+
+    // "Use the bridge key" fills the (now visible, text) API-key field with the
+    // generated key — and it matches the one shown in the setup command.
+    const keyField = page.locator('input[placeholder="leave blank if the endpoint needs no auth"]');
+    await expect(keyField).toHaveAttribute('type', 'text');
+    await page.getByRole('button', { name: 'Use the bridge key' }).click();
+    await expect(keyField).toHaveValue(/^pw-[0-9a-f]{48}$/);
   });
 });

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -729,10 +729,10 @@ test.describe('Multi-provider AI', () => {
 
     // Enable is gated on the endpoint URL (the API key is optional), so it's
     // disabled until a URL is set, then flips on — no key required.
-    await expect(modal.locator('button:has-text("Enable Custom endpoint")')).toBeDisabled();
+    await expect(modal.getByRole('button', { name: 'Enable Custom endpoint', exact: true })).toBeDisabled();
     await urlInput.fill('http://localhost:8080/v1');
     await modal.locator('input[placeholder^="e.g. llama"]').fill('my-model');
-    await expect(modal.locator('button:has-text("Enable Custom endpoint")')).toBeEnabled();
+    await expect(modal.getByRole('button', { name: 'Enable Custom endpoint', exact: true })).toBeEnabled();
   });
 
   test('Enable is gated on a connected key, except local', async ({ page }) => {
@@ -746,11 +746,11 @@ test.describe('Multi-provider AI', () => {
 
     // OpenAI tab with no key → Enable is disabled.
     await page.locator('button:has-text("OpenAI (cloud)")').dispatchEvent('click');
-    await expect(page.locator('button:has-text("Enable OpenAI")')).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Enable OpenAI', exact: true })).toBeDisabled();
 
     // Local needs no key → Enable is always available.
     await page.locator('button:has-text("Local (WebGPU)")').dispatchEvent('click');
-    await expect(page.locator('button:has-text("Enable Local model")')).toBeEnabled();
+    await expect(page.getByRole('button', { name: 'Enable Local model', exact: true })).toBeEnabled();
 
     // Plant an OpenAI key, return to the OpenAI tab → Enable flips on.
     await page.evaluate(async () => {
@@ -775,7 +775,7 @@ test.describe('Multi-provider AI', () => {
       });
     });
     await page.locator('button:has-text("OpenAI (cloud)")').dispatchEvent('click');
-    await expect(page.locator('button:has-text("Enable OpenAI")')).toBeEnabled();
+    await expect(page.getByRole('button', { name: 'Enable OpenAI', exact: true })).toBeEnabled();
   });
 
   test('every hosted provider can load models from the key', async ({ page }) => {
@@ -907,7 +907,7 @@ test.describe('Multi-provider AI', () => {
     await page.locator('#ai-panel button[title^="AI settings"]').dispatchEvent('click');
     await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
     await page.locator('button:has-text("Anthropic (cloud)")').dispatchEvent('click');
-    await page.locator('button:has-text("Enable Anthropic Claude")').dispatchEvent('click');
+    await page.getByRole('button', { name: 'Enable Anthropic Claude', exact: true }).dispatchEvent('click');
     await page.waitForTimeout(200);
     // Close the modal via the shell ✕ and confirm the header restored the
     // previously-chosen Anthropic model (not reset to the preset default).

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -180,9 +180,9 @@ test.describe('AI chat panel', () => {
     await expect(page.locator('input[type="password"]')).toBeVisible();
     await expect(page.locator('button:has-text("Connect Anthropic API")')).toBeVisible();
 
-    // Done closes the modal; no key was persisted. The AI control now lives in
+    // Close closes the modal; no key was persisted. The AI control now lives in
     // the rail and shows the disconnected state via its status dot (grey).
-    await page.locator('.bg-zinc-800.rounded-xl button:text-is("Done")').click();
+    await page.locator('.bg-zinc-800.rounded-xl button:text-is("Close")').click();
     await expect(page.locator('input[type="password"]')).toHaveCount(0);
     await expect(page.locator('#ai-status-dot')).toHaveClass(/bg-zinc-500/);
   });


### PR DESCRIPTION
## Summary

Lets people who already pay for a **Claude Pro/Max** (or ChatGPT/Codex) subscription drive Partwright's AI **without an API key or per-token billing**, by running an off-the-shelf local bridge and connecting to it through the existing **Custom (OpenAI-compatible)** provider.

The key realization: the app's `custom` provider already does everything on the client side — `/v1/chat/completions`, optional bearer auth, SSE streaming, "Test connection" / "Fetch models", and the CSP already whitelists `http://localhost:*`. So this PR adds **onboarding, not infrastructure** — no new provider, transport, or settings.

### What's new

A **"Use a Claude or Codex subscription"** quick-setup card at the top of **AI Settings → Custom** tab (`src/ui/preact/cliBridgeSetup.tsx`):

- Points users at [**CLIProxyAPI**](https://github.com/router-for-me/CLIProxyAPI) — the off-the-shelf bridge that exposes a subscription's authenticated CLI as an OpenAI-compatible endpoint on `localhost:8317`.
- **OS-aware** (auto-detect + manual pills): `brew install cliproxyapi` on macOS, `winget install …` on Windows, releases link for Linux/other.
- **Step 1 — install & start**, with a link to `http://localhost:8317` to confirm the bridge is running or surface config errors.
- **Step 2 — set an API key (required).** CLIProxyAPI refuses to start while its config holds template keys, so the card generates a strong random key in the browser and hands the user a runnable one-liner (`sed` + `brew services restart` on macOS; manual fallback on Windows) that writes it in and restarts the bridge.
- **Step 3 — log in** (`cliproxyapi --claude-login`, `--codex-login`).
- **Step 4 — connect**: one-click **"Use this endpoint (localhost:8317)"** fills the Base URL and runs the connection test.

### Endpoint + key UX

- The Custom **API-key field is now plain text** (not masked) so the user can match it against the bridge config, with a **"Use the bridge key"** button that fills the same generated key — guaranteeing the value the proxy expects and the value Partwright sends match.
- The settings footer renames **"Done" → "Close"** and adds **"Done & enable &lt;provider&gt;"**, which makes the currently-viewed tab the active provider and closes — fixing the confusion that editing fields doesn't auto-enable. Readiness is shared with the enable row via a new `useProviderReady` hook.

### Why CLIProxyAPI

Of the surveyed wrappers, it's the only one that clears the two bars a **browser** client needs *and* is broadly distributed:

- **Wildcard CORS** — most IDE-oriented wrappers omit it (Cursor/Continue are same-origin native apps), which would silently fail from `www.partwrightstudio.com`.
- **OpenAI function/tool calling** — Partwright's geometry tools depend on streamed `tool_calls`.
- `brew` / `winget` install, runs as a localhost service, covers **Claude + Codex + Gemini**.

### Security & ToS (surfaced in-UI)

- The card walks the user through setting a real API key (also closing the wildcard-CORS hole — only requests bearing the key work) and recommends keeping the bridge bound to `127.0.0.1`.
- Notes that subscription use outside the official client is community-supported, not vendor-endorsed — "confirm it's allowed under your plan."

## Test plan

- `npm run build` ✅ · `npm run test:unit` ✅ (718) · `lint:deadcode` (no new findings) ✅ · `lint:deps` (acyclic) ✅
- `tests/ai-cli-bridge-setup.spec.ts`: asserts the card steps (incl. required-key step) render, the footer's disabled→enabled "Done & enable" flow, the plain-text key field, and that "Use the bridge key" fills a `pw-…` key. ✅
- `tests/smoke.spec.ts` updated for the "Done" → "Close" rename; full smoke suite (17) re-run green. ✅
- Manual browser screenshots (auto-detected + macOS variants) posted in the session.

🤖 https://claude.ai/code/session_01RqLbso92d13deaaR8gJSqY