### PR TITLE
feat: preserve camera on AI re-renders and persist the view per session

### DIFF
--- a/prompts/20260607-172423-persist-view-and-ai-camera.md
+++ b/prompts/20260607-172423-persist-view-and-ai-camera.md
@@ -1,0 +1,64 @@
+---
+session: "fvIqe7"
+timestamp: "2026-06-07T17:24:23Z"
+model: claude-opus-4-8
+tools: [explore, playwright]
+sequence: 4
+---
+
+## Human
+
+(Follow-up to the camera-persistence feature.) Asked which other cases would
+benefit. Agreed on two clear wins and asked for a new PR:
+1. In-app AI chat re-renders should preserve the camera (they auto-frame today
+   because they route through partwright.run/runAndSave → runCodeSync directly).
+2. Persist the working-view angle per session so it survives reload / reopen
+   (today it's in-memory only).
+
+## Assistant
+
+## Key decisions
+
+### Task 1 — AI re-renders preserve the camera
+The AI tools call `window.partwright.run`/`runAndSave`, the *same* methods a
+console user (and the e2e tests) call — and those must keep auto-framing
+(`viewport-reset-view.spec.ts` relies on `pw.run(CUBE)` framing). So I added an
+optional, backward-compatible `opts: { preserveCamera?: boolean }` to `run` and
+`runAndSave`; the AI tool dispatcher (`src/ai/tools.ts`) passes
+`{ preserveCamera: true }`, bare console calls omit it and auto-frame as before.
+`forkVersion` (a version-creation op) also now preserves. The same-session gate
+(`captureCameraToPreserve`) still auto-frames a fresh run, so passing the flag is
+safe even on a first render.
+
+### Task 2 — persist the working-view camera per session
+Modeled on the existing `session.thumbCamera`:
+- Added `session.workCamera: { position, target }` (world-space pose) to the
+  Session schema (db.ts), `updateSession`'s Pick union, the export payload, and
+  the import-restore path; bumped `SCHEMA_VERSION` 1.12 → 1.13 (additive nullable
+  field, no IndexedDB `DB_VERSION` bump needed).
+- `setSessionWorkCamera()` + `asWorkCamera()` validator in sessionManager.ts,
+  with the same `isViewerTab()` guard as thumbCamera (a read-only viewer must not
+  write the shared row).
+- New `onOrbitEnd()` hook in viewport.ts (fires on the OrbitControls 'end'
+  gesture; programmatic moves drive 'change', not 'end', so auto-frames/restores
+  never write back). main.ts debounces a save on it
+  (`ui.workCameraSaveDebounceMs`, default 500, wired into appConfig + advanced
+  settings per the no-magic-numbers rule).
+- Restore: extended `captureCameraToPreserve` so the *first* framing of a session
+  returns its saved `workCamera` (else null → auto-frame). All session-open
+  render paths now pass `preserveCamera: true` (console `openSession`,
+  import-session open) so the restore fires; UI open already did via
+  `loadVersionIntoEditor`.
+
+**Subtlety found via testing**: the orbit-end save originally snapshotted the
+pose *at gesture release*, while OrbitControls damping was still gliding — so the
+persisted angle was where you "let go," not where it settled. Moved the
+`getCameraPose()` read *into* the debounced callback so it captures the rested
+pose; reload now matches what the user sees (verified: distance exact, angle
+within ~2°).
+
+**Verification**: extended `tests/viewport-camera-persistence.spec.ts` with two
+cases — AI-path runAndSave preserves while bare console runAndSave auto-frames;
+and the orbited view survives a full page reload. Confirmed visually with
+before/after reload screenshots. Re-ran session/import/version/thumbnail/
+reset-view specs (17) — all green. build + unit (718) + lint:deps (acyclic) clean.

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1811,9 +1811,11 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
     case 'setCode':
       return api.setCode(input.code as string);
     case 'runCode':
-      return api.run(input.code as string | undefined);
+      // preserveCamera: an AI re-render keeps the user's current orbit/zoom
+      // instead of snapping back to the default framing every turn.
+      return api.run(input.code as string | undefined, { preserveCamera: true });
     case 'runAndSave':
-      return api.runAndSave(input.code as string, input.label as string | undefined, input.assertions as Record<string, unknown> | undefined);
+      return api.runAndSave(input.code as string, input.label as string | undefined, input.assertions as Record<string, unknown> | undefined, { preserveCamera: true });
     case 'getParams':
       return api.getParams();
     case 'setParams':

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -145,6 +145,10 @@ export interface AppConfig {
      *  draft is autosaved, so companion edits survive a reload without writing
      *  to IndexedDB on every keystroke. */
     companionDraftDebounceMs: number;
+    /** Debounce delay (ms) after the user finishes an orbit/zoom before the
+     *  interactive working-view camera is persisted to the session row, so a
+     *  burst of small adjustments coalesces into one IndexedDB write. */
+    workCameraSaveDebounceMs: number;
     /** Debounce delay (ms) for the surface-modifier live preview. */
     surfacePreviewDebounceMs: number;
     /** Debounce delay (ms) for the relief import 2D preview. */
@@ -247,6 +251,7 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     tooltipDelayMs: 150,
     codeEditorErrorIdleMs: 800,
     companionDraftDebounceMs: 600,
+    workCameraSaveDebounceMs: 500,
     surfacePreviewDebounceMs: 250,
     reliefPreviewDebounceMs: 120,
     reliefPreview3dDebounceMs: 250,

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { resolveParamValues, pruneParamValues, type ParamSpec, type ParamValue } from './geometry/params';
 import { createParamsPanel, type ParamsPanelController } from './ui/paramsPanel';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
-import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCameraPose, setCameraPose, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange, resetView } from './renderer/viewport';
+import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCameraPose, setCameraPose, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange, resetView, onOrbitEnd } from './renderer/viewport';
 // Side-effect import: registers the phantom/annotation/session-plane viewport
 // hooks. Must load before initViewport runs (below). See viewportSubsystems.ts.
 import './renderer/viewportSubsystems';
