### PR TITLE
feat: close AI-tool parity gaps and warn on destructive engine baking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,7 @@ Static site, no backend. Vanilla TypeScript + Vite.
 - `src/geometry/engines/manifoldJs.ts` — manifold-3d sandbox. Exposes `api = { Manifold, CrossSection, Curves, BREP, ... }` to user code. `BREP` is `null` until `ensureBrepLoaded()` runs in the Worker (triggered by `sourceUsesBrep(code)`).
 - `src/geometry/engines/openscad.ts` — OpenSCAD WASM via `openscad-wasm-prebuilt`, lazy-loaded on first SCAD session.
 - `src/geometry/engines/replicad.ts` — BREP/replicad engine for full BREP-language sessions. The returned BREP shape is retained in `lastShape` so `exportSTEP` can grab it. Imported STEP files appear in `api.imports[0]` as `BrepShape` (separate from `api.meshImports` for STL); the pending-imports list lives in `brepRuntime.ts` so it survives across runs.
+- `src/geometry/engines/voxel.ts` — voxel-grid engine (pure JS, no WASM). User code calls `api.voxels()` then `v.set`/`v.fillBox`/`v.sphere`/`v.line` and `return v`. Backs the `voxel` language, VOX export, the image→voxel import, and the `voxelize` surface modifier.
 - `src/geometry/brepRuntime.ts` — Lazy loader + chainable `BrepShape` wrapper. The single source of truth for "is OCCT loaded?" and `getBrepNamespace()` — used by both the manifold-js sandbox (Phase C — `api.BREP.*`) and the replicad engine (Phase A — full BREP session). Also houses `parseStepBlob` and the pending-BREP-imports side-channel used by the STEP import flow.
 - `src/renderer/viewport.ts` — Three.js interactive viewport
 - `src/renderer/multiview.ts` — Offscreen multi-angle render API (`renderViews`/`renderView`/`renderCompositeCanvas` for thumbnails)
@@ -251,15 +252,18 @@ Static site, no backend. Vanilla TypeScript + Vite.
 - `src/import/importedMesh.ts` — Active-imports register exposed to the sandbox as `api.imports`
 - `src/surface/modifiers.ts` — Surface modifier pipeline (`SurfaceModifierId = 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'smooth' | 'voxelize'`): `applyFuzzy` (noise-displaced skin), the fabric-texture family `applyKnit` / `applyCable` / `applyWaffle` / `applyFur` / `applyWoven` (stockinette knit, cable knit, waffle stitch, fur/velvet, woven fabric — displaced along normals over a UV unwrap, with WebGPU compute where available), `applySmooth` (Taubin smoothing pass), `applyVoxelize` (mesh → voxel grid), `applyScale` (non-destructive resize). Each modifier also has an `apply*Patch` variant that textures only a selected triangle set. Each returns a `ModifierResult` — either `'manifold'` (baked mesh + wrapper code, mirroring the STL import path) or `'voxel'` (encoded grid + inline `voxels.decode(…)` code). Pure math lives in sibling modules: `fuzzySkin.ts`, `knitTexture.ts`, `knitTextureGPU.ts`, `cableKnit.ts`, `waffleStitch.ts`, `furVelvet.ts`, `wovenFabric.ts`, `smoothSurface.ts`, `voxelizeMesh.ts`, `meshSubdivide.ts`, `colorTransfer.ts`, `scaleMesh.ts`, plus the UV layers `uvParameterize.ts`, `uvUnwrap.ts`, and `placement.ts` (region placement). Unit tests: `tests/unit/surface.test.ts`.
 
-### Modeling engines (three of them)
+### Modeling engines (four of them)
 
