### PR TITLE
feat: keep voxel smoothing flat/blocky at the base for printability

### DIFF
--- a/prompts/20260607-181941-voxel-base-pinning.md
+++ b/prompts/20260607-181941-voxel-base-pinning.md
@@ -1,0 +1,63 @@
+---
+session: "1utra1"
+timestamp: "2026-06-07T18:00:00Z"
+model: claude-opus-4-8
+tools: [explore]
+---
+
+## Human
+
+Feedback from a modeling agent: voxel smoothing is "all-or-nothing", which is
+the biggest hurdle to print-safe voxel models. Three requests: (1) `flatBottom`
+/ `pinZMin` to keep the build-plate face flat, (2) masking / `excludeBox` to keep
+a custom base region blocky, (3) `pinNormals` to freeze faces by direction. The
+user's real goal: smooth voxel models with a solid non-smooth base; also open to
+alternate smoothing algorithms that leave the bottom layer flat. Think critically
+and report a plan rather than blindly implementing.
+
+User chose scope: all three (flatBottom + baseLayers + lockBox), flatBottom = Z-only pin.
+
+## Assistant
+
+## Key decisions
+
+**Unifying primitive: vertex pinning in the Taubin pass.** All three requests
+reduce to "which vertices don't move." Rather than three bespoke code paths, I
+added a per-vertex axis-freeze mask to `taubinSmooth` (`smooth.ts`) and derived
+it from the vertex positions — no changes to the mesher's topology or the grid
+encoding. The mesh is boundary-only with vertices at exact integer voxel
+corners, so a geometric `minZ` / band / box test identifies the pinned set
+exactly.
+
+**flatBottom = Z-only pin (Neumann/reflective boundary).** Freezes only Z on the
+minimum-Z plane: the build-plate face stays flat while sides/edges still round.
+This is the textbook "flat against a plane" smoothing boundary condition and
+matches the agent's literal request.
+
+**baseLayers + lockBox = full pin (Dirichlet boundary).** `baseLayers: N` freezes
+all axes for `z <= minZ + N`, keeping the bottom N voxel layers blocky as a solid
+pedestal — this is what the user actually described ("solid non-smooth base"),
+which is distinct from (and more print-stable than) flatBottom. `lockBox` does
+the same for an arbitrary voxel-coordinate box. A pinned region acts as a fixed
+boundary the smoothed part still relaxes toward, so the base↔body seam stays clean.
+
+**Declined `pinNormals` (agent option 3).** The only useful normal is straight-down,
+which `flatBottom` already covers more robustly; general normal-pinning needs
+per-vertex normal estimation on a welded blocky mesh (ambiguous at corners) for
+near-zero added value.
+
+**Coordinate handling.** Options are authored in grid (voxel) coordinates and
+stored on `Surfacing`; `meshGrid` resolves them to mesh space, scaling thresholds
+by `detail` (flatBottom is plane-relative and needs none) since smoothing runs on
+the supersampled grid before the `1/detail` rescale. `applyVoxelize` codegen left
+unchanged — agents reach the new options directly via `v.smooth({...})`.
+
+**Validation** follows the repo's strict contract: booleans/integers checked,
+unknown keys rejected, `lockBox` validated as two integer triples and normalized
+to sorted `{min,max}`.
+
+**Verification:** new pure-logic unit tests (`tests/unit/voxelSmooth.test.ts`)
+assert the pinned planes/bands/boxes stay exactly in place while the body still
+moves; a new real-WASM e2e (`voxel-engine.spec.ts`) proves each option still
+feeds `ofMesh` as a single watertight component. Browser screenshots confirmed a
+smooth sphere on a sharp pedestal and a plate-flat smoothed sphere.

--- a/public/ai/voxel.md
+++ b/public/ai/voxel.md
@@ -134,6 +134,36 @@ Smoothing only moves vertices — topology is unchanged — so per-voxel colors 
 preserved and the result stays a watertight manifold (exports/paint still work).
 Call `.blocky()` to switch back to hard faces (the default).
 
