### PR TITLE
feat: constrain image imports and painting to the filament palette

### DIFF
--- a/prompts/20260608-133224-palette-usage-import-constrain.md
+++ b/prompts/20260608-133224-palette-usage-import-constrain.md
@@ -1,0 +1,62 @@
+---
+session: "c9f1a4"
+timestamp: "2026-06-08T13:32:24Z"
+model: claude-opus-4-8
+tools: [explore]
+---
+
+## Human
+
+I recently added a colour-palette feature but I'm not sure I'm using it
+everywhere. I'd like a "constrain colours to palette" option in the places it's
+relevant — e.g. importing an image to voxels or to a relief map, a checkbox that
+says "constrain the colours to the palette". And I thought the palette could
+also do find/replace/merge of colours, but I don't remember if I built that.
+Investigate, report back — then (follow-up) implement both and open a PR.
+
+## Assistant
+
+## Investigation findings
+
+- The palette already had the merge/replace/swap capability the user had
+  forgotten building: the paint panel's **Replace** tool (`replaceRegionColors`)
+  plus the palette manager's **"Colours in this model"** reconciliation
+  (`reassignRegionColor` Replace/Merge, `applyPaletteAutoMatch` "Apply palette").
+  So the "after the fact" recolour story was done.
+- The genuine gaps were **at import time**: the voxel modal already had a
+  fixed-palette snap path (`palette` field + `nearestPalette`) but it was only
+  ever seeded from the *image's* k-means colours, never the filament palette; the
+  relief modal had no palette option at all.
+- **Constrain mode was cosmetic** — `isPaletteConstrained()` only hid the custom
+  colour picker; nothing stopped an ad-hoc colour from actually being painted.
+
+## Key decisions
+
+**Two import flows, one mental model ("Constrain to filament palette" checkbox),
+but deliberately asymmetric plumbing — driven by what each modal already had:**
+
+- *Voxel*: reused the existing `palette` snap field. Added a modal-intent flag
+  `constrainToPalette` to `ImageToVoxelOptions` (the conversion still only reads
+  `palette`; the flag exists so a recent-import re-click reopens in constrain
+  mode and **re-resolves the palette live** from the current filament slots
+  rather than trusting a stored snapshot). When the checkbox is on, the
+  All/Posterize/Palette reduction picker is replaced by a read-only filament
+  swatch strip — constrain is a distinct mode, not a fourth reduction.
+- *Relief*: there was no palette concept, so added `fixedPalette` to
+  `QuantizedOptions` and taught `sampleQuantized` to skip k-means and snap each
+  cell to the nearest fixed colour (reusing the existing `nearestPalette`, so the
+  dither path needed no change). Presence of `fixedPalette` *is* the toggle (no
+  separate flag needed — there's no competing image-palette mode to disambiguate
+  from, unlike voxel). Re-resolved live on open for the same reason.
+
+**Shared helper, not copy-paste**: `listSlotRgb255()` (active slots as 0–255
+triples) lives in `palette.ts` so both modals snap to the same source.
+
+**Real constrain enforcement** lives at the *active-paint-colour* chokepoint in
+`paintMode.ts`, NOT in `regions.addRegion`. `addRegion` is also the rehydration
+path for loading saved sessions, and snapping there would silently rewrite the
+colours of old off-palette models on load. Instead `setColor` snaps to the
+nearest slot when constrained, an `enforcePaletteConstraint()` re-snaps on
+`activate()` and on every `onPaletteChange` (so toggling constrain on can't leave
+the held-over default red off-palette), and the script/API paint path is left
+explicit by design. Empty palette ⇒ no slot ⇒ falls through to ad-hoc.

--- a/prompts/20260608-141500-relief-constrain-clamp-fix.md
+++ b/prompts/20260608-141500-relief-constrain-clamp-fix.md
@@ -1,0 +1,32 @@
+---
+session: "c9f1a4"
+timestamp: "2026-06-08T14:15:00Z"
+sequence: 2
+model: claude-opus-4-8
+---
+
+## Human
+
+I don't see "Constrain to filament palette" really enforcing the colours. It
+does on the preview but the generated model still has all the colours.
+
+## Assistant
+
+## Root cause
+
+The relief *preview* renders straight from the modal's live `opts` (which carry
+`quantized.fixedPalette`), but the *create* path
+(`createReliefFromImageData`) runs options through `clampReliefQuantized()`
+first — and that helper rebuilds the quantized object field-by-field, so it
+silently dropped the new `fixedPalette`. The committed model therefore fell
+back to k-means clustering (all colours) even though the preview snapped to the
+palette. Same class of bug as the app's "every URL param must be read back
+everywhere" rule: a new option field has to be threaded through every
+clamp/rebuild site, not just the producer and the consumer.
+
+## Fix
+
+Preserve `fixedPalette` in `clampReliefQuantized` (validated as 0–255 RGB
+triples, dropped when empty/malformed). The voxel path needs no change — it
+hands the modal options straight to `imageDataToVoxelGrid` with no intervening
+clamp, so its palette snap already reached the model.

--- a/prompts/20260608-142500-relief-palette-default-and-labels.md
+++ b/prompts/20260608-142500-relief-palette-default-and-labels.md
@@ -1,0 +1,43 @@
+---
+session: "c9f1a4"
+timestamp: "2026-06-08T14:25:00Z"
+sequence: 3
+model: claude-opus-4-8
+tools: [AskUserQuestion]
+---
+
+## Human
+
+I'm starting to think a regular keychain/tile should just use the palette.
+The relief settings feel like they overlap — maybe reliefs should be their own
+menu. There's ambiguous feature overlap; open to a better plan. (Then chose, via
+AskUserQuestion: palette = default for colour tiles; keep one wizard with a
+clearer Tile-vs-Relief switch; keep the Voxel-vs-Relief chooser.)
+
+## Assistant
+
+## Decisions taken
+
+The relief wizard conflated four intents (colour tile / keychain / silhouette /
+stepped relief — all colour — plus the tonal lithophane, which is height-from-
+brightness and has no palette). Per the user's choices:
+
+1. **Palette is now the DEFAULT colour source for colour tiles.** A fresh
+   colour-tile open seeds `quantized.fixedPalette` from the live filament slots;
+   k-means clustering becomes the opt-out. The checkbox is reframed "Use filament
+   palette colours" (default on) and dims the Clusters knob while on. This is a
+   *modal* default only — the console API and `DEFAULT_RELIEF_OPTIONS` stay
+   k-means unless `fixedPalette` is passed, so agent/script imports and the
+   existing API tests are unaffected (the API path should be explicit).
+2. **Clearer top-level switch**: mode buttons relabelled `Colour` → "Colour
+   tile" and `Tonal (relief)` → "Relief / lithophane". Kept one wizard (no
+   structural split) — lower churn, same clarity. Stepped-relief stays an output
+   of the colour-tile mode rather than being hoisted out (that would mean
+   refactoring generateRelief for no real gain).
+3. Plain-image import keeps its Voxel-vs-Relief chooser (unchanged).
+
+Also exposed `fixedPalette` on the `importImageAsRelief` console API (added to
+the allowed quantized keys + a triple-array validator) so agents can request a
+palette-constrained tile — and so an e2e can drive the full create path. That
+e2e (`fixedPalette snaps the committed model to the given colours`) is the
+regression lock for the clamp bug fixed in the previous commit.

