### PR TITLE
fix: correct voxel rotate pivot and tighten paint mode coordination

### DIFF
--- a/prompts/20260607-214653-voxel-paint-correctness.md
+++ b/prompts/20260607-214653-voxel-paint-correctness.md
@@ -1,0 +1,47 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T21:46:53Z"
+sequence: 2
+---
+
+## Human
+
+Pre-production audit follow-up: "fix them and group the prs however you think
+is most appropriate." This PR collects the voxel + paint correctness findings.
+
+## Assistant
+
+## Key decisions
+
+**Voxel `rotate()` one-voxel pivot bug** (`grid.ts`): a voxel at integer coord
+`n` owns the cube `[n, n+1]`, so its centre is at `n+0.5`. `rotate()` applied the
+rotation matrix to the min-corner directly, which is equivalent to pivoting about
+`(−0.5,−0.5,−0.5)` — every non-identity 90°/180° rotation shifted the solid by a
+voxel. The existing "4×90° round-trips" test passed only because the shift
+cancels at 360°, masking it. Fixed by rotating cube centres about the origin and
+mapping back to the min-corner (`round(rot(n+0.5) − 0.5)`), the same reasoning
+`mirror()` already uses (`n → −1−n`). Updated the three rotate unit tests to the
+correct target cells (they previously asserted the buggy results). Verified no
+example/catalog model calls `v.rotate()` with 90° steps, so nothing shifts.
+Also documented that a stored `smooth({ lockBox })` is in voxel coords and isn't
+remapped by rotate (set surfacing after transforms), and range-guarded `get()`
+to match `has()`.
+
+**Voxel Studio outside modeExclusion** (`voxelPaint.ts` + the mesh/annotate
+tools): the studio attaches a capture-phase pointer handler exactly like mesh
+paint but was separated from paint/imagePaint only by UI visibility — and the AI
+API can drive either regardless of the active language, so two handlers could
+fight over the canvas. Added `'voxelStudio'` to `ExclusiveMode`, registered the
+studio's deactivator, had `activate()` tear down the mesh-paint + annotate
+siblings, and had those siblings call `deactivateMode('voxelStudio')` on
+activate. All through the modeExclusion leaf — no mode imports another.
+
+**imagePaintUI back-edge** (`imagePaintUI.ts`): it read `getCurrentMesh`
+directly from `paintMode` instead of the `paintAccessors` leaf the drag tools
+use — a latent cycle edge. Switched to the leaf.
+
+**paintPreview cylinder `topOnly`** (`main.ts`): the dry-run cylinder path passed
+`normalCone` straight through, with no `topOnly`, so it couldn't reproduce a
+`paintInCylinder({ topOnly: true })` selection and over-reported triangles. Added
+`topOnly` to the preview opts and routed it through `resolvePaintCone`, matching
+the commit path.

