### PR TITLE
fix: wipe drafts/reliefSources, invert renderer layering, expose palette config

### DIFF
--- a/prompts/20260608-storage-settings-renderer-layering.md
+++ b/prompts/20260608-storage-settings-renderer-layering.md
@@ -1,0 +1,47 @@
+---
+session: "serene-allen"
+timestamp: "2026-06-08T00:36:00Z"
+sequence: 4
+---
+
+## Human
+
+Pre-release cleanup (12-agent audit, leader-verified): fix the
+hygiene/architecture findings as a topical PR off latest main.
+
+## Assistant
+
+## Key decisions
+
+**Wipe + Data inventory ignored two stores** (`storage/dataInventory.ts`,
+`ui/dataExplorer.ts`): `ALL_STORES` and the `wipeData` modeling-data list omitted
+`drafts` (per-part editor buffers) and `reliefSources` (original relief import
+images — potentially large blobs). The audit called this a multi-tab edge case,
+but it's worse: `wipeData` deletes the database named `'mainifold'`, which is the
+*legacy* DB name — `DB_NAME` is now `'partwright'`. So a modeling-data wipe
+cleared 6 stores from the current DB and left `drafts`/`reliefSources` behind
+**unconditionally**, orphaned forever, while the Data tab under-reported usage.
+Added both to `StoreName`/`ALL_STORES`/`STORE_LABELS` and the modeling-data wipe
+list. No `objectStoreNames.contains` guard needed: `openPartwrightDB` always
+opens at `DB_VERSION = 8`, which creates both stores, so they always exist by the
+time any of this runs. Also extended `dataExplorer`'s exhaustive `recordLabel`
+switch (TS flagged the missing cases) and taught `recordKey` that
+`reliefSources` is keyed by `sessionId`, not `id`.
+
+**Renderer imported a feature layer** (`renderer/multiview.ts`): the offscreen
+multi-view renderer imported `buildStrokesGroup`/`disposeStrokesGroup` from
+`annotations/annotationOverlay` (which imports back `renderer/viewport`), a
+layering inversion the docs forbid — invisible to `lint:deps` because the file
+chain is acyclic. Inverted it with the existing leaf-registry pattern: added an
+offscreen-overlay provider slot to `viewportRegistry.ts`, registered the
+annotation builder in `viewportSubsystems.ts` (the sanctioned side-effect wiring
+module that's *allowed* to import features), and switched multiview to pull the
+group through the leaf. No renderer module imports a feature layer now; `madge`
+stays clean.
+
+**Two palette config fields were unreachable** (`ui/advancedSettingsModal.tsx`):
+`defaultPaletteCapacity` and `paletteHistoryMax` exist in `appConfig` (and are
+read live in `color/palette.ts`) but had no `<Field>`, so users couldn't override
+them despite the numeric-constants convention requiring it (two independent audit
+agents flagged this). Added both to the UI section, wired to the defaults.
+Verified in-browser (screenshot posted).

--- a/src/renderer/multiview.ts
+++ b/src/renderer/multiview.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { createWhiteMaterial, createBlackWireframeMaterial, createCreaseEdgeMaterial } from './materials';
 import type { MeshData } from '../geometry/types';
-import { buildStrokesGroup, disposeStrokesGroup } from '../annotations/annotationOverlay';
+import { buildOffscreenOverlay, disposeOffscreenOverlay } from './viewportRegistry';
 import { presetIndex } from '../storage/db';
 import { CREASE_ANGLE_DEG, resolveEdgeMode, type EdgeMode } from './edgeMode';
 import { getConfig } from '../config/appConfig';
@@ -203,7 +203,7 @@ export function renderCompositeCanvas(meshData: MeshData): HTMLCanvasElement {
   const camera = new THREE.PerspectiveCamera(40, 1, 0.1, 1000);
   const renderer = getOffscreenRenderer(viewSize);
 
-  const annotations = buildStrokesGroup(new THREE.Vector2(viewSize, viewSize));
+  const annotations = buildOffscreenOverlay(viewSize);
   if (annotations) scene.add(annotations);
 
   const labelHeight = 28;
@@ -243,7 +243,7 @@ export function renderCompositeCanvas(meshData: MeshData): HTMLCanvasElement {
 
   if (annotations) {
     scene.remove(annotations);
-    disposeStrokesGroup(annotations);
+    disposeOffscreenOverlay(annotations);
   }
   disposeScene(scene);
   geometry.dispose();
@@ -401,7 +401,7 @@ export function renderSingleViewCanvas(meshData: MeshData, options: {
   const camera = buildViewCamera(meshData, options);
   const renderer = getOffscreenRenderer(viewSize);
 
-  const annotations = buildStrokesGroup(new THREE.Vector2(viewSize, viewSize));
+  const annotations = buildOffscreenOverlay(viewSize);
   if (annotations) scene.add(annotations);
 
   renderer.render(scene, camera);
@@ -414,7 +414,7 @@ export function renderSingleViewCanvas(meshData: MeshData, options: {
 
   if (annotations) {
     scene.remove(annotations);
-    disposeStrokesGroup(annotations);
+    disposeOffscreenOverlay(annotations);
   }
   disposeScene(scene);
   geometry.dispose();

--- a/src/renderer/viewportRegistry.ts
+++ b/src/renderer/viewportRegistry.ts
@@ -47,3 +47,35 @@ export function runViewportInitHooks(ctx: ViewportContext): void {
 export function runViewportResizeHooks(widthPx: number, heightPx: number): void {
   for (const hook of resizeHooks) hook(widthPx, heightPx);
 }
+
+// ── Offscreen overlay provider ───────────────────────────────────────────────
+// The multi-view thumbnail renderer (multiview.ts) lives in the renderer layer
+// but needs the annotation-overlay group to composite marks into its offscreen
+// snapshots. The renderer must not import the annotations feature layer, so the
+// annotation layer registers a builder here (via viewportSubsystems.ts) and
+// multiview pulls the group through this leaf — keeping the dependency
+// one-directional, the same inversion used for the init/resize hooks above.
+
+export interface OffscreenOverlayProvider {
+  /** Build the overlay group for a square offscreen view of `viewSizePx`
+   *  device pixels, or null when there's nothing to draw. */
+  build: (viewSizePx: number) => THREE.Group | null;
+  dispose: (group: THREE.Group) => void;
+}
+
+let offscreenOverlayProvider: OffscreenOverlayProvider | null = null;
+
+export function registerOffscreenOverlayProvider(provider: OffscreenOverlayProvider): void {
+  offscreenOverlayProvider = provider;
+}
+
+/** Build the annotation overlay group for an offscreen scene, or null when no
+ *  provider is registered (e.g. before subsystems wire up) or there's nothing
+ *  to draw. Callers must pass the result to {@link disposeOffscreenOverlay}. */
+export function buildOffscreenOverlay(viewSizePx: number): THREE.Group | null {
+  return offscreenOverlayProvider?.build(viewSizePx) ?? null;
+}
+
+export function disposeOffscreenOverlay(group: THREE.Group): void {
+  offscreenOverlayProvider?.dispose(group);
+}

--- a/src/renderer/viewportSubsystems.ts
+++ b/src/renderer/viewportSubsystems.ts
@@ -3,10 +3,19 @@
 // viewport itself never imports them. Import this module once for its side
 // effects before calling initViewport (see main.ts).
 
-import { onViewportInit, onViewportResize } from './viewportRegistry';
+import * as THREE from 'three';
+import { onViewportInit, onViewportResize, registerOffscreenOverlayProvider } from './viewportRegistry';
 import { initPhantomGroup } from './phantomGeometry';
-import { initAnnotationOverlay, setLiveResolution as setAnnotationResolution } from '../annotations/annotationOverlay';
+import { initAnnotationOverlay, setLiveResolution as setAnnotationResolution, buildStrokesGroup, disposeStrokesGroup } from '../annotations/annotationOverlay';
 import { configureSessionPlane } from '../annotations/sessionPlane';
+
+// Let the offscreen multi-view renderer (renderer layer) composite annotation
+// marks into its snapshots without importing the annotations feature layer —
+// the same inversion as the init/resize hooks (see viewportRegistry).
+registerOffscreenOverlayProvider({
+  build: (viewSizePx) => buildStrokesGroup(new THREE.Vector2(viewSizePx, viewSizePx)),
+  dispose: (group) => disposeStrokesGroup(group),
+});
 
 onViewportInit(({ scene, controls }) => {
   // Phantom geometry group (for reference/fitment overlays)

--- a/src/storage/dataInventory.ts
+++ b/src/storage/dataInventory.ts
@@ -4,15 +4,17 @@
 
 import { openPartwrightDB } from './db';
 
-export type StoreName = 'sessions' | 'versions' | 'parts' | 'notes' | 'aiKeys' | 'aiChats' | 'aiAttachments' | 'importInbox' | 'exportInbox';
+export type StoreName = 'sessions' | 'versions' | 'parts' | 'notes' | 'drafts' | 'reliefSources' | 'aiKeys' | 'aiChats' | 'aiAttachments' | 'importInbox' | 'exportInbox';
 
-export const ALL_STORES: StoreName[] = ['sessions', 'versions', 'parts', 'notes', 'aiKeys', 'aiChats', 'aiAttachments', 'importInbox', 'exportInbox'];
+export const ALL_STORES: StoreName[] = ['sessions', 'versions', 'parts', 'notes', 'drafts', 'reliefSources', 'aiKeys', 'aiChats', 'aiAttachments', 'importInbox', 'exportInbox'];
 
 export const STORE_LABELS: Record<StoreName, string> = {
   sessions: 'Sessions',
   versions: 'Versions',
   parts: 'Parts',
   notes: 'Session notes',
+  drafts: 'Editor drafts',
+  reliefSources: 'Relief source images',
   aiKeys: 'AI API keys',
   aiChats: 'AI chat messages',
   aiAttachments: 'Image attachments',
@@ -175,7 +177,12 @@ export async function wipeData(sel: WipeSelection): Promise<void> {
   const stores: StoreName[] = [];
   // The Recent Imports / Exports lists cache imported & exported model files,
   // so they ride along with the modeling-data category (and thus a full wipe).
-  if (sel.modelingData) stores.push('sessions', 'versions', 'parts', 'notes', 'importInbox', 'exportInbox');
+  // `drafts` (per-part editor buffers) and `reliefSources` (original relief
+  // import images, potentially large blobs) are also modeling data — they were
+  // previously omitted here, and since the DB delete below targets the LEGACY
+  // 'mainifold' database (DB_NAME is now 'partwright'), they survived every wipe
+  // as orphaned rows. db.ts's deleteSession/clearAllData already sweep them.
+  if (sel.modelingData) stores.push('sessions', 'versions', 'parts', 'notes', 'drafts', 'reliefSources', 'importInbox', 'exportInbox');
   if (sel.chats) stores.push('aiChats');
   if (sel.apiKeys) stores.push('aiKeys');
   if (sel.attachments) stores.push('aiAttachments');

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -734,6 +734,24 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           onChange={v => set('ui', 'toastDurationMs', v)}
         />
         <Field
+          label="Default palette capacity"
+          hint="How many filament slots the paint panel assumes your printer has."
+          tooltip="The default number of colour slots (e.g. 4 for one Bambu AMS). Drives the paint panel's over-budget warning when a model uses more colours than your printer can load. Never blocks painting or export — it's just a heads-up."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.defaultPaletteCapacity}
+          value={c.ui.defaultPaletteCapacity}
+          min={1} max={16} integer
+          onChange={v => set('ui', 'defaultPaletteCapacity', v)}
+        />
+        <Field
+          label="Palette history size"
+          hint="How many recent colours the palette keeps in its history."
+          tooltip="The size of the palette's recent-colour history ring. Raise it to keep more previously-used colours one click away; lower it to keep the history compact."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.paletteHistoryMax}
+          value={c.ui.paletteHistoryMax}
+          min={8} max={256} integer
+          onChange={v => set('ui', 'paletteHistoryMax', v)}
+        />
+        <Field
           label="Tooltip delay"
           unit="ms"
           hint="Hover delay before a tooltip appears."

--- a/src/ui/dataExplorer.ts
+++ b/src/ui/dataExplorer.ts
@@ -38,6 +38,7 @@ export function refreshDataExplorer(): void {
 
 function recordKey(store: StoreName, rec: Record<string, unknown>): string {
   if (store === 'aiKeys') return String(rec.provider ?? '');
+  if (store === 'reliefSources') return String(rec.sessionId ?? ''); // keyed by sessionId, no `id`
   return String(rec.id ?? '');
 }
 
@@ -47,6 +48,8 @@ function recordLabel(store: StoreName, rec: Record<string, unknown>): string {
     case 'versions': return `v${rec.index ?? '?'} · ${String(rec.label ?? '')}`.trim();
     case 'parts': return String(rec.name ?? rec.id ?? '(unnamed)');
     case 'notes': return truncate(String(rec.text ?? ''), 60);
+    case 'drafts': return `${String(rec.language ?? '?')} · ${truncate(String(rec.code ?? ''), 50)}`.trim();
+    case 'reliefSources': return `${String(rec.filename ?? rec.sessionId ?? '')}${rec.isSvg ? ' (SVG)' : ''}`.trim();
     case 'aiKeys': return String(rec.provider ?? '');
     case 'aiChats': return `${String(rec.role ?? '?')} · ${truncate(blocksToText(rec.blocks), 50)}`;
     case 'aiAttachments': return String(rec.label || rec.mediaType || rec.id || '');


### PR DESCRIPTION
## Summary

Hygiene / architecture findings from the pre-release 12-agent audit (leader-verified).

1. **Wipe + Data inventory ignored two stores** — `src/storage/dataInventory.ts`, `src/ui/dataExplorer.ts`
   `ALL_STORES` and the `wipeData` modeling-data list omitted `drafts` (per-part editor buffers) and `reliefSources` (original relief import images — potentially large blobs). **Worse than the audit reported:** `wipeData` deletes the database named `'mainifold'`, but that's the *legacy* name — `DB_NAME` is now `'partwright'`. So a modeling-data wipe cleared 6 stores from the current DB and left `drafts`/`reliefSources` behind **unconditionally**, orphaned forever, while the Data tab under-reported usage. Added both stores to `StoreName`/`ALL_STORES`/`STORE_LABELS` and the wipe set. No version guard needed — `openPartwrightDB` always opens at `DB_VERSION = 8`, which creates both. Also extended `dataExplorer`'s exhaustive label switch (TS caught the gap) and keyed `reliefSources` by `sessionId`.

2. **Renderer imported a feature layer** — `src/renderer/{multiview,viewportRegistry,viewportSubsystems}.ts`
   `multiview.ts` imported `buildStrokesGroup`/`disposeStrokesGroup` from `annotations/annotationOverlay` (which imports back `renderer/viewport`) — the layering inversion the docs forbid, invisible to `lint:deps` because the file chain is acyclic. Inverted it with the existing leaf-registry pattern: an offscreen-overlay provider slot in `viewportRegistry.ts`, registered in `viewportSubsystems.ts` (the sanctioned wiring module), with multiview pulling the group through the leaf. No renderer module imports a feature layer now.

3. **Two palette config fields were unreachable** — `src/ui/advancedSettingsModal.tsx`
   `defaultPaletteCapacity` and `paletteHistoryMax` exist in `appConfig` and are read live in `color/palette.ts`, but had no `<Field>` — so users couldn't override them (flagged independently by two audit agents). Added both to the UI section.

## Test plan
- `npm run build` ✅
- `npm run test:unit` ✅ (797)
- `npm run lint:deps` ✅ — no circular dependency; the renderer→annotations edge is gone.
- Verified the new settings fields in-browser (screenshot in chat).
- Full PR-checks e2e shards run on this draft.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LXVj4afR7JeDkVPGMKwE7i

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXVj4afR7JeDkVPGMKwE7i)_