### PR TITLE
fix: lay-flat picks the largest contiguous flat face

### DIFF
--- a/prompts/20260607-lay-flat-largest-face.md
+++ b/prompts/20260607-lay-flat-largest-face.md
@@ -1,0 +1,74 @@
+---
+date: 2026-06-07
+branch: claude/admiring-einstein-kQLx7
+files_changed:
+  - src/surface/placement.ts
+  - tests/unit/placement.test.ts
+---
+
+## Human
+
+I recently merged a rotate-in-place set of functionality in the UI, with a
+"lay flat" function. But I feel like it's just grabbing whatever the nearest
+flat surface of an object is. What I really wanted is to find the side of an
+object with the *largest* flat surface — like a coin should rest on its broad
+face, not its rim; a book on its cover where you get the most square millimeters
+of contact. Investigate and report what fixes/improvements we could do.
+
+Scope chosen: the focused "largest flat face" fix (cluster contiguous coplanar
+triangles, pick the largest true face). Not the heavier convex-hull/centre-of-
+mass stability version.
+
+## Assistant
+
+Investigated `bestFlatDownRotation` (`src/surface/placement.ts`), the only
+lay-flat implementation, wired to the Place/Rotate panel's "Lay flat" button.
+The rotation math (shortest-arc normal→−Z, Euler extraction) was correct; the
+flaw was purely in *face selection*. The old code bucketed every triangle by its
+quantized normal *direction* (`round(n*100)`) and laid the largest-area bucket
+down. Two failure modes:
+
+1. **Buckets by direction, not plane.** Faces pointing the same way at different
+   heights (stair steps, embossed text, scattered ledges) were summed into one
+   phantom "face", so the part could be tipped onto a small protrusion whose
+   pooled area beat the real largest face.
+2. **Hard quantization degenerates on organic meshes.** For a coin/book — one
+   shared normal per flat face — it happened to work. But for any curved,
+   smoothed, voxelized, or photo-derived model, no two triangles share a normal,
+   so each bucket holds ~1 triangle and "largest bucket" collapses to "biggest
+   single triangle" — an arbitrary facet. That's exactly the "grabs whatever
+   flat-ish surface is nearby" behaviour reported.
+
+**Fix:** region-grow contiguous coplanar triangles into real faces, then pick
+the largest by total area.
+- Weld vertices by quantized position (scaled to the model diagonal) so adjacency
+  survives meshes that duplicate vertices per triangle (imported STL / some
+  bakes); a no-op for manifold's own shared-index meshes.
+- Build triangle adjacency over shared welded edges.
+- BFS-grow each region, **seeded from the largest triangles first** and comparing
+  every candidate to the region's *seed* normal (not just its neighbour, dot >
+  0.999). Seed-relative comparison bounds drift, so a curved surface grows into
+  thin near-flat bands instead of swallowing the whole mesh (and never produces a
+  whole-rim component whose area-weighted normal cancels to zero).
+- Largest region's area-weighted normal → `rotationFromTo(n, [0,0,-1])`. The two
+  hardcoded tolerances live as named module consts (`COPLANAR_DOT`,
+  `WELD_FRACTION`) — structural geometric epsilons in the spirit of the other
+  inline epsilons already in this pure unit-tier module, not user-tunable knobs.
+
+Deliberately does **not** pool non-coplanar same-direction faces — the part rests
+on one contact plane, so inventing a face from scattered area would be wrong.
+(Convex-hull resting-face enumeration + centre-of-mass stability is the heavier
+follow-up the user declined for now.)
+
+**Tests** (`tests/unit/placement.test.ts`): added closed-mesh builders
+(`solidBox`, faceted `disk`, `mergeMeshes`) and three cases — coin stood on its
+rim lands on its broad face (height = thickness), a book stood on its spine lands
+on its largest face, and a part with two stacked +Z ledges (pooled area 158)
+beside one tall wall (single face 90) lays on the wall's side, proving
+non-coplanar faces are no longer summed. The original tilted-slab + degenerate
+tests still pass. 21/21 in the file, 784/784 unit tier, build clean.
+
+**Browser check:** drove a cylinder (`Manifold.cylinder(...).rotate([90,0,0])`,
+standing on its rim) through `partwright.layFlatModel()` — it rotated onto its
+broad face, resting on Z=0 with bbox `[36,36,3]` (height = the 3-unit thickness).
+Posted before/after screenshots.

