### PR TITLE
feat: add cylinder/slab dry-run to paintPreview + fix paint/revolve docs

### DIFF
--- a/prompts/20260607-paintpreview-shapes-and-paint-docs.md
+++ b/prompts/20260607-paintpreview-shapes-and-paint-docs.md
@@ -1,0 +1,66 @@
+---
+session: "QoRxL"
+timestamp: "2026-06-07T17:10:00Z"
+model: claude-opus-4-8
+tools: [explore, playwright]
+---
+
+## Human
+
+User shared a retro from an in-app AI agent whose mug-modeling session went
+poorly, plus follow-up feedback with five concrete asks (paint regions
+silently invalidated by retessellation; no paintInCylinder preview; a
+radial-vs-box selection heuristic missing from docs; revolve axis convention;
+api.label rejecting Curves.sweep output). Asked: do I agree, and are there
+features to implement? After verifying the claims against source, the user
+chose to ship the doc fixes + the paintInCylinder/Slab preview as a single PR.
+
+## Assistant
+
+## Key decisions
+
+**Verified the retro before acting — two of its confident claims were wrong**,
+so I did NOT build fixes premised on them:
+
+- "Smooth paint silently zeros earlier raw-triangle regions via subdivision" —
+  inaccurate. Subdivision carries regions forward via a parent→children remap
+  (`remapTriangleIds`, `src/main.ts`). What actually invalidates a
+  `kind:'triangles'` region is a **model re-run** (new base mesh), a different
+  trigger. So no "retessellation invalidated N regions" warning was added — it
+  would chase the wrong cause. Documented the real distinction instead.
+- "`Curves.sweep` output isn't label-able" — false. `Curves.sweep` returns a
+  real `Manifold` (`Manifold.ofMesh(...)`, `src/geometry/curves.ts`), which
+  `api.label` accepts. The clean `paintByLabel("handle")` workflow already
+  works; the agent passed the wrong thing. Documented this to correct the
+  misconception rather than changing code.
+
+**Found and fixed a doc bug**: `colors.md` listed `paintInCylinder` among the
+id-baking, non-smoothable selectors, but it actually persists a re-resolvable
+`cylinder` descriptor and smooths by default (confirmed in source). Rewrote the
+section to group selectors by durability: re-resolvable analytic descriptors
+(`paintSlab`/`paintInOrientedBox`/`paintInCylinder`/`paintStroke`) + `byLabel`
+(most durable) vs. id-baking (`paintInBox`/`paintNear`/`paintFaces`/
+`paintConnected`, die on re-run). Added the ordering heuristic and the
+radial-vs-box ("paint a feature past a round body by radius, not a box plane")
+guidance the agent wished for.
+
+**Revolve convention**: `ai.md` was already correct (Y internal → Z-up remap);
+the misleading line was `curves.md`'s "just +Y" for `revolveAxis`. Reconciled
+it to state the Z-up convention explicitly (matches the precise code comment in
+`curves.ts`). Added a note that `Curves.sweep`/`loft`/`revolveAxis` return
+label-able Manifolds.
+
+**Feature — `paintPreview` cylinder/slab forms** (`src/main.ts`): extended the
+selector chain to accept `{ cylinder: {center?, rMin, rMax, zMin, zMax} }` and
+`{ slab: {axis|normal, offset, thickness} }`, reusing the same
+`collectTrianglesByCylinder` / `findSlabTriangles` collectors the real paint
+ops use. Preview is **unsmoothed by design** (never subdivides) — it's the
+cheap dry-run before committing the smoothing paint. Updated the tool schema in
+`src/ai/tools.ts` and the paintInCylinder/paintSlab empty-result error hints to
+point at the new preview forms.
+
+**Verification**: New golden-path spec `tests/paint-preview-shapes.spec.ts`
+asserts the cylinder preview count exactly equals `paintInCylinder({smooth:false})`
+on a hollow tube, the slab band selects from z=0, and a reversed shell errors.
+Dumped the `withImage` thumbnail to confirm the inner wall highlights yellow.
+`npm run build` + `npm run test:unit` (718) green.

