### PR TITLE
feat: interactive view menu — direct display toggles, sticky menus, consistent tool panels

### DIFF
--- a/prompts/20260607-153000-viewport-menu-behavior.md
+++ b/prompts/20260607-153000-viewport-menu-behavior.md
@@ -1,0 +1,59 @@
+---
+session: "89rxW"
+timestamp: "2026-06-07T15:30:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 1
+---
+
+## Human
+
+The viewport controls were recently collapsed into pop-open menus (View /
+Inspect / Tools). Two changes wanted:
+
+1. Take the buttons that just *change the view* out of the View menu and put
+   them back directly on the interactive viewport, the way they used to be.
+2. For the menus that stay (Tools, etc.), opening a submenu/tool from the list
+   shouldn't close the list — so switching tools doesn't cost an extra click.
+   The list should close only by clicking the button that opened it, opening
+   another menu, or clicking away. Open to other suggestions.
+
+## Assistant
+
+## Key decisions
+
+**Dissolve the View menu → direct pills.** All four View-menu items
+(`wireframe`/`grid`/`dimensions`/`orbit-lock`) are pure view-state toggles, so
+they move out of the popover and back onto the bar as one-click pills next to
+Reset View. The View popover is removed entirely. Button ids are unchanged, so
+the toggle-wiring in `main.ts` (which only ever finds them by id) is untouched.
+
+**Make the surviving popovers sticky.** Dropped `closeOnSelect` from
+`popoverMenu.ts` — after the View menu's removal no caller wanted close-on-
+select, so the option and its delegated-click branch were dead. Inspect and
+Tools now stay open when you click an item; they close on the group button, a
+sibling popover (the existing single-open sweep), click-outside, or Escape.
+
+**The wrinkle that needed a design call.** Verified the sticky Tools menu in the
+browser and found that floating-panel tools (Paint, Annotate, Image, Voxel,
+Quality, Surface, Resize) open in the *same* top-right spot as the Tools
+dropdown, so the now-sticky list was visually covered — the stickiness bought
+nothing for those tools. Surfaced this with before/after screenshots and asked;
+the user chose "shift the panels left so they sit beside the open list."
+
+**Shift docked panels beside the open list.** Added `panelDockRightOffset()` to
+the shared `viewportPanelDrag.ts`: panels normally hug the right edge (8px), but
+when `#viewport-tools-menu` is open on desktop they shift left by the menu's
+width + gap so both stay visible. `setInitialPanelPosition` is the single
+chokepoint for 8 of the 9 docked panels, so they all inherit it. Image Paint is
+the outlier (it positions via its own Tailwind classes + drag logic), so its
+`openPanel`/`closePanel` apply/clear the same offset inline (desktop +
+undragged only; mobile stays a bottom sheet, dragged panels keep their spot).
+Palette manager is a centered modal, so it's unaffected. Verified with a probe
+that measured zero menu/panel overlap and that one click switches tools from the
+still-open list.
+
+**Tests.** Rewrote `viewport-toolbar-groups.spec.ts` (display toggles now direct
+and visible; no View group; Inspect/Tools assert sticky behavior + single-open
+across siblings) and updated `paint-controls-extended.spec.ts` (the edge/grid
+toggle test no longer opens a View popover).

--- a/prompts/20260607-171000-tool-panel-consistency.md
+++ b/prompts/20260607-171000-tool-panel-consistency.md
@@ -1,0 +1,75 @@
+---
+session: "89rxW"
+timestamp: "2026-06-07T17:10:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 2
+---
+
+## Human
+
+Make the viewport tool menus behave and look consistent. Specifically:
+1. List the Tools submenu buttons horizontally, and have each tool's panel pop
+   up just beneath and to the right.
+2. Palette opens centered with an overlay and isn't draggable — make it like the
+   paint menu (docked right, draggable).
+3. Quality opens on top of other panels instead of closing them — all tool
+   panels should close the others when opened.
+4. Image Paint doesn't close on Escape.
+5. Resize/Surface don't have the same grey look as the others.
+6. Find and fix any other inconsistencies; make them all consistent.
+
+Confirmed by Q&A: horizontal row with panels docked beneath, right-aligned; and
+unify the active toggle accent to blue.
+
+## Assistant
+
+## Key decisions
+
+**One shared standard (`src/ui/toolPanel.ts`).** An audit found every tool hand-
+rolled its own shell: backgrounds (zinc-800/95 vs zinc-900), borders, z-indices
+(z-20 vs z-[60]), header markup, close glyphs (× vs ✕), hit areas (w-7 vs w-6 vs
+none), title sizes, and active accents (blue/pink/emerald). New module is the
+single source of truth: `TOOL_PANEL_CLASS`, `TOOL_PANEL_HEADER/TITLE/CLOSE`,
+`TOOL_TOGGLE_IDLE/ACTIVE`, `createToolPanelHeader()`, and `createToolPanelShell()`
+(the docked-panel equivalent of `createModalShell`, with `{ body, footer, close }`).
+Every tool (Paint, Image, Voxel, Annotate, Quality, Surface, Resize, Palette)
+was pointed at it.
+
+**Unified mutual exclusion through the existing single-open registry.** Root
+cause of "Quality opens on top" and the general inconsistency: Image Paint used
+*neither* exclusion registry, and tools only half-closed each other. Fix: route
+every panel through `viewportPanelRegistry.openViewportPanel` on open /
+`closeViewportPanel` on close. Image Paint now registers; opening any tool closes
+whatever else is open. Image Paint also gained an Escape handler.
+
+**Palette: modal → docked panel.** Swapped `createModalShell` for
+`createToolPanelShell`; all the palette content code is untouched (same body/
+footer/close interface). It's now draggable, right-docked, grey, and part of the
+single-open set. Kept it a non-modal `role="dialog"` (aria-modal=false) so the
+existing tests stay valid; its Escape defers to any layered modal (the photo
+picker). The photo-import flow closes the panel while the picker is up and the
+picker's onClose reopens it (mirrors the old single-shell behaviour).
+
+**Horizontal menu + docking beneath it.** `popoverMenu` rows now use
+`flex-row flex-wrap w-max` (an abspos flex-wrap box otherwise collapses to its
+widest child and stacks). `setInitialPanelPosition` now drops a panel below the
+*open Tools menu* (its bottom edge), right-aligned — replacing the earlier
+"shift left beside the list" logic from the previous PR, which no longer applies
+to a horizontal row.
+
+**Other inconsistencies fixed:** active accent unified to blue (Annotate pink →
+blue, Voxel emerald → blue, Quality blue-500/20 → /30); slider/tab accents
+sky/emerald/pink → blue; close glyph ✕ → × everywhere; close hit-area unified to
+28px; Surface/Resize dropped from z-[60] to z-20 and from `<h2>` titles to the
+standard title style.
+
+**Behaviour change flagged to the user:** opening Palette now closes the Paint
+panel (per "all tool panels close the others"). Two palette tests were updated
+to reopen Paint / drop a now-redundant close. Surfaced for confirmation in case
+Palette should instead be exempt (it's Paint's companion editor).
+
+**Tests:** new `tool-panel-consistency.spec.ts` (mutual exclusion, docked
+non-modal palette, Escape); updated `paint-palette.spec.ts` for the docked
+palette + exclusion. Verified the full paint/voxel/annotate/simplify/surface/
+resize/image/relief/command-palette e2e set (180+ specs) green.

--- a/src/annotations/annotateUI.ts
+++ b/src/annotations/annotateUI.ts
@@ -43,6 +43,7 @@ import { endSession as endSessionPlane, hidePlaneOutline } from './sessionPlane'
 import { openViewportPanel, closeViewportPanel } from '../ui/viewportPanelRegistry';
 import { attachViewportPanelDrag, setInitialPanelPosition } from '../ui/viewportPanelDrag';
 import { viewportToolsMount } from '../ui/popoverMenu';
