### PR TITLE
docs: sync changelog, architecture list, and command references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ The AI chat input supports `/command` shortcuts (`src/ai/slashCommands.ts`). A l
 | `/review` | Open the cross-provider review modal |
 | `/export` | Download the conversation as Markdown |
 | `/models` (alias `/settings`) | Open AI settings modal |
+| `/portrait` (alias `/bust`) | Prefill a prompt to model a stylized 3D bust from a photo you attach |
 | `/help` (alias `/commands`) | List all commands in chat |
 
 The command names and descriptions are defined in `SLASH_COMMANDS` in `slashCommands.ts`; the panel's handler map is type-checked against `SlashCommandName` so a name can't exist without a handler. Tests: `tests/unit/slashCommands.test.ts` (unit), `tests/ai-slash-commands.spec.ts` (e2e).
@@ -248,7 +249,7 @@ Static site, no backend. Vanilla TypeScript + Vite.
 - `src/import/parsers/stl.ts` — STL import (binary + ASCII)
 - `src/import/codegen.ts` — Generates `Manifold.ofMesh(api.imports[i])` wrapper code
 - `src/import/importedMesh.ts` — Active-imports register exposed to the sandbox as `api.imports`
-- `src/surface/modifiers.ts` — Surface modifier pipeline: `applyFuzzy` (noise-displaced skin), `applySmooth` (Taubin smoothing pass), `applyVoxelize` (mesh → voxel grid), `applyScale` (non-destructive resize). Each returns a `ModifierResult` — either `'manifold'` (baked mesh + wrapper code, mirroring the STL import path) or `'voxel'` (encoded grid + inline `voxels.decode(…)` code). Pure math lives in sibling modules: `fuzzySkin.ts`, `smoothSurface.ts`, `voxelizeMesh.ts`, `meshSubdivide.ts`, `colorTransfer.ts`, `scaleMesh.ts`. Unit tests: `tests/unit/surface.test.ts`.
+- `src/surface/modifiers.ts` — Surface modifier pipeline (`SurfaceModifierId = 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'smooth' | 'voxelize'`): `applyFuzzy` (noise-displaced skin), the fabric-texture family `applyKnit` / `applyCable` / `applyWaffle` / `applyFur` / `applyWoven` (stockinette knit, cable knit, waffle stitch, fur/velvet, woven fabric — displaced along normals over a UV unwrap, with WebGPU compute where available), `applySmooth` (Taubin smoothing pass), `applyVoxelize` (mesh → voxel grid), `applyScale` (non-destructive resize). Each modifier also has an `apply*Patch` variant that textures only a selected triangle set. Each returns a `ModifierResult` — either `'manifold'` (baked mesh + wrapper code, mirroring the STL import path) or `'voxel'` (encoded grid + inline `voxels.decode(…)` code). Pure math lives in sibling modules: `fuzzySkin.ts`, `knitTexture.ts`, `knitTextureGPU.ts`, `cableKnit.ts`, `waffleStitch.ts`, `furVelvet.ts`, `wovenFabric.ts`, `smoothSurface.ts`, `voxelizeMesh.ts`, `meshSubdivide.ts`, `colorTransfer.ts`, `scaleMesh.ts`, plus the UV layers `uvParameterize.ts`, `uvUnwrap.ts`, and `placement.ts` (region placement). Unit tests: `tests/unit/surface.test.ts`.
 
 ### Modeling engines (three of them)
 