+### Keeping a flat / blocky base (printability)
+
+Plain `.smooth()` rounds the bottom too, so the model rocks on the build plate.
+Three options pin part of the model so it stays printable while the rest rounds:
+
+- **`flatBottom: true`** — pins the Z of the bottom-most plane. The build-plate
+  face stays perfectly flat; sides and edges still round. The cheap fix for
+  "it won't sit flat" — reach for this first.
+- **`baseLayers: N`** — keeps the bottom `N` voxel layers fully **blocky** (a
+  solid, sharp pedestal) while the body above smooths. Use when you want a
+  deliberate base/stand, or sharp first-layer walls for adhesion.
+- **`lockBox: [[x0,y0,z0],[x1,y1,z1]]`** — keeps the voxels in that inclusive
+  box (voxel coordinates, any corner order) blocky, for a custom base region
+  that isn't the whole bottom.
+
+```js
+// Smooth character on a perfectly flat bottom face:
+return voxels().sphere([0,0,6], 6, '#e7b').fillBox([-2,-2,0],[2,2,1],'#888')
+  .smooth({ iterations: 3, flatBottom: true });
+
+// Smooth body on a sharp 2-layer pedestal:
+return voxels().sphere([0,0,8], 6, '#6cf').fillBox([-7,-7,0],[7,7,2],'#444')
+  .smooth({ baseLayers: 2 });
+```
+
+All three combine with `iterations` / `detail`, and the pinned region acts as a
+fixed boundary the smoothed part still relaxes toward — so the seam between the
+blocky base and the rounded body stays clean. (`baseLayers` already covers the
+bottom plane, so it subsumes `flatBottom`.)
+
 **Smoothing wants features at least 2 voxels thick.** A `λ` pass pulls each
 vertex toward its neighbours, so smoothing a 1-voxel-thick wall or a
 `hollow(1)` shell can draw opposite faces together and self-intersect (the mesh

--- a/src/geometry/voxel/grid.ts
+++ b/src/geometry/voxel/grid.ts
@@ -7,7 +7,7 @@
 // unit-tested directly in the vitest tier and imported into the geometry
 // Worker without pulling in browser globals.
 
-import { assertNumber, assertNumberTuple, assertObject, assertEnum, assertNoUnknownKeys, ValidationError } from '../../validation/apiValidation';
+import { assertNumber, assertNumberTuple, assertObject, assertEnum, assertBoolean, assertArray, assertNoUnknownKeys, ValidationError } from '../../validation/apiValidation';
 
 export type Vec3 = [number, number, number];
 /** A color the sandbox API accepts: `[r,g,b]` 0–255, `'#rgb'`/`'#rrggbb'`, or a
@@ -72,8 +72,42 @@ export interface GridBounds { min: Vec3; max: Vec3 }
 /** How a grid is turned into a mesh. `blocks` = hard cube faces (default);
  *  `smooth` = Taubin-rounded edges (optionally over a `detail`× supersampled
  *  grid for finer rounding). Carried on the grid so the mesher/engine can read
- *  it off the returned value. */
-export interface Surfacing { mode: 'blocks' | 'smooth'; iterations: number; detail: number }
+ *  it off the returned value.
+ *
+ *  The optional `flatBottom` / `baseLayers` / `lockBox` fields make smoothing
+ *  selective so a model can keep a flat or blocky base for printing — see
+ *  `VoxelGrid.smooth`. They are in grid (voxel) coordinates; the mesher scales
+ *  them to the supersampled mesh when `detail > 1`. */
+export interface Surfacing {
+  mode: 'blocks' | 'smooth';
+  iterations: number;
+  detail: number;
+  /** Pin the Z of the bottom-most plane so the build-plate face stays flat. */
+  flatBottom?: boolean;
+  /** Keep the bottom N voxel layers fully blocky (a solid, sharp pedestal). */
+  baseLayers?: number;
+  /** Keep the voxels in this inclusive box (voxel coords) blocky. */
+  lockBox?: { min: Vec3; max: Vec3 };
+}
+
+/** Validate + normalize a `lockBox` argument (`[[x0,y0,z0],[x1,y1,z1]]`, in any
+ *  corner order) into a sorted `{ min, max }` of integer voxel coordinates. */
+function normalizeLockBox(val: unknown): { min: Vec3; max: Vec3 } {
+  const arr = assertArray(val, 'smooth.lockBox');
+  if (arr.length !== 2) {
+    throw new ValidationError(`smooth.lockBox must be two corners [[x0,y0,z0],[x1,y1,z1]], got length=${arr.length}. See /ai.md#argument-validation`);
+  }
+  const a = assertNumberTuple(arr[0], 3, 'smooth.lockBox[0]');
+  const b = assertNumberTuple(arr[1], 3, 'smooth.lockBox[1]');
+  for (let i = 0; i < 3; i++) {
+    if (!Number.isInteger(a[i])) throw new ValidationError(`smooth.lockBox[0][${i}] must be an integer voxel coordinate, got ${a[i]}. See /ai.md#argument-validation`);
+    if (!Number.isInteger(b[i])) throw new ValidationError(`smooth.lockBox[1][${i}] must be an integer voxel coordinate, got ${b[i]}. See /ai.md#argument-validation`);
+  }
+  return {
+    min: [Math.min(a[0], b[0]), Math.min(a[1], b[1]), Math.min(a[2], b[2])],
+    max: [Math.max(a[0], b[0]), Math.max(a[1], b[1]), Math.max(a[2], b[2])],
+  };
+}
 
 /** A mutable sparse voxel grid. Builder methods chain (`return this`). */
 export class VoxelGrid {
@@ -286,19 +320,34 @@ export class VoxelGrid {
   // ---- Surfacing (how the grid is meshed) -------------------------------
 
   /** Select rounded-edge surfacing. Accepts an iteration count or
-   *  `{ iterations, detail }`; more iterations = rounder, higher detail
-   *  (supersample factor) = finer rounding on coarse models. Chainable. */
-  smooth(opts: number | { iterations?: number; detail?: number } = {}): this {
+   *  `{ iterations, detail, flatBottom, baseLayers, lockBox }`; more iterations
+   *  = rounder, higher detail (supersample factor) = finer rounding on coarse
+   *  models. The base-pinning options keep part of the model from rounding so
+   *  it stays printable:
+   *    - `flatBottom` — pin the bottom plane's Z so the build-plate face stays
+   *      flat (edges/sides still round).
+   *    - `baseLayers` — keep the bottom N voxel layers fully blocky (a solid
+   *      pedestal under a smoothed body).
+   *    - `lockBox` — keep the voxels in `[[x0,y0,z0],[x1,y1,z1]]` (voxel coords)
+   *      blocky, for a custom base region.
+   *  Chainable. */
+  smooth(opts: number | { iterations?: number; detail?: number; flatBottom?: boolean; baseLayers?: number; lockBox?: [Vec3, Vec3] } = {}): this {
     let iterations = 2, detail = 1;
+    let flatBottom: boolean | undefined;
+    let baseLayers: number | undefined;
+    let lockBox: { min: Vec3; max: Vec3 } | undefined;
     if (typeof opts === 'number') {
       iterations = assertNumber(opts, 'smooth(iterations)', { integer: true, min: 1, max: 8 })!;
     } else {
       const o = assertObject(opts, 'smooth(opts)')!;
-      assertNoUnknownKeys(o, ['iterations', 'detail'], 'smooth(opts)');
+      assertNoUnknownKeys(o, ['iterations', 'detail', 'flatBottom', 'baseLayers', 'lockBox'], 'smooth(opts)');
       if (o.iterations !== undefined) iterations = assertNumber(o.iterations, 'smooth.iterations', { integer: true, min: 1, max: 8 })!;
       if (o.detail !== undefined) detail = assertNumber(o.detail, 'smooth.detail', { integer: true, min: 1, max: 4 })!;
+      if (o.flatBottom !== undefined) flatBottom = assertBoolean(o.flatBottom, 'smooth.flatBottom')!;
+      if (o.baseLayers !== undefined) baseLayers = assertNumber(o.baseLayers, 'smooth.baseLayers', { integer: true, min: 1, max: HALF })!;
+      if (o.lockBox !== undefined) lockBox = normalizeLockBox(o.lockBox);
     }
-    this._surfacing = { mode: 'smooth', iterations, detail };
+    this._surfacing = { mode: 'smooth', iterations, detail, flatBottom, baseLayers, lockBox };
     return this;
   }
 

--- a/src/geometry/voxel/mesher.ts
+++ b/src/geometry/voxel/mesher.ts
@@ -16,8 +16,8 @@
 // Pure logic (no DOM/WASM): unit-tested in the vitest tier.
 
 import type { MeshData } from '../types';
-import { VoxelGrid, colorComponents } from './grid';
-import { taubinSmooth, scaleMeshPositions } from './smooth';
+import { VoxelGrid, colorComponents, type Surfacing } from './grid';
+import { taubinSmooth, scaleMeshPositions, type SmoothPins } from './smooth';
 
 /** Per-triangle voxel coordinate provenance. `triVoxel` is `numTri * 3`,
  *  flattened (x, y, z, x, y, z, …), giving the integer coord of the voxel
@@ -116,11 +116,33 @@ export function gridToMeshData(grid: VoxelGrid): MeshData {
 export function meshGrid(grid: VoxelGrid): MeshData {
   const surf = grid.surfacing();
   if (surf.mode !== 'smooth') return gridToMeshData(grid);
-  const dense = surf.detail > 1 ? grid.supersample(surf.detail) : grid;
+  const detail = surf.detail;
+  const dense = detail > 1 ? grid.supersample(detail) : grid;
   let mesh = gridToMeshData(dense);
-  mesh = taubinSmooth(mesh, surf.iterations);
-  if (surf.detail > 1) scaleMeshPositions(mesh, 1 / surf.detail);
+  mesh = taubinSmooth(mesh, surf.iterations, resolveSmoothPins(surf, detail));
+  if (detail > 1) scaleMeshPositions(mesh, 1 / detail);
   return mesh;
+}
+
+/** Translate grid-space base-pinning options into mesh-space `SmoothPins`.
+ *  `gridToMeshData` runs on the (possibly supersampled) grid, so voxel-coord
+ *  thresholds scale by `detail`; `flatBottom` is plane-relative and needs none.
+ *  A voxel at index i spans corner range [i, i+1], so a lockBox over voxels
+ *  [min..max] covers corners [min, max+1]. Returns undefined when nothing is
+ *  pinned (the smoother then takes its plain fast path). */
+function resolveSmoothPins(surf: Surfacing, detail: number): SmoothPins | undefined {
+  if (!surf.flatBottom && surf.baseLayers === undefined && !surf.lockBox) return undefined;
+  const pins: SmoothPins = {};
+  if (surf.flatBottom) pins.flatBottom = true;
+  if (surf.baseLayers !== undefined) pins.baseBandZ = surf.baseLayers * detail;
+  if (surf.lockBox) {
+    const { min, max } = surf.lockBox;
+    pins.lockBox = {
+      min: [min[0] * detail, min[1] * detail, min[2] * detail],
+      max: [(max[0] + 1) * detail, (max[1] + 1) * detail, (max[2] + 1) * detail],
+    };
+  }
+  return pins;
 }
 
 /** Block-mesh a grid AND record which voxel each triangle came from. Voxel

--- a/src/geometry/voxel/smooth.ts
+++ b/src/geometry/voxel/smooth.ts
@@ -20,6 +20,55 @@ import type { MeshData } from '../types';
 const LAMBDA = 0.5;
 const MU = -0.53;
 
+// Per-vertex axis-freeze flags. A frozen axis keeps its initial coordinate
+// through every relaxation pass, so the smoother leaves that part of the mesh
+// in place. This is how a smoothed voxel model can keep a flat build-plate
+// face or a blocky base while everything else rounds.
+const FREEZE_X = 1, FREEZE_Y = 2, FREEZE_Z = 4;
+const FREEZE_ALL = FREEZE_X | FREEZE_Y | FREEZE_Z;
+
+/** Which vertices the smoother must hold in place, expressed in the SAME world
+ *  coordinates as the mesh being smoothed (i.e. supersampled space when
+ *  `detail > 1` — the caller scales these to match). All fields are optional;
+ *  an empty/absent spec smooths every vertex (the original behavior). */
+export interface SmoothPins {
+  /** Pin the Z coordinate of every vertex on the minimum-Z plane, so the
+   *  build-plate face stays flat while sides and edges still round. */
+  flatBottom?: boolean;
+  /** Fully pin (all axes) every vertex with `z <= minZ + baseBandZ`, keeping
+   *  the bottom band perfectly blocky as a solid pedestal. */
+  baseBandZ?: number;
+  /** Fully pin (all axes) every vertex inside this inclusive AABB, keeping an
+   *  arbitrary region blocky. */
+  lockBox?: { min: [number, number, number]; max: [number, number, number] };
+}
+
+/** Build a per-vertex freeze mask from a pin spec, or `undefined` when nothing
+ *  is pinned (so the smoother takes its original allocation-free fast path).
+ *  Evaluated once against the initial positions and reused across passes. */
+function buildPinMask(pos: Float32Array, numVert: number, pins?: SmoothPins): Uint8Array | undefined {
+  if (!pins || (!pins.flatBottom && pins.baseBandZ === undefined && !pins.lockBox)) return undefined;
+  let minZ = Infinity;
+  for (let v = 0; v < numVert; v++) { const z = pos[v * 3 + 2]; if (z < minZ) minZ = z; }
+  // Voxel-corner coordinates are exact integers; a small epsilon absorbs the
+  // float32 round-trip and includes the band's top corner ring (the clean seam
+  // between blocky base and smooth body).
+  const EPS = 1e-3;
+  const bandTop = pins.baseBandZ !== undefined ? minZ + pins.baseBandZ + EPS : -Infinity;
+  const box = pins.lockBox;
+  const mask = new Uint8Array(numVert);
+  for (let v = 0; v < numVert; v++) {
+    const x = pos[v * 3], y = pos[v * 3 + 1], z = pos[v * 3 + 2];
+    if (z <= bandTop) { mask[v] = FREEZE_ALL; continue; }
+    if (box
+      && x >= box.min[0] - EPS && x <= box.max[0] + EPS
+      && y >= box.min[1] - EPS && y <= box.max[1] + EPS
+      && z >= box.min[2] - EPS && z <= box.max[2] + EPS) { mask[v] = FREEZE_ALL; continue; }
+    if (pins.flatBottom && z <= minZ + EPS) mask[v] = FREEZE_Z;
+  }
+  return mask;
+}
+
 /** Build, for each vertex, the set of vertices it shares an edge with. */
 function buildAdjacency(triVerts: Uint32Array, numVert: number): number[][] {
   const adj: Set<number>[] = Array.from({ length: numVert }, () => new Set<number>());
@@ -34,12 +83,15 @@ function buildAdjacency(triVerts: Uint32Array, numVert: number): number[][] {
 
 /** One Laplacian relaxation pass: move each vertex a `factor` of the way
  *  toward the centroid of its edge-neighbours. Reads from `src`, writes `dst`
- *  (both length numVert*3). */
-function relaxPass(src: Float32Array, dst: Float32Array, adj: number[][], factor: number): void {
+ *  (both length numVert*3). When a `mask` is given, any frozen axis keeps its
+ *  `src` value (pinned vertices act as fixed boundary conditions their
+ *  neighbours still relax toward). */
+function relaxPass(src: Float32Array, dst: Float32Array, adj: number[][], factor: number, mask?: Uint8Array): void {
   for (let v = 0; v < adj.length; v++) {
     const nbrs = adj[v];
     const i = v * 3;
-    if (nbrs.length === 0) { // isolated vertex (shouldn't happen on a closed mesh)
+    const m = mask ? mask[v] : 0;
+    if (m === FREEZE_ALL || nbrs.length === 0) { // pinned, or isolated vertex (shouldn't happen on a closed mesh)
       dst[i] = src[i]; dst[i + 1] = src[i + 1]; dst[i + 2] = src[i + 2];
       continue;
     }
@@ -47,9 +99,9 @@ function relaxPass(src: Float32Array, dst: Float32Array, adj: number[][], factor
     for (const n of nbrs) { cx += src[n * 3]; cy += src[n * 3 + 1]; cz += src[n * 3 + 2]; }
     const inv = 1 / nbrs.length;
     cx *= inv; cy *= inv; cz *= inv;
-    dst[i] = src[i] + factor * (cx - src[i]);
-    dst[i + 1] = src[i + 1] + factor * (cy - src[i + 1]);
-    dst[i + 2] = src[i + 2] + factor * (cz - src[i + 2]);
+    dst[i] = (m & FREEZE_X) ? src[i] : src[i] + factor * (cx - src[i]);
+    dst[i + 1] = (m & FREEZE_Y) ? src[i + 1] : src[i + 1] + factor * (cy - src[i + 1]);
+    dst[i + 2] = (m & FREEZE_Z) ? src[i + 2] : src[i + 2] + factor * (cz - src[i + 2]);
   }
 }
 
@@ -57,18 +109,19 @@ function relaxPass(src: Float32Array, dst: Float32Array, adj: number[][], factor
  *  λ/μ pass pairs (more = rounder). Returns a NEW MeshData sharing the input's
  *  triangle and color arrays (topology is untouched). Assumes `numProp === 3`
  *  (voxel meshes are position-only), which all callers satisfy. */
-export function taubinSmooth(mesh: MeshData, iterations = 2): MeshData {
+export function taubinSmooth(mesh: MeshData, iterations = 2, pins?: SmoothPins): MeshData {
   const n = Math.max(0, Math.floor(iterations));
   if (n === 0 || mesh.numVert === 0) return mesh;
 
   const adj = buildAdjacency(mesh.triVerts, mesh.numVert);
   let pos = Float32Array.from(mesh.vertProperties);
   let scratch = new Float32Array(pos.length);
+  const mask = buildPinMask(pos, mesh.numVert, pins);
 
   for (let i = 0; i < n; i++) {
-    relaxPass(pos, scratch, adj, LAMBDA);
+    relaxPass(pos, scratch, adj, LAMBDA, mask);
     [pos, scratch] = [scratch, pos];
-    relaxPass(pos, scratch, adj, MU);
+    relaxPass(pos, scratch, adj, MU, mask);
     [pos, scratch] = [scratch, pos];
   }
 

--- a/tests/unit/voxelSmooth.test.ts
+++ b/tests/unit/voxelSmooth.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { VoxelGrid } from '../../src/geometry/voxel/grid';
+import { meshGrid } from '../../src/geometry/voxel/mesher';
+import type { MeshData } from '../../src/geometry/types';
+
+/** A solid voxel box from voxel (0,0,0) to (s-1,s-1,s-1), sitting on z=0. */
+function box(s = 5): VoxelGrid {
+  return new VoxelGrid().fillBox([0, 0, 0], [s - 1, s - 1, s - 1], '#888');
+}
+
+function zValues(m: MeshData): number[] {
+  const out: number[] = [];
+  for (let v = 0; v < m.numVert; v++) out.push(m.vertProperties[v * 3 + 2]);
+  return out;
+}
+
+function minZ(m: MeshData): number {
+  return Math.min(...zValues(m));
+}
+
+describe('voxel smooth — base pinning', () => {
+  it('plain smooth pulls the bottom off the build plate (it rocks)', () => {
+    // Baseline: without pinning, Taubin moves the bottom plane off z=0 (the
+    // anti-shrink μ pass even bulges it below), so the model no longer sits flat.
+    const m = meshGrid(box(5).smooth({ iterations: 3 }));
+    expect(Math.abs(minZ(m))).toBeGreaterThan(0.05);
+  });
+
+  it('flatBottom keeps the bottom plane flat at z=0 while still rounding above', () => {
+    const grid = box(5);
+    const blocky = meshGrid(grid.clone()); // default surfacing
+    const m = meshGrid(grid.smooth({ iterations: 3, flatBottom: true }));
+
+    // Same topology / vertex order (same occupancy → same gridToMeshData).
+    expect(m.numVert).toBe(blocky.numVert);
+
+    // No vertex drops below or rises off the z=0 plane: the floor stays flat.
+    expect(minZ(m)).toBeCloseTo(0, 5);
+
+    let pinnedZ = 0, movedXY = 0, movedAbove = 0;
+    for (let v = 0; v < m.numVert; v++) {
+      const bz = blocky.vertProperties[v * 3 + 2];
+      const z = m.vertProperties[v * 3 + 2];
+      if (bz === 0) {
+        // Bottom-plane vertices keep z exactly; x/y may relax inward.
+        expect(z).toBeCloseTo(0, 6);
+        pinnedZ++;
+        if (m.vertProperties[v * 3] !== blocky.vertProperties[v * 3]
+          || m.vertProperties[v * 3 + 1] !== blocky.vertProperties[v * 3 + 1]) movedXY++;
+      } else if (z !== bz) {
+        movedAbove++;
+      }
+    }
+    expect(pinnedZ).toBeGreaterThan(0);
+    expect(movedXY).toBeGreaterThan(0);   // sides still round (x/y free)
+    expect(movedAbove).toBeGreaterThan(0); // body above still smooths
+  });
+
+  it('baseLayers keeps the bottom N layers fully blocky (sharp pedestal)', () => {
+    const grid = box(6);
+    const blocky = meshGrid(grid.clone());
+    const m = meshGrid(grid.smooth({ iterations: 4, baseLayers: 2 }));
+
+    let pinned = 0, moved = 0;
+    for (let v = 0; v < m.numVert; v++) {
+      const bx = blocky.vertProperties[v * 3];
+      const by = blocky.vertProperties[v * 3 + 1];
+      const bz = blocky.vertProperties[v * 3 + 2];
+      const z = m.vertProperties[v * 3 + 2];
+      if (bz <= 2 + 1e-6) {
+        // Fully pinned: identical position on all axes.
+        expect(m.vertProperties[v * 3]).toBe(bx);
+        expect(m.vertProperties[v * 3 + 1]).toBe(by);
+        expect(z).toBe(bz);
+        pinned++;
+      } else if (z !== bz) {
+        moved++;
+      }
+    }
+    expect(pinned).toBeGreaterThan(0);
+    expect(moved).toBeGreaterThan(0);
+  });
+
+  it('lockBox keeps the voxels in the box blocky', () => {
+    const grid = box(6);
+    const blocky = meshGrid(grid.clone());
+    // Lock the bottom layer of voxels (z=0) → corners span z in [0,1].
+    const m = meshGrid(grid.smooth({ iterations: 4, lockBox: [[0, 0, 0], [5, 5, 0]] }));
+
+    let pinned = 0;
+    for (let v = 0; v < m.numVert; v++) {
+      const bz = blocky.vertProperties[v * 3 + 2];
+      if (bz <= 1 + 1e-6) {
+        expect(m.vertProperties[v * 3]).toBe(blocky.vertProperties[v * 3]);
+        expect(m.vertProperties[v * 3 + 1]).toBe(blocky.vertProperties[v * 3 + 1]);
+        expect(m.vertProperties[v * 3 + 2]).toBe(bz);
+        pinned++;
+      }
+    }
+    expect(pinned).toBeGreaterThan(0);
+  });
+
+  it('flatBottom composes with detail without dropping below the plane', () => {
+    const m = meshGrid(box(5).smooth({ iterations: 2, detail: 2, flatBottom: true }));
+    expect(minZ(m)).toBeCloseTo(0, 5);
+  });
+
+  it('rejects unknown smooth keys and bad lockBox shapes', () => {
+    expect(() => new VoxelGrid().smooth({ flatBotom: true } as never)).toThrow();
+    expect(() => new VoxelGrid().smooth({ lockBox: [[0, 0, 0]] } as never)).toThrow();
+    expect(() => new VoxelGrid().smooth({ lockBox: [[0, 0, 0], [1, 1, 1.5]] } as never)).toThrow();
+    expect(() => new VoxelGrid().smooth({ baseLayers: 0 } as never)).toThrow();
+  });
+});

--- a/tests/voxel-engine.spec.ts
+++ b/tests/voxel-engine.spec.ts
@@ -435,6 +435,36 @@ test.describe('voxel engine', () => {
     expect(result.isManifold).toBe(true);
   });
 
+  test('base-pinned smooth (flatBottom / baseLayers / lockBox) stays a valid manifold', async ({ page }) => {
+    // The pinning options keep part of the model from rounding so it prints
+    // flat. The real-WASM proof: each still feeds ofMesh as a single watertight
+    // component (topology is untouched — only some vertices are held in place).
+    const result = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.setActiveLanguage('voxel');
+      const flat = await pw.run(`
+        const { voxels } = api;
+        return voxels().sphere([0,0,8], 8, '#e76ba8').smooth({ iterations: 4, flatBottom: true });
+      `);
+      const base = await pw.run(`
+        const { voxels } = api;
+        return voxels().sphere([0,0,10], 8, '#6cf').fillBox([-9,-9,0],[9,9,2], '#3a3a4a').smooth({ baseLayers: 3 });
+      `);
+      const locked = await pw.run(`
+        const { voxels } = api;
+        return voxels().fillBox([0,0,0],[7,7,9],'#88aaff').smooth({ iterations: 4, lockBox: [[0,0,0],[7,7,1]] });
+      `);
+      return { flat, base, locked };
+    });
+    for (const r of [result.flat, result.base, result.locked]) {
+      expect(r.error).toBeFalsy();
+      expect(r.isManifold).toBe(true);
+      expect(r.componentCount).toBe(1);
+      expect(r.volume).toBeGreaterThan(0);
+    }
+  });
+
   test('exportVOXData round-trips a voxel model back through the parser', async ({ page }) => {
     const result = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Smoothing a voxel model with `.smooth()` previously rounded the **bottom** too, so the print rocks on the build plate (the anti-shrink Taubin pass can even bulge the floor below z=0). This adds three opt-in **base-pinning** options to `v.smooth()` so part of the model stays flat/blocky while the rest rounds:

- **`flatBottom: true`** — pins the **Z** of the bottom-most plane. The build-plate face stays perfectly flat; sides/edges still round. The cheap fix for "it won't sit flat."
- **`baseLayers: N`** — keeps the bottom **N voxel layers fully blocky** (a solid, sharp pedestal) while the body above smooths. This is the "solid non-smooth base."
- **`lockBox: [[x0,y0,z0],[x1,y1,z1]]`** — keeps the voxels in an arbitrary inclusive box (voxel coords, any corner order) blocky, for a custom base region.

All three combine with `iterations` / `detail`.

### Design

They share **one primitive**: a per-vertex axis-freeze mask in the Taubin smoother (`smooth.ts`). Pinned vertices act as fixed boundary conditions the smoothed region still relaxes toward, so the base↔body seam stays clean. `flatBottom` is a Z-only (reflective) pin; `baseLayers`/`lockBox` are full-axis (Dirichlet) pins. The mesh is boundary-only with vertices at exact integer voxel corners, so the pinned set is identified geometrically — **no change to mesh topology or grid encoding** (colors and manifoldness carry through unchanged). Options are authored in grid coordinates on `Surfacing` and resolved to mesh space in `meshGrid` (thresholds scale by `detail`; `flatBottom` is plane-relative).

The agent's third request (`pinNormals` / normal-based pinning) was **deliberately not implemented**: the only practically useful normal is straight-down, which `flatBottom` covers more robustly, and general normal-pinning needs ambiguous per-vertex normal estimation on a welded blocky mesh for near-zero added value.

### Example

```js
// Smooth body on a sharp 2-layer pedestal:
return voxels().sphere([0,0,8], 6, '#6cf').fillBox([-7,-7,0],[7,7,2],'#444')
  .smooth({ baseLayers: 2 });
```

## Test plan

- **Unit** (`tests/unit/voxelSmooth.test.ts`, new): asserts pinned planes/bands/boxes stay exactly in place (flatBottom keeps `minZ === 0`; baseLayers/lockBox keep full positions) while the body above still moves; flatBottom composes with `detail` without dropping below the plane; bad args rejected. Full unit tier green (729 tests).
- **E2E** (`tests/voxel-engine.spec.ts`, new case): real-WASM proof that each option still feeds `ofMesh` as a single watertight, positive-volume component. All 17 voxel-engine tests pass.
- **Manual**: rendered a smooth sphere on a sharp blocky pedestal (`baseLayers`) and a plate-flat smoothed sphere (`flatBottom`) in the browser, both `isManifold` — screenshots posted in the session.
- `npm run build` (tsc) clean.

## Docs

`public/ai/voxel.md` gains a "Keeping a flat / blocky base (printability)" section so the in-app/extension AI agents discover the options.

https://claude.ai/code/session_01CLnYRdXEwzs1rgzuB7xjZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLnYRdXEwzs1rgzuB7xjZC)_