### PR TITLE
feat: add mesh import and version management to window.partwright

### DIFF
--- a/prompts/20260608-134500-ai-api-parity-import-versions.md
+++ b/prompts/20260608-134500-ai-api-parity-import-versions.md
@@ -1,0 +1,57 @@
+---
+session: "qvftq2"
+timestamp: "2026-06-08T13:30:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 2
+---
+
+## Human
+
+I merged 502, go ahead and start the next PR.
+
+(Context: #502 closed the first batch of audit findings. The agreed "next PR"
+is the highest-leverage remaining UI→`window.partwright` parity group from the
+20-agent audit — import + version management — toward the goal of an AI driving
+everything a user can do.)
+
+## Assistant
+
+## Key decisions
+
+**Scope**: Branched off the post-#502 `main` and implemented the
+console/external-agent parity gaps that had existing primitives behind them, so
+each was a thin, low-risk wrapper rather than new subsystem work:
+
+- **`importMeshData(base64, filename, {sessionName?})`** — STL import (binary or
+  ASCII) for agents, which have no file picker. Refactored the interactive
+  `parseSTLFile` to extract a non-interactive `parseSTLBytes` core (the
+  weld-tolerance ladder + manifold trial), shared by both paths — the file path
+  keeps its render-only confirm dialog; the API auto-accepts render-only and
+  reports `isManifold` in the return. Round-trips with `exportSTLData().base64`.
+
+- **`renameVersion` / `deleteVersion` / `diffVersions`** — wrappers over the
+  existing `sessionManager` primitives (`renameVersion`, `deleteVersion`,
+  `computeStatDiff`, `peekVersion`), reusing `parseVersionTarget` for the
+  `{index}|{id}` contract. `deleteVersion` re-renders the replacement version
+  (language/colour/annotation restore, mirroring `loadVersion`) when the active
+  version is the one removed; refuses the last version (handled in the store).
+
+**Layer choice**: This PR adds to `window.partwright` (the console + external
+Claude Code agent surface) and documents in `ai.md`/`file-io.md` + the `help()`
+table. I deliberately did NOT add in-app `src/ai/tools.ts` schemas this round:
+`importMeshData` needs file bytes an in-app agent can't supply, and exposing
+`deleteVersion` to an autonomous in-app agent needs a gating decision
+(SAVE-scope vs a new destructive scope) better made on its own. Flagged as the
+next follow-up.
+
+**Deferred to a later PR** (still open from the audit): image-stamp paint
+(`paintImage`/`stampImageOntoMesh`), filament-palette + replace-color APIs, and
+STEP import (its UI picks a BREP-vs-mesh target interactively, so the API needs
+a non-interactive target arg). Kept this PR coherent around session data I/O.
+
+**Verification**: `npm run build` (tsc) + 800 unit tests + `lint:deps` pass. A
+throwaway Playwright spec drove `window.partwright` to round-trip a cube through
+`exportSTLData → importMeshData` (new session, `isManifold:true`, 12 tris), then
+`renameVersion` → `diffVersions` (volume +50%, bbox 20→30) → `deleteVersion`
+(fell back to v1, count 2→1) with no console errors.

--- a/public/ai.md
+++ b/public/ai.md
@@ -253,6 +253,7 @@ await partwright.exportSessionData()    // -> {filename, mimeType, data, sizeByt
 partwright.exportCodeData()             // -> {filename, mimeType, language, text, sizeBytes}
 await partwright.importSessionData(parsedJson)         // -> {sessionId} or {error}
 await partwright.importCodeData(code, language, name?) // -> {sessionId}
+await partwright.importMeshData(base64, filename, {sessionName?}) // Import STL bytes (binary/ASCII; bare base64 or data: URL) as a new session -> {sessionId, isManifold, triangleCount, vertexCount} or {error}. isManifold:false = render-only (no booleans/paint/slicing).
 partwright.listRecentExports()                         // Recent Exports inbox
 await partwright.getRecentExport(id)
 partwright.downloadRecentExport(id)