@@ -218,6 +218,7 @@ import {
   reorderParts,
   getState,
   setSessionThumbCamera,
+  setSessionWorkCamera,
   getSessionUrl,
   getGalleryUrl,
   exportSession,
@@ -420,17 +421,22 @@ let currentMeshData: MeshData | null = null;
  *  render of a freshly-opened session (let the camera auto-frame the new model). */
 let lastFramedSessionId: string | null = null;
 type CameraPose = { position: [number, number, number]; target: [number, number, number] };
-/** Snapshot the live camera pose to restore after a re-render, but only when the
- *  active session's geometry is already on screen — i.e. the impending render is
- *  a version switch or re-run within the session, where the user's interactive
- *  angle/zoom should be kept instead of snapping back to the default 3/4 framing.
- *  Returns null for the first render of a freshly-opened session (let it
+/** Pose to apply after a render so the camera lands where the user expects
+ *  rather than at the default 3/4 framing. Two cases:
+ *   • Re-render within an already-framed session (version switch, re-run, AI
+ *     edit) → keep the live angle (snapshot it now).
+ *   • First framing of a session that has a persisted working-view camera →
+ *     restore that saved pose, so the angle survives reload / reopen.
+ *  Returns null for the first framing of a session with no saved view (let it
  *  auto-frame). Restore with `if (pose) setCameraPose(pose)` after the render. */
 function captureCameraToPreserve(): CameraPose | null {
   const sid = getState().session?.id ?? null;
-  return currentMeshData !== null && sid !== null && sid === lastFramedSessionId
-    ? getCameraPose()
-    : null;
+  if (sid === null) return null;
+  if (currentMeshData !== null && sid === lastFramedSessionId) {
+    return getCameraPose();
+  }
+  const saved = getState().session?.workCamera;
+  return saved ? { position: [...saved.position], target: [...saved.target] } : null;
 }
 /** WASM heap high-water (bytes) reported by the geometry Worker for the most
  *  recent manifold-js run. Surfaced in the geometry-data stats and engine-error
@@ -5433,6 +5439,25 @@ async function main() {
   // Init viewport
   initViewport(viewportPane);
 
+  // Persist the interactive working-view camera per session so the angle/zoom
+  // survives reload and reopening (restored on open via captureCameraToPreserve).
+  // Debounced on the orbit-end gesture; only when a model is shown for the active
+  // session. Programmatic camera moves don't fire 'end', so auto-frames and
+  // restores never write back.
+  let _workCameraSaveTimer: number | undefined;
+  onOrbitEnd(() => {
+    if (_workCameraSaveTimer !== undefined) clearTimeout(_workCameraSaveTimer);
+    // Snapshot inside the debounced callback, not here: 'end' fires at gesture
+    // release while OrbitControls damping is still gliding, so reading the pose
+    // now would persist a pre-settle angle. By the time the debounce elapses the
+    // camera has come to rest, so the saved view matches what the user sees.
+    _workCameraSaveTimer = window.setTimeout(() => {
+      _workCameraSaveTimer = undefined;
+      if (currentMeshData === null || !getState().session) return;
+      void setSessionWorkCamera(getCameraPose());
+    }, getConfig().ui.workCameraSaveDebounceMs);
+  });
+
   // Indeterminate progress bar shown over the viewport while WASM loads on
   // first editor open. Hidden by ensureEngineStarted's finally block.
   {
@@ -7445,11 +7470,14 @@ async function main() {
       } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
     },
     /** Run code string and update all views. Returns geometry data object. */
-    async run(code?: string): Promise<Record<string, unknown>> {
+    async run(code?: string, opts?: { preserveCamera?: boolean }): Promise<Record<string, unknown>> {
       assertString(code, 'run(code)', { optional: true, allowEmpty: false });
       const src = code ?? getValue();
       if (code !== undefined) setValue(code);
-      const applied = await runCodeSync(src);
+      // The in-app AI passes preserveCamera so iterating on a model doesn't snap
+      // the user's orbit back to default every turn; bare console callers omit it
+      // and keep auto-framing (the same-session gate still frames a fresh run).
+      const applied = await runCodeSync(src, { preserveCamera: opts?.preserveCamera === true });
       if (!applied) {
         return { status: 'error', error: 'Run was superseded by a concurrent execution — retry' };
       }
@@ -8566,7 +8594,7 @@ async function main() {
           await switchLanguage(lang);
         }
         setValue(version.code);
-        await runCodeSync(version.code);
+        await runCodeSync(version.code, { preserveCamera: true });
       }
       // Restore images from session
       const sessionImages = await getImagesFromSession();
@@ -8796,7 +8824,7 @@ async function main() {
      *  Optional assertions — if provided, validates after running. Saves only if assertions pass.
      *  The editor and viewport always update to reflect the new code (including on assertion failure),
      *  so the model can inspect the failing geometry. The version is NOT saved on failure. */
-    async runAndSave(code: string, label?: string, assertions?: GeometryAssertions) {
+    async runAndSave(code: string, label?: string, assertions?: GeometryAssertions, opts?: { preserveCamera?: boolean }) {
       const check = guard(() => {
         assertString(code, 'runAndSave(code)', { allowEmpty: false });
         assertString(label, 'runAndSave(label)', { optional: true });
@@ -8810,8 +8838,10 @@ async function main() {
       // Single execution — run the code, update editor + viewport, read geometry.
       // Assertions are checked against the live result rather than a separate
       // isolation run. This halves execution time for assertion-guarded saves.
+      // preserveCamera (set by the AI tool path) keeps the user's orbit across
+      // AI iterations; bare console callers omit it and auto-frame.
       setValue(code);
-      const applied = await runCodeSync(code);
+      const applied = await runCodeSync(code, { preserveCamera: opts?.preserveCamera === true });
       if (!applied) {
         return { passed: false, failures: ['Run was superseded by a concurrent execution — retry'], geometry: null, version: null, diff: null, galleryUrl: getGalleryUrl() };
       }
@@ -8930,7 +8960,7 @@ async function main() {
       const prevGeoData = getState().currentVersion?.geometryData as Record<string, unknown> | null;
       const parentColors = carryColors ? versionColorRegions(parent) : [];
       setValue(newCode);
-      const forkApplied = await runCodeSync(newCode);
+      const forkApplied = await runCodeSync(newCode, { preserveCamera: true });
       if (!forkApplied) {
         return { error: 'Run was superseded by a concurrent execution — retry' };
       }
@@ -9172,7 +9202,7 @@ async function main() {
       const version = await openSession(session.id);
       if (version) {
         setValue(version.code);
-        await runCodeSync(version.code);
+        await runCodeSync(version.code, { preserveCamera: true });
       }
       // Restore images from imported session
       const sessionImages = await getImagesFromSession();

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -55,6 +55,13 @@ export function setOnContextRestored(fn: () => void): void { onContextRestored =
 let needsRender = true;
 let lastPointerActivity = 0;
 
+// Subscribers notified when the user finishes an orbit/pan/zoom gesture (the
+// OrbitControls 'end' event). Used to debounce-persist the working-view camera.
+// Programmatic camera moves (setCameraPose, frameModel) drive 'change', not
+// 'end', so they never trigger these.
+const orbitEndListeners: Array<() => void> = [];
+export function onOrbitEnd(cb: () => void): void { orbitEndListeners.push(cb); }
+
 // === Adaptive resolution ===
 // Full (capped) device pixel ratio when the camera is still; a reduced ratio
 // while actively orbiting/panning/zooming, where the lower fragment count keeps
@@ -181,6 +188,7 @@ export function initViewport(container: HTMLElement): {
     interacting = false;
     applyRenderScale(1);
     needsRender = true;
+    orbitEndListeners.forEach(cb => cb());
   });
 
   // Any pointer activity anywhere in the viewport region may drive a scene

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -30,6 +30,13 @@ export interface Session {
    *  via `partwright.setThumbnailCamera({ azimuth, elevation })`; absent ⇒ the
    *  default iso view. Persisted so re-bakes and reloads reuse the angle. */
   thumbCamera?: { azimuth: number; elevation: number };
+  /** Persisted interactive working-view camera (world-space position + orbit
+   *  target). Unlike `thumbCamera` (which only steers thumbnail capture), this
+   *  records the angle/zoom the user last orbited the live viewport to, so it
+   *  survives reload / reopening the session instead of snapping back to the
+   *  default 3/4 framing. Written (debounced) when the user finishes an orbit;
+   *  restored on session open. Absent ⇒ auto-frame on open. */
+  workCamera?: { position: [number, number, number]; target: [number, number, number] };
 }
 
 /** A modeling target within a session. A session holds one or more parts; each
@@ -593,7 +600,7 @@ export function legacyImagesObjectToArray(obj: LegacyImagesObject): AttachedImag
   return result;
 }
 
-export async function updateSession(id: string, updates: Partial<Pick<Session, 'name' | 'created' | 'updated' | 'images' | 'language' | 'currentPartId' | 'aiPreference' | 'thumbCamera'>>): Promise<void> {
+export async function updateSession(id: string, updates: Partial<Pick<Session, 'name' | 'created' | 'updated' | 'images' | 'language' | 'currentPartId' | 'aiPreference' | 'thumbCamera' | 'workCamera'>>): Promise<void> {
   const store = await tx('sessions', 'readwrite');
   // Read-modify-write inside one transaction: queue the put from the get's
   // callback (awaiting between them risks auto-commit), then await oncomplete.

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -141,8 +141,13 @@ import { effectiveVersionLanguage, asLanguage } from './languageFallback';
  *           `{ azimuth, elevation }` in degrees; when present, captured
  *           thumbnails render from this angle instead of the default iso view.
  *           Absent ⇒ the default iso 3/4 view. Older readers ignore the field.
+ *  - `1.13` — session-level interactive working-view camera (`session.workCamera`).
+ *           `{ position, target }` world-space vectors recording the angle/zoom
+ *           the user last orbited the live viewport to, restored on session open
+ *           so the view survives reload. Absent ⇒ auto-frame. Older readers
+ *           ignore the field.
  */
-export const SCHEMA_VERSION = '1.12';
+export const SCHEMA_VERSION = '1.13';
 
 const CURRENT_MAJOR = 1;
 
@@ -164,7 +169,7 @@ export interface ExportedSession {
   mainifold?: string;
   /** Images may be the array form or the legacy object map ({front, right, ...}).
    * Both also exist under `referenceImages` for pre-rename exports. */
-  session: { name: string; created: number; updated: number; images?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; referenceImages?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; language?: 'manifold-js' | 'scad' | 'replicad' | 'voxel'; thumbCamera?: { azimuth: number; elevation: number } };
+  session: { name: string; created: number; updated: number; images?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; referenceImages?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; language?: 'manifold-js' | 'scad' | 'replicad' | 'voxel'; thumbCamera?: { azimuth: number; elevation: number }; workCamera?: { position: [number, number, number]; target: [number, number, number] } };
   /**
    * The session's parts, ordered by `order`. Present from schema 1.7. Pre-1.7
    * files omit this; on import they collapse into a single default part.
@@ -681,6 +686,38 @@ export async function setSessionThumbCamera(camera: { azimuth: number; elevation
   await dbUpdateSession(id, { thumbCamera: next });
   if (currentState.session?.id === id) {
     currentState.session = { ...currentState.session, thumbCamera: next };
+  }
+}
+
+// === Per-session working-view camera ===
+
+/** Coerce an untrusted value into a valid working-view camera pose (world-space
+ *  position + orbit target, each a finite [x, y, z]), or null. */
+function asWorkCamera(v: unknown): { position: [number, number, number]; target: [number, number, number] } | null {
+  if (!v || typeof v !== 'object') return null;
+  const { position, target } = v as { position?: unknown; target?: unknown };
+  const vec = (a: unknown): [number, number, number] | null =>
+    Array.isArray(a) && a.length === 3 && a.every(n => typeof n === 'number' && Number.isFinite(n))
+      ? [a[0], a[1], a[2]]
+      : null;
+  const p = vec(position);
+  const t = vec(target);
+  return p && t ? { position: p, target: t } : null;
+}
+
+/** Persist (or clear, with `null`) the interactive working-view camera for the
+ *  current session, so the angle/zoom survives reload and reopening. Mirrors
+ *  `setSessionThumbCamera`: no-op when nothing is open or in a viewer tab (a
+ *  read-only viewer must not mutate the shared session row, and its viewport
+ *  angle isn't the owner's). */
+export async function setSessionWorkCamera(camera: { position: [number, number, number]; target: [number, number, number] } | null): Promise<void> {
+  if (!currentState.session) return;
+  if (isViewerTab()) return;
+  const next = camera ? asWorkCamera(camera) ?? undefined : undefined;
+  const id = currentState.session.id;
+  await dbUpdateSession(id, { workCamera: next });
+  if (currentState.session?.id === id) {
+    currentState.session = { ...currentState.session, workCamera: next };
   }
 }
 
@@ -1635,7 +1672,7 @@ export async function exportSession(
 
   return {
     partwright: SCHEMA_VERSION,
-    session: { name: session.name, created: session.created, updated: session.updated, images: session.images ?? null, ...(session.language ? { language: session.language } : {}), ...(session.thumbCamera ? { thumbCamera: session.thumbCamera } : {}) },
+    session: { name: session.name, created: session.created, updated: session.updated, images: session.images ?? null, ...(session.language ? { language: session.language } : {}), ...(session.thumbCamera ? { thumbCamera: session.thumbCamera } : {}), ...(session.workCamera ? { workCamera: session.workCamera } : {}) },
     parts: parts.map(p => ({ name: p.name, order: p.order })),
     versions: flat.map(({ v, partOrder }, i) => {
       const colorRegions = opts.includeColorRegions ? extractColorRegions(v.geometryData) : undefined;
@@ -1713,6 +1750,11 @@ export async function importSession(
   // are finite numbers so a malformed export can't poison captureThumbnail.
   const cam = asThumbCamera(data.session.thumbCamera);
   if (cam) await dbUpdateSession(session.id, { thumbCamera: cam });
+
+  // Restore the interactive working-view camera (schema 1.13+). Validated so a
+  // malformed export can't feed a bad pose to setCameraPose on open.
+  const workCam = asWorkCamera(data.session.workCamera);
+  if (workCam) await dbUpdateSession(session.id, { workCamera: workCam });
 
   // Determine the index of the latest exported version. Schema 1.2 stored
   // annotations at the top level; for back-compat we attach them to whichever

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -732,6 +732,15 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           onChange={v => set('ui', 'companionDraftDebounceMs', v)}
         />
         <Field
+          label="Working-view camera save debounce"
+          unit="ms"
+          tooltip="After you finish orbiting or zooming the 3D viewport, the app waits this long before saving the camera angle to the session so it's restored on reload. Coalesces a burst of adjustments into one write. Lower it to capture the angle sooner; raise it to write less often."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.workCameraSaveDebounceMs}
+          value={c.ui.workCameraSaveDebounceMs}
+          min={0} max={5_000} integer
+          onChange={v => set('ui', 'workCameraSaveDebounceMs', v)}
+        />
+        <Field
           label="Surface preview debounce"
           unit="ms"
           tooltip="When adjusting parameters in the surface-modifier panel (texture, fuzzy, etc.), this debounce delays the preview render until you've stopped changing values for this long. Lower it for more responsive live preview; raise it if previewing is slow on your machine."

--- a/tests/chat-export.spec.ts
+++ b/tests/chat-export.spec.ts
@@ -106,7 +106,7 @@ test.describe('Chat export', () => {
         chat?: { id?: string; sessionId?: string; blocks: { type: string; text?: string }[] }[];
       };
     }, id);
-    expect(exported.partwright).toBe('1.12'); // tracks SCHEMA_VERSION (bumped to 1.12 for thumbCamera)
+    expect(exported.partwright).toBe('1.13'); // tracks SCHEMA_VERSION (bumped to 1.13 for workCamera)
     expect(exported.chat?.length).toBe(3);
     expect(exported.chat?.[0].blocks[0].text).toBe('Design a widget bracket');
     expect(exported.chat?.[0].id).toBeUndefined();

--- a/tests/viewport-camera-persistence.spec.ts
+++ b/tests/viewport-camera-persistence.spec.ts
@@ -1,17 +1,20 @@
-// Golden-path tests for interactive camera-angle persistence across version
-// switches within a session. Switching versions re-renders the geometry; that
-// re-render used to auto-frame the camera back to the default 3/4 view, throwing
-// away whatever angle/zoom the user had orbited to. The fix snapshots the live
-// camera pose and restores it after the new geometry is in — but only within the
-// same session (the first render of a freshly-opened session still auto-frames).
+// Golden-path tests for interactive camera-angle persistence. Re-rendering used
+// to auto-frame the camera back to the default 3/4 view, throwing away whatever
+// angle/zoom the user had orbited to. Coverage here:
+//   • version switches and live code edits keep the angle (same-session gate)
+//   • a freshly-opened session still auto-frames
+//   • the in-app AI path (runAndSave with preserveCamera) keeps the angle, while
+//     a bare console runAndSave still auto-frames
+//   • the orbited view is persisted per-session and restored on reload
 //
-// See src/main.ts captureCameraToPreserve / setCameraPose (src/renderer/viewport.ts).
+// See src/main.ts captureCameraToPreserve / setCameraPose (src/renderer/viewport.ts)
+// and session.workCamera (src/storage + setSessionWorkCamera).
 
 import { test, expect, type Page } from 'playwright/test';
 
 type PW = {
   run: (code: string) => Promise<unknown>;
-  runAndSave: (code: string, label?: string) => Promise<unknown>;
+  runAndSave: (code: string, label?: string, assertions?: unknown, opts?: { preserveCamera?: boolean }) => Promise<unknown>;
   listVersions: () => Promise<Array<{ index: number; id: string }>>;
   loadVersion: (t: { index?: number; id?: string }) => Promise<unknown>;
   getViewState: () => { camera: { azimuth: number; elevation: number; distance: number; target: [number, number, number] } };
@@ -132,5 +135,67 @@ test.describe('viewport camera persistence', () => {
     // did not carry over the orbited angle.
     expect(Math.abs(fresh.azimuth - orbited.azimuth)).toBeGreaterThan(5);
     expect(Math.abs(fresh.elevation - 35)).toBeLessThan(5);
+  });
+
+  // The in-app AI re-renders via runAndSave with { preserveCamera: true } (set by
+  // the tool dispatcher) so iterating on a model keeps the user's orbit; a bare
+  // console runAndSave (no opts) still auto-frames.
+  test('AI-path runAndSave preserves the camera; bare console runAndSave auto-frames', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+    await page.evaluate(async () => {
+      await (window as unknown as { partwright: PW }).partwright.run('const { Manifold } = api; return Manifold.cube([12, 12, 12], true);');
+    });
+    await page.waitForTimeout(700);
+    await orbitAndZoom(page);
+    await page.waitForTimeout(800); // let damping settle before sampling
+    const before = await camera(page);
+    expect(Math.abs(before.azimuth - 45) > 5 || Math.abs(before.elevation - 35) > 5).toBe(true);
+
+    // AI path: preserveCamera keeps the angle across the re-render.
+    await page.evaluate(async () => {
+      await (window as unknown as { partwright: PW }).partwright.runAndSave('const { Manifold } = api; return Manifold.cube([6, 6, 6], true);', 'ai-edit', undefined, { preserveCamera: true });
+    });
+    await page.waitForTimeout(700);
+    const afterAI = await camera(page);
+    expect(Math.abs(afterAI.azimuth - before.azimuth)).toBeLessThan(2);
+    expect(Math.abs(afterAI.distance - before.distance)).toBeLessThan(2);
+
+    // Bare console runAndSave (no opts) auto-frames back to the default ~45/35.
+    await page.evaluate(async () => {
+      await (window as unknown as { partwright: PW }).partwright.runAndSave('const { Manifold } = api; return Manifold.cube([20, 20, 20], true);', 'console-edit');
+    });
+    await page.waitForTimeout(700);
+    const afterBare = await camera(page);
+    expect(Math.abs(afterBare.azimuth - 45)).toBeLessThan(5);
+    expect(Math.abs(afterBare.elevation - 35)).toBeLessThan(5);
+  });
+
+  // The orbited view is persisted per-session and restored on reload, instead of
+  // snapping back to the default framing.
+  test('persists the working-view camera across a reload', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+    await page.evaluate(async () => {
+      await (window as unknown as { partwright: PW }).partwright.runAndSave('const { Manifold } = api; return Manifold.cube([12, 12, 12], true);', 'box');
+    });
+    await page.waitForTimeout(700);
+    await orbitAndZoom(page);
+    // Wait past the workCamera save debounce + IDB write, then sample the settled
+    // pose (which is what got persisted).
+    await page.waitForTimeout(1600);
+    const before = await camera(page);
+    expect(Math.abs(before.azimuth - 45) > 5 || Math.abs(before.elevation - 35) > 5).toBe(true);
+    const url = page.url();
+    expect(url).toContain('session=');
+
+    // Reload the same session URL — fresh page, IndexedDB persists.
+    await page.goto(url);
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+    await page.waitForTimeout(2500); // WASM + first render + workCamera restore
+    const after = await camera(page);
+    expect(Math.abs(after.azimuth - before.azimuth)).toBeLessThan(3);
+    expect(Math.abs(after.elevation - before.elevation)).toBeLessThan(3);
+    expect(Math.abs(after.distance - before.distance)).toBeLessThan(3);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the [camera-angle-persistence work](https://github.com/kemper/mainifold/pull/472) — extends it to the two cases that were still resetting the view:

### 1. In-app AI chat re-renders preserve the camera
When the AI iterates on a model (`runAndSave`/`run`/`forkVersion`), it no longer snaps your orbit/zoom back to the default 3/4 framing each turn. The AI tool dispatcher passes a new **optional, backward-compatible** `preserveCamera` flag to `partwright.run`/`runAndSave`; **bare console calls (and the e2e tests) omit it and keep auto-framing**, so direct console use and `pw.run(...)`-based test setup are unchanged. The same-session gate still auto-frames a fresh run.

### 2. The working-view angle is persisted per session
The angle/zoom you orbit to now **survives a page reload and reopening the session** instead of resetting. Modeled on the existing `session.thumbCamera`:
- New `session.workCamera` (world-space `{ position, target }`), schema `1.12 → 1.13` (additive nullable field — no IndexedDB `DB_VERSION` bump).
- Saved **debounced on the orbit-end gesture**, captured *after* OrbitControls damping settles (so it records where the view rests, not where you released).
- Restored on session open via `captureCameraToPreserve` (first framing of a session returns its saved pose, else auto-frames).
- Round-trips through session export/import; `isViewerTab()` write guard (a read-only viewer never mutates the shared row); configurable save debounce (`ui.workCameraSaveDebounceMs`, default 500ms, exposed in Advanced Settings).

### What changed
- `src/main.ts` — `preserveCamera` opt on `partwright.run`/`runAndSave`; `forkVersion` + session-open paths preserve; `captureCameraToPreserve` extended to restore `session.workCamera` on first framing; debounced orbit-end save wired via `onOrbitEnd`.
- `src/ai/tools.ts` — AI dispatch passes `{ preserveCamera: true }` for `runCode`/`runAndSave`.
- `src/renderer/viewport.ts` — new `onOrbitEnd()` hook (OrbitControls 'end').
- `src/storage/db.ts` + `src/storage/sessionManager.ts` — `workCamera` field, `setSessionWorkCamera()` + `asWorkCamera()` validator, schema bump, export/import.
- `src/config/appConfig.ts` + `src/ui/advancedSettingsModal.tsx` — `workCameraSaveDebounceMs` knob.

### Scope / safety
- Programmatic console `pw.run`/`runAndSave` and the import thumbnail-capture loop keep auto-framing.
- A fresh session with no saved view still auto-frames; **Reset View** remains the explicit re-frame.
- No `DB_VERSION` change; old sessions (no `workCamera`) load and auto-frame normally.

## Test plan
- Extended `tests/viewport-camera-persistence.spec.ts` (now 5 cases): version switch, live code edit, fresh-session auto-frame, **AI-path preserve vs bare-console auto-frame**, **persistence across a full page reload**.
- Re-ran session / import / version / thumbnail / reset-view specs (17) — all green; the thumbnail "current ≈ iso" test confirms a fresh session still auto-frames.
- `npm run build` (tsc) + `npm run test:unit` (718) + `npm run lint:deps` (acyclic) clean.
- Manually verified in the browser with before/after reload screenshots — the orbited view is restored, distance exact.

https://claude.ai/code/session_01VqvJEGcQhXi7wvNg7qKcpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqvJEGcQhXi7wvNg7qKcpm)_