### PR TITLE
fix: respect AI config in the worker + provider/voice robustness

### DIFF
--- a/prompts/20260607-220138-ai-provider-robustness.md
+++ b/prompts/20260607-220138-ai-provider-robustness.md
@@ -1,0 +1,59 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T22:01:38Z"
+sequence: 4
+---
+
+## Human
+
+Pre-production audit follow-up: "fix them and group the prs however you think
+is most appropriate." This PR collects the AI provider / chat-loop / panel
+findings.
+
+## Assistant
+
+## Key decisions
+
+**Worker config overrides silently ignored** (`appConfig.ts`, `agentWorkerClient.ts`,
+`agentWorker.ts`): the hosted-provider chat loop runs inside the agent Worker,
+where `getConfig()` returns static defaults (no localStorage). Only
+`toolCallTimeoutMs` was threaded through `run_turn`, despite an in-code comment
+claiming thinking budgets were too — so user overrides for thinking budgets,
+max-output tokens, transient-retry counts/backoff, and auto-resume caps did
+nothing on every hosted turn. Fix: pass the whole `ai` config section in the
+`run_turn` message and seed the Worker's config cache with it
+(`applyWorkerAiConfig`, a no-op outside a Worker) before anything reads
+`getConfig()`. One change covers every ai-config field at once.
+
+**readDoc schema-blocked 5 subdocs** (`tools.ts`): the readDoc tool's input-schema
+`enum` listed 15 names but the runtime `SUBDOC_NAMES` validator (and ai.md, and
+the tool's own description) listed 20 — so the model was schema-blocked from ever
+requesting iteration-workflow/gotchas/visual-verification/spending/manifold-api.
+Extracted a single `SUBDOC_NAMES_LIST` and derived both the enum and the Set from
+it so they can't drift again.
+
+**OpenAI-compatible tool-call drop** (`openai.ts`): the Chat-Completions path only
+set `stopReason` from `finish_reason`, never forcing `tool_use` from buffered
+calls. A self-hosted server (llama.cpp/vLLM/Ollama) that streams tool deltas
+without a clean `finish_reason:'tool_calls'` left stopReason 'unknown', which
+chatLoop treats as a non-tool turn and drops the calls. Now forces `tool_use`
+when calls were collected, mirroring the Responses and Gemini paths.
+
+**Transient-error misclassification** (`transientError.ts`): the status regex
+matched any 3-digit run, so a status inside an error *body* (e.g. a model name)
+could flip fatal↔transient. Anchored it to the actual `[Provider ]<status>:`
+message shape and added regression tests (custom no-prefix format + an embedded
+digit run that must be ignored).
+
+**Voice input lifecycle** (`voiceInput.ts`, `aiPanel.ts`): the mic kept recording
+into the hidden textarea when the panel closed or the route left the editor —
+now `hideDrawer()` and `setAiPanelRouteActive(false)` stop it. And `onend`
+unconditionally restarted while `wantListening`, so a persistent error spun
+onerror→onend→start(); added a consecutive-empty-restart cap (reset on a real
+result) so the loop can't run away.
+
+**Diagnostics clipboard** (`aiDiagnosticsModal.tsx`): the Copy-JSON
+`clipboard.writeText().then()` had no `.catch`, so a blocked/absent clipboard was
+an unhandled rejection with no feedback. Added a `.catch` that routes through
+`showToast`. Also removed a dangling JSDoc block in `diagnostics.ts` left by a
+deleted export.

--- a/src/ai/agentWorker.ts
+++ b/src/ai/agentWorker.ts
@@ -20,6 +20,7 @@ import { runTurn, type RunTurnInput, type RunTurnCallbacks } from './chatLoop';
 import { setEventForwarder } from './diagnostics';
 import type { ChatBlock } from './types';
 import type { ToolExecResult } from './tools';
+import { applyWorkerAiConfig, getConfig, type AppConfig } from '../config/appConfig';
 
 // The chat loop records each provider API call via diagnostics.recordEvent.
 // Inside this Worker those land in the Worker's own module-instance ring
@@ -37,9 +38,11 @@ setEventForwarder((event) => {
  *  signal, onDrainQueuedBlocks and executeToolFn are managed by the Worker
  *  itself rather than transferred (functions and signals can't cross threads). */
 export type AgentWorkerInput = Omit<RunTurnInput, 'signal' | 'onDrainQueuedBlocks' | 'executeToolFn'> & {
-  /** Tool-call round-trip timeout (ms). Read from the main-thread app config
-   *  and passed here because Workers have no localStorage access. */
-  toolCallTimeoutMs?: number;
+  /** The main thread's `ai` config section. Workers have no localStorage, so
+   *  this carries the user's overrides (thinking budgets, max-output tokens,
+   *  transient-retry/auto-resume tuning, tool-call timeout) across the boundary;
+   *  the Worker seeds its config cache from it before running the turn. */
+  aiConfig?: AppConfig['ai'];
 };
 
 // Pending tool-call promises keyed by callId.
@@ -104,7 +107,10 @@ self.onmessage = async (event: MessageEvent) => {
   // ── run_turn ───────────────────────────────────────────────────────────
   if (msg.type === 'run_turn') {
     const input = msg.input as AgentWorkerInput;
-    activeToolCallTimeoutMs = input.toolCallTimeoutMs ?? 60_000;
+    // Seed the Worker's config cache with the user's overrides BEFORE anything
+    // reads getConfig() (providers, transient-retry, thinking budgets).
+    if (input.aiConfig) applyWorkerAiConfig(input.aiConfig);
+    activeToolCallTimeoutMs = getConfig().ai.toolCallTimeoutMs;
     abortController = new AbortController();
 
     // Map every RunTurnCallbacks slot to a postMessage so the main thread

--- a/src/ai/agentWorkerClient.ts
+++ b/src/ai/agentWorkerClient.ts
@@ -171,15 +171,18 @@ export async function runTurn(
   }
 
   // Strip non-serialisable fields before sending across the thread boundary.
-  // toolCallTimeoutMs is read here (main thread has localStorage) and passed to
-  // the Worker which has no localStorage access.
+  // The whole `ai` config section is read here (main thread has localStorage)
+  // and passed to the Worker, which has none — so the providers' getConfig()
+  // reads inside the Worker see the user's overrides (thinking budgets,
+  // max-output tokens, transient-retry/auto-resume tuning, tool-call timeout)
+  // rather than falling back to defaults.
   const workerInput: AgentWorkerInput = {
     apiKey:             input.apiKey,
     toggles:            input.toggles,
     sessionId:          input.sessionId,
     history:            input.history,
     userBlocks:         input.userBlocks,
-    toolCallTimeoutMs:  getConfig().ai.toolCallTimeoutMs,
+    aiConfig:           getConfig().ai,
   };
 
   return new Promise<ChatMessage[]>((resolve, reject) => {

--- a/src/ai/diagnostics.ts
+++ b/src/ai/diagnostics.ts
@@ -143,7 +143,3 @@ export function onEventsChange(fn: () => void): () => void {
   listeners.add(fn);
   return () => { listeners.delete(fn); };
 }
-
-/** True when there's at least one error event since the last clear. The
- *  panel status bar uses this to decide whether to surface a "View
- *  diagnostics" affordance after an error. */

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -660,6 +660,14 @@ async function consumeChatStream(
     input: parseToolArgs(buf.argsText),
   }));
 
+  // If the stream produced tool calls, force a tool_use stop regardless of the
+  // reported finish_reason. OpenAI proper sends finish_reason:'tool_calls', but
+  // an OpenAI-compatible server (llama.cpp/vLLM/Ollama) may stream tool-call
+  // deltas without a clean finish_reason, leaving stopReason 'unknown' — which
+  // chatLoop treats as a non-tool turn and silently drops the calls. Mirrors
+  // the Responses and Gemini paths.
+  if (toolCalls.length > 0) stopReason = 'tool_use';
+
   return { text: collectedText, toolCalls, stopReason, usage };
 }
 

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -42,6 +42,18 @@ export interface ToolExecResult {
   image?: ImageSource;
 }
 
+/** The subdocs `readDoc` can fetch from /ai/<name>.md. Single source of truth
+ *  for both the readDoc tool's input-schema `enum` (what the model is allowed
+ *  to request) and the runtime `SUBDOC_NAMES` validator — keep them derived
+ *  from this so the schema can't silently omit a name the validator accepts
+ *  (which previously schema-blocked the model from 5 valid subdocs). */
+export const SUBDOC_NAMES_LIST = [
+  'curves', 'bosl2', 'replicad', 'sdf', 'voxel', 'colors', 'print-safety',
+  'print-fit', 'reference-images', 'file-io', 'annotations', 'printing',
+  'relief', 'textures', 'mechanisms', 'iteration-workflow', 'gotchas',
+  'visual-verification', 'spending', 'manifold-api',
+] as const;
+
 const ALL_TOOLS: ToolDefinition[] = [
   {
     name: 'getActiveLanguage',
@@ -434,7 +446,7 @@ const ALL_TOOLS: ToolDefinition[] = [
       properties: {
         name: {
           type: 'string',
-          enum: ['curves', 'bosl2', 'replicad', 'sdf', 'voxel', 'colors', 'print-safety', 'print-fit', 'reference-images', 'file-io', 'annotations', 'printing', 'relief', 'textures', 'mechanisms'],
+          enum: [...SUBDOC_NAMES_LIST],
           description: 'Subdoc name without the .md extension.',
         },
       },
@@ -1670,7 +1682,7 @@ function detectLanguageMismatch(code: string): string | null {
  *  `tools.ts` to import the engine module statically. The function lives
  *  in `src/geometry/engine.ts` and is already loaded by the app shell at
  *  startup, so a require-style lookup via `window.partwright` is safe. */
-const SUBDOC_NAMES = new Set(['curves', 'bosl2', 'replicad', 'sdf', 'voxel', 'colors', 'print-safety', 'print-fit', 'reference-images', 'file-io', 'annotations', 'printing', 'relief', 'textures', 'mechanisms', 'iteration-workflow', 'gotchas', 'visual-verification', 'spending', 'manifold-api']);
+const SUBDOC_NAMES = new Set<string>(SUBDOC_NAMES_LIST);
 
 /** Fetch a topic subdoc by short name. Same fetch path for Anthropic and
  *  local providers — both run inside the user's browser tab, so this is

--- a/src/ai/transientError.ts
+++ b/src/ai/transientError.ts
@@ -9,9 +9,13 @@ export function httpStatusOf(err: unknown): number | null {
   const e = err as { status?: unknown; message?: unknown };
   if (typeof e?.status === 'number') return e.status;
   const msg = typeof e?.message === 'string' ? e.message : '';
-  // Matches "OpenAI 503:", "Gemini 500:", "Anthropic 529 …" — an optional
-  // provider name followed by a 3-digit status near the start of the message.
-  const m = msg.match(/(?:^|\b)(?:OpenAI|Gemini|Anthropic|Custom)?\s*(\d{3})\b/);
+  // The raw-fetch providers throw "<Provider> <status>: <body>" (and custom
+  // throws "<status>: <body>" with no name), so anchor to the START of the
+  // message and require the trailing colon. Matching a bare 3-digit run
+  // anywhere (the old pattern) could pick a status out of the error *body*
+  // (e.g. "OpenAI 400: … model gpt-512 …") and misclassify a fatal request as
+  // transient or vice-versa.
+  const m = msg.match(/^(?:OpenAI|Gemini|Anthropic|Custom)?\s*(\d{3}):/);
   return m ? Number(m[1]) : null;
 }
 

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -346,6 +346,20 @@ export function getConfig(): AppConfig {
   return loadAppConfig();
 }
 
+/** Seed the worker's config cache with the main thread's `ai` overrides.
+ *  Workers have no localStorage, so without this `getConfig().ai.*` reads inside
+ *  the agent Worker (every hosted-provider turn runs there) silently fall back
+ *  to defaults — ignoring the user's saved thinking budgets, max-output tokens,
+ *  transient-retry and auto-resume tuning. The main thread passes its `ai`
+ *  section through the run_turn message and the Worker applies it here before
+ *  the providers read config. No-op outside a Worker (the main thread already
+ *  has the real values). */
+export function applyWorkerAiConfig(ai: AppConfig['ai']): void {
+  if (!isWorkerContext()) return;
+  const base = loadAppConfig();
+  cachedConfig = { ...base, ai: { ...base.ai, ...ai } };
+}
+
 /** Subscribe to config changes (saved overrides or a reset). Returns an
  *  unsubscribe function. Fires with the new config after every persist. */
 export function onConfigChange(fn: (cfg: AppConfig) => void): () => void {

--- a/src/ui/aiDiagnosticsModal.tsx
+++ b/src/ui/aiDiagnosticsModal.tsx
@@ -14,6 +14,7 @@ import {
   onEventsChange,
   type DiagnosticEvent,
 } from '../ai/diagnostics';
+import { showToast } from './toast';
 import { providerLabel } from '../ai/settings';
 import { mountPreactModal } from './preact/mount';
 import { confirmDialog } from './dialogs';
@@ -70,6 +71,10 @@ function DiagnosticsBody() {
               void navigator.clipboard.writeText(json).then(() => {
                 copyLabel.value = 'Copied!';
                 setTimeout(() => { copyLabel.value = 'Copy JSON'; }, 1500);
+              }).catch(() => {
+                // Clipboard can be unavailable (insecure context / blocked
+                // permission) — surface it instead of an unhandled rejection.
+                showToast("Couldn't copy to clipboard", { variant: 'warn' });
               });
             }}
           >{copyLabel.value}</button>

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -419,6 +419,9 @@ function showDrawer(focusInput = true): void {
 function hideDrawer(): void {
   if (!drawerEl) return;
   state.open = false;
+  // Stop dictation when the panel closes — otherwise the mic keeps recording
+  // into the now-hidden textarea with no visible stop affordance.
+  voiceController?.stop();
   drawerEl.classList.add('hidden');
   window.dispatchEvent(new CustomEvent('ai-panel-toggled', { detail: { open: false } }));
   window.dispatchEvent(new Event('resize'));
@@ -433,6 +436,9 @@ export function setAiPanelRouteActive(active: boolean): void {
   if (routeActive === active) return;
   routeActive = active;
   if (!drawerEl) return;
+  // Leaving the editor route hides the panel — stop any active dictation so the
+  // mic doesn't keep recording on an overlay page where the panel isn't shown.
+  if (!active) voiceController?.stop();
   const visible = state.open && routeActive;
   drawerEl.classList.toggle('hidden', !visible);
   if (visible) applyDockLayout();

--- a/src/ui/voiceInput.ts
+++ b/src/ui/voiceInput.ts
@@ -126,6 +126,12 @@ export function createVoiceController(opts: VoiceControllerOptions): VoiceContro
   // its own (Chrome stops after a pause even in continuous mode). While the
   // user still wants to dictate, we restart on `onend`.
   let wantListening = false;
+  // Auto-restarts since the last successful result. A persistent error (e.g.
+  // a flaky `network` code) makes onerror → onend → start() spin without ever
+  // producing speech; cap the consecutive empty restarts so the loop can't run
+  // away (and stop spamming onError). Reset on any real transcript.
+  const MAX_EMPTY_RESTARTS = 4;
+  let emptyRestarts = 0;
   // Final transcript accumulated across auto-restarts within one user session,
   // so chaining restarts doesn't drop earlier sentences.
   let committed = '';
@@ -143,6 +149,7 @@ export function createVoiceController(opts: VoiceControllerOptions): VoiceContro
       if (result.isFinal) committed += text + ' ';
       else interim += text;
     }
+    emptyRestarts = 0; // made progress — the restart loop is healthy
     emit(interim, false);
   };
 
@@ -156,15 +163,19 @@ export function createVoiceController(opts: VoiceControllerOptions): VoiceContro
   };
 
   rec.onend = () => {
-    if (wantListening) {
+    if (wantListening && emptyRestarts < MAX_EMPTY_RESTARTS) {
       // Engine ended the turn but the user still holds the mic open — restart.
       try {
         rec.start();
+        emptyRestarts++;
         return;
       } catch {
         // Fall through to the stopped state if restart throws (rare).
       }
     }
+    // Either the user stopped, or we hit the empty-restart cap (a persistent
+    // error was spinning the loop) — settle into the stopped state.
+    wantListening = false;
     listening = false;
     emit('', true);
     opts.onStateChange(false);
@@ -173,6 +184,7 @@ export function createVoiceController(opts: VoiceControllerOptions): VoiceContro
   function start(): void {
     if (listening) return;
     committed = '';
+    emptyRestarts = 0;
     wantListening = true;
     try {
       rec.start();

--- a/tests/unit/transientError.test.ts
+++ b/tests/unit/transientError.test.ts
@@ -11,6 +11,14 @@ describe('httpStatusOf', () => {
     expect(httpStatusOf(new Error('OpenAI 500: internal error'))).toBe(500);
     expect(httpStatusOf(new Error('Gemini 503: service unavailable'))).toBe(503);
     expect(httpStatusOf(new Error('Custom 502: bad gateway'))).toBe(502);
+    // Custom endpoints throw with no provider-name prefix ("<status>: <body>").
+    expect(httpStatusOf(new Error('400: bad request'))).toBe(400);
+  });
+
+  it('ignores 3-digit runs in the error body (only the leading status counts)', () => {
+    // The status must be at the start before the colon — a digit run inside the
+    // body (e.g. a model name) must not be mistaken for the HTTP status.
+    expect(httpStatusOf(new Error('OpenAI 400: unknown model gpt-512 not found'))).toBe(400);
   });
 
   it('returns null when there is no status', () => {


### PR DESCRIPTION
## Summary

Pre-production audit fix (4 of 9) — AI providers, chat loop & panel.

- **Worker config ignored**: the hosted chat loop runs inside the agent Worker, where `getConfig()` returns static defaults — so user overrides for thinking budgets, max-output tokens, transient-retry tuning, and auto-resume caps were silently ignored every hosted turn (only `toolCallTimeoutMs` was threaded, despite a comment claiming otherwise). Now passes the whole `ai` config section through `run_turn` and seeds the Worker's cache (`applyWorkerAiConfig`) before any provider reads config.
- **readDoc enum**: omitted 5 subdocs the runtime validator accepts (iteration-workflow/gotchas/visual-verification/spending/manifold-api), schema-blocking the model from them. Derived both the enum and the Set from one `SUBDOC_NAMES_LIST`.
- **OpenAI-compatible tool calls**: the Chat path now forces `stopReason: 'tool_use'` when tool calls were buffered, so self-hosted servers (llama.cpp/vLLM/Ollama) with a non-standard `finish_reason` don't drop calls (mirrors Responses/Gemini).
- **Transient-error regex**: anchored to the real `<Provider> <status>:` shape so a digit run in the error *body* can't flip fatal↔transient (+ regression tests).
- **Voice input**: stops the mic when the panel hides or the route leaves the editor; caps consecutive empty auto-restarts so a persistent error can't busy-loop.
- **Diagnostics**: Copy-JSON now catches clipboard failures via `showToast`; removed a dangling JSDoc block.

## Test plan
- `npm run build` ✅ · `npm run test:unit` (785, +1) ✅ · `npm run lint:deps` ✅

https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo)_