@@ -305,6 +306,9 @@ await partwright.createSessionWithVersions(name, [{code, label},...]) // Batch c
 await partwright.saveVersion(label?)     // Save current state as version
 await partwright.listVersions()          // -> [{id, index, label, timestamp, status}]
 await partwright.loadVersion({index} | {id})  // Load version into editor -> {id, index, label, code, geometryData, labelsAvailable, labelCount} or {error}
+await partwright.renameVersion({index} | {id}, label) // Relabel a version (index is immutable) -> {ok, id, index, label} or {error}
+await partwright.deleteVersion({index} | {id})  // Delete a version (refuses the last one; re-renders the replacement if the active one was deleted) -> {ok, deleted, newCurrent} or {error}
+await partwright.diffVersions({index} | {id}, {index} | {id}) // Compare two versions -> {a, b, codeChanged, statDiff} (each side carries its code); the programmatic Diff tab
 await partwright.forkVersion({index} | {id}, transformFn, label?, assertions?, carryColors=true) // Load + modify + validate + save atomically; carries parent colors -> {..., codeDiff, colors}
 await partwright.copyColorsFromVersion({index} | {id}) // Re-apply a prior version's colors onto the current mesh -> {source, carried, dropped}
 await partwright.getShareLink()          // -> {url, encodedBytes} read-only share link (or {error}); external/console agents hand this to the user — in-app users click the toolbar Share (↗) button instead

--- a/public/ai/file-io.md
+++ b/public/ai/file-io.md
@@ -41,6 +41,15 @@ const r = await partwright.importSessionData(parsedJson)
 // Import raw source as a new session
 await partwright.importCodeData(code, 'manifold-js')           // optional sessionName arg
 await partwright.importCodeData(scadCode, 'scad', 'my-shape')