-Partwright supports three language/engine pairs. The mesh-side pipeline below the engine boundary (painting, render, ray-cast, export, queries) is engine-agnostic — anything new that lives there works across all three.
+Partwright supports four language/engine pairs. The mesh-side pipeline below the engine boundary (painting, render, ray-cast, export, queries) is engine-agnostic — anything new that lives there works across all four.
 
 | Language | Engine | Kernel | Unique features |
 |---|---|---|---|
 | `manifold-js` (default) | manifold-3d | mesh | `warp`, `levelSet`, `smoothOut`, `Curves` helpers, fast booleans on weird shapes |
 | `scad` | OpenSCAD via `openscad-wasm-prebuilt` | CSG | BOSL2 (`threaded_rod`, `spur_gear`, `cuboid(rounding=)`, …) |
 | `replicad` | OpenCASCADE via `replicad-opencascadejs` | BREP | True selective edge fillets/chamfers, STEP export, exact surfaces |
+| `voxel` | in-house JS voxel grid (`src/geometry/engines/voxel.ts`) | voxel grid | Blocky colored cubes (Minecraft / pixel-art); `api.voxels()` + `v.set`/`v.fillBox`/`v.sphere`/`v.line`; VOX export; target of image→voxel import and `voxelizeModel` |
+
+> **Engine awareness for mesh-side tools.** Most tools work off the engine-agnostic tessellated mesh and need no special casing. But anything that *bakes a result back into a session* (surface modifiers, scale/place/rotate transforms, voxelize) converts a SCAD/BREP session into a `manifold-js` (or `voxel`) mesh, discarding the parametric source — and for BREP, STEP export. Those paths emit a user-facing warning via `engineBakeWarning` (see `commitSurfaceModifier` / `commitTransform` in `src/main.ts`); preserve that warning when adding new commit paths.
 
 **Two ways to reach BREP** — these are deliberately complementary, not competing:
 