+import { createToolPanelHeader, TOOL_TOGGLE_IDLE, TOOL_TOGGLE_ACTIVE } from '../ui/toolPanel';
 
 const PRESET_COLORS: [number, number, number][] = [
   [0.95, 0.20, 0.45], // hot pink (default)
@@ -82,11 +83,11 @@ let restoreViewBtn: HTMLButtonElement | null = null;
 let redoBtn: HTMLButtonElement | null = null;
 let selectionInfo: HTMLElement | null = null;
 
-const inactiveBtnClass = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
-const activeBtnClass = 'px-2 py-1 rounded text-xs bg-pink-500/30 backdrop-blur text-pink-200 border border-pink-400/60 transition-colors';
+const inactiveBtnClass = TOOL_TOGGLE_IDLE;
+const activeBtnClass = TOOL_TOGGLE_ACTIVE;
 
 const tabInactiveClass = 'flex-1 px-2 py-1 rounded text-[11px] bg-zinc-700/40 text-zinc-400 hover:bg-zinc-600/60 transition-colors';
-const tabActiveClass = 'flex-1 px-2 py-1 rounded text-[11px] bg-pink-500/30 text-pink-200 ring-1 ring-pink-400/60 transition-colors';
+const tabActiveClass = 'flex-1 px-2 py-1 rounded text-[11px] bg-blue-500/30 text-blue-200 ring-1 ring-blue-400/60 transition-colors';
 
 export function initAnnotateUI(controlsContainer: HTMLElement): void {
   annotateBtn = document.createElement('button');
@@ -96,7 +97,7 @@ export function initAnnotateUI(controlsContainer: HTMLElement): void {
   annotateBtn.title = 'Draw, type, or move marks pinned to a virtual plane in front of the model';
 
   countBadge = document.createElement('span');
-  countBadge.className = 'hidden ml-1 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-pink-500 text-white leading-none';
+  countBadge.className = 'hidden ml-1 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-blue-500 text-white leading-none';
   annotateBtn.appendChild(countBadge);
 
   annotateBtn.addEventListener('click', toggleAnnotateMode);
@@ -231,20 +232,8 @@ function createPickerPanel(): HTMLElement {
   panel.className = 'hidden absolute z-20 bg-zinc-800/95 backdrop-blur border border-zinc-600/60 rounded-lg shadow-xl';
   panel.style.minWidth = '220px';
 
-  // Header: drag handle + title + × close button.
-  const header = document.createElement('div');
-  header.className = 'flex items-center justify-between px-2.5 py-2 border-b border-zinc-700/70';
-  const headerTitle = document.createElement('div');
-  headerTitle.className = 'text-[11px] text-zinc-300 font-medium';
-  headerTitle.textContent = '✏️ Annotate';
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'text-zinc-400 hover:text-zinc-200 transition-colors leading-none w-6 h-6 flex items-center justify-center rounded hover:bg-zinc-700/60';
-  closeBtn.textContent = '×';
-  closeBtn.title = 'Close annotate menu';
-  closeBtn.setAttribute('aria-label', 'Close annotate menu');
-  closeBtn.addEventListener('click', () => { toggleAnnotateMode(); });
-  header.appendChild(headerTitle);
-  header.appendChild(closeBtn);
+  // Header: drag handle + title + × close button (shared tool-panel chrome).
+  const header = createToolPanelHeader('✏️ Annotate', () => { toggleAnnotateMode(); });
   panel.appendChild(header);
   attachViewportPanelDrag(header, panel);
 
@@ -255,7 +244,7 @@ function createPickerPanel(): HTMLElement {
 
   // Info banner — explains the purpose of annotations to the user.
   const info = document.createElement('div');
-  info.className = 'mb-2 p-2 rounded bg-pink-500/10 border border-pink-400/30 text-[10px] text-pink-200 leading-snug';
+  info.className = 'mb-2 p-2 rounded bg-blue-500/10 border border-blue-400/30 text-[10px] text-blue-200 leading-snug';
   info.textContent = 'Annotations are saved with this session and exported in the JSON. Use them to point out specific improvements for an AI working on the model.';
   content.appendChild(info);
 

--- a/src/annotations/annotateUI.ts
+++ b/src/annotations/annotateUI.ts
@@ -233,7 +233,7 @@ function createPickerPanel(): HTMLElement {
   panel.style.minWidth = '220px';
 
   // Header: drag handle + title + × close button (shared tool-panel chrome).
-  const header = createToolPanelHeader('✏️ Annotate', () => { toggleAnnotateMode(); });
+  const header = createToolPanelHeader('✏️ Annotate', () => { toggleAnnotateMode(); }, 'Close annotate menu');
   panel.appendChild(header);
   attachViewportPanelDrag(header, panel);
 

--- a/src/color/imagePaintUI.ts
+++ b/src/color/imagePaintUI.ts
@@ -426,7 +426,7 @@ function buildPanel(): HTMLElement {
   ].join(' ');
 
   // ── Header / drag handle (shared tool-panel chrome) ──
-  const header = createToolPanelHeader('🖼️ Image Paint', toggleImagePaint);
+  const header = createToolPanelHeader('🖼️ Image Paint', toggleImagePaint, 'Close image paint panel');
   el.appendChild(header);
   attachViewportPanelDrag(header, el);
 

--- a/src/color/imagePaintUI.ts
+++ b/src/color/imagePaintUI.ts
@@ -34,6 +34,7 @@ import { getCurrentMesh as getPaintMesh } from './paintMode';
 import { deactivateMode, registerExclusiveMode } from '../ui/modeExclusion';
 import { forceDeactivate as closeSimplifyMenu } from '../ui/simplifyUI';
 import { viewportToolsMount } from '../ui/popoverMenu';
+import { panelDockRightOffset } from '../ui/viewportPanelDrag';
 import { forceDeactivate as closeAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as closeAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as closeAnnotateSelect } from '../annotations/selectMode';
@@ -191,6 +192,15 @@ function openPanel(): void {
   isOpen = true;
   imagePaintBtn!.className = btnClass(true);
   panel?.classList.remove('hidden');
+  // Launched from the sticky Tools menu, shift left so the open list stays
+  // visible beside the panel. Desktop + undragged only; mobile is a bottom
+  // sheet (positioned by its inset-x classes), and a dragged panel keeps its
+  // user-chosen spot.
+  if (panel && panelLeft < 0 && window.matchMedia('(min-width: 768px)').matches) {
+    panel.style.right = `${panelDockRightOffset()}px`;
+    panel.style.left = 'auto';
+    panel.style.top = '48px';
+  }
   updateStampMode();
 }
 
@@ -198,6 +208,12 @@ function closePanel(): void {
   isOpen = false;
   imagePaintBtn!.className = btnClass(false);
   panel?.classList.add('hidden');
+  // Drop any inline docking offset so the responsive classes govern next open.
+  if (panel && panelLeft < 0) {
+    panel.style.right = '';
+    panel.style.left = '';
+    panel.style.top = '';
+  }
   updateStampMode();
 }
 

--- a/src/color/imagePaintUI.ts
+++ b/src/color/imagePaintUI.ts
@@ -34,7 +34,9 @@ import { getCurrentMesh as getPaintMesh } from './paintMode';
 import { deactivateMode, registerExclusiveMode } from '../ui/modeExclusion';
 import { forceDeactivate as closeSimplifyMenu } from '../ui/simplifyUI';
 import { viewportToolsMount } from '../ui/popoverMenu';
-import { panelDockRightOffset } from '../ui/viewportPanelDrag';
+import { setInitialPanelPosition, attachViewportPanelDrag } from '../ui/viewportPanelDrag';
+import { createToolPanelHeader } from '../ui/toolPanel';
+import { openViewportPanel, closeViewportPanel } from '../ui/viewportPanelRegistry';
 import { forceDeactivate as closeAnnotate } from '../annotations/annotateUI';
 import { forceDeactivate as closeAnnotateText } from '../annotations/textMode';
 import { forceDeactivate as closeAnnotateSelect } from '../annotations/selectMode';
@@ -62,12 +64,6 @@ let pickedImageThumb: ImageData | null = null;    // downscaled for the preview 
 let previewCanvas: HTMLCanvasElement | null = null;
 let previewCtx: CanvasRenderingContext2D | null = null;
 let sourceLabel: HTMLElement | null = null;
-
-// Panel drag state
-let dragAnchorX = 0;
-let dragAnchorY = 0;
-let panelLeft = -1; // -1 = not yet dragged (use CSS right: 8px)
-let panelTop = 48;
 
 // Settings state
 let opts: {
@@ -188,19 +184,33 @@ function toggleImagePaint(): void {
   }
 }
 
+/** Registry entry so opening any other tool panel closes Image Paint, and
+ *  opening Image Paint closes whatever else is open (single panel at a time). */
+const imagePanelEntry = { close: (): void => { if (isOpen) closePanel(); } };
+
+function onImagePaintEscape(e: KeyboardEvent): void {
+  if (e.key !== 'Escape') return;
+  // Let a centered dialog (e.g. a confirm) consume Escape first.
+  if (document.querySelector('[role="dialog"]')) return;
+  if (isOpen) closePanel();
+}
+
 function openPanel(): void {
   isOpen = true;
   imagePaintBtn!.className = btnClass(true);
+  openViewportPanel(imagePanelEntry); // close any other open tool panel
   panel?.classList.remove('hidden');
-  // Launched from the sticky Tools menu, shift left so the open list stays
-  // visible beside the panel. Desktop + undragged only; mobile is a bottom
-  // sheet (positioned by its inset-x classes), and a dragged panel keeps its
-  // user-chosen spot.
-  if (panel && panelLeft < 0 && window.matchMedia('(min-width: 768px)').matches) {
-    panel.style.right = `${panelDockRightOffset()}px`;
-    panel.style.left = 'auto';
-    panel.style.top = '48px';
+  // Desktop: dock beneath the toolbar (or the open Tools menu), right-aligned —
+  // same as every other tool panel. Mobile: a bottom sheet positioned by its
+  // inset-x classes, so clear any inline offsets left from a desktop session.
+  if (panel) {
+    if (window.matchMedia('(min-width: 768px)').matches) {
+      setInitialPanelPosition(panel);
+    } else {
+      panel.style.top = ''; panel.style.right = ''; panel.style.left = ''; panel.style.bottom = '';
+    }
   }
+  document.addEventListener('keydown', onImagePaintEscape);
   updateStampMode();
 }
 
@@ -208,12 +218,8 @@ function closePanel(): void {
   isOpen = false;
   imagePaintBtn!.className = btnClass(false);
   panel?.classList.add('hidden');
-  // Drop any inline docking offset so the responsive classes govern next open.
-  if (panel && panelLeft < 0) {
-    panel.style.right = '';
-    panel.style.left = '';
-    panel.style.top = '';
-  }
+  document.removeEventListener('keydown', onImagePaintEscape);
+  closeViewportPanel(imagePanelEntry);
   updateStampMode();
 }
 
@@ -419,55 +425,10 @@ function buildPanel(): HTMLElement {
     'md:inset-x-auto md:bottom-auto md:left-auto md:right-2 md:top-12 md:w-64 md:max-h-[calc(100%-3.5rem)] md:rounded-lg',
   ].join(' ');
 
-  // ── Header / drag handle ──
-  const header = document.createElement('div');
-  header.className = 'shrink-0 flex items-center justify-between gap-2 px-2.5 py-2 border-b border-zinc-700/70 cursor-grab active:cursor-grabbing select-none';
-  header.title = 'Drag to reposition';
-
-  const titleEl = document.createElement('div');
-  titleEl.className = 'text-[11px] text-zinc-300 font-medium';
-  titleEl.textContent = '🖼️ Image Paint';
-  header.appendChild(titleEl);
-
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'shrink-0 -mr-1 w-7 h-7 flex items-center justify-center rounded text-base leading-none text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700/60 transition-colors';
-  closeBtn.title = 'Close image paint panel';
-  closeBtn.setAttribute('aria-label', 'Close');
-  closeBtn.textContent = '✕';
-  closeBtn.addEventListener('click', toggleImagePaint);
-  header.appendChild(closeBtn);
-
-  // Drag-to-move
-  header.addEventListener('pointerdown', (e) => {
-    if (e.button !== 0 || !el) return;
-    // Don't capture drag when the user is clicking an interactive child (e.g. the
-    // close button) — setPointerCapture + preventDefault would swallow the click.
-    if ((e.target as HTMLElement).closest('button')) return;
-    const rect = el.getBoundingClientRect();
-    // Initialize absolute left/top from current render position on first drag
-    if (panelLeft < 0) {
-      panelLeft = rect.left;
-      panelTop = rect.top;
-      el.style.right = '';
-      el.style.top = '';
-    }
-    dragAnchorX = e.clientX - panelLeft;
-    dragAnchorY = e.clientY - panelTop;
-    header.setPointerCapture(e.pointerId);
-    e.preventDefault();
-  });
-  header.addEventListener('pointermove', (e) => {
-    if (!header.hasPointerCapture(e.pointerId) || !el) return;
-    panelLeft = e.clientX - dragAnchorX;
-    panelTop = e.clientY - dragAnchorY;
-    el.style.left = `${panelLeft}px`;
-    el.style.top = `${panelTop}px`;
-  });
-  header.addEventListener('pointerup', (e) => {
-    if (header.hasPointerCapture(e.pointerId)) header.releasePointerCapture(e.pointerId);
-  });
-
+  // ── Header / drag handle (shared tool-panel chrome) ──
+  const header = createToolPanelHeader('🖼️ Image Paint', toggleImagePaint);
   el.appendChild(header);
+  attachViewportPanelDrag(header, el);
 
   // ── Scrollable content ──
   const content = document.createElement('div');

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -95,6 +95,7 @@ import { openViewportPanel, closeViewportPanel } from '../ui/viewportPanelRegist
 import { attachViewportPanelDrag, setInitialPanelPosition } from '../ui/viewportPanelDrag';
 import { registerExclusiveMode, deactivateMode } from '../ui/modeExclusion';
 import { viewportToolsMount } from '../ui/popoverMenu';
+import { createToolPanelHeader, TOOL_TOGGLE_IDLE, TOOL_TOGGLE_ACTIVE } from '../ui/toolPanel';
 
 let paintBtn: HTMLButtonElement | null = null;
 let pickerPanel: HTMLElement | null = null;
@@ -118,7 +119,7 @@ const shapeSmoothSyncs: (() => void)[] = [];
 export function initPaintUI(controlsContainer: HTMLElement): void {
   paintBtn = document.createElement('button');
   paintBtn.id = 'paint-toggle';
-  paintBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  paintBtn.className = TOOL_TOGGLE_IDLE;
   paintBtn.textContent = '\uD83C\uDFA8 Paint';
   paintBtn.title = 'Paint color regions on model faces';
 
@@ -135,7 +136,7 @@ export function initPaintUI(controlsContainer: HTMLElement): void {
   // entering paint mode. Edits propagate to the paint swatches and relief.
   const paletteBtn = document.createElement('button');
   paletteBtn.id = 'palette-manager-toggle';
-  paletteBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  paletteBtn.className = TOOL_TOGGLE_IDLE;
   paletteBtn.textContent = '🧵 Palette';
   paletteBtn.title = 'Manage the filament palette (slots, colours, capacity)';
   paletteBtn.addEventListener('click', () => openPaletteManager());
@@ -197,11 +198,7 @@ function togglePaintMode(): void {
 
 function updateButtonState(active: boolean): void {
   if (!paintBtn) return;
-  if (active) {
-    paintBtn.className = 'px-2 py-1 rounded text-xs bg-blue-500/30 backdrop-blur text-blue-300 border border-blue-500/50 transition-colors';
-  } else {
-    paintBtn.className = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
-  }
+  paintBtn.className = active ? TOOL_TOGGLE_ACTIVE : TOOL_TOGGLE_IDLE;
 }
 
 /** Build the palette section: the slot swatch grid, an over-budget badge, the
@@ -330,20 +327,8 @@ function createPickerPanel(): HTMLElement {
   // no matter how long the region list grows.
   panel.className = 'hidden z-20 flex flex-col overflow-hidden bg-zinc-800/95 backdrop-blur border border-zinc-600/60 shadow-xl absolute rounded-lg w-60 max-h-[calc(100%-3.5rem)]';
 
-  // === Header: drag handle + title + \u00D7 close button ===
-  const header = document.createElement('div');
-  header.className = 'shrink-0 flex items-center justify-between gap-2 px-2.5 py-2 border-b border-zinc-700/70';
-  const headerTitle = document.createElement('div');
-  headerTitle.className = 'text-[11px] text-zinc-300 font-medium';
-  headerTitle.textContent = '\uD83C\uDFA8 Paint';
-  header.appendChild(headerTitle);
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'shrink-0 -mr-1 w-7 h-7 flex items-center justify-center rounded text-base leading-none text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700/60 transition-colors';
-  closeBtn.title = 'Close paint menu';
-  closeBtn.setAttribute('aria-label', 'Close paint menu');
-  closeBtn.textContent = '\u00D7';
-  closeBtn.addEventListener('click', () => { togglePaintMode(); });
-  header.appendChild(closeBtn);
+  // === Header: drag handle + title + \u00D7 close button (shared tool-panel chrome) ===
+  const header = createToolPanelHeader('\uD83C\uDFA8 Paint', () => { togglePaintMode(); });
   panel.appendChild(header);
   attachViewportPanelDrag(header, panel);
 

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -328,7 +328,7 @@ function createPickerPanel(): HTMLElement {
   panel.className = 'hidden z-20 flex flex-col overflow-hidden bg-zinc-800/95 backdrop-blur border border-zinc-600/60 shadow-xl absolute rounded-lg w-60 max-h-[calc(100%-3.5rem)]';
 
   // === Header: drag handle + title + \u00D7 close button (shared tool-panel chrome) ===
-  const header = createToolPanelHeader('\uD83C\uDFA8 Paint', () => { togglePaintMode(); });
+  const header = createToolPanelHeader('\uD83C\uDFA8 Paint', () => { togglePaintMode(); }, 'Close paint menu');
   panel.appendChild(header);
   attachViewportPanelDrag(header, panel);
 

--- a/src/color/paletteManager.ts
+++ b/src/color/paletteManager.ts
@@ -5,7 +5,7 @@
 // Studio. Kept separate from the paint panel so the palette can be curated
 // without entering paint mode.
 
-import { createModalShell } from '../ui/modalShell';
+import { createToolPanelShell } from '../ui/toolPanel';
 import { BUTTON_PRIMARY } from '../ui/styleConstants';
 import { showToast } from '../ui/toast';
 import { promptDialog, confirmDialog } from '../ui/dialogs';
@@ -46,15 +46,14 @@ import { openPhotoColorPicker } from './photoColorPicker';
 
 let open = false;
 
-/** Open the palette manager modal. Idempotent — a second call is a no-op while
- *  one is showing. */
+/** Open the palette manager — a docked, draggable tool panel (like Paint).
+ *  Idempotent — a second call is a no-op while one is showing. */
 export function openPaletteManager(): void {
   if (open) return;
   open = true;
-  const shell = createModalShell({
+  const shell = createToolPanelShell({
     title: '🎨 Filament palette',
-    maxWidth: 'sm',
-    scrollable: true,
+    width: 'w-[22rem]',
     onClose: () => { open = false; },
   });
 
@@ -217,8 +216,9 @@ export function openPaletteManager(): void {
   importBtn.className = 'px-2.5 py-1 rounded text-xs bg-zinc-700/60 text-zinc-200 hover:bg-zinc-600/60 transition-colors';
   importBtn.textContent = '🖼️ Import from photo…';
   importBtn.addEventListener('click', () => {
-    // Opening the picker auto-closes this manager (modalShell allows one shell);
-    // its onClose reopens the manager so the imported slots + history show.
+    // Close this panel while the centered photo picker is up (so the two don't
+    // stack); the picker's onClose reopens the manager with the imported slots.
+    shell.close();
     openPhotoColorPicker(
       (hexes) => {
         for (const hex of hexes) {

--- a/src/color/voxelPaintUI.ts
+++ b/src/color/voxelPaintUI.ts
@@ -229,7 +229,7 @@ function createPanel(): HTMLElement {
   p.className = 'hidden z-20 flex flex-col overflow-hidden bg-zinc-800/95 backdrop-blur border border-zinc-600/60 shadow-xl absolute rounded-lg w-56 max-h-[calc(100%-3.5rem)] text-xs text-zinc-200';
 
   // Header: drag handle + title + × close (shared tool-panel chrome).
-  const header = createToolPanelHeader('🧊 Voxel Studio', () => { void doDeactivate(); });
+  const header = createToolPanelHeader('🧊 Voxel Studio', () => { void doDeactivate(); }, 'Close Voxel Studio');
   p.appendChild(header);
   attachViewportPanelDrag(header, p);
 

--- a/src/color/voxelPaintUI.ts
+++ b/src/color/voxelPaintUI.ts
@@ -8,6 +8,7 @@ import * as voxelPaint from './voxelPaint';
 import type { VoxelTool, BrushShape } from './voxelPaint';
 import { viewportToolsMount } from '../ui/popoverMenu';
 import { attachViewportPanelDrag, setInitialPanelPosition } from '../ui/viewportPanelDrag';
+import { createToolPanelHeader, TOOL_TOGGLE_IDLE, TOOL_TOGGLE_ACTIVE } from '../ui/toolPanel';
 import { openViewportPanel, closeViewportPanel } from '../ui/viewportPanelRegistry';
 
 const SWATCHES: string[] = [
@@ -92,7 +93,7 @@ export function initVoxelPaintUI(controlsContainer: HTMLElement, callbacks: Voxe
 
   paintBtn = document.createElement('button');
   paintBtn.id = 'voxel-paint-toggle';
-  paintBtn.className = 'hidden px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+  paintBtn.className = `hidden ${TOOL_TOGGLE_IDLE}`;
   paintBtn.textContent = '🧊 Voxel Studio';
   paintBtn.title = 'Add, remove, brush, and recolor voxels — then bake to code.';
   paintBtn.addEventListener('click', toggle);
@@ -131,15 +132,17 @@ export function syncActiveState(): void {
   const exited = !nowActive && active;
   active = nowActive;
   if (!paintBtn || !panel) return;
+  // Reassigning className wipes the availability-driven `hidden` class, so
+  // preserve it across the swap to the shared idle/active toggle styling.
+  const wasHidden = paintBtn.classList.contains('hidden');
   if (active) {
-    paintBtn.classList.add('bg-emerald-700/60', 'text-emerald-100', 'border-emerald-500/50');
-    paintBtn.classList.remove('text-zinc-400');
+    paintBtn.className = TOOL_TOGGLE_ACTIVE;
     panel.classList.remove('hidden');
   } else {
-    paintBtn.classList.remove('bg-emerald-700/60', 'text-emerald-100', 'border-emerald-500/50');
-    paintBtn.classList.add('text-zinc-400');
+    paintBtn.className = TOOL_TOGGLE_IDLE;
     panel.classList.add('hidden');
   }
+  paintBtn.classList.toggle('hidden', wasHidden);
   if (entered) {
     setInitialPanelPosition(panel);          // place it below the toolbar
     openViewportPanel(registryEntry);        // close any other viewport panel
@@ -192,9 +195,9 @@ function refreshControls(): void {
 
 function setActive(btn: HTMLElement | null | undefined, on: boolean): void {
   if (!btn) return;
-  btn.classList.toggle('bg-emerald-600', on);
+  btn.classList.toggle('bg-blue-600', on);
   btn.classList.toggle('text-white', on);
-  btn.classList.toggle('border-emerald-400', on);
+  btn.classList.toggle('border-blue-400', on);
 }
 
 async function toggle(): Promise<void> {
@@ -225,20 +228,8 @@ function createPanel(): HTMLElement {
   // to the viewport, single rounded card.
   p.className = 'hidden z-20 flex flex-col overflow-hidden bg-zinc-800/95 backdrop-blur border border-zinc-600/60 shadow-xl absolute rounded-lg w-56 max-h-[calc(100%-3.5rem)] text-xs text-zinc-200';
 
-  // Header: drag handle + title + × close (matches paintUI).
-  const header = document.createElement('div');
-  header.className = 'shrink-0 flex items-center justify-between gap-2 px-2.5 py-2 border-b border-zinc-700/70';
-  const headerTitle = document.createElement('div');
-  headerTitle.className = 'text-[11px] text-zinc-300 font-medium';
-  headerTitle.textContent = '🧊 Voxel Studio';
-  header.appendChild(headerTitle);
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'shrink-0 -mr-1 w-7 h-7 flex items-center justify-center rounded text-base leading-none text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700/60 transition-colors';
-  closeBtn.title = 'Close Voxel Studio (discards edits)';
-  closeBtn.setAttribute('aria-label', 'Close Voxel Studio');
-  closeBtn.textContent = '×';
-  closeBtn.addEventListener('click', () => { void doDeactivate(); });
-  header.appendChild(closeBtn);
+  // Header: drag handle + title + × close (shared tool-panel chrome).
+  const header = createToolPanelHeader('🧊 Voxel Studio', () => { void doDeactivate(); });
   p.appendChild(header);
   attachViewportPanelDrag(header, p);
 
@@ -340,7 +331,7 @@ function buildBrushSection(): HTMLElement {
   sizeSlider.max = '8';
   sizeSlider.step = '1';
   sizeSlider.value = '0';
-  sizeSlider.className = 'w-full accent-emerald-500';
+  sizeSlider.className = 'w-full accent-blue-500';
   sizeSlider.title = 'Brush radius in voxels (0 = a single voxel)';
   sizeSlider.addEventListener('input', () => { voxelPaint.setBrushRadius(Number(sizeSlider!.value)); refreshControls(); });
   sec.appendChild(sizeSlider);
@@ -381,7 +372,7 @@ function buildBrushSection(): HTMLElement {
   density.max = '100';
   density.step = '5';
   density.value = String(Math.round(voxelPaint.getSprayDensity() * 100));
-  density.className = 'flex-1 accent-emerald-500';
+  density.className = 'flex-1 accent-blue-500';
   density.addEventListener('input', () => voxelPaint.setSprayDensity(Number(density.value) / 100));
   sprayRow.appendChild(density);
   sec.appendChild(sprayRow);
@@ -443,7 +434,7 @@ function buildActions(): HTMLElement {
   // Primary: keep the procedural code, append the edits as readable ops.
   const updateBtn = document.createElement('button');
   updateBtn.type = 'button';
-  updateBtn.className = 'w-full px-2 py-1 rounded text-xs bg-emerald-700 hover:bg-emerald-600 text-white transition-colors';
+  updateBtn.className = 'w-full px-2 py-1 rounded text-xs bg-blue-700 hover:bg-blue-600 text-white transition-colors';
   updateBtn.textContent = 'Update code';
   updateBtn.title = 'Keep your code and append these edits as v.set/v.remove statements, then save a version';
   updateBtn.addEventListener('click', async () => { if (onUpdateCode) await onUpdateCode(); syncActiveState(); });

--- a/src/main.ts
+++ b/src/main.ts
@@ -5467,9 +5467,9 @@ async function main() {
   });
   viewportPane.appendChild(paramsPanel.element);
   // Customize is a contextual primary: hidden until a model declares params,
-  // then surfaced top-level (just before the View group) as a strong "this model
-  // is tweakable" signal — not buried inside the Tools popover.
-  const customizeAnchor = clipControls.querySelector('#viewport-view-group');
+  // then surfaced top-level (just before the Inspect popover) as a strong "this
+  // model is tweakable" signal — not buried inside the Tools popover.
+  const customizeAnchor = clipControls.querySelector('#viewport-inspect-group');
   if (customizeAnchor) clipControls.insertBefore(customizeBtn, customizeAnchor);
   else clipControls.appendChild(customizeBtn);
 
@@ -6433,7 +6433,7 @@ async function main() {
   reliefViewportBtn.addEventListener('click', () => toggleReliefStudio());
   // Relief edit is a contextual primary too (shown only in relief sessions), so
   // it sits top-level alongside Customize rather than inside the Tools popover.
-  const reliefAnchor = clipControls.querySelector('#viewport-view-group');
+  const reliefAnchor = clipControls.querySelector('#viewport-inspect-group');
   if (reliefAnchor) clipControls.insertBefore(reliefViewportBtn, reliefAnchor);
   else clipControls.appendChild(reliefViewportBtn);
 

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -719,11 +719,13 @@ function makeViewportPill(id: string, text: string, title: string, className = V
 }
 
 // The viewport overlay bar. Historically a flat row of ~16 buttons that grew with
-// every feature; now collapsed into a couple of always-visible primaries plus
-// three labelled popover groups so the strip stays short while everything is one
+// every feature. Now: the always-visible primaries plus the display toggles
+// (edges/grid/dims/lock — frequent one-click view-state flips) sit directly on
+// the bar, and the tool-launching buttons collapse into two labelled popover
+// groups (Inspect / Tools) so the strip stays short while everything is one
 // click (and one ⌘K search) away. Button ids are unchanged — the toggle-wiring
-// in main.ts finds them by id regardless of which popover they now live in, and
-// the injected tool buttons mount into the Tools popover via `viewportToolsMount`.
+// in main.ts finds them by id wherever they live, and the injected tool buttons
+// mount into the Tools popover via `viewportToolsMount`.
 function createClipControls(): HTMLElement {
   const container = document.createElement('div');
   container.id = 'clip-controls';
@@ -742,30 +744,35 @@ function createClipControls(): HTMLElement {
   const resetBtn = makeViewportPill('reset-view', '↻ Reset View', 'Reset camera to the default view');
   container.appendChild(resetBtn);
 
-  // View popover — display preferences set once and forgotten. closeOnSelect is
-  // left off so users can flip several toggles without the menu dismissing.
-  const viewGroup = createPopoverGroup({ id: 'viewport-view', label: 'View', title: 'Display options: edges, grid, dimensions, camera lock' });
-  viewGroup.menu.appendChild(makeViewportPill('wireframe-toggle', '△ Edges', 'Show mesh edges'));
-  viewGroup.menu.appendChild(makeViewportPill('grid-toggle', '▦ Grid', 'Show grid plane'));
+  // Display toggles — the buttons that only change how the model is *shown*
+  // (edges, grid, dimensions, camera lock). These live directly on the bar as
+  // one-click pills (not collapsed into a menu): they're frequent, mutually
+  // independent flips, and a menu round-trip per toggle was pure friction.
+  container.appendChild(makeViewportPill('wireframe-toggle', '△ Edges', 'Show mesh edges'));
+  container.appendChild(makeViewportPill('grid-toggle', '▦ Grid', 'Show grid plane'));
   // Dimensions defaults on — give it the active blue styling to match its state.
-  viewGroup.menu.appendChild(makeViewportPill(
+  container.appendChild(makeViewportPill(
     'dimensions-toggle', '⬚ Dims', 'Toggle bounding box dimensions',
     'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-blue-500/20 backdrop-blur text-blue-400 [@media(hover:hover)]:hover:bg-blue-500/30 transition-colors border border-blue-500/30 text-left',
   ));
-  viewGroup.menu.appendChild(makeViewportPill('orbit-lock-toggle', '\uD83D\uDD13 Lock', 'Lock camera rotation'));
-  container.appendChild(viewGroup.wrapper);
+  container.appendChild(makeViewportPill('orbit-lock-toggle', '\uD83D\uDD13 Lock', 'Lock camera rotation'));
 
-  // Inspect popover — read-only analysis tools that never mutate the model.
-  const inspectGroup = createPopoverGroup({ id: 'viewport-inspect', label: 'Inspect', title: 'Measure distances and cross-section the model', closeOnSelect: true });
+  // Inspect popover — read-only analysis tools that never mutate the model. The
+  // menu is sticky: clicking an item activates the tool but leaves the list open
+  // so you can flip between Measure and Cross Section without re-opening it. It
+  // closes on the group button, a sibling popover, click-outside, or Escape.
+  const inspectGroup = createPopoverGroup({ id: 'viewport-inspect', label: 'Inspect', title: 'Measure distances and cross-section the model' });
   inspectGroup.menu.appendChild(makeViewportPill('measure-toggle', '\uD83D\uDCCF Measure', 'Measure distance between two points on your model'));
   inspectGroup.menu.appendChild(makeViewportPill('clip-toggle', '✂ Cross Section', 'Toggle cross-section clipping plane'));
   container.appendChild(inspectGroup.wrapper);
 
   // Tools popover — the mutate/decorate tools (Paint, Annotate, Surface, Resize,
   // Quality, ...). Starts empty; each tool module appends its button here at init
-  // via `viewportToolsMount`. closeOnSelect on so picking a tool reveals its
-  // floating panel. Stable id `viewport-tools-menu` is the injection contract.
-  const toolsGroup = createPopoverGroup({ id: 'viewport-tools', label: 'Tools', title: 'Editing tools: paint, annotate, surface modifiers, resize, quality', closeOnSelect: true });
+  // via `viewportToolsMount`. The menu is sticky: picking a tool reveals its
+  // floating panel but keeps the list open, so switching between tools is one
+  // click each instead of re-opening Tools every time. Stable id
+  // `viewport-tools-menu` is the injection contract.
+  const toolsGroup = createPopoverGroup({ id: 'viewport-tools', label: 'Tools', title: 'Editing tools: paint, annotate, surface modifiers, resize, quality' });
   container.appendChild(toolsGroup.wrapper);
 
   return container;

--- a/src/ui/popoverMenu.ts
+++ b/src/ui/popoverMenu.ts
@@ -73,8 +73,14 @@ export function createPopoverGroup(opts: PopoverGroupOptions): PopoverGroup {
 
   const menu = document.createElement('div');
   menu.id = `${opts.id}-menu`;
+  // Horizontal button row (right-aligned, wraps on narrow screens). A clicked
+  // tool's own panel then docks beneath this row, so the row stays a compact
+  // launcher strip rather than a tall vertical list.
+  // `w-max` makes the row size to its full content (an abspos flex-wrap box
+  // otherwise collapses to its widest item, stacking the buttons); max-w caps it
+  // so it wraps instead of overflowing on narrow screens.
   menu.className =
-    'absolute right-0 top-full mt-1 hidden z-20 bg-zinc-800 border border-zinc-600 rounded shadow-lg p-1 flex flex-col gap-1 min-w-[9rem] max-w-[80vw] max-h-[70vh] overflow-y-auto';
+    'absolute right-0 top-full mt-1 hidden z-20 bg-zinc-800 border border-zinc-600 rounded shadow-lg p-1 flex flex-row flex-wrap items-center justify-end gap-1 w-max max-w-[90vw]';
   wrapper.appendChild(menu);
 
   const isOpen = () => !menu.classList.contains('hidden');

--- a/src/ui/popoverMenu.ts
+++ b/src/ui/popoverMenu.ts
@@ -3,7 +3,7 @@
 // Promoted out of `toolbar.ts` (Import/Export dropdowns) so the viewport overlay
 // bar can reuse the same labelled-section / divider look, plus a self-contained
 // `createPopoverGroup` flyout used to collapse the bar's many buttons into a few
-// labelled groups (View / Inspect / Tools). One source of truth for menu chrome.
+// labelled groups (Inspect / Tools). One source of truth for menu chrome.
 
 /** Small uppercase section label inside a menu (e.g. "From file", "3D model"). */
 export function createMenuSectionHeader(text: string): HTMLElement {
@@ -49,12 +49,6 @@ export interface PopoverGroupOptions {
   label: string;
   /** Button tooltip / aria-label. */
   title: string;
-  /**
-   * Close the popover when an item button inside it is clicked. True for action
-   * menus (Inspect/Tools — picking a tool should reveal its panel); false for
-   * preference menus (View — users flip several toggles in a row).
-   */
-  closeOnSelect?: boolean;
 }
 
 /**
@@ -104,13 +98,10 @@ export function createPopoverGroup(opts: PopoverGroupOptions): PopoverGroup {
     isOpen() ? close() : open();
   });
 
-  if (opts.closeOnSelect) {
-    // Closing on item click reveals the tool's own panel. Skip clicks that aren't
-    // on an actionable button (e.g. a section header) so headers don't dismiss.
-    menu.addEventListener('click', (e) => {
-      if ((e.target as HTMLElement).closest('button')) close();
-    });
-  }
+  // The menu is sticky: clicking an item inside it (a toggle, a tool) runs that
+  // item's own handler but does NOT dismiss the menu, so users can flip several
+  // toggles or switch tools in a row without re-opening it. It closes only via
+  // the group button, opening a sibling popover, click-outside, or Escape.
 
   // Click-outside and Escape close the menu. Singleton bar — listeners persist
   // for the life of the page, matching the Import/Export dropdown pattern.

--- a/src/ui/resizeModal.ts
+++ b/src/ui/resizeModal.ts
@@ -9,6 +9,7 @@ import { registerCommands } from './commandPalette';
 import { getConfig } from '../config/appConfig';
 import { openViewportPanel, closeViewportPanel } from './viewportPanelRegistry';
 import { setInitialPanelPosition, attachViewportPanelDrag } from './viewportPanelDrag';
+import { TOOL_PANEL_CLASS, TOOL_PANEL_HEADER, TOOL_PANEL_TITLE, TOOL_PANEL_CLOSE } from './toolPanel';
 
 type ApplyResult = { error?: string; label?: string } | Record<string, unknown>;
 
@@ -88,12 +89,12 @@ export function openResizeModal(api: ResizeApi): void {
   const container = getViewportContainer();
 
   // Absolutely positioned inside the viewport container, below the toolbar.
-  const panel = el('div', 'absolute z-[60] bg-zinc-900 text-zinc-100 rounded-lg border border-zinc-700 shadow-xl w-[min(94vw,360px)] select-none flex flex-col');
+  const panel = el('div', `${TOOL_PANEL_CLASS} text-zinc-100 w-[min(94vw,360px)] max-h-[calc(100%-3.5rem)] select-none`);
 
-  // Header — drag handle + title + × button.
-  const header = el('div', 'flex items-center justify-between px-4 py-3 border-b border-zinc-700 shrink-0');
-  header.append(el('h2', 'text-sm font-semibold', 'Resize model'));
-  const closeBtn = el('button', 'text-zinc-400 hover:text-zinc-100 text-lg leading-none cursor-pointer', '×');
+  // Header — drag handle + title + × button (shared tool-panel chrome).
+  const header = el('div', TOOL_PANEL_HEADER);
+  header.append(el('h2', TOOL_PANEL_TITLE, 'Resize model'));
+  const closeBtn = el('button', TOOL_PANEL_CLOSE, '×');
   closeBtn.setAttribute('aria-label', 'Close resize panel');
   header.append(closeBtn);
   panel.append(header);
@@ -109,7 +110,7 @@ export function openResizeModal(api: ResizeApi): void {
   modeRow.append(el('span', 'text-xs text-zinc-400', 'Scale by'));
   const btnPct = el('button', '', '%');
   const btnUnits = el('button', '', 'Raw units');
-  const ACTIVE_TAB = 'px-2.5 py-1 rounded text-xs bg-sky-600 text-white';
+  const ACTIVE_TAB = 'px-2.5 py-1 rounded text-xs bg-blue-600 text-white';
   const IDLE_TAB = 'px-2.5 py-1 rounded text-xs bg-zinc-800 text-zinc-300 hover:bg-zinc-700';
   function syncModeBtns() {
     btnPct.className = mode === 'percent' ? ACTIVE_TAB : IDLE_TAB;
@@ -123,7 +124,7 @@ export function openResizeModal(api: ResizeApi): void {
 
   // ---- Uniform toggle ----
   const uniformRow = el('label', 'flex items-center gap-2 mb-4 text-xs text-zinc-300 cursor-pointer');
-  const uniformCheck = el('input', 'accent-sky-500');
+  const uniformCheck = el('input', 'accent-blue-500');
   uniformCheck.type = 'checkbox';
   uniformCheck.checked = uniform;
   uniformCheck.addEventListener('change', () => {
@@ -172,7 +173,7 @@ export function openResizeModal(api: ResizeApi): void {
   // ---- Preserve colors checkbox (only when the model has paint) ----
   if (hasColor) {
     const colorRow = el('label', 'flex items-center gap-2 mb-3 text-xs text-zinc-300 cursor-pointer');
-    const colorCheck = el('input', 'accent-sky-500');
+    const colorCheck = el('input', 'accent-blue-500');
     colorCheck.type = 'checkbox';
     colorCheck.checked = preserveColor;
     colorCheck.addEventListener('change', () => {
@@ -196,7 +197,7 @@ export function openResizeModal(api: ResizeApi): void {
   const footer = el('div', 'flex justify-end gap-2 px-4 pb-4 shrink-0');
   const resetBtn = el('button', 'px-3 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-xs', 'Reset');
   const cancelBtn = el('button', 'px-3 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs', 'Cancel');
-  const applyBtn = el('button', 'px-3 py-1.5 rounded bg-sky-600 hover:bg-sky-500 text-white text-xs font-medium', 'Apply');
+  const applyBtn = el('button', 'px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium', 'Apply');
   footer.append(resetBtn, cancelBtn, applyBtn);
   panel.append(footer);
 
@@ -209,7 +210,7 @@ export function openResizeModal(api: ResizeApi): void {
     labelRow.append(label, readout);
 
     const controlRow = el('div', 'flex items-center gap-2');
-    const slider = el('input', 'flex-1 accent-sky-500');
+    const slider = el('input', 'flex-1 accent-blue-500');
     slider.type = 'range';
     const numInput = el('input', 'w-20 bg-zinc-800 border border-zinc-600 rounded px-1 py-0.5 text-right text-zinc-200 font-mono focus:border-blue-400 focus:outline-none text-xs');
     numInput.type = 'number';

--- a/src/ui/simplifyUI.ts
+++ b/src/ui/simplifyUI.ts
@@ -730,7 +730,7 @@ function buildPanel(): HTMLElement {
   p.style.maxWidth = '280px';
 
   // Header: drag handle + title + × close button (shared tool-panel chrome).
-  const header = createToolPanelHeader('Quality', closePanel);
+  const header = createToolPanelHeader('Quality', closePanel, 'Close quality panel');
   panelHeader = header;
   p.appendChild(header);
 

--- a/src/ui/simplifyUI.ts
+++ b/src/ui/simplifyUI.ts
@@ -31,6 +31,7 @@ import { isWireframeVisible, setWireframeVisible } from '../renderer/viewport';
 import { openViewportPanel, closeViewportPanel } from './viewportPanelRegistry';
 import { attachViewportPanelDrag, setInitialPanelPosition } from './viewportPanelDrag';
 import { viewportToolsMount } from './popoverMenu';
+import { createToolPanelHeader, TOOL_TOGGLE_IDLE, TOOL_TOGGLE_ACTIVE } from './toolPanel';
 import { QUALITY_OPTIONS, QUALITY_SEGMENTS, loadQualitySettings, type QualitySettings } from '../geometry/qualitySettings';
 import { saveQualityForLang, initQualityLogic, notifyLanguageChange as notifyQualityLangChange } from './curvatureQualityPanel';
 import { showHeavyEnhanceConfirm } from './heavyMeshConfirmModal';
@@ -139,8 +140,8 @@ export interface SimplifyHandlers {
   save(): Promise<SimplifySaveResult>;
 }
 
-const BTN_INACTIVE = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
-const BTN_ACTIVE = 'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-blue-500/20 backdrop-blur text-blue-400 [@media(hover:hover)]:hover:bg-blue-500/30 transition-colors border border-blue-500/30';
+const BTN_INACTIVE = TOOL_TOGGLE_IDLE;
+const BTN_ACTIVE = TOOL_TOGGLE_ACTIVE;
 const MODE_INACTIVE = 'flex-1 px-2 py-1 rounded text-xs text-zinc-400 bg-zinc-700/50 [@media(hover:hover)]:hover:bg-zinc-600/50 transition-colors border border-zinc-600/40';
 const MODE_ACTIVE = 'flex-1 px-2 py-1 rounded text-xs text-blue-300 bg-blue-500/20 transition-colors border border-blue-500/40';
 
@@ -728,20 +729,9 @@ function buildPanel(): HTMLElement {
   p.style.minWidth = '240px';
   p.style.maxWidth = '280px';
 
-  // Header: drag handle + title + × close button.
-  const header = document.createElement('div');
-  header.className = 'flex items-center justify-between px-2.5 py-2 border-b border-zinc-700/70';
+  // Header: drag handle + title + × close button (shared tool-panel chrome).
+  const header = createToolPanelHeader('Quality', closePanel);
   panelHeader = header;
-  const titleEl = document.createElement('div');
-  titleEl.className = 'text-[10px] text-zinc-500 uppercase tracking-wider font-medium';
-  titleEl.textContent = 'Quality';
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'text-zinc-400 hover:text-zinc-200 transition-colors leading-none w-6 h-6 flex items-center justify-center rounded hover:bg-zinc-700/60';
-  closeBtn.textContent = '×';
-  closeBtn.title = 'Close';
-  closeBtn.setAttribute('aria-label', 'Close quality panel');
-  closeBtn.addEventListener('click', closePanel);
-  header.append(titleEl, closeBtn);
   p.appendChild(header);
 
   // Padded content area beneath the header.

--- a/src/ui/surfaceModal.ts
+++ b/src/ui/surfaceModal.ts
@@ -14,6 +14,7 @@ import { registerCommands } from './commandPalette';
 import { getConfig } from '../config/appConfig';
 import { openViewportPanel, closeViewportPanel } from './viewportPanelRegistry';
 import { setInitialPanelPosition, attachViewportPanelDrag } from './viewportPanelDrag';
+import { TOOL_PANEL_CLASS, TOOL_PANEL_HEADER, TOOL_PANEL_TITLE, TOOL_PANEL_CLOSE } from './toolPanel';
 import { pickFace } from '../color/facePicker';
 import { addPointerSuppressor } from '../renderer/viewport';
 import { buildAdjacency, findConnectedFromSeed } from '../color/adjacency';
@@ -82,7 +83,7 @@ function slider(label: string, min: number, max: number, value: number, step: nu
   head.append(el('span', '', label));
   const readout = el('span', 'text-zinc-400 tabular-nums', fmt(value));
   head.append(readout);
-  const input = el('input', 'w-full accent-sky-500');
+  const input = el('input', 'w-full accent-blue-500');
   input.type = 'range';
   input.min = String(min); input.max = String(max); input.step = String(step); input.value = String(value);
   input.addEventListener('input', () => { readout.textContent = fmt(input.valueAsNumber); onChange(); });
@@ -92,7 +93,7 @@ function slider(label: string, min: number, max: number, value: number, step: nu
 
 function checkbox(label: string, checked: boolean, onChange: () => void) {
   const wrap = el('label', 'flex items-center gap-2 mb-3 text-xs text-zinc-300 cursor-pointer');
-  const input = el('input', 'accent-sky-500');
+  const input = el('input', 'accent-blue-500');
   input.type = 'checkbox'; input.checked = checked;
   input.addEventListener('change', onChange);
   wrap.append(input, el('span', '', label));
@@ -133,12 +134,12 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
   const container = getViewportContainer();
 
   // Floating panel — absolutely positioned inside the viewport container.
-  const panel = el('div', 'absolute z-[60] bg-zinc-900 text-zinc-100 rounded-lg border border-zinc-700 shadow-xl w-[min(94vw,400px)] select-none flex flex-col') as HTMLDivElement;
+  const panel = el('div', `${TOOL_PANEL_CLASS} text-zinc-100 w-[min(94vw,400px)] max-h-[calc(100%-3.5rem)] select-none`) as HTMLDivElement;
 
-  // Header — drag handle + title + × button.
-  const header = el('div', 'flex items-center justify-between px-4 py-3 border-b border-zinc-700 shrink-0');
-  header.append(el('h2', 'text-sm font-semibold', 'Surface modifiers'));
-  const closeBtn = el('button', 'text-zinc-400 hover:text-zinc-100 text-lg leading-none', '×');
+  // Header — drag handle + title + × button (shared tool-panel chrome).
+  const header = el('div', TOOL_PANEL_HEADER);
+  header.append(el('h2', TOOL_PANEL_TITLE, 'Surface modifiers'));
+  const closeBtn = el('button', TOOL_PANEL_CLOSE, '×');
   closeBtn.setAttribute('aria-label', 'Close surface panel');
   header.append(closeBtn);
   panel.append(header);
@@ -183,7 +184,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
   // --- Region selector UI (created once, moved above tabs) ---
 
   // Mode toggle: Region | Whole model
-  const MODE_ACTIVE = 'px-2.5 py-1 rounded text-xs bg-sky-600 text-white';
+  const MODE_ACTIVE = 'px-2.5 py-1 rounded text-xs bg-blue-600 text-white';
   const MODE_IDLE   = 'px-2.5 py-1 rounded text-xs bg-zinc-800 text-zinc-300 hover:bg-zinc-700';
   const modeRegionBtn = el('button', MODE_ACTIVE, 'Region');
   const modeWholeBtn  = el('button', MODE_IDLE, 'Whole model');
@@ -193,7 +194,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
   // Cursor-arrow icon for the pick-regions toggle
   const PICK_ICON_SVG = `<svg class="w-3.5 h-3.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M15.042 21.672 13.684 16.6m0 0-2.51 2.225.569-9.47 5.227 7.917-3.286-.672Zm-7.518-.267A8.25 8.25 0 1 1 20.25 10.5M8.288 14.212A5.25 5.25 0 1 1 17.25 10.5"/></svg>`;
   const SEL_IDLE   = BTN_BASE + ' flex items-center gap-1.5';
-  const SEL_ACTIVE = 'flex items-center gap-1.5 px-2.5 py-1 rounded text-xs bg-sky-700 text-white border border-sky-500 ring-2 ring-sky-500 ring-offset-1 ring-offset-zinc-900';
+  const SEL_ACTIVE = 'flex items-center gap-1.5 px-2.5 py-1 rounded text-xs bg-blue-700 text-white border border-blue-500 ring-2 ring-blue-500 ring-offset-1 ring-offset-zinc-800';
   const selectingBtn = el('button', SEL_IDLE);
   selectingBtn.innerHTML = PICK_ICON_SVG + '<span>Pick regions</span>';
   selectingBtn.title = 'Click faces on the model to flood-fill select regions';
@@ -234,8 +235,8 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
     const blocked = regionBlocked();
     applyBtn.disabled = blocked;
     applyBtn.className = blocked
-      ? 'px-3 py-1.5 rounded bg-sky-900/40 text-sky-300/40 text-xs font-medium cursor-not-allowed'
-      : 'px-3 py-1.5 rounded bg-sky-600 hover:bg-sky-500 text-white text-xs font-medium';
+      ? 'px-3 py-1.5 rounded bg-blue-900/40 text-blue-300/40 text-xs font-medium cursor-not-allowed'
+      : 'px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium';
     previewBtn.disabled = blocked;
     previewBtn.className = blocked
       ? 'px-3 py-1.5 rounded bg-zinc-800/40 text-zinc-400/40 text-xs cursor-not-allowed'
@@ -264,7 +265,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
     const seeds = seedTriangles.length;
     if (count === 0) {
       regionStatus.textContent = 'Pick at least one region to preview.';
-      regionStatus.className = 'text-[11px] text-sky-400/80 min-h-[1rem] mt-1 mb-1';
+      regionStatus.className = 'text-[11px] text-blue-400/80 min-h-[1rem] mt-1 mb-1';
     } else {
       const regionWord = seeds === 1 ? 'region' : 'regions';
       const suffix = inSelectionMode ? ' — click to add more' : '';
@@ -344,7 +345,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
     selectingBtn.innerHTML = PICK_ICON_SVG + '<span>Stop picking</span>';
     if (seedTriangles.length === 0) {
       regionStatus.textContent = 'Click the model to add regions…';
-      regionStatus.className = 'text-[11px] text-sky-400/80 min-h-[1rem] mt-1 mb-1';
+      regionStatus.className = 'text-[11px] text-blue-400/80 min-h-[1rem] mt-1 mb-1';
     } else {
       updateRegionStatus();
     }
@@ -533,7 +534,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
     // Region mode with nothing selected: don't fire a preview at all
     if (regionBlocked()) {
       clearPreviewIfDirty();
-      updateRegionStatus(); // ensures the sky-400 nudge text is shown
+      updateRegionStatus(); // ensures the blue-400 nudge text is shown
       return;
     }
     status.textContent = 'Updating preview…';
@@ -553,7 +554,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
   function styleTabs() {
     for (const [id, b] of tabBtns) {
       b.className = id === active
-        ? 'px-2.5 py-1 rounded text-xs bg-sky-600 text-white'
+        ? 'px-2.5 py-1 rounded text-xs bg-blue-600 text-white'
         : 'px-2.5 py-1 rounded text-xs bg-zinc-800 text-zinc-300 hover:bg-zinc-700';
     }
   }
@@ -572,7 +573,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
   const footer = el('div', 'flex justify-end gap-2 mt-2');
   const cancelBtn = el('button', 'px-3 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs', 'Cancel');
   const previewBtn = el('button', 'px-3 py-1.5 rounded bg-zinc-700 hover:bg-zinc-600 text-zinc-200 text-xs', 'Preview');
-  const applyBtn = el('button', 'px-3 py-1.5 rounded bg-sky-600 hover:bg-sky-500 text-white text-xs font-medium', 'Apply');
+  const applyBtn = el('button', 'px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium', 'Apply');
   footer.append(cancelBtn, previewBtn, applyBtn);
   scrollBody.append(footer);
 

--- a/src/ui/toolPanel.ts
+++ b/src/ui/toolPanel.ts
@@ -1,0 +1,130 @@
+// Shared standard for the viewport "Tools" panels (Paint, Image, Voxel,
+// Annotate, Quality, Surface, Resize, Palette). Before this, each tool hand-
+// rolled its own shell — different backgrounds (zinc-800/95 vs zinc-900),
+// borders, z-indices, header markup, close glyphs (× vs ✕), and hit areas — so
+// the panels looked and behaved subtly differently. These constants + helpers
+// are the single source of truth for that chrome; every tool uses them so the
+// panels read as one consistent family.
+
+import { attachViewportPanelDrag, setInitialPanelPosition } from './viewportPanelDrag';
+import { openViewportPanel, closeViewportPanel, type ViewportPanel } from './viewportPanelRegistry';
+
+/** Root shell of a docked viewport tool panel — grey, bordered, drop-shadowed,
+ *  above the model (z-20) but below centered dialogs. Does NOT include `hidden`:
+ *  singleton panels that toggle visibility prepend it themselves. */
+export const TOOL_PANEL_CLASS =
+  'absolute z-20 flex flex-col overflow-hidden bg-zinc-800/95 backdrop-blur border border-zinc-600/60 rounded-lg shadow-xl';
+
+/** Drag-handle header bar (title + close ×). Pass to attachViewportPanelDrag. */
+export const TOOL_PANEL_HEADER =
+  'shrink-0 flex items-center justify-between gap-2 px-2.5 py-2 border-b border-zinc-700/70';
+
+/** Panel title text. */
+export const TOOL_PANEL_TITLE = 'text-[11px] text-zinc-300 font-medium';
+
+/** Close (×) button — 28px square hit area, consistent across all panels. */
+export const TOOL_PANEL_CLOSE =
+  'shrink-0 -mr-1 w-7 h-7 flex items-center justify-center rounded text-base leading-none text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700/60 transition-colors';
+
+/** The Tools-menu toggle button in its idle state. */
+export const TOOL_TOGGLE_IDLE =
+  'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+
+/** The Tools-menu toggle button while its panel is open — one shared blue
+ *  accent across every tool (was blue/pink/emerald per-tool before). */
+export const TOOL_TOGGLE_ACTIVE =
+  'px-2 py-1 rounded text-xs bg-blue-500/30 backdrop-blur text-blue-300 border border-blue-500/50 transition-colors';
+
+/** Build the standard drag-handle header: a title plus a × close button.
+ *  The close button is excluded from drag initiation by attachViewportPanelDrag
+ *  (it skips clicks landing on a <button>). */
+export function createToolPanelHeader(title: string, onClose: () => void): HTMLElement {
+  const header = document.createElement('div');
+  header.className = TOOL_PANEL_HEADER;
+  const titleEl = document.createElement('div');
+  titleEl.className = TOOL_PANEL_TITLE;
+  titleEl.textContent = title;
+  header.appendChild(titleEl);
+  const closeBtn = document.createElement('button');
+  closeBtn.className = TOOL_PANEL_CLOSE;
+  closeBtn.textContent = '×'; // × (multiplication sign) — one glyph everywhere
+  closeBtn.title = 'Close';
+  closeBtn.setAttribute('aria-label', 'Close');
+  closeBtn.addEventListener('click', onClose);
+  header.appendChild(closeBtn);
+  return header;
+}
+
+export interface ToolPanelShell {
+  /** The panel root (already mounted and positioned). */
+  panel: HTMLElement;
+  /** Scrollable body — append your rows here. */
+  body: HTMLElement;
+  /** Right-aligned footer row with a top divider — append action buttons. */
+  footer: HTMLElement;
+  /** Tear down: remove the panel, drop listeners, release the registry slot.
+   *  Safe to call multiple times. */
+  close: () => void;
+}
+
+/**
+ * A fully wired docked tool panel — the panel equivalent of `createModalShell`,
+ * for tools that want the modal's `{ body, footer, close }` ergonomics but the
+ * standard look and behaviour of the other viewport tools: grey shell, draggable
+ * header, Escape-to-close, single-open mutual exclusion via the viewport panel
+ * registry, and docking beneath the toolbar (or the open Tools menu).
+ */
+export function createToolPanelShell(opts: {
+  title: string;
+  /** Full Tailwind width class(es), e.g. `'w-[22rem]'`. Defaults to `w-80`. */
+  width?: string;
+  onClose?: () => void;
+}): ToolPanelShell {
+  const host = document.getElementById('clip-controls')?.parentElement ?? document.body;
+
+  const panel = document.createElement('div');
+  panel.className = `${TOOL_PANEL_CLASS} ${opts.width ?? 'w-80'} max-w-[calc(100vw-1rem)] max-h-[calc(100%-3.5rem)] select-none`;
+  // A non-modal dialog: it doesn't trap focus or block the page behind it.
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'false');
+  panel.setAttribute('aria-label', opts.title);
+
+  let closed = false;
+  const entry: ViewportPanel = { close: () => doClose() };
+  const onEsc = (e: KeyboardEvent) => {
+    if (e.key !== 'Escape') return;
+    // Defer to any open *modal* dialog (e.g. the photo-colour picker layered on
+    // top) so Escape dismisses that first, not the panel underneath it.
+    if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+    doClose();
+  };
+
+  function doClose(): void {
+    if (closed) return;
+    closed = true;
+    document.removeEventListener('keydown', onEsc);
+    drag.destroy();
+    closeViewportPanel(entry);
+    panel.remove();
+    opts.onClose?.();
+  }
+
+  const header = createToolPanelHeader(opts.title, doClose);
+  panel.appendChild(header);
+
+  const body = document.createElement('div');
+  body.className = 'flex-1 min-h-0 overflow-y-auto px-4 py-3 flex flex-col gap-3 text-sm text-zinc-200';
+  panel.appendChild(body);
+
+  const footer = document.createElement('div');
+  footer.className = 'shrink-0 px-4 py-3 border-t border-zinc-700/70 flex items-center justify-end gap-2';
+  panel.appendChild(footer);
+
+  host.appendChild(panel);
+  const drag = attachViewportPanelDrag(header, panel);
+  setInitialPanelPosition(panel);
+  document.addEventListener('keydown', onEsc);
+  openViewportPanel(entry); // close any other open tool panel
+
+  return { panel, body, footer, close: doClose };
+}

--- a/src/ui/toolPanel.ts
+++ b/src/ui/toolPanel.ts
@@ -37,8 +37,9 @@ export const TOOL_TOGGLE_ACTIVE =
 
 /** Build the standard drag-handle header: a title plus a × close button.
  *  The close button is excluded from drag initiation by attachViewportPanelDrag
- *  (it skips clicks landing on a <button>). */
-export function createToolPanelHeader(title: string, onClose: () => void): HTMLElement {
+ *  (it skips clicks landing on a <button>). `closeLabel` is the close button's
+ *  title/aria-label — pass a descriptive one (e.g. "Close paint menu"). */
+export function createToolPanelHeader(title: string, onClose: () => void, closeLabel = 'Close'): HTMLElement {
   const header = document.createElement('div');
   header.className = TOOL_PANEL_HEADER;
   const titleEl = document.createElement('div');
@@ -48,8 +49,8 @@ export function createToolPanelHeader(title: string, onClose: () => void): HTMLE
   const closeBtn = document.createElement('button');
   closeBtn.className = TOOL_PANEL_CLOSE;
   closeBtn.textContent = '×'; // × (multiplication sign) — one glyph everywhere
-  closeBtn.title = 'Close';
-  closeBtn.setAttribute('aria-label', 'Close');
+  closeBtn.title = closeLabel;
+  closeBtn.setAttribute('aria-label', closeLabel);
   closeBtn.addEventListener('click', onClose);
   header.appendChild(closeBtn);
   return header;

--- a/src/ui/viewportPanelDrag.ts
+++ b/src/ui/viewportPanelDrag.ts
@@ -3,28 +3,23 @@
 // visible area of its offset parent. Position resets on each open (not
 // persisted) — the panel always starts below the clip-controls toolbar.
 
-// px gap between a docked panel and the viewport's right edge (mirrors the
-// toolbar's own right-2 inset). Also reused as the gap between an open Tools
-// menu and a panel shifted to sit beside it.
+// px gap between a docked panel and the bar/menu above it (mirrors the toolbar's
+// own right-2 inset, reused as the vertical breathing room under the menu).
 const PANEL_EDGE_GAP = 8;
 
-/**
- * Right offset (px) for a top-right docked viewport panel. Normally the panel
- * hugs the right edge (PANEL_EDGE_GAP). But when the sticky viewport Tools menu
- * is open, that corner is occupied by the still-open tool list — so on desktop
- * we shift the panel left to sit *beside* the menu, keeping the list visible for
- * one-click tool switching. Mobile panels are bottom sheets, so they're left be.
- */
-export function panelDockRightOffset(): number {
-  if (!window.matchMedia('(min-width: 768px)').matches) return PANEL_EDGE_GAP;
+/** The bottom edge (viewport-relative px) that a docked panel should sit under:
+ *  normally the toolbar, but the open horizontal Tools menu when it's showing,
+ *  so the panel drops *beneath* the menu row rather than under it. */
+function dockUnderBottom(controls: HTMLElement): number {
   const menu = document.getElementById('viewport-tools-menu');
   if (menu && !menu.classList.contains('hidden') && menu.offsetWidth > 0) {
-    return PANEL_EDGE_GAP + menu.offsetWidth + PANEL_EDGE_GAP;
+    return menu.getBoundingClientRect().bottom;
   }
-  return PANEL_EDGE_GAP;
+  return controls.getBoundingClientRect().bottom;
 }
 
-/** Position the panel below the #clip-controls toolbar buttons.
+/** Position the panel below the #clip-controls toolbar buttons (or below the
+ *  open Tools menu), docked to the right edge.
  *  Prefers the panel's own offset parent as the coordinate reference so
  *  top/right values land in the correct space. Falls back to clip-controls'
  *  positioned ancestor for callers that position while the panel is hidden
@@ -34,10 +29,9 @@ export function setInitialPanelPosition(panel: HTMLElement): void {
   if (controls) {
     const host = (panel.offsetParent ?? controls.offsetParent ?? controls.parentElement) as HTMLElement | null;
     if (host) {
-      const cr = controls.getBoundingClientRect();
       const hr = host.getBoundingClientRect();
-      panel.style.top = `${Math.round(cr.bottom - hr.top + 4)}px`;
-      panel.style.right = `${panelDockRightOffset()}px`;
+      panel.style.top = `${Math.round(dockUnderBottom(controls) - hr.top + PANEL_EDGE_GAP / 2)}px`;
+      panel.style.right = `${PANEL_EDGE_GAP}px`;
       panel.style.left = 'auto';
       panel.style.bottom = 'auto';
       return;
@@ -45,7 +39,7 @@ export function setInitialPanelPosition(panel: HTMLElement): void {
   }
   // Fallback when clip-controls isn't in the DOM yet.
   panel.style.top = '48px';
-  panel.style.right = `${panelDockRightOffset()}px`;
+  panel.style.right = `${PANEL_EDGE_GAP}px`;
   panel.style.left = 'auto';
   panel.style.bottom = 'auto';
 }

--- a/src/ui/viewportPanelDrag.ts
+++ b/src/ui/viewportPanelDrag.ts
@@ -3,6 +3,27 @@
 // visible area of its offset parent. Position resets on each open (not
 // persisted) — the panel always starts below the clip-controls toolbar.
 
+// px gap between a docked panel and the viewport's right edge (mirrors the
+// toolbar's own right-2 inset). Also reused as the gap between an open Tools
+// menu and a panel shifted to sit beside it.
+const PANEL_EDGE_GAP = 8;
+
+/**
+ * Right offset (px) for a top-right docked viewport panel. Normally the panel
+ * hugs the right edge (PANEL_EDGE_GAP). But when the sticky viewport Tools menu
+ * is open, that corner is occupied by the still-open tool list — so on desktop
+ * we shift the panel left to sit *beside* the menu, keeping the list visible for
+ * one-click tool switching. Mobile panels are bottom sheets, so they're left be.
+ */
+export function panelDockRightOffset(): number {
+  if (!window.matchMedia('(min-width: 768px)').matches) return PANEL_EDGE_GAP;
+  const menu = document.getElementById('viewport-tools-menu');
+  if (menu && !menu.classList.contains('hidden') && menu.offsetWidth > 0) {
+    return PANEL_EDGE_GAP + menu.offsetWidth + PANEL_EDGE_GAP;
+  }
+  return PANEL_EDGE_GAP;
+}
+
 /** Position the panel below the #clip-controls toolbar buttons.
  *  Prefers the panel's own offset parent as the coordinate reference so
  *  top/right values land in the correct space. Falls back to clip-controls'
@@ -16,7 +37,7 @@ export function setInitialPanelPosition(panel: HTMLElement): void {
       const cr = controls.getBoundingClientRect();
       const hr = host.getBoundingClientRect();
       panel.style.top = `${Math.round(cr.bottom - hr.top + 4)}px`;
-      panel.style.right = '8px';
+      panel.style.right = `${panelDockRightOffset()}px`;
       panel.style.left = 'auto';
       panel.style.bottom = 'auto';
       return;
@@ -24,7 +45,7 @@ export function setInitialPanelPosition(panel: HTMLElement): void {
   }
   // Fallback when clip-controls isn't in the DOM yet.
   panel.style.top = '48px';
-  panel.style.right = '8px';
+  panel.style.right = `${panelDockRightOffset()}px`;
   panel.style.left = 'auto';
   panel.style.bottom = 'auto';
 }

--- a/tests/paint-controls-extended.spec.ts
+++ b/tests/paint-controls-extended.spec.ts
@@ -179,10 +179,9 @@ test.describe('extended paint controls', () => {
     expect(result.bad.error).toBeTruthy();
   });
 
-  test('mesh-edge toggle sits above the grid toggle in the View popover and defaults off', async ({ page }) => {
+  test('mesh-edge toggle sits above the grid toggle on the bar and defaults off', async ({ page }) => {
     await openEditor(page);
-    // Edges/Grid now live inside the View popover — open it to reveal them.
-    await page.locator('#viewport-view-group-btn').dispatchEvent('click');
+    // Edges/Grid are direct pills on the viewport bar — visible without a menu.
     const wireBtn = page.locator('#wireframe-toggle');
     await expect(wireBtn).toBeVisible();
     await expect(page.locator('#grid-toggle')).toBeVisible();

--- a/tests/paint-palette.spec.ts
+++ b/tests/paint-palette.spec.ts
@@ -67,7 +67,9 @@ test.describe('filament palette + slot painting', () => {
     expect(regions[1].color[0]).toBeLessThan(0.3);
 
     // Drop the printer capacity to 1 via the palette manager → 2 slots used now
-    // exceeds it, so the over-budget badge appears in the paint panel.
+    // exceeds it, so the over-budget badge appears in the paint panel. Opening
+    // the palette panel closes Paint (one tool panel at a time), so reopen Paint
+    // afterwards to see the badge.
     await page.locator('#palette-manager-toggle').dispatchEvent('click');
     const dialog = page.locator('[role="dialog"]');
     const capInput = dialog.locator('input[type="number"]');
@@ -75,6 +77,8 @@ test.describe('filament palette + slot painting', () => {
     await capInput.dispatchEvent('change');
     await dialog.locator('button:has-text("Done")').dispatchEvent('click');
 
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
     const badge = page.locator('#paint-picker-panel').getByText(/\/1 slots/);
     await expect(badge).toBeVisible();
   });
@@ -158,8 +162,8 @@ test.describe('filament palette + slot painting', () => {
     await cap.dispatchEvent('change');
     await page.locator('[role="dialog"] button:has-text("Done")').dispatchEvent('click');
     await page.waitForSelector('[role="dialog"]', { state: 'detached' });
-    // Close the paint panel so it can't intercept the toolbar click.
-    await page.locator('#paint-toggle').dispatchEvent('click');
+    // Opening the palette panel already closed the paint panel (one tool panel
+    // at a time), so nothing overlaps the toolbar Export menu below.
 
     // Trigger 3MF export from the toolbar Export menu (the 3MF item is unique by
     // its Bambu description).

--- a/tests/tool-panel-consistency.spec.ts
+++ b/tests/tool-panel-consistency.spec.ts
@@ -1,0 +1,63 @@
+// Golden-path coverage for the consistent tool-panel behaviour: every tool in
+// the (horizontal) Tools menu opens a docked panel, opening one closes any
+// other (single panel at a time), the Palette is a docked panel rather than a
+// centered modal, and Escape closes panels.
+
+import { test, expect } from 'playwright/test';
+
+async function openEditor(page: import('playwright/test').Page) {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', new Date().toISOString()); } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 20000 });
+  await page.waitForFunction(() => Boolean((window as { partwright?: { run?: unknown } }).partwright?.run), null, { timeout: 15000 });
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (window as any).partwright.run(`const { Manifold } = api; return Manifold.cube([12, 12, 12], true);`);
+  });
+  await page.locator('#viewport-tools-group-btn').dispatchEvent('click');
+}
+
+test.describe('tool panel consistency', () => {
+  test('opening a tool panel closes the previously open one', async ({ page }) => {
+    await openEditor(page);
+
+    // Open Paint.
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    // Opening Quality must close Paint (was the "opens on top" bug).
+    await page.locator('#simplify-toggle').dispatchEvent('click');
+    await page.waitForSelector('#simplify-panel:not(.hidden)');
+    await expect(page.locator('#paint-picker-panel:not(.hidden)')).toHaveCount(0);
+
+    // Opening Surface must close Quality.
+    await page.locator('#surface-viewport-toggle').dispatchEvent('click');
+    await expect(page.locator('#simplify-panel:not(.hidden)')).toHaveCount(0);
+  });
+
+  test('the palette manager is a docked, non-modal panel (no centered overlay)', async ({ page }) => {
+    await openEditor(page);
+    await page.locator('#palette-manager-toggle').dispatchEvent('click');
+
+    const dialog = page.locator('[role="dialog"][aria-modal="false"]');
+    await expect(dialog).toContainText('Filament palette');
+    // It is NOT a centered backdrop overlay (the old modalShell look).
+    await expect(page.locator('.fixed.inset-0.bg-black\\/60')).toHaveCount(0);
+
+    // Opening Paint closes it (single tool panel at a time).
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+    await expect(dialog).toHaveCount(0);
+  });
+
+  test('Escape closes the image-paint panel', async ({ page }) => {
+    await openEditor(page);
+    await page.locator('#image-paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#image-paint-panel:not(.hidden)');
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#image-paint-panel:not(.hidden)')).toHaveCount(0);
+  });
+});

--- a/tests/viewport-toolbar-groups.spec.ts
+++ b/tests/viewport-toolbar-groups.spec.ts
@@ -1,8 +1,10 @@
-// Golden-path coverage for the grouped viewport overlay bar: the View / Inspect
-// / Tools popovers that collapse the previously-flat strip of ~16 buttons.
+// Golden-path coverage for the viewport overlay bar: the display toggles that
+// sit directly on the strip (edges/grid/dims/lock) plus the Inspect / Tools
+// popovers that collect the tool-launching buttons. The popovers are sticky —
+// clicking an item inside leaves the list open so you can flip tools in a row.
 //
-// Uses `dispatchEvent('click')` on the group buttons to dodge the onboarding
-// tour backdrop that intercepts real pointer events on first paint.
+// Uses `dispatchEvent('click')` on the buttons to dodge the onboarding tour
+// backdrop that intercepts real pointer events on first paint.
 
 import { test, expect } from 'playwright/test';
 
@@ -21,37 +23,42 @@ async function openEditor(page: import('playwright/test').Page) {
 }
 
 test.describe('viewport toolbar groups', () => {
-  test('the bar collapses to primaries plus three labelled group buttons', async ({ page }) => {
+  test('the bar shows primaries, direct display toggles, and two group buttons', async ({ page }) => {
     await openEditor(page);
     // Always-visible primaries.
     await expect(page.locator('#triangle-count')).toBeVisible();
     await expect(page.locator('#reset-view')).toBeVisible();
-    // The three group buttons.
-    await expect(page.locator('#viewport-view-group-btn')).toBeVisible();
-    await expect(page.locator('#viewport-inspect-group-btn')).toBeVisible();
-    await expect(page.locator('#viewport-tools-group-btn')).toBeVisible();
-  });
-
-  test('View popover holds the display toggles; Inspect holds measure + cross-section', async ({ page }) => {
-    await openEditor(page);
-
-    // Display toggles live inside the View popover and are hidden until opened.
-    await expect(page.locator('#wireframe-toggle')).toBeHidden();
-    await page.locator('#viewport-view-group-btn').dispatchEvent('click');
+    // Display toggles sit directly on the bar — visible immediately, no menu.
     await expect(page.locator('#wireframe-toggle')).toBeVisible();
     await expect(page.locator('#grid-toggle')).toBeVisible();
     await expect(page.locator('#dimensions-toggle')).toBeVisible();
     await expect(page.locator('#orbit-lock-toggle')).toBeVisible();
-
-    // Opening Inspect closes View (single popover at a time) and reveals the
-    // read-only analysis tools.
-    await page.locator('#viewport-inspect-group-btn').dispatchEvent('click');
-    await expect(page.locator('#wireframe-toggle')).toBeHidden();
-    await expect(page.locator('#measure-toggle')).toBeVisible();
-    await expect(page.locator('#clip-toggle')).toBeVisible();
+    // The View menu is gone; only Inspect and Tools remain as popovers.
+    await expect(page.locator('#viewport-view-group-btn')).toHaveCount(0);
+    await expect(page.locator('#viewport-inspect-group-btn')).toBeVisible();
+    await expect(page.locator('#viewport-tools-group-btn')).toBeVisible();
   });
 
-  test('Tools popover collects the editing tools and a tool opens from it', async ({ page }) => {
+  test('Inspect popover holds measure + cross-section and stays open across picks', async ({ page }) => {
+    await openEditor(page);
+
+    // Hidden until opened.
+    await expect(page.locator('#measure-toggle')).toBeHidden();
+    await page.locator('#viewport-inspect-group-btn').dispatchEvent('click');
+    await expect(page.locator('#measure-toggle')).toBeVisible();
+    await expect(page.locator('#clip-toggle')).toBeVisible();
+
+    // Sticky: picking a tool inside leaves the list open (no closeOnSelect).
+    await page.locator('#measure-toggle').dispatchEvent('click');
+    await expect(page.locator('#measure-toggle')).toBeVisible();
+    await expect(page.locator('#clip-toggle')).toBeVisible();
+
+    // Clicking the group button again closes it.
+    await page.locator('#viewport-inspect-group-btn').dispatchEvent('click');
+    await expect(page.locator('#measure-toggle')).toBeHidden();
+  });
+
+  test('Tools popover collects the editing tools and stays open when a tool opens', async ({ page }) => {
     await openEditor(page);
     await page.locator('#viewport-tools-group-btn').dispatchEvent('click');
 
@@ -60,9 +67,17 @@ test.describe('viewport toolbar groups', () => {
       await expect(page.locator(`#viewport-tools-menu ${id}`)).toHaveCount(1);
     }
 
-    // Selecting a tool from the popover opens its panel.
+    // Selecting a tool opens its panel AND keeps the Tools menu open so the user
+    // can switch to another tool without re-opening the list.
     await page.locator('#paint-toggle').dispatchEvent('click');
     await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+    await expect(page.locator('#paint-toggle')).toBeVisible();
+    await expect(page.locator('#annotate-toggle')).toBeVisible();
+
+    // Opening a sibling popover (Inspect) closes Tools — single popover at a time.
+    await page.locator('#viewport-inspect-group-btn').dispatchEvent('click');
+    await expect(page.locator('#paint-toggle')).toBeHidden();
+    await expect(page.locator('#measure-toggle')).toBeVisible();
   });
 
   test('grouped viewport tools are reachable from the command palette', async ({ page }) => {


### PR DESCRIPTION
## Summary

A series of improvements to the interactive viewport menus/panels.

### 1. Display toggles back as direct pills + sticky menus
- View-state toggles (`△ Edges`, `▦ Grid`, `⬚ Dims`, `🔓 Lock`) moved out of the collapsed View popover and back onto the viewport bar as one-click pills. The **View menu is removed**.
- The remaining Inspect/Tools popovers are **sticky** — clicking an item no longer dismisses the list (closes only via its group button, a sibling popover, click-outside, or Escape).

### 2. Consistent tool panels (Paint · Image · Voxel · Annotate · Quality · Surface · Resize · Palette)
An audit found every tool hand-rolled its own shell (different backgrounds `zinc-800/95` vs `zinc-900`, borders, z-indices `z-20` vs `z-[60]`, header markup, close glyphs `×` vs `✕`, hit areas, title sizes, and active accents blue/pink/emerald) plus inconsistent open/close logic. Fixes:

- **One shared standard** — new `src/ui/toolPanel.ts` (panel/header/toggle classes, `createToolPanelHeader`, `createToolPanelShell`); every tool uses it.
- **Horizontal menus** — the Tools/Inspect rows lay out horizontally; a tool's panel docks **beneath the open menu row, right-aligned**.
- **Single-open mutual exclusion** — every panel now routes through the one-panel-at-a-time registry, so opening one closes the others. Fixes *Quality opening on top*; **Image Paint** now participates and **closes on Escape**.
- **Palette** is now a **docked, draggable grey panel** (was a centered modal with a backdrop).
- **Surface/Resize** use the shared grey shell + `z-20` (were darker `zinc-900`, `z-[60]`, bold `<h2>` titles).
- **Unified details** — active accent → blue everywhere; slider/tab accents sky/emerald/pink → blue; close glyph → `×`; close hit-area → 28px.

> **Behaviour note:** opening **Palette** now closes the **Paint** panel (per "all tool panels close the others"). It's Paint's companion editor, so I can exempt it from the single-open set if you'd rather it coexist with Paint — let me know.

## Screenshots
Posted in the session chat: horizontal Tools row; Paint/Resize panels docked beneath it; docked grey Palette; one-click tool switching.

## Test plan
- `npm run build` clean (type-check) · `npm run test:unit` 718 pass · `npm run lint:deps` no cycles
- New `tests/tool-panel-consistency.spec.ts` (mutual exclusion, docked non-modal palette, Escape)
- Updated `tests/viewport-toolbar-groups.spec.ts` (direct toggles + sticky behavior) and `tests/paint-palette.spec.ts` (docked palette + exclusion)
- Verified 180+ e2e specs across paint/voxel/annotate/simplify/surface/resize/image/relief/command-palette/palette green

🤖 Generated in a Claude Code session.

https://claude.ai/code/session_01NxbrVQ6igGhvKdAESgzBEF