--- a/src/annotations/annotateMode.ts
+++ b/src/annotations/annotateMode.ts
@@ -80,6 +80,7 @@ function notifyActiveChange(): void {
 export function activate(): void {
   if (active) return;
   deactivateMode('paint');
+  deactivateMode('voxelStudio');
   closeSimplifyMenu();
   deactivateMode('select');
   // Detach text mode's handlers but keep the session plane alive — pen and

--- a/src/annotations/selectMode.ts
+++ b/src/annotations/selectMode.ts
@@ -77,6 +77,7 @@ function notifyActiveChange(): void {
 export function activate(): void {
   if (active) return;
   deactivateMode('paint');
+  deactivateMode('voxelStudio');
   closeSimplifyMenu();
   deactivateMode('pen', { keepSession: false });
   deactivateMode('text', { keepSession: false });

--- a/src/annotations/textMode.ts
+++ b/src/annotations/textMode.ts
@@ -68,6 +68,7 @@ function notifyActiveChange(): void {
 export function activate(): void {
   if (active) return;
   deactivateMode('paint');
+  deactivateMode('voxelStudio');
   closeSimplifyMenu();
   deactivateMode('select');
 

--- a/src/color/imagePaintUI.ts
+++ b/src/color/imagePaintUI.ts
@@ -30,7 +30,10 @@ import {
   canRedoRegion,
   redoLastRegion,
 } from './regions';
-import { getCurrentMesh as getPaintMesh } from './paintMode';
+// Read the current mesh through the paintAccessors leaf (published by paintMode)
+// rather than importing paintMode directly — same one-way dependency the drag
+// tools (boxDrag/slabDrag) use, so this stays a leaf read, not a back-edge.
+import { getCurrentMesh as getPaintMesh } from './paintAccessors';
 import { deactivateMode, registerExclusiveMode } from '../ui/modeExclusion';
 import { forceDeactivate as closeSimplifyMenu } from '../ui/simplifyUI';
 import { viewportToolsMount } from '../ui/popoverMenu';
@@ -176,6 +179,7 @@ function toggleImagePaint(): void {
   } else {
     // Close conflicting modes
     deactivateMode('paint');
+    deactivateMode('voxelStudio');
     closeSimplifyMenu();
     closeAnnotate();
     closeAnnotateText();

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -188,6 +188,7 @@ function togglePaintMode(): void {
     closeSimplifyMenu();
     closePrintToolsMenu();
     deactivateMode('imagePaint');
+    deactivateMode('voxelStudio');
     activate();
     updateButtonState(true);
     if (pickerPanel) setInitialPanelPosition(pickerPanel);

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -24,6 +24,7 @@ import { diffGrids, type VoxelEditOps } from '../geometry/voxel/editCodegen';
 import { generateVoxelImportCode } from '../import/imageToVoxel';
 import { addPointerSuppressor, isPointerOverModel, getRenderer } from '../renderer/viewport';
 import { pickFace } from './facePicker';
+import { registerExclusiveMode, deactivateMode } from '../ui/modeExclusion';
 
 export type { BrushShape } from '../geometry/voxel/edits';
 
@@ -201,6 +202,15 @@ export function activate(code: string, callbacks: VoxelPaintCallbacks, paramOver
   cbMeshUpdate = callbacks.onMeshUpdate;
   cbLockChange = callbacks.onLockChange ?? null;
   cbStateChange = callbacks.onStateChange ?? null;
+  // Exclusive with the mesh-paint and annotate tools: they each attach a
+  // capture-phase pointer handler to the same canvas, so only one may own it.
+  // UI visibility alone doesn't enforce this (the AI API can drive either tool
+  // regardless of the active language), so coordinate through modeExclusion.
+  deactivateMode('paint');
+  deactivateMode('imagePaint');
+  deactivateMode('pen', { keepSession: false });
+  deactivateMode('text', { keepSession: false });
+  deactivateMode('select', { keepSession: false });
   attachPointerHandler();
   cbLockChange?.(true);
   cbMeshUpdate(run.mesh);
@@ -228,6 +238,10 @@ export function deactivate(): void {
   strokeLastVoxel = null;
   notify?.();
 }
+
+// Take our turn in the exclusive-tool registry so activating a mesh-paint or
+// annotate tool tears the studio down (and vice-versa, via activate() above).
+registerExclusiveMode('voxelStudio', () => deactivate());
 
 /** Paint or erase the voxel that owns the given triangle — the legacy
  *  single-voxel primitive driven by the `eraser` flag. Kept for the

--- a/src/geometry/voxel/grid.ts
+++ b/src/geometry/voxel/grid.ts
@@ -141,6 +141,7 @@ export class VoxelGrid {
 
   /** Color of the voxel at (x,y,z), or null if empty. */
   get(x: number, y: number, z: number): number | null {
+    if (x < COORD_MIN || x > COORD_MAX || y < COORD_MIN || y > COORD_MAX || z < COORD_MIN || z > COORD_MAX) return null;
     const v = this.cells.get(packKey(x | 0, y | 0, z | 0));
     return v === undefined ? null : v;
   }
@@ -266,12 +267,22 @@ export class VoxelGrid {
     return this;
   }
 
-  /** Rotate the whole grid about the origin around one axis, by a multiple of
-   *  90° (the only angles that keep voxels on the integer lattice). Positive
-   *  degrees follow the right-hand rule (CCW looking down the +axis). Rotation
-   *  is about (0,0,0), so `translate` first if you want a different pivot.
-   *  Handy for reorienting a model built facing one way — e.g. spin a +Y-facing
-   *  figure to face the −Y front with `v.rotate('z', 180)`. Chainable.
+  /** Rotate the whole grid about the world origin around one axis, by a
+   *  multiple of 90° (the only angles that keep voxels on the integer lattice).
+   *  Positive degrees follow the right-hand rule (CCW looking down the +axis).
+   *  Rotation is about (0,0,0), so `translate` first if you want a different
+   *  pivot. Handy for reorienting a model built facing one way — e.g. spin a
+   *  +Y-facing figure to face the −Y front with `v.rotate('z', 180)`. Chainable.
+   *
+   *  A voxel at integer coord `n` owns the cube `[n, n+1]`, so its CENTER is at
+   *  `n+0.5`. We rotate the centres about the origin and convert back to the
+   *  min-corner (`round(rotate(n+0.5) − 0.5)`); rotating the min-corner directly
+   *  would pivot about (−0.5,−0.5,−0.5) and shift the solid by a voxel per turn.
+   *  (This is why `mirror` uses `n → −1−n` rather than `n → −n`.)
+   *
+   *  NOTE: a stored `smooth({ lockBox })` region is in voxel coords and is NOT
+   *  remapped by rotate; set surfacing/`lockBox` AFTER any rotate/translate.
+   *  `flatBottom`/`baseLayers` are plane-relative and stay correct.
    *
    *  Voxels rotated past the asymmetric grid edge (COORD_MIN..COORD_MAX) are
    *  dropped, same as `translate`/`mirror`; models near the origin are safe. */
@@ -283,12 +294,15 @@ export class VoxelGrid {
     if (t === 0) return this;
     const c = t === 180 ? -1 : 0;          // cos of 0/90/180/270 as exact ints
     const s = t === 90 ? 1 : t === 270 ? -1 : 0; // sin of same
+    // Rotate cube centres about the origin, then map back to the min-corner.
+    // (p+0.5,q+0.5)·R − 0.5 is an exact integer for 90° steps; round defensively.
+    const r = (p: number, q: number, cc: number, ss: number) => Math.round((p + 0.5) * cc + (q + 0.5) * ss - 0.5);
     const rotated = new Map<number, number>();
     this.forEach((x, y, z, col) => {
       let nx = x, ny = y, nz = z;
-      if (ax === 'z') { nx = x * c - y * s; ny = x * s + y * c; }
-      else if (ax === 'x') { ny = y * c - z * s; nz = y * s + z * c; }
-      else { nx = x * c + z * s; nz = z * c - x * s; }
+      if (ax === 'z') { nx = r(x, y, c, -s); ny = r(x, y, s, c); }
+      else if (ax === 'x') { ny = r(y, z, c, -s); nz = r(y, z, s, c); }
+      else { nx = r(x, z, c, s); nz = r(x, z, -s, c); }
       if (inRange(nx, ny, nz)) rotated.set(packKey(nx, ny, nz), col);
     });
     this.cells = rotated;

--- a/src/main.ts
+++ b/src/main.ts
@@ -10806,6 +10806,10 @@ async function main() {
       cylinder?: { center?: [number, number]; rMin: number; rMax: number; zMin: number; zMax: number };
       slab?: { axis?: 'x' | 'y' | 'z'; normal?: [number, number, number]; offset: number; thickness: number };
       normalCone?: { axis: [number, number, number]; angleDeg: number };
+      /** Cylinder selector only — mirrors `paintInCylinder.topOnly`. Keeps just
+       *  the outward-radial faces so the dry-run matches what a
+       *  `paintInCylinder({ topOnly: true })` commit would actually paint. */
+      topOnly?: boolean;
       point?: [number, number, number];
       radius?: number;
       triangleIds?: number[];
@@ -10856,9 +10860,12 @@ async function main() {
         if (c.rMin < 0 || c.rMax <= c.rMin) return { error: 'cylinder requires rMin >= 0 and rMax > rMin' };
         if (c.zMax <= c.zMin) return { error: 'cylinder requires zMax > zMin' };
         if (c.center !== undefined && (!Array.isArray(c.center) || c.center.length !== 2)) return { error: 'cylinder.center must be [x, y]' };
-        const coneErr = validateNormalCone(opts.normalCone);
+        // Resolve topOnly into a cone the same way paintInCylinder does, so the
+        // preview's selection matches a topOnly commit instead of over-reporting.
+        const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
+        const coneErr = validateNormalCone(cone);
         if (coneErr) return { error: coneErr };
-        triangles = collectTrianglesByCylinder(mesh, c.center ?? [0, 0], c.rMin, c.rMax, c.zMin, c.zMax, opts.normalCone, opts.coverageMode, opts.maxTriangleArea);
+        triangles = collectTrianglesByCylinder(mesh, c.center ?? [0, 0], c.rMin, c.rMax, c.zMin, c.zMax, cone, opts.coverageMode, opts.maxTriangleArea);
       } else if (opts.slab !== undefined) {
         const s = opts.slab;
         if (typeof s !== 'object' || s === null) return { error: 'slab must be { axis|normal, offset, thickness }' };

--- a/src/ui/modeExclusion.ts
+++ b/src/ui/modeExclusion.ts
@@ -15,8 +15,12 @@
 // that per-transition option, so we keep the exact existing calls — only the
 // import edge changes.
 
-/** Identifiers for the mutually-exclusive viewport tools. */
-export type ExclusiveMode = 'paint' | 'imagePaint' | 'pen' | 'text' | 'select';
+/** Identifiers for the mutually-exclusive viewport tools. `voxelStudio` is the
+ *  voxel-language click-to-edit canvas; like the mesh-paint tools it attaches a
+ *  capture-phase pointer handler, so it must take its turn through this registry
+ *  rather than relying on UI visibility (the AI API can drive either regardless
+ *  of the active language). */
+export type ExclusiveMode = 'paint' | 'imagePaint' | 'pen' | 'text' | 'select' | 'voxelStudio';
 
 /** Options forwarded verbatim to a mode's `forceDeactivate`. Only the annotate
  *  sub-modes honour `keepSession`; paint ignores it. */

--- a/tests/unit/voxel.test.ts
+++ b/tests/unit/voxel.test.ts
@@ -90,14 +90,18 @@ describe('VoxelGrid', () => {
     v.set(2, 5, 1, '#abc');            // a feature on +Y
     v.rotate('z', 180);
     expect(v.has(2, 5, 1)).toBe(false);
-    expect(v.get(-2, -5, 1)).toBe(0xaabbcc); // 180° about Z: (x,y) → (−x,−y)
+    // Rotation is about the world origin of the cube CENTRES, so 180° about Z
+    // maps cell (x,y) → (−x−1,−y−1) — not (−x,−y), which would shift by a voxel.
+    expect(v.get(-3, -6, 1)).toBe(0xaabbcc);
+    expect(v.has(-2, -5, 1)).toBe(false);
     expect(v.size).toBe(1);
   });
 
   it('rotate follows the right-hand rule for each axis (90°)', () => {
-    expect(new VoxelGrid().set(3, 0, 0, '#fff').rotate('z', 90).has(0, 3, 0)).toBe(true);  // +X → +Y
-    expect(new VoxelGrid().set(0, 3, 0, '#fff').rotate('x', 90).has(0, 0, 3)).toBe(true);  // +Y → +Z
-    expect(new VoxelGrid().set(0, 0, 3, '#fff').rotate('y', 90).has(3, 0, 0)).toBe(true);  // +Z → +X
+    // 90° rotates the cube centre about the origin; cell n → round(rot(n+0.5)−0.5).
+    expect(new VoxelGrid().set(3, 0, 0, '#fff').rotate('z', 90).has(-1, 3, 0)).toBe(true);  // +X → +Y
+    expect(new VoxelGrid().set(0, 3, 0, '#fff').rotate('x', 90).has(0, -1, 3)).toBe(true);  // +Y → +Z
+    expect(new VoxelGrid().set(0, 0, 3, '#fff').rotate('y', 90).has(3, 0, -1)).toBe(true);  // +Z → +X
   });
 
   it('rotate is exact and reversible (4×90° returns to start)', () => {
@@ -111,7 +115,7 @@ describe('VoxelGrid', () => {
 
   it('rotate rejects non-90° multiples and normalizes negatives', () => {
     expect(() => new VoxelGrid().rotate('z', 45)).toThrow();
-    expect(new VoxelGrid().set(3, 0, 0, '#fff').rotate('z', -90).has(0, -3, 0)).toBe(true); // −90° = 270°
+    expect(new VoxelGrid().set(3, 0, 0, '#fff').rotate('z', -90).has(0, -4, 0)).toBe(true); // −90° = 270°: (x,y)→(y,−x−1)
   });
 });
 


### PR DESCRIPTION
## Summary

Pre-production audit fix (2 of 9) — voxel + paint correctness.

- **Voxel `rotate()` one-voxel pivot bug**: it rotated voxel *min-corners* about the world origin, but each voxel owns the cube `[n, n+1]` (centre at `n+0.5`), so that effectively pivots about `(−0.5,−0.5,−0.5)` and shifts the solid by one voxel per 90°/180° turn. The "4×90° round-trips" unit test passed only because the shift cancels at 360°, masking it. Now rotates cube centres about the origin and maps back to the min-corner (`round(rot(n+0.5) − 0.5)`), the same reasoning `mirror()` uses. Updated the rotate tests to the correct target cells.
- **Voxel Studio joins `modeExclusion`**: it attaches a capture-phase pointer handler like mesh paint but was separated only by UI visibility, and the AI API can drive either tool regardless of language. Activating the studio now tears down paint/imagePaint/annotate and vice-versa, all through the leaf.
- **`imagePaintUI`** now reads `getCurrentMesh` from the `paintAccessors` leaf instead of importing `paintMode` directly (removes a latent back-edge).
- **`paintPreview`** cylinder selector now honours `topOnly` via `resolvePaintCone`, so the dry-run matches a `paintInCylinder({ topOnly: true })` commit instead of over-reporting.
- Range-guarded `VoxelGrid.get()` to match `has()`.

## Test plan
- `npm run build` ✅ · `npm run test:unit` (784) ✅ · `npm run lint:deps` ✅ (no new cycle)
- Verified no example/catalog model calls `v.rotate()` with 90° steps, so the corrected pivot shifts nothing already committed.

https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo)_