--- a/prompts/20260608-041500-multi-engine-feature-audit.md
+++ b/prompts/20260608-041500-multi-engine-feature-audit.md
@@ -1,0 +1,73 @@
+---
+session: "qvftq1"
+timestamp: "2026-06-08T03:55:00Z"
+model: claude-opus-4-8
+tools: [subagent, playwright]
+---
+
+## Human
+
+I've merged many new features recently. I've had multiple rounds of AI
+investigating defects and bugs — crashes, things not behaving as wanted —
+but also UI inconsistencies (menus that don't match other menus), tools that
+work with one modeling engine but were never considered for the others,
+missing documentation/skills, and features that are reachable from the UI but
+NOT from the `window.partwright` JavaScript API. The end goal is for an AI to
+be able to drive almost everything a user can do, through that JS API. Create
+~20 subagents to investigate the codebase and report back. For things that
+very obviously need fixing, open a PR; otherwise just report findings.
+
+## Assistant
+
+## Key decisions
+
+**Approach**: Ran a 20-agent read-only audit fleet, each scoped to one
+non-overlapping concern across five themes — UI↔JS-API parity, cross-engine
+tool coverage, UI consistency, bugs/crashes, and docs/skills gaps. Agents
+returned structured findings (severity + file:line + obvious-fix flag), not
+file dumps, so the synthesis stayed in budget. Then implemented only the
+clearly-correct, self-contained subset and reported the rest for triage.
+
+**What shipped in this PR** (the "obviously needs fixing" cluster):
+
+- **AI-tool parity (the user's central goal).** `smoothModel`, `voxelizeModel`,
+  `scaleModel`, `placeModel`, `rotateModel`, `layFlatModel` already existed on
+  `window.partwright` and in the UI/command palette but had no `src/ai/tools.ts`
+  schema or dispatch — the in-app AI literally couldn't smooth, voxelize,
+  resize, or orient a model. Added schemas + dispatch + SAVE_GATED membership,
+  mirroring the existing texture tools. Params are plain/serializable.
+
+- **Destructive-bake warning (cross-engine correctness).** Applying any surface
+  modifier or scale to a SCAD/replicad session silently baked it to a
+  manifold-js mesh — discarding the parametric source, and for BREP the STEP
+  export — with no warning. The transform/place path already warned
+  (`commitTransform`); the surface-modifier commit path (`commitSurfaceModifier`)
+  did not. Added `engineBakeWarning(priorLang, target)`, emitted as a `warn`
+  toast (source `engine`, auto-mirrored to the Diagnostic Log) AND returned in
+  the result `warnings` for AI/console callers. `commitTransform` passes
+  `warnOnBake:false` so the transform path isn't double-warned (it keeps its
+  more specific message).
+
+- **Silent clipboard failure** in the Diagnostics panel copy button: added the
+  missing `.catch` → `showToast` warn, matching the pattern used elsewhere.
+
+- **Docs.** CLAUDE.md still said "three engines"; `voxel` is a real fourth
+  engine (registered, typed, in the help page) — bumped to four, added the
+  `voxel.ts` architecture bullet and an engine-awareness note about bake paths.
+  `public/ai/printing.md` actively told the AI to hand bed-fit/orientation off
+  to UI tools; rewrote it to use `scaleModel`/`placeModel`/`rotateModel`/
+  `layFlatModel` directly. Added `smoothModel`/`voxelizeModel` to
+  `public/ai/textures.md` with the cross-engine bake caveat.
+
+**Deliberately NOT in this PR** (reported for triage — broader or need design):
+image-stamp/filament-palette/replace-color paint API, STL/STEP import API,
+version rename/delete/diff API, patch/triangle-selection AI primitive, the
+hand-rolled-modal → `createModalShell`/`confirmDialog` consolidations, AI-modal
+button-constant migration, and the `kind:'triangles'` paint-region
+re-tessellation fragility. The IndexedDB layer, cross-tab isolation, resource
+disposal, and cross-engine import/export wiring all audited clean.
+
+**Verification**: `npm run build` (tsc) + 800 unit tests pass; a throwaway
+Playwright spec drove `window.partwright` to confirm `scaleModel` on a manifold
+model is warning-free while `smoothModel` on a SCAD model bakes to manifold-js
+and surfaces the "OpenSCAD model was baked to a mesh" toast.

--- a/public/ai/printing.md
+++ b/public/ai/printing.md
@@ -32,10 +32,12 @@ geometry change. It returns a structured report; every entry in `checks[]` has a
 `level` of `pass` / `warn` / `fail` (a `fail` means it won't print as-is).
 
 What it inspects:
-- **Bed fit** — bounding box vs the build volume (fail = too big → use the
-  Resize tool to shrink, or the Split tool to cut into bed-sized pieces).
+- **Bed fit** — bounding box vs the build volume (fail = too big → call
+  `scaleModel(sx, sy, sz)` to shrink, or the Split tool to cut into bed-sized
+  pieces).
 - **Overhangs** — downward faces shallower than `overhangAngleDeg` (default 45°
-  from horizontal) that will need support. Consider re-orienting to remove them.
+  from horizontal) that will need support. Re-orient with `rotateModel` /
+  `layFlatModel` to remove them.
 - **Thin walls** — a *sampled* interior-ray estimate of the thinnest wall vs the
   nozzle (fail < 1 nozzle width, warn < 2). It's an estimate, not exact.
 - **Small features** — smallest overall dimension near the nozzle limit.
@@ -47,9 +49,22 @@ const r = partwright.checkPrintability();
 // r.ok === false → read r.checks, fix the `fail` items, re-check.
 ```
 
-Then fix problems at the source: thicken walls, re-orient, edit the dimension
-constants in the model code (preferred for parametric models), or steer the
-user toward the Resize / Split tools when bed fit is the blocker.
+Then fix problems at the source: thicken walls, edit the dimension constants in
+the model code (preferred for parametric models), or apply a transform directly.
+You can drive orientation and sizing yourself — no need to hand off to the UI:
+
+- `scaleModel(sx, sy, sz, { preserveColor })` — resize by per-axis factors (1 =
+  unchanged). Use a uniform factor to shrink an oversized model onto the bed.
+- `placeModel({ dropToFloor, centerX, centerY, centerZ })` — sit the model on
+  Z=0 / center it on the bed.
+- `rotateModel({ x, y, z })` — rotate by Euler degrees about the model's center.
+- `layFlatModel()` — auto-orient the largest flat face onto the bed and drop it.
+
+Each saves a new version and returns `{ ok, geometry, warnings? }`. On a SCAD or
+BREP/replicad model these **bake the model to a manifold-js mesh** (the warning
+says so) — the parametric source and STEP export are then gone, so prefer
+editing the source for parametric models when you can. Use the Split tool when a
+model is too big to print in one piece even at scale.
 
 ## Automatic warning on export
 

--- a/public/ai/textures.md
+++ b/public/ai/textures.md
@@ -1,4 +1,4 @@
-# Surface Texture Operations
+# Surface Texture & Mesh Operations
 
 Post-hoc operations that add surface detail to a finished model by displacing
 vertices along their normals. Six textures are available:
@@ -11,6 +11,19 @@ vertices along their normals. Six textures are available:
 | `applyWaffleStitch` | Recessed grid cells with raised borders | Waffle-knit, waffle irons, honeycomb patterns |
 | `applyFurVelvet` | Directional anisotropic pile (velvet, fur, chenille) | Animal fur, velvet fabric, soft plush surfaces |
 | `applyWovenFabric` | Plain-weave over/under interlacing | Baskets, woven cloth, twill, burlap |
+
+Two further mesh operations live in the same panel and share the same
+apply→save→verify workflow:
+
+| Operation | What it does | Notes |
+|-----------|--------------|-------|
+| `smoothModel({ iterations, subdivide, preserveColor })` | Taubin λ/μ smoothing — rounds sharp edges/facets without the shrinkage of a naive Laplacian | Mesh smoothing, not a true fillet; for exact fillets use the replicad (BREP) engine. Returns `{ ok, label, geometry, warnings? }`. |
+| `voxelizeModel({ resolution, smooth, preserveColor })` | Converts the model into the `voxel` engine (colored cubes) and switches the session language to `voxel` | `resolution` = voxels along the longest axis (~32 default). Replaces the code with a `voxels.decode(...)` program — see the `voxel` subdoc. |
+
+> **Cross-engine note:** every operation here bakes to a mesh. On a SCAD or
+> BREP/replicad model this discards the parametric source (and, for BREP, STEP
+> export) — the returned `warnings` array says so. Prefer editing the source for
+> parametric models when the change can be expressed there.
 
 ---
 

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1467,6 +1467,100 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'smoothModel',
+    description: `Smooth/round the current model with a Taubin λ/μ pass — softens sharp edges and facets without the shrinkage a naive Laplacian causes. Saves a new version.
+
+**When to use:** to round a blocky/low-poly model or take the edge off hard corners, after the geometry is final. This is mesh smoothing, not a true fillet — for exact fillets/chamfers use the replicad (BREP) engine.
+
+**Parameters:** iterations = smoothing passes (more → rounder/softer; start ~5); subdivide = densify the mesh first for finer smoothing (default true); preserveColor = carry existing paint (default true).
+
+**Cross-engine note:** a SCAD or BREP/replicad model is baked to a manifold-js mesh by this operation — the parametric source (and STEP export for BREP) is then unavailable. Returns { ok, label, geometry, warnings? } — always check warnings.`,
+    input_schema: {
+      type: 'object',
+      properties: {
+        iterations: { type: 'integer', description: 'Number of Taubin smoothing passes. More = rounder/softer. Default ~5.', minimum: 1, maximum: 50 },
+        subdivide: { type: 'boolean', description: 'Subdivide the mesh before smoothing for finer results. Default true.' },
+        preserveColor: { type: 'boolean', description: 'Carry existing paint regions onto the smoothed mesh. Default true.' },
+      },
+    },
+  },
+  {
+    name: 'voxelizeModel',
+    description: `Convert the current model into the voxel engine — a grid of colored cubes (Minecraft / pixel-art look). Saves a new version and switches the session to the voxel language.
+
+**When to use:** for a deliberately blocky aesthetic, or to hand a model to the voxel-paint tools.
+
+**Parameters:** resolution = voxels along the longest axis (higher → finer and slower; start ~32); smooth = lightly round the voxel result (default false); preserveColor = sample existing paint into the voxels (default true).
+
+**Cross-engine note:** this replaces the session's code with a voxels.decode(...) program; the prior manifold-js / SCAD / BREP source is no longer editable. Returns { ok, label, geometry, warnings? }.`,
+    input_schema: {
+      type: 'object',
+      properties: {
+        resolution: { type: 'integer', description: 'Voxels along the longest axis. Higher = finer and slower. Default ~32.', minimum: 4, maximum: 256 },
+        smooth: { type: 'boolean', description: 'Lightly round the voxelized result. Default false.' },
+        preserveColor: { type: 'boolean', description: 'Sample existing paint into the voxel colors. Default true.' },
+      },
+    },
+  },
+  {
+    name: 'scaleModel',
+    description: `Resize the current model by per-axis multiplicative factors and save a new version. 1 = unchanged, 2 = double, 0.5 = half. For a uniform resize pass the same factor for sx, sy, and sz.
+
+**Cross-engine note:** a SCAD or BREP/replicad model is baked to a manifold-js mesh; a manifold-js model stays editable. Returns { ok, label, geometry, warnings? }.`,
+    input_schema: {
+      type: 'object',
+      properties: {
+        sx: { type: 'number', description: 'X-axis scale factor (1 = no change).', exclusiveMinimum: 0 },
+        sy: { type: 'number', description: 'Y-axis scale factor (1 = no change).', exclusiveMinimum: 0 },
+        sz: { type: 'number', description: 'Z-axis scale factor (1 = no change).', exclusiveMinimum: 0 },
+        preserveColor: { type: 'boolean', description: 'Carry existing paint onto the scaled mesh. Default true.' },
+      },
+      required: ['sx', 'sy', 'sz'],
+    },
+  },
+  {
+    name: 'placeModel',
+    description: `Reposition the current model on the print bed and save a new version. Combine any of dropToFloor (sit the model's bottom on Z=0), centerX, centerY, centerZ. Use this to fix a model that floats above or sinks below the bed, or to center it.
+
+**Write-back:** mode 'auto' (default) keeps the model parametric (an editable .translate) when safe, otherwise bakes to a mesh; 'parametric' forces editable code; 'bake' flattens to a mesh. A SCAD/BREP/painted model can only bake. Returns { ok, noop?, geometry, warnings? } — noop:true when already positioned.`,
+    input_schema: {
+      type: 'object',
+      properties: {
+        dropToFloor: { type: 'boolean', description: "Move the model so its lowest point sits on Z=0 (the bed)." },
+        centerX: { type: 'boolean', description: 'Center the model on the X axis.' },
+        centerY: { type: 'boolean', description: 'Center the model on the Y axis.' },
+        centerZ: { type: 'boolean', description: 'Center the model on the Z axis.' },
+        mode: { type: 'string', enum: ['auto', 'parametric', 'bake'], description: "Write-back mode. Default 'auto'." },
+        preserveColor: { type: 'boolean', description: 'Carry existing paint when baking. Default true.' },
+      },
+    },
+  },
+  {
+    name: 'rotateModel',
+    description: `Rotate the current model by Euler angles in degrees, about its own center, and save a new version. Same write-back modes as placeModel (auto / parametric / bake). Returns { ok, geometry, warnings? }.`,
+    input_schema: {
+      type: 'object',
+      properties: {
+        x: { type: 'number', description: 'Rotation about the X axis, in degrees.' },
+        y: { type: 'number', description: 'Rotation about the Y axis, in degrees.' },
+        z: { type: 'number', description: 'Rotation about the Z axis, in degrees.' },
+        mode: { type: 'string', enum: ['auto', 'parametric', 'bake'], description: "Write-back mode. Default 'auto'." },
+        preserveColor: { type: 'boolean', description: 'Carry existing paint when baking. Default true.' },
+      },
+    },
+  },
+  {
+    name: 'layFlatModel',
+    description: `Auto-orient the current model for printing: rotate its largest flat face down onto the bed and drop it to the floor. Saves a new version. Same write-back modes as placeModel. Returns { ok, geometry, warnings? }.`,
+    input_schema: {
+      type: 'object',
+      properties: {
+        mode: { type: 'string', enum: ['auto', 'parametric', 'bake'], description: "Write-back mode. Default 'auto'." },
+        preserveColor: { type: 'boolean', description: 'Carry existing paint when baking. Default true.' },
+      },
+    },
+  },
+  {
     name: 'finish',
     description: 'Signal that the user\'s request is fully complete and you have nothing left to do. This ENDS your turn. Auto-continue is on: if you stop WITHOUT calling finish, you will be automatically resumed to keep working — so never end with a plain "all done" message; call finish instead. Call it once, only when the task is genuinely complete and verified. Optionally include a one-line summary of what you accomplished.',
     input_schema: {
@@ -1566,7 +1660,7 @@ export const RETRY_SAFE_TOOLS = new Set([
 ]);
 
 const RUN_GATED = new Set(['runCode', 'setParams']);
-const SAVE_GATED = new Set(['runAndSave', 'loadVersion', 'saveVersion', 'applyFuzzySkin', 'applyKnitTexture', 'applyCableKnit', 'applyWaffleStitch', 'applyFurVelvet', 'applyWovenFabric']);
+const SAVE_GATED = new Set(['runAndSave', 'loadVersion', 'saveVersion', 'applyFuzzySkin', 'applyKnitTexture', 'applyCableKnit', 'applyWaffleStitch', 'applyFurVelvet', 'applyWovenFabric', 'smoothModel', 'voxelizeModel', 'scaleModel', 'placeModel', 'rotateModel', 'layFlatModel']);
 const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);
 /** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
@@ -2068,6 +2162,18 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.applyFurVelvet(input);
     case 'applyWovenFabric':
       return api.applyWovenFabric(input);
+    case 'smoothModel':
+      return api.smoothModel(input);
+    case 'voxelizeModel':
+      return api.voxelizeModel(input);
+    case 'scaleModel':
+      return api.scaleModel(input.sx as number, input.sy as number, input.sz as number, { preserveColor: input.preserveColor as boolean | undefined });
+    case 'placeModel':
+      return api.placeModel(input);
+    case 'rotateModel':
+      return api.rotateModel(input);
+    case 'layFlatModel':
+      return api.layFlatModel(input);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7159,7 +7159,28 @@ async function main() {
     return { regions, transferredTris };
   }
 
-  async function commitSurfaceModifier(result: ModifierResult, preserveColor: boolean): Promise<Record<string, unknown>> {
+  /** A user-facing warning when committing a modifier converts a SCAD or BREP
+   *  session into a baked manifold-js/voxel mesh — the parametric source (and,
+   *  for BREP, STEP export) is discarded. Returns null when nothing of value is
+   *  lost (manifold-js → manifold-js, or the explicit manifold-js → voxelize). */
+  function engineBakeWarning(priorLang: Language, target: 'manifold-js' | 'voxel'): string | null {
+    if (priorLang === target) return null;
+    if (priorLang === 'replicad') {
+      return 'This BREP model was baked to a mesh — the parametric BREP source and STEP export are no longer available.';
+    }
+    if (priorLang === 'scad') {
+      return 'This OpenSCAD model was baked to a mesh — the parametric SCAD source is no longer editable.';
+    }
+    return null;
+  }
+
+  async function commitSurfaceModifier(result: ModifierResult, preserveColor: boolean, opts?: { warnOnBake?: boolean }): Promise<Record<string, unknown>> {
+    // Capture the language *before* the commit switches it, so we can warn when a
+    // SCAD/BREP session is silently baked to a mesh. The transform path
+    // (commitTransform) emits its own, more specific warning and passes
+    // warnOnBake:false to avoid double-reporting.
+    const priorLang = getActiveLanguage();
+    const warnOnBake = opts?.warnOnBake !== false;
     // For manifold results the modifier already baked colors into its input and
     // carried them through subdivision — result.mesh.triColors has the correct
     // per-triangle paint (dense mesh, same shape as the engine output). We use
@@ -7210,12 +7231,15 @@ async function main() {
           );
         }
       }
