### PR TITLE
feat: add print-in-place ballJoint and flexi to printFit API

### DIFF
--- a/prompts/20260607-190000-printfit-flexi-balljoint.md
+++ b/prompts/20260607-190000-printfit-flexi-balljoint.md
@@ -1,0 +1,48 @@
+---
+session: "mjTpB"
+timestamp: "2026-06-07T19:00:00Z"
+model: claude-opus-4-8
+tools: [explore, model:preview, playwright]
+---
+
+## Human
+
+After adding a print-fit API, asked what other algorithmic operations could be
+added — using flexi joints as the motivating example (guessing they are made by a
+lathe/carve operation). Asked for feedback on the idea, whether flexi and other
+popular operations can be done with concepts, and what advanced print-fit-type
+capabilities to add. Then: "spec it out, then go ahead and implement phase 1".
+
+## Assistant
+
+## Key decisions
+
+**Corrected the mental model**: flexi prints are not a lathe carve — they are
+print-in-place *segmented ball-and-socket chains* with a printed clearance gap so
+links decompose into separate free components rather than fusing. This maps
+directly onto the existing repo idiom (subtract a clearance cutter, decompose,
+assert componentCount).
+
+**Placement**: kept both new builders in `api.printFit` rather than a new
+`articulate` namespace or the surface-modifier pipeline. printFit is literally the
+joinery namespace, it is already injected into the sandbox and registered as an AI
+subdoc, and ball-socket joinery is print-fit in spirit — so this adds zero wiring.
+The modifier pipeline (MeshData + main.ts dispatcher + surfaceModal UI) was the
+wrong, heavyweight home for a Manifold->Manifold transform.
+
+**Scope of Phase 1**: shipped `ballJoint({...}) -> {ball, socket}` (the captured-
+joint atom, mirroring the existing pin/socket and dovetail pair pattern) and
+`flexi(solid, {segments, axis})` (Tier-1: segment along a chosen straight bbox
+axis through the centroid). Deferred Tier-2 auto-skeletonisation of curved limbs —
+that needs medial-axis extraction and is research-grade; documented the limitation.
+
+**Joint geometry**: lower link carries a ball-on-stem crossing the cut; upper link
+carries a spherical cavity (ball + clearance) opening through a mouth NARROWER than
+the ball (capture) but wider than the neck + swing (pivot). Ball center placed at
+cut + gap/2 + 0.8r so the full socket sits inside the upper link. Verified the
+proportions empirically with model:preview (componentCount === segments, isManifold)
+rather than trusting the analytic tangency.
+
+**Verification**: model:preview for both builders, 5 new e2e cases asserting
+componentCount and the validation errors, plus an in-app screenshot of a fanned
+7-link tentacle. Build + 749 unit tests green.

--- a/public/ai.md
+++ b/public/ai.md
@@ -100,9 +100,10 @@ Reach for the right tool the first time. If the table sends you to a subdoc, fet
 | Clearance hole sized to a real screw (M2–M8) | `api.printFit.screwHole({size:"M3", length, head})` → subtract -> `/ai/print-fit.md` | BOSL2 `screw_hole()` | (use manifold-js printFit) |
 | Heat-set insert boss | `api.printFit.insertBoss({size:"M3"})` → union -> `/ai/print-fit.md` | (write a tapered bore manually) | (use manifold-js printFit) |
 | Captive / clearance nut pocket | `api.printFit.nutPocket({size:"M3", captive:true})` → subtract -> `/ai/print-fit.md` | BOSL2 `nut_trap_side()` | (use manifold-js printFit) |
-| Snap-fit, dovetail, or alignment-pin joint | `api.printFit.snapFit/dovetail/pin/socket(...)` -> `/ai/print-fit.md` | (build manually) | (use manifold-js printFit) |
+| Snap-fit, dovetail, alignment-pin, or ball-and-socket joint | `api.printFit.snapFit/dovetail/pin/socket/ballJoint(...)` -> `/ai/print-fit.md` | (build manually) | (use manifold-js printFit) |
+| Flexi chain — slice an arm/tube into a print-in-place articulated body | `api.printFit.flexi(solid, {segments, axis})` -> `/ai/print-fit.md` | (build manually) | (use manifold-js printFit) |
 | Dial in printer fit tolerances | `api.printFit.clearanceCoupon({size:"M3"})` + `api.printFit.clearance(fit)` -> `/ai/print-fit.md` | (build manually) | (use manifold-js printFit) |
