### PR TITLE
fix: validate relief import args and tidy relief/scad edges

### DIFF
--- a/prompts/20260607-221207-relief-import-robustness.md
+++ b/prompts/20260607-221207-relief-import-robustness.md
@@ -1,0 +1,82 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T22:12:07Z"
+sequence: 6
+---
+
+## Human
+
+Pre-production audit surfaced a set of relief + import robustness findings in
+the window.partwright API and the relief/SCAD edges. Fix them as one focused
+commit:
+
+1. `importImageAsRelief` / `importSvgAsRelief` merge their `options` /
+   `quantized` / `preprocess` / `crop` sub-objects with loose `{...spread}` and
+   no validation, unlike every other window.partwright tool (CLAUDE.md: unknown
+   keys rejected).
+2. The /ideas "smooth relief / lithophane" tile opens the blocky colour mode by
+   default instead of the smooth/tonal mode it promises.
+3. Per-session relief settings (localStorage) are never cleaned up on session
+   deletion, unlike the relief source blob which cascade-deletes.
+4. The SCAD internal STL round-trip hardcodes weld tolerance `1e5` — verify
+   whether that's actually wrong or a quantization multiplier.
+
+## Assistant
+
+## Key decisions
+
+**Fix 1 — relief import arg validation (`src/main.ts`).** Added a shared
+`validateReliefOptionArgs(args, fn)` helper next to the existing `clampRelief*`
+functions and wired both `importImageAsRelief` and `importSvgAsRelief` to call
+it through the standard `guard()` pattern (same idiom as `checkPrintability`),
+returning `{ error }` on bad input. The clamp* helpers already tolerate bad
+numerics by falling back to defaults, but that silently swallows typos like
+`{ widthToDeep: 100 }`; the rest of the API rejects unknown keys and wrong
+types outright, so the relief importers were the odd ones out. The helper uses
+`assertObject` / `assertNoUnknownKeys` / `assertNumber` / `assertBoolean` /
+`assertEnum` and enumerates the allowed keys per sub-object (common, quantized,
+preprocess, crop). Numeric bounds deliberately mirror the clamp* ranges so the
+validator and the clamps agree. Also validated `mode` for the image importer via
+`assertEnum(['luminance','quantized','ai'])`. Kept the existing top-level
+`{ src }` / `{ svgText }` string checks as-is (they predate the helper and read
+cleanly).
+
+**Fix 2 — /ideas smooth-relief tile (`src/main.ts`).** The `relief-portrait`
+idea ("Turn your photo into a smooth relief … lithophane-style, non-blocky")
+routed through `handleIdeaPhotoToRelief` → `openReliefImportFlow(file)` with no
+initial options, so the wizard opened in `DEFAULT_RELIEF_OPTIONS.mode`
+(`'quantized'` — flat blocky colour clusters), contradicting the tile's promise.
+Confirmed `'luminance'` is the smooth/tonal `ReliefMode` enum value in
+`src/relief/types.ts`. Fixed by passing `initialOptions` cloned from the
+defaults with `mode: 'luminance'`, so only the mode is overridden and every
+other default knob is preserved.
+
+**Fix 3 — relief settings cleanup (`src/relief/reliefSettings.ts`,
+`src/storage/sessionManager.ts`).** The relief *source* blob (IndexedDB) is
+cascade-deleted with the session in `db.ts`, but the per-session relief
+*settings* live in a single localStorage record keyed by sessionId and were
+never pruned, leaking a stale entry per deleted session. Added a
+`clearReliefSettings(sessionId)` export (mirroring the existing read/write
+helpers; no-op when the key is absent) and called it from
+`sessionManager.deleteSession` right after `dbDeleteSession`. Put the call in
+sessionManager (not db.ts) because db.ts is a pure IndexedDB layer and
+reliefSettings is localStorage-backed; sessionManager already orchestrates the
+session lifecycle, and the import edge (sessionManager → reliefSettings) is
+downward and cycle-free (verified with `lint:deps`).
+
+**Fix 4 — SCAD STL weld tolerance (`src/geometry/engines/scadToManifold.ts`):
+NO behaviour change, comment only.** Investigated the hardcoded `1e5` and
+confirmed it is a quantization *multiplier*, not a tolerance:
+`Math.round(v * 1e5) / 1e5` snaps coordinates to a 1e-5 grid, i.e. an effective
+weld tolerance of 1e-5 — exactly `getConfig().import.stlWeldTolerance`'s default
+(`1e-5`, `APP_CONFIG_DEFAULTS.import.stlWeldTolerance` in
+`src/config/appConfig.ts`). The math is correct, so per the conservative
+"prefer a comment over a behaviour change if uncertain" guidance I left it
+alone and only expanded the comment to explain that `1e5` is the inverse of the
+tolerance, that it mirrors the config default, and that threading getConfig()
+through buys nothing here because this runs in the engine Worker (where
+getConfig() returns static defaults and can't see the user's localStorage
+override).
+
+**Verification.** `npm run build` (tsc + vite) passed, `npm run test:unit`
+green (784 tests), `npm run lint:deps` reports no circular dependency.