--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -501,9 +501,24 @@ partwright.paintInOrientedBox({
 });
 ```
 
-**Smoothing applies to the analytic shape tools.** `paintSlab` and `paintInOrientedBox` persist a *re-resolvable* descriptor (the slab plane / oriented box), so their boundary can be subdivided for a clean edge and reconstructed deterministically on reload — smoothing is on by default, exactly like `paintStroke`. The id-baking selectors (`paintInBox`, `paintNear`, `paintInCylinder`, `paintFaces`, `paintConnected`, …) lock onto the existing tessellation, so they cannot be smoothed; refine the mesh first (`.refine(n)` in the model code) if you need a finer edge from those.
+**Two kinds of region — durable descriptors vs. baked triangle ids.** This distinction matters more than any other when you paint several regions in a session:
 
-**Verifying paint before you commit it.** `paintPreview` accepts the same selectors as `paintInBox` / `paintNear` / `paintFaces`, *without* adding a region. Default: count-only (free sanity check). Pass `withImage: true` to also get a thumbnail with the candidate triangles tinted bright yellow on top of any existing paint.
+- **Re-resolvable analytic descriptors** — `paintSlab`, `paintInOrientedBox`, `paintInCylinder`, and `paintStroke` persist *what they meant* (the slab plane, oriented box, cylindrical shell, or brush path), not a fixed triangle list. On every reconcile they re-collect against the live mesh, so they **survive both subdivision and a model re-run**, and their boundary can be subdivided for a clean edge (smoothing is on by default for these). These are the robust choice.
+- **`paintByLabel`** is the most durable of all: it re-resolves by *name* from the label map each time, so it tracks the geometry through any re-tessellation as long as the label exists. If a feature is its own part, `api.label(part, "handle")` it in the model code and `paintByLabel("handle", color)` — no coordinates to guess.
+- **Id-baking selectors** — `paintInBox`, `paintNear`, `paintFaces`, `paintConnected` — lock onto the *current* tessellation and store raw triangle ids. They **cannot be smoothed** (refine the mesh first with `.refine(n)` if you need a finer edge), and their ids are valid only against the base mesh they were taken on. They are carried across in-session subdivision via a parent→children remap, but a **model re-run replaces the base mesh and the ids no longer point at the same surface** — that's the usual cause of a previously-good region reporting `triangleCount: 0` or landing on the wrong faces. After any code change, repaint id-baked regions or, better, re-express them as an analytic/`byLabel` descriptor.
+
+> **Ordering heuristic:** prefer the durable forms (analytic descriptors, `paintByLabel`) so order doesn't matter. If you must use id-baked selectors alongside smoothing paints, commit the mesh-changing ops first (or keep them in a single saved version), since a later subdivision/re-run is what disturbs raw ids.
+
+**Painting a feature that sticks out past a round body — select by radius, not a box plane.** A flat box face cutting across a curved junction (e.g. a handle meeting a cylindrical mug wall) leaves a ragged, stair-stepped boundary, because the box plane and the curved surface disagree. Select by *radial distance from the part's axis* instead — `paintInCylinder({ rMin, rMax, zMin, zMax })` (or a `normalCone` to grab only the outward-facing skin) — so the boundary follows the curve cleanly. Radius-based selection is the canonical tool for inner/outer walls of mugs, vases, and any revolved shape.
+
+**Verifying paint before you commit it.** `paintPreview` accepts the same selectors as `paintInBox` / `paintNear` / `paintFaces` *and* the analytic `cylinder` / `slab` forms, *without* adding a region. Default: count-only (free sanity check). Pass `withImage: true` to also get a thumbnail with the candidate triangles tinted bright yellow on top of any existing paint. The `cylinder` / `slab` previews show the **unsmoothed** selection (preview never subdivides) — use it to validate a radial shell or slab offset/thickness in one cheap call before committing the real smoothing paint:
+
+```js
+// Validate the inner wall of a mug before painting it:
+partwright.paintPreview({ cylinder: { rMin: 18, rMax: 22, zMin: 2, zMax: 88 } });
+// Validate a slab band:
+partwright.paintPreview({ slab: { axis: "z", offset: 0, thickness: 5 } });
+```
 
 ```js
 const dry = partwright.paintPreview({

--- a/public/ai/curves.md
+++ b/public/ai/curves.md
@@ -120,9 +120,21 @@ return Curves.sweep(profile, path);
 `closed: true` treats the path as a loop (no end caps, last segment wraps to
 first). Use this for torus-like sweeps.
 
+`Curves.sweep` (and `loft` / `revolveAxis`) return a **regular `Manifold`** —
+not some special curve type. So you can union it, subtract it, and crucially
+**`api.label()` it**: `const handle = api.label(Curves.sweep(profile, path),
+"handle")`. Label it before unioning it into the body and you can recolor the
+whole feature later with one `paintByLabel("handle", color)` call — no triangle
+coordinates to guess. (The `api.label "must be a Manifold"` error only fires for
+a `CrossSection` or a raw `Mesh`, never for a `Curves.*` result.)
+
 ### `Curves.revolveAxis(profile, axis, {angle?, segments?})`
-Like `Manifold.revolve`, but the axis can be any `[x,y,z]` direction instead of
-just +Y. Useful when the natural axis of your part is X or skew.
+`Manifold.revolve` spins the XY profile (X = radial distance, Y = height) and
+produces a **Z-up** solid — internally it revolves about Y, then remaps Y→Z, so
+the result's axis of symmetry is **+Z** (height runs +Z). `revolveAxis` is the
+same revolve with that natural +Z axis rotated to any `[x,y,z]` direction —
+useful when the natural axis of your part is X or skew. Passing `[0,0,1]` is
+identical to a plain `Manifold.revolve`.
 
 ```js
 // Revolve around the X axis instead of Y.

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -362,11 +362,13 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintPreview',
-    description: 'DRY-RUN: returns {triangleCount, bbox, centroid, totalArea, largestTriangleArea} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces. The cheapest way to catch a bad selector — count alone is essentially free; ALWAYS call before any non-trivial paint. The `largestTriangleArea / (totalArea / triangleCount)` ratio is the fan-topology diagnostic: ratios > ~10 mean a long radial triangle is dragging the selection beyond its intended footprint (common with cylinder / revolve meshes) — fix with `coverageMode: "fully_inside"` or a `maxTriangleArea` cap, or refine the mesh before painting. Pass `withImage: true` when the count or area ratio is suspicious — the thumbnail shows the real triangle extents tinted yellow.',
+    description: 'DRY-RUN: returns {triangleCount, bbox, centroid, totalArea, largestTriangleArea} for what a paint op WOULD select, WITHOUT committing. Same selector args as paintInBox / paintNear / paintFaces / paintInCylinder / paintSlab (pass `cylinder` or `slab` to dry-run those). The cheapest way to catch a bad selector — count alone is essentially free; ALWAYS call before any non-trivial paint. The `cylinder` / `slab` previews show the UNSMOOTHED selection (preview never subdivides) — perfect for validating a radial-shell or slab offset/thickness before committing the real smoothing paint. The `largestTriangleArea / (totalArea / triangleCount)` ratio is the fan-topology diagnostic: ratios > ~10 mean a long radial triangle is dragging the selection beyond its intended footprint (common with cylinder / revolve meshes) — fix with `coverageMode: "fully_inside"` or a `maxTriangleArea` cap, or refine the mesh before painting. Pass `withImage: true` when the count or area ratio is suspicious — the thumbnail shows the real triangle extents tinted yellow.',
     input_schema: {
       type: 'object',
       properties: {
         box: { type: 'object', description: '{min: [x,y,z], max: [x,y,z]}' },
+        cylinder: { type: 'object', description: 'Radial-shell selector: {rMin, rMax, zMin, zMax, center?: [x,y]}. Previews the same triangles paintInCylinder would select (unsmoothed).' },
+        slab: { type: 'object', description: 'Slab selector: {axis: "x"|"y"|"z" OR normal: [nx,ny,nz], offset, thickness}. Previews the same triangles paintSlab would select (unsmoothed).' },
         point: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         radius: { type: 'number' },
         normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n} to restrict to faces pointing roughly in that direction.' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -10092,7 +10092,7 @@ async function main() {
       if (maxTriangleArea !== undefined && triangles.size > 0) {
         triangles = new Set([...triangles].filter(t => triangleArea(t, currentMeshData!) <= maxTriangleArea));
       }
-      if (triangles.size === 0) return { error: 'No triangles found inside the slab' };
+      if (triangles.size === 0) return { error: 'No triangles found inside the slab. Dry-run paintPreview({ slab: { axis|normal, offset, thickness } }) to check the offset/thickness against the model bbox first.' };
 
       const regionName = name ?? `Region ${getRegions().length + 1}`;
       const { smooth, maxEdge } = resolveShapeSmoothFields(opts);
@@ -10453,7 +10453,7 @@ async function main() {
         opts.maxTriangleArea,
       );
       if (triangles.size === 0) {
-        return { error: `paintInCylinder: no triangles in cylindrical shell (rMin=${opts.rMin}, rMax=${opts.rMax}, z=${opts.zMin}..${opts.zMax})${cone ? ' with normalCone filter' : ''}. Try widening the shell, checking the center, or calling paintPreview with a box first to locate the geometry.` };
+        return { error: `paintInCylinder: no triangles in cylindrical shell (rMin=${opts.rMin}, rMax=${opts.rMax}, z=${opts.zMin}..${opts.zMax})${cone ? ' with normalCone filter' : ''}. Try widening the shell, checking the center, or dry-running paintPreview({ cylinder: { rMin, rMax, zMin, zMax } }) to locate the geometry.` };
       }
 
       const regionName = opts.name ?? `Region ${getRegions().length + 1}`;
@@ -10486,21 +10486,29 @@ async function main() {
 
     /** Render a preview of the current model with a candidate region tinted
      *  bright yellow, *without* committing the paint to the regions list.
-     *  Accepts the same selectors as `paintInBox` / `paintNear` plus an
-     *  optional explicit `triangleIds` set. Returns
-     *  `{ thumbnail, triangleCount, bbox, centroid }` so an agent can verify
-     *  the shape of the would-be region in one call instead of paint → render → undo.
+     *  Accepts the same selectors as `paintInBox` / `paintNear` /
+     *  `paintInCylinder` / `paintSlab` plus an optional explicit `triangleIds`
+     *  set. Returns `{ thumbnail, triangleCount, bbox, centroid }` so an agent
+     *  can verify the shape of the would-be region in one call instead of
+     *  paint → render → undo. The `cylinder` / `slab` forms preview the
+     *  *unsmoothed* selection (preview never subdivides), which is the cheap
+     *  way to validate a radial-shell or slab selection before committing the
+     *  real smoothing paint.
      *
      *  ```
      *  const preview = partwright.paintPreview({
      *    box: { min: [...], max: [...] },
      *    normalCone: { axis: [...], angleDeg: 25 },
      *  })
+     *  // Or a radial shell — the inner wall of a mug:
+     *  partwright.paintPreview({ cylinder: { rMin: 18, rMax: 22, zMin: 2, zMax: 88 } })
      *  // Display preview.thumbnail (data URL) to confirm before committing.
      *  ```
      *  `view` is forwarded to `renderView` (elevation/azimuth/ortho/size). */
     paintPreview(opts: {
       box?: { min: [number, number, number]; max: [number, number, number] };
+      cylinder?: { center?: [number, number]; rMin: number; rMax: number; zMin: number; zMax: number };
+      slab?: { axis?: 'x' | 'y' | 'z'; normal?: [number, number, number]; offset: number; thickness: number };
       normalCone?: { axis: [number, number, number]; angleDeg: number };
       point?: [number, number, number];
       radius?: number;
@@ -10544,8 +10552,40 @@ async function main() {
         const err = validateBoxAndCone(opts.box, opts.normalCone);
         if (err) return { error: err };
         triangles = collectTrianglesByFilter(mesh, opts.box, opts.normalCone, null, opts.coverageMode, opts.maxTriangleArea);
+      } else if (opts.cylinder !== undefined) {
+        const c = opts.cylinder;
+        if (typeof c !== 'object' || c === null) return { error: 'cylinder must be { rMin, rMax, zMin, zMax, center? }' };
+        if (typeof c.rMin !== 'number' || typeof c.rMax !== 'number') return { error: 'cylinder.rMin and cylinder.rMax must be numbers' };
+        if (typeof c.zMin !== 'number' || typeof c.zMax !== 'number') return { error: 'cylinder.zMin and cylinder.zMax must be numbers' };
+        if (c.rMin < 0 || c.rMax <= c.rMin) return { error: 'cylinder requires rMin >= 0 and rMax > rMin' };
+        if (c.zMax <= c.zMin) return { error: 'cylinder requires zMax > zMin' };
+        if (c.center !== undefined && (!Array.isArray(c.center) || c.center.length !== 2)) return { error: 'cylinder.center must be [x, y]' };
+        const coneErr = validateNormalCone(opts.normalCone);
+        if (coneErr) return { error: coneErr };
+        triangles = collectTrianglesByCylinder(mesh, c.center ?? [0, 0], c.rMin, c.rMax, c.zMin, c.zMax, opts.normalCone, opts.coverageMode, opts.maxTriangleArea);
+      } else if (opts.slab !== undefined) {
+        const s = opts.slab;
+        if (typeof s !== 'object' || s === null) return { error: 'slab must be { axis|normal, offset, thickness }' };
+        let slabNormal: [number, number, number];
+        if (s.axis !== undefined) {
+          if (s.axis !== 'x' && s.axis !== 'y' && s.axis !== 'z') return { error: "slab.axis must be 'x', 'y', or 'z'" };
+          slabNormal = s.axis === 'x' ? [1, 0, 0] : s.axis === 'y' ? [0, 1, 0] : [0, 0, 1];
+        } else if (Array.isArray(s.normal) && s.normal.length === 3) {
+          const [nx, ny, nz] = s.normal;
+          const len = Math.hypot(nx, ny, nz);
+          if (!Number.isFinite(len) || len === 0) return { error: 'slab.normal must be a non-zero 3-vector' };
+          slabNormal = [nx / len, ny / len, nz / len];
+        } else {
+          return { error: 'slab requires either axis (x|y|z) or normal [nx,ny,nz]' };
+        }
+        if (typeof s.offset !== 'number' || !Number.isFinite(s.offset)) return { error: 'slab.offset must be a finite number' };
+        if (typeof s.thickness !== 'number' || !Number.isFinite(s.thickness) || s.thickness <= 0) return { error: 'slab.thickness must be a positive finite number' };
+        triangles = findSlabTriangles(mesh, slabNormal, s.offset, s.thickness, opts.coverageMode);
+        if (opts.maxTriangleArea !== undefined && triangles.size > 0) {
+          triangles = new Set([...triangles].filter(t => triangleArea(t, mesh) <= opts.maxTriangleArea!));
+        }
       } else {
-        return { error: 'paintPreview requires one of: { triangleIds }, { point, radius }, or { box }' };
+        return { error: 'paintPreview requires one of: { triangleIds }, { point, radius }, { box }, { cylinder }, or { slab }' };
       }
 
       const stats = regionTriangleStats(triangles, mesh);

--- a/tests/paint-preview-shapes.spec.ts
+++ b/tests/paint-preview-shapes.spec.ts
@@ -1,0 +1,79 @@
+// Golden path for the analytic-shape selectors on paintPreview: the
+// `cylinder` and `slab` dry-run forms added so paintInCylinder / paintSlab
+// can be validated without the commit -> render -> undo round-trip. A
+// preview must return the same (unsmoothed) selection the real paint op
+// would seed, and must reject malformed shells.
+
+import { test, expect } from 'playwright/test';
+
+test.describe('paintPreview analytic shapes', () => {
+  test('cylinder and slab previews select triangles and match the paint op', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    // A hollow tube: outer R=10, inner R=6, height 20. Its inner wall is the
+    // canonical paintInCylinder target.
+    const ran = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.run(
+        'const outer = api.Manifold.cylinder(20, 10, 10, 64);' +
+        'const inner = api.Manifold.cylinder(22, 6, 6, 64).translate([0, 0, -1]);' +
+        'return outer.subtract(inner);',
+      );
+    });
+    expect(ran.error).toBeUndefined();
+
+    // Dry-run the inner wall via the new cylinder selector.
+    const cyl = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintPreview({ cylinder: { rMin: 5.5, rMax: 6.5, zMin: 1, zMax: 19 } });
+    });
+    expect(cyl.error).toBeUndefined();
+    expect(cyl.triangleCount).toBeGreaterThan(0);
+    // The inner wall sits at radius ~6, so the bbox must stay inside the outer skin.
+    expect(cyl.bbox.max[0]).toBeLessThanOrEqual(6.6);
+
+    // The preview's count must equal what paintInCylinder seeds with smoothing
+    // OFF (preview never subdivides, so compare against smooth:false).
+    const committed = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintInCylinder({ rMin: 5.5, rMax: 6.5, zMin: 1, zMax: 19, smooth: false, color: [0.2, 0.6, 1] });
+    });
+    expect(committed.error).toBeUndefined();
+    expect(committed.triangles).toBe(cyl.triangleCount);
+
+    // Dry-run a Z slab band across the bottom of the tube.
+    const slab = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintPreview({ slab: { axis: 'z', offset: 0, thickness: 4 } });
+    });
+    expect(slab.error).toBeUndefined();
+    expect(slab.triangleCount).toBeGreaterThan(0);
+    expect(slab.bbox.min[2]).toBeGreaterThanOrEqual(-0.01);
+
+    // Malformed shells are rejected, not silently empty.
+    const bad = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintPreview({ cylinder: { rMin: 8, rMax: 4, zMin: 0, zMax: 10 } });
+    });
+    expect(bad.error).toMatch(/rMin >= 0 and rMax > rMin/);
+
+    // Visual sanity check for the manual-verification screenshot.
+    await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      return pw.paintPreview({
+        cylinder: { rMin: 5.5, rMax: 6.5, zMin: 1, zMax: 19 },
+        withImage: true,
+        view: { elevation: 25, azimuth: 35, size: 360 },
+      });
+    });
+    await page.waitForTimeout(500);
+    await page.screenshot({ path: 'test-results/paint-preview-shapes.png' });
+  });
+});


### PR DESCRIPTION
## Summary

Acts on an in-app AI agent's retro from a mug-modeling session. I verified each claim against source first — two of the most confident ones were **inaccurate**, so I deliberately did *not* build fixes premised on them. What shipped here is the subset that's clearly correct and useful: one small feature + doc corrections.

### Feature — `paintPreview` cylinder/slab dry-run
`paintInCylinder` / `paintSlab` previously had no dry-run, so the agent had to commit → render → undo to validate a radial-shell or slab selection. `paintPreview` now accepts two new selector forms, reusing the exact collectors the real paint ops use:

```js
partwright.paintPreview({ cylinder: { rMin: 18, rMax: 22, zMin: 2, zMax: 88 } });
partwright.paintPreview({ slab: { axis: "z", offset: 0, thickness: 5 } });
```

Preview is **unsmoothed by design** (it never subdivides) — the cheap check before committing the real smoothing paint. The cylinder preview's count matches `paintInCylinder({ smooth: false })` exactly (asserted in the new spec). Tool schema and the empty-result error hints updated to point at the new forms.

### Docs
- **`colors.md` bug fix + rewrite:** the doc listed `paintInCylinder` among the id-baking, non-smoothable selectors, but it actually persists a re-resolvable `cylinder` descriptor and smooths by default. Regrouped selectors by **durability** (re-resolvable analytic descriptors + `paintByLabel` vs. id-baking selectors whose raw triangle ids die on a model re-run), added the **ordering heuristic** and the **radial-vs-box** selection guidance ("paint a feature past a round body by radius, not a box plane").
- **Revolve convention:** `curves.md`'s "just +Y" line was the thing that misled the agent. Reconciled it with `ai.md` / the `curves.ts` code comment to state the Y-internal → **Z-up** convention explicitly.
- **`Curves.sweep` label-ability:** documented that `sweep` / `loft` / `revolveAxis` return regular, label-able `Manifold`s — correcting the agent's belief that `api.label` rejects them (it doesn't; it only rejects a `CrossSection` or raw `Mesh`).

### What I intentionally did NOT do
- No "retessellation invalidated N regions" warning — the retro's premise (smooth paint silently zeros earlier raw-triangle regions) is wrong: subdivision remaps regions forward; only a **model re-run** invalidates raw ids. A warning would chase the wrong cause.
- No change to default selector storage — cylinder/slab/byLabel already re-resolve; reworking the raw-id selectors is a back-compat-sensitive refactor out of scope here.

## Test plan
- `npm run build` (typecheck) ✅
- `npm run test:unit` — 718 passing ✅
- New e2e `tests/paint-preview-shapes.spec.ts`: cylinder preview count == `paintInCylinder({smooth:false})` on a hollow tube, slab band selects from z=0, reversed shell errors. ✅
- Manual: dumped the `withImage` thumbnail — inner wall of the tube highlights yellow (posted in session).

https://claude.ai/code/session_01SYiKj6c1psprA6WE3K89FF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYiKj6c1psprA6WE3K89FF)_