### PR TITLE
feat: 3D-printable AI toggle (on by default) + system-prompt preview bubble

### DIFF
--- a/prompts/20260607-3d-printable-toggle.md
+++ b/prompts/20260607-3d-printable-toggle.md
@@ -1,0 +1,63 @@
+---
+session: "8dTkz"
+timestamp: "2026-06-07T00:00:00Z"
+model: claude-opus-4-8
+tools: [subagent, playwright]
+---
+
+## Human
+
+In the AI panel, add a button — selected by default — that says something like
+"3D printable". Make it work like the Plan button, but instead of changing the
+flow, inject extra instructions into the prompt telling the model to make the
+model as good for 3D printing as possible (flat base that fits the build plate,
+not too many floating components, walls that grow by ~45° rather than 90° so
+they don't need supports, etc.). Recommend any other print-friendly tips worth
+including. Implement it, select it by default, open a PR. Ask questions if needed.
+
+## Assistant
+
+## Key decisions
+
+**Modeled on the Plan pill, but a prompt-injection toggle — not a flow gate.**
+The Plan pill (`planFirst`) empties the tool list and replaces the system
+suffix. The user asked for the *opposite* effect: keep all tools, just add
+guidance. So the new `printOptimized` toggle injects a guidance block into the
+per-turn system suffix and gates nothing — it composes with every other toggle.
+Added it to the `ChatToggles` interface and threaded it through all eight
+settings touch-points (three presets, `cloneToggles`, `applyPreset`,
+`setToggles`, `mergeWithDefaults`), so old localStorage records pick up the new
+default via the `?? DEFAULT` merge.
+
+**Default ON in every preset.** The user wants it selected by default, so
+`printOptimized: true` ships in `minimal`/`standard`/`full`. `mergeWithDefaults`
+backfills `true` for sessions saved before this field existed.
+
+**Where the guidance is injected.** `toggleSuffix()` in `systemPrompt.ts`. The
+suffix is regenerated every turn, so the guidance is live and the user can flip
+it mid-conversation. Injected in *both* branches: the normal capabilities suffix
+AND the plan-mode suffix (when Plan + 3D-printable are both on, the plan itself
+becomes print-aware). Pulled the text into a `printableGuidance()` helper so the
+two call sites can't drift.
+
+**The guidance content.** Beyond the user's three (flat base, ≤45° overhangs,
+no floating islands) I added the high-value FDM rules an AI authoring geometry
+should bake in: chamfer the bottom edge instead of filleting it (a base fillet
+curls into a thin overhang); short unsupported bridges (<~5 units); minimum
+feature sizes (~1-unit walls, ~0.4-unit detail = nozzle-width floors);
+watertight single manifold / avoid sealed cavities; low center of mass so the
+print doesn't tip; ~0.2–0.4-unit clearances for mating/moving parts. Anchored
+the thresholds with "treat 1 unit ≈ 1 mm" since app units are nominal. Framed it
+as "bake into geometry, don't recite," and told the model to build the printable
+interpretation + note the trade-off when a request inherently fights
+printability — so the toggle doesn't make it refuse floating-shape requests.
+
+**Naming.** Field is `printOptimized` (not `printable`) to avoid colliding with
+the existing viewport printability pill / `computePrintability`, which is a
+different concept (live structural status, not an AI-guidance toggle).
+
+**Verification.** Build + unit green. Manually confirmed in the browser (the
+pill renders green/ON by default next to Plan). Added e2e coverage in
+`smoke.spec.ts`: pill in the tooltip array, a default-ON + flip-off assertion,
+and a `page.evaluate` check that `toggleSuffix` contains the guidance when on and
+omits it when off.

--- a/prompts/20260607-3d-printable-toggle.md
+++ b/prompts/20260607-3d-printable-toggle.md
@@ -61,3 +61,29 @@ pill renders green/ON by default next to Plan). Added e2e coverage in
 `smoke.spec.ts`: pill in the tooltip array, a default-ON + flip-off assertion,
 and a `page.evaluate` check that `toggleSuffix` contains the guidance when on and
 omits it when off.
