### PR TITLE
fix: show fast tooltips on catalog tags instead of slow native hints

### DIFF
--- a/prompts/20260607-150000-catalog-fast-tag-tooltips.md
+++ b/prompts/20260607-150000-catalog-fast-tag-tooltips.md
@@ -1,0 +1,44 @@
+---
+date: 2026-06-07
+branch: claude/adoring-mendel-JoRLs
+files_changed:
+  - src/content/catalogEntry.ts
+---
+
+## Human
+
+There is a long delay when hovering over tags in the catalog. I want the hover
+hints to show much faster.
+
+## Assistant
+
+**Root cause: the catalog tags used the browser's native `title` tooltip.** The
+tile badges (Parametric, print-tested) and the language filter pills are
+rendered server-side by the static pre-renderer (`render.ts`) with plain
+`title=` attributes. The browser shows native `title` tooltips only after a
+long, JS-uncontrollable delay (~0.5–1.5s) — that's the lag.
+
+The app already solves this everywhere else: `src/ui/tooltip.ts` (`initTooltips`)
+installs a delegated `[title]` listener that suppresses the native tooltip and
+shows a fast styled bubble after a short, config-driven delay
+(`ui.tooltipDelayMs`, default 150ms). But `/catalog` is a static pre-rendered
+page that loads `src/content/catalogEntry.ts` instead of `main.ts`, so
+`initTooltips()` (called from `main.ts`) never ran there — leaving the tags on
+the slow native path.
+
+**Fix: call `initTooltips()` from `catalogEntry.ts`.** One import + one call in
+`init()`. This reuses the exact same fast tooltip and the user's configurable
+delay, so the catalog matches the editor.
+
+**Honoring the "empty import graph" rule.** `catalogEntry.ts` deliberately
+avoids pulling in app/engine code. `tooltip.ts`'s only dependency is
+`getConfig` from `appConfig.ts`, which is fully self-contained (zero imports,
+pure TS + localStorage — no DOM/engine/WASM). Confirmed the build splits it into
+its own ~5 KB chunk; the catalog entry chunk stays tiny and no engine code
+leaks in. Updated the header comment to reflect that the new import is still
+dependency-free.
+
+Verified in a real browser: a throwaway Playwright spec on `/catalog` hovered a
+language pill and asserted the `.pw-tooltip.visible` bubble appears within
+400 ms (well inside the native delay) — passed, screenshot confirmed the styled
+"Hide JS models" bubble. Build + unit tests green.

--- a/src/content/catalogEntry.ts
+++ b/src/content/catalogEntry.ts
@@ -7,9 +7,11 @@
 // the full catalog renders server-side; this just hides/shows on top).
 //
 // Keep the import graph empty: this must not pull in any app/engine code. The
-// one import below (wireCatalogFilter) is itself dependency-free, pure DOM.
+// imports below are dependency-free — wireCatalogFilter is pure DOM, and
+// initTooltips pulls in only the self-contained appConfig (no engine/WASM).
 
 import { wireCatalogFilter } from './catalogFilter';
+import { initTooltips } from '../ui/tooltip';
 
 interface CatalogThumbs {
   /** Map of catalog file name → latest-version thumbnail data URL. */
@@ -53,6 +55,11 @@ async function hydrateThumbnails(): Promise<void> {
 
 function init(): void {
   wireCatalogFilter(document);
+  // Replace the slow native `title` tooltips on the catalog's tags/badges with
+  // the same fast styled bubbles the editor uses (config-driven ~150ms delay).
+  // The static catalog page never boots main.ts, so without this the tags fall
+  // back to the browser's ~0.5–1.5s native tooltip delay.
+  initTooltips();
   void hydrateThumbnails();
 }
 


### PR DESCRIPTION
## Summary

Hovering over the tags in the catalog (the language filter pills and the per-tile **Parametric** / **Print-tested** badges) had a long delay before the hint appeared.

**Root cause:** those tags use plain `title=` attributes baked in by the static catalog pre-renderer, and the browser's native `title` tooltip only shows after a long, JS-uncontrollable delay (~0.5–1.5s). The app already replaces this everywhere else via `initTooltips()` (`src/ui/tooltip.ts`) — a fast styled bubble with a config-driven ~150ms delay (`ui.tooltipDelayMs`). But `/catalog` is a static pre-rendered page that loads `src/content/catalogEntry.ts` instead of `main.ts`, so `initTooltips()` never ran there and the tags stayed on the slow native path.

**Fix:** call the existing `initTooltips()` from `catalogEntry.ts` (one import + one call). The catalog now uses the exact same fast tooltip + user-configurable delay as the editor.

This keeps the catalog page's deliberately-empty import graph clean: `tooltip.ts`'s only dependency is `getConfig` from `appConfig.ts`, which is fully self-contained (zero imports, pure TS + localStorage — no DOM/engine/WASM). Vite splits it into its own ~5 KB chunk; the catalog entry chunk stays tiny.

## Test plan

- `npm run build` — green (type-check passes)
- `npm run test:unit` — 723 passed
- Manual browser check: a Playwright spec on `/catalog` hovered a language pill and asserted the `.pw-tooltip.visible` bubble appears within 400 ms (well inside the native delay) — passed; screenshot confirmed the styled "Hide JS models" bubble appearing immediately.

https://claude.ai/code/session_01WaDvnQZ3B2xCVadMWT4W92

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaDvnQZ3B2xCVadMWT4W92)_