### PR TITLE
fix: prevent voxel-grid overflow corruption and worker import races

### DIFF
--- a/prompts/20260608-voxel-overflow-worker-imports.md
+++ b/prompts/20260608-voxel-overflow-worker-imports.md
@@ -1,0 +1,45 @@
+---
+session: "serene-allen"
+timestamp: "2026-06-08T00:22:00Z"
+sequence: 2
+---
+
+## Human
+
+Pre-release cleanup (12-agent audit, leader-verified): fix the geometry-engine
+correctness findings as a topical PR off latest main.
+
+## Assistant
+
+## Key decisions
+
+**Voxel grid encode/decode silently corrupted wide bounding boxes**
+(`geometry/voxel/grid.ts`): `encodeGrid` lays a dense occupancy bitmap over the
+whole bounding box, indexing bytes with `idx >> 3` / `(cellCount + 7) >> 3`.
+Those bitwise shifts coerce to signed int32, so once the box exceeds 2^31 cells
+(reachable with two voxels at opposite corners of the ±1024 range → 2048³ ≈
+8.6e9) the index went negative: `Uint8Array(0)` was allocated and writes landed
+on `bitmap[-1]` (a silent no-op), round-tripping the grid through `voxels.decode`
+to empty/corrupt. Fixed by (a) indexing with floored division (`Math.floor(idx/8)`,
+overflow-proof) and (b) capping the box at the 2^31 boundary with a clear
+`ValidationError` on both encode and decode. The cap sits exactly where the old
+code began to corrupt, so every box the old encoder handled correctly (< 2^31)
+still encodes *and* decodes — no regression, no back-compat break — while the
+pathological wide-sparse boxes above it (which also made the O(cellCount) encode
+loop crawl) now fail fast. Added a unit test asserting a full-extent box throws
+rather than corrupting. (Didn't add a "wide box round-trips" test: the overflow
+only triggers ≥2^31 cells, where the O(cellCount) encode loop is itself too slow
+to run in a unit test — and the cap throws there anyway.)
+
+**Concurrent worker runs clobbered the shared import registry**
+(`geometry/engineWorker.ts`): `self.onmessage` is `async` and `setActiveImports`
+is a module-global set synchronously at message receipt, then read *after* the
+lazy-init / font / BREP-preload awaits by engines that read `getActiveImports()`
+synchronously at the top of their evaluation (verified `runReplicadAsync` reads
+at entry with no preceding await; `manifoldJsEngine.run` is synchronous). A
+second `execute` arriving mid-init overwrote the registry, so the first run
+tessellated with the wrong imports. Fixed by snapshotting `runImports` per run
+and installing it at the last synchronous moment before each engine reads it
+(after the awaits), closing the interleaving window. Left the author's
+deliberate `circularSegments` last-writer-wins design (documented at the
+no-clear comment) untouched — it's independent and intentional.

