### PR TITLE
fix: align command palette, tour, and keybinding labels with the toolbar

### DIFF
--- a/prompts/20260607-221211-menu-nav-consistency.md
+++ b/prompts/20260607-221211-menu-nav-consistency.md
@@ -1,0 +1,40 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T22:12:11Z"
+sequence: 8
+---
+
+## Human
+
+Pre-production audit follow-up: "fix them and group the prs however you think
+is most appropriate." This PR collects the menus / navigation / keyboard
+findings.
+
+## Assistant
+
+## Key decisions
+
+**Command palette fell behind the toolbar** (`main.ts`): after the view-menu
+refactor moved Surface, Resize, Place/Rotate, Print, and Voxel-Studio behind the
+collapsed Tools/Inspect popovers, those tools had no command-palette entry — yet
+the palette is documented as "the flat, searchable index of everything" and is
+now the only keyboard/search path to them. Added five `tool-*` commands that
+fire the existing overlay toggles by id (click works even while the toggle sits
+in a collapsed popover, matching the existing tool entries). Verified all five
+toggle ids exist; gated the mesh tools on `viewportToolEnabled` and voxel-studio
+on the voxel language (mirroring export-vox).
+
+**Guided tour spotlighted hidden popover buttons** (`tour.ts`): steps targeting
+`#measure-toggle`/`#paint-toggle`/`#simplify-toggle` now live inside collapsed
+popovers, so on first run their targets reported a 0×0 rect and the spotlight
+rendered over an empty corner. The skip loop only checked existence, not
+visibility. Added an `openSelector` to those steps (the Inspect/Tools popover
+trigger, mirroring hintsData), clicked open before measuring, plus a zero-rect
+skip as a safety net (matching coachmark's guard).
+
+**Find/Replace advertised an unbound key** (`layout.ts`, `shortcutDefs.ts`): the
+button title said "Ctrl+H", which nothing binds — the button opens CodeMirror's
+search panel (Mod-F; Mod-Alt-F for replace). Fixed the title to the real,
+platform-aware binding via the shared MOD_LABEL/combo helpers, and added a
+Find/Replace row to the `?` cheat sheet (it was absent), so the documented keys
+match what actually fires.

--- a/prompts/20260607-231716-tour-zero-rect-scope-fix.md
+++ b/prompts/20260607-231716-tour-zero-rect-scope-fix.md
@@ -1,0 +1,29 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T23:17:16Z"
+sequence: 11
+---
+
+## Human
+
+PR #494 CI: two tour-entry-points e2e tests failed — the tour opened on step 2
+("Modeling Engine") instead of step 1 ("Code Editor"). (A share-link test in the
+same shard was flaky and passed on retry — unrelated.)
+
+## Assistant
+
+## Key decisions
+
+**Root cause**: my blanket zero-rect skip in the tour's showStep loop was too
+aggressive. `#editor-container` (step 1) can momentarily report a 0×0
+`getBoundingClientRect()` at tour start — before layout settles in the
+rail-button / landing-CTA entry flows — so the guard skipped it and the tour
+opened on step 2.
+
+**Fix**: scope the rect check to steps that have an `openSelector` (the
+popover-nested Measure/Paint/Simplify steps — the actual targets of the original
+hidden-popover bug). Those still get their popover opened and are skipped only if
+they remain 0×0 after opening (tool genuinely absent in this session). Plain
+top-level steps keep the original existence-only check, so a valid first step
+that briefly measures 0×0 is never skipped. The popover fix (openSelector) is
+unchanged.

--- a/src/main.ts
+++ b/src/main.ts
@@ -4459,6 +4459,14 @@ async function main() {
     { id: 'tool-annotate', title: 'Annotate (draw / text)', hint: 'Tools', keywords: 'draw pen text label note markup sketch arrow', run: () => document.getElementById('annotate-toggle')?.click(), enabled: viewportToolEnabled },
     { id: 'tool-quality', title: 'Quality: simplify / enhance', hint: 'Tools', keywords: 'simplify enhance decimate reduce triangles quality curvature smoothness', run: () => document.getElementById('simplify-toggle')?.click(), enabled: viewportToolEnabled },
     { id: 'tool-customize', title: 'Customize parameters', hint: 'Tools', keywords: 'parameters params sliders tweak knobs', run: () => document.getElementById('customize-toggle')?.click(), enabled: () => isEditorActive() && !document.getElementById('customize-toggle')?.classList.contains('hidden') },
+    // These tools moved behind the Tools/Inspect popovers after the view-menu
+    // refactor, so the palette is their only keyboard/search entry point. Each
+    // fires the existing overlay toggle by id (click() works even collapsed).
+    { id: 'tool-surface', title: 'Surface textures', hint: 'Tools', keywords: 'fuzzy knit cable waffle fur woven smooth voxelize texture modifier displace', run: () => document.getElementById('surface-viewport-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-resize', title: 'Resize / scale model', hint: 'Tools', keywords: 'scale resize size dimensions grow shrink mm', run: () => document.getElementById('resize-viewport-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-place', title: 'Place / orient on bed', hint: 'Tools', keywords: 'place orient rotate move position lay flat drop floor center bed', run: () => document.getElementById('place-viewport-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-print', title: 'Print tools / check printability', hint: 'Inspect', keywords: 'print printability fdm overhang support wall thickness bed fit slicer 3d', run: () => document.getElementById('print-tools-toggle')?.click(), enabled: viewportToolEnabled },
+    { id: 'tool-voxel-paint', title: 'Voxel Studio (edit voxels)', hint: 'Tools', keywords: 'voxel studio paint edit cube blocky pixel sculpt', run: () => document.getElementById('voxel-paint-toggle')?.click(), enabled: () => isEditorActive() && getActiveLanguage() === 'voxel' },
     { id: 'toggle-ai', title: 'Toggle AI panel', hint: 'View', keywords: 'chat assistant drawer', run: () => toggleAiPanel() },
     { id: 'toggle-diagnostics', title: 'Toggle diagnostics', hint: 'View', keywords: 'errors warnings console workers webworkers threads memory wasm performance restarts crash timing health log', run: () => toggleDiagnosticsPanel() },
     { id: 'open-catalog', title: 'Open catalog', hint: 'Navigate', keywords: 'examples premade browse', run: () => { void showCatalogPage(); } },

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -3,6 +3,7 @@ import { showAdvancedSettingsModal } from './advancedSettingsModal';
 import { showAboutModal } from './aboutModal';
 import { loadSettings, saveSettings } from '../ai/settings';
 import { createPopoverGroup } from './popoverMenu';
+import { MOD_LABEL, combo } from './shortcutDefs';
 
 export type TabName = 'interactive' | 'gallery' | 'versions' | 'images' | 'diff' | 'notes' | 'data';
 
@@ -96,7 +97,9 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   findReplaceBtn.id = 'find-replace-btn';
   findReplaceBtn.className = 'shrink-0 px-2 py-0.5 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700 text-xs leading-none border border-transparent hover:border-zinc-600';
   findReplaceBtn.textContent = 'Find/Replace';
-  findReplaceBtn.title = 'Find/Replace (Ctrl+H)';
+  // Opens CodeMirror's search panel (find + replace), whose binding is Mod-F —
+  // not Ctrl+H, which nothing binds. Mod-Alt-F jumps to the replace field.
+  findReplaceBtn.title = `Find/Replace (${combo(MOD_LABEL, 'F')})`;
   editorHeader.appendChild(findReplaceBtn);
 
   const formatBtn = document.createElement('button');

--- a/src/ui/shortcutDefs.ts
+++ b/src/ui/shortcutDefs.ts
@@ -69,5 +69,9 @@ export function getShortcutDocs(): ShortcutDoc[] {
       keys: combo(SHIFT_LABEL, ALT_LABEL, 'F'),
       description: 'Reformat the code in the editor.',
     },
+    {
+      keys: `${combo(MOD_LABEL, 'F')} / ${combo(MOD_LABEL, ALT_LABEL, 'F')}`,
+      description: 'Open the code editor’s Find / Find-and-Replace panel (replace jumps straight to the replace field).',
+    },
   ];
 }

--- a/src/ui/tour.ts
+++ b/src/ui/tour.ts
@@ -242,21 +242,26 @@ function cleanup(): void {
 function showStep(): void {
   if (!spotlight || !tooltip) return;
 
-  // Find next valid step (skip missing OR hidden targets). A target nested in a
-  // collapsed popover exists but reports a 0×0 rect — spotlighting it would
-  // highlight an empty corner — so open its popover first (openSelector) and
-  // treat a still-zero rect as "not visible", mirroring coachmark's guard.
+  // Find next valid step (skip missing targets). For a step whose target is
+  // nested in a collapsed popover, open the popover first (openSelector) so the
+  // spotlight doesn't land on a 0×0 element in an empty corner; if it's STILL
+  // zero-size after opening, the tool isn't available in this session, so skip.
+  // The rect check is scoped to openSelector steps on purpose: a top-level
+  // target like #editor-container can briefly report a 0×0 rect at tour start
+  // (before layout settles) yet is a valid first step, so plain steps keep the
+  // original existence-only check and are never skipped for size.
   while (currentStep < STEPS.length) {
     const step = STEPS[currentStep];
+    const target = document.querySelector(step.target) as HTMLElement | null;
+    if (!target) { currentStep++; continue; }
     if (step.openSelector) {
       const opener = document.querySelector(step.openSelector) as HTMLElement | null;
       // Only click if collapsed — clicking an open popover would toggle it shut.
       if (opener && opener.getAttribute('aria-expanded') !== 'true') opener.click();
+      const rect = target.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) { currentStep++; continue; }
     }
-    const target = document.querySelector(step.target) as HTMLElement | null;
-    const rect = target?.getBoundingClientRect();
-    if (target && rect && rect.width > 0 && rect.height > 0) break;
-    currentStep++;
+    break;
   }
 
   if (currentStep >= STEPS.length) {

--- a/src/ui/tour.ts
+++ b/src/ui/tour.ts
@@ -7,6 +7,11 @@ interface TourStep {
   title: string;
   description: string;
   placement: 'top' | 'bottom' | 'left' | 'right';
+  /** A popover trigger to click open before spotlighting `target`, for targets
+   *  that live inside a collapsed popover (Inspect/Tools). Without this the
+   *  target reports a 0×0 rect and the spotlight lands on an empty corner.
+   *  Mirrors the same field on the editor hints (hintsData.ts). */
+  openSelector?: string;
 }
 
 const STEPS: TourStep[] = [
@@ -51,6 +56,7 @@ const STEPS: TourStep[] = [
     description:
       'Inspect a model without changing it: 📏 Measure the distance between two points, and ✂ Cross Section slices through it with a draggable plane. The same toolbar toggles the grid, bounding-box dimensions, and orbit lock.',
     placement: 'left',
+    openSelector: '#viewport-inspect-group-btn',
   },
   {
     target: '#paint-toggle',
@@ -58,6 +64,7 @@ const STEPS: TourStep[] = [
     description:
       'Paint coplanar regions for multi-color 3D prints (exported via 3MF or OBJ). Surface-following geodesic and airbrush brushes follow curvature, you can label and paint regions by name from code, and voxel models paint cube-by-cube. Painting locks the version read-only until you unlock it.',
     placement: 'left',
+    openSelector: '#viewport-tools-group-btn',
   },
   {
     target: '#simplify-toggle',
@@ -65,6 +72,7 @@ const STEPS: TourStep[] = [
     description:
       'Reduce a dense model’s triangle count to a target budget — great for shrinking imported STLs or heavy booleans. Set a target, click Apply to run it, then save the result as a new version.',
     placement: 'left',
+    openSelector: '#viewport-tools-group-btn',
   },
   {
     target: '#parts-rail',
@@ -234,11 +242,20 @@ function cleanup(): void {
 function showStep(): void {
   if (!spotlight || !tooltip) return;
 
-  // Find next valid step (skip missing targets)
+  // Find next valid step (skip missing OR hidden targets). A target nested in a
+  // collapsed popover exists but reports a 0×0 rect — spotlighting it would
+  // highlight an empty corner — so open its popover first (openSelector) and
+  // treat a still-zero rect as "not visible", mirroring coachmark's guard.
   while (currentStep < STEPS.length) {
     const step = STEPS[currentStep];
-    const target = document.querySelector(step.target);
-    if (target) break;
+    if (step.openSelector) {
+      const opener = document.querySelector(step.openSelector) as HTMLElement | null;
+      // Only click if collapsed — clicking an open popover would toggle it shut.
+      if (opener && opener.getAttribute('aria-expanded') !== 'true') opener.click();
+    }
+    const target = document.querySelector(step.target) as HTMLElement | null;
+    const rect = target?.getBoundingClientRect();
+    if (target && rect && rect.width > 0 && rect.height > 0) break;
     currentStep++;
   }
 


### PR DESCRIPTION
## Summary

Pre-production audit fix (6 of 9) — menus, navigation, keyboard. **Verified in-browser** (command palette screenshot posted in the session).

- **Command palette fell behind the toolbar**: after the view-menu refactor tucked Surface, Resize, Place/Rotate, Print, and Voxel Studio behind collapsed popovers, none had a palette entry — even though the palette is the only keyboard/search path to them. Added five `tool-*` commands firing the existing toggles by id (verified all five ids exist; gated correctly).
- **Tour spotlighted hidden buttons**: the Measure/Paint/Simplify steps targeted those now-collapsed popover buttons, so the spotlight landed on an empty corner. Added an `openSelector` to open the Inspect/Tools popover before spotlighting (mirroring hintsData), plus a zero-rect skip safety net.
- **Find/Replace key label**: advertised "Ctrl+H", which nothing binds — it opens CodeMirror's search panel (Mod-F / Mod-Alt-F). Fixed the button title to the real binding and added the missing Find/Replace row to the `?` cheat sheet.

## Test plan
- `npm run build` ✅ · `npm run test:unit` (784) ✅ · `npm run lint:deps` ✅
- Manual: scratch Playwright spec confirmed all four new tool entries render in the palette (screenshot in session).

https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo)_