+      const bakeWarning = warnOnBake ? engineBakeWarning(priorLang, 'manifold-js') : null;
+      if (bakeWarning) showToast(bakeWarning, { variant: 'warn', source: 'engine' });
+      const allWarnings = [...(bakeWarning ? [bakeWarning] : []), ...colorWarnings];
       return {
         ok: true,
         label: result.label,
         geometry: getGeometryDataObj(),
         colorsCarried: carried,
-        ...(colorWarnings.length > 0 ? { warnings: colorWarnings } : {}),
+        ...(allWarnings.length > 0 ? { warnings: allWarnings } : {}),
       };
     }
     // Voxel result: a self-contained `voxels.decode(...)` program, no imports.
@@ -7228,7 +7252,14 @@ async function main() {
     if (!ok) return { error: `Failed to apply ${result.label}` };
     const thumbnail = await captureThumbnail();
     await saveVersion(result.code, getGeometryDataObj(), thumbnail, result.label, undefined, { force: true });
-    return { ok: true, label: result.label, geometry: getGeometryDataObj() };
+    const voxelBakeWarning = warnOnBake ? engineBakeWarning(priorLang, 'voxel') : null;
+    if (voxelBakeWarning) showToast(voxelBakeWarning, { variant: 'warn', source: 'engine' });
+    return {
+      ok: true,
+      label: result.label,
+      geometry: getGeometryDataObj(),
+      ...(voxelBakeWarning ? { warnings: [voxelBakeWarning] } : {}),
+    };
   }
 
   // ---- Place / Rotate (drop-to-floor, center, free rotate, auto lay-flat) --
