### PR TITLE
fix: survive transient AI provider errors and resume failed turns in place

### DIFF
--- a/prompts/ai-chat-retry-and-transient-errors.md
+++ b/prompts/ai-chat-retry-and-transient-errors.md
@@ -1,0 +1,70 @@
+---
+session: "FgPph"
+timestamp: "2026-06-07T17:30:00Z"
+model: claude-opus-4-8
+tools: [explore, Read, Grep, Edit, Write, Bash]
+---
+
+## Human
+
+In the AI chat pane, when a turn errors and you click "retry last message", it
+seems to undo the entire agent run — even after 30 thinking/tool steps it wiped
+all that away and replayed the *initial* message, leaving the model confused
+about current state. I was also seeing the chat history be cleared in the UI.
+Separately: I got a 500 from the server, but I have "auto-continue" on (the
+model should loop until the task is done) — I'd expect that to survive server
+errors, and I'm not convinced it does. Investigate, then fix: resume in place
+(don't clear history), and make auto-continue ride through transient errors.
+
+## Assistant
+
+## Key decisions
+
+**Two distinct root causes, confirmed by tracing the loop + panel.**
+
+1. *Auto-continue died on any provider error.* `runTurn`'s `catch` around the
+   `streamTurn` dispatch (`src/ai/chatLoop.ts`) unconditionally fired `onError`
+   + `onTurnComplete({reason:'error'})` and `return`ed — `autoResume` was never
+   consulted there, and there was **no** retry/backoff for transient failures.
+   Every hosted provider `throw`s on a non-2xx (`OpenAI 500: …`, `Gemini 503:
+   …`, Anthropic SDK `APIError`), so a 500 tore the whole agent loop down. (The
+   only existing retry, `executeAllWithRetry`/`autoRetry`, is for *tool*
+   execution, not API calls.)
+
+2. *Retry re-prompted instead of resuming.* `retryLastUserMessage` walked back
+   to the last *text-bearing* user message — which in a 30-step agentic run is
+   the **original prompt** (all intermediate user turns are tool-results with no
+   text block) — and re-sent it via `sendMessage`, appending a duplicate task
+   request on top of all completed work. That both confused the model and, via
+   the re-send path's history/bucket handling, made the run look wiped.
+
+**Fix 1 — transient-retry with backoff in the loop.** Wrapped the `streamTurn`
+dispatch in a bounded retry loop. A new pure module `src/ai/transientError.ts`
+(`httpStatusOf` + `isTransientError`) classifies errors: 408/409/425/429 + all
+5xx (incl. Anthropic 529) and network/dropped-stream messages are transient;
+4xx auth/validation, missing-key, and user aborts are fatal. Transient failures
+back off (exp + full jitter, `abortableSleep` so Stop still cancels) and re-issue
+the *same* request **without** consuming an agent iteration; only a fatal error
+or exhausting `maxTransientRetries` surfaces `onError`. New config knobs in
+`appConfig.ts` (`maxTransientRetries`=4, `transientRetryBaseMs`=1000,
+`transientRetryMaxMs`=16000) + advanced-settings fields. Read via `getConfig()`
+directly in `chatLoop`, matching the sibling `maxConsecutiveAutoResumes` knob —
+so the default applies in the agent Worker (where `getConfig` returns defaults);
+the tooltip notes overrides only affect the local provider.
+
+**Fix 2 — resume in place, never re-prompt or clear.** Replaced
+`retryLastUserMessage` with `retryFailedTurn`, modelled on the amber "Keep
+going" `resumeFromNotice`: it drops only the in-memory error bubble and calls
+`runTurnWithStallRetry(..., [])` (empty userBlocks) against the existing,
+persisted history, so the model continues from its last tool results instead of
+replaying the seed prompt. No `sendMessage`, no history reload, no clear — the
+completed work stays intact. Button relabeled "↻ Retry" with a clarifying
+tooltip.
+
+**Verification.** New `tests/unit/transientError.test.ts` (classifier) and
+`tests/ai-transient-retry.spec.ts` (loop: 5xx-then-success retries & completes;
+persistent 503 exhausts the bound then errors; 401 fails fast — no retry).
+Manual browser check confirmed the AI Call Log shows `transient, retrying 3/4`,
+`4/4`, then `gave up after 4 transient retries`, and the error bubble keeps the
+prior message visible with the new Retry button. Build + unit (726) + autoresume
+/call-log regressions all green.

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -23,6 +23,7 @@ import { loadSettings } from './settings';
 import { turnCostUsd } from './cost';
 import { activeModel, ITERATION_CAP, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type PersistedToolCall, type PersistedToolResult, type Provider, type TurnOutcomeReason } from './types';
 import { getConfig } from '../config/appConfig';
+import { isTransientError } from './transientError';
 
 /** Look up the stored API key for a hosted provider. Returns null when
  *  no key is stored; chatLoop turns that into an "open AI Settings to
@@ -91,6 +92,24 @@ const AUTO_RESUME_PROMPT =
  *  tools). Hitting it just falls through to the normal end_turn outcome (a
  *  resumable Keep-going notice), never an infinite loop. */
 function getMaxConsecutiveAutoResumes(): number { return getConfig().ai.maxConsecutiveAutoResumes; }
+
+/** Exponential backoff with full jitter, capped. attempt is 1-based. */
+function transientBackoffMs(attempt: number): number {
+  const cfg = getConfig().ai;
+  const ceiling = Math.min(cfg.transientRetryBaseMs * 2 ** (attempt - 1), cfg.transientRetryMaxMs);
+  return Math.round(Math.random() * ceiling);
+}
+
+/** Sleep that resolves early if the abort signal fires, so a queued backoff
+ *  doesn't keep a stopped turn alive. */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise(resolve => {
+    if (signal?.aborted) { resolve(); return; }
+    const t = setTimeout(() => { signal?.removeEventListener('abort', onAbort); resolve(); }, ms);
+    const onAbort = () => { clearTimeout(t); resolve(); };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
 
 export interface RunTurnInput {
   /** Hosted-provider API key. Required only when toggles.provider === 'anthropic'. */
@@ -291,9 +310,19 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
       },
     };
 
-    const apiCallStart = Date.now();
     const requestSummary = `${workingHistory.length} msg(s), ${tools.length} tool def(s), vision=${toggles.vision.views ? 'on' : 'off'}, thinking=${toggles.thinking}`;
+    // Transient provider failures (HTTP 429/5xx, dropped stream, network blip)
+    // are retried in place with exponential backoff so an auto-continue run
+    // survives a flaky server. These retries do NOT consume the agent's
+    // per-turn iteration budget — only a *fatal* error (auth, bad request,
+    // user abort) or exhausting maxTransientRetries surfaces onError and ends
+    // the turn.
+    const maxTransientRetries = getConfig().ai.maxTransientRetries;
+    let transientAttempt = 0;
+    let apiCallStart = Date.now();
     let result;
+    for (;;) { // transient-retry loop — see maxTransientRetries below
+    apiCallStart = Date.now();
     try {
       if (toggles.provider === 'anthropic') {
         if (!apiKey) throw new Error('Anthropic API key is required.');
@@ -365,26 +394,45 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
           tools,
         }, streamCallbacks, signal);
       }
+      break; // streamTurn succeeded — leave the transient-retry loop
     } catch (err) {
-      // Surface the error to the caller; runTurn returns normally and the
-      // caller's awaited post-cleanup runs the history reload. The
-      // in-memory "Thinking…" placeholder gets wiped there. The per-call
-      // diagnostics buffer records the full message (the panel's onError
-      // also routes it into the app-wide errorLog with source='ai').
       const message = err instanceof Error ? err.message : String(err);
+      // Retryable hiccup? Back off and re-issue the same request without
+      // burning an agent iteration. Keeps auto-continue alive through 5xx /
+      // rate-limit / dropped-stream blips instead of tearing the loop down.
+      if (!signal?.aborted && transientAttempt < maxTransientRetries && isTransientError(err)) {
+        transientAttempt++;
+        const waitMs = transientBackoffMs(transientAttempt);
+        recordEvent({
+          provider: toggles.provider,
+          model: model ?? '(no model)',
+          kind: 'streamTurn',
+          durationMs: Date.now() - apiCallStart,
+          status: 'error',
+          errorMessage: `${message} — transient, retrying ${transientAttempt}/${maxTransientRetries} after ${waitMs}ms`,
+          requestSummary,
+        });
+        callbacks.onProgress?.({ phase: 'thinking', detail: `Server error — retrying (${transientAttempt}/${maxTransientRetries})…` });
+        await abortableSleep(waitMs, signal);
+        continue; // re-run streamTurn
+      }
+      // Fatal, or retries exhausted: surface the error and end the turn. The
+      // per-call diagnostics buffer records the full message (the panel's
+      // onError also routes it into the app-wide errorLog with source='ai').
       recordEvent({
         provider: toggles.provider,
         model: model ?? '(no model)',
         kind: 'streamTurn',
         durationMs: Date.now() - apiCallStart,
         status: 'error',
-        errorMessage: message,
+        errorMessage: transientAttempt > 0 ? `${message} (gave up after ${transientAttempt} transient retr${transientAttempt === 1 ? 'y' : 'ies'})` : message,
         requestSummary,
       });
       callbacks.onError?.(err instanceof Error ? err : new Error(message));
       callbacks.onTurnComplete?.({ totalCostUsd, toolCalls: totalToolCalls, reason: 'error', iterations: iter + 1 });
       return workingHistory;
     }
+    } // end transient-retry loop
 
     const durationMs = Date.now() - apiCallStart;
     turnApiTimeMs += durationMs;

