### PR TITLE
fix: honor render-only contract in print/export pipeline

### DIFF
--- a/prompts/20260607-213951-render-only-printability.md
+++ b/prompts/20260607-213951-render-only-printability.md
@@ -1,0 +1,45 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T21:39:51Z"
+sequence: 1
+---
+
+## Human
+
+Holistic pre-production review of the codebase (via 10 audit subagents),
+then: "fix them and group the prs however you think is most appropriate."
+
+Two independent audit agents (relief subsystem + engines/import/export/print)
+converged on the same defect: the render-only printability contract is only
+half-implemented.
+
+## Assistant
+
+## Key decisions
+
+**Root cause**: `computePrintability` (the viewport pill) correctly treats
+`manifoldStatus === 'render-only (not manifold)'` as *unverified* watertightness
+rather than a failure. But `analyzePrintability` — the detailed report used by
+the Print panel's "Check printability", the auto-warn toast fired on every
+STL/OBJ/3MF/GLB export, and the AI `checkPrintability` tool — took only a bare
+`isManifold` boolean and unconditionally emitted a `level:'fail'` "Not watertight
+— repair before printing." So every colour/SVG relief (deliberately render-only,
+verified watertight at build time) tripped a bogus blocker on export and to the
+AI agent. This is exactly the false-positive the contract exists to prevent,
+just relocated from the pill to the export/AI path.
+
+**Fix**: Added an optional `renderOnly` flag to `PrintabilityOptions`. When set,
+`analyzePrintability` reports the watertightness check as `level:'info'`
+("unverified — render-only import") instead of `'fail'`, and the wall-thickness
+skip message reflects the render-only reason. Both call sites in `main.ts`
+(`warnIfNotPrintable` for export, the `checkPrintability` tool) now derive
+`renderOnly` from `geo.manifoldStatus`, mirroring `computePrintability`. Chose a
+flag over passing the whole stats object to keep `printability.ts` a pure
+function over a minimal options bag (its existing contract).
+
+**Export hygiene (related)**: `buildSTL` iterated raw `triVerts` and, unlike the
+OBJ and 3MF exporters, never dropped degenerate (zero-area) triangles — a
+collapsed triangle writes a zero-length normal and trips slicer "non-manifold
+edge" warnings. Routed STL through the shared `cleanMeshForExport` and consumed
+its `validTris` (STL is unindexed, so only the degenerate filter is needed, not
+the vertex dedup). Now all three mesh exporters share the same cleanup.

--- a/src/export/stl.ts
+++ b/src/export/stl.ts
@@ -1,12 +1,22 @@
 import type { MeshData } from '../geometry/types';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
-import { assertFiniteMesh } from './meshClean';
+import { assertFiniteMesh, cleanMeshForExport } from './meshClean';
 import type { BuiltExport } from './gltf';
 
 /** Build the binary STL blob for a mesh without triggering a download. */
 export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
   assertFiniteMesh(meshData);
-  const { vertProperties, triVerts, numTri, numProp } = meshData;
+  const { numProp } = meshData;
+
+  // Drop degenerate (zero-area) triangles before writing, consistent with the
+  // OBJ and 3MF exporters — a collapsed triangle yields a zero-length normal
+  // and trips slicer "non-manifold edge" warnings. cleanMeshForExport also
+  // merges duplicate vertices, but STL is unindexed so we only consume
+  // `validTris` (the non-degenerate triangle indices) and read the original
+  // vertex positions.
+  const { validTris } = cleanMeshForExport(meshData);
+  const { vertProperties, triVerts } = meshData;
+  const numTri = validTris.length;
 
   // Binary STL format
   const headerSize = 80;
@@ -41,9 +51,10 @@ export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
 
   let offset = 84;
   for (let t = 0; t < numTri; t++) {
-    const i0 = triVerts[t * 3];
-    const i1 = triVerts[t * 3 + 1];
-    const i2 = triVerts[t * 3 + 2];
+    const origT = validTris[t];
+    const i0 = triVerts[origT * 3];
+    const i1 = triVerts[origT * 3 + 1];
+    const i2 = triVerts[origT * 3 + 2];
 
     const v0x = vertProperties[i0 * numProp];
     const v0y = vertProperties[i0 * numProp + 1];

--- a/src/geometry/printability.ts
+++ b/src/geometry/printability.ts
@@ -41,6 +41,12 @@ export interface PrintabilityOptions {
   overhangAngleDeg: number;
   /** Whether the source manifold is watertight/valid. From geometry stats. */
   isManifold: boolean;
+  /** True when `isManifold` is false purely because the geometry is a
+   *  render-only import (e.g. a colour relief) that carries no live Manifold to
+   *  re-measure — NOT because the mesh was found non-watertight. Such meshes are
+   *  validated watertight at build time, so the watertightness check is reported
+   *  as `info` (unverified) rather than `fail`. Mirrors `computePrintability`. */
+  renderOnly?: boolean;
 }
 
 type Vec3 = [number, number, number];
@@ -215,7 +221,7 @@ function estimateThinWalls(mesh: MeshData, nozzleWidth: number, bbDiag: number):
 }
 
 export function analyzePrintability(mesh: MeshData, opts: PrintabilityOptions): PrintabilityReport {
-  const { bed, nozzleWidth, overhangAngleDeg, isManifold } = opts;
+  const { bed, nozzleWidth, overhangAngleDeg, isManifold, renderOnly = false } = opts;
   const bb = boundingBox(mesh);
   const checks: PrintabilityCheck[] = [];
 
@@ -302,7 +308,9 @@ export function analyzePrintability(mesh: MeshData, opts: PrintabilityOptions): 
       }
     }
   } else if (!isManifold) {
-    checks.push({ id: 'walls', level: 'info', text: 'Wall-thickness check skipped — needs a watertight (manifold) model.' });
+    checks.push({ id: 'walls', level: 'info', text: renderOnly
+      ? 'Wall-thickness check skipped — render-only import has no live manifold to sample.'
+      : 'Wall-thickness check skipped — needs a watertight (manifold) model.' });
   }
 
   const smallestDimension = bb ? Math.min(...bb.dimensions) : null;