--- a/prompts/20260607-221019-docs-sync-postaudit.md
+++ b/prompts/20260607-221019-docs-sync-postaudit.md
@@ -1,0 +1,42 @@
+---
+session: "a7f3c2"
+timestamp: 2026-06-07T22:10:19Z
+sequence: 7
+---
+
+## Human
+
+A pre-production audit surfaced several places where the docs/content had
+drifted from the shipped code: the changelog was missing recently merged
+user-visible features, the CLAUDE.md architecture list and slash-command table
+were stale, and the ai.md subdoc index plus the textures subdoc itself didn't
+match the actual tool surface. Fix them — docs/content only, no runtime changes.
+
+## Assistant
+
+Verified each claim against the source before writing, then applied
+documentation-only edits:
+
+- Added a June 7, 2026 changelog entry to `whatsNew.ts` covering voxel
+  `rotate()`, the 3D-printable AI toggle, AI voice input, and per-session
+  camera persistence, matching the existing date-grouped `WeekEntry` shape.
+- Refreshed the `src/surface/modifiers.ts` architecture bullet in `CLAUDE.md`
+  to describe the fabric-texture family and list the new sibling modules
+  (UV + GPU paths).
+- Documented `/portrait` (alias `/bust`) in the `CLAUDE.md` slash-command table.
+- Added the `textures` row to the `readDoc` subdoc table in `public/ai.md`.
+- Added the `quality?` (1–5 mesh detail) param to the six texture signatures
+  and parameter tables in `public/ai/textures.md`.
+
+## Key decisions
+
+- Treated today (2026-06-07) as a new date group at the top of the changelog
+  rather than folding into the June 5 entry, matching the file's per-day
+  grouping convention and keeping newest-first ordering.
+- Cross-checked the texture tool schemas in `src/ai/tools.ts` (every `apply*`
+  texture declares `quality` integer 1–5, default 3) and the
+  `SurfaceModifierId` union + exported `apply*` functions in
+  `src/surface/modifiers.ts` so the prose lists exactly what exists — avoiding
+  introducing fresh drift.
+- Used root-relative phrasing and kept descriptions concise to match the
+  surrounding entries/rows.

--- a/public/ai.md
+++ b/public/ai.md
@@ -148,6 +148,7 @@ The main reference splits into focused subdocs. **Fetch each by calling `readDoc
 | `file-io` | Before exporting or importing programmatically — `*Data()` byte-returning methods, Recent Exports inbox, session payload shape. |
 | `annotations` | When the user has marked up the model with the Annotate tool (or you need to write annotations programmatically). |
 | `relief` | When making an image-derived part (keychain / tile / silhouette / stepped relief) via `importImageAsRelief`, or reading the single-nozzle swap guide (`getReliefSwapGuide`) / optical preview (`setReliefPreviewMode`). |
+| `textures` | Before adding fabric/knit surface detail with `applyFuzzySkin` / `applyKnitTexture` / `applyCableKnit` / `applyWaffleStitch` / `applyFurVelvet` / `applyWovenFabric` — normal-displaced textures (knit, cable, waffle, fur/velvet, woven, fuzzy skin), their parameters, and the paint-ordering rules. |
 | `iteration-workflow` | Before calling `runAndSave`, `forkVersion`, `modifyAndTest`, `createSessionWithVersions`, or managing session notes — the full versioning and iteration workflow. |
 | `gotchas` | When something looks wrong — boolean overlap requirements, disconnected components, `paintRegion` on smooth surfaces, `probeRay` normals, `rotate` direction, re-running invalidating painted colors. |
 | `visual-verification` | Before declaring a build done — all-faces check, edge overlay options, feature-specific checks, stat-based validation. |

--- a/public/ai/textures.md
+++ b/public/ai/textures.md
@@ -39,7 +39,7 @@ the texture (`loadVersion`) and re-applying.
 ## applyFuzzySkin
 
 ```
