### PR TITLE
feat: make the "Did you know?" hints card adapt between one and two rows

### DIFF
--- a/prompts/20260608-hints-two-row-card.md
+++ b/prompts/20260608-hints-two-row-card.md
@@ -1,0 +1,32 @@
+---
+date: 2026-06-08
+author: kriskemper@gmail.com
+prefix: feat
+---
+
+## Human
+
+Make the "Did you know?" hints menu more compact: a two-row card where the
+"Did you know?" label, the link/CTA, and the previous/next/close buttons sit
+on the first row, and the actual hint text sits on the second row.
+
+## Assistant
+
+Restructured the hints ticker card (`src/ui/hints/hintsTicker.ts`) from a
+single horizontal flex row into a vertical `flex flex-col` card with two rows:
+
+- **Why two rows:** the old single row forced the hint text to compete with the
+  badge/CTA/controls for horizontal space, so when room got tight (e.g. AI panel
+  open) the text wrapped to up to three lines and the whole strip ballooned
+  wide. Stacking the header above the text keeps the header compact and lets the
+  text wrap beneath without pushing the controls around.
+- **Row 1 (header):** icon + "Did you know?" badge + CTA grouped on the left;
+  the ‹ › ✕ controls pushed to the right edge with `ml-auto` (kept their divider
+  so they still read as the hints' own controls).
+- **Row 2:** the rotating hint text (`#editor-hints-text`), unchanged classes
+  (`break-words line-clamp-3`) so the existing wrap/clamp behavior carries over.
+
+Left the responsive `applyWidth` logic untouched — it still drops the badge as
+the host narrows and hides the whole card when there's genuinely no room. No
+behavior change to rotation, seen-tracking, CTA dispatch, or the session-dismiss
+flow, so the existing e2e spec (`tests/editor-hints.spec.ts`) passes as-is.

--- a/prompts/20260608-hints-two-row-card.md
+++ b/prompts/20260608-hints-two-row-card.md
@@ -6,27 +6,36 @@ prefix: feat
 
 ## Human
 
-Make the "Did you know?" hints menu more compact: a two-row card where the
-"Did you know?" label, the link/CTA, and the previous/next/close buttons sit
-on the first row, and the actual hint text sits on the second row.
+1. Make the "Did you know?" hints menu more compact: a two-row card where the
+   "Did you know?" label, the link/CTA, and the previous/next/close buttons sit
+   on the first row, and the actual hint text sits on the second row.
+2. Follow-up: keep a single row by default when there's room, and only fall back
+   to the two-row layout when the box has to reduce its horizontal size.
 
 ## Assistant
 
-Restructured the hints ticker card (`src/ui/hints/hintsTicker.ts`) from a
-single horizontal flex row into a vertical `flex flex-col` card with two rows:
+Reworked the hints ticker card (`src/ui/hints/hintsTicker.ts`) so it adapts
+between two arrangements driven by available width *and* the current hint's
+length:
 
-- **Why two rows:** the old single row forced the hint text to compete with the
-  badge/CTA/controls for horizontal space, so when room got tight (e.g. AI panel
-  open) the text wrapped to up to three lines and the whole strip ballooned
-  wide. Stacking the header above the text keeps the header compact and lets the
-  text wrap beneath without pushing the controls around.
-- **Row 1 (header):** icon + "Did you know?" badge + CTA grouped on the left;
-  the ‹ › ✕ controls pushed to the right edge with `ml-auto` (kept their divider
-  so they still read as the hints' own controls).
-- **Row 2:** the rotating hint text (`#editor-hints-text`), unchanged classes
-  (`break-words line-clamp-3`) so the existing wrap/clamp behavior carries over.
+- **Single row (default, when it fits):** icon + "Did you know?" + hint text +
+  CTA + ‹ › ✕ controls all inline — the pre-feature layout, with the text on one
+  line (`whitespace-nowrap`).
+- **Two rows (fallback, when tight):** a compact header (icon + label + CTA,
+  controls pushed right with `ml-auto`) and the hint text on its own line below
+  (`break-words line-clamp-3`), so the text never competes with the header.
 
-Left the responsive `applyWidth` logic untouched — it still drops the badge as
-the host narrows and hides the whole card when there's genuinely no room. No
-behavior change to rotation, seen-tracking, CTA dispatch, or the session-dismiss
-flow, so the existing e2e spec (`tests/editor-hints.spec.ts`) passes as-is.
+How the switch is decided (`relayout()`): on resize, breakpoint change, and each
+text rotation it lays out single-row, measures the intrinsic single-line width
+off-flow (`position:absolute; width:max-content`, restored synchronously so it
+never paints), and falls back to two rows only when that width exceeds the host.
+Because the measurement runs inside the ResizeObserver callback / the rotation's
+synchronous task, the transient single-row state is never painted — no flicker.
+`setLayout()` reparents the shared elements between a flat strip and a
+`topRow + text` column, no-op when the mode is unchanged.
+
+Kept the existing visibility degradation (hide below the md breakpoint or when
+the host is under 200px; drop the badge under 360px). No change to rotation,
+seen-tracking, CTA dispatch, or session-dismiss. Added an e2e case
+(`tests/editor-hints.spec.ts`) that pins the toolbar middle wide vs tight and
+asserts the badge and hint text share a row (single) vs stack (two).

--- a/src/ui/hints/hintsTicker.ts
+++ b/src/ui/hints/hintsTicker.ts
@@ -177,17 +177,24 @@ function renderStrip(): void {
   order = buildOrder();
   idx = 0;
 
-  // Centered, self-contained pill in the toolbar's middle: a subtle bordered
-  // box holding the icon, "Did you know?" label, the rotating hint, its CTA, and
-  // the ‹ › ✕ controls — all one section, distinct from the toolbar's button
-  // clusters. The host centers it (justify-center) and stays flex-1 so it also
-  // right-aligns the AI/Import/Export cluster.
+  // Centered, self-contained card in the toolbar's middle: a subtle bordered
+  // box stacked into two rows. The top row is the compact header — icon,
+  // "Did you know?" label, the rotating hint's CTA, and the ‹ › ✕ controls
+  // (right-aligned). The hint text gets its own row beneath, so it never
+  // competes horizontally with the header and can wrap freely. The host centers
+  // it (justify-center) and stays flex-1 so it also right-aligns the
+  // AI/Import/Export cluster.
   strip = document.createElement('div');
   strip.id = 'editor-hints';
   strip.setAttribute('role', 'note');
   strip.setAttribute('aria-label', 'Did you know');
   strip.className =
-    'min-w-0 max-w-full inline-flex items-center gap-2 pl-2.5 pr-1.5 py-1 rounded-md bg-zinc-800/60 border border-zinc-700/70 text-xs text-zinc-400';
+    'min-w-0 max-w-full flex flex-col gap-0.5 pl-2.5 pr-1.5 py-1 rounded-md bg-zinc-800/60 border border-zinc-700/70 text-xs text-zinc-400';
+
+  // Row 1 — the header: icon + label + CTA on the left, ‹ › ✕ controls pushed
+  // to the right edge with ml-auto.
+  const topRow = document.createElement('div');
+  topRow.className = 'flex items-center gap-2';
 
   const icon = document.createElement('span');
   icon.className = 'shrink-0 text-amber-300 flex items-center';
@@ -198,30 +205,33 @@ function renderStrip(): void {
   badge.className = 'shrink-0 text-zinc-500 select-none';
   badge.textContent = 'Did you know?';
 
-  textEl = document.createElement('span');
-  textEl.id = 'editor-hints-text';
-  // Wrap onto multiple lines when horizontal room is tight (e.g. the AI panel
-  // is open) instead of truncating to a single ellipsised line — the strip
-  // grows vertically and the toolbar row grows with it. A long hint still fits
-  // on one line when there's room; line-clamp-3 caps the growth at three lines
-  // so a very long hint on a very narrow strip can't balloon the toolbar.
-  textEl.className = 'min-w-0 text-zinc-300 break-words line-clamp-3';
-
   ctaEl = document.createElement('button');
   ctaEl.type = 'button';
   ctaEl.className = 'shrink-0 text-blue-400 hover:text-blue-300 hover:underline font-medium transition-colors';
 
-  // ‹ › step + ✕ dismiss, kept inside the section, set off by a thin divider so
-  // they read as the hints' own controls.
+  // ‹ › step + ✕ dismiss, kept inside the section and right-aligned (ml-auto),
+  // set off by a thin divider so they read as the hints' own controls.
   const controls = document.createElement('div');
-  controls.className = 'shrink-0 flex items-center gap-0.5 pl-1.5 ml-0.5 border-l border-zinc-700/70 text-zinc-500';
+  controls.className = 'shrink-0 flex items-center gap-0.5 ml-auto pl-1.5 border-l border-zinc-700/70 text-zinc-500';
 
   const prevBtn = makeIconBtn('‹', 'Previous hint', () => advance(-1));
   const nextBtn = makeIconBtn('›', 'Next hint', () => advance(1));
   const closeBtn = makeIconBtn('✕', 'Hide hints for this session', dismissForSession);
 
   controls.append(prevBtn, nextBtn, closeBtn);
-  strip.append(icon, badge, textEl, ctaEl, controls);
+  topRow.append(icon, badge, ctaEl, controls);
+
+  // Row 2 — the rotating hint text on its own line beneath the header.
+  textEl = document.createElement('span');
+  textEl.id = 'editor-hints-text';
+  // Wrap onto multiple lines when horizontal room is tight (e.g. the AI panel
+  // is open) instead of truncating to a single ellipsised line — the card grows
+  // vertically and the toolbar row grows with it. A long hint still fits on one
+  // line when there's room; line-clamp-3 caps the growth at three lines so a
+  // very long hint on a very narrow card can't balloon the toolbar.
+  textEl.className = 'min-w-0 text-zinc-300 break-words line-clamp-3';
+
+  strip.append(topRow, textEl);
   host.appendChild(strip);
 
   // Degrade gracefully as the toolbar's middle shrinks (e.g. the AI panel opens

--- a/src/ui/hints/hintsTicker.ts
+++ b/src/ui/hints/hintsTicker.ts
@@ -39,6 +39,10 @@ let configUnsub: (() => void) | null = null;
 let sessionUnsub: (() => void) | null = null;
 let resizeObs: ResizeObserver | null = null;
 let desktopMqCleanup: (() => void) | null = null;
+/** Re-evaluate single-vs-two-row layout for the current width + hint text.
+ *  Set while a strip is mounted (closure over its elements), cleared on
+ *  teardown. Called on resize, breakpoint change, and each text rotation. */
+let relayoutFn: (() => void) | null = null;
 /** Last session id seen, so we only restore hints on a real session transition
  *  (new / opened / switched session) — not on intra-session changes like
  *  version navigation, which also fire 'session-changed'. */
@@ -136,6 +140,9 @@ function showCurrent(): void {
   ctaEl.textContent = hint.ctaLabel ?? DEFAULT_CTA_LABEL;
   ctaEl.onclick = () => runCta(hint.cta);
   markSeen(hint.id);
+  // A longer/shorter hint can change whether everything still fits on one line,
+  // so re-pick the single-vs-two-row layout for the new text.
+  relayoutFn?.();
 }
 
 function advance(delta: number): void {
@@ -167,6 +174,7 @@ function teardownStrip(): void {
   strip = null;
   textEl = null;
   ctaEl = null;
+  relayoutFn = null;
 }
 
 /** Render the strip into the host (idempotent — rebuilds in place). */
@@ -178,21 +186,21 @@ function renderStrip(): void {
   idx = 0;
 
   // Centered, self-contained card in the toolbar's middle: a subtle bordered
-  // box stacked into two rows. The top row is the compact header — icon,
-  // "Did you know?" label, the rotating hint's CTA, and the ‹ › ✕ controls
-  // (right-aligned). The hint text gets its own row beneath, so it never
-  // competes horizontally with the header and can wrap freely. The host centers
-  // it (justify-center) and stays flex-1 so it also right-aligns the
-  // AI/Import/Export cluster.
-  strip = document.createElement('div');
-  strip.id = 'editor-hints';
-  strip.setAttribute('role', 'note');
-  strip.setAttribute('aria-label', 'Did you know');
-  strip.className =
-    'min-w-0 max-w-full flex flex-col gap-0.5 pl-2.5 pr-1.5 py-1 rounded-md bg-zinc-800/60 border border-zinc-700/70 text-xs text-zinc-400';
+  // box. It adapts between two arrangements (see relayout below):
+  //   • single row (default, when there's room) — icon, "Did you know?", hint
+  //     text, CTA, and the ‹ › ✕ controls all inline, as before this feature;
+  //   • two rows (when horizontal space is tight) — a compact header (icon +
+  //     label + CTA, controls right-aligned) with the hint text on its own line
+  //     beneath, so the text never competes with the header for width.
+  // The host centers it (justify-center) and stays flex-1 so it also
+  // right-aligns the AI/Import/Export cluster.
+  const stripEl = document.createElement('div');
+  strip = stripEl;
+  stripEl.id = 'editor-hints';
+  stripEl.setAttribute('role', 'note');
+  stripEl.setAttribute('aria-label', 'Did you know');
 
-  // Row 1 — the header: icon + label + CTA on the left, ‹ › ✕ controls pushed
-  // to the right edge with ml-auto.
+  // The header-row wrapper used only in the two-row arrangement.
   const topRow = document.createElement('div');
   topRow.className = 'flex items-center gap-2';
 
@@ -205,67 +213,111 @@ function renderStrip(): void {
   badge.className = 'shrink-0 text-zinc-500 select-none';
   badge.textContent = 'Did you know?';
 
-  ctaEl = document.createElement('button');
-  ctaEl.type = 'button';
-  ctaEl.className = 'shrink-0 text-blue-400 hover:text-blue-300 hover:underline font-medium transition-colors';
+  const ctaBtn = document.createElement('button');
+  ctaEl = ctaBtn;
+  ctaBtn.type = 'button';
+  ctaBtn.className = 'shrink-0 text-blue-400 hover:text-blue-300 hover:underline font-medium transition-colors';
 
-  // ‹ › step + ✕ dismiss, kept inside the section and right-aligned (ml-auto),
-  // set off by a thin divider so they read as the hints' own controls.
+  // ‹ › step + ✕ dismiss, kept inside the section, set off by a thin divider so
+  // they read as the hints' own controls.
   const controls = document.createElement('div');
-  controls.className = 'shrink-0 flex items-center gap-0.5 ml-auto pl-1.5 border-l border-zinc-700/70 text-zinc-500';
 
   const prevBtn = makeIconBtn('‹', 'Previous hint', () => advance(-1));
   const nextBtn = makeIconBtn('›', 'Next hint', () => advance(1));
   const closeBtn = makeIconBtn('✕', 'Hide hints for this session', dismissForSession);
-
   controls.append(prevBtn, nextBtn, closeBtn);
-  topRow.append(icon, badge, ctaEl, controls);
 
-  // Row 2 — the rotating hint text on its own line beneath the header.
-  textEl = document.createElement('span');
-  textEl.id = 'editor-hints-text';
-  // Wrap onto multiple lines when horizontal room is tight (e.g. the AI panel
-  // is open) instead of truncating to a single ellipsised line — the card grows
-  // vertically and the toolbar row grows with it. A long hint still fits on one
-  // line when there's room; line-clamp-3 caps the growth at three lines so a
-  // very long hint on a very narrow card can't balloon the toolbar.
-  textEl.className = 'min-w-0 text-zinc-300 break-words line-clamp-3';
+  const textSpan = document.createElement('span');
+  textEl = textSpan;
+  textSpan.id = 'editor-hints-text';
 
-  strip.append(topRow, textEl);
-  host.appendChild(strip);
+  host.appendChild(stripEl);
+
+  // ── single-vs-two-row layout ──────────────────────────────────────────────
+  const STRIP_BASE =
+    'min-w-0 max-w-full pl-2.5 pr-1.5 py-1 rounded-md bg-zinc-800/60 border border-zinc-700/70 text-xs text-zinc-400';
+  let layoutMode: 'single' | 'two' | null = null;
+
+  /** Reparent + restyle into the requested arrangement (no-op if unchanged). */
+  const setLayout = (mode: 'single' | 'two'): void => {
+    if (layoutMode === mode) return;
+    layoutMode = mode;
+    if (mode === 'single') {
+      stripEl.className = `${STRIP_BASE} flex flex-row items-center gap-2`;
+      // One line, no wrap: if the text won't fit, relayout() switches to 'two'
+      // rather than letting it wrap inside the single row.
+      textSpan.className = 'min-w-0 text-zinc-300 whitespace-nowrap';
+      controls.className =
+        'shrink-0 flex items-center gap-0.5 pl-1.5 ml-0.5 border-l border-zinc-700/70 text-zinc-500';
+      stripEl.replaceChildren(icon, badge, textSpan, ctaBtn, controls);
+    } else {
+      stripEl.className = `${STRIP_BASE} flex flex-col gap-0.5`;
+      // On its own line the text may wrap; line-clamp-3 caps the growth so a
+      // very long hint on a narrow card can't balloon the toolbar.
+      textSpan.className = 'min-w-0 text-zinc-300 break-words line-clamp-3';
+      controls.className =
+        'shrink-0 flex items-center gap-0.5 ml-auto pl-1.5 border-l border-zinc-700/70 text-zinc-500';
+      topRow.replaceChildren(icon, badge, ctaBtn, controls);
+      stripEl.replaceChildren(topRow, textSpan);
+    }
+  };
+
+  /** Intrinsic width the single-row arrangement needs, measured off-flow so the
+   *  flex parent can't shrink it. Assumes single-row structure is applied. */
+  const measureSingleNeeded = (): number => {
+    const s = stripEl.style;
+    const saved = { position: s.position, width: s.width, maxWidth: s.maxWidth, visibility: s.visibility };
+    s.position = 'absolute';
+    s.visibility = 'hidden';
+    s.maxWidth = 'none';
+    s.width = 'max-content';
+    const needed = stripEl.offsetWidth;
+    s.position = saved.position;
+    s.width = saved.width;
+    s.maxWidth = saved.maxWidth;
+    s.visibility = saved.visibility;
+    return needed;
+  };
 
   // Degrade gracefully as the toolbar's middle shrinks (e.g. the AI panel opens
   // or on a narrow screen). On mobile the toolbar already wraps and is cramped,
-  // so the discovery strip isn't worth the space — hide it outright below the
-  // md (768px) breakpoint. On desktop, drop the "💡 Did you know?" badge first
-  // as room tightens, let the hint text wrap to multiple lines (see textEl
-  // above), and finally hide the whole strip when there's genuinely no room —
-  // so it never overflows into the adjacent toolbar buttons. The host stays
-  // flex-1, so it keeps right-aligning the AI/Import/Export cluster even when
-  // the strip is hidden.
+  // so the discovery card isn't worth the space — hide it outright below the md
+  // (768px) breakpoint. On desktop: drop the "Did you know?" badge as room
+  // tightens, prefer the single-row arrangement while it fits, fall back to two
+  // rows when it doesn't, and finally hide the whole card when there's genuinely
+  // no room — so it never overflows into the adjacent toolbar buttons. The host
+  // stays flex-1, so it keeps right-aligning the AI/Import/Export cluster even
+  // when the card is hidden.
   const desktopMq = window.matchMedia('(min-width: 768px)');
-  const applyWidth = () => {
+  const relayout = (): void => {
     if (!strip) return;
     const w = host!.clientWidth;
-    strip.style.display = desktopMq.matches && w >= 200 ? '' : 'none';
+    const visible = desktopMq.matches && w >= 200;
+    stripEl.style.display = visible ? '' : 'none';
+    if (!visible) return;
     badge.style.display = w >= 360 ? '' : 'none';
+    // Try single row first; measure its intrinsic width and fall back to two
+    // rows only when it would overflow the available width.
+    setLayout('single');
+    if (measureSingleNeeded() > w) setLayout('two');
   };
+  relayoutFn = relayout;
+
   resizeObs?.disconnect();
-  resizeObs = new ResizeObserver(applyWidth);
+  resizeObs = new ResizeObserver(relayout);
   resizeObs.observe(host);
   // Re-evaluate on breakpoint crossings: resizing the window across 768px may
   // not shift the host's own width enough to trip the ResizeObserver.
-  desktopMq.addEventListener('change', applyWidth);
-  desktopMqCleanup = () => desktopMq.removeEventListener('change', applyWidth);
-  applyWidth();
+  desktopMq.addEventListener('change', relayout);
+  desktopMqCleanup = () => desktopMq.removeEventListener('change', relayout);
 
   // Pause rotation while the user is reading (hover) or interacting (focus).
-  strip.addEventListener('pointerenter', () => { paused = true; });
-  strip.addEventListener('pointerleave', () => { paused = false; });
-  strip.addEventListener('focusin', () => { paused = true; });
-  strip.addEventListener('focusout', () => { paused = false; });
+  stripEl.addEventListener('pointerenter', () => { paused = true; });
+  stripEl.addEventListener('pointerleave', () => { paused = false; });
+  stripEl.addEventListener('focusin', () => { paused = true; });
+  stripEl.addEventListener('focusout', () => { paused = false; });
 
-  showCurrent();
+  showCurrent();   // sets the text, then triggers relayout() via relayoutFn
   scheduleRotate();
 }
 

--- a/tests/editor-hints.spec.ts
+++ b/tests/editor-hints.spec.ts
@@ -57,6 +57,31 @@ test.describe('editor hints ticker', () => {
     await expect(strip).toBeVisible({ timeout: 8000 });
   });
 
+  test('lays out on one row when there is room, two rows when tight', async ({ page }) => {
+    await page.goto('/editor');
+    const strip = page.locator('#editor-hints');
+    await expect(strip).toBeVisible({ timeout: 15_000 });
+
+    // Pin the toolbar middle to a chosen width and report whether the badge and
+    // the hint text share a row (single) or the text sits below it (two-row).
+    const rowsAtWidth = async (px: number): Promise<'single' | 'two'> => {
+      await page.evaluate((w) => {
+        const host = document.getElementById('editor-hints-host')!;
+        host.style.flex = `0 0 ${w}px`;
+        host.style.maxWidth = `${w}px`;
+      }, px);
+      await page.waitForTimeout(300);
+      const badge = await strip.locator('span', { hasText: 'Did you know?' }).first().boundingBox();
+      const text = await page.locator('#editor-hints-text').boundingBox();
+      if (!badge || !text) throw new Error('missing badge/text box');
+      // Same row ⟺ their vertical centers roughly coincide.
+      return Math.abs((badge.y + badge.height / 2) - (text.y + text.height / 2)) < 6 ? 'single' : 'two';
+    };
+
+    expect(await rowsAtWidth(900)).toBe('single');
+    expect(await rowsAtWidth(430)).toBe('two');
+  });
+
   test('a coach CTA pulses an arrow at the target control', async ({ page }) => {
     await page.goto('/editor');
     const strip = page.locator('#editor-hints');


### PR DESCRIPTION
## Summary

Makes the editor's "Did you know?" hints card **adapt its layout to the available width** instead of always being one fixed shape:

- **Single row (default, when there's room):** ✨ icon + "Did you know?" + hint text + CTA + ‹ › ✕ controls all inline — the original pre-feature layout, text on one line.
- **Two rows (fallback, when horizontal space is tight):** a compact header (icon + label + CTA, controls right-aligned) with the hint text on its own line beneath, so the text never competes with the header for width.

The switch is driven by both the available width *and* the current hint's length: on resize, breakpoint change, and each text rotation, `relayout()` lays the card out single-row, measures the intrinsic single-line width off-flow (`position:absolute; width:max-content`, restored synchronously so it never paints → no flicker), and falls back to two rows only when that width would overflow the toolbar's middle. `setLayout()` reparents the shared elements between the flat strip and the `header + text` column, and is a no-op when the mode is unchanged.

Existing visibility degradation is preserved (hidden below the md breakpoint or under ~200px; the badge drops under ~360px). No behavior change to rotation, seen-tracking, CTA dispatch, or the session-dismiss flow.

### What it looks like

| Wide host | Tight host |
|---|---|
| `✨ Did you know?  <hint text…>  <CTA →>   ‹ › ✕` (one line) | `✨ Did you know?  <CTA →>   ‹ › ✕` over `<hint text, wrapping>` (two rows) |

## Test plan

- [x] `npm run build` (type-check) — passes
- [x] `npm run test:unit` — 800 passed
- [x] `npx playwright test editor-hints` — 4 passed, incl. a **new** responsive case that pins the toolbar middle wide vs tight and asserts the badge + hint text share a row (single) vs stack (two)
- [x] Manual browser check: screenshots of both the single-row and two-row states posted in the session
- [ ] PR-checks shards green

https://claude.ai/code/session_01VQtNRBYhqrYxULbhWhhLEX