@@ -7310,7 +7341,7 @@ async function main() {
       result = await commitTransformParametric(steps, label);
     } else {
       const preserve = preserveColor ?? true;
-      result = await commitSurfaceModifier(applyTransform(meshForModifier(preserve), steps, label), preserve);
+      result = await commitSurfaceModifier(applyTransform(meshForModifier(preserve), steps, label), preserve, { warnOnBake: false });
     }
     return warnings.length && !result.error ? { ...result, warnings } : result;
   }

--- a/src/ui/diagnosticsPanel.ts
+++ b/src/ui/diagnosticsPanel.ts
@@ -10,6 +10,7 @@
 // arrive.
 
 import { errorLog, type LogEntry, type ErrorLevel } from '../diagnostics/errorLog';
+import { showToast } from './toast';
 import {
   getWorkerHealth,
   getWorkerRuns,
@@ -419,6 +420,8 @@ function buildPanel(): HTMLElement {
     void navigator.clipboard.writeText(text).then(() => {
       copyBtn.textContent = 'Copied!';
       setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
+    }).catch(() => {
+      showToast("Couldn't copy to clipboard", { variant: 'warn' });
     });
   });
   lSub.appendChild(copyBtn);


### PR DESCRIPTION
## Summary

Output of a 20-subagent, read-only feature audit of the codebase across five themes: **UI↔JS-API parity**, **cross-engine tool coverage**, **UI consistency**, **bugs/crashes**, and **docs/skills gaps**. This PR implements only the clearly-correct, self-contained subset; the rest of the findings are reported in the session for triage (see the "Reported, not in this PR" list below).