--- a/src/ai/transientError.ts
+++ b/src/ai/transientError.ts
@@ -1,0 +1,35 @@
+/** Classification of provider stream errors into transient (worth retrying as-is)
+ *  vs fatal (would just fail again). Pure logic, no dependencies — kept out of
+ *  chatLoop so it can be unit-tested in the node tier. */
+
+/** Pull an HTTP status code out of a thrown provider error. The Anthropic SDK
+ *  attaches a numeric `.status`; the raw-fetch providers (OpenAI/Gemini/custom)
+ *  throw `new Error("OpenAI 503: …")`, so we parse the leading status token. */
+export function httpStatusOf(err: unknown): number | null {
+  const e = err as { status?: unknown; message?: unknown };
+  if (typeof e?.status === 'number') return e.status;
+  const msg = typeof e?.message === 'string' ? e.message : '';
+  // Matches "OpenAI 503:", "Gemini 500:", "Anthropic 529 …" — an optional
+  // provider name followed by a 3-digit status near the start of the message.
+  const m = msg.match(/(?:^|\b)(?:OpenAI|Gemini|Anthropic|Custom)?\s*(\d{3})\b/);
+  return m ? Number(m[1]) : null;
+}
+
+/** A transient failure is one worth retrying as-is: the request was well-formed
+ *  but the server/network hiccuped (rate limit, 5xx, dropped stream). Fatal
+ *  errors (auth, bad request, missing key, user abort) are NOT retried — they'd
+ *  just fail again. */
+export function isTransientError(err: unknown): boolean {
+  const e = err as { name?: unknown; message?: unknown };
+  if (e?.name === 'AbortError') return false; // user/stop abort — never retry
+  const status = httpStatusOf(err);
+  if (status !== null) {
+    // 408 timeout, 409 conflict, 425 too-early, 429 rate-limit, all 5xx
+    // (incl. Anthropic's 529 "overloaded"). 4xx auth/validation are fatal.
+    return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
+  }
+  // No status → likely a network-layer failure (fetch rejects with a TypeError)
+  // or a mid-stream drop. Match on the common phrasings.
+  const msg = (typeof e?.message === 'string' ? e.message : '').toLowerCase();
+  return /failed to fetch|networkerror|network error|connection|econnreset|socket|timeout|timed out|temporarily|overloaded|interrupted|terminated|premature|stream/.test(msg);
+}

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -16,6 +16,17 @@ export interface AppConfig {
     /** Max consecutive auto-resume nudges with no tool call before the loop
      *  falls through to a normal end_turn outcome. Resets on any tool call. */
     maxConsecutiveAutoResumes: number;
+    /** Max times a single provider API call is retried after a *transient*
+     *  failure (HTTP 429/5xx, network/stream drop) before the turn surfaces a
+     *  hard error. These retries don't consume the agent's per-turn iteration
+     *  budget — they keep an auto-continue run alive through server blips. */
+    maxTransientRetries: number;
+    /** Base backoff (ms) between transient provider-error retries. The actual
+     *  wait grows exponentially (base · 2^(attempt-1)) with jitter, capped at
+     *  transientRetryMaxMs. */
+    transientRetryBaseMs: number;
+    /** Ceiling (ms) on a single transient-error backoff wait. */
+    transientRetryMaxMs: number;
     /** Tool execution wall-clock time (ms) above which a console warning fires. */
     slowToolMs: number;
     /** In-memory ring buffer size for the AI diagnostics log. */
@@ -187,6 +198,9 @@ export interface AppConfig {
 export const APP_CONFIG_DEFAULTS: AppConfig = {
   ai: {
     maxConsecutiveAutoResumes: 8,
+    maxTransientRetries: 4,
+    transientRetryBaseMs: 1000,
+    transientRetryMaxMs: 16_000,
     slowToolMs: 250,
     diagnosticsRingSize: 50,
     maxAttachments: 20,

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -196,6 +196,36 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           onChange={v => set('ai', 'maxConsecutiveAutoResumes', v)}
         />
         <Field
+          label="Max transient API retries"
+          unit="retries"
+          hint="How many times a provider call is retried after a transient failure (HTTP 429/5xx, dropped stream) before the turn surfaces a hard error."
+          tooltip="Provider servers occasionally return rate-limit (429) or server (5xx) errors, or drop the streaming connection. Rather than tearing the whole agent loop down — which is especially disruptive mid auto-continue — the chat loop retries the same request with exponential backoff up to this many times. These retries do NOT consume the agent's per-turn iteration budget. Set to 0 to disable and fail fast. Note: this value is read from defaults inside the agent Worker, so overriding it only affects the local (WebGPU) provider."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.maxTransientRetries}
+          value={c.ai.maxTransientRetries}
+          min={0} max={10} integer
+          onChange={v => set('ai', 'maxTransientRetries', v)}
+        />
+        <Field
+          label="Transient retry base backoff"
+          unit="ms"
+          hint="Base wait between transient-error retries; grows exponentially with jitter."
+          tooltip="The first transient-error retry waits up to this long, the second up to 2×, the third up to 4×, and so on (with random jitter), capped by the max backoff below. Larger values are gentler on a struggling server but slow recovery from a brief blip."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.transientRetryBaseMs}
+          value={c.ai.transientRetryBaseMs}
+          min={100} max={30_000} integer
+          onChange={v => set('ai', 'transientRetryBaseMs', v)}
+        />
+        <Field
+          label="Transient retry max backoff"
+          unit="ms"
+          hint="Ceiling on a single transient-error backoff wait."
+          tooltip="Caps how long any one transient-error retry will wait, so exponential growth can't stall the turn for minutes. The actual wait is a random value up to min(base · 2^(attempt-1), this ceiling)."
+          defaultValue={APP_CONFIG_DEFAULTS.ai.transientRetryMaxMs}
+          value={c.ai.transientRetryMaxMs}
+          min={1_000} max={120_000} integer
+          onChange={v => set('ai', 'transientRetryMaxMs', v)}
+        />
+        <Field
           label="Slow-tool warning threshold"
           unit="ms"
           hint="Tool calls exceeding this time emit a console warning (does not affect behavior)."

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1956,7 +1956,8 @@ async function discardPartial(messageId: string): Promise<void> {
 
 /** Rendered for turns that errored mid-flight — visually distinct so the
  *  user can spot the failure point in a long chat, and offers a Retry that
- *  re-sends the immediately preceding user message. */
+ *  *resumes* the agent loop from the existing (persisted) history rather than
+ *  re-sending the original prompt. */
 function renderErrorBubble(msg: ChatMessage): HTMLElement {
   const card = document.createElement('div');
   card.className = 'max-w-[95%] rounded border border-red-700/60 bg-red-900/15 px-3 py-2 flex flex-col gap-2';
@@ -1975,8 +1976,9 @@ function renderErrorBubble(msg: ChatMessage): HTMLElement {
   actions.className = 'flex items-center gap-2 pt-1';
   const retryBtn = document.createElement('button');
   retryBtn.className = 'px-2 py-1 rounded text-[11px] text-zinc-100 bg-zinc-700 hover:bg-zinc-600 border border-zinc-600';
-  retryBtn.textContent = '↻ Retry last message';
-  retryBtn.addEventListener('click', () => { void retryLastUserMessage(msg.id); });
+  retryBtn.textContent = '↻ Retry';
+  retryBtn.title = 'Resume the agent from where it failed — all completed work above is kept, nothing is replayed.';
+  retryBtn.addEventListener('click', () => { void retryFailedTurn(msg.id); });
   actions.appendChild(retryBtn);
 
   const dismissBtn = document.createElement('button');
@@ -1992,34 +1994,36 @@ function renderErrorBubble(msg: ChatMessage): HTMLElement {
   return card;
 }
 
-/** Find the most recent user message before this error, dismiss the error
- *  bubble, and replay the user message verbatim. */
-async function retryLastUserMessage(errorMsgId: string): Promise<void> {
+/** Recover from a failed turn by *resuming* the agent loop from the existing
+ *  history, exactly like the amber "Keep going" notice — NOT by re-sending the
+ *  original prompt. Re-prompting used to append a duplicate request on top of
+ *  all the completed work (tool calls, renders, saved versions), which both
+ *  confused the model about the current state and made the long run look like
+ *  it had been thrown away. Here we only drop the in-memory error bubble and
+ *  re-issue the request against the persisted conversation; the model picks up
+ *  from its last tool results / message. Completed work is never touched. */
+async function retryFailedTurn(errorMsgId: string): Promise<void> {
   if (state.inFlight) {
     setTransientStatus('Wait for the current turn to finish before retrying.');
     return;
   }
-  const errorIdx = state.history.findIndex(m => m.id === errorMsgId);
-  if (errorIdx < 0) return;
-  let lastUser: ChatMessage | null = null;
-  for (let i = errorIdx - 1; i >= 0; i--) {
-    const m = state.history[i];
-    if (m.role === 'user' && m.blocks.some(b => b.type === 'text' || b.type === 'image')) {
-      lastUser = m;
-      break;
-    }
-  }
-  if (!lastUser) {
-    setTransientStatus('Nothing to retry — couldn\'t find your last message.');
-    return;
-  }
+  if (!writeOwner) return;
+  if (state.history.findIndex(m => m.id === errorMsgId) < 0) return;
+
+  const settings = loadSettings();
+  const apiKey = await preflightTurn(settings, () => { void retryFailedTurn(errorMsgId); });
+  if (apiKey === PREFLIGHT_ABORT) return;
+
+  // Drop the in-memory error bubble (it was never persisted) but keep every
+  // completed turn intact, then resume with empty userBlocks: the provider
+  // request builders drop the trailing empty user message, so the model
+  // continues from the last real turn instead of replaying the seed prompt.
   state.history = state.history.filter(m => m.id !== errorMsgId);
   renderTranscript();
-  if (!inputEl) return;
-  const text = lastUser.blocks.find(b => b.type === 'text')?.text ?? '';
-  state.pendingImages = lastUser.blocks.filter(b => b.type === 'image').map(b => (b as { source: ImageSource }).source);
-  inputEl.value = text;
-  await sendMessage();
+  progressState.retryCount = 0;
+  stalledByWatchdog = false;
+  pinTranscriptToBottom();
+  await runTurnWithStallRetry(apiKey, settings.toggles, []);
 }
 
 /** Rendered for turns that auto-stopped early but can be picked back up — the

--- a/tests/ai-transient-retry.spec.ts
+++ b/tests/ai-transient-retry.spec.ts
@@ -36,8 +36,7 @@ test.describe('Transient provider-error retry', () => {
       const origFetch = window.fetch;
       // @ts-expect-error test stub
       window.fetch = async (input: unknown, init?: RequestInit) => {
-        const url = String(input);
-        if (!url.includes('generativelanguage.googleapis.com')) return origFetch(input as RequestInfo, init);
+        if (new URL(String(input), location.href).hostname !== 'generativelanguage.googleapis.com') return origFetch(input as RequestInfo, init);
         n++;
         // Calls 1 & 2: HTTP 500 (transient). Call 3: a clean text end_turn.
         if (n <= 2) return new Response('{"error":{"message":"backend overloaded"}}', { status: 500 });
@@ -79,8 +78,7 @@ test.describe('Transient provider-error retry', () => {
       const origFetch = window.fetch;
       // @ts-expect-error test stub
       window.fetch = async (input: unknown, init?: RequestInit) => {
-        const url = String(input);
-        if (!url.includes('generativelanguage.googleapis.com')) return origFetch(input as RequestInfo, init);
+        if (new URL(String(input), location.href).hostname !== 'generativelanguage.googleapis.com') return origFetch(input as RequestInfo, init);
         n++;
         return new Response('{"error":{"message":"still down"}}', { status: 503 }); // always transient
       };
@@ -119,8 +117,7 @@ test.describe('Transient provider-error retry', () => {
       const origFetch = window.fetch;
       // @ts-expect-error test stub
       window.fetch = async (input: unknown, init?: RequestInit) => {
-        const url = String(input);
-        if (!url.includes('generativelanguage.googleapis.com')) return origFetch(input as RequestInfo, init);
+        if (new URL(String(input), location.href).hostname !== 'generativelanguage.googleapis.com') return origFetch(input as RequestInfo, init);
         n++;
         return new Response('{"error":{"message":"invalid api key"}}', { status: 401 });
       };

--- a/tests/ai-transient-retry.spec.ts
+++ b/tests/ai-transient-retry.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from 'playwright/test';
+import { waitForEditorReady } from './helpers/aiPanel';
+
+// Transient-error resilience: a provider HTTP 5xx / 429 / dropped stream used to
+// tear the whole agent loop down — fatal even mid auto-continue. The chat loop
+// now retries the same request with exponential backoff (bounded by
+// ai.maxTransientRetries), WITHOUT consuming the agent's per-turn iteration
+// budget. Fatal errors (auth/validation) still fail fast. These tests drive the
+// real chatLoop on the main thread with a stubbed Gemini transport (the same
+// trick ai-autoresume.spec.ts uses).
+
+/** Shrink the backoff so retries don't add real wall-clock time to the suite. */
+async function fastBackoff(page: import('playwright/test').Page, maxTransientRetries: number): Promise<void> {
+  await page.evaluate(async (n) => {
+    const cfg = await import('/src/config/appConfig.ts');
+    const cur = cfg.getConfig();
+    cfg.saveAppConfig({ ...cur, ai: { ...cur.ai, maxTransientRetries: n, transientRetryBaseMs: 1, transientRetryMaxMs: 2 } });
+  }, maxTransientRetries);
+}
+
+test.describe('Transient provider-error retry', () => {
+  test('a 5xx blip is retried, then the turn completes normally', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    await fastBackoff(page, 4);
+
+    const out = await page.evaluate(async () => {
+      const chatLoop = await import('/src/ai/chatLoop.ts');
+      const settings = await import('/src/ai/settings.ts');
+      const toggles = settings.setToggles(settings.loadSettings(), {
+        provider: 'gemini', geminiModel: 'gemini-flash-latest',
+        autoResume: false, maxIterations: 'medium', vision: { views: false },
+      }).toggles;
+
+      let n = 0;
+      const origFetch = window.fetch;
+      // @ts-expect-error test stub
+      window.fetch = async (input: unknown, init?: RequestInit) => {
+        const url = String(input);
+        if (!url.includes('generativelanguage.googleapis.com')) return origFetch(input as RequestInfo, init);
+        n++;
+        // Calls 1 & 2: HTTP 500 (transient). Call 3: a clean text end_turn.
+        if (n <= 2) return new Response('{"error":{"message":"backend overloaded"}}', { status: 500 });
+        const frame = 'data: {"candidates":[{"content":{"parts":[{"text":"Done."}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1}}';
+        return new Response(new Blob([frame + '\r\n\r\n']), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+      };
+
+      const ev = { errors: 0, reason: '' };
+      try {
+        await chatLoop.runTurn(
+          { apiKey: 'k', toggles, sessionId: 'transient-5xx', history: [], userBlocks: [{ type: 'text', text: 'go' }] },
+          { onError: () => { ev.errors++; }, onTurnComplete: info => { ev.reason = info.reason; } },
+        );
+      } finally {
+        window.fetch = origFetch;
+      }
+      return { calls: n, ...ev };
+    });
+
+    expect(out.calls).toBe(3);       // 2 failed attempts retried, then success
+    expect(out.errors).toBe(0);      // the blip never surfaced as a hard error
+    expect(out.reason).toBe('end_turn');
+  });
+
+  test('retries are bounded by maxTransientRetries, then surface a hard error', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    await fastBackoff(page, 2);
+
+    const out = await page.evaluate(async () => {
+      const chatLoop = await import('/src/ai/chatLoop.ts');
+      const settings = await import('/src/ai/settings.ts');
+      const toggles = settings.setToggles(settings.loadSettings(), {
+        provider: 'gemini', geminiModel: 'gemini-flash-latest',
+        autoResume: false, maxIterations: 'medium', vision: { views: false },
+      }).toggles;
+
+      let n = 0;
+      const origFetch = window.fetch;
+      // @ts-expect-error test stub
+      window.fetch = async (input: unknown, init?: RequestInit) => {
+        const url = String(input);
+        if (!url.includes('generativelanguage.googleapis.com')) return origFetch(input as RequestInfo, init);
+        n++;
+        return new Response('{"error":{"message":"still down"}}', { status: 503 }); // always transient
+      };
+
+      const ev = { errors: 0, reason: '' };
+      try {
+        await chatLoop.runTurn(
+          { apiKey: 'k', toggles, sessionId: 'transient-exhaust', history: [], userBlocks: [{ type: 'text', text: 'go' }] },
+          { onError: () => { ev.errors++; }, onTurnComplete: info => { ev.reason = info.reason; } },
+        );
+      } finally {
+        window.fetch = origFetch;
+      }
+      return { calls: n, ...ev };
+    });
+
+    expect(out.calls).toBe(3);       // 1 initial + maxTransientRetries(2) retries
+    expect(out.errors).toBe(1);      // then a single hard error
+    expect(out.reason).toBe('error');
+  });
+
+  test('a fatal 4xx (auth) is NOT retried — it fails fast', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEditorReady(page);
+    await fastBackoff(page, 4);
+
+    const out = await page.evaluate(async () => {
+      const chatLoop = await import('/src/ai/chatLoop.ts');
+      const settings = await import('/src/ai/settings.ts');
+      const toggles = settings.setToggles(settings.loadSettings(), {
+        provider: 'gemini', geminiModel: 'gemini-flash-latest',
+        autoResume: false, maxIterations: 'medium', vision: { views: false },
+      }).toggles;
+
+      let n = 0;
+      const origFetch = window.fetch;
+      // @ts-expect-error test stub
+      window.fetch = async (input: unknown, init?: RequestInit) => {
+        const url = String(input);
+        if (!url.includes('generativelanguage.googleapis.com')) return origFetch(input as RequestInfo, init);
+        n++;
+        return new Response('{"error":{"message":"invalid api key"}}', { status: 401 });
+      };
+
+      const ev = { errors: 0, reason: '' };
+      try {
+        await chatLoop.runTurn(
+          { apiKey: 'k', toggles, sessionId: 'fatal-4xx', history: [], userBlocks: [{ type: 'text', text: 'go' }] },
+          { onError: () => { ev.errors++; }, onTurnComplete: info => { ev.reason = info.reason; } },
+        );
+      } finally {
+        window.fetch = origFetch;
+      }
+      return { calls: n, ...ev };
+    });
+
+    expect(out.calls).toBe(1);       // no retries on a fatal auth error
+    expect(out.errors).toBe(1);
+    expect(out.reason).toBe('error');
+  });
+});

--- a/tests/unit/transientError.test.ts
+++ b/tests/unit/transientError.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { httpStatusOf, isTransientError } from '../../src/ai/transientError';
+
+describe('httpStatusOf', () => {
+  it('reads a numeric .status (Anthropic SDK APIError shape)', () => {
+    expect(httpStatusOf(Object.assign(new Error('overloaded'), { status: 529 }))).toBe(529);
+    expect(httpStatusOf({ status: 429 })).toBe(429);
+  });
+
+  it('parses the leading status token from raw-fetch provider errors', () => {
+    expect(httpStatusOf(new Error('OpenAI 500: internal error'))).toBe(500);
+    expect(httpStatusOf(new Error('Gemini 503: service unavailable'))).toBe(503);
+    expect(httpStatusOf(new Error('Custom 502: bad gateway'))).toBe(502);
+  });
+
+  it('returns null when there is no status', () => {
+    expect(httpStatusOf(new Error('Failed to fetch'))).toBeNull();
+    expect(httpStatusOf(new Error('something went wrong'))).toBeNull();
+    expect(httpStatusOf('a bare string')).toBeNull();
+  });
+});
+
+describe('isTransientError', () => {
+  it('treats 429 + 5xx as transient', () => {
+    expect(isTransientError(new Error('OpenAI 500: x'))).toBe(true);
+    expect(isTransientError(new Error('Gemini 503: x'))).toBe(true);
+    expect(isTransientError(new Error('OpenAI 429: rate limited'))).toBe(true);
+    expect(isTransientError(Object.assign(new Error('overloaded'), { status: 529 }))).toBe(true);
+    expect(isTransientError(new Error('Gemini 408: timeout'))).toBe(true);
+  });
+
+  it('treats 4xx auth/validation as fatal (not retried)', () => {
+    expect(isTransientError(new Error('OpenAI 401: invalid api key'))).toBe(false);
+    expect(isTransientError(new Error('OpenAI 400: bad request'))).toBe(false);
+    expect(isTransientError(new Error('Gemini 403: forbidden'))).toBe(false);
+    expect(isTransientError(new Error('OpenAI 404: model not found'))).toBe(false);
+  });
+
+  it('treats network / dropped-stream failures (no status) as transient', () => {
+    expect(isTransientError(new Error('Failed to fetch'))).toBe(true);
+    expect(isTransientError(new Error('NetworkError when attempting to fetch resource'))).toBe(true);
+    expect(isTransientError(new Error('The stream was interrupted'))).toBe(true);
+    expect(isTransientError(new Error('socket hang up'))).toBe(true);
+    expect(isTransientError(new Error('request timed out'))).toBe(true);
+  });
+
+  it('never retries a user/stop abort', () => {
+    expect(isTransientError(Object.assign(new Error('aborted'), { name: 'AbortError' }))).toBe(false);
+  });
+
+  it('treats a missing-key / config error as fatal', () => {
+    expect(isTransientError(new Error('OpenAI API key is required. Open AI Settings → OpenAI to connect one.'))).toBe(false);
+    expect(isTransientError(new Error('No model is active. Open AI settings and choose a provider + model.'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two related problems in the AI chat error/recovery path that the user hit when a mid-run **500** killed a long agentic turn and clicking **Retry** appeared to wipe the whole run.

### 1. Auto-continue now rides through transient provider errors
The chat loop's `catch` around the `streamTurn` dispatch (`src/ai/chatLoop.ts`) used to fire `onError` and **`return` unconditionally** — `autoResume` was never consulted there, and there was **no** retry/backoff. Since every hosted provider `throw`s on a non-2xx (`OpenAI 500: …`, `Gemini 503: …`, Anthropic SDK `APIError`), a single transient blip tore the entire agent loop down. (The only pre-existing retry, `autoRetry`/`executeAllWithRetry`, is for *tool* execution, not API calls.)

Now the dispatch is wrapped in a bounded retry loop:
- A new pure module `src/ai/transientError.ts` classifies errors. **Transient** (retried): 408/409/425/429, all 5xx (incl. Anthropic's 529 "overloaded"), and network / dropped-stream failures. **Fatal** (fails fast): 4xx auth/validation, missing key, user abort.
- Transient failures back off (exponential + full jitter, cancellable via the abort signal) and re-issue the **same** request — **without** consuming the agent's per-turn iteration budget.
- Only a fatal error or exhausting `maxTransientRetries` surfaces `onError` and ends the turn.
- New tunable knobs in `appConfig.ts` (`maxTransientRetries`=4, `transientRetryBaseMs`=1000, `transientRetryMaxMs`=16000) + advanced-settings fields. Read via `getConfig()` directly in `chatLoop`, matching the sibling `maxConsecutiveAutoResumes` knob (so the default applies inside the agent Worker).

### 2. "Retry" resumes in place instead of replaying the seed prompt
`retryLastUserMessage` walked back to the last *text-bearing* user message — which in a 30-step run is the **original prompt** (intermediate user turns are tool-results with no text block) — and re-sent it via `sendMessage`, stacking a duplicate task request on top of all completed work. That confused the model and made the run look wiped.

`retryFailedTurn` (renamed) now mirrors the amber **"Keep going"** resume: it drops only the in-memory error bubble and re-issues the turn with **empty** `userBlocks` against the existing persisted history, so the model continues from its last tool results. No `sendMessage`, no history reload, no clear — completed work stays intact. Button relabeled **"↻ Retry"** with a clarifying tooltip.

## Test plan
- `tests/unit/transientError.test.ts` — classifier (status parsing, 5xx/429 transient, 4xx fatal, network transient, abort never retried).
- `tests/ai-transient-retry.spec.ts` — loop behavior with a stubbed Gemini transport: 5xx-then-success retries & completes; persistent 503 exhausts the bound then errors; 401 fails fast (no retry).
- Manual browser check (agent Worker path): AI Call Log shows `transient, retrying 3/4`, `4/4`, then `gave up after 4 transient retries`; the error bubble keeps the prior message visible with the new Retry button.
- `npm run build`, `npm run test:unit` (726), `lint:deps`/`lint:deadcode`, and the `ai-autoresume` + `ai-call-log` e2e specs all green.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgPphttaRZaJUy3patmnfu)_