--- a/prompts/20260607-232017-relief-test-arg-shape-fix.md
+++ b/prompts/20260607-232017-relief-test-arg-shape-fix.md
@@ -1,0 +1,29 @@
+---
+session: "a7f3c2"
+timestamp: "2026-06-07T232017Z"
+sequence: 12
+---
+
+## Human
+
+PR #496 CI: relief.spec.ts:66 ("colour relief import does not raise a false 'not
+watertight' verdict") failed — the new relief arg validation rejected
+`options.quantized`.
+
+## Assistant
+
+## Key decisions
+
+The new `validateReliefOptionArgs` guard is **correct**: `importImageAsRelief`
+consumes `quantized`/`preprocess`/`crop` as *top-level* args
+(`opts.quantized = { ...opts.quantized, ...args.quantized }`), so `quantized`
+nested inside `options` is a genuine typo. The old loose code silently dropped it
+(it became a junk key on `opts.common`); the test only produced a quantized
+relief via `mode: 'quantized'` + defaults. Every other relief test already passes
+`quantized` top-level — line 84 was the lone outlier.
+
+So the fix is in the **test**, not the guard: moved `quantized` out of `options`
+to the top level. This preserves the test's intent (a 2-cluster, output:'relief'
+quantized import → render-only) and now actually applies those options, while
+keeping the guard that catches typos in real caller code. Verified the test
+passes.

--- a/src/geometry/engines/scadToManifold.ts
+++ b/src/geometry/engines/scadToManifold.ts
@@ -24,6 +24,13 @@ export function parseBinarySTLToMeshGL(bytes: Uint8Array): MeshData | null {
   const tris: number[] = [];
 
   // Weld tolerance: quantize coordinates to 5 decimal places before hashing.
+  // `1e5` is the inverse of the tolerance, not a tolerance itself —
+  // `round(v * 1e5) / 1e5` snaps to a 1e-5 grid, i.e. a 1e-5 weld tolerance.
+  // That deliberately mirrors getConfig().import.stlWeldTolerance's default
+  // (1e-5, see APP_CONFIG_DEFAULTS in src/config/appConfig.ts). We inline the
+  // literal here because this runs in the engine Worker, where getConfig()
+  // can't read the user's localStorage override anyway (it returns the static
+  // defaults), so threading the config through would buy nothing.
   const quantize = (v: number) => Math.round(v * 1e5) / 1e5;
 
   let offset = 84;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2217,6 +2217,64 @@ async function main() {
     }
   }
 
