### PR TITLE
fix: give modals an accessible close label and dedupe confirm dialog

### DIFF
--- a/prompts/20260607-221626-ui-component-consistency.md
+++ b/prompts/20260607-221626-ui-component-consistency.md
@@ -1,0 +1,42 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T22:16:26Z"
+sequence: 9
+---
+
+## Human
+
+Pre-production audit follow-up: "fix them and group the prs however you think
+is most appropriate." This PR collects the shared-UI-component consistency
+findings.
+
+## Assistant
+
+## Key decisions
+
+**Shared modal close button had no accessible name** (`modalShell.ts`): the
+close `✕` set neither `aria-label` nor `title`, so a screen reader announced the
+bare glyph — and EVERY modalShell-based modal inherited it. The recent
+conformance work added descriptive close labels to tool *panels* but never
+reached *modals*. One fix on the shared shell (`aria-label`/`title` = "Close
+<title>") covers them all.
+
+**`showInlineConfirm` duplicated `confirmDialog`** (`main.ts`): a ~70-line
+hand-rolled confirm overlay with a single caller (the render-only import
+fallback), reimplementing `confirmDialog` at the wrong z-index with no focus
+trap and inlined button classes. Replaced the call with the shared
+`confirmDialog` (which has the focus trap, focus restore, Escape/backdrop
+handling, multi-line support, and BUTTON_* styling) and deleted the function plus
+its local ConfirmOptions interface.
+
+**Button-constant drift** (`uninstallModal.tsx`, `aboutModal.tsx`,
+`aiAttachmentModal.tsx`): primary/danger buttons re-inlined the Tailwind string
+at the wrong padding/size (`px-3 text-xs` vs the standard `px-4 text-sm`), so
+they rendered visibly smaller than every shared-button modal. Swapped to
+`BUTTON_PRIMARY`/`BUTTON_DANGER` from styleConstants (preserving uninstall's
+extra `disabled:` classes via template string).
+
+Deferred (noted for a follow-up, lower value / larger surface): porting
+`progressModal.tsx` off its inline hex styles onto Tailwind tokens, and moving
+`stepImportTargetModal`'s hand-rolled Cancel into the shell footer with
+BUTTON_CANCEL.

--- a/prompts/20260607-231431-modalshell-aria-collision-fix.md
+++ b/prompts/20260607-231431-modalshell-aria-collision-fix.md
@@ -1,0 +1,35 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T23:14:31Z"
+sequence: 10
+---
+
+## Human
+
+PR #495 CI: three e2e tests failed (import-merge-url ×2, ai-cli-bridge, and
+language-help-modal) after the modalShell close-button aria-label change.
+
+## Assistant
+
+## Key decisions
+
+**Root cause**: my fix gave the shared modal close ✕ an accessible name derived
+from the modal title (`aria-label="Close <title>"`). That name *contains* the
+title and the word "Close", so Playwright's substring role-name queries matched
+the ✕ in addition to their intended target:
+- `getByRole('button', { name: 'Import' })` matched "Close **Import** from URL".
+- `getByRole('button', { name: 'Close' })` matched the ✕ *and* the AI-settings
+  footer's own "Close" button.
+- `getByLabel('Pick a modeling language')` matched the ✕ *and* the dialog.
+
+These are real ambiguities (two controls sharing a name in one dialog), not just
+test brittleness.
+
+**Fix**: give the ✕ a distinct accessible name — `aria-label="Dismiss"` — that
+doesn't shadow footer action buttons or title substrings. The dialog is already
+named via `aria-labelledby`, so "Dismiss" is still correct, descriptive a11y;
+`title="Close"` keeps the familiar tooltip for sighted users. Verified all four
+previously-failing tests pass locally (import-merge-url, ai-cli-bridge-setup,
+language-help-modal) plus a clean build. Chose a new label over editing the
+tests because the duplicate-name was a genuine smell and touching unseen tests
+across shards would have been fragile.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3157,8 +3157,7 @@ async function main() {
 
     // All tolerances failed. Offer render-only fallback — most users importing
     // a Baby Yoda / Eiffel Tower scan just want to look at it, not boolean-op it.
-    const accepted = await showInlineConfirm(
-      editorUI,
+    const accepted = await confirmDialog(
       `${file.name} won't form a clean manifold — typical for sculpted or scanned models with self-intersections, open edges, or T-junctions.\n\n` +
       `You can still import it as render-only: the mesh displays and exports normally, but boolean operations, paint, and cross-sections won't work.\n\n` +
       `For full editing, repair the mesh first in MeshLab or Blender, then re-import.\n\n` +
@@ -13665,90 +13664,6 @@ function setStatus(el: HTMLElement, state: 'ready' | 'running' | 'error' | 'load
       el.className += 'text-red-400';
       break;
   }
-}
-
-interface ConfirmOptions {
-  /** Optional bold title above the message. */
-  title?: string;
-  /** Label for the confirm button. Default 'Continue'. */
-  confirmLabel?: string;
-  /** Label for the cancel button. Default 'Cancel'. */
-  cancelLabel?: string;
-}
-
-/** Modal confirmation dialog with semi-transparent backdrop overlay.
- *  Message preserves newlines (single `\n` becomes a soft break, `\n\n` a
- *  paragraph break) so callers can lay out multi-line prompts cleanly.
- *  Returns a Promise that resolves true (confirm) or false (cancel / Escape / click overlay). */
-function showInlineConfirm(_container: HTMLElement, message: string, options: ConfirmOptions = {}): Promise<boolean> {
-  return new Promise((resolve) => {
-    // Remove any existing modal
-    document.querySelector('.confirm-modal-overlay')?.remove();
-
-    // Backdrop overlay
-    const overlay = document.createElement('div');
-    overlay.className = 'confirm-modal-overlay fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center';
-
-    // Modal box — wider than the default 'max-w-sm' so multi-line prompts
-    // don't reflow into long thin columns.
-    const modal = document.createElement('div');
-    modal.className = 'bg-zinc-800 border border-zinc-600 rounded-xl shadow-2xl p-5 max-w-md mx-4 animate-modal-in';
-
-    if (options.title) {
-      const title = document.createElement('h2');
-      title.className = 'text-zinc-100 text-base font-semibold mb-2';
-      title.textContent = options.title;
-      modal.appendChild(title);
-    }
-
-    const msg = document.createElement('p');
-    // `whitespace-pre-line` preserves \n as line breaks while still collapsing
-    // other whitespace runs, so single-line callers behave unchanged.
-    msg.className = 'text-zinc-200 text-sm leading-relaxed mb-5 whitespace-pre-line';
-    msg.textContent = message;
-
-    const btnGroup = document.createElement('div');
-    btnGroup.className = 'flex items-center justify-end gap-2';
-
-    const cancelBtn = document.createElement('button');
-    cancelBtn.className = 'px-4 py-1.5 rounded-lg text-sm text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 transition-colors';
-    cancelBtn.textContent = options.cancelLabel ?? 'Cancel';
-
-    const continueBtn = document.createElement('button');
-    continueBtn.className = 'px-4 py-1.5 rounded-lg text-sm font-medium bg-blue-600 text-white hover:bg-blue-500 transition-colors';
-    continueBtn.textContent = options.confirmLabel ?? 'Continue';
-
-    btnGroup.appendChild(cancelBtn);
-    btnGroup.appendChild(continueBtn);
-    modal.appendChild(msg);
-    modal.appendChild(btnGroup);
-    overlay.appendChild(modal);
-
-    let resolved = false;
-    function finish(result: boolean) {
-      if (resolved) return;
-      resolved = true;
-      overlay.remove();
-      document.removeEventListener('keydown', onKey);
-      resolve(result);
-    }
-
-    continueBtn.addEventListener('click', () => finish(true));
-    cancelBtn.addEventListener('click', () => finish(false));
-
-    // Click on overlay (outside modal) dismisses
-    overlay.addEventListener('mousedown', (e) => {
-      if (e.target === overlay) finish(false);
-    });
-
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') finish(false);
-    }
-    document.addEventListener('keydown', onKey);
-
-    document.body.appendChild(overlay);
-    continueBtn.focus();
-  });
 }
 
 main().catch(console.error);

--- a/src/ui/aboutModal.tsx
+++ b/src/ui/aboutModal.tsx
@@ -5,6 +5,7 @@
 import { useSignal } from '@preact/signals';
 import type { ComponentChildren } from 'preact';
 import { mountPreactModal } from './preact/mount';
+import { BUTTON_PRIMARY } from './styleConstants';
 import { partwrightMarkSvg } from './brand';
 import {
   buildInfo,
@@ -143,7 +144,7 @@ function AboutFooter(props: { close: () => void }) {
       >{copyLabel.value}</button>
       <button
         type="button"
-        class="px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white"
+        class={BUTTON_PRIMARY}
         onClick={props.close}
       >Done</button>
     </>

--- a/src/ui/aiAttachmentModal.tsx
+++ b/src/ui/aiAttachmentModal.tsx
@@ -5,6 +5,7 @@
 import { signal, type Signal } from '@preact/signals';
 import { useEffect, useRef } from 'preact/hooks';
 import { mountPreactModal } from './preact/mount';
+import { BUTTON_PRIMARY } from './styleConstants';
 import { loadSettings } from '../ai/settings';
 import { resolveLocalModel } from '../ai/local';
 import { fileToImageSource } from '../ai/images';
@@ -80,7 +81,7 @@ function AttachmentBody(props: {
       <div class="flex items-center gap-2">
         <button
           type="button"
-          class="px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white"
+          class={BUTTON_PRIMARY}
           onClick={() => fileInputRef.current?.click()}
         >Choose file…</button>
         <input

--- a/src/ui/modalShell.ts
+++ b/src/ui/modalShell.ts
@@ -98,6 +98,11 @@ export function createModalShell(opts: ModalShellOptions): ModalShell {
   const closeBtn = document.createElement('button');
   closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
   closeBtn.textContent = '✕';
+  // The bare ✕ glyph reads as "multiplication x" to a screen reader; give every
+  // modalShell close button a descriptive accessible name + tooltip. One fix
+  // covers every modal built on the shared shell.
+  closeBtn.setAttribute('aria-label', `Close ${opts.title}`);
+  closeBtn.title = `Close ${opts.title}`;
   header.appendChild(closeBtn);
   modal.appendChild(header);
 

--- a/src/ui/modalShell.ts
+++ b/src/ui/modalShell.ts
@@ -98,11 +98,15 @@ export function createModalShell(opts: ModalShellOptions): ModalShell {
   const closeBtn = document.createElement('button');
   closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
   closeBtn.textContent = '✕';
-  // The bare ✕ glyph reads as "multiplication x" to a screen reader; give every
-  // modalShell close button a descriptive accessible name + tooltip. One fix
-  // covers every modal built on the shared shell.
-  closeBtn.setAttribute('aria-label', `Close ${opts.title}`);
-  closeBtn.title = `Close ${opts.title}`;
+  // The bare ✕ glyph reads as "multiplication x" to a screen reader, so give it
+  // an accessible name. Use a distinct verb ("Dismiss") rather than "Close" or
+  // "Close <title>": the dialog is already named via aria-labelledby, and a
+  // "Close"/title-derived name would shadow a modal's own footer "Close" button
+  // or a title substring (e.g. "Import from URL" → "Import") under role-name
+  // queries — an ambiguity for both assistive tech and tests. `title` keeps the
+  // familiar "Close" tooltip for sighted users.
+  closeBtn.setAttribute('aria-label', 'Dismiss');
+  closeBtn.title = 'Close';
   header.appendChild(closeBtn);
   modal.appendChild(header);
 

--- a/src/ui/uninstallModal.tsx
+++ b/src/ui/uninstallModal.tsx
@@ -6,6 +6,7 @@
 import { signal, type Signal } from '@preact/signals';
 import { useEffect } from 'preact/hooks';
 import { mountPreactModal } from './preact/mount';
+import { BUTTON_DANGER } from './styleConstants';
 import {
   getStoreCounts,
   listLocalStorageEntries,
@@ -127,7 +128,7 @@ function UninstallFooter(props: {
       >Cancel</button>
       <button
         type="button"
-        class="px-3 py-1.5 rounded text-sm bg-red-600 hover:bg-red-500 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+        class={`${BUTTON_DANGER} disabled:opacity-50 disabled:cursor-not-allowed`}
         disabled={!anySelected || running.value}
         onClick={() => { void runWipe(); }}
       >{running.value ? 'Deleting…' : 'Delete selected data'}</button>


### PR DESCRIPTION
## Summary

Pre-production audit fix (7 of 9) — shared UI component consistency.

- **Modal close button a11y**: the shared `modalShell` close ✕ had no `aria-label` or `title`, so screen readers announced the bare glyph — and every modal built on the shell inherited it. The recent conformance work labelled tool panels but not modals; one fix on the shell covers them all.
- **Dedupe**: replaced `showInlineConfirm` (a ~70-line hand-rolled confirm with one caller, no focus trap, wrong z-index) with the shared `confirmDialog`, and deleted it plus its local `ConfirmOptions` interface.
- **Button drift**: swapped the primary/danger buttons in the uninstall, about, and AI-attachment modals to `BUTTON_PRIMARY`/`BUTTON_DANGER` — they were re-inlined at the wrong padding and rendered visibly smaller than the shared standard.

Deferred to a follow-up (noted): porting `progressModal` off inline hex onto Tailwind tokens, and moving `stepImportTargetModal`'s Cancel into the shell footer.

## Test plan
- `npm run build` ✅ · `npm run test:unit` (784) ✅

https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo)_