@@ -337,8 +345,12 @@ export function analyzePrintability(mesh: MeshData, opts: PrintabilityOptions): 
   // ── Manifold / watertight ───────────────────────────────────────────────
   if (isManifold) {
     checks.push({ id: 'manifold', level: 'pass', text: 'Watertight (manifold) — slices cleanly.' });
+  } else if (renderOnly) {
+    // Verified watertight when the import was created; there's just no live
+    // Manifold to re-measure now. Unverified, not a defect — don't block.
+    checks.push({ id: 'manifold', level: 'info', text: 'Watertightness unverified — render-only import (validated watertight when created; no live manifold to re-measure).' });
   } else {
-    checks.push({ id: 'manifold', level: 'fail', text: 'Not watertight — render-only or non-manifold geometry will not slice reliably. Repair before printing.' });
+    checks.push({ id: 'manifold', level: 'fail', text: 'Not watertight — non-manifold geometry will not slice reliably. Repair before printing.' });
   }
 
   const ok = !checks.some(c => c.level === 'fail');

--- a/src/main.ts
+++ b/src/main.ts
@@ -3895,15 +3895,18 @@ async function main() {
     if (!currentMeshData) return;
     const settings = loadPrinterSettings();
     let isManifold = false;
+    let renderOnly = false;
     try {
       const geo = JSON.parse(geometryDataEl.textContent || '{}');
       isManifold = !!geo.isManifold;
+      renderOnly = geo.manifoldStatus === 'render-only (not manifold)';
     } catch { /* default false */ }
     const report: PrintabilityReport = analyzePrintability(currentMeshData, {
       bed: settings.bed,
       nozzleWidth: settings.nozzleWidth,
       overhangAngleDeg: settings.overhangAngleDeg,
       isManifold,
+      renderOnly,
     });
     const fails = report.checks.filter(c => c.level === 'fail');
     const warns = report.checks.filter(c => c.level === 'warn');
@@ -9776,6 +9779,7 @@ async function main() {
         nozzleWidth: opts?.nozzleWidth ?? settings.nozzleWidth,
         overhangAngleDeg: opts?.overhangAngleDeg ?? settings.overhangAngleDeg,
         isManifold: stats.isManifold === true,
+        renderOnly: stats.manifoldStatus === 'render-only (not manifold)',
       });
     },
 


### PR DESCRIPTION
## Summary

Pre-production audit fix (1 of 9). **Two independent audit agents converged on this defect**, making it the highest-confidence finding.

`analyzePrintability` — used by the Print panel's "Check printability", the auto-warn toast on every STL/OBJ/3MF/GLB export, and the AI `checkPrintability` tool — took a bare `isManifold` boolean and emitted a `level:'fail'` "Not watertight — repair before printing" whenever it was false. Render-only imports (colour reliefs, sculpted STLs) carry no live Manifold to re-measure, so `isManifold` is false purely for lack of measurement — they were validated watertight at build time. This fired a bogus blocker on every relief export and to the AI.

`computePrintability` (the viewport pill) already handles this via a `renderOnly` branch; `analyzePrintability` did not.

- Added an optional `renderOnly` flag to `PrintabilityOptions`; when set, the watertightness check is reported as `level:'info'` (unverified, not failed), and the wall-thickness skip message reflects the render-only reason.
- Both call sites in `main.ts` derive `renderOnly` from `geo.manifoldStatus`, mirroring `computePrintability`.
- Bonus: routed `buildSTL` through the shared `cleanMeshForExport` to drop degenerate triangles, matching the OBJ and 3MF exporters (a collapsed triangle wrote a zero-length normal and tripped slicer non-manifold-edge warnings).

## Test plan
- `npm run build` ✅ · `npm run test:unit` (784) ✅ · `npm run lint:deps` ✅
- PR-checks e2e will exercise the export + printability paths.

https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo)_