### What's fixed here

1. **AI-tool parity (the headline goal — let the AI drive what the UI can).** `smoothModel`, `voxelizeModel`, `scaleModel`, `placeModel`, `rotateModel`, `layFlatModel` already existed on `window.partwright` and in the UI/command palette, but had **no schema or dispatch in `src/ai/tools.ts`** — so the in-app AI literally could not smooth, voxelize, resize, or orient a model. Added tool schemas + dispatch cases + `SAVE_GATED` membership, mirroring the existing texture tools. All params are plain/serializable.

2. **Guard the silent destructive engine-bake (cross-engine correctness).** Applying any surface modifier or scale to a **SCAD or BREP/replicad** session silently baked it to a manifold-js mesh — discarding the parametric source, and for BREP the **STEP export** — with no warning. The transform/place path already warned (`commitTransform`); the surface-modifier commit path (`commitSurfaceModifier`) did not. Added `engineBakeWarning(priorLang, target)`, emitted as a `warn` toast (auto-mirrored to the Diagnostic Log) **and** returned in the result `warnings` for AI/console callers. `commitTransform` now passes `warnOnBake:false` so the transform path isn't double-warned.

3. **Silent clipboard failure** in the Diagnostics panel copy button — added the missing `.catch` → warn toast.

4. **Docs.** CLAUDE.md said "three engines" — `voxel` is a real fourth engine (registered, typed, in the help page already); bumped to four + added the `voxel.ts` architecture bullet and an engine-bake-awareness note. `public/ai/printing.md` was actively telling the AI to hand bed-fit/orientation off to UI tools — rewrote it to use `scaleModel`/`placeModel`/`rotateModel`/`layFlatModel` directly. Added `smoothModel`/`voxelizeModel` to `public/ai/textures.md` with the cross-engine bake caveat.

