### PR TITLE
fix: make the mesh-detail slider work for all surface textures

### DIFF
--- a/prompts/20260607-215443-surface-texture-quality-and-tests.md
+++ b/prompts/20260607-215443-surface-texture-quality-and-tests.md
@@ -1,0 +1,42 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T21:54:43Z"
+sequence: 3
+---
+
+## Human
+
+Pre-production audit follow-up: "fix them and group the prs however you think
+is most appropriate." This PR collects the surface-modifier findings.
+
+## Assistant
+
+## Key decisions
+
+**Mesh-detail slider dead for 5 of 6 textures** (`main.ts` `buildSurfaceModifier`):
+the opts objects for fuzzy/cable/waffle/fur/woven omitted `quality`, so the pure
+functions fell back to `opts.quality ?? 3` and the slider — shipped specifically
+to control mesh detail — was a no-op in both preview and apply for everything but
+knit (which builds its own opts on a separate async path). The `base` defaults
+already carry `quality: 3`, and every texture function reads `opts.quality ?? 3`,
+so threading `quality` into each opts object fixes preview and apply at once.
+Added it to all six branches and refreshed the stale "all three modifiers" /
+partial-id-list doc comments (there are eight modifiers now).
+
+**Unguarded scaleMesh** (`modifiers.ts` `applyScale`): a negative factor mirrors
+the mesh (inverting winding → non-manifold) and a zero factor collapses an axis.
+The public `scaleModel`/`previewScale` API takes raw numbers from callers/AI with
+no validation. Added a positive-finite guard at `applyScale` — the engine-agnostic
+boundary both API methods route through inside a try/catch, so a bad factor now
+returns a clear `{ error }` instead of broken geometry.
+
+**Dead code + test pointed at it** (`knitTexture.ts`, `surface.test.ts`): the
+sync triplanar `knitTexture` was superseded by the UV rewrite (`knitTextureUV*`)
+but never deleted, and the only thing importing it was the unit test — so the
+knit invariants were verified against an algorithm production never runs. Deleted
+`knitTexture` (and its now-orphaned `triplanarCoords` import), and retargeted the
+test at the live `knitTextureUV`. Added a parameterized test table covering the
+four newest textures (cable/waffle/fur/woven) for determinism, finite output,
+subdivision, and color carry-through — they had zero unit coverage. Also fixed
+`subdivideToMaxEdge(c, 3)` → `{ maxEdge: 3 }` (a bare number left `maxEdge`
+undefined, so the test asserted nothing about edge length).

--- a/src/main.ts
+++ b/src/main.ts
@@ -7317,9 +7317,11 @@ async function main() {
   }
 
   // Build a modifier result from an id + options (shared by apply and preview).