+  // Validate the optional sub-objects an AI/console caller may pass to
+  // importImageAsRelief / importSvgAsRelief. The clamp* helpers below tolerate
+  // bad numerics by falling back to defaults, but the rest of the
+  // window.partwright API rejects unknown keys and wrong types outright
+  // (CLAUDE.md: "unknown keys rejected") so a typo like `{ widthToDeep: 100 }`
+  // is loud rather than silently ignored. Throws ValidationError; callers wrap
+  // this in guard() to surface it as { error }. The numeric bounds mirror the
+  // clamp* ranges below.
+  const RELIEF_COMMON_KEYS = ['widthMm', 'layerHeight', 'baseThickness', 'maxHeight', 'resolution', 'smoothing', 'removeBackground'] as const;
+  const RELIEF_QUANTIZED_KEYS = ['clusters', 'colorSpace', 'dither', 'output', 'shape', 'cornerRadiusMm', 'chamferMm', 'paintingMode', 'invertHeights', 'holes', 'holeEnabled', 'holeDiameterMm', 'holeOffsetMm', 'manualBackground', 'doubleSided', 'backMirror'] as const;
+  const RELIEF_PREPROCESS_KEYS = ['brightness', 'contrast', 'saturation', 'levelsLow', 'levelsHigh'] as const;
+  const RELIEF_CROP_KEYS = ['left', 'top', 'right', 'bottom'] as const;
+  function validateReliefOptionArgs(args: { options?: unknown; quantized?: unknown; preprocess?: unknown; crop?: unknown }, fn: string): void {
+    if (args.options !== undefined) {
+      const o = assertObject(args.options, `${fn}(options)`)!;
+      assertNoUnknownKeys(o, RELIEF_COMMON_KEYS, `${fn}(options)`);
+      assertNumber(o.widthMm, `${fn}(options).widthMm`, { optional: true, min: 1, max: 2000 });
+      assertNumber(o.layerHeight, `${fn}(options).layerHeight`, { optional: true, min: 0.02, max: 2 });
+      assertNumber(o.baseThickness, `${fn}(options).baseThickness`, { optional: true, min: 0, max: 50 });
+      assertNumber(o.maxHeight, `${fn}(options).maxHeight`, { optional: true, min: 0.1, max: 100 });
+      assertNumber(o.resolution, `${fn}(options).resolution`, { optional: true, min: 8, max: 512 });
+      assertNumber(o.smoothing, `${fn}(options).smoothing`, { optional: true, min: 0, max: 20 });
+      assertBoolean(o.removeBackground, `${fn}(options).removeBackground`, { optional: true });
+    }
+    if (args.quantized !== undefined) {
+      const q = assertObject(args.quantized, `${fn}(quantized)`)!;
+      assertNoUnknownKeys(q, RELIEF_QUANTIZED_KEYS, `${fn}(quantized)`);
+      assertNumber(q.clusters, `${fn}(quantized).clusters`, { optional: true, min: 2, max: 12, integer: true });
+      if (q.colorSpace !== undefined) assertEnum(q.colorSpace, ['rgb', 'lab'], `${fn}(quantized).colorSpace`);
+      assertBoolean(q.dither, `${fn}(quantized).dither`, { optional: true });
+      if (q.output !== undefined) assertEnum(q.output, ['relief', 'flat', 'silhouette'], `${fn}(quantized).output`);
+      if (q.shape !== undefined) assertEnum(q.shape, ['rect', 'rounded', 'circle'], `${fn}(quantized).shape`);
+      assertNumber(q.cornerRadiusMm, `${fn}(quantized).cornerRadiusMm`, { optional: true, min: 0, max: 50 });
+      assertNumber(q.chamferMm, `${fn}(quantized).chamferMm`, { optional: true, min: 0, max: 5 });
+      if (q.paintingMode !== undefined) assertEnum(q.paintingMode, ['multi-color', 'single-nozzle'], `${fn}(quantized).paintingMode`);
+      assertBoolean(q.invertHeights, `${fn}(quantized).invertHeights`, { optional: true });
+      assertBoolean(q.doubleSided, `${fn}(quantized).doubleSided`, { optional: true });
+      assertBoolean(q.backMirror, `${fn}(quantized).backMirror`, { optional: true });
+    }
+    if (args.preprocess !== undefined) {
+      const p = assertObject(args.preprocess, `${fn}(preprocess)`)!;
+      assertNoUnknownKeys(p, RELIEF_PREPROCESS_KEYS, `${fn}(preprocess)`);
+      assertNumber(p.brightness, `${fn}(preprocess).brightness`, { optional: true, min: -1, max: 1 });
+      assertNumber(p.contrast, `${fn}(preprocess).contrast`, { optional: true, min: -1, max: 1 });
+      assertNumber(p.saturation, `${fn}(preprocess).saturation`, { optional: true, min: -1, max: 1 });
+      assertNumber(p.levelsLow, `${fn}(preprocess).levelsLow`, { optional: true, min: 0, max: 254 });
+      assertNumber(p.levelsHigh, `${fn}(preprocess).levelsHigh`, { optional: true, min: 1, max: 255 });
+    }
+    if (args.crop !== undefined) {
+      const c = assertObject(args.crop, `${fn}(crop)`)!;
+      assertNoUnknownKeys(c, RELIEF_CROP_KEYS, `${fn}(crop)`);
+      assertNumber(c.left, `${fn}(crop).left`, { min: 0, max: 1 });
+      assertNumber(c.top, `${fn}(crop).top`, { min: 0, max: 1 });
+      assertNumber(c.right, `${fn}(crop).right`, { min: 0, max: 1 });
+      assertNumber(c.bottom, `${fn}(crop).bottom`, { min: 0, max: 1 });
+    }
+  }
+
   // Clamp the common knobs to sane physical/perf bounds. The wizard enforces
   // these via input attributes, but the programmatic (AI/console) path bypasses
   // the UI, so guard here against OOM (huge resolution) and degenerate values.