## Test plan

- ✅ `npm run build` (includes the `tsc` type-check)
- ✅ `npm run test:unit` — 800 passed
- ✅ Browser-verified via a throwaway Playwright spec driving `window.partwright`: `scaleModel` on a manifold model returns `{ok:true}` with no warning; `smoothModel` on a **SCAD** model bakes the session to manifold-js and surfaces the *"This OpenSCAD model was baked to a mesh — the parametric SCAD source is no longer editable"* warn toast (screenshot posted in session).
- PR-checks will run the full e2e shards on this draft.

## Reported, not in this PR (need design or are broader)

From the audit, surfaced for triage rather than auto-fixed:

- **More UI→API parity gaps:** image-stamp painting (`stampImageOntoMesh`), filament-palette management, replace-color; **STL/STEP import** API; **version rename/delete/diff** API. Patch/triangle-selection for the AI needs a new selection primitive first.
- **UI consistency:** `showToolConfirmation` should be `confirmDialog`; `sessionList`/`aiLocalModal`/`shareUI`/`showAttachImageModal` hand-roll overlays instead of `createModalShell`; six AI/settings modal footers bypass `BUTTON_PRIMARY`/`BUTTON_CANCEL` (root cause: `primitives.tsx` `PrimaryButton` is a competing standard).
- **Cross-engine fragility:** `kind:'triangles'` paint regions can mismap on SCAD/replicad re-tessellation (IDs are tessellation-bound).
- **Small bugs:** `uninstallModal` swallows wipe failure then reloads as success; `imagesView.ts` leaks a `document` keydown listener on non-Escape close (the `gallery.ts` twin has the fix).

**Audited clean:** IndexedDB transaction layer, cross-tab isolation, Three.js/blob/listener disposal, and cross-engine import/export wiring.

https://claude.ai/code/session_01Qv19e5UnM7HzMvaDuh512k

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv19e5UnM7HzMvaDuh512k)_