-applyFuzzySkin({ amplitude?, scale?, octaves?, seed?, preserveColor? })
+applyFuzzySkin({ amplitude?, scale?, octaves?, seed?, quality?, preserveColor? })
 ```
 
 Applies multi-octave value-noise (FBM) displacement along per-vertex normals.
@@ -50,6 +50,7 @@ Applies multi-octave value-noise (FBM) displacement along per-vertex normals.
 | `scale` | ~4% of diagonal | Characteristic feature size. Smaller = finer fuzz. |
 | `octaves` | 2 | Fractal layers 1–5. More = busier surface. |
 | `seed` | 1 | Different seeds → different patterns with identical params. |
+| `quality` | 3 | Mesh detail 1 (draft, ~4× fewer triangles) to 5 (ultra, ~4× more). Higher = smoother displacement, slower. |
 | `preserveColor` | true | Carry paint through subdivision. |
 
 **Size guidance (model diagonal `d`):**
@@ -63,7 +64,7 @@ Applies multi-octave value-noise (FBM) displacement along per-vertex normals.
 
 ```
 applyKnitTexture({ amplitude?, stitchWidth?, stitchHeight?, rowOffset?,
-                   roundness?, grainAngleDeg?, variation?, seed?, preserveColor? })
+                   roundness?, grainAngleDeg?, variation?, seed?, quality?, preserveColor? })
 ```
 
 Applies a brick-offset grid of smooth cosine bumps shaped by the V-profile of
@@ -79,6 +80,7 @@ stockinette stitch loops.
 | `grainAngleDeg` | 0 | Rotate grain in XY plane. 0 = stitches run up Z. 90 = horizontal. |
 | `variation` | 0.1 | Per-stitch amplitude jitter (0 = machine-uniform, 0.1 = handmade feel). |
 | `seed` | 1 | Deterministic seed for per-stitch variation. |
+| `quality` | 3 | Mesh detail 1 (draft, ~4× fewer triangles) to 5 (ultra, ~4× more). Higher = smoother displacement, slower. |
 | `preserveColor` | true | Carry paint through subdivision. |
 
 **Look guidance by `roundness`:**
@@ -92,7 +94,7 @@ stockinette stitch loops.
 
 ```
 applyCableKnit({ amplitude?, cableWidth?, cablePitch?, plyWidth?,
-                 grainAngleDeg?, variation?, seed?, preserveColor? })
+                 grainAngleDeg?, variation?, seed?, quality?, preserveColor? })
 ```
 
 Two Gaussian ply ridges cross sinusoidally within each cable column, creating
@@ -107,6 +109,7 @@ rope-like Aran/cable-knit relief.
 | `grainAngleDeg` | 0 | Rotate cable columns in the XY plane. 0 = cables run up Z. |
 | `variation` | 0.08 | Per-cable amplitude jitter. |
 | `seed` | 1 | Deterministic seed. |
+| `quality` | 3 | Mesh detail 1 (draft, ~4× fewer triangles) to 5 (ultra, ~4× more). Higher = smoother displacement, slower. |
 | `preserveColor` | true | Carry paint through subdivision. |
 
 **Size guidance:**
@@ -120,7 +123,7 @@ rope-like Aran/cable-knit relief.
 
 ```
 applyWaffleStitch({ amplitude?, cellWidth?, cellHeight?, sharpness?,
-                    rowOffset?, grainAngleDeg?, seed?, preserveColor? })
+                    rowOffset?, grainAngleDeg?, seed?, quality?, preserveColor? })
 ```
 
 Regular grid of recessed cells with raised border ridges. `rowOffset=0.5`
@@ -134,6 +137,7 @@ produces a honeycomb/brick variant.
 | `sharpness` | 3 | 1 = soft rounded, 3 = crisp waffle, 8+ = very thin border. |
 | `rowOffset` | 0 | 0 = straight grid; 0.5 = honeycomb offset; any value [0,1]. |
 | `grainAngleDeg` | 0 | Rotate the cell grid in the XY plane. |
+| `quality` | 3 | Mesh detail 1 (draft, ~4× fewer triangles) to 5 (ultra, ~4× more). Higher = smoother displacement, slower. |
 | `preserveColor` | true | Carry paint through subdivision. |
 
 **Look guidance:**
@@ -147,7 +151,7 @@ produces a honeycomb/brick variant.
 
 ```
 applyFurVelvet({ amplitude?, fiberSpacing?, fiberLength?, octaves?,
-                 grainAngleDeg?, seed?, preserveColor? })
+                 grainAngleDeg?, seed?, quality?, preserveColor? })
 ```
 
 Anisotropic FBM noise: fine sampling cross-grain (individual fiber width),
@@ -162,6 +166,7 @@ or short fur.
 | `octaves` | 2 | Fractal detail 1–4. More = finer sub-fiber variation. |
 | `grainAngleDeg` | 0 | Rotate grain direction in XY plane. 0 = fibers run up Z. |
 | `seed` | 1 | Deterministic noise seed. |
+| `quality` | 3 | Mesh detail 1 (draft, ~4× fewer triangles) to 5 (ultra, ~4× more). Higher = smoother displacement, slower. |
 | `preserveColor` | true | Carry paint through subdivision. |
 
 **Look guidance:**
@@ -175,7 +180,7 @@ or short fur.
 
 ```
 applyWovenFabric({ amplitude?, threadSpacing?, threadWidth?, underDepth?,
-                   grainAngleDeg?, seed?, preserveColor? })
+                   grainAngleDeg?, seed?, quality?, preserveColor? })
 ```
 
 Plain-weave interlacing: alternating warp and weft thread ridges cross at each
@@ -190,6 +195,7 @@ slightly depressed.
 | `underDepth` | 0.3 | Under-thread depression depth [0–1]. 0 = flat valleys; 1 = deep recess. |
 | `grainAngleDeg` | 0 | Rotate the weave in the XY plane. 0 = warp runs up Z. |
 | `seed` | 1 | Deterministic seed. |
+| `quality` | 3 | Mesh detail 1 (draft, ~4× fewer triangles) to 5 (ultra, ~4× more). Higher = smoother displacement, slower. |
 | `preserveColor` | true | Carry paint through subdivision. |
 
 **Look guidance:**

--- a/src/content/data/whatsNew.ts
+++ b/src/content/data/whatsNew.ts
@@ -26,6 +26,43 @@ export const WHATS_NEW_INTRO =
 // Most recent first. Each entry is a calendar week (Mon–Sun) of shipped work.
 export const WHATS_NEW_WEEKS: WeekEntry[] = [
   {
+    range: 'June 7, 2026',
+    headline: 'Voxel rotation, print-ready AI, voice input, and remembered views',
+    groups: [
+      {
+        label: 'Voxel',
+        items: [
+          {
+            title: 'Rotate voxel models',
+            body: 'Voxel code gained a rotate() operation for 90° turns on the lattice, so you can reorient a voxel build along any axis without rebuilding it cube by cube.',
+          },
+        ],
+      },
+      {
+        label: 'AI assistant',
+        items: [
+          {
+            title: '3D-printable mode',
+            body: 'A new 3D-printable toggle feeds the assistant FDM design guidance — wall thickness, overhangs, and bed-friendly geometry — so the models it builds come out print-ready. On by default.',
+          },
+          {
+            title: 'Voice input',
+            body: 'A mic button in the AI panel lets you dictate prompts instead of typing them.',
+          },
+        ],
+      },
+      {
+        label: 'Sessions',
+        items: [
+          {
+            title: 'Remembered camera view',
+            body: 'Each session now remembers its working view, so reopening a model frames it the way you left it instead of resetting the camera.',
+          },
+        ],
+      },
+    ],
+  },
+  {
     range: 'June 5, 2026',
     headline: 'Filament palettes, the Self-Modeling Studio, and a searchable catalog',
     groups: [


### PR DESCRIPTION
## Summary

Pre-production audit fix (9 of 9) — documentation/content drift (docs-only, no runtime changes).

- **whatsNew.ts**: added the newest shipped features (voxel `rotate()`, 3D-printable AI toggle, voice input, per-session camera persistence) — they were absent, the exact changelog-drift pattern CLAUDE.md warns about.
- **CLAUDE.md architecture list**: the `src/surface/modifiers.ts` bullet listed only the original 4 modifiers; updated to the full `SurfaceModifierId` union and the 9 new sibling modules (fabric textures + UV/GPU paths).
- **ai.md readDoc table**: added the missing `textures` subdoc row.
- **CLAUDE.md slash-commands table**: added the `/portrait` (alias `/bust`) command that exists in `SLASH_COMMANDS` but was undocumented.
- **textures.md**: added the `quality?` param to the six `apply*` signatures + tables.

## Test plan
- `npm run test:unit` (784) ✅ — confirms no schema/version assertions broke.
- All claims verified against the source before writing; internal links root-relative.
- (Developed in an isolated worktree by a delegated subagent.)

https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjwKSreUHVPwmRtmzcTuCo)_