+
+## Follow-up: system-prompt preview bubble
+
+The user couldn't tell the guidance was being used — the system prompt is never
+rendered in the chat transcript. Rather than just explain it, they asked for a
+collapsible "System prompt" bubble (like the thinking bubbles) pinned before the
+first message, expandable to read what's sent.
+
+- **Faithful, not reconstructed.** Extracted the provider/override/local-tier
+  dispatch that built `systemPrompt` inside `chatLoop.runTurn` into an exported
+  `buildActiveSystemPrompt(toggles)`; `runTurn` now calls it, and the panel calls
+  the *same* function so the bubble shows exactly what the model gets (base
+  prompt + `toggleSuffix`). Avoided a `systemPrompt.ts → local.ts` import cycle
+  by housing the helper in `chatLoop.ts` (which already imports `resolveLocalModel`
+  and the builders) — the panel already depends on `chatLoop`, so no new edge.
+- **Bubble UI** mirrors `renderThinkingBox` (`<details>/<summary>/<pre>`) in amber
+  to read as a distinct category. Pinned at the very top of `renderTranscript`
+  (above the empty state too, so a fresh chat can preview). Body fills async
+  because the cloud prompt awaits the fetch-once-cached `ai.md`; a `seq` guard
+  stops a stale fill from clobbering a newer bubble. Open state persists across
+  the transcript's `replaceChildren()` re-renders via a module flag.
+- **Live updates on pill flips.** Pills only re-render the toggle strip, not the
+  transcript, so `applyToggleChange` (the single choke point) now also calls
+  `refreshSystemPromptBubble()` to re-fill the body in place.
+- Added a golden-path smoke test: bubble visible, expands to the guidance, and
+  flipping the pill off drops the guidance from the live preview.

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -180,6 +180,29 @@ export interface RunTurnCallbacks {
   confirmTool?: (toolName: string, input: Record<string, unknown>) => Promise<boolean>;
 }
 
+/** Resolve the base system prompt for the active provider + model, honoring
+ *  any per-provider override and the slim/medium local variants. This is the
+ *  "prompt" half sent to the model; the per-turn toggle suffix (toggleSuffix)
+ *  rides alongside it. Extracted from runTurn so the panel can reproduce
+ *  exactly what's sent (the "System prompt" disclosure in the transcript). */
+export async function buildActiveSystemPrompt(toggles: ChatToggles): Promise<string> {
+  const settings = loadSettings();
+  const override = settings.systemPromptOverrides?.[toggles.provider] ?? null;
+  if (override !== null) return override;
+  if (toggles.provider === 'local' && toggles.localModel) {
+    try {
+      const info = resolveLocalModel(toggles.localModel);
+      return info.promptTier === 'medium'
+        ? buildMediumLocalSystemPrompt()
+        : buildLocalSystemPrompt();
+    } catch {
+      return buildLocalSystemPrompt();
+    }
+  }
+  if (toggles.provider === 'local') return buildLocalSystemPrompt();
+  return buildSystemPrompt(await loadAiMd());
+}
+
 /** Run one user turn through the agent loop. Returns the final history. */
 export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks = {}): Promise<ChatMessage[]> {
   const { apiKey, toggles, sessionId, history, userBlocks, signal } = input;
@@ -192,25 +215,7 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
   // conversation + the reply) and call readDoc to pull subdocs on demand.
   // Either path honors the per-provider user override if one is set in
   // AI settings.
-  const settings = loadSettings();
-  const override = settings.systemPromptOverrides?.[toggles.provider] ?? null;
-  let systemPrompt: string;
-  if (override !== null) {
-    systemPrompt = override;
-  } else if (toggles.provider === 'local' && toggles.localModel) {
-    try {
-      const info = resolveLocalModel(toggles.localModel);
-      systemPrompt = info.promptTier === 'medium'
-        ? buildMediumLocalSystemPrompt()
-        : buildLocalSystemPrompt();
-    } catch {
-      systemPrompt = buildLocalSystemPrompt();
-    }
-  } else if (toggles.provider === 'local') {
-    systemPrompt = buildLocalSystemPrompt();
-  } else {
-    systemPrompt = buildSystemPrompt(await loadAiMd());
-  }
+  const systemPrompt = await buildActiveSystemPrompt(toggles);
 
   const seqStart = nextSeq(history);
 

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -105,6 +105,7 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
     // belongs in the same "off to minimize spend" bucket as vision/thinking.
     autoResume: false,
     planFirst: false,
+    printOptimized: true,
     anthropicModel: 'claude-haiku-4-5',
   },
   standard: {
@@ -123,6 +124,7 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
     thinking: 'high',
     autoResume: true,
     planFirst: false,
+    printOptimized: true,
     anthropicModel: 'claude-sonnet-4-6',
   },
   full: {
@@ -134,6 +136,7 @@ const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatTogg
     thinking: 'high',
     autoResume: true,
     planFirst: false,
+    printOptimized: true,
     anthropicModel: 'claude-opus-4-7',
   },
 };