--- a/src/surface/placement.ts
+++ b/src/surface/placement.ts
@@ -219,40 +219,107 @@ export function rotateAboutCenterSteps(box: PlacementBox, euler: Vec3): Transfor
 
 // ---- auto lay-flat: find the flattest face --------------------------------
 
-/** Find the model's largest flat face and the Euler rotation (manifold order)
- *  that lays it on the bed (its outward normal → −Z). Returns null for a
- *  degenerate mesh or one with no usable area. The rotation is about the world
- *  origin; callers wrap it about the model center and then drop to the floor. */
+// Two coplanar triangles are merged into one face only when their normals agree
+// to within this dot product (~2.6°). Comparing every candidate to the region's
+// *seed* normal (not just its neighbour) bounds the total drift, so a curved
+// surface grows into thin near-flat bands rather than swallowing the whole mesh.
+const COPLANAR_DOT = 0.999;
+// Vertices closer than this fraction of the model diagonal are welded so that
+// adjacency survives meshes that duplicate vertices per-triangle (imported STL,
+// some bakes). Manifold's own meshes already share indices; welding is a no-op
+// for them but makes the clustering robust for the rest.
+const WELD_FRACTION = 1e-6;
+
+/** Find the model's largest *contiguous flat face* and the Euler rotation
+ *  (manifold order) that lays it on the bed (its outward normal → −Z). Returns
+ *  null for a degenerate mesh or one with no usable area. The rotation is about
+ *  the world origin; callers wrap it about the model center and then drop to the
+ *  floor.
+ *
+ *  Triangles are region-grown over shared edges into connected coplanar faces,
+ *  then the largest by total area wins — so a coin lands on its broad side, not
+ *  its rim, and a book on its cover. This deliberately does *not* sum faces that
+ *  merely share a normal direction at different heights (stair steps, embossed
+ *  text, scattered ledges): the part can only rest on the contact plane, so
+ *  pooling non-coplanar area would invent a face that isn't there. */
 export function bestFlatDownRotation(mesh: MeshData): Vec3 | null {
   const np = mesh.numProp;
   const pos = mesh.vertProperties;
   const tv = mesh.triVerts;
-  // Bucket triangles by quantized normal, summing area and an area-weighted
-  // normal so we recover a precise representative direction per flat face.
-  const buckets = new Map<string, { area: number; n: Vec3 }>();
+  const nTri = mesh.numTri;
+  if (nTri === 0) return null;
   const get = (i: number): Vec3 => [pos[i * np], pos[i * np + 1], pos[i * np + 2]];
-  for (let t = 0; t < mesh.numTri; t++) {
+
+  // Weld vertices by quantized position so edge-adjacency works even when the
+  // mesh stores a fresh vertex per triangle corner.
+  const box = meshBox(mesh);
+  const diag = Math.hypot(box.max[0] - box.min[0], box.max[1] - box.min[1], box.max[2] - box.min[2]) || 1;
+  const cell = Math.max(1e-9, diag * WELD_FRACTION);
+  const canon = new Int32Array(mesh.numVert);
+  const weld = new Map<string, number>();
+  for (let i = 0; i < mesh.numVert; i++) {
+    const k = `${Math.round(pos[i * np] / cell)},${Math.round(pos[i * np + 1] / cell)},${Math.round(pos[i * np + 2] / cell)}`;
+    let id = weld.get(k);
+    if (id === undefined) { id = weld.size; weld.set(k, id); }
+    canon[i] = id;
+  }
+
+  // Per-triangle unit normal + area; degenerate/non-finite triangles are left
+  // null (a NaN vertex would otherwise poison the chosen rotation).
+  const triN: (Vec3 | null)[] = new Array(nTri);
+  const triA = new Float64Array(nTri);
+  for (let t = 0; t < nTri; t++) {
     const a = get(tv[t * 3]), b = get(tv[t * 3 + 1]), c = get(tv[t * 3 + 2]);
-    const e1: Vec3 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
-    const e2: Vec3 = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
-    const cr = cross(e1, e2);
+    const cr = cross([b[0] - a[0], b[1] - a[1], b[2] - a[2]], [c[0] - a[0], c[1] - a[1], c[2] - a[2]]);
     const area2 = len(cr);
-    // Skip degenerate and non-finite triangles (a NaN vertex would otherwise
-    // bucket under "NaN,NaN,NaN" and poison the chosen rotation).
-    if (!(area2 >= 1e-12)) continue;
-    const n: Vec3 = [cr[0] / area2, cr[1] / area2, cr[2] / area2];
-    const area = area2 / 2;
-    const key = `${Math.round(n[0] * 100)},${Math.round(n[1] * 100)},${Math.round(n[2] * 100)}`;
-    const cur = buckets.get(key);
-    if (cur) {
-      cur.area += area;
-      cur.n = [cur.n[0] + n[0] * area, cur.n[1] + n[1] * area, cur.n[2] + n[2] * area];
-    } else {
-      buckets.set(key, { area, n: [n[0] * area, n[1] * area, n[2] * area] });
+    if (!(area2 >= 1e-12)) { triN[t] = null; continue; }
+    triN[t] = [cr[0] / area2, cr[1] / area2, cr[2] / area2];
+    triA[t] = area2 / 2;
+  }
+
+  // Build triangle adjacency: triangles sharing a welded edge are neighbours.
+  const edgeTris = new Map<string, number[]>();
+  for (let t = 0; t < nTri; t++) {
+    if (!triN[t]) continue;
+    const v0 = canon[tv[t * 3]], v1 = canon[tv[t * 3 + 1]], v2 = canon[tv[t * 3 + 2]];
+    for (const [p, q] of [[v0, v1], [v1, v2], [v2, v0]] as [number, number][]) {
+      const key = p < q ? `${p}_${q}` : `${q}_${p}`;
+      const arr = edgeTris.get(key);
+      if (arr) arr.push(t); else edgeTris.set(key, [t]);
     }
   }
+  const adj: number[][] = Array.from({ length: nTri }, () => []);
+  for (const tris of edgeTris.values()) {
+    for (let i = 0; i < tris.length; i++)
+      for (let j = i + 1; j < tris.length; j++) { adj[tris[i]].push(tris[j]); adj[tris[j]].push(tris[i]); }
+  }
+
+  // Region-grow connected coplanar faces, seeding from the largest triangles so
+  // a broad flat face is captured whole before tiny facets are visited.
+  const order = [];
+  for (let t = 0; t < nTri; t++) if (triN[t]) order.push(t);
+  order.sort((a, b) => triA[b] - triA[a]);
+  const seen = new Uint8Array(nTri);
   let best: { area: number; n: Vec3 } | null = null;
-  for (const v of buckets.values()) if (!best || v.area > best.area) best = v;
+  for (const seed of order) {
+    if (seen[seed]) continue;
+    const sn = triN[seed]!;
+    seen[seed] = 1;
+    let area = 0;
+    const wn: Vec3 = [0, 0, 0];
+    const stack = [seed];
+    while (stack.length) {
+      const t = stack.pop()!;
+      const a = triA[t], n = triN[t]!;
+      area += a;
+      wn[0] += n[0] * a; wn[1] += n[1] * a; wn[2] += n[2] * a;
+      for (const u of adj[t]) {
+        if (seen[u] || !triN[u]) continue;
+        if (dot(triN[u]!, sn) > COPLANAR_DOT) { seen[u] = 1; stack.push(u); }
+      }
+    }
+    if (!best || area > best.area) best = { area, n: wn };
+  }
   if (!best) return null;
   const nl = len(best.n) || 1;
   const normal: Vec3 = [best.n[0] / nl, best.n[1] / nl, best.n[2] / nl];

--- a/tests/unit/placement.test.ts
+++ b/tests/unit/placement.test.ts
@@ -31,6 +31,67 @@ function cube(min: Vec3 = [0, 0, 0], size: Vec3 = [10, 10, 10]): MeshData {
   return { vertProperties, triVerts, numVert: 8, numTri: 2, numProp: 3 };
 }
 
+/** A closed axis-aligned box (8 verts, 12 triangles) so region-grow has real
+ *  shared edges to walk — unlike `cube`, which is just two loose triangles. */
+function solidBox(size: Vec3 = [10, 10, 10]): MeshData {
+  const [sx, sy, sz] = size;
+  const vertProperties = new Float32Array([
+    0, 0, 0, sx, 0, 0, sx, sy, 0, 0, sy, 0,
+    0, 0, sz, sx, 0, sz, sx, sy, sz, 0, sy, sz,
+  ]);
+  const triVerts = new Uint32Array([
+    0, 2, 1, 0, 3, 2, // bottom (−Z)
+    4, 5, 6, 4, 6, 7, // top (+Z)
+    0, 1, 5, 0, 5, 4, // −Y
+    1, 2, 6, 1, 6, 5, // +X
+    2, 3, 7, 2, 7, 6, // +Y
+    3, 0, 4, 3, 4, 7, // −X
+  ]);
+  return { vertProperties, triVerts, numVert: 8, numTri: 12, numProp: 3 };
+}
+
+/** A short cylinder ("coin"): broad ±Z faces vs a faceted rim. radius/height
+ *  chosen so the flat faces dominate the rim by area. */
+function disk(radius = 10, height = 2, segs = 48): MeshData {
+  const v: number[] = [];
+  const cb = 0, ct = 1;            // bottom/top center vertices
+  v.push(0, 0, 0, 0, 0, height);
+  for (let i = 0; i < segs; i++) {
+    const a = (i / segs) * Math.PI * 2;
+    const x = Math.cos(a) * radius, y = Math.sin(a) * radius;
+    v.push(x, y, 0, x, y, height); // rim bottom (2+2i), rim top (3+2i)
+  }
+  const rb = (i: number) => 2 + 2 * (i % segs);
+  const rt = (i: number) => 3 + 2 * (i % segs);
+  const tri: number[] = [];
+  for (let i = 0; i < segs; i++) {
+    tri.push(cb, rb(i + 1), rb(i));            // bottom fan (−Z)
+    tri.push(ct, rt(i), rt(i + 1));            // top fan (+Z)
+    tri.push(rb(i), rb(i + 1), rt(i + 1));     // side
+    tri.push(rb(i), rt(i + 1), rt(i));
+  }
+  return {
+    vertProperties: new Float32Array(v), triVerts: new Uint32Array(tri),
+    numVert: v.length / 3, numTri: tri.length / 3, numProp: 3,
+  };
+}
+
+/** Concatenate several meshes into one (offsetting triangle indices). */
+function mergeMeshes(...meshes: MeshData[]): MeshData {
+  const verts: number[] = [];
+  const tris: number[] = [];
+  let base = 0;
+  for (const m of meshes) {
+    verts.push(...m.vertProperties);
+    for (let i = 0; i < m.triVerts.length; i++) tris.push(m.triVerts[i] + base);
+    base += m.numVert;
+  }
+  return {
+    vertProperties: new Float32Array(verts), triVerts: new Uint32Array(tris),
+    numVert: verts.length / 3, numTri: tris.length / 3, numProp: 3,
+  };
+}
+
 function applyMat(m: number[], p: Vec3): Vec3 {
   return [
     m[0] * p[0] + m[1] * p[1] + m[2] * p[2],
@@ -117,6 +178,48 @@ describe('bestFlatDownRotation + lay-flat', () => {
     // Laid flat, the thin dimension (4) becomes the height again.
     const box = meshBox(rotated);
     expect(box.max[2] - box.min[2]).toBeCloseTo(4, 4);
+  });
+
+  it('lays a coin on its broad face, not its rim', () => {
+    // Stand the coin on its rim (90° about X puts the flat faces vertical),
+    // then lay-flat must rotate a flat face back down.
+    const coin = applySteps(disk(10, 2, 48), [{ kind: 'rotate', v: [90, 0, 0] }]);
+    const euler = bestFlatDownRotation(coin);
+    expect(euler).not.toBeNull();
+    const box = meshBox(applySteps(coin, rotateAboutCenterSteps(meshBox(coin), euler!)));
+    // On its face the height is the 2-unit thickness, not the 20-unit diameter.
+    expect(box.max[2] - box.min[2]).toBeCloseTo(2, 3);
+  });
+
+  it('lays a standing box on its largest face', () => {
+    // A book stood on its spine: largest face (8×10) has a ±X normal.
+    const standing = solidBox([2, 8, 10]);
+    const euler = bestFlatDownRotation(standing);
+    expect(euler).not.toBeNull();
+    const box = meshBox(applySteps(standing, rotateAboutCenterSteps(meshBox(standing), euler!)));
+    // Largest face down ⇒ the 2-unit thickness becomes the height.
+    expect(box.max[2] - box.min[2]).toBeCloseTo(2, 4);
+  });
+
+  it('does not pool non-coplanar faces that share a normal', () => {
+    // Two thin slabs stacked with a gap: each top face (+Z) is small on its own,
+    // but together they out-area the genuinely-largest face (a side). The old
+    // direction-bucketing summed them and tipped the part onto a tiny ledge;
+    // contiguous clustering keeps them separate and picks the real big face.
+    const lower = solidBox([8, 8, 1]);                                   // +Z face area 64
+    const upper = applySteps(solidBox([8, 8, 1]), [{ kind: 'translate', v: [0, 0, 5] }]); // +Z face area 64, z=6
+    // +Z pool (old algo) = 64 + 64 + the wall's own small +Z (30) = 158.
+    // A tall thin wall whose ±X face (30×3 = 90) is the single largest flat face.
+    const wall = applySteps(solidBox([1, 30, 3]), [{ kind: 'translate', v: [20, 0, 0] }]);
+    const merged = mergeMeshes(lower, upper, wall);
+    const euler = bestFlatDownRotation(merged);
+    expect(euler).not.toBeNull();
+    const out = applySteps(merged, rotateAboutCenterSteps(meshBox(merged), euler!));
+    const n = applyMat(eulerToMatrix(euler![0], euler![1], euler![2]), [1, 0, 0]);
+    // The chosen down-face is the wall's ±X side (its normal maps to −Z), not the
+    // +Z ledges (which would have left +Z mapping to −Z, i.e. n[2] ≈ 0 here).
+    expect(Math.abs(n[2])).toBeCloseTo(1, 3);
+    void out;
   });
 
   it('returns null for a degenerate mesh', () => {


### PR DESCRIPTION
## Summary

The Place/Rotate panel's **"Lay flat"** was tipping models onto whatever flat-ish facet was handy rather than their largest flat surface — a coin could land on its rim, not its broad face.

The rotation math in `bestFlatDownRotation` (`src/surface/placement.ts`) was correct; the flaw was face *selection*. The old code bucketed every triangle by its quantized normal **direction** (`round(n*100)`) and laid the largest-area bucket down. Two failure modes:

1. **Buckets by direction, not plane.** Faces pointing the same way at different heights (stair steps, embossed text, scattered ledges) were summed into one phantom face — so the part could be tipped onto a small protrusion whose *pooled* area beat the real largest face.
2. **Hard quantization degenerates on organic meshes.** Coins/books (one shared normal per flat face) happened to work, but on any curved, smoothed, voxelized, or photo-derived model no two triangles share a normal, so each bucket holds ~1 triangle and "largest bucket" collapses to "biggest single triangle" — an arbitrary facet. That's the reported "grabs whatever flat surface is nearby" behaviour.

## Fix

Region-grow **contiguous coplanar** triangles into real faces, then lay the largest-area face down:

- **Weld** vertices by quantized position (scaled to the model diagonal) so edge-adjacency survives meshes that duplicate vertices per triangle (imported STL / some bakes); a no-op for manifold's own shared-index meshes.
- Build triangle **adjacency** over shared welded edges.
- **BFS-grow** each region, seeded from the largest triangles first and comparing every candidate to the region's *seed* normal (dot > `COPLANAR_DOT`). Seed-relative comparison bounds drift, so a curved surface grows into thin near-flat bands instead of swallowing the whole mesh — and never forms a whole-rim component whose area-weighted normal cancels to zero.
- Largest region's area-weighted normal → `rotationFromTo(n, [0,0,-1])`.

Deliberately does **not** pool non-coplanar same-direction faces: the part rests on one contact plane, so inventing a face from scattered area would be wrong. (Convex-hull resting-face enumeration + centre-of-mass stability is a heavier follow-up, intentionally out of scope here.)

The two tolerances are named module consts (`COPLANAR_DOT`, `WELD_FRACTION`) — structural geometric epsilons in the spirit of the other inline epsilons already in this pure unit-tier module, not user-tunable knobs.

## Test plan

- **Unit** (`tests/unit/placement.test.ts`): added closed-mesh builders (`solidBox`, faceted `disk`, `mergeMeshes`) and three cases — a coin stood on its rim lands on its broad face (height = thickness), a book stood on its spine lands on its largest face, and a part with two stacked +Z ledges (pooled area 158) beside one tall wall (single face 90) lays on the wall's side (proving non-coplanar faces are no longer summed). Original tilted-slab + degenerate-mesh tests still pass. **21/21 in file, 784/784 unit tier, `npm run build` clean.**
- **Browser**: drove a cylinder stood on its rim (`Manifold.cylinder(...).rotate([90,0,0])`) through `partwright.layFlatModel()` — it rotated onto its broad face, resting on Z=0 with bbox `[36, 36, 3]` (height = the 3-unit thickness). Before/after screenshots posted in the session.

https://claude.ai/code/session_011jKfASFKSLRcncGddm3LMD

---
_Generated by [Claude Code](https://claude.ai/code/session_011jKfASFKSLRcncGddm3LMD)_