+
+// Import an STL mesh (binary or ASCII) from base64 bytes as a new session.
+// This is the only way an agent can import an STL — there's no file picker to
+// click. `base64` may be a bare base64 string or a `data:` URL; it round-trips
+// with exportSTLData().base64.
+const imp = await partwright.importMeshData(base64, 'part.stl', { sessionName: 'imported part' })
+// -> { sessionId, isManifold, triangleCount, vertexCount } or { error }
+// isManifold:false = welded render-only (displays + exports, but no booleans /
+// paint / cross-sections) — typical for sculpted or scanned models.
 ```
 
 ## Recent Exports inbox

--- a/src/main.ts
+++ b/src/main.ts
@@ -213,6 +213,8 @@ import {
   navigateVersion,
   loadVersion as loadVersionFromStore,
   peekVersion,
+  renameVersion as renameVersionInStore,
+  deleteVersion as deleteVersionFromStore,
   listCurrentVersions,
   listCurrentParts,
   getCurrentPart,
@@ -3164,16 +3166,19 @@ async function main() {
    *  If the mesh still won't form a manifold (common for sculpted/scanned models
    *  with self-intersections or open edges), prompts the user to import as
    *  render-only — visible and exportable, but no booleans/paint/slice. */
-  async function parseSTLFile(file: File): Promise<ParsedSTL | null> {
-    const bytes = new Uint8Array(await file.arrayBuffer());
-
-    // Sanity-check that the file parses to *something* before doing the more
-    // expensive ofMesh trial.
+  /** Non-interactive STL parse: tries a ladder of weld tolerances and reports
+   *  whether the welded result forms a clean manifold. Shared by the interactive
+   *  file path (`parseSTLFile`, which adds the render-only confirm dialog) and
+   *  the programmatic `importMeshData` API (which auto-accepts render-only).
+   *  Returns null only when the bytes don't parse as STL at all. */
+  type ParsedSTLProbe =
+    | { mesh: ImportedMesh; isManifold: true }
+    | { mesh: ImportedMesh; isManifold: false; manifoldError: string | null; maxTried: number; triCount: number; vertCount: number };
+  function parseSTLBytes(bytes: Uint8Array, filename: string): ParsedSTLProbe | null {
+    // Sanity-check that the file parses to *something* before the more expensive
+    // ofMesh trials.
     const probe = parseSTL(bytes);
-    if (!probe || probe.numTri === 0) {
-      showToast(`Could not parse "${file.name}" as an STL file.`, { variant: 'warn', source: 'import' });
-      return null;
-    }
+    if (!probe || probe.numTri === 0) return null;
 
     // Scale-aware fallback tolerance: 5 ppm of the mesh's bounding-box diagonal
     // catches imports that ship in unusual units (μm or m) where 1e-3 absolute
@@ -3192,13 +3197,29 @@ async function main() {
       const mesh = parseSTL(bytes, { weldTolerance: tol });
       if (!mesh || mesh.numTri === 0) continue;
       const trial = tryConstructManifold(mesh);
-      if (trial.ok) {
-        return { mesh: toImportedMesh(file.name, mesh), isManifold: true };
-      }
+      if (trial.ok) return { mesh: toImportedMesh(filename, mesh), isManifold: true };
       manifoldError = trial.error;
       if (tol > maxTried) maxTried = tol;
       bestMesh = mesh;
     }
+    return {
+      mesh: toImportedMesh(filename, bestMesh),
+      isManifold: false,
+      manifoldError,
+      maxTried,
+      triCount: probe.numTri,
+      vertCount: probe.numVert,
+    };
+  }
+
+  async function parseSTLFile(file: File): Promise<ParsedSTL | null> {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const parsed = parseSTLBytes(bytes, file.name);
+    if (!parsed) {
+      showToast(`Could not parse "${file.name}" as an STL file.`, { variant: 'warn', source: 'import' });
+      return null;
+    }
+    if (parsed.isManifold) return { mesh: parsed.mesh, isManifold: true };
 
     // All tolerances failed. Offer render-only fallback — most users importing
     // a Baby Yoda / Eiffel Tower scan just want to look at it, not boolean-op it.
@@ -3206,7 +3227,7 @@ async function main() {
       `${file.name} won't form a clean manifold — typical for sculpted or scanned models with self-intersections, open edges, or T-junctions.\n\n` +
       `You can still import it as render-only: the mesh displays and exports normally, but boolean operations, paint, and cross-sections won't work.\n\n` +
       `For full editing, repair the mesh first in MeshLab or Blender, then re-import.\n\n` +
