### PR TITLE
feat: make AI voice-input mic button larger and more noticeable

### DIFF
--- a/prompts/20260607-voice-mic-icon-larger.md
+++ b/prompts/20260607-voice-mic-icon-larger.md
@@ -1,0 +1,32 @@
+---
+date: 2026-06-07
+branch: claude/voice-mic-icon-larger
+files_changed:
+  - src/ui/aiPanel.ts
+---
+
+## Human
+
+The merged voice-input microphone icon should be larger / more noticeable.
+Make a new PR with that change.
+
+## Assistant
+
+Follow-up to the merged voice-input feature (#471). The mic button originally
+shared the `text-[11px]` glyph size of the neighbouring Show AI / 📎 buttons,
+which made it blend in.
+
+To make it stand out:
+
+- Bumped the glyph from `text-[11px]` to `text-lg` (with `leading-none` so the
+  larger emoji doesn't inflate the row height) and nudged horizontal padding to
+  `px-2.5`.
+- Gave the idle state a blue accent — `text-blue-300` with a
+  `border-blue-500/40` border that brightens to `border-blue-500` on hover — so
+  it reads as the distinct "voice" affordance rather than another grey utility
+  button. The active (listening) state keeps its red `animate-pulse` treatment,
+  just at the new larger size.
+
+Verified in the browser with a throwaway screenshot spec (mic visibly larger and
+blue-accented next to the other buttons) and re-ran the existing
+`ai-voice-input` e2e spec to confirm the wiring still passes.

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -889,8 +889,8 @@ function buildDrawer(): void {
   if (isVoiceInputSupported()) {
     const micBtn = document.createElement('button');
     micBtn.id = 'btn-ai-mic';
-    const micIdleClass = 'shrink-0 px-2 py-1 rounded text-[11px] text-zinc-300 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700';
-    const micActiveClass = 'shrink-0 px-2 py-1 rounded text-[11px] text-white bg-red-600 hover:bg-red-500 border border-red-500 animate-pulse';
+    const micIdleClass = 'shrink-0 px-2.5 py-1 rounded text-lg leading-none text-blue-300 bg-zinc-800 hover:bg-zinc-700 border border-blue-500/40 hover:border-blue-500';
+    const micActiveClass = 'shrink-0 px-2.5 py-1 rounded text-lg leading-none text-white bg-red-600 hover:bg-red-500 border border-red-500 animate-pulse';
     micBtn.className = micIdleClass;
     micBtn.textContent = '🎤';
     micBtn.title = 'Dictate your message (voice to text). Click again to stop.';


### PR DESCRIPTION
## Summary

Follow-up to #471 (merged): the voice-input microphone button shared the small `text-[11px]` glyph size of its neighbours and blended in. This makes it larger and more noticeable.

- Glyph bumped from `text-[11px]` → `text-lg` (with `leading-none` so it doesn't inflate the row height), padding nudged to `px-2.5`.
- Idle state gets a blue accent (`text-blue-300` + `border-blue-500/40`, brightening on hover) so it reads as the distinct "voice" affordance rather than another grey utility button.
- The active/listening state keeps its red `animate-pulse` treatment, just at the new larger size.

## Test plan

- `npm run build` ✅ (type-check)
- `npx playwright test ai-voice-input` ✅ (2 passed — existing golden-path spec still green)
- Manually screenshotted the input row: mic is visibly larger and blue-accented next to the Show AI / 📎 buttons.

https://claude.ai/code/session_012ymHzJopFi6hs88gC3rBQm

---
_Generated by [Claude Code](https://claude.ai/code/session_012ymHzJopFi6hs88gC3rBQm)_