-| Print-in-place mechanism (screw, spinner, hinge, captive ball, slider) | Separate parts via `labeledUnion`, separated by a ~0.3–0.5 mm clearance gap; assert `componentCount` -> `/ai/mechanisms.md` | (model parts + clearance manually) | (model parts + clearance manually) |
+| Print-in-place mechanism (screw, spinner, hinge, captive ball, slider) | Separate parts via `labeledUnion`, separated by a ~0.3–0.5 mm clearance gap; assert `componentCount`; for articulated chains use `api.printFit.flexi` -> `/ai/mechanisms.md` | (model parts + clearance manually) | (model parts + clearance manually) |
 | Helical thread / auger / spiral flute | `cs.extrude(h, nDiv, 360*turns, scaleTop)` on a bumped/fluted profile -> `/ai/mechanisms.md` | `linear_extrude(twist=)`, or BOSL2 `threaded_rod()` | (use manifold-js) |
 | Smooth fillet / blend between two shapes (no edge-picking) | `a.smoothUnion(b, k)` via `api.sdf` -> `/ai/sdf.md` | (not available) | (mesh-only; not in BREP) |
 | Lattice / gyroid / periodic infill | `api.sdf.gyroid(cell, thickness)` -> `/ai/sdf.md` | (not available) | (mesh-only; not in BREP) |

--- a/public/ai/print-fit.md
+++ b/public/ai/print-fit.md
@@ -2,7 +2,8 @@
 
 Parametric joinery & hardware primitives for parts that have to **physically
 assemble** — clearance holes sized to a real screw, heat-set insert bosses,
-captive-nut pockets, alignment pins, sliding dovetails, cantilever snaps, and a
+captive-nut pockets, alignment pins, sliding dovetails, cantilever snaps,
+captured ball-and-socket joints, print-in-place flexi chains, and a
 printer-calibration coupon. Available in the **manifold-js** engine as
 `api.printFit.*`. Read this before building anything that mates with hardware or
 another printed part.
@@ -13,12 +14,14 @@ input (unknown size, missing dimension) so you can self-correct.
 ## Two kinds of result — read this first
 
 - **Negative tools** (`screwHole`, `socket`, `nutPocket`, `dovetail().socket`,
-  `snapFit().catch`) return a Manifold you **subtract** from your part. They
-  already poke ~0.1mm above their entrance face so the cut breaks the surface
-  cleanly — position the entrance flush with (or just below) the face you're
-  cutting into.
+  `snapFit().catch`, `ballJoint().socket`) return a Manifold you **subtract**
+  from your part. They already poke ~0.1mm above their entrance face so the cut
+  breaks the surface cleanly — position the entrance flush with (or just below)
+  the face you're cutting into.
 - **Solids** (`insertBoss`, `pin`, `dovetail().tail`, `snapFit().clip`,
-  `clearanceCoupon`) return a Manifold you **union** onto your part.
+  `ballJoint().ball`, `clearanceCoupon`) return a Manifold you **union** onto
+  your part.
+- **Transforms** (`flexi`) take a solid and return a new multi-component solid.
 
 Position results with `.translate(...)`, `.rotate(...)`, or `meshOps.placeOn` /
 `meshOps.alignTo`.
@@ -101,6 +104,46 @@ mating wall).
 const sf = api.printFit.snapFit({ width:8, length:14, hookDepth:1.5 });
 const lid  = lidWall.add(sf.clip);
 const body = bodyWall.subtract(sf.catch);