-      `${probe.numTri.toLocaleString()} triangles · ${probe.numVert.toLocaleString()} vertices · tried weld tolerances up to ${maxTried.toExponential(1)} · ${manifoldError}`,
+      `${parsed.triCount.toLocaleString()} triangles · ${parsed.vertCount.toLocaleString()} vertices · tried weld tolerances up to ${parsed.maxTried.toExponential(1)} · ${parsed.manifoldError}`,
       {
         title: 'Import as render-only?',
         confirmLabel: 'Import render-only',
@@ -3215,7 +3236,7 @@ async function main() {
     );
     if (!accepted) return null;
 
-    return { mesh: toImportedMesh(file.name, bestMesh), isManifold: false };
+    return { mesh: parsed.mesh, isManifold: false };
   }
 
   function toImportedMesh(filename: string, mesh: MeshData, format: ImportedMesh['format'] = 'stl'): ImportedMesh {
@@ -8134,6 +8155,45 @@ async function main() {
       return { sessionId: result.sessionId };
     },
 
+    /** Import an STL mesh (binary or ASCII) from base64-encoded bytes as a new
+     *  session — the programmatic equivalent of the Import → choose-file flow for
+     *  STL (which an agent can't reach: there's no file picker). The mesh is
+     *  welded across a tolerance ladder; when it forms a clean manifold it's
+     *  imported as an editable manifold-js model, otherwise it lands render-only
+     *  (display + export only — no booleans/paint/slicing), reflected by
+     *  `isManifold: false` in the return. `base64` may be a bare base64 string or
+     *  a `data:` URL. `filename` names the import; `opts.sessionName` overrides
+     *  the new session's name. Returns `{ sessionId, isManifold, triangleCount,
+     *  vertexCount }` or `{ error }`. */
+    async importMeshData(base64: string, filename: string, opts: { sessionName?: string } = {}) {
+      const check = guard(() => {
+        assertString(base64, 'importMeshData(base64)', { allowEmpty: false });
+        assertString(filename, 'importMeshData(filename)', { allowEmpty: false });
+        assertObject(opts, 'importMeshData(opts)', { optional: true });
+        assertString(opts?.sessionName, 'importMeshData(opts.sessionName)', { optional: true, allowEmpty: false });
+      });
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      let bytes: Uint8Array;
+      try {
+        const raw = (base64.includes(',') ? base64.slice(base64.indexOf(',') + 1) : base64).replace(/\s/g, '');
+        const binary = atob(raw);
+        bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      } catch {
+        return { error: 'importMeshData(base64): not valid base64-encoded data.' };
+      }
+      const parsed = parseSTLBytes(bytes, filename);
+      if (!parsed) return { error: `Could not parse "${filename}" as an STL file (binary or ASCII).` };
+      const sessionName = opts?.sessionName ?? filename.replace(/\.[^.]+$/, '');
+      const { sessionId } = await importMeshPayload(parsed.mesh, sessionName, { manifold: parsed.isManifold });
+      return {
+        sessionId,
+        isManifold: parsed.isManifold,
+        triangleCount: parsed.mesh.numTri,
+        vertexCount: parsed.mesh.numVert,
+      };
+    },
+
     /** Import an image (a `data:` URL or a same-origin URL) as a colored voxel
      *  model in a new voxel session — the programmatic equivalent of the
      *  Import → image file flow. `mode: 'billboard'` (default) extrudes every
@@ -9080,6 +9140,80 @@ async function main() {
         timestamp: v.timestamp,
         status: (v.geometryData as Record<string, unknown> | null)?.status ?? null,
       }));
+    },
+
+    /** Rename a version's display label (its index is immutable). Pass { index }
+     *  or { id } from listVersions(), plus the new label. Returns the updated
+     *  { id, index, label }, or { error } if the version isn't in this session. */
+    async renameVersion(target: { index?: number; id?: string }, label: string) {
+      const parsed = parseVersionTarget(target, 'renameVersion');
+      if ('error' in parsed) return parsed;
+      const check = guard(() => assertString(label, 'renameVersion(label)', { allowEmpty: false }));
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      if (!getState().session) return { error: 'No active session. Call openSession(id) or createSession() first.' };
+      const version = await peekVersion(parsed.value);
+      if (!version) return { error: `No version found with ${parsed.kind} "${parsed.value}" in the active session. Use listVersions() to see valid ${parsed.kind}s.` };
+      const updated = await renameVersionInStore(version.id, label);
+      if (!updated) return { error: `Could not rename version "${parsed.value}".` };
+      return { ok: true, id: updated.id, index: updated.index, label: updated.label };
+    },
+
+    /** Delete a version from the active session. Pass { index } or { id }. Refuses
+     *  to remove the last remaining version. When the active version is deleted,
+     *  the nearest earlier version becomes active and is re-rendered. Returns
+     *  { ok, deleted, newCurrent } or { error }. */
+    async deleteVersion(target: { index?: number; id?: string }) {
+      const parsed = parseVersionTarget(target, 'deleteVersion');
+      if ('error' in parsed) return parsed;
+      if (!getState().session) return { error: 'No active session. Call openSession(id) or createSession() first.' };
+      const version = await peekVersion(parsed.value);
+      if (!version) return { error: `No version found with ${parsed.kind} "${parsed.value}" in the active session. Use listVersions() to see valid ${parsed.kind}s.` };
+      const result = await deleteVersionFromStore(version.id);
+      if (!result) return { error: 'Could not delete — a session must keep at least one version.' };
+      // If the active version changed, re-render the replacement so the viewport
+      // and editor reflect the new state (mirrors loadVersion's language/colour/
+      // annotation restore).
+      if (result.wasCurrent && result.newCurrent) {
+        const nv = result.newCurrent;
+        const versionLang = effectiveVersionLanguage(nv, getState().session);
+        if (versionLang !== getActiveLanguage()) await switchLanguage(versionLang);
+        setValue(nv.code);
+        currentParamValues = { ...(nv.paramValues ?? {}) };
+        await runCodeSync(nv.code, { preserveCamera: true });
+        await rehydrateColorRegions(nv.geometryData);
+        applyVersionAnnotations(nv);
+      }
+      return {
+        ok: true,
+        deleted: { id: result.deleted.id, index: result.deleted.index, label: result.deleted.label },
+        newCurrent: result.newCurrent ? { id: result.newCurrent.id, index: result.newCurrent.index, label: result.newCurrent.label } : null,
+      };
+    },
+
+    /** Compare two versions' code and geometry stats — the programmatic form of
+     *  the Diff tab. Pass two targets (each { index } or { id }) from
+     *  listVersions(). Returns each version's code + a per-field stat delta, or
+     *  { error } if either version isn't found. */
+    async diffVersions(a: { index?: number; id?: string }, b: { index?: number; id?: string }) {
+      const pa = parseVersionTarget(a, 'diffVersions');
+      if ('error' in pa) return pa;
+      const pb = parseVersionTarget(b, 'diffVersions');
+      if ('error' in pb) return pb;
+      if (!getState().session) return { error: 'No active session. Call openSession(id) or createSession() first.' };
+      const va = await peekVersion(pa.value);
+      if (!va) return { error: `No version found with ${pa.kind} "${pa.value}" in the active session.` };
+      const vb = await peekVersion(pb.value);
+      if (!vb) return { error: `No version found with ${pb.kind} "${pb.value}" in the active session.` };
+      const statDiff = computeStatDiff(
+        (va.geometryData ?? {}) as Record<string, unknown>,
+        (vb.geometryData ?? {}) as Record<string, unknown>,
+      );
+      return {
+        a: { id: va.id, index: va.index, label: va.label, code: va.code },
+        b: { id: vb.id, index: vb.index, label: vb.label, code: vb.code },
+        codeChanged: va.code !== vb.code,
+        statDiff,
+      };
     },
 
     /** Load a version into the editor. Pass { index } or { id } from listVersions().
@@ -12386,6 +12520,9 @@ async function main() {
         'saveVersion':     { signature: 'await saveVersion(label?) -- Save current state as version', docs: '/ai.md#console-api--windowpartwright' },
         'listVersions':    { signature: 'await listVersions() -- List all versions in session', docs: '/ai.md#console-api--windowpartwright' },
         'loadVersion':     { signature: 'await loadVersion({index} | {id}) -- Load version into editor -> {id, index, label, code, geometryData} or {error}', docs: '/ai.md#console-api--windowpartwright' },
+        'renameVersion':   { signature: 'await renameVersion({index} | {id}, label) -- Relabel a version -> {ok, id, index, label} or {error}', docs: '/ai.md#console-api--windowpartwright' },
+        'deleteVersion':   { signature: 'await deleteVersion({index} | {id}) -- Delete a version (refuses the last) -> {ok, deleted, newCurrent} or {error}', docs: '/ai.md#console-api--windowpartwright' },
+        'diffVersions':    { signature: 'await diffVersions({index} | {id}, {index} | {id}) -- Compare two versions -> {a, b, codeChanged, statDiff}', docs: '/ai.md#console-api--windowpartwright' },
         'forkVersion':     { signature: 'await forkVersion({index} | {id}, transformFn, label?, assertions?, carryColors=true) -- Load + modify + validate + save in one call; carries parent colors -> {..., codeDiff, colors}', docs: '/ai.md#forking-a-prior-version' },
         'copyColorsFromVersion': { signature: 'await copyColorsFromVersion({index} | {id}) -- Re-apply a prior version\'s color regions onto the current mesh -> {source, carried, dropped}', docs: '/ai.md#forking-a-prior-version' },
         'openSession':     { signature: 'await openSession(id) -- Open existing session', docs: '/ai.md#resuming-a-session' },
@@ -12450,6 +12587,7 @@ async function main() {
         // AI-friendly import — bypass the file picker
         'importSessionData': { signature: 'await importSessionData(jsonObjectOrString) -- Import .partwright.json payload -> {sessionId} or {error}', docs: '/ai/file-io.md' },
         'importCodeData':  { signature: 'await importCodeData(code, language, sessionName?) -- Import raw source as new session', docs: '/ai/file-io.md' },
+        'importMeshData':  { signature: 'await importMeshData(base64, filename, {sessionName?}) -- Import STL bytes (binary/ASCII) as a new session -> {sessionId, isManifold, triangleCount, vertexCount} or {error}', docs: '/ai/file-io.md' },
         // Recent Exports inbox (also visible in toolbar Export dropdown)
         'listRecentExports': { signature: 'listRecentExports() -- Recent export metadata, newest first', docs: '/ai/file-io.md' },
         'getRecentExport': { signature: 'await getRecentExport(id) -- Look up bytes by id -> {filename, mimeType, text? | base64, ...}', docs: '/ai/file-io.md' },


### PR DESCRIPTION
## Summary

Second PR from the feature audit, closing the highest-leverage remaining **UI→`window.partwright` parity** gaps — the session data I/O group — so the console / external AI agent can drive what a user can. All three build on existing primitives, so each is a thin, low-risk wrapper.

1. **`importMeshData(base64, filename, {sessionName?})`** — STL import (binary **and** ASCII) for agents, which have no file picker. Refactors the interactive `parseSTLFile` to extract a non-interactive **`parseSTLBytes`** core (the weld-tolerance ladder + manifold trial), shared by both paths: the file path keeps its render-only confirm dialog, the API auto-accepts render-only and reports `isManifold` in the return. Round-trips with `exportSTLData().base64`. Returns `{ sessionId, isManifold, triangleCount, vertexCount }`.

2. **`renameVersion({index}|{id}, label)`**, **`deleteVersion({index}|{id})`**, **`diffVersions(a, b)`** — wrappers over the existing `sessionManager` primitives (`renameVersion`/`deleteVersion`/`computeStatDiff`/`peekVersion`), reusing `parseVersionTarget` for the `{index}|{id}` contract. `deleteVersion` re-renders the replacement version (language/colour/annotation restore, mirroring `loadVersion`) when the active version is the one removed, and refuses the last remaining version.

Docs updated: `public/ai.md`, `public/ai/file-io.md`, and the `window.partwright.help()` table.

## Why this scope / layer

These land on **`window.partwright`** (the console + external Claude Code agent surface — the audit's actual gap) plus the AI docs. I deliberately did **not** add in-app `src/ai/tools.ts` schemas this round: `importMeshData` needs file bytes an in-app agent can't supply, and exposing `deleteVersion` to an autonomous in-app agent needs a gating decision (reuse SAVE-scope vs a new destructive scope) better made on its own — flagged as the next follow-up.

**Deferred to a later PR** (still open from the audit): image-stamp paint (`paintImage`/`stampImageOntoMesh`), filament-palette + replace-color APIs, and STEP import (its UI picks a BREP-vs-mesh target interactively, so the API needs a non-interactive target arg).

## Test plan

- ✅ `npm run build` (includes `tsc`)
- ✅ `npm run test:unit` — 800 passed
- ✅ `npm run lint:deps` — no circular deps
- ✅ Browser-verified via a throwaway Playwright spec driving `window.partwright`: round-tripped a cube through `exportSTLData → importMeshData` (new session, `isManifold:true`, 12 tris/8 verts), then `renameVersion` → `diffVersions` (volume +50%, bbox 20→30) → `deleteVersion` (fell back to v1, count 2→1), no console errors. Screenshot posted in session.
- PR-checks will run the full e2e shards on this draft.

https://claude.ai/code/session_01Qv19e5UnM7HzMvaDuh512k

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv19e5UnM7HzMvaDuh512k)_