--- a/src/color/paintMode.ts
+++ b/src/color/paintMode.ts
@@ -13,7 +13,7 @@ import { activate as activateSlabDrag, deactivate as deactivateSlabDrag, onMeshC
 import { activate as activateBoxDrag, deactivate as deactivateBoxDrag, onMeshChanged as onBoxDragMeshChanged } from './boxDrag';
 import { smoothEdgeForResolution } from './slabPaint';
 import { setPaintAccessors } from './paintAccessors';
-import { getSlotById, hexToRgb } from './palette';
+import { getSlotById, hexToRgb, isPaletteConstrained, nearestSlot, onPaletteChange } from './palette';
 import { tangentBasis, wrapAngleGate, type BrushShape } from './subdivide';
 export { setSlabAxis, getSlabAxis } from './slabDrag';
 
@@ -155,9 +155,32 @@ let onToolChange: ((tool: PaintTool) => void) | null = null;
 export function isActive(): boolean { return active; }
 
 export function setColor(color: [number, number, number]): void {
+  // Constrain mode forbids ad-hoc colours: snap the requested colour onto the
+  // nearest filament slot so every paint tool — and the Replace tool's target,
+  // and any programmatic setColor — stays on palette. The custom picker is also
+  // hidden in the UI, but this is the actual enforcement. Empty palette ⇒ no
+  // slot to snap to, so fall through to the ad-hoc colour.
+  if (isPaletteConstrained()) {
+    const slot = nearestSlot(color);
+    if (slot) { currentColor = hexToRgb(slot.hex); currentSlotId = slot.id; return; }
+  }
   currentColor = color;
   currentSlotId = null; // ad-hoc colour — no longer tied to a palette slot
 }
+
+/** Re-snap the active paint colour onto the palette when constrain mode is on
+ *  and the current colour is ad-hoc (unslotted) — e.g. the user enabled
+ *  constrain while the default red was active, or activated paint with an
+ *  ad-hoc colour held over. Keeps an already-slotted colour as-is. */
+function enforcePaletteConstraint(): void {
+  if (!isPaletteConstrained() || currentSlotId !== null) return;
+  const slot = nearestSlot(currentColor);
+  if (slot) { currentColor = hexToRgb(slot.hex); currentSlotId = slot.id; }
+}
+
+// Constrain toggles and palette edits fire onPaletteChange; re-enforce so the
+// active colour can never linger off-palette while constrain is on.
+onPaletteChange(enforcePaletteConstraint);
 
 export function getColor(): [number, number, number] {
   return currentColor;
@@ -384,6 +407,7 @@ export function updatePaintMesh(mesh: MeshData): void {
 export function activate(): void {
   if (active) return;
   active = true;
+  enforcePaletteConstraint(); // a constrained palette must not paint an ad-hoc held-over colour
 
   if (currentMesh && !adjacency) {
     // Fallback: pre-warm callback hasn't fired yet (e.g. user opened paint

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -261,6 +261,14 @@ function createPaletteSection(): HTMLElement {
   customRow.appendChild(customLabel);
   wrap.appendChild(customRow);
 
+  // Shown instead of the custom picker when the palette is constrained — makes
+  // the enforcement legible (painting snaps to the nearest slot; see
+  // enforcePaletteConstraint in paintMode).
+  const constrainNote = document.createElement('div');
+  constrainNote.className = 'hidden text-[10px] text-zinc-500 leading-snug';
+  constrainNote.textContent = 'Constrained to palette — painting snaps to the nearest slot.';
+  wrap.appendChild(constrainNote);
+
   function renderSwatches(): void {
     grid.replaceChildren();
     const slots = getActivePalette().slots;
@@ -292,7 +300,9 @@ function createPaletteSection(): HTMLElement {
   }
 
   function renderConstrain(): void {
-    customRow.classList.toggle('hidden', isPaletteConstrained());
+    const on = isPaletteConstrained();
+    customRow.classList.toggle('hidden', on);
+    constrainNote.classList.toggle('hidden', !on);
   }
 
   // Don't pre-select a slot: that would override the default paint colour with

--- a/src/color/palette.ts
+++ b/src/color/palette.ts
@@ -390,6 +390,32 @@ export function rgbToHex([r, g, b]: [number, number, number]): string {
   return `#${c(r)}${c(g)}${c(b)}`;
 }
 
+/** The active palette's slot colours as 0–255 RGB triples, in slot order.
+ *  Shared by the image-import flows ("constrain colours to palette"), which snap
+ *  each pixel/cell to the nearest of these. */
+export function listSlotRgb255(): [number, number, number][] {
+  return load().map(f => {
+    const [r, g, b] = hexToRgb(f.hex);
+    return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+  });
+}
+
+/** The active-palette slot nearest to an RGB (0–1) colour by Euclidean distance,
+ *  or null if the palette is empty. Used to snap interactive painting onto the
+ *  palette when constrain mode is on (see `setColor` enforcement in paintMode). */
+export function nearestSlot(rgb: readonly [number, number, number]): Filament | null {
+  const slots = load();
+  if (slots.length === 0) return null;
+  let best = slots[0];
+  let bestD = Infinity;
+  for (const s of slots) {
+    const [r, g, b] = hexToRgb(s.hex);
+    const d = (r - rgb[0]) ** 2 + (g - rgb[1]) ** 2 + (b - rgb[2]) ** 2;
+    if (d < bestD) { bestD = d; best = s; }
+  }
+  return best;
+}
+
 /** @internal Reset the in-memory cache so tests can re-read storage. */
 export function __resetPaletteCacheForTests(): void {
   collectionsMem = null;

--- a/src/color/paletteManager.ts
+++ b/src/color/paletteManager.ts
@@ -304,7 +304,7 @@ export function openPaletteManager(): void {
   constrainBox.className = 'accent-blue-500';
   constrainBox.addEventListener('change', () => setPaletteConstrained(constrainBox.checked));
   const constrainText = document.createElement('span');
-  constrainText.textContent = 'Constrain painting to the palette (hide the custom colour picker)';
+  constrainText.textContent = 'Constrain painting to the palette (snap colours to the nearest slot)';
   constrainRow.append(constrainBox, constrainText);
   shell.body.appendChild(constrainRow);
 

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -25,6 +25,7 @@ import { generateVoxelImportCode } from '../import/imageToVoxel';
 import { addPointerSuppressor, isPointerOverModel, getRenderer } from '../renderer/viewport';
 import { pickFace } from './facePicker';
 import { registerExclusiveMode, deactivateMode } from '../ui/modeExclusion';
+import { isPaletteConstrained, nearestSlot, hexToRgb, onPaletteChange } from './palette';
 
 export type { BrushShape } from '../geometry/voxel/edits';
 
@@ -80,7 +81,24 @@ export function isActive(): boolean { return active; }
 export function setColor(c: [number, number, number] | string | number): void {
   const rgb = normalizeColor(c, 'setColor(color)');
   color = [(rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff];
+  enforceVoxelConstraint();
 }
+
+/** When the palette is constrained, snap the active voxel colour (0–255 RGB)
+ *  onto the nearest filament slot — the voxel-studio counterpart of mesh
+ *  paint's enforcement, so the global "Constrain to palette" toggle holds here
+ *  too. No-op when unconstrained or the palette is empty. */
+function enforceVoxelConstraint(): void {
+  if (!isPaletteConstrained()) return;
+  const slot = nearestSlot([color[0] / 255, color[1] / 255, color[2] / 255]);
+  if (!slot) return;
+  const [r, g, b] = hexToRgb(slot.hex);
+  color = [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+}
+
+// Re-snap the active colour whenever constrain is toggled or the palette is
+// edited, so a constrained voxel session can never keep an off-palette colour.
+onPaletteChange(enforceVoxelConstraint);
 export function isEraser(): boolean { return eraser; }
 export function setEraser(on: boolean): void { eraser = !!on; }
 
@@ -191,6 +209,7 @@ export function activate(code: string, callbacks: VoxelPaintCallbacks, paramOver
   run = r.data;
   baselineGrid = r.data.grid.clone();
   active = true;
+  enforceVoxelConstraint(); // a constrained palette must not paint the held-over default colour
   tool = 'paint';
   boxCorner = null;
   undoStack = [];

--- a/src/import/imageToVoxel.ts
+++ b/src/import/imageToVoxel.ts
@@ -69,6 +69,12 @@ export interface ImageToVoxelOptions {
    *  `posterizeColors`. Omit / empty / null = keep per-pixel color (or
    *  posterize). Use {@link extractImagePalette} to seed it from the image. */
   palette?: [number, number, number][] | null;
+  /** Modal intent flag: the fixed `palette` above was sourced from the user's
+   *  filament palette ("constrain colours to palette") rather than extracted from
+   *  the image. The conversion itself only reads `palette`; this is persisted so a
+   *  recent-import re-click reopens the modal in constrain mode and re-resolves
+   *  the palette live from the current filament slots. */
+  constrainToPalette?: boolean;
   /** Drop a solid-color background so an opaque photo's subject voxelizes
    *  without its backdrop (the alpha cutoff only catches transparency). */
   removeBackground?: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2213,7 +2213,7 @@ async function main() {
   // this in guard() to surface it as { error }. The numeric bounds mirror the
   // clamp* ranges below.
   const RELIEF_COMMON_KEYS = ['widthMm', 'layerHeight', 'baseThickness', 'maxHeight', 'resolution', 'smoothing', 'removeBackground'] as const;
-  const RELIEF_QUANTIZED_KEYS = ['clusters', 'colorSpace', 'dither', 'output', 'shape', 'cornerRadiusMm', 'chamferMm', 'paintingMode', 'invertHeights', 'holes', 'holeEnabled', 'holeDiameterMm', 'holeOffsetMm', 'manualBackground', 'doubleSided', 'backMirror'] as const;
+  const RELIEF_QUANTIZED_KEYS = ['clusters', 'colorSpace', 'dither', 'fixedPalette', 'output', 'shape', 'cornerRadiusMm', 'chamferMm', 'paintingMode', 'invertHeights', 'holes', 'holeEnabled', 'holeDiameterMm', 'holeOffsetMm', 'manualBackground', 'doubleSided', 'backMirror'] as const;
   const RELIEF_PREPROCESS_KEYS = ['brightness', 'contrast', 'saturation', 'levelsLow', 'levelsHigh'] as const;
   const RELIEF_CROP_KEYS = ['left', 'top', 'right', 'bottom'] as const;
   function validateReliefOptionArgs(args: { options?: unknown; quantized?: unknown; preprocess?: unknown; crop?: unknown }, fn: string): void {
@@ -2242,6 +2242,15 @@ async function main() {
       assertBoolean(q.invertHeights, `${fn}(quantized).invertHeights`, { optional: true });
       assertBoolean(q.doubleSided, `${fn}(quantized).doubleSided`, { optional: true });
       assertBoolean(q.backMirror, `${fn}(quantized).backMirror`, { optional: true });
+      // "Constrain to filament palette": an array of [r,g,b] 0–255 triples each
+      // cell snaps to. The clamp re-sanitises, but reject the obviously-wrong
+      // shape here so a typo is loud rather than silently ignored.
+      if (q.fixedPalette !== undefined) {
+        const pal = q.fixedPalette;
+        const ok = Array.isArray(pal) && pal.every(c =>
+          Array.isArray(c) && c.length === 3 && c.every(n => typeof n === 'number' && Number.isFinite(n) && n >= 0 && n <= 255));
+        if (!ok) throw new ValidationError(`${fn}(quantized).fixedPalette must be an array of [r,g,b] triples (0–255). See /ai.md#argument-validation`);
+      }
     }
     if (args.preprocess !== undefined) {
       const p = assertObject(args.preprocess, `${fn}(preprocess)`)!;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2305,6 +2305,16 @@ async function main() {
         diameterMm: num(q.holeDiameterMm ?? 6, 6),
       })];
     }
+    // Preserve the "constrain to filament palette" snap colours (0–255 triples).
+    // Must be threaded through here — the create path runs options through this
+    // clamp before generateRelief, so dropping it would make the committed model
+    // ignore the palette even though the live preview honoured it.
+    const byte = (v: number) => Math.max(0, Math.min(255, Math.round(num(v, 0))));
+    const fixedPalette = Array.isArray(q.fixedPalette)
+      ? q.fixedPalette
+          .filter(c => Array.isArray(c) && c.length === 3 && c.every(n => Number.isFinite(n)))
+          .map(c => [byte(c[0]), byte(c[1]), byte(c[2])] as [number, number, number])
+      : undefined;
     return {
       clusters: Math.max(2, Math.min(12, Math.floor(num(q.clusters, 5)))),
       colorSpace: q.colorSpace === 'rgb' ? 'rgb' : 'lab',
@@ -2319,6 +2329,7 @@ async function main() {
       manualBackground: q.manualBackground,
       doubleSided: !!q.doubleSided,
       backMirror: q.backMirror !== false,
+      ...(fixedPalette && fixedPalette.length > 0 ? { fixedPalette } : {}),
     };
   }
 

--- a/src/relief/imageToRelief.ts
+++ b/src/relief/imageToRelief.ts
@@ -442,16 +442,38 @@ function sampleQuantized(rgb: Float32Array, w: number, h: number, opts: ReliefOp
   const count = w * h;
   const { maxHeight, layerHeight } = opts.common;
   const lab = opts.quantized.colorSpace === 'lab';
-  const k = Math.max(2, Math.floor(opts.quantized.clusters));
+  const fixed = opts.quantized.fixedPalette;
 
-  // Cluster in the chosen colour space (shared with image→voxel posterize).
-  const { assign, repRGB, k: kk } = quantizeColors(rgb, count, k, lab ? 'lab' : 'rgb');
+  // Build the colour palette + per-cell cluster assignment. With a fixed palette
+  // ("constrain colours to filament palette") we skip k-means and snap each cell
+  // to its nearest fixed colour; otherwise we cluster in the chosen colour space
+  // (shared with image→voxel posterize). Either way `palette` is the per-cluster
+  // sRGB and `assign[i]` the cluster index for cell i.
+  let palette: Array<[number, number, number]>;
+  let assign: Int32Array;
+  let kk: number;
+  if (fixed && fixed.length > 0) {
+    palette = fixed.map(c => [clamp255(c[0]), clamp255(c[1]), clamp255(c[2])] as [number, number, number]);
+    kk = palette.length;
+    const palFeat: Array<[number, number, number]> = palette.map(p => (lab ? rgbToLab(p[0], p[1], p[2]) : [p[0], p[1], p[2]]));
+    assign = new Int32Array(count);
+    for (let i = 0; i < count; i++) {
+      const o = i * 3;
+      const fl = lab ? rgbToLab(rgb[o], rgb[o + 1], rgb[o + 2]) : [rgb[o], rgb[o + 1], rgb[o + 2]] as [number, number, number];
+      assign[i] = nearestPalette(fl[0], fl[1], fl[2], palFeat);
+    }
+  } else {
+    const k = Math.max(2, Math.floor(opts.quantized.clusters));
+    const res = quantizeColors(rgb, count, k, lab ? 'lab' : 'rgb');
+    assign = res.assign;
+    kk = res.k;
+    palette = [];
+    for (let c = 0; c < kk; c++) palette.push([clamp255(res.repRGB[c * 3]), clamp255(res.repRGB[c * 3 + 1]), clamp255(res.repRGB[c * 3 + 2])]);
+  }
 
-  // Representative sRGB palette + per-cluster height. Clusters are ordered by
-  // luminance and given evenly spaced heights snapped to layer multiples, so
-  // each colour reads as one clean flat terrace (darkest sits lowest).
-  const palette: Array<[number, number, number]> = [];
-  for (let c = 0; c < kk; c++) palette.push([clamp255(repRGB[c * 3]), clamp255(repRGB[c * 3 + 1]), clamp255(repRGB[c * 3 + 2])]);
+  // Clusters are ordered by luminance and given evenly spaced heights snapped to
+  // layer multiples, so each colour reads as one clean flat terrace (darkest
+  // sits lowest).
   const order = palette.map((_, i) => i).sort((a, b) => luminance255(palette[a][0], palette[a][1], palette[a][2]) - luminance255(palette[b][0], palette[b][1], palette[b][2]));
   // `invertHeights` flips the cluster → height map so DARKER colours land
   // TALLER. Useful when an image's background is the lightest cluster: with

--- a/src/relief/types.ts
+++ b/src/relief/types.ts
@@ -109,6 +109,12 @@ export interface QuantizedOptions {
   colorSpace: 'rgb' | 'lab';
   /** Floyd–Steinberg dithering when assigning pixels to clusters. */
   dither: boolean;
+  /** When set (non-empty), skip k-means clustering and snap every cell to the
+   *  nearest of these fixed RGB (0–255) colours instead — the "constrain colours
+   *  to filament palette" option. The cluster count (`clusters`) is then ignored;
+   *  the palette size defines the number of colour regions. Omitted/empty =
+   *  ordinary k-means quantization. */
+  fixedPalette?: [number, number, number][];
   /** Output geometry kind — 'flat' makes a printable colour tile (default,
    *  Bambu-keychain style); 'relief' keeps the original cluster->height cliffs;
    *  'silhouette' cuts the flat tile to the image's subject outline. */

--- a/src/ui/imageVoxelImportModal.tsx
+++ b/src/ui/imageVoxelImportModal.tsx
@@ -21,6 +21,7 @@ import {
   type ImageVoxelMode,
   type ImageVoxelColorMode,
 } from '../import/imageToVoxel';
+import { listSlotRgb255 } from '../color/palette';
 
 export interface ImageVoxelModalOptions {
   filename?: string;
@@ -91,6 +92,7 @@ function getDefaultOpts(): Opts {
     saturation: 0,
     posterizeColors: 0,
     palette: null,
+    constrainToPalette: false,
     removeBackground: false,
     codeStyle: 'decode',
   };
@@ -112,6 +114,7 @@ const DEFAULT_OPTS: Opts = {
   saturation: 0,
   posterizeColors: 0,
   palette: null,
+  constrainToPalette: false,
   removeBackground: false,
   codeStyle: 'decode',
 };
@@ -138,7 +141,11 @@ function seedOpts(init?: ImageToVoxelOptions): Opts {
     contrast: init.contrast ?? DEFAULT_OPTS.contrast,
     saturation: init.saturation ?? DEFAULT_OPTS.saturation,
     posterizeColors: init.posterizeColors ?? DEFAULT_OPTS.posterizeColors,
-    palette: init.palette ?? DEFAULT_OPTS.palette,
+    // Constrain-to-palette is a live binding to the filament palette: when a
+    // recent-import re-click carries the flag, re-resolve the colours from the
+    // current palette rather than trusting the stored snapshot.
+    palette: init.constrainToPalette ? listSlotRgb255() : (init.palette ?? DEFAULT_OPTS.palette),
+    constrainToPalette: init.constrainToPalette ?? DEFAULT_OPTS.constrainToPalette,
     removeBackground: init.removeBackground ?? DEFAULT_OPTS.removeBackground,
     codeStyle: init.codeStyle ?? DEFAULT_OPTS.codeStyle,
   };
@@ -290,6 +297,31 @@ function PaletteEditor(props: {
   );
 }
 
+/** Read-only swatch strip of the filament palette the voxels will snap to, shown
+ *  when "Constrain to filament palette" is on. */
+function FilamentStrip(props: { palette: [number, number, number][] | null }) {
+  const palette = props.palette ?? [];
+  if (palette.length === 0) {
+    return (
+      <div class="text-[10px] text-amber-400 leading-snug">
+        Your filament palette is empty — add colours in the palette manager (🧵) first.
+      </div>
+    );
+  }
+  return (
+    <div class="flex flex-col gap-1">
+      <div class="flex flex-wrap items-center gap-1">
+        {palette.map(c => (
+          <div class="w-6 h-6 rounded border border-zinc-700" style={`background-color:${toHex(c)}`} title={toHex(c)} />
+        ))}
+      </div>
+      <div class="text-[10px] text-zinc-500 leading-snug">
+        Every voxel snaps to the nearest of your {palette.length} filament colour{palette.length === 1 ? '' : 's'}.
+      </div>
+    </div>
+  );
+}
+
 function ImageVoxelBody(props: {
   imageSig: Signal<ImageDataLike | null>;
   filenameSig: Signal<string>;
@@ -330,6 +362,20 @@ function ImageVoxelBody(props: {
     });
     set('palette', colors.length ? colors : [[180, 180, 180]]);
     set('posterizeColors', Math.max(2, k));
+  };
+
+  // Toggle "constrain to filament palette": on → snap to the live filament
+  // colours (overriding any image-derived reduction); off → back to per-pixel
+  // original colour. Re-reads the palette each time it's switched on.
+  const toggleConstrain = (on: boolean) => {
+    if (on) {
+      set('constrainToPalette', true);
+      set('palette', listSlotRgb255());
+    } else {
+      set('constrainToPalette', false);
+      set('palette', null);
+      set('posterizeColors', 0);
+    }
   };
 
   // Swap the source image while keeping every tuned knob. Decoding replaces the
@@ -548,31 +594,43 @@ function ImageVoxelBody(props: {
             </div>
             {opts.colorMode === 'original' && (
               <div class="mt-1.5">
-                <div class="flex gap-1">
-                  <SegButton<ColorReduction> value="all" current={reductionOf(opts)} onPick={pickReduction}>
-                    All colors
-                  </SegButton>
-                  <SegButton<ColorReduction> value="posterize" current={reductionOf(opts)} onPick={pickReduction}>
-                    Posterize
-                  </SegButton>
-                  <SegButton<ColorReduction> value="palette" current={reductionOf(opts)} onPick={pickReduction}>
-                    Palette
-                  </SegButton>
-                </div>
-                {reductionOf(opts) === 'posterize' && (
-                  <label class="flex items-center gap-2 text-[11px] text-zinc-300 mt-1.5">
-                    Colors
-                    <input
-                      type="range"
-                      class="flex-1 accent-blue-500"
-                      min={2} max={12} step={1}
-                      value={opts.posterizeColors}
-                      onInput={e => set('posterizeColors', Number((e.target as HTMLInputElement).value))}
-                    />
-                    <span class="text-zinc-200 tabular-nums">{opts.posterizeColors}</span>
-                  </label>
+                <label class="flex items-center gap-2 text-[11px] text-zinc-300 cursor-pointer mb-1.5"
+                  title="Snap every voxel to the nearest colour in your filament palette, so the model uses only your loaded filaments.">
+                  <input type="checkbox" class="accent-blue-500" checked={opts.constrainToPalette}
+                    onChange={e => toggleConstrain((e.target as HTMLInputElement).checked)} />
+                  Constrain to filament palette
+                </label>
+                {opts.constrainToPalette ? (
+                  <FilamentStrip palette={opts.palette} />
+                ) : (
+                  <>
+                    <div class="flex gap-1">
+                      <SegButton<ColorReduction> value="all" current={reductionOf(opts)} onPick={pickReduction}>
+                        All colors
+                      </SegButton>
+                      <SegButton<ColorReduction> value="posterize" current={reductionOf(opts)} onPick={pickReduction}>
+                        Posterize
+                      </SegButton>
+                      <SegButton<ColorReduction> value="palette" current={reductionOf(opts)} onPick={pickReduction}>
+                        Palette
+                      </SegButton>
+                    </div>
+                    {reductionOf(opts) === 'posterize' && (
+                      <label class="flex items-center gap-2 text-[11px] text-zinc-300 mt-1.5">
+                        Colors
+                        <input
+                          type="range"
+                          class="flex-1 accent-blue-500"
+                          min={2} max={12} step={1}
+                          value={opts.posterizeColors}
+                          onInput={e => set('posterizeColors', Number((e.target as HTMLInputElement).value))}
+                        />
+                        <span class="text-zinc-200 tabular-nums">{opts.posterizeColors}</span>
+                      </label>
+                    )}
+                    {reductionOf(opts) === 'palette' && <PaletteEditor image={image} opts={opts} set={set} />}
+                  </>
                 )}
-                {reductionOf(opts) === 'palette' && <PaletteEditor image={image} opts={opts} set={set} />}
               </div>
             )}
           </div>
@@ -653,6 +711,9 @@ function emitOptions(o: Opts): ImageToVoxelOptions {
   };
   // Only emit a fixed palette when one is actually in use (original mode).
   if (o.colorMode === 'original' && o.palette && o.palette.length > 0) out.palette = o.palette;
+  // Persist the constrain intent so a recent-import re-click reopens in
+  // constrain mode and re-resolves the palette live (see seedOpts).
+  if (o.colorMode === 'original' && o.constrainToPalette) out.constrainToPalette = true;
   return out;
 }
 

--- a/src/ui/reliefImportModal.ts
+++ b/src/ui/reliefImportModal.ts
@@ -7,6 +7,7 @@
 import type { ReliefOptions, ReliefImportMode, TileOutputKind, TileShapeKind, HeightGrid, ReliefMesh, SeedRegion } from '../relief/types';
 import { DEFAULT_RELIEF_OPTIONS } from '../relief/types';
 import { sampleImageToGrid, detectBackgroundMask, bgMaskFromColor, generateRelief, generateReliefFromSvg } from '../relief/imageToRelief';
+import { listSlotRgb255 } from '../color/palette';
 import { registerImportSnapshot, type ImportMetadata } from '../import/importInbox';
 import { createThumbnailFromBlob } from '../import/imageThumbnail';
 import { createModalShell } from './modalShell';
@@ -67,6 +68,12 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
   // re-enters the wizard with their tweaks intact. Merge (not replace) so any
   // new option fields added since that import still get their defaults.
   if (options.initialOptions) mergeOptions(opts, options.initialOptions);
+  // "Constrain to palette" is a live binding to the current filament palette, so
+  // re-resolve it from the palette on open rather than trusting a snapshot a
+  // recent-import re-click carried in (the palette may have changed since).
+  if (opts.quantized.fixedPalette && opts.quantized.fixedPalette.length > 0) {
+    opts.quantized.fixedPalette = listSlotRgb255();
+  }
   let image: ImageData | null = null;
   let svgText: string | null = null;
   // The currently-picked source File, captured so we can register it with the
@@ -203,12 +210,29 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
   sliderControl(luminanceSection.grid, 'Levels', '', () => opts.luminance.levels, v => (opts.luminance.levels = v), { min: 2, max: 32, step: 1, int: true });
 
   // Quantized knobs — quantized mode only.
-  sliderControl(quantizedSection.grid, 'Clusters', '', () => opts.quantized.clusters, v => (opts.quantized.clusters = v), { min: 2, max: 12, step: 1, int: true });
+  const clustersRow = sliderControl(quantizedSection.grid, 'Clusters', '', () => opts.quantized.clusters, v => (opts.quantized.clusters = v), { min: 2, max: 12, step: 1, int: true });
   selectControl(quantizedSection.grid, 'Color space', () => opts.quantized.colorSpace, v => (opts.quantized.colorSpace = v), [
     { value: 'rgb', label: 'RGB' },
     { value: 'lab', label: 'Lab' },
   ]);
   checkboxControl(quantizedSection.grid, 'Dither', () => opts.quantized.dither, v => (opts.quantized.dither = v));
+  // "Constrain colours to filament palette" — snap every region to the nearest
+  // filament colour instead of free k-means clusters. Re-reads the live palette
+  // each time it's switched on; clears the snap when off. While on, the cluster
+  // count is set by the palette, so the Clusters slider is dimmed (ignored).
+  const constrainRow = checkboxControl(
+    quantizedSection.grid,
+    'Constrain to filament palette',
+    () => !!(opts.quantized.fixedPalette && opts.quantized.fixedPalette.length > 0),
+    v => { opts.quantized.fixedPalette = v ? listSlotRgb255() : undefined; syncConstrain(); },
+  );
+  constrainRow.title = 'Map each colour region onto the nearest filament in your palette, so the print uses only your loaded colours.';
+  function syncConstrain(): void {
+    const on = !!(opts.quantized.fixedPalette && opts.quantized.fixedPalette.length > 0);
+    clustersRow.classList.toggle('opacity-40', on);
+    clustersRow.classList.toggle('pointer-events-none', on);
+  }
+  syncConstrain();
 
   // Tile knobs — visible for 'quantized' mode and for SVG imports. The Output
   // picker switches between a stepped relief, a flat colour tile (keychain
@@ -1207,7 +1231,7 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
     get: () => number,
     set: (v: number) => void,
     range: { min: number; max: number; step: number; int?: boolean },
-  ): void {
+  ): HTMLElement {
     // Slider for dragged exploration, plus a typeable number input for exact
     // entry. Two-way bound and clamped to the slider's range.
     const { wrap, labelRow, valueEl } = fieldWrap(label, unit);
@@ -1260,6 +1284,7 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
     });
     wrap.appendChild(input);
     parent.appendChild(wrap);
+    return wrap;
   }
 
   function checkboxControl(

--- a/src/ui/reliefImportModal.ts
+++ b/src/ui/reliefImportModal.ts
@@ -51,8 +51,8 @@ const MODES: ModeDef[] = [
   // first, tonal heightmaps (lithophanes) second. 'ai' is intentionally absent
   // — what used to live as a tab is now the Auto-tune button below the knobs,
   // since it never had its own knob set and read as a phantom mode.
-  { id: 'quantized', label: 'Colour' },
-  { id: 'luminance', label: 'Tonal (relief)' },
+  { id: 'quantized', label: 'Colour tile' },
+  { id: 'luminance', label: 'Relief / lithophane' },
 ];
 
 // Only one relief wizard at a time; createModalShell already enforces a single
@@ -68,10 +68,15 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
   // re-enters the wizard with their tweaks intact. Merge (not replace) so any
   // new option fields added since that import still get their defaults.
   if (options.initialOptions) mergeOptions(opts, options.initialOptions);
-  // "Constrain to palette" is a live binding to the current filament palette, so
-  // re-resolve it from the palette on open rather than trusting a snapshot a
-  // recent-import re-click carried in (the palette may have changed since).
-  if (opts.quantized.fixedPalette && opts.quantized.fixedPalette.length > 0) {
+  // Colour tiles default to the filament palette as their colour source — you
+  // print a keychain with the filaments you have, so a fresh open starts on the
+  // palette and k-means is the opt-out. A recent-import re-click (initialOptions)
+  // is respected verbatim, so a tile the user switched to auto-extract reopens
+  // that way. Either way, re-resolve a present palette from the *current* slots
+  // rather than trusting a stale snapshot.
+  if (!options.initialOptions && opts.mode === 'quantized') {
+    opts.quantized.fixedPalette = listSlotRgb255();
+  } else if (opts.quantized.fixedPalette && opts.quantized.fixedPalette.length > 0) {
     opts.quantized.fixedPalette = listSlotRgb255();
   }
   let image: ImageData | null = null;
@@ -216,17 +221,17 @@ export function openReliefImportModal(options: ReliefImportModalOptions): void {
     { value: 'lab', label: 'Lab' },
   ]);
   checkboxControl(quantizedSection.grid, 'Dither', () => opts.quantized.dither, v => (opts.quantized.dither = v));
-  // "Constrain colours to filament palette" — snap every region to the nearest
-  // filament colour instead of free k-means clusters. Re-reads the live palette
-  // each time it's switched on; clears the snap when off. While on, the cluster
-  // count is set by the palette, so the Clusters slider is dimmed (ignored).
+  // Colour source: filament palette (default — snap every region to the nearest
+  // loaded filament) vs auto-extract (free k-means clusters). Re-reads the live
+  // palette each time it's switched on; clears the snap when off. While on the
+  // colour set is the palette, so the Clusters slider is dimmed (ignored).
   const constrainRow = checkboxControl(
     quantizedSection.grid,
-    'Constrain to filament palette',
+    'Use filament palette colours',
     () => !!(opts.quantized.fixedPalette && opts.quantized.fixedPalette.length > 0),
     v => { opts.quantized.fixedPalette = v ? listSlotRgb255() : undefined; syncConstrain(); },
   );
-  constrainRow.title = 'Map each colour region onto the nearest filament in your palette, so the print uses only your loaded colours.';
+  constrainRow.title = 'On (default): each colour region maps onto the nearest filament in your palette, so the tile prints in your loaded colours. Off: auto-extract colours with k-means clustering.';
   function syncConstrain(): void {
     const on = !!(opts.quantized.fixedPalette && opts.quantized.fixedPalette.length > 0);
     clustersRow.classList.toggle('opacity-40', on);

--- a/tests/paint-palette.spec.ts
+++ b/tests/paint-palette.spec.ts
@@ -83,6 +83,48 @@ test.describe('filament palette + slot painting', () => {
     await expect(badge).toBeVisible();
   });
 
+  test('constrain mode snaps an ad-hoc colour to the nearest slot when painting', async ({ page }) => {
+    await openEditorWithSlab(page);
+
+    // Pick an off-palette ad-hoc colour via the custom picker (pure green).
+    await page.evaluate(() => {
+      const input = document.querySelector('#paint-picker-panel input[type="color"][title="Custom color (unslotted)"]') as HTMLInputElement;
+      input.value = '#00ff00';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    // Turn on constrain mode via the palette manager (opening it closes Paint).
+    await page.locator('#palette-manager-toggle').dispatchEvent('click');
+    await page.getByRole('checkbox', { name: /Constrain painting to the palette/ })
+      .evaluate((el: HTMLInputElement) => { el.checked = true; el.dispatchEvent(new Event('change', { bubbles: true })); });
+    await page.getByRole('button', { name: 'Done' }).dispatchEvent('click');
+
+    // Reopen Paint — activate() re-snaps the held-over ad-hoc colour — and the
+    // constrain note now shows in place of the custom picker.
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+    await page.locator('#paint-picker-panel button:has-text("Bucket")').dispatchEvent('click');
+    await expect(page.locator('#paint-picker-panel').getByText(/Constrained to palette/)).toBeVisible();
+
+    await bucketPaintCentre(page);
+
+    const regions = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (window as any).partwright.listRegions();
+    });
+    expect(regions.length).toBe(1);
+    const [r, g, b] = regions[0].color as [number, number, number];
+    // NOT the off-palette green we picked…
+    expect(g > 0.9 && r < 0.1 && b < 0.1).toBe(false);
+    // …it snapped to one of the six default filament slot colours.
+    const slots: number[][] = [
+      [0xf5, 0xf5, 0xf0], [0x18, 0x18, 0x18], [0xc0, 0x25, 0x25],
+      [0xe8, 0xc0, 0x24], [0x24, 0x52, 0xc0], [0x80, 0x80, 0x80],
+    ].map(c => c.map(v => v / 255));
+    const onPalette = slots.some(s => Math.abs(s[0] - r) < 0.02 && Math.abs(s[1] - g) < 0.02 && Math.abs(s[2] - b) < 0.02);
+    expect(onPalette).toBe(true);
+  });
+
   test('the palette manager opens from the viewport and its edits reach the swatches', async ({ page }) => {
     await page.goto('/editor');
     await page.waitForSelector('text=Ready', { timeout: 20000 });

--- a/tests/palette-import-constrain.spec.ts
+++ b/tests/palette-import-constrain.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from 'playwright/test';
+
+// Golden path for "constrain colours to filament palette" in the two image
+// import flows (voxel + relief). Each opens the modal programmatically with a
+// synthetic image, toggles the new checkbox, and asserts the mode switches.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+});
+
+test('voxel import: constrain to palette swaps the reduction picker for filament swatches', async ({ page }) => {
+  await page.goto('/editor');
+  await page.waitForTimeout(4000);
+  await page.evaluate(async () => {
+    const c = document.createElement('canvas');
+    c.width = 24; c.height = 24;
+    const ctx = c.getContext('2d')!;
+    const g = ctx.createLinearGradient(0, 0, 24, 24);
+    g.addColorStop(0, '#e02525'); g.addColorStop(1, '#2452c0');
+    ctx.fillStyle = g; ctx.fillRect(0, 0, 24, 24);
+    const image = ctx.getImageData(0, 0, 24, 24);
+    const m = await import('/src/ui/imageVoxelImportModal.tsx');
+    void m.showImageVoxelImportModal({ filename: 'probe.png', image });
+  });
+
+  // Off by default: the All/Posterize/Palette reduction picker is shown.
+  await expect(page.getByRole('button', { name: 'All colors' })).toBeVisible();
+  const constrain = page.getByText('Constrain to filament palette');
+  await expect(constrain).toBeVisible();
+
+  // On: reduction picker is replaced by the filament-snap note.
+  await constrain.click();
+  await expect(page.getByText(/Every voxel snaps to the nearest/)).toBeVisible();
+  await expect(page.getByRole('button', { name: 'All colors' })).toHaveCount(0);
+
+  // Off again: reduction picker returns.
+  await constrain.click();
+  await expect(page.getByRole('button', { name: 'All colors' })).toBeVisible();
+});
+
+test('relief import: constrain to palette toggles and dims the clusters slider', async ({ page }) => {
+  await page.goto('/editor');
+  await page.waitForTimeout(4000);
+  await page.evaluate(async () => {
+    const c = document.createElement('canvas');
+    c.width = 24; c.height = 24;
+    const ctx = c.getContext('2d')!;
+    ctx.fillStyle = '#e02525'; ctx.fillRect(0, 0, 12, 24);
+    ctx.fillStyle = '#2452c0'; ctx.fillRect(12, 0, 12, 24);
+    const blob: Blob = await new Promise(res => c.toBlob(b => res(b!), 'image/png'));
+    const file = new File([blob], 'probe.png', { type: 'image/png' });
+    const m = await import('/src/ui/reliefImportModal.ts');
+    m.openReliefImportModal({ aiAvailable: false, initialFile: file, onCreate() {} });
+  });
+  await page.waitForTimeout(1200);
+
+  const constrain = page.getByText('Constrain to filament palette');
+  await expect(constrain).toBeVisible();
+  const checkbox = constrain.locator('xpath=preceding-sibling::input[@type="checkbox"]');
+  await expect(checkbox).not.toBeChecked();
+
+  await constrain.click();
+  await expect(checkbox).toBeChecked();
+});

--- a/tests/palette-import-constrain.spec.ts
+++ b/tests/palette-import-constrain.spec.ts
@@ -38,7 +38,7 @@ test('voxel import: constrain to palette swaps the reduction picker for filament
   await expect(page.getByRole('button', { name: 'All colors' })).toBeVisible();
 });
 
-test('relief import: constrain to palette toggles and dims the clusters slider', async ({ page }) => {
+test('relief import: colour tiles default to the filament palette, and it can be toggled off', async ({ page }) => {
   await page.goto('/editor');
   await page.waitForTimeout(4000);
   await page.evaluate(async () => {
@@ -54,11 +54,15 @@ test('relief import: constrain to palette toggles and dims the clusters slider',
   });
   await page.waitForTimeout(1200);
 
-  const constrain = page.getByText('Constrain to filament palette');
+  const constrain = page.getByText('Use filament palette colours');
   await expect(constrain).toBeVisible();
   const checkbox = constrain.locator('xpath=preceding-sibling::input[@type="checkbox"]');
-  await expect(checkbox).not.toBeChecked();
+  // A fresh colour-tile open defaults to the filament palette.
+  await expect(checkbox).toBeChecked();
 
+  // It's an opt-out: unchecking falls back to auto-extracted (k-means) colours.
+  await constrain.click();
+  await expect(checkbox).not.toBeChecked();
   await constrain.click();
   await expect(checkbox).toBeChecked();
 });

--- a/tests/relief.spec.ts
+++ b/tests/relief.spec.ts
@@ -245,6 +245,46 @@ test.describe('Relief Studio', () => {
     expect(res.maxLum).toBeGreaterThan(0.8); // a near-white cluster (background) survived
   });
 
+  // Regression: "constrain to filament palette" (fixedPalette) must reach the
+  // COMMITTED model, not just the preview. The create path runs options through
+  // clampReliefQuantized before generateRelief; that clamp used to drop
+  // fixedPalette, so the generated tile kept its k-means colours.
+  test('fixedPalette snaps the committed model to the given colours', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const res = await page.evaluate(async () => {
+      const c = document.createElement('canvas');
+      c.width = 120; c.height = 120;
+      const x = c.getContext('2d')!;
+      // Three distinct source colours, none of which is a palette member.
+      x.fillStyle = '#d83a2a'; x.fillRect(0, 0, 40, 120);
+      x.fillStyle = '#2ad84a'; x.fillRect(40, 0, 40, 120);
+      x.fillStyle = '#2a4ad8'; x.fillRect(80, 0, 40, 120);
+      const src = c.toDataURL('image/png');
+
+      const pw = (window as unknown as { partwright: Record<string, (...a: unknown[]) => unknown> }).partwright;
+      // Snap to a 2-colour palette: pure black + pure white.
+      const created = await pw.importImageAsRelief({
+        src, mode: 'quantized',
+        options: { resolution: 60 },
+        quantized: { fixedPalette: [[0, 0, 0], [255, 255, 255]] },
+      }) as { sessionId?: string; error?: string };
+      const regions = pw.listRegions() as Array<{ color: [number, number, number] }>;
+      // Every region colour must be one of the two palette members (0..1 RGB).
+      const onPalette = regions.every(r => {
+        const isBlack = r.color.every(v => v < 0.02);
+        const isWhite = r.color.every(v => v > 0.98);
+        return isBlack || isWhite;
+      });
+      return { created, count: regions.length, onPalette };
+    });
+
+    expect(res.created.error).toBeFalsy();
+    expect(res.count).toBeGreaterThan(0);
+    expect(res.onPalette).toBe(true);
+  });
+
   // The new "flat tile" output is the default for color-quantized — colours
   // become regions on a flat tile (Bambu-keychain style) instead of the noisy
   // cluster->height cliffs of the old relief mode.

--- a/tests/unit/palette.test.ts
+++ b/tests/unit/palette.test.ts
@@ -27,6 +27,8 @@ import {
   clearColorHistory,
   hexToRgb,
   rgbToHex,
+  listSlotRgb255,
+  nearestSlot,
   __resetPaletteCacheForTests,
 } from '../../src/color/palette';
 
@@ -228,5 +230,33 @@ describe('palette: colour helpers', () => {
 
   it('falls back to black on malformed hex', () => {
     expect(hexToRgb('nope')).toEqual([0, 0, 0]);
+  });
+});
+
+describe('palette: import-constrain helpers', () => {
+  it('listSlotRgb255 returns the active slots as 0–255 triples in order', () => {
+    resetPalette();
+    const rgb = listSlotRgb255();
+    expect(rgb.length).toBe(DEFAULT_FILAMENTS.length);
+    // First default is White (#f5f5f0).
+    expect(rgb[0]).toEqual([0xf5, 0xf5, 0xf0]);
+    // Second is Black (#181818).
+    expect(rgb[1]).toEqual([0x18, 0x18, 0x18]);
+  });
+
+  it('nearestSlot snaps an RGB (0–1) colour to the closest slot', () => {
+    resetPalette();
+    // Pure red is closest to the Red slot (#c02525), not White/Black/etc.
+    const slot = nearestSlot([1, 0, 0]);
+    expect(slot?.id).toBe('def-red');
+    // Near-white snaps to White.
+    expect(nearestSlot([0.96, 0.96, 0.94])?.id).toBe('def-white');
+  });
+
+  it('nearestSlot returns null for an empty palette', () => {
+    // Drain every slot (removeFilament refuses nothing here).
+    for (const f of listFilaments()) removeFilament(f.id);
+    expect(listFilaments().length).toBe(0);
+    expect(nearestSlot([0.5, 0.5, 0.5])).toBeNull();
   });
 });

--- a/tests/unit/reliefPalette.test.ts
+++ b/tests/unit/reliefPalette.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { sampleImageToGrid } from '../../src/relief/imageToRelief';
+import { DEFAULT_RELIEF_OPTIONS, type ReliefOptions } from '../../src/relief/types';
+
+// Minimal ImageData-like from a 2D array of [r,g,b] pixels (alpha forced opaque).
+function img(rows: [number, number, number][][]): ImageData {
+  const h = rows.length;
+  const w = rows[0].length;
+  const data = new Uint8ClampedArray(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const [r, g, b] = rows[y][x];
+      const o = (y * w + x) * 4;
+      data[o] = r; data[o + 1] = g; data[o + 2] = b; data[o + 3] = 255;
+    }
+  }
+  return { width: w, height: h, data } as ImageData;
+}
+
+function quantizedOpts(over: Partial<ReliefOptions['quantized']>): ReliefOptions {
+  const o = structuredClone(DEFAULT_RELIEF_OPTIONS);
+  o.mode = 'quantized';
+  o.common.resolution = 8; // keep the grid tiny + exact
+  o.common.smoothing = 0;
+  Object.assign(o.quantized, over);
+  return o;
+}
+
+function distinctColors(grid: { colors?: Uint8Array }): Set<string> {
+  const set = new Set<string>();
+  const c = grid.colors!;
+  for (let i = 0; i < c.length; i += 3) set.add(`${c[i]},${c[i + 1]},${c[i + 2]}`);
+  return set;
+}
+
+describe('relief "constrain to filament palette" (fixedPalette)', () => {
+  // A 4×4 split: left half pure red, right half pure blue.
+  const red: [number, number, number] = [220, 30, 30];
+  const blue: [number, number, number] = [30, 30, 220];
+  const rows = Array.from({ length: 4 }, () =>
+    ([red, red, blue, blue] as [number, number, number][]));
+
+  it('snaps every cell to a member of the fixed palette', () => {
+    const grid = sampleImageToGrid(img(rows), quantizedOpts({
+      fixedPalette: [[255, 0, 0], [0, 0, 255]],
+    }));
+    const colors = distinctColors(grid);
+    // Output colours are exactly palette members — nothing else.
+    for (const c of colors) expect(['255,0,0', '0,0,255']).toContain(c);
+  });
+
+  it('ignores the cluster count — palette size drives the colour set', () => {
+    const grid = sampleImageToGrid(img(rows), quantizedOpts({
+      clusters: 12, // would normally try for 12 clusters; fixed palette wins
+      fixedPalette: [[255, 0, 0], [0, 0, 255]],
+    }));
+    expect(distinctColors(grid).size).toBeLessThanOrEqual(2);
+  });
+
+  it('keeps both palette colours present (red and blue regions both survive)', () => {
+    const grid = sampleImageToGrid(img(rows), quantizedOpts({
+      fixedPalette: [[255, 0, 0], [0, 0, 255]],
+    }));
+    const colors = distinctColors(grid);
+    expect(colors.has('255,0,0')).toBe(true);
+    expect(colors.has('0,0,255')).toBe(true);
+  });
+
+  it('falls back to k-means clustering when no fixed palette is set', () => {
+    const grid = sampleImageToGrid(img(rows), quantizedOpts({ clusters: 2 }));
+    const colors = distinctColors(grid);
+    // Clustered reps are the mean sRGB of members — the actual source colours,
+    // NOT the pure primaries the fixed palette would force.
+    expect(colors.has('255,0,0')).toBe(false);
+    expect(colors.size).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Wires the colour palette into image imports + painting, and resolves the tile-vs-relief overlap in the image wizard.

Two things surfaced during investigation:
- The palette **already** had find/replace/merge (paint **Replace** tool + the palette manager's reconciliation). So this PR fills the **import-time** and **enforcement** gaps.
- **Constrain mode was cosmetic** — it only hid the custom picker; nothing stopped an ad-hoc colour from being painted.

### What changed

**1. Image → Relief wizard reframed around intent** (per design review):
- **Colour tiles / keychains default to the filament palette** as their colour source — you print with the filaments you have. k-means clustering becomes the opt-out (reframed **"Use filament palette colours"** toggle, default on, dims the Clusters knob). This is a *modal* default only — the console API + `DEFAULT_RELIEF_OPTIONS` stay k-means unless `fixedPalette` is passed, so agent/script imports are unaffected.
- Clearer top-level switch: **"Colour tile"** vs **"Relief / lithophane"** (was "Colour" / "Tonal"). One wizard, no structural split.
- New `fixedPalette` in `QuantizedOptions`; `sampleQuantized` snaps each cell to the nearest filament colour instead of k-means. Also exposed on the `importImageAsRelief` console API.

**2. Image → Voxel**: opt-in **"Constrain to filament palette"** checkbox — swaps the reduction picker for a filament swatch strip; every voxel snaps to the nearest filament colour.

**3. Real paint enforcement** — `setColor` snaps an ad-hoc colour to the nearest slot when constrained, and the active colour re-snaps on `activate()` / `onPaletteChange`. Applied to **both** mesh paint (`paintMode.ts`) and the voxel studio (`voxelPaint.ts`), since the toggle reads as global. Enforcement lives at the active-colour chokepoint, **not** `addRegion`, so session rehydration of old off-palette models is untouched.

**4. Bug fix**: the relief preview honoured the palette but the committed model didn't — `clampReliefQuantized` rebuilt the options and dropped `fixedPalette` before `generateRelief`. Now threaded through (validated 0–255 triples). Voxel needed no fix (no intervening clamp).

All new option fields are optional → old saved sessions and recent-import entries load unchanged.

## Test plan

- **Unit**: `palette.test.ts` (listSlotRgb255 / nearestSlot / empty palette), `reliefPalette.test.ts` (fixedPalette snapping, cluster-count ignored, k-means fallback). 807 unit tests pass.
- **E2E**: `palette-import-constrain.spec.ts` (voxel checkbox swaps reduction picker; relief colour-tile defaults to palette + toggles off); `relief.spec.ts` adds **`fixedPalette snaps the committed model to the given colours`** — the regression lock for the clamp bug, exercising the full create path; `paint-palette.spec.ts` adds the ad-hoc-green-snaps-under-constrain case.
- **Manual**: confirmed in-browser — voxel filament strip, relief colour-tile defaulting to palette with Clusters dimmed.
- `npm run build`, `lint:deps` (no cycles), `lint:deadcode` (no new dead code) clean; `work-reviewer` pass came back 0 blocking / 0 should-fix.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013d88yhUi9tazT9XBeonGan