### PR TITLE
fix: prevent cross-session camera writes and Back-button skips

### DIFF
--- a/prompts/20260607-220540-history-and-camera.md
+++ b/prompts/20260607-220540-history-and-camera.md
@@ -1,0 +1,36 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T22:05:40Z"
+sequence: 5
+---
+
+## Human
+
+Pre-production audit follow-up: "fix them and group the prs however you think
+is most appropriate." This PR collects the session-history + camera-persistence
+findings.
+
+## Assistant
+
+## Key decisions
+
+**Work-camera debounce could stamp the wrong session** (`main.ts`): the orbit-end
+debounce calls `setSessionWorkCamera(getCameraPose())` inside the timer, which
+writes to whatever session is active *at fire time*. Orbiting session A then
+switching to B within the debounce window (default 500 ms) wrote A's pose into
+B's row. Fixed by capturing the session id at orbit-end and discarding the save
+if the active session changed before the timer fires. (Losing A's last micro-
+orbit when you switch away inside 500 ms is fine; corrupting B's saved view is
+not.)
+
+**Sessions-modal navigation broke the Back button** (`sessionList.ts`): opening,
+importing, or creating a session from the Sessions modal called
+openSession/createSession/importSession directly, and updateURL() only
+replaceState's — so the current history entry was overwritten and Back skipped
+the prior session. Per CLAUDE.md's push-before-mutate rule, each now pushes the
+editor entry first.
+
+To do that without a cycle (sessionList importing main.ts would create one), I
+extracted `updateAppHistory`/`currentURLPathAndSearch` from main.ts into a new
+leaf `src/ui/appHistory.ts` (pure History-API wrappers, no imports) and pointed
+both main.ts and sessionList at it.

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,7 @@ import { showAdvancedSettingsModal } from './ui/advancedSettingsModal';
 import { combo, MOD_LABEL, SHIFT_LABEL, ALT_LABEL } from './ui/shortcutDefs';
 import { showToast } from './ui/toast';
 import { confirmDialog, promptDialog } from './ui/dialogs';
+import { updateAppHistory, currentURLPathAndSearch } from './ui/appHistory';
 import { initAiPanel, setActiveSession as setAiActiveSession, toggleAiPanel, toggleAiPanelFromToolbar, prefillAiInput, setAiPanelRouteActive } from './ui/aiPanel';
 import { getKey, mergeChatBucket } from './ai/db';
 import { requestPersistentStorage } from './storage/persist';
@@ -1914,20 +1915,6 @@ function getTabFromURL(): TabName {
   if (params.has('gallery')) return 'gallery';
   return 'interactive';
 }