@@ -196,6 +199,7 @@ function cloneToggles(t: ChatToggles): ChatToggles {
     thinking: t.thinking,
     autoResume: t.autoResume,
     planFirst: t.planFirst,
+    printOptimized: t.printOptimized,
     provider: t.provider,
     anthropicModel: t.anthropicModel,
     localModel: t.localModel,
@@ -286,6 +290,7 @@ export function applyPreset(settings: AiSettings, preset: Preset): AiSettings {
       thinking: p.thinking,
       autoResume: p.autoResume,
       planFirst: p.planFirst,
+      printOptimized: p.printOptimized,
       // Presets target Anthropic, but if the user is currently on a
       // different provider, keep them on it — the preset only adjusts
       // cost/scope/views.
@@ -443,6 +448,7 @@ export function setToggles(settings: AiSettings, partial: DeepPartial<ChatToggle
     thinking: partial.thinking ?? settings.toggles.thinking,
     autoResume: partial.autoResume ?? settings.toggles.autoResume,
     planFirst: partial.planFirst ?? settings.toggles.planFirst,
+    printOptimized: partial.printOptimized ?? settings.toggles.printOptimized,
     provider: partial.provider ?? settings.toggles.provider,
     anthropicModel: partial.anthropicModel ?? settings.toggles.anthropicModel,
     localModel: partial.localModel ?? settings.toggles.localModel,
@@ -526,6 +532,7 @@ function mergeWithDefaults(partial: LegacyAiSettings): AiSettings {
       thinking: tgls.thinking ?? DEFAULT_SETTINGS.toggles.thinking,
       autoResume: tgls.autoResume ?? DEFAULT_SETTINGS.toggles.autoResume,
       planFirst: tgls.planFirst ?? DEFAULT_SETTINGS.toggles.planFirst,
+      printOptimized: tgls.printOptimized ?? DEFAULT_SETTINGS.toggles.printOptimized,
       provider,
       anthropicModel: tgls.anthropicModel ?? legacyAnthropic ?? DEFAULT_SETTINGS.toggles.anthropicModel,
       localModel: validLocalModel,

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -306,7 +306,10 @@ export function toggleSuffix(toggles: ChatToggles): string {
     ];
     // When 3D-printing optimization is also on, fold the design rules into the
     // plan so the proposed approach is print-aware from the outset.
-    if (toggles.printOptimized) plan.push(printableGuidance());
+    if (toggles.printOptimized) {
+      plan.push('');
+      plan.push(printableGuidance());
+    }
     return plan.join('\n');
   }
 

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -287,7 +287,7 @@ export function toggleSuffix(toggles: ChatToggles): string {
   if (toggles.planFirst) {
     const lang = currentLanguage();
     const model = activeModel(toggles) ?? '(none picked)';
-    return [
+    const plan = [
       '',
       '## Session toggle state',
       '',
@@ -303,7 +303,11 @@ export function toggleSuffix(toggles: ChatToggles): string {
       '',
       'If you need clarification before you can write a useful plan, ask your questions now.',
       'The user will approve the plan (triggering a new turn with full tools) or reply to refine it further.',
-    ].join('\n');
+    ];
+    // When 3D-printing optimization is also on, fold the design rules into the
+    // plan so the proposed approach is print-aware from the outset.
+    if (toggles.printOptimized) plan.push(printableGuidance());
+    return plan.join('\n');
   }
 
   // Behavioural guidance for each capability that's currently OFF — tells the
@@ -359,6 +363,10 @@ export function toggleSuffix(toggles: ChatToggles): string {
     `- Session notes: ${onOff(toggles.scope.sessionNotes)}`,
     `- Auto-render (renderView / renderViews): ${onOff(toggles.vision.views)}`,
   ];
+  if (toggles.printOptimized) {
+    lines.push('');
+    lines.push(printableGuidance());
+  }
   if (toggles.autoResume) {
     lines.push('');
     lines.push('**Auto-continue is ON.** Keep working until the user\'s request is fully complete. Do NOT end your turn with a plain "all done" message and wait for the user — either call a tool to make progress, or, when the task is genuinely finished and verified, call the `finish` tool (the only clean way to end your turn). If you stop without calling `finish`, you will be automatically resumed to continue, so stopping early just wastes a round-trip. This is bounded by the iteration and spend caps above, so don\'t pad with busy-work — call `finish` as soon as the task is actually done.');
@@ -394,6 +402,33 @@ function qualityLine(): string {
     ? 'Custom'
     : QUALITY_OPTIONS.find(o => o.id === quality)?.label ?? 'Very High';
   return `Modeling quality: the user picked "${label}" (~${segs} segments per full circle), already applied before every run. OMIT the segments argument on cylinder/sphere/circle/revolve/extrude so curves inherit this preset — do NOT pass a smaller explicit count (e.g. 32) just to "make it smooth", as that shadows the user's choice and looks chunky to them. Pass an explicit count only for a deliberately faceted/low-poly look or a user-tunable parameter, or a HIGHER count when one specific feature needs extra resolution.`;
+}
+
+/** Guidance block injected when the 3D-printing-optimization toggle is ON.
+ *  Frames the model's geometry decisions around FDM (filament) printability so
+ *  the result comes off the build plate cleanly with minimal supports. Kept
+ *  terse and actionable — it rides on every turn while the toggle is on, so it
+ *  earns its tokens by being rules the model bakes into geometry, not prose to
+ *  recite back. Units in this app are nominal; the parenthetical "1 unit ≈ 1 mm"
+ *  anchors the size thresholds to typical FDM tolerances. */
+function printableGuidance(): string {
+  return [
+    '## Design for 3D printing (ON)',
+    '',
+    'The user intends to 3D-print this model on a typical FDM / filament printer. Design for printability from the very first version — it is far cheaper to build print-friendly than to fix it later. Bake these into the geometry (treat 1 unit ≈ 1 mm for the size thresholds):',
+    '',
+    '- **Flat base on the build plate.** Give the model a broad, flat bottom face so it sits stable on the plate with good adhesion. Orient the natural "down" of the object downward; avoid balancing it on a point, a sphere, or a thin edge.',
+    '- **Respect the ~45° overhang rule.** Surfaces that lean more than ~45° away from vertical need support material. Prefer chamfers over flat horizontal overhangs, taper walls in/out gradually, and angle features so they self-support. A 45° slope prints clean; a sudden 90° ledge does not.',
+    '- **No floating or disconnected islands.** Every part of the body must connect to the rest (or rest on the plate). Geometry floating in mid-air can\'t print without supports — unless print-in-place separation is the explicit goal, return one connected solid (check componentCount).',
+    '- **Keep unsupported bridges short.** Flat ceilings spanning open space sag; keep bridges under ~5 units or arch/taper the gap so it self-supports.',
+    '- **Mind the minimum feature size.** Walls thinner than ~1 unit (≈2 nozzle widths) and raised/recessed detail below ~0.4 unit (one nozzle width) won\'t print reliably. Keep text, pins, and thin ribs above that.',
+    '- **Watertight, single manifold.** Verify isManifold === true and the expected componentCount. Avoid fully sealed internal cavities (they trap unprintable air/material) unless intended.',
+    '- **Chamfer the bottom edge instead of filleting it.** A small 45° chamfer at the base aids adhesion and removal; a fillet at the very bottom curls into a thin, hard-to-print overhang.',
+    '- **Keep it stable, not top-heavy.** Favor a low center of mass and a footprint wide enough that the print won\'t tip mid-job.',
+    '- **Leave clearance for parts that fit or move.** ~0.2–0.4 units of gap between mating or moving parts so they aren\'t fused after printing.',
+    '',
+    'You don\'t need to recite these rules to the user — just design to them. If a request fundamentally fights printability (e.g. an inherently floating shape), build the printable interpretation and briefly note the trade-off you made.',
+  ].join('\n');
 }
 
 export function buildSystemPrompt(aiMd: string): string {

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -116,6 +116,13 @@ export interface ChatToggles {
    *  proceeds with full tools) or reject it (planning messages are removed from
    *  history and the original input is restored). OFF by default. */
   planFirst: boolean;
+  /** 3D-printing optimization. When ON, a block of FDM-printing design
+   *  guidance is appended to the per-turn system suffix so the model designs
+   *  print-friendly geometry from the start (flat base on the build plate,
+   *  the 45° overhang rule, no floating islands, minimum feature sizes, …).
+   *  Injects prompt text only — it does not gate any tool, so it composes
+   *  with every other toggle. ON by default. */
+  printOptimized: boolean;
   /** Which backend the chat is talking to right now. */
   provider: Provider;
   /** Anthropic model for cloud chats. Plain string so dated snapshots

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -2310,14 +2310,15 @@ function renderThinkingBox(text: string): HTMLElement {
  *  capabilities list, auto-continue note, and the 3D-printable design guidance
  *  when that pill is on). The model never echoes the system prompt into the
  *  chat, so this is the only place the user can read what the AI is actually
- *  being told. Collapsed by default; the body fills asynchronously because the
- *  cloud prompt awaits the (fetch-once-cached) ai.md. */
+ *  being told. Collapsed by default; the body is filled lazily on first expand
+ *  (and re-filled when toggles change while open). Keeping the body empty while
+ *  collapsed also keeps the bubble out of text-based `details` locators in the
+ *  e2e suite — the full prompt text overlaps a lot of tool-chip fixtures. */
 function renderSystemPromptBubble(): HTMLElement {
   const chip = document.createElement('details');
   chip.dataset.systemPromptBox = '1';
   chip.open = systemPromptBubbleOpen;
   chip.className = 'self-stretch text-[11px] rounded border border-amber-800/50 bg-amber-950/20 px-2 py-1';
-  chip.addEventListener('toggle', () => { systemPromptBubbleOpen = chip.open; });
   const summary = document.createElement('summary');
   summary.className = 'cursor-pointer text-amber-300/90 select-none';
   summary.textContent = '📄 System prompt';
@@ -2326,7 +2327,13 @@ function renderSystemPromptBubble(): HTMLElement {
   const pre = document.createElement('pre');
   pre.className = 'mt-1 text-[10px] text-zinc-400 overflow-x-auto whitespace-pre-wrap leading-snug max-h-72 overflow-y-auto';
   chip.appendChild(pre);
-  fillSystemPromptBody(pre);
+  chip.addEventListener('toggle', () => {
+    systemPromptBubbleOpen = chip.open;
+    if (chip.open) fillSystemPromptBody(pre);
+  });
+  // Setting `open` via property doesn't fire `toggle`, so restore the filled
+  // body ourselves when a re-render recreates an already-open bubble.
+  if (chip.open) fillSystemPromptBody(pre);
   return chip;
 }
 
@@ -2351,10 +2358,13 @@ function fillSystemPromptBody(pre: HTMLElement): void {
 }
 
 /** Re-fill the system-prompt preview in place (without rebuilding the whole
- *  transcript) so flipping a toggle pill updates it immediately. No-op when the
- *  bubble isn't currently mounted (empty session). */
+ *  transcript) so flipping a toggle pill updates it immediately. Only acts when
+ *  the bubble is expanded — collapsed bodies are left empty (filled on expand),
+ *  which is what keeps the bubble out of text-based e2e `details` locators. */
 function refreshSystemPromptBubble(): void {
-  const pre = transcriptEl?.querySelector<HTMLElement>('details[data-system-prompt-box] > pre');
+  const chip = transcriptEl?.querySelector<HTMLDetailsElement>('details[data-system-prompt-box]');
+  if (!chip || !chip.open) return;
+  const pre = chip.querySelector<HTMLElement>('pre');
   if (pre) fillSystemPromptBody(pre);
 }
 

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -3,14 +3,14 @@
 // input row, the cost meter, and the compact button. State lives in the
 // ai/* modules; this file is mostly DOM wiring.
 
-import { totalCost, totalTokensEstimate, estimateCachedPrefixTokens, runTurn as runTurnOnMainThread, type RunTurnInput, type RunTurnCallbacks } from '../ai/chatLoop';
+import { totalCost, totalTokensEstimate, estimateCachedPrefixTokens, runTurn as runTurnOnMainThread, buildActiveSystemPrompt, type RunTurnInput, type RunTurnCallbacks } from '../ai/chatLoop';
 import { runTurn as runTurnInWorker, pushQueuedBlocks } from '../ai/agentWorkerClient';
 import { listMessages, GLOBAL_CHAT_BUCKET, putMessages, deleteMessages, getKey, clearChat, mergeChatBucket } from '../ai/db';
 import { proposeCompaction } from '../ai/compaction';
 import { captureIsoViews, fileToImageSource } from '../ai/images';
 import { PHOTO_BUST_PROMPT } from '../ai/photoModelPrompt';
 import { loadSettings, saveSettings, setAnthropicModel, setOpenaiModel, setGeminiModel, setCustomModel, setProvider, setLocalModel, setToggles, providerLabel, aiConnectionMode, ANTHROPIC_MODEL_OPTIONS, OPENAI_MODEL_OPTIONS, GEMINI_MODEL_OPTIONS, MAX_ITERATIONS_OPTIONS, MAX_SPEND_OPTIONS, THINKING_OPTIONS, RENDER_RESOLUTION_OPTIONS, VERIFY_ANGLE_OPTIONS, type AiSettings } from '../ai/settings';
-import { buildLocalSystemPrompt, buildMediumLocalSystemPrompt, buildSystemPrompt, loadAiMd } from '../ai/systemPrompt';
+import { buildLocalSystemPrompt, buildMediumLocalSystemPrompt, buildSystemPrompt, loadAiMd, toggleSuffix } from '../ai/systemPrompt';
 import { estimateTurnCostUsd, formatUsd } from '../ai/cost';
 import { getLimits } from '../ai/catalog';
 import { generateId } from '../storage/db';
@@ -213,6 +213,15 @@ let mountTarget: HTMLElement | null = null;
 /** Set by the watchdog when it abort()s mid-stream so sendMessage knows
  *  this was a stall recovery (auto-resume), not a user-initiated stop. */
 let stalledByWatchdog = false;
+
+/** Whether the collapsible "System prompt" disclosure at the top of the
+ *  transcript is expanded. Persisted across transcript re-renders (which wipe
+ *  and rebuild the container) so flipping a toggle doesn't snap it shut. */
+let systemPromptBubbleOpen = false;
+/** Monotonic token guarding the async system-prompt fill — the bubble is
+ *  recreated on every re-render, so a stale in-flight assemble must not
+ *  overwrite a newer bubble's body. */
+let systemPromptFillSeq = 0;
 
 export interface AiPanelOptions {
   /** main.ts hands in a navigation helper so the panel can move the user
@@ -475,6 +484,9 @@ function recordSessionAiPreference(): void {
 function applyToggleChange(partial: Parameters<typeof setToggles>[1]): void {
   saveSettings(setToggles(loadSettings(), partial));
   recordSessionAiPreference();
+  // The toggle suffix (capabilities, 3D-printable guidance, …) is part of what
+  // the system-prompt preview shows; keep it live as pills flip.
+  refreshSystemPromptBubble();
 }
 
 /** Restore the session's remembered AI config into THIS tab's settings — called
@@ -1791,6 +1803,11 @@ function renderTranscript(): void {
   }
 
   transcriptEl.replaceChildren();
+  // Pin the collapsible system-prompt preview at the very top — above the first
+  // message and even the empty state — so the user can always read exactly what
+  // the model is being told this session (the base prompt + live toggle suffix,
+  // including the 3D-printable guidance when that pill is on).
+  transcriptEl.appendChild(renderSystemPromptBubble());
   const hasHistory = state.history.length > 0;
   const hasQueue = state.queuedBlocks.length > 0;
   if (!hasHistory && !hasQueue) {
@@ -2285,6 +2302,60 @@ function renderThinkingBox(text: string): HTMLElement {
   pre.textContent = text;
   chip.appendChild(pre);
   return chip;
+}
+
+/** Collapsible "System prompt" disclosure pinned at the top of the transcript.
+ *  Shows the exact prompt sent to the model on every turn — the base system
+ *  prompt for the active provider PLUS the live per-turn toggle suffix (the
+ *  capabilities list, auto-continue note, and the 3D-printable design guidance
+ *  when that pill is on). The model never echoes the system prompt into the
+ *  chat, so this is the only place the user can read what the AI is actually
+ *  being told. Collapsed by default; the body fills asynchronously because the
+ *  cloud prompt awaits the (fetch-once-cached) ai.md. */
+function renderSystemPromptBubble(): HTMLElement {
+  const chip = document.createElement('details');
+  chip.dataset.systemPromptBox = '1';
+  chip.open = systemPromptBubbleOpen;
+  chip.className = 'self-stretch text-[11px] rounded border border-amber-800/50 bg-amber-950/20 px-2 py-1';
+  chip.addEventListener('toggle', () => { systemPromptBubbleOpen = chip.open; });
+  const summary = document.createElement('summary');
+  summary.className = 'cursor-pointer text-amber-300/90 select-none';
+  summary.textContent = '📄 System prompt';
+  summary.title = 'The full system prompt sent to the model on every turn, including the live toggle guidance (capabilities, auto-continue, and the 3D-printable design rules when that pill is on). Expand to read exactly what the AI is told.';
+  chip.appendChild(summary);
+  const pre = document.createElement('pre');
+  pre.className = 'mt-1 text-[10px] text-zinc-400 overflow-x-auto whitespace-pre-wrap leading-snug max-h-72 overflow-y-auto';
+  chip.appendChild(pre);
+  fillSystemPromptBody(pre);
+  return chip;
+}
+
+/** Fill (or re-fill) a system-prompt bubble's body from the same assembly the
+ *  chat loop uses, so it's faithful rather than a reconstruction. Reads live
+ *  toggles each call. The seq guard stops a stale in-flight assemble (the
+ *  bubble is recreated on every transcript re-render) from clobbering a newer
+ *  body. */
+function fillSystemPromptBody(pre: HTMLElement): void {
+  pre.textContent = 'Assembling…';
+  const seq = ++systemPromptFillSeq;
+  const toggles = loadSettings().toggles;
+  void buildActiveSystemPrompt(toggles)
+    .then((base) => {
+      if (seq !== systemPromptFillSeq) return;
+      pre.textContent = `${base}\n\n${toggleSuffix(toggles)}`;
+    })
+    .catch(() => {
+      if (seq !== systemPromptFillSeq) return;
+      pre.textContent = 'Could not assemble the system prompt (the prompt doc failed to load). It is still sent to the model.';
+    });
+}
+
+/** Re-fill the system-prompt preview in place (without rebuilding the whole
+ *  transcript) so flipping a toggle pill updates it immediately. No-op when the
+ *  bubble isn't currently mounted (empty session). */
+function refreshSystemPromptBubble(): void {
+  const pre = transcriptEl?.querySelector<HTMLElement>('details[data-system-prompt-box] > pre');
+  if (pre) fillSystemPromptBody(pre);
 }
 
 /** Open box used while reasoning streams: a capped-height scrolling preview

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1321,6 +1321,15 @@ function renderToggleStrip(): void {
       renderToggleStrip();
     },
   ));
+  primary.appendChild(togglePill(
+    '🖨 3D-printable',
+    toggles.printOptimized,
+    'Design for 3D printing: when ON, the AI is told to make print-friendly geometry from the start — a flat base on the build plate, the ~45° overhang rule (avoid supports), no floating islands, printable wall/feature sizes, and clearances for moving parts. Injects guidance only; it doesn\'t restrict any tool, so it works alongside the other toggles. ON by default; turn it OFF for purely on-screen models you won\'t print.',
+    () => {
+      applyToggleChange({ printOptimized: !toggles.printOptimized });
+      renderToggleStrip();
+    },
+  ));
 
   const retry = document.createElement('select');
   retry.className = 'px-1.5 py-0.5 rounded text-[10px] bg-zinc-800 border border-zinc-700 text-zinc-300 focus:outline-none';

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -234,7 +234,7 @@ test.describe('AI chat panel', () => {
   test('toggle pills carry tooltips explaining what they do', async ({ page }) => {
     await page.goto('/editor');
     await openAiPanel(page);
-    const pillNames = ['📸 Auto-render', '▶ Run', '💾 Save', '🎨 Paint'];
+    const pillNames = ['📸 Auto-render', '▶ Run', '💾 Save', '🎨 Paint', '🖨 3D-printable'];
     for (const name of pillNames) {
       const pill = page.locator('#ai-panel button', { hasText: name });
       await expect(pill).toBeVisible();
@@ -243,6 +243,35 @@ test.describe('AI chat panel', () => {
       expect(title!.length).toBeGreaterThan(20);
       expect(title!.toLowerCase()).toMatch(/on|off|click/);
     }
+  });
+
+  test('the 3D-printable pill is ON by default and flips off', async ({ page }) => {
+    await page.goto('/editor');
+    await openAiPanel(page);
+    const pill = page.locator('#ai-panel button', { hasText: /🖨 3D-printable/ });
+    await expect(pill).toBeVisible();
+    // Default-on: standard preset ships printOptimized: true, so a fresh
+    // session presents the pill pressed.
+    await expect(pill).toHaveAttribute('aria-pressed', 'true');
+    await pill.dispatchEvent('click');
+    await expect(pill).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('3D-printable toggle injects FDM design guidance into the system suffix', async ({ page }) => {
+    await page.goto('/editor');
+    const result = await page.evaluate(async () => {
+      const { loadSettings } = await import('/src/ai/settings.ts');
+      const { toggleSuffix } = await import('/src/ai/systemPrompt.ts');
+      const base = loadSettings().toggles;
+      const on = toggleSuffix({ ...base, printOptimized: true, planFirst: false });
+      const off = toggleSuffix({ ...base, printOptimized: false, planFirst: false });
+      return {
+        onHas: on.includes('Design for 3D printing') && on.includes('45°'),
+        offHas: off.includes('Design for 3D printing'),
+      };
+    });
+    expect(result.onHas).toBe(true);
+    expect(result.offHas).toBe(false);
   });
 
   test('the AI drawer (and app bundle) does not load on the landing route', async ({ page }) => {

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -257,6 +257,21 @@ test.describe('AI chat panel', () => {
     await expect(pill).toHaveAttribute('aria-pressed', 'false');
   });
 
+  test('the system-prompt bubble shows the prompt and updates with the 3D-printable pill', async ({ page }) => {
+    await page.goto('/editor');
+    await openAiPanel(page);
+    const bubble = page.locator('#ai-transcript details[data-system-prompt-box]');
+    await expect(bubble).toBeVisible();
+    // Expand it; the body fills async from the same assembly the chat loop uses.
+    await bubble.locator('summary').click();
+    const body = bubble.locator('pre');
+    await expect(body).toContainText('Design for 3D printing', { timeout: 15000 });
+    // Flipping the pill OFF must drop the guidance from the live preview without
+    // a full page reload (applyToggleChange refreshes the bubble in place).
+    await page.locator('#ai-panel button', { hasText: /🖨 3D-printable/ }).dispatchEvent('click');
+    await expect(body).not.toContainText('Design for 3D printing', { timeout: 15000 });
+  });
+
   test('3D-printable toggle injects FDM design guidance into the system suffix', async ({ page }) => {
     await page.goto('/editor');
     const result = await page.evaluate(async () => {


### PR DESCRIPTION
## Summary

Two related additions to the AI panel:

### 1. "🖨 3D-printable" toggle pill (ON by default)

A new pill in the toggle strip, right after **📋 Plan** and **selected by default**. When ON it appends a block of FDM-printing design guidance to the per-turn system prompt so the model designs print-friendly geometry from the first version. Unlike Plan it **gates no tool** — it only injects prompt text — so it composes cleanly with every other toggle (and with Plan, where it also makes the plan itself print-aware).

The injected guidance covers: flat base on the build plate · the ~45° overhang rule (avoid supports) · no floating/disconnected islands · short unsupported bridges · minimum wall/feature sizes (nozzle-width floors) · watertight single manifold / no sealed cavities · chamfer-the-bottom-edge-don't-fillet-it · low center of mass · ~0.2–0.4-unit clearances for mating/moving parts. Thresholds anchored with "treat 1 unit ≈ 1 mm". It tells the model to *bake these into geometry, not recite them*, and — when a request inherently fights printability — to build the printable interpretation and note the trade-off rather than refuse.

### 2. "📄 System prompt" preview bubble

The system prompt is never echoed into the chat transcript, so there was no way to confirm the 3D-printable (or any) guidance was actually being sent. This adds a collapsible disclosure pinned at the top of the transcript — mirroring the thinking-bubble style — that expands to show the **exact** prompt sent to the model: the base system prompt for the active provider **plus** the live per-turn toggle suffix. It updates in place the instant you flip a pill.

## Implementation

- `src/ai/types.ts` — new `printOptimized: boolean` on `ChatToggles` (default **true**)
- `src/ai/settings.ts` — default `true` in all three presets; threaded through `cloneToggles`, `applyPreset`, `setToggles`, and `mergeWithDefaults` (older saved sessions backfill the default)
- `src/ai/systemPrompt.ts` — `printableGuidance()` helper injected into both the normal capabilities suffix and the plan-mode suffix
- `src/ui/aiPanel.ts` — the new pill (modeled on Plan) + the `renderSystemPromptBubble()` disclosure
- `src/ai/chatLoop.ts` — extracted the provider/override/local-tier system-prompt dispatch out of `runTurn` into an exported **`buildActiveSystemPrompt()`** so the bubble reproduces exactly what's sent (not a reconstruction); `runTurn` now calls it too. Housed here (not `systemPrompt.ts`) to avoid a `systemPrompt → local` import cycle.

Named `printOptimized` (not `printable`) to avoid colliding with the existing viewport printability pill / `computePrintability`, which is a different concept (live structural status, not an AI-guidance toggle).

## Test plan

- `npm run build` (type-check) ✅
- `npm run test:unit` ✅
- Full `tests/smoke.spec.ts` (18) + `ai-autoresume` + `ai-providers` (37) e2e ✅ locally
- Manual browser checks (screenshots posted in session): pill green/ON by default; system-prompt bubble visible, expands to the guidance, and drops it live when the pill is flipped off
- Added smoke coverage: pill in the tooltip array; default-ON + flip-off assertion; `toggleSuffix` contains the guidance when on and omits it when off; and a golden-path test for the bubble (visible → expand → guidance present → flip pill → guidance gone)

https://claude.ai/code/session_01JH8gzo8Y2xH56iMypDX8jn