-  // All three modifiers receive the color-baked mesh when preserveColor is on:
-  // fuzzy/smooth carry triColors (with _painted) through subdivision so the
-  // result already has correct per-triangle paint — no post-hoc transfer needed.
+  // Every modifier receives the color-baked mesh when preserveColor is on:
+  // the texture/smooth paths carry triColors (with _painted) through subdivision
+  // so the result already has correct per-triangle paint — no post-hoc transfer.
+  // `quality` (mesh-detail) is threaded into each opts object so the surface
+  // panel's detail slider takes effect in both preview and apply.
   function buildSurfaceModifier(
     id: 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'smooth' | 'voxelize',
     opts: Record<string, unknown> | undefined,
@@ -7334,6 +7336,7 @@ async function main() {
         scale: (opts?.scale as number) ?? base.scale,
         octaves: (opts?.octaves as number) ?? base.octaves,
         seed: (opts?.seed as number) ?? base.seed,
+        quality: (opts?.quality as number) ?? base.quality,
       };
       if (sel && sel.size > 0) return applyFuzzyPatch(mesh, fuzzyOpts, sel);
       return applyFuzzy(mesh, fuzzyOpts);
@@ -7350,6 +7353,7 @@ async function main() {
         grainAngleDeg: (opts?.grainAngleDeg as number) ?? base.grainAngleDeg,
         variation: (opts?.variation as number) ?? base.variation,
         seed: (opts?.seed as number) ?? base.seed,
+        quality: (opts?.quality as number) ?? base.quality,
         // LSCM/harmonic require disk topology — only use them on a selected patch.
         // On a closed mesh they produce partial coverage; fall back to BFS.
         algorithm: (sel && sel.size > 0)
@@ -7370,6 +7374,7 @@ async function main() {
         grainAngleDeg: (opts?.grainAngleDeg as number) ?? base.grainAngleDeg,
         variation: (opts?.variation as number) ?? base.variation,
         seed: (opts?.seed as number) ?? base.seed,
+        quality: (opts?.quality as number) ?? base.quality,
       };
       if (sel && sel.size > 0) return applyCablePatch(mesh, cableOpts, sel);
       return applyCable(mesh, cableOpts);
@@ -7384,6 +7389,7 @@ async function main() {
         sharpness: (opts?.sharpness as number) ?? base.sharpness,
         rowOffset: (opts?.rowOffset as number) ?? base.rowOffset,
         grainAngleDeg: (opts?.grainAngleDeg as number) ?? base.grainAngleDeg,
+        quality: (opts?.quality as number) ?? base.quality,
       };
       if (sel && sel.size > 0) return applyWafflePatch(mesh, waffleOpts, sel);
       return applyWaffle(mesh, waffleOpts);
@@ -7398,6 +7404,7 @@ async function main() {
         octaves: (opts?.octaves as number) ?? base.octaves,
         grainAngleDeg: (opts?.grainAngleDeg as number) ?? base.grainAngleDeg,
         seed: (opts?.seed as number) ?? base.seed,
+        quality: (opts?.quality as number) ?? base.quality,
       };
       if (sel && sel.size > 0) return applyFurPatch(mesh, furOpts, sel);
       return applyFur(mesh, furOpts);
@@ -7412,6 +7419,7 @@ async function main() {
         underDepth: (opts?.underDepth as number) ?? base.underDepth,
         grainAngleDeg: (opts?.grainAngleDeg as number) ?? base.grainAngleDeg,
         seed: (opts?.seed as number) ?? base.seed,
+        quality: (opts?.quality as number) ?? base.quality,
       };
       if (sel && sel.size > 0) return applyWovenPatch(mesh, wovenOpts, sel);
       return applyWoven(mesh, wovenOpts);
@@ -7439,7 +7447,8 @@ async function main() {
      *  color-clearing modifier, or offer "preserve colors"). */
     modelHasColor(): boolean { return modelHasColor(); },
     /** Non-destructive viewport preview of a surface modifier (no version saved).
-     *  Call clearSurfacePreview() / re-run to restore. id: 'fuzzy'|'knit'|'smooth'|'voxelize'. */
+     *  Call clearSurfacePreview() / re-run to restore.
+     *  id: 'fuzzy'|'knit'|'cable'|'waffle'|'fur'|'woven'|'smooth'|'voxelize'. */
     previewSurfaceModifier(id: 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'smooth' | 'voxelize', opts?: Record<string, unknown>, preserveColor = true): { ok: true } | { error: string } {
       try {
         previewSurfaceModifier(buildSurfaceModifier(id, opts, preserveColor), preserveColor);

--- a/src/surface/knitTexture.ts
+++ b/src/surface/knitTexture.ts
@@ -28,7 +28,6 @@ import {
   extractPositions,
   computeVertexNormals,
   bboxOf,
-  triplanarCoords,
 } from './meshSubdivide';
 import { unwrapMesh, type UVAlgorithm } from './uvParameterize';
 import { knitDisplaceGPU, type KnitGPUParams } from './knitTextureGPU';
@@ -84,87 +83,6 @@ function distToSeg(px: number, py: number, ax: number, ay: number, bx: number, b
   if (len2 < 1e-14) return Math.hypot(px - ax, py - ay);
   const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / len2));
   return Math.hypot(px - ax - t * dx, py - ay - t * dy);
-}
-
-// --- Main algorithm -----------------------------------------------------------
-
-/** Apply knit-stitch displacement, returning a new position-only MeshData. */
-export function knitTexture(mesh: MeshData, opts: KnitTextureOptions): MeshData {
-  const amplitude = Math.max(0, opts.amplitude);
-  const stitchW = Math.max(1e-4, opts.stitchWidth);
-  const stitchH = Math.max(1e-4, opts.stitchHeight ?? stitchW * 1.4);
-  const rowOffset = opts.rowOffset ?? 0.5;
-  const roundness = Math.max(0, Math.min(1, opts.roundness ?? 0.5));
-  const variation = Math.max(0, Math.min(1, opts.variation ?? 0.1));
-  const seed = (opts.seed ?? 1) | 0;
-  const angleRad = ((opts.grainAngleDeg ?? 0) * Math.PI) / 180;
-  const cosA = Math.cos(angleRad);
-  const sinA = Math.sin(angleRad);
-
-  // Densify so a coarse mesh shows the stitch pattern. Target edge roughly
-  // stitch_min/4, but never smaller than diag/400 to avoid triangle explosion.
-  let base: MeshData = mesh;
-  if (opts.subdivide !== false && amplitude > 0) {
-    const quality = Math.max(1, Math.min(5, Math.round(opts.quality ?? 3)));
-    const qScale = 2 ** ((quality - 3) / 2);  // 0.5 at q=1, 1.0 at q=3, 2.0 at q=5
-    const diag = Math.hypot(...bboxOf(extractPositions(mesh)).size);
-    const targetEdge = Math.max(Math.min(stitchW, stitchH) / (4 * qScale), diag / (400 * qScale));
-    base = subdivideToMaxEdge(mesh, { maxEdge: targetEdge, maxRounds: 6 });
-  }
-
-  const positions = base.numProp === 3
-    ? Float32Array.from(base.vertProperties)
-    : extractPositions(base);
-  const normals = computeVertexNormals(positions, base.triVerts);
-
-  const TAU = 2 * Math.PI;
-
-  for (let v = 0; v < base.numVert; v++) {
-    const px = positions[v * 3], py = positions[v * 3 + 1], pz = positions[v * 3 + 2];
-    const nx = normals[v * 3], ny = normals[v * 3 + 1], nz = normals[v * 3 + 2];
-
-    // Triplanar blend: sample the stitch pattern from all three axis planes
-    // weighted by how much the surface normal faces each plane. This makes
-    // the pattern follow the surface on every face of a cube or sphere
-    // instead of degenerating into columns when a face is perpendicular to Z.
-    const { pairs, weights } = triplanarCoords(px, py, pz, nx, ny, nz);
-    let d = 0;
-    for (let i = 0; i < 3; i++) {
-      const [s, t] = pairs[i];
-      const gx = cosA * s + sinA * t;   // column axis (grain-rotated)
-      const gz = -sinA * s + cosA * t;  // row    axis (perpendicular)
-
-      const col = gx / stitchW;
-      const row = gz / stitchH;
-
-      const rowInt = Math.floor(row);
-      const evenRow = ((rowInt % 2) + 2) % 2 === 0;
-      const colShifted = col + (evenRow ? 0 : rowOffset);
-
-      const uf = ((colShifted % 1) + 1) % 1;
-      const vf = ((row % 1) + 1) % 1;
-
-      const colInt = Math.floor(colShifted);
-      const stitchScale = 1 + variation * (hash2(colInt, rowInt, seed) * 2 - 1);
-
-      const uWave = Math.cos(uf * TAU);
-      const vShape = (1 + Math.cos(vf * TAU)) / 2;
-      d += weights[i] * amplitude * stitchScale * uWave * (1 - roundness + roundness * vShape);
-    }
-
-    positions[v * 3]     = px + nx * d;
-    positions[v * 3 + 1] = py + ny * d;
-    positions[v * 3 + 2] = pz + nz * d;
-  }
-
-  return {
-    vertProperties: positions,
-    triVerts: base.triVerts,
-    numVert: base.numVert,
-    numTri: base.numTri,
-    numProp: 3,
-    triColors: base.triColors,
-  };
 }
 
 // --- UV-unwrap path -----------------------------------------------------------

--- a/src/surface/modifiers.ts
+++ b/src/surface/modifiers.ts
@@ -468,6 +468,15 @@ export function applyScale(
   sy: number,
   sz: number,
 ): ModifierManifoldResult {
+  // A negative factor mirrors the mesh (inverting triangle winding → inside-out,
+  // non-manifold) and a zero factor collapses an axis to a degenerate sheet.
+  // Guard at this engine-agnostic boundary so the public scaleModel/previewScale
+  // API (which takes raw numbers from callers/AI) can't produce broken geometry.
+  for (const [name, f] of [['sx', sx], ['sy', sy], ['sz', sz]] as const) {
+    if (!Number.isFinite(f) || f <= 0) {
+      throw new Error(`scale: ${name} must be a positive, finite factor (got ${f}). Use a value > 0 — a negative or zero scale would mirror or collapse the mesh into non-manifold geometry.`);
+    }
+  }
   const baked = scaleMesh(mesh, sx, sy, sz);
   const uniform = sx === sy && sy === sz;
   const desc = uniform

--- a/tests/unit/surface.test.ts
+++ b/tests/unit/surface.test.ts
@@ -9,7 +9,11 @@ import {
   bboxOf,
 } from '../../src/surface/meshSubdivide';
 import { fuzzySkin } from '../../src/surface/fuzzySkin';
-import { knitTexture } from '../../src/surface/knitTexture';
+import { knitTextureUV } from '../../src/surface/knitTexture';
+import { cableKnit } from '../../src/surface/cableKnit';
+import { waffleStitch } from '../../src/surface/waffleStitch';
+import { furVelvet } from '../../src/surface/furVelvet';
+import { wovenFabric } from '../../src/surface/wovenFabric';
 import { smoothSurface } from '../../src/surface/smoothSurface';
 import { voxelizeMesh } from '../../src/surface/voxelizeMesh';
 import { applyFuzzy, applyKnit, applySmooth, applyVoxelize } from '../../src/surface/modifiers';
@@ -127,10 +131,10 @@ describe('fuzzySkin', () => {
   });
 });
 
-describe('knitTexture', () => {
+describe('knitTextureUV', () => {
   it('is deterministic for a given seed and perturbs the surface', () => {
-    const a = knitTexture(cube(10), { amplitude: 0.5, stitchWidth: 2, seed: 7 });
-    const b = knitTexture(cube(10), { amplitude: 0.5, stitchWidth: 2, seed: 7 });
+    const a = knitTextureUV(cube(10), { amplitude: 0.5, stitchWidth: 2, seed: 7 });
+    const b = knitTextureUV(cube(10), { amplitude: 0.5, stitchWidth: 2, seed: 7 });
     expect([...a.vertProperties]).toEqual([...b.vertProperties]);
     // Subdivided, so more triangles than the input cube.
     expect(a.numTri).toBeGreaterThan(12);
@@ -140,30 +144,65 @@ describe('knitTexture', () => {
   });
 
   it('a different seed produces different geometry', () => {
-    const a = knitTexture(cube(10), { amplitude: 0.5, stitchWidth: 2, seed: 1 });
-    const b = knitTexture(cube(10), { amplitude: 0.5, stitchWidth: 2, seed: 2 });
+    const a = knitTextureUV(cube(10), { amplitude: 0.5, stitchWidth: 2, seed: 1 });
+    const b = knitTextureUV(cube(10), { amplitude: 0.5, stitchWidth: 2, seed: 2 });
     expect([...a.vertProperties]).not.toEqual([...b.vertProperties]);
   });
 
   it('zero amplitude leaves the cube unchanged (no subdivision)', () => {
-    const out = knitTexture(cube(10), { amplitude: 0, stitchWidth: 2 });
+    const out = knitTextureUV(cube(10), { amplitude: 0, stitchWidth: 2 });
     expect(out.numVert).toBe(8);
   });
 
   it('grainAngleDeg rotates the pattern (produces different geometry from angle 0)', () => {
-    const a = knitTexture(cube(10), { amplitude: 0.5, stitchWidth: 2, grainAngleDeg: 0 });
-    const b = knitTexture(cube(10), { amplitude: 0.5, stitchWidth: 2, grainAngleDeg: 45 });
+    const a = knitTextureUV(cube(10), { amplitude: 0.5, stitchWidth: 2, grainAngleDeg: 0 });
+    const b = knitTextureUV(cube(10), { amplitude: 0.5, stitchWidth: 2, grainAngleDeg: 45 });
     expect([...a.vertProperties]).not.toEqual([...b.vertProperties]);
   });
 
   it('carries per-triangle colors through subdivision', () => {
     const c = cube(10);
     c.triColors = new Uint8Array(c.numTri * 3).fill(42);
-    const out = knitTexture(c, { amplitude: 0.5, stitchWidth: 2 });
+    const out = knitTextureUV(c, { amplitude: 0.5, stitchWidth: 2 });
     expect(out.triColors).toBeTruthy();
     expect(out.triColors!.length).toBe(out.numTri * 3);
     expect([...out.triColors!].every(v => v === 42)).toBe(true);
   });
+});
+
+// The four fabric textures added after fuzzySkin share its structure (densify →
+// displace along normals, deterministic per seed, color carried through
+// subdivision). One parameterized table guards the invariants for all of them.
+describe('fabric textures (cable / waffle / fur / woven)', () => {
+  const cases = [
+    { name: 'cableKnit', fn: cableKnit as (m: MeshData, o: Record<string, number>) => MeshData, opts: { amplitude: 0.5, cableWidth: 2, seed: 3 } },
+    { name: 'waffleStitch', fn: waffleStitch as (m: MeshData, o: Record<string, number>) => MeshData, opts: { amplitude: 0.5, cellWidth: 2, seed: 3 } },
+    { name: 'furVelvet', fn: furVelvet as (m: MeshData, o: Record<string, number>) => MeshData, opts: { amplitude: 0.5, fiberSpacing: 2, seed: 3 } },
+    { name: 'wovenFabric', fn: wovenFabric as (m: MeshData, o: Record<string, number>) => MeshData, opts: { amplitude: 0.5, threadSpacing: 2, seed: 3 } },
+  ] as const;
+
+  for (const { name, fn, opts } of cases) {
+    it(`${name} is deterministic, finite, and subdivides`, () => {
+      const a = fn(cube(10), { ...opts });
+      const b = fn(cube(10), { ...opts });
+      expect([...a.vertProperties]).toEqual([...b.vertProperties]);
+      expect([...a.vertProperties].every(Number.isFinite)).toBe(true);
+      expect(a.numTri).toBeGreaterThan(12); // densified before displacement
+    });
+
+    it(`${name} zero amplitude is a no-op (no subdivision)`, () => {
+      const out = fn(cube(10), { ...opts, amplitude: 0 });
+      expect(out.numVert).toBe(8);
+    });
+
+    it(`${name} carries per-triangle colors through subdivision`, () => {
+      const c = cube(10);
+      c.triColors = new Uint8Array(c.numTri * 3).fill(42);
+      const out = fn(c, { ...opts });
+      expect(out.triColors!.length).toBe(out.numTri * 3);
+      expect([...out.triColors!].every(v => v === 42)).toBe(true);
+    });
+  }
 });
 
 describe('smoothSurface', () => {
@@ -243,7 +282,7 @@ describe('modifiers (codegen)', () => {
 
     it('maps each subdivided child to a triangle near its parent', () => {
       const c = cube(10);
-      const dense = subdivideToMaxEdge(c, 3); // re-tessellated, same shape
+      const dense = subdivideToMaxEdge(c, { maxEdge: 3 }); // re-tessellated, same shape
       const map = nearestTriangleMap(c, dense);
       expect(map.length).toBe(dense.numTri);
       // Every child must map to a real old triangle, and a child's nearest old


### PR DESCRIPTION
## Summary

Pre-production audit fix (3 of 9) — surface modifiers.

- **Mesh-detail slider was dead for 5 of 6 textures**: `buildSurfaceModifier` dropped the `quality` option from the opts it built for fuzzy/cable/waffle/fur/woven, so they fell back to quality 3 and the surface panel's detail slider was a no-op for those five (only knit, on a separate path, honored it). Threaded `quality` into all six opts objects so it takes effect in both preview and apply.
- **`applyScale` guard**: a negative factor mirrors the mesh (non-manifold) and zero collapses an axis; the public `scaleModel` API took raw numbers. Added a positive-finite guard at the engine-agnostic boundary.
- **Dead code**: deleted the sync `knitTexture` (superseded by the UV rewrite; only the test imported it) and retargeted that test at the live `knitTextureUV`.
- **Test coverage**: added a parameterized table covering cable/waffle/fur/woven (determinism, finite output, subdivision, colour carry) which had none, and fixed a `subdivideToMaxEdge(c, 3)` call passing a bare number where options go.

## Test plan
- `npm run build` ✅ · `npm run test:unit` (796, +12) ✅
- `tests/unit/surface.test.ts` extended; all texture invariants now exercise the live code paths.

https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo)_