-
-function currentURLPathAndSearch(): string {
-  return `${window.location.pathname}${window.location.search}`;
-}
-
-function updateAppHistory(url: string, mode: 'push' | 'replace'): void {
-  if (url === currentURLPathAndSearch()) return;
-  if (mode === 'push') {
-    window.history.pushState(null, '', url);
-  } else {
-    window.history.replaceState(null, '', url);
-  }
-}
-
 
 // Hide landing/help and show the editor UI
 function showEditorUI(landingEl: HTMLElement | null, helpEl: HTMLElement | null, editorUI: HTMLElement) {
@@ -5484,13 +5471,21 @@ async function main() {
   let _workCameraSaveTimer: number | undefined;
   onOrbitEnd(() => {
     if (_workCameraSaveTimer !== undefined) clearTimeout(_workCameraSaveTimer);
+    // Capture which session this orbit belongs to. setSessionWorkCamera writes
+    // to whatever session is active *at fire time*, so if the user switches
+    // sessions within the debounce window the pending save would otherwise
+    // stamp the new session's row with the old session's pose. Discard the
+    // save if the active session changed before the timer elapses.
+    const orbitedSessionId = getState().session?.id ?? null;
     // Snapshot inside the debounced callback, not here: 'end' fires at gesture
     // release while OrbitControls damping is still gliding, so reading the pose
     // now would persist a pre-settle angle. By the time the debounce elapses the
     // camera has come to rest, so the saved view matches what the user sees.
     _workCameraSaveTimer = window.setTimeout(() => {
       _workCameraSaveTimer = undefined;
-      if (currentMeshData === null || !getState().session) return;
+      if (currentMeshData === null) return;
+      const cur = getState().session;
+      if (!cur || cur.id !== orbitedSessionId) return; // session changed — discard
       void setSessionWorkCamera(getCameraPose());
     }, getConfig().ui.workCameraSaveDebounceMs);
   });

--- a/src/ui/appHistory.ts
+++ b/src/ui/appHistory.ts
@@ -1,0 +1,22 @@
+// Leaf helper for top-level page/route history. Pure wrappers over the History
+// API with no imports, so any module (main.ts, the Sessions modal, …) can push
+// the destination history entry *before* a session-mutating call without
+// importing main.ts (which would create a cycle).
+//
+// Why this matters: sessionManager.updateURL() uses history.replaceState, so a
+// session switch that doesn't push first silently overwrites the current entry
+// and the Back button skips the previous session. See
+// CLAUDE.md › "Browser History (Back Button) Preservation".
+
+export function currentURLPathAndSearch(): string {
+  return `${window.location.pathname}${window.location.search}`;
+}
+
+export function updateAppHistory(url: string, mode: 'push' | 'replace'): void {
+  if (url === currentURLPathAndSearch()) return;
+  if (mode === 'push') {
+    window.history.pushState(null, '', url);
+  } else {
+    window.history.replaceState(null, '', url);
+  }
+}

--- a/src/ui/sessionList.ts
+++ b/src/ui/sessionList.ts
@@ -17,6 +17,7 @@ import { getSessionLatestVersion, getSessionVersionCount } from '../storage/db';
 import { languageBadge } from './languageBadge';
 import { showToast } from './toast';
 import { confirmDialog, promptDialog } from './dialogs';
+import { updateAppHistory } from './appHistory';
 
 let modalEl: HTMLElement | null = null;
 let onLoadVersion: ((code: string) => void | Promise<void>) | null = null;
@@ -83,6 +84,9 @@ export async function showSessionList(): Promise<void> {
           return;
         }
         const session = await importSession(data, regenerateThumbnailFn ?? undefined, (msg) => showToast(msg, { variant: 'warn', source: 'import' }));
+        // Push the editor entry before the session-mutating open so the Back
+        // button returns to the prior session (updateURL only replaceState's).
+        updateAppHistory('/editor', 'push');
         const version = await openSession(session.id);
         if (version && onLoadVersion) onLoadVersion(version.code);
         closeModal();
@@ -111,6 +115,7 @@ export async function showSessionList(): Promise<void> {
   newBtn.addEventListener('click', async () => {
     const name = await promptDialog('Session name:', { title: 'New session', placeholder: 'Untitled' });
     if (name === null) return;
+    updateAppHistory('/editor', 'push'); // push before mutating so Back returns to the prior session
     await createSession(name || undefined);
     onNewSessionFn?.();
     closeModal();
@@ -168,6 +173,7 @@ async function createSessionRow(session: Session): Promise<HTMLElement> {
   row.className = 'flex items-center gap-3 px-5 py-3 hover:bg-zinc-700/50 cursor-pointer border-b border-zinc-700/50 transition-colors';
 
   row.addEventListener('click', async () => {
+    updateAppHistory('/editor', 'push'); // push before mutating so Back returns to the prior session
     const version = await openSession(session.id);
     if (version && onLoadVersion) {
       await onLoadVersion(version.code);


### PR DESCRIPTION
## Summary

Pre-production audit fix (5 of 9) — session history + camera persistence.

- **Cross-session camera write**: the work-camera orbit-end debounce wrote the pose to whatever session was active *at fire time*, so orbiting session A then switching to B within the debounce window stamped B's row with A's view. Now captures the session id at orbit-end and discards the save if the active session changed.
- **Back-button skip**: opening/importing/creating a session from the Sessions modal mutated state without first pushing a history entry, so `updateURL`'s `replaceState` overwrote the current entry and Back skipped the prior session. Each now pushes the editor entry first (per the push-before-mutate rule). Extracted `updateAppHistory` into a new leaf `src/ui/appHistory.ts` so `sessionList` can use it without importing `main.ts` (which would create a cycle).

## Test plan
- `npm run build` ✅ · `npm run test:unit` (784) ✅ · `npm run lint:deps` ✅ (no new cycle)

https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo)_