--- a/src/geometry/engineWorker.ts
+++ b/src/geometry/engineWorker.ts
@@ -127,8 +127,15 @@ self.onmessage = async (event: MessageEvent) => {
       // most-recently-started run, whose result the main thread keeps, sets the
       // override last and so always reads the correct value.
       if (typeof circularSegments === 'number') setCircularSegmentsOverride(circularSegments);
-      // Populate the per-run import registry so api.imports works in user code.
-      setActiveImports(imports ?? []);
+      // Snapshot this run's imports. `setActiveImports` writes a module-global
+      // registry, and the lazy-init / font / BREP-preload awaits below yield the
+      // event loop — so a second `execute` message arriving mid-init would
+      // overwrite the registry out from under this run, and the engine (which
+      // reads getActiveImports() synchronously at the top of its evaluation)
+      // would then tessellate with the wrong imports. Install the snapshot at
+      // the last synchronous moment before each engine reads it, after the
+      // awaits, instead of here — closing that interleaving window.
+      const runImports = imports ?? [];
 
       const effectiveLang: Language =
         lang === 'scad' ? 'scad' :
@@ -138,10 +145,12 @@ self.onmessage = async (event: MessageEvent) => {
       let result;
       if (effectiveLang === 'voxel') {
         // Pure-JS voxel meshing — no WASM, no lazy init, synchronous.
+        setActiveImports(runImports);
         result = voxelEngine.run(code as string, params ?? undefined);
       } else if (effectiveLang === 'scad') {
         // Ensure the OpenSCAD engine is loaded (lazy init).
         if (!openscadEngine.isReady()) await openscadEngine.init();
+        setActiveImports(runImports);
         // Preview callback: post the rough mesh to the main thread so it can
         // update the viewport immediately while Phase 2 (full quality) runs.
         const onScadPreview = (previewResult: { mesh: import('./types').MeshData | null }) => {
@@ -160,6 +169,7 @@ self.onmessage = async (event: MessageEvent) => {
         // Full replicad-language session — lazy-init OCCT then evaluate as
         // BREP. Tessellation happens inside the engine before returning.
         if (!replicadEngine.isReady()) await replicadEngine.init();
+        setActiveImports(runImports);
         result = await runReplicadAsync(code as string, params ?? undefined);
       } else {
         if (!manifoldReady) {
@@ -183,6 +193,7 @@ self.onmessage = async (event: MessageEvent) => {
         if (sourceUsesManifoldText(code as string) || /\bapi\.printFit\b/.test(code as string) || /[{,]\s*printFit\s*[,}]/.test(code as string)) {
           await preloadTextFonts();
         }
+        setActiveImports(runImports);
         result = manifoldJsEngine.run(code as string, params ?? undefined);
       }
 

--- a/src/geometry/voxel/grid.ts
+++ b/src/geometry/voxel/grid.ts
@@ -23,6 +23,20 @@ const HALF = DIM >> 1;          // 1024
 export const COORD_MIN = -HALF;     // -1024
 export const COORD_MAX = HALF - 1;  //  1023
 
+// encodeGrid lays a DENSE occupancy bitmap over the whole bounding box, so the
+// cell count is sx*sy*sz — independent of how many voxels are actually set. The
+// coordinate range (±1024) allows boxes up to 2048³ ≈ 8.6e9 cells. Past 2^31 a
+// cell index overflowed the 32-bit `>>3` byte-index math (it went negative,
+// silently dropping voxels and round-tripping the grid to empty/corrupt). We
+// now (a) index with floored division so the math is overflow-proof, and
+// (b) cap the box at the 2^31 boundary and throw a clear error instead of
+// silently corrupting. The cap sits exactly where the old code began to
+// corrupt, so every box the old encoder handled correctly (< 2^31) still
+// encodes *and* decodes — no regression, no back-compat break — while the
+// pathological wide-sparse boxes above it (which also made the O(cellCount)
+// encode loop crawl) fail fast with an actionable message.
+const MAX_GRID_CELLS = 0x7fffffff; // 2^31 - 1
+
 function assertCoord(v: number, name: string): number {
   const n = assertNumber(v, name, { integer: true, min: COORD_MIN, max: COORD_MAX })!;
   return n;
@@ -487,7 +501,12 @@ export function encodeGrid(grid: VoxelGrid): string {
   const sy = b.max[1] - b.min[1] + 1;
   const sz = b.max[2] - b.min[2] + 1;
   const cellCount = sx * sy * sz;
-  const bitmapBytes = (cellCount + 7) >> 3;
+  if (cellCount > MAX_GRID_CELLS) {
+    throw new ValidationError(
+      `voxel grid bounding box too large to encode (${sx}×${sy}×${sz} = ${cellCount} cells). `
+      + `Reduce the model's extent or voxel resolution.`);
+  }
+  const bitmapBytes = Math.ceil(cellCount / 8);
 
   // Header: magic(2) + min x/y/z (int16 ×3) + size x/y/z (uint16 ×3) = 14 bytes.
   const header = new Uint8Array(14);
@@ -506,7 +525,7 @@ export function encodeGrid(grid: VoxelGrid): string {
       for (let z = 0; z < sz; z++, idx++) {
         const rgb = grid.get(b.min[0] + x, b.min[1] + y, b.min[2] + z);
         if (rgb !== null) {
-          bitmap[idx >> 3] |= 1 << (idx & 7);
+          bitmap[Math.floor(idx / 8)] |= 1 << (idx & 7);
           colors.push((rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff);
         }
       }
@@ -533,7 +552,10 @@ export function decodeGrid(b64: string): VoxelGrid {
   const minX = dv.getInt16(2, true), minY = dv.getInt16(4, true), minZ = dv.getInt16(6, true);
   const sx = dv.getUint16(8, true), sy = dv.getUint16(10, true), sz = dv.getUint16(12, true);
   const cellCount = sx * sy * sz;
-  const bitmapBytes = (cellCount + 7) >> 3;
+  if (cellCount > MAX_GRID_CELLS) {
+    throw new ValidationError('voxels.decode(): grid bounding box too large (corrupt or unsupported data).');
+  }
+  const bitmapBytes = Math.ceil(cellCount / 8);
   const bitmapStart = 14;
   const colorStart = bitmapStart + bitmapBytes;
   let colorPtr = colorStart;
@@ -541,7 +563,7 @@ export function decodeGrid(b64: string): VoxelGrid {
   for (let x = 0; x < sx; x++) {
     for (let y = 0; y < sy; y++) {
       for (let z = 0; z < sz; z++, idx++) {
-        const occupied = (bytes[bitmapStart + (idx >> 3)] >> (idx & 7)) & 1;
+        const occupied = (bytes[bitmapStart + Math.floor(idx / 8)] >> (idx & 7)) & 1;
         if (occupied) {
           const r = bytes[colorPtr++], g = bytes[colorPtr++], b = bytes[colorPtr++];
           grid.set(minX + x, minY + y, minZ + z, [r, g, b]);

--- a/tests/unit/voxel.test.ts
+++ b/tests/unit/voxel.test.ts
@@ -140,6 +140,17 @@ describe('encodeGrid / decodeGrid', () => {
   it('rejects garbage input', () => {
     expect(() => decodeGrid('bm90LXZveGVscw==')).toThrow();
   });
+
+  it('rejects a bounding box too large to encode rather than silently corrupting it', () => {
+    // Full-extent corners span 2048³ ≈ 8.6e9 cells — past the 2^31 boundary
+    // where the old `idx >> 3` byte index went negative and dropped voxels,
+    // round-tripping the grid to empty. The guard now throws before the
+    // O(cellCount) loop instead of producing a corrupt encoding.
+    const v = new VoxelGrid();
+    v.set(COORD_MAX, COORD_MAX, COORD_MAX, '#fff');
+    v.set(-1024, -1024, -1024, '#000');
+    expect(() => encodeGrid(v)).toThrow(/too large/i);
+  });
 });
 
 // Build a directed-edge multiset for the mesh. For a closed, consistently-wound


### PR DESCRIPTION
## Summary

Geometry-engine correctness findings from the pre-release 12-agent audit (leader-verified).

1. **Voxel grid encode/decode silently corrupted wide bounding boxes** — `src/geometry/voxel/grid.ts`
   `encodeGrid` lays a dense occupancy bitmap over the whole bounding box and indexed bytes with `idx >> 3` / `(cellCount + 7) >> 3`. Those bitwise shifts coerce to **signed int32**, so once the box exceeds 2³¹ cells — reachable with two voxels at opposite corners of the ±1024 range (2048³ ≈ 8.6e9) — the index went negative: `Uint8Array(0)` was allocated and writes landed on `bitmap[-1]` (a silent no-op), round-tripping the grid through `voxels.decode` to **empty/corrupt**. This is a silent data-loss bug on a persistence path, invisible to the existing tests (which only use small near-origin grids).

   Fix: index with floored division (overflow-proof) and cap the box at the 2³¹ boundary with a clear `ValidationError` on both encode and decode. The cap sits exactly where the old code began to corrupt, so **every box the old encoder handled correctly (< 2³¹) still encodes and decodes — no regression, no back-compat break** — while the pathological wide-sparse boxes above it fail fast.

2. **Concurrent worker runs clobbered the shared import registry** — `src/geometry/engineWorker.ts`
   `self.onmessage` is `async`; `setActiveImports` is a module-global set synchronously at message receipt, then read *after* the lazy-init / font / BREP-preload `await`s by engines that read `getActiveImports()` synchronously at the top of their evaluation (`runReplicadAsync` reads at entry; `manifoldJsEngine.run` is synchronous). A second `execute` arriving mid-init overwrote the registry, so the in-flight run tessellated with the wrong imports.

   Fix: snapshot `runImports` per run and install it at the last synchronous moment before each engine reads it (after the awaits), closing the interleaving window. The author's deliberate `circularSegments` last-writer-wins design is left untouched — it's independent and intentional.

## Test plan
- `npm run build` ✅
- `npm run test:unit` ✅ (798 passed, incl. new voxel reject test)
- Pure-logic + worker plumbing; no UI surface. Full PR-checks e2e shards run on this draft.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LXVj4afR7JeDkVPGMKwE7i

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXVj4afR7JeDkVPGMKwE7i)_