@@ -5043,7 +5101,12 @@ async function main() {
   async function handleIdeaPhotoToRelief(file: File): Promise<void> {
     await enterEditorForIdea();
     if (window.location.pathname !== '/editor') return;
-    openReliefImportFlow(file);
+    // The "smooth relief / lithophane" idea tile promises a non-blocky, tonal
+    // result, so open the wizard in 'luminance' mode rather than the global
+    // default ('quantized' — flat blocky colour clusters). Clone the defaults
+    // so we only override the mode.
+    const initialOptions: ReliefOptions = { ...structuredClone(DEFAULT_RELIEF_OPTIONS), mode: 'luminance' };
+    openReliefImportFlow(file, initialOptions);
     updateDocumentTitle({ page: 'editor' });
   }
 
@@ -8655,6 +8718,13 @@ async function main() {
       if (!args || typeof args !== 'object') return { error: 'importImageAsRelief: expected an object { src, mode?, options?, quantized?, crop? }' };
       const src = (args as { src?: unknown }).src;
       if (typeof src !== 'string' || src.length === 0) return { error: 'importImageAsRelief: src must be a non-empty data: or http(s) URL string' };
+      const argCheck = guard(() => {
+        const mode = (args as { mode?: unknown }).mode;
+        if (mode !== undefined) assertEnum(mode, ['luminance', 'quantized', 'ai'], 'importImageAsRelief(mode)');
+        validateReliefOptionArgs(args, 'importImageAsRelief');
+        return true;
+      });
+      if (typeof argCheck === 'object' && argCheck !== null && 'error' in argCheck) return argCheck;
       try {
         const image = await dataUrlToImageData(src);
         const opts: ReliefOptions = structuredClone(DEFAULT_RELIEF_OPTIONS);
@@ -8679,6 +8749,11 @@ async function main() {
       if (!args || typeof args !== 'object') return { error: 'importSvgAsRelief: expected an object { svgText, options?, quantized? }' };
       const svgText = (args as { svgText?: unknown }).svgText;
       if (typeof svgText !== 'string' || svgText.length === 0) return { error: 'importSvgAsRelief: svgText must be a non-empty SVG string' };
+      const argCheck = guard(() => {
+        validateReliefOptionArgs(args, 'importSvgAsRelief');
+        return true;
+      });
+      if (typeof argCheck === 'object' && argCheck !== null && 'error' in argCheck) return argCheck;
       try {
         const opts: ReliefOptions = structuredClone(DEFAULT_RELIEF_OPTIONS);
         const o = (args as { options?: unknown }).options;

--- a/src/relief/reliefSettings.ts
+++ b/src/relief/reliefSettings.ts
@@ -51,6 +51,16 @@ export function updateReliefSettings(sessionId: string, patch: Partial<ReliefSet
   return next;
 }
 
+/** Drop a session's persisted relief settings. Called from the session-delete
+ *  cascade so a removed session doesn't leak a stale localStorage entry — the
+ *  IndexedDB-side reliefSources blob is cascade-deleted alongside it (db.ts). */
+export function clearReliefSettings(sessionId: string): void {
+  const store = read();
+  if (!(sessionId in store)) return;
+  delete store[sessionId];
+  write(store);
+}
+
 export function isReliefSession(sessionId: string | null | undefined): boolean {
   if (!sessionId) return false;
   return getReliefSettings(sessionId)?.isRelief === true;

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -43,6 +43,7 @@ import {
   type AttachedImage,
 } from './db';
 import { publishTabSync, onTabSync } from './tabSync';
+import { clearReliefSettings } from '../relief/reliefSettings';
 import { listMessages as dbListMessages, putMessages as dbPutMessages } from '../ai/db';
 import { getSpendingSummary } from '../ai/settings';
 import type { ChatMessage } from '../ai/types';
@@ -568,6 +569,10 @@ export async function listSessions(): Promise<Session[]> {
 
 export async function deleteSession(id: string): Promise<void> {
   await dbDeleteSession(id);
+  // The IndexedDB cascade (dbDeleteSession) sweeps the relief *source* blob,
+  // but the per-session relief settings live in localStorage — clear them here
+  // so a deleted session doesn't leak a stale entry.
+  clearReliefSettings(id);
   publishTabSync({ kind: 'session-deleted', sessionId: id });
   if (currentState.session?.id === id) {
     await closeSession();

--- a/tests/relief.spec.ts
+++ b/tests/relief.spec.ts
@@ -81,7 +81,8 @@ test.describe('Relief Studio', () => {
       const created = await pw.importImageAsRelief({
         src,
         mode: 'quantized',
-        options: { resolution: 32, quantized: { output: 'relief', clusters: 2 } },
+        options: { resolution: 32 },
+        quantized: { output: 'relief', clusters: 2 },
       }) as { sessionId?: string; error?: string };
       const geo = pw.getGeometryData() as {
         isManifold?: boolean;


### PR DESCRIPTION
## Summary

Pre-production audit fix (8 of 9) — relief & import robustness.

- **Relief import arg validation**: `importImageAsRelief` / `importSvgAsRelief` merged options with a loose spread and no validation, unlike every other `window.partwright` tool. Added a shared `validateReliefOptionArgs` helper (`assertObject`/`assertNoUnknownKeys`/`assertNumber`/…) wired in via the standard `guard()` pattern, returning `{ error }` on bad input.
- **/ideas smooth-relief tile**: the "Turn your photo into a smooth relief / lithophane" idea opened the wizard in the default blocky `quantized` mode. `handleIdeaPhotoToRelief` now passes `mode: 'luminance'` so the wizard matches the tile's promise.
- **Per-session relief settings cleanup**: added `clearReliefSettings(sessionId)` and call it from `deleteSession` (they previously leaked in localStorage forever).
- **SCAD weld tolerance**: investigated and **left the math alone** — the `1e5` literal is a quantization multiplier (`round(v*1e5)/1e5` = a 1e-5 grid), which matches `stlWeldTolerance`'s default; only expanded the comment.

## Test plan
- `npm run build` ✅ · `npm run test:unit` (784) ✅ · `npm run lint:deps` ✅
- (Developed in an isolated worktree by a delegated subagent; verified independently.)

https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo)_