### PR TITLE
fix: AI tool-call buffering, auto-retry safety, and abort usage

### DIFF
--- a/prompts/20260608-ai-toolcall-retry-correctness.md
+++ b/prompts/20260608-ai-toolcall-retry-correctness.md
@@ -1,0 +1,50 @@
+---
+session: "serene-allen"
+timestamp: "2026-06-08T00:15:00Z"
+sequence: 1
+---
+
+## Human
+
+Pre-release cleanup: 12 subagents audited the codebase for bugs. After
+leader-verifying the findings, fix them and split into topical draft PRs off the
+latest main. This PR collects the AI chat-loop / provider-transport correctness
+findings.
+
+## Assistant
+
+## Key decisions
+
+**OpenAI-compatible servers silently dropped tool calls** (`openai.ts`): the
+Chat Completions stream keyed tool-call buffers on `tc.index ?? 0`. OpenAI
+proper always sends a numeric `index`, but llama.cpp/vLLM/Ollama compat shims
+(the Custom provider's whole audience) routinely omit it, so every distinct call
+collapsed into bucket 0 — their argument fragments concatenated into one
+invalid-JSON blob, `parseToolArgs` returned `{}`, and all calls after the first
+vanished. Reworked the buffer to a string-keyed map plus a `toolOrder` array
+(mirroring the Responses path): key on `index` when present, else the call `id`,
+else treat a bare delta as a continuation of the current call (`lastToolKey`).
+This handles indexed streaming, whole-call deltas with distinct ids, and the
+id-on-first-then-bare-continuation pattern. Rejected the sibling audit claim that
+`Object.values` reorders ≥10 calls — integer-keyed iteration is ascending
+numeric, so order was already correct; the real defect was the merge, not order.
+Added an e2e regression (`ai-providers.spec.ts`) asserting two index-less calls
+survive with parsed args.
+
+**Auto-retry re-ran non-idempotent tools** (`chatLoop.ts` + `tools.ts`): the
+`autoRetry` loop re-invoked any tool that returned `isError`, including
+`runAndSave`/`saveVersion`/`forkVersion` (duplicate a version), the `paint*`
+family (double-paint), `addSessionNote` (append twice), the relief imports
+(retry skips the confirm prompt), and the surface modifiers. A tool that
+partially succeeds then errors would double-apply. Added a `RETRY_SAFE_TOOLS`
+allowlist of pure reads, idempotent renders, and non-committing runs; the loop
+now only retries members. Default `autoRetry` is 0, so this only changes
+behavior for users who opted into 1/3 retries — toward correctness.
+
+**Aborted Anthropic turns reported zero usage** (`anthropic.ts`): the abort
+branch returned `{0,0,0,0}` even though input/cache tokens are billed at request
+time and partial output is billed too, so the spend cap and cost meter
+under-counted every Stop/stall. Accumulate usage from the streamed
+`message_start` (input/cache) and `message_delta` (running output) events into a
+`partialUsage`, and return that on abort — matching the OpenAI/Gemini abort paths
+that already preserve usage.

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -217,12 +217,25 @@ export async function streamTurn(
   // the 'text' event) and tool_use block starts (so the UI can render a
   // "calling X..." chip before the input finishes streaming).
   let collectedThinking = '';
+  // Track usage as it streams so an aborted turn can still report the tokens it
+  // already consumed (input + cache tokens are billed at request time, and any
+  // output produced before the abort is billed too). `message_start` carries
+  // the input/cache counts; `message_delta` carries the running output count.
+  const partialUsage: TurnUsage = { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
   stream.on('streamEvent', event => {
     if (event.type === 'content_block_delta' && event.delta.type === 'thinking_delta') {
       collectedThinking += event.delta.thinking;
       callbacks.onThinking?.(event.delta.thinking);
     } else if (event.type === 'content_block_start' && event.content_block.type === 'tool_use') {
       callbacks.onToolStart?.(event.content_block.id, event.content_block.name);
+    } else if (event.type === 'message_start') {
+      const u = event.message.usage;
+      partialUsage.inputTokens = u.input_tokens ?? 0;
+      partialUsage.outputTokens = u.output_tokens ?? 0;
+      partialUsage.cacheCreationInputTokens = u.cache_creation_input_tokens ?? 0;
+      partialUsage.cacheReadInputTokens = u.cache_read_input_tokens ?? 0;
+    } else if (event.type === 'message_delta') {
+      if (event.usage?.output_tokens != null) partialUsage.outputTokens = event.usage.output_tokens;
     }
   });
 
@@ -252,7 +265,9 @@ export async function streamTurn(
         text: collectedText,
         toolCalls: [],
         stopReason: 'aborted',
-        usage: { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        // Report the tokens consumed before the abort rather than zeros, so the
+        // spend cap and cost meter don't under-count an aborted turn.
+        usage: partialUsage,
         // Surface partial reasoning for display, but no replay payload: an
         // aborted turn dropped its tool calls, so there's no tool_use that
         // would require a signed thinking block on the next request. (A

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -17,7 +17,7 @@ import { streamTurn as streamTurnGemini, type StreamCallbacks as GeminiStreamCal
 import { streamTurn as streamTurnCustom } from './custom';
 import { getKey, recordUsage, putMessages } from './db';
 import { recordEvent } from './diagnostics';
-import { buildToolList, executeTool, CONFIRM_REQUIRED_TOOLS } from './tools';
+import { buildToolList, executeTool, CONFIRM_REQUIRED_TOOLS, RETRY_SAFE_TOOLS } from './tools';
 import { buildLocalSystemPrompt, buildMediumLocalSystemPrompt, buildSystemPrompt, loadAiMd, toggleSuffix } from './systemPrompt';
 import { loadSettings } from './settings';
 import { turnCostUsd } from './cost';
@@ -729,7 +729,12 @@ async function executeAllWithRetry(
     }
     let attempt = 0;
     let result = await timedExecuteTool(tc.name, tc.input, executeToolFn);
-    while (result.isError && attempt < toggles.autoRetry && !signal?.aborted) {
+    // Only auto-retry idempotent tools. Re-running a mutation (save a version,
+    // paint a region, append a note, confirm an import) that partially
+    // succeeded before erroring would double-apply it; the retry budget is for
+    // transient read/render/run failures, not state changes.
+    const retryable = RETRY_SAFE_TOOLS.has(tc.name);
+    while (result.isError && retryable && attempt < toggles.autoRetry && !signal?.aborted) {
       attempt++;
       result = await timedExecuteTool(tc.name, tc.input, executeToolFn);
     }

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -598,7 +598,19 @@ async function consumeChatStream(
   signal?: AbortSignal,
 ): Promise<StreamResult> {
   let collectedText = '';
-  const toolBuffers: Record<number, ChatToolBuffer> = {};
+  // Keyed by a stable string per tool call, in emission order (`toolOrder`).
+  // OpenAI proper always sends a numeric `index` that disambiguates parallel
+  // calls and threads streamed argument fragments to the right call. Some
+  // OpenAI-compatible servers (llama.cpp/vLLM/Ollama shims — the Custom
+  // provider's whole audience) omit `index`; keying on `index ?? 0` then
+  // collapsed every distinct call into bucket 0, concatenating their argument
+  // fragments into one invalid-JSON blob so `parseToolArgs` returned `{}` and
+  // all calls after the first were silently dropped. Derive the key from
+  // `index` when present, else the call `id`, else treat a bare delta as a
+  // continuation of the current call.
+  const toolBuffers: Record<string, ChatToolBuffer> = {};
+  const toolOrder: string[] = [];
+  let lastToolKey: string | null = null;
   let stopReason = 'unknown';
   let usage: TurnUsage = { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
 
@@ -632,11 +644,16 @@ async function consumeChatStream(
       }
       if (Array.isArray(delta.tool_calls)) {
         for (const tc of delta.tool_calls) {
-          const idx: number = tc.index ?? 0;
-          let buf = toolBuffers[idx];
+          let key: string;
+          if (tc.index != null) key = `i${tc.index}`;
+          else if (typeof tc.id === 'string' && tc.id.length > 0) key = `d${tc.id}`;
+          else key = lastToolKey ?? 'd0'; // bare continuation delta → current call
+          lastToolKey = key;
+          let buf = toolBuffers[key];
           if (!buf) {
-            buf = { id: tc.id ?? `call_${idx}`, name: '', argsText: '', startedNotified: false };
-            toolBuffers[idx] = buf;
+            buf = { id: tc.id ?? `call_${key}`, name: '', argsText: '', startedNotified: false };
+            toolBuffers[key] = buf;
+            toolOrder.push(key);
           }
           if (typeof tc.id === 'string' && tc.id.length > 0) buf.id = tc.id;
           if (tc.function?.name && !buf.name) buf.name = tc.function.name;
@@ -654,11 +671,10 @@ async function consumeChatStream(
     throw err;
   }
 
-  const toolCalls: PersistedToolCall[] = Object.values(toolBuffers).map(buf => ({
-    id: buf.id,
-    name: buf.name,
-    input: parseToolArgs(buf.argsText),
-  }));
+  const toolCalls: PersistedToolCall[] = toolOrder.map(key => {
+    const buf = toolBuffers[key];
+    return { id: buf.id, name: buf.name, input: parseToolArgs(buf.argsText) };
+  });
 
   // If the stream produced tool calls, force a tool_use stop regardless of the
   // reported finish_reason. OpenAI proper sends finish_reason:'tool_calls', but

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1541,6 +1541,30 @@ export const CONFIRM_REQUIRED_TOOLS = new Set([
   'importSvgAsRelief',
 ]);
 
+/** Tools that are safe to auto-retry on error: pure reads/queries, idempotent
+ *  renders, and runs that don't commit (re-executing reproduces the same
+ *  transient state). The chat loop's `autoRetry` re-invokes a failed tool, so
+ *  it must NOT re-run non-idempotent mutations — `runAndSave`/`saveVersion`/
+ *  `forkVersion` (would duplicate a version), the `paint*` family (would
+ *  double-paint or stack a second region), `addSessionNote` (would append
+ *  twice), the relief imports (already confirmed once — a retry skips the
+ *  prompt), the surface modifiers (re-bake), `modifyAndTest` (a patch won't
+ *  re-match after it's applied), and the part/code mutators. Anything not in
+ *  this set runs exactly once even when the user opted into retries. */
+export const RETRY_SAFE_TOOLS = new Set([
+  // Pure reads / queries
+  'getActiveLanguage', 'getCode', 'getParams', 'getGeometryData', 'getMeshSummary',
+  'getFeatureCentroids', 'getReferenceImages', 'getSessionContext', 'listVersions',
+  'listSessionNotes', 'readDoc', 'findFaces', 'listComponents', 'listLabels',
+  'listRegions', 'probePixel', 'paintPreview', 'paintExplain', 'query', 'probeRay',
+  'listParts', 'getCurrentPart', 'assertPaint', 'sliceAtZVisual', 'checkPrintability',
+  'getPrinterSettings', 'getReliefSwapGuide',
+  // Idempotent renders (produce a snapshot; no persistent mutation)
+  'renderView', 'renderViews', 'runIsolated',
+  // Run-without-commit (re-running the same code reproduces the same state)
+  'runCode', 'runAndAssert', 'runAndExplain',
+]);
+
 const RUN_GATED = new Set(['runCode', 'setParams']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion', 'saveVersion', 'applyFuzzySkin', 'applyKnitTexture', 'applyCableKnit', 'applyWaffleStitch', 'applyFurVelvet', 'applyWovenFabric']);
 const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -495,6 +495,40 @@ test.describe('Multi-provider AI', () => {
     expect(toolIdx).toBeLessThan(userIdx);
   });
 
+  test('OpenAI (Chat Completions) keeps tool calls distinct when an OpenAI-compatible server omits tool_calls[].index', async ({ page }) => {
+    // llama.cpp/vLLM/Ollama OpenAI-compat shims frequently stream tool calls
+    // without the numeric `index`. Keying buffers on `index ?? 0` collapsed
+    // every call into bucket 0, concatenating their argument fragments into
+    // invalid JSON so all calls after the first were silently dropped. With the
+    // id-based fallback both calls must survive with correctly-parsed args.
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    const result = await page.evaluate(async () => {
+      const openai = await import('/src/ai/openai.ts');
+      const origFetch = window.fetch;
+      // Two distinct tool calls, each delivered whole, with NO `index` field.
+      const body = [
+        'data: {"choices":[{"delta":{"tool_calls":[{"id":"call_A","function":{"name":"renderView","arguments":"{\\"view\\":\\"front\\"}"}}]},"finish_reason":null}]}',
+        'data: {"choices":[{"delta":{"tool_calls":[{"id":"call_B","function":{"name":"query","arguments":"{\\"q\\":\\"volume\\"}"}}]},"finish_reason":null}]}',
+        'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}',
+        'data: [DONE]',
+        '',
+      ].join('\n\n');
+      // @ts-expect-error test stub
+      window.fetch = async () => new Response(new Blob([body]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const r = await openai.streamTurn({ apiKey: 'k', model: 'gpt-4o', systemPrompt: 'sys', systemSuffix: '', history: [] as any, tools: [] });
+        return { ids: r.toolCalls.map(c => c.id), names: r.toolCalls.map(c => c.name), inputs: r.toolCalls.map(c => c.input) };
+      } finally {
+        window.fetch = origFetch;
+      }
+    });
+    expect(result.ids).toEqual(['call_A', 'call_B']);
+    expect(result.names).toEqual(['renderView', 'query']);
+    expect(result.inputs).toEqual([{ view: 'front' }, { q: 'volume' }]);
+  });
+
   test('Anthropic sends the thinking param with budget when enabled, omits it when off', async ({ page }) => {
     // Off must reproduce the pre-feature request exactly (no `thinking`
     // field); a non-off level enables extended thinking with budget_tokens


### PR DESCRIPTION
## Summary

First of several topical PRs from the pre-release 12-agent audit (leader-verified). This one collects the **AI chat-loop / provider-transport** correctness findings.

1. **OpenAI-compatible servers silently dropped tool calls** — `src/ai/openai.ts`
   The Chat Completions stream keyed tool-call buffers on `tc.index ?? 0`. OpenAI proper always sends a numeric `index`, but llama.cpp / vLLM / Ollama OpenAI-compat shims (the **Custom** provider's whole audience) routinely omit it — so every distinct call collapsed into bucket `0`, their argument fragments concatenated into one invalid-JSON blob, `parseToolArgs` returned `{}`, and **all calls after the first were silently dropped**. Reworked the buffer to a string-keyed map + `toolOrder` array (mirroring the Responses path): key on `index` when present, else the call `id`, else treat a bare delta as a continuation of the current call. Handles indexed streaming, whole-call deltas, and id-on-first-then-bare-continuation.

2. **Auto-retry re-ran non-idempotent tools** — `src/ai/chatLoop.ts`, `src/ai/tools.ts`
   The `autoRetry` loop re-invoked **any** tool returning `isError`, including `runAndSave`/`saveVersion`/`forkVersion`, the `paint*` family, `addSessionNote`, the relief imports, and surface modifiers. A tool that partially succeeds then errors would double-apply (duplicate version, double paint, second confirmed import). Added a `RETRY_SAFE_TOOLS` allowlist (pure reads, idempotent renders, non-committing runs); the loop now only retries members. Default `autoRetry` is `0`, so behavior only changes for users who opted into 1/3 retries — toward correctness.

3. **Aborted Anthropic turns reported zero usage** — `src/ai/anthropic.ts`
   The abort branch returned `{0,0,0,0}` even though input/cache tokens are billed at request time and partial output is billed too, so the spend cap and cost meter under-counted every Stop/stall. Now accumulates usage from the streamed `message_start` / `message_delta` events and returns it on abort, matching the OpenAI/Gemini abort paths.

### Rejected during verification
A sibling audit claim that `Object.values(toolBuffers)` reorders ≥10 parallel calls was **wrong** — integer-keyed object iteration is ascending-numeric, matching OpenAI's emission order. The real defect was the index-merge, not ordering.

## Test plan
- `npm run build` ✅ (type-check)
- `npm run test:unit` ✅ (797 passed)
- New e2e regression in `tests/ai-providers.spec.ts` asserting two index-less tool calls survive with correctly-parsed args ✅
- Full PR-checks e2e shards run on this draft.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LXVj4afR7JeDkVPGMKwE7i

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXVj4afR7JeDkVPGMKwE7i)_