+```
+
+### `ballJoint({ diameter, fit?, neck?, stem?, segments? }) → { ball, socket }`
+Captured ball-and-socket joint — the atom of **print-in-place articulation**. Both
+parts share the pivot at the origin.
+- `ball` = **solid** (union onto part A): sphere of `diameter` on a stem (`neck`
+  diameter, `stem` long) descending −Z to root into part A.
+- `socket` = **negative** (subtract from part B): spherical cavity sized
+  `diameter + 2·clearance(fit)`, opening downward through a mouth **narrower than
+  the ball**, so the ball is captured but free to pivot.
+
+Print it **assembled** (the clearance gap is printed in place) — this is not a
+snap-together joint. Translate both halves to the same pivot.
+
+```js
+const j = api.printFit.ballJoint({ diameter: 8, fit: 'normal' });
+const a = lowerPart.add(j.ball);
+const b = upperPart.subtract(j.socket);
+return a.add(b);   // decomposes into 2 free components
+```
+
+### `flexi(solid, { segments, axis?, fit?, gap?, jointDiameter?, segments? }) → Manifold`
+Turn a solid into a **print-in-place articulated chain** (the flexi-snake / flexi-arm
+trick). Slices `solid` into `segments` links along `axis` (`'x'|'y'|'z'`, default
+`'z'`) and embeds a captured ball-and-socket joint on the bounding-box centerline
+at each of the `segments-1` cuts, separated by a printed clearance gap. Returns a
+single Manifold that **decomposes into `segments` free components** — prints as one
+object, flexes after printing.
+
+- `fit` / `gap`: joint + inter-link clearance (`gap` overrides the `fit` preset).
+- `jointDiameter`: ball diameter (defaults to scale with the cross-section).
+- Second `segments` key on facets: cylinder/sphere tessellation.
+
+Works best on **tube/arm-like solids that run along one axis** — pick the axis the
+body runs along. (Auto-skeletonisation of curved limbs isn't done; segment along a
+straight axis.) Verify with `componentCount === segments`.
+
+```js
+const arm = api.Manifold.cylinder(60, 6, 6, 64).rotate([0, 90, 0]); // along X
+return api.printFit.flexi(arm, { segments: 6, axis: 'x', fit: 'normal' });
 ```
 
 ### `clearanceCoupon({ size, fits?, thickness?, segments? })`

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -485,7 +485,7 @@ Available tools you'll use most:
   replicad (BREP / OpenCASCADE — exact fillets / chamfers / STEP export),
   colors (paintRegion + paint helpers),
   print-safety (FDM rules before exporting STL/3MF),
-  print-fit (api.printFit.* screw holes / insert bosses / nut pockets / snap-fits / dovetails / pins / clearance presets),
+  print-fit (api.printFit.* screw holes / insert bosses / nut pockets / snap-fits / dovetails / pins / ball-and-socket joints / flexi chains / clearance presets),
   mechanisms (print-in-place joints, hinges, sliders, captive balls, helical threads),
   reference-images (when the user attaches photos),
   file-io (programmatic export/import),

--- a/src/geometry/printFit.ts
+++ b/src/geometry/printFit.ts
@@ -208,8 +208,18 @@ export function createPrintFitNamespace(module: any, deps: PrintFitDeps = {}) {
   function cone(z0: number, z1: number, rLow: number, rHigh: number, segments?: number): any {
     return Manifold.cylinder(z1 - z0, rLow, rHigh, segments ?? 0).translate([0, 0, z0]);
   }
+  /** Sphere of radius r centered at (0, 0, cz). */
+  function ball(cz: number, r: number, segments?: number): any {
+    return Manifold.sphere(r, segments ?? 0).translate([0, 0, cz]);
+  }
   function seg(o: Record<string, unknown>): number | undefined {
     return o.segments === undefined ? undefined : num(o.segments, 'segments', { min: 3 });
+  }
+  /** Duck-typed Manifold check — flexi takes a real solid as its first arg. */
+  function isManifold(v: unknown): boolean {
+    const m = v as any;
+    return !!m && typeof m.boundingBox === 'function' && typeof m.subtract === 'function'
+      && typeof m.decompose === 'function' && typeof m.intersect === 'function';
   }
 
   return {
@@ -509,6 +519,131 @@ export function createPrintFitNamespace(module: any, deps: PrintFitDeps = {}) {
         }
       });
       return coupon;
+    },
+
+    /**
+     * Captured ball-and-socket joint — the atom of print-in-place articulation.
+     * Returns { ball, socket }. Both share the pivot at the origin.
+     *   • `ball` (SOLID): a sphere of `diameter` at the origin on a stem that
+     *     descends −Z to root into the part below. UNION onto part A.
+     *   • `socket` (NEGATIVE): a spherical cavity (`diameter + 2·clearance(fit)`)
+     *     opening downward through a mouth NARROWER than the ball, so a printed-
+     *     in-place ball is captured but free to pivot. SUBTRACT from part B.
+     * Translate both to the same pivot location. Mate parts with a clearance
+     * gap — this is meant to be printed assembled, not snapped together.
+     *
+     * opts: { diameter, fit?, neck?, stem?, segments? }
+     *   neck: stem diameter (default diameter·0.5); stem: stem length (default
+     *   diameter·0.75).
+     */
+    ballJoint(o0: unknown): { ball: any; socket: any } {
+      const o = opts(o0, 'ballJoint');
+      const d = num(o.diameter, 'diameter', { min: 0.6 });
+      const r = d / 2;
+      const gap = clearance(o.fit ?? 'normal');
+      const neck = num(o.neck, 'neck', { def: d * 0.5, min: 0.4 });
+      const neckR = neck / 2;
+      const stem = num(o.stem, 'stem', { def: d * 0.75, min: 0.2 });
+      const s = seg(o);
+      // Mouth must stay narrower than the ball (capture) yet clear the neck so it
+      // can pivot. swing widens the channel for swing angle.
+      const swing = r * 0.15;
+      const mouthR = Math.min(neckR + gap + swing, r - gap - 0.2);
+      if (mouthR <= neckR) {
+        throw new ValidationError('printFit.ballJoint: diameter too small for the neck — increase diameter or reduce neck.');
+      }
+
+      const ballSolid = ball(0, r, s).add(cyl(-stem, 0, neckR, s));
+      const cavity = ball(0, r + gap, s);
+      const mouth = cyl(-(r + gap) - LIP, 0, mouthR, s);
+      return { ball: ballSolid, socket: cavity.add(mouth) };
+    },
+
+    /**
+     * Flexi — turn a solid into a print-in-place articulated chain. Slices
+     * `solid` into `segments` links along `axis` and embeds a captured ball-and-
+     * socket joint on the bounding-box centerline at each of the `segments-1`
+     * cuts, separated by a printed clearance gap. Returns one Manifold that
+     * decomposes into `segments` free components — it prints as a single object
+     * but flexes. Works best on tube/arm-like solids that run along one axis;
+     * curved-arm auto-skeletonisation is not done here — pick the axis the body
+     * runs along.
+     *
+     * opts: { segments, axis?, fit?, gap?, jointDiameter?, segments? (facets) }
+     *   axis: 'x' | 'y' | 'z' (default 'z'); gap: explicit clearance (overrides
+     *   fit); jointDiameter: ball diameter (default scales with cross-section).
+     */
+    flexi(solidArg: unknown, o0: unknown): any {
+      if (!isManifold(solidArg)) {
+        throw new ValidationError('printFit.flexi(solid, opts): first argument must be a Manifold.');
+      }
+      const o = opts(o0, 'flexi');
+      const segments = num(o.segments, 'segments', { min: 2 });
+      if (!Number.isInteger(segments)) {
+        throw new ValidationError(`printFit.flexi: segments must be an integer >= 2, got ${segments}.`);
+      }
+      const axis = o.axis ?? 'z';
+      if (axis !== 'x' && axis !== 'y' && axis !== 'z') {
+        throw new ValidationError(`printFit.flexi: axis must be "x" | "y" | "z", got ${describe(axis)}.`);
+      }
+      const gap = o.gap !== undefined ? num(o.gap, 'gap', { min: 0 }) : clearance(o.fit ?? 'normal');
+      const s = seg(o);
+
+      // Work in a canonical frame where the chain axis is +Z, then rotate back.
+      const fwd: [number, number, number] = axis === 'x' ? [0, -90, 0] : axis === 'y' ? [90, 0, 0] : [0, 0, 0];
+      const inv: [number, number, number] = axis === 'x' ? [0, 90, 0] : axis === 'y' ? [-90, 0, 0] : [0, 0, 0];
+      const solid = axis === 'z' ? (solidArg as any) : (solidArg as any).rotate(fwd);
+
+      const bb = solid.boundingBox();
+      const zmin = bb.min[2], zmax = bb.max[2];
+      const span = zmax - zmin;
+      if (span <= 0) throw new ValidationError('printFit.flexi: model has no extent along the chosen axis.');
+      const cx = (bb.min[0] + bb.max[0]) / 2;
+      const cy = (bb.min[1] + bb.max[1]) / 2;
+      const crossA = bb.max[0] - bb.min[0];
+      const crossB = bb.max[1] - bb.min[1];
+      const minCross = Math.min(crossA, crossB);
+      const segLen = span / segments;
+
+      const r = o.jointDiameter !== undefined
+        ? num(o.jointDiameter, 'jointDiameter', { min: 0.6 }) / 2
+        : Math.max(1.0, Math.min(minCross * 0.30, segLen * 0.4));
+      const neckR = r * 0.5;
+      const swing = r * 0.15;
+      const mouthR = Math.min(neckR + gap + swing, r - gap - 0.2);
+
+      const bigX = crossA + 10, bigY = crossB + 10;
+      const slab = (z0: number, z1: number): any =>
+        Manifold.cube([bigX, bigY, z1 - z0], false).translate([cx - bigX / 2, cy - bigY / 2, z0]);
+
+      let result: any = null;
+      for (let i = 0; i < segments; i++) {
+        const cutLow = zmin + i * segLen;       // shared plane with the link below
+        const cutHigh = zmin + (i + 1) * segLen; // shared plane with the link above
+        const bottom = i === 0 ? zmin - LIP : cutLow + gap / 2;
+        const top = i === segments - 1 ? zmax + LIP : cutHigh - gap / 2;
+        let link = solid.intersect(slab(bottom, top));
+
+        // Carry the ball up across the cut to the link above.
+        if (i < segments - 1) {
+          const cz = cutHigh;
+          const zc = cz + gap / 2 + r * 0.8;
+          const stemBottom = cz - gap / 2 - Math.min(segLen * 0.3, r);
+          link = link
+            .add(cyl(stemBottom, zc, neckR, s).translate([cx, cy, 0]))
+            .add(ball(zc, r, s).translate([cx, cy, 0]));
+        }
+        // Carve the socket that captures the ball from the link below.
+        if (i > 0) {
+          const cz = cutLow;
+          const zc = cz + gap / 2 + r * 0.8;
+          const cavity = ball(zc, r + gap, s).translate([cx, cy, 0]);
+          const mouth = cyl(cz + gap / 2 - LIP, zc, mouthR, s).translate([cx, cy, 0]);
+          link = link.subtract(cavity.add(mouth));
+        }
+        result = result === null ? link : result.add(link);
+      }
+      return axis === 'z' ? result : result.rotate(inv);
     },
   };
 }

--- a/tests/print-fit.spec.ts
+++ b/tests/print-fit.spec.ts
@@ -92,3 +92,61 @@ test.describe('printFit builders produce valid manifolds', () => {
     expect(r.error).toMatch(/unknown fastener size/i);
   });
 });
+
+test.describe('printFit articulation (print-in-place)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+    await page.goto('/editor');
+    await waitForEngine(page);
+  });
+
+  test('ballJoint captures two parts as free components', async ({ page }) => {
+    const r = await run(page, `
+      const { Manifold, printFit } = api;
+      const j = printFit.ballJoint({ diameter: 8, fit: 'normal' });
+      const lower = Manifold.cube([20, 20, 6], true).translate([0, 0, -9]).add(j.ball);
+      const upper = Manifold.cube([20, 20, 12], true).translate([0, 0, 6]).subtract(j.socket);
+      return lower.add(upper);
+    `);
+    if (r.status === 'error') throw new Error(`ballJoint failed:\n${r.error}`);
+    expect(r.isManifold).toBe(true);
+    expect(r.componentCount).toBe(2);
+  });
+
+  test('flexi slices a bar into N free links', async ({ page }) => {
+    const r = await run(page, `
+      const { Manifold, printFit } = api;
+      const bar = Manifold.cylinder(60, 6, 6, 64).rotate([0, 90, 0]); // along X
+      return printFit.flexi(bar, { segments: 6, axis: 'x', fit: 'normal' });
+    `);
+    if (r.status === 'error') throw new Error(`flexi failed:\n${r.error}`);
+    expect(r.isManifold).toBe(true);
+    expect(r.componentCount, 'flexi should decompose into one component per segment').toBe(6);
+  });
+
+  test('flexi works along the default Z axis too', async ({ page }) => {
+    const r = await run(page, `
+      const { Manifold, printFit } = api;
+      const tube = Manifold.cylinder(50, 5, 5, 48);
+      return printFit.flexi(tube, { segments: 4 });
+    `);
+    if (r.status === 'error') throw new Error(`flexi(Z) failed:\n${r.error}`);
+    expect(r.isManifold).toBe(true);
+    expect(r.componentCount).toBe(4);
+  });
+
+  test('flexi rejects a non-Manifold first argument', async ({ page }) => {
+    const r = await run(page, `return api.printFit.flexi({ not: 'a solid' }, { segments: 3 });`);
+    expect(r.status).toBe('error');
+    expect(r.error).toMatch(/must be a Manifold/i);
+  });
+
+  test('flexi rejects segments < 2', async ({ page }) => {
+    const r = await run(page, `
+      const bar = api.Manifold.cylinder(20, 4, 4, 32);
+      return api.printFit.flexi(bar, { segments: 1 });
+    `);
+    expect(r.status).toBe('error');
+    expect(r.error).toMatch(/segments/i);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of **algorithmic print-in-place articulation**, building on the recently-added `api.printFit` namespace. Two new builders, no new wiring (printFit is already injected into the manifold-js sandbox and registered as an AI subdoc):

- **`printFit.ballJoint({ diameter, fit?, neck?, stem?, segments? }) → { ball, socket }`** — a captured ball-and-socket joint, the atom of articulation. Mirrors the existing `pin`/`socket` and `dovetail` pair pattern: `ball` is a solid to **union**, `socket` a negative to **subtract**. The socket mouth is narrower than the ball, so a ball printed in place is captured but free to pivot.
- **`printFit.flexi(solid, { segments, axis?, fit?|gap?, jointDiameter?, segments? }) → Manifold`** — the flexi-snake/flexi-arm transform. Slices a solid into `segments` links along `axis` (`'x'|'y'|'z'`, default `'z'`) and embeds a ball-socket joint on the bbox centerline at each cut with a printed clearance gap. Returns **one Manifold that decomposes into `segments` free components** — prints as a single object, flexes after printing.

### Why this shape
Flexi prints aren't a lathe/carve — they're print-in-place segmented joints with a printed clearance gap (subtract a clearance cutter → `decompose()` → assert `componentCount`, the existing repo idiom). Both builders live in `printFit` rather than a new namespace or the surface-modifier pipeline: printFit *is* the joinery namespace, and this is joinery in spirit, so it adds zero plumbing.

### Scope / follow-ups
This is **Tier 1**: `flexi` segments along a chosen straight axis through the bbox centroid — ideal for tube/arm-like bodies. Auto-skeletonisation of curved limbs (medial-axis extraction) is deferred to a Tier-2 follow-up and the limitation is documented.

## Test plan
- `npm run build` (typecheck) ✅ · `npm run test:unit` (749) ✅
- 5 new e2e cases in `tests/print-fit.spec.ts` assert `componentCount === segments`, the 2-component ball joint, default-axis flexi, and both validation errors — all green in-browser
- `model:preview` confirms `isManifold: true` + correct `componentCount` for both
- In-app screenshot: a 7-link tentacle fanned apart to show each captured joint (posted in session)

## Docs
`public/ai.md` capability table, `public/ai/print-fit.md` subdoc (two new builder sections + result-kind lists), and the `systemPrompt.ts` subdoc summary all updated.

https://claude.ai/code/session_011uhbEQqPB5kjeGgu4PqSxu

---
_Generated by [Claude Code](https://claude.ai/code/session_011uhbEQqPB5kjeGgu4PqSxu)_