### PR TITLE
feat: add filament-palette and replaceColor APIs to window.partwright

### DIFF
--- a/.claude/agents/work-reviewer.md
+++ b/.claude/agents/work-reviewer.md
@@ -40,6 +40,16 @@ file:line-cited list of findings the primary agent or a human will act on.
 - Functionality silently dropped in a merge — compare BOTH sides of any merge;
   never assume the new side is complete.
 
+**UI ↔ JS-API parity**
+- A new user-facing capability (toolbar/command-palette/modal action) should be
+  drivable by an AI agent too: flag when a UI affordance lands with no matching
+  `window.partwright` method in `partwrightAPI` (`src/main.ts`), no `help()`
+  table entry, or no `public/ai.md` / subdoc mention. The goal is "anything the
+  UI can do, the API can do." A missing in-app AI tool (`src/ai/tools.ts`) is a
+  should-fix only when the capability is one the chat AI ought to drive.
+- Cross-engine: a commit/bake path must handle (or warn about) all four engines
+  — flag any that silently assumes manifold-js without an `engineBakeWarning`.
+
 **Back-compat (hard requirement)**
 - Backwards-incompatible schema changes: old IndexedDB sessions and previously
   exported files (STL / 3MF / OBJ / GLB / session payloads) MUST still load.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,19 @@ The app runs in multiple browser windows/tabs at once, often each driving a **di
 
 See `docs/architecture-notes.md` for the concrete implementation patterns (per-tab prefs, `storage`-event scoping, global-state rules).
 
+### UI ↔ JS-API parity — the AI must be able to drive what the UI can
+
+A core product goal: **anything a user can do from the UI, an AI agent can do through `window.partwright`** (the console / external-agent surface) and, where it fits, the in-app AI tool layer. New UI affordances drift out of parity *silently* — the mid-2026 feature audit found whole capabilities (smooth/voxelize/scale/orient, image-stamp paint, STL import, version rename/delete) reachable only by clicking. When you add or change a user-facing capability, close the loop in the **same PR**:
+
+1. **Add the `window.partwright` method** in `partwrightAPI` (`src/main.ts`), validating arguments with the `guard()` / `assert*` helpers (`src/validation/apiValidation.ts`) so console/MCP callers get the same checks as the UI. Return `{ error }` on bad input from value-returning methods; don't throw.
+2. **Register it in the `help()` table** (`src/main.ts`) — that's the discoverability surface and it must not drift from the implementation.
+3. **Document it** in `public/ai.md` (the console-API list) and the relevant `public/ai/*.md` subdoc (`file-io`, `textures`, `printing`, …). External agents read these.
+4. **Consider an in-app AI tool** (`src/ai/tools.ts`): a schema + dispatch case + the correct gating set (`SAVE_GATED` / `PAINT_GATED` / …) when the chat AI should drive it. Skip it only when it can't be driven from chat (e.g. needs local file bytes) or is too destructive to expose unscoped — and say which in the PR.
+
+> A pure static lint can't tell that a new DOM button lacks an API method — there's no typed link between the two — so **this same-PR norm plus the `work-reviewer`'s parity check are the enforcement**, not a gate. (The robust structural fix would be a single capability registry both the command palette and the API derive from; that's a deliberate larger refactor, not done yet.) `npm run lint:consistency` (ast-grep) *does* catch the related UI-*consistency* drift — modals not on `modalShell`, buttons bypassing the `BUTTON_*` constants — so run it, and prefer promoting a clean rule to `error`.
+
+**Cross-engine parity is part of this.** A tool that bakes or commits a result must work for — or explicitly warn about — all four engines; don't add a commit path that silently assumes manifold-js. See the engine-bake note under [Modeling engines](#modeling-engines-four-of-them).
+
 ### Numeric Constants and App Config
 
 Never hardcode numeric tuning constants — timeouts, limits, thresholds, budgets, quality knobs — directly in source files. Instead:

--- a/prompts/20260608-141500-ui-api-parity-guideline.md
+++ b/prompts/20260608-141500-ui-api-parity-guideline.md
@@ -1,0 +1,47 @@
+---
+session: "qvftq3"
+timestamp: "2026-06-08T14:10:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+Can we also add something to CLAUDE.md/AGENTS.md so that future agents are more
+likely to keep the JS API in parity with UI capabilities — or would extra agent
+instructions or non-AI lint tasks have prevented the issues you found?
+
+## Assistant
+
+## Key decisions
+
+**Assessment of preventability** (which drove what I added):
+
+- **UI→API parity gaps** (the main finding: capabilities reachable only by
+  clicking) are *not* reliably catchable by a static lint — there's no typed
+  link between a DOM button/command and a `window.partwright` method, so a
+  scanner can't know a capability is "missing." The robust structural fix is a
+  shared capability registry both layers derive from (a larger refactor, noted
+  as aspirational). Pragmatic prevention = a documented **same-PR parity norm** +
+  a **review-time check**. So I added both rather than a lint.
+- **UI-consistency drift** (hand-rolled modals, ad-hoc button classes) *is*
+  catchable — `lint:consistency` (ast-grep) already exists; the guidance now
+  points at it and at promoting clean rules to `error`.
+- **Doc drift** (the `help()` table covering only ~half the API) *is* catchable
+  by a cheap test asserting `help()` keys stay in sync with the live API — I
+  recommended it as a follow-up but did not build it here (it needs an
+  allow-list seed + lives in the e2e tier; out of scope for a docs change).
+
+**What I changed:**
+
+1. `CLAUDE.md` — new "UI ↔ JS-API parity" development guideline: the product
+   goal (anything the UI can do, the API can do), the same-PR 4-step checklist
+   (add the `partwrightAPI` method + validation → register in `help()` →
+   document in `ai.md`/subdoc → consider an `src/ai/tools.ts` tool), an honest
+   note on why a static lint can't enforce it, and the cross-engine bake caveat.
+   (`AGENTS.md` is a symlink to `CLAUDE.md`, so one edit covers both.)
+2. `.claude/agents/work-reviewer.md` — added a "UI ↔ JS-API parity" hunt item so
+   the pre-merge review agent flags a UI affordance that lands with no API
+   method / `help()` entry / doc, and any commit path that assumes manifold-js
+   without `engineBakeWarning`.
+
+Docs/instruction-only change — no source touched, so no build/test impact.

--- a/prompts/20260608-143000-ai-api-parity-paint-palette.md
+++ b/prompts/20260608-143000-ai-api-parity-paint-palette.md
@@ -1,0 +1,52 @@
+---
+session: "qvftq4"
+timestamp: "2026-06-08T14:25:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 2
+---
+
+## Human
+
+We can roll any agent file updates into the next PR. I also want to start the
+3rd PR tasks you suggested (the paint APIs).
+
+## Assistant
+
+## Key decisions
+
+**Scope split**: The audit's paint gaps were image-stamp paint, filament-palette
+management, and replace-color. I shipped the two *clean* ones here and deferred
+image-stamp:
+
+- **Filament palette API** (`getPalette`, `listPalettes`, `createPalette`,
+  `setActivePalette`, `addFilament`, `updateFilament`, `removeFilament`,
+  `setPaletteCapacity`, `setPaletteConstrained`) — thin, validated wrappers over
+  the pure localStorage-backed `src/color/palette.ts` functions. This lets an AI
+  read and manage the print-filament slots a multi-color model maps onto
+  (AMS/MMU), which the audit rated the highest-value clean paint gap. Migrated
+  main.ts's palette import from the `relief/filaments` re-export to the
+  `color/palette` source of truth.
+- **`replaceColor({from, to, tolerance?})`** — wraps `replaceRegionColors`
+  (colors are [r,g,b] 0..1 to match the rest of the paint API) + a color refresh.
+
+- **Deferred `paintImage` (image-stamp) to its own PR.** Its engine
+  (`stampImageOntoMesh`) exists, but the *commit* path is a large inline closure
+  in `main()` (≈ main.ts 6300–6520) tightly coupled to paint state — confined
+  subdivision, per-region remapping, `suspendReconcile`, and a stamp commit
+  hook. A faithful programmatic `paintImage` needs that closure refactored into
+  a callable (taking imageData + hitPoint/hitNormal/size/rotation) and an
+  image-based browser verification — too much to fold in safely here.
+
+**Rolled in** (per the user): the UI↔JS-API parity guideline added to `CLAUDE.md`
+and the parity check added to `.claude/agents/work-reviewer.md` (committed
+separately on this branch).
+
+**Docs**: `public/ai.md` console list + `public/ai/colors.md` (new "filament
+palette" + "bulk recolor" sections) + the `help()` table.
+
+**Verification**: build (tsc) + 800 unit tests + `lint:deps` pass. A throwaway
+Playwright spec drove `window.partwright`: add/update/remove filament,
+capacity/constrain setters, hex-validation rejecting bad input, create/list
+palette, and `replaceColor` recoloring a painted cube `[1,0,0] → [0,0,1]`
+(screenshot showed the cube turn blue), no console errors.

--- a/public/ai.md
+++ b/public/ai.md
@@ -356,6 +356,12 @@ partwright.listRegions() / listComponents() / listLabels()                // inv
 partwright.undoLastPaint() / redoLastPaint()                              // single-op undo
 partwright.removeRegion(id) / setRegionVisibility(id, visible)            // per-region edits
 partwright.hideRegion(id) / showRegion(id) / clearColors()
+partwright.replaceColor({from:[r,g,b], to:[r,g,b], tolerance?})           // bulk-recolor matching regions (0..1 colors) -> {replaced}
+// Filament palette — the print slots (AMS/MMU) regions map onto; see /ai/colors.md
+partwright.getPalette()                                                   // -> {id, name, capacity, constrained, slots:[{id,name,hex,td}]}
+partwright.listPalettes() / setActivePalette(id) / createPalette(name)
+partwright.addFilament({name, hex, td?}) / updateFilament(id, patch) / removeFilament(id)
+partwright.setPaletteCapacity(n) / setPaletteConstrained(on)
 partwright.getBucketTolerance() / setBucketTolerance(t)                   // UI bucket tool config
 partwright.getBrushSize() / setBrushSize(r)                               // UI brush tool config
 partwright.getBrushSmooth() / setBrushSmooth(on) / setBrushSmoothDivisor(2..1024) // UI smooth-brush config (detail = radius ÷ divisor)

--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -577,3 +577,46 @@ partwright.assertPaint({
 - `export3MF()` -- regions become `<basematerials>` entries with per-triangle `pid` attributes (compatible with PrusaSlicer / Bambu Studio multi-material slicing).
 - `exportSTL()` and `exportOBJ()` -- formats don't carry color, so colors are dropped.
 
+## Recoloring regions in bulk
+
+`replaceColor({from, to, tolerance?})` recolors **every** region whose color matches `from` (within `tolerance`, default 0.01) to `to`. Colors are `[r,g,b]` in 0..1 — the same range as `paintFaces`/`paintRegion`. Returns `{ replaced: count }`.
+
+```js
+// turn every red region blue
+partwright.replaceColor({ from: [1, 0, 0], to: [0, 0, 1] })  // -> { replaced: 3 }
+```
+
+This only changes region *colors*, not which triangles they cover — to repaint different triangles, use the paint selectors.
+
+## The filament palette — paint to real print slots
+
+A multi-color model prints by mapping its regions onto a printer's loaded **filament slots** (AMS / MMU). The palette is the shared set of those slots; painting with palette colors keeps a model printable on a known spool set. The palette is a cross-session user preference (localStorage), not part of the session.
+
+```js
+partwright.getPalette()
+// -> { id, name, capacity, constrained, slots: [{ id, name, hex, td }, ...] }
+//    capacity   = how many slots the printer can load at once (the AMS/MMU budget)
+//    constrained= true means paint snaps to the nearest slot color
+//    td         = a slot's transmission distance (drives the relief optical preview)
+
+// Paint a region with a palette slot's color (convert its hex to the 0..1 rgb paint takes):
+const slot = partwright.getPalette().slots[0];
+const [r, g, b] = [parseInt(slot.hex.slice(1,3),16)/255, parseInt(slot.hex.slice(3,5),16)/255, parseInt(slot.hex.slice(5,7),16)/255];
+partwright.paintByLabel({ label: 'body', color: [r, g, b] });
+```
+
+Manage the palette (all return `{ ok }`/`{ id }`/the slot, or `{ error }`):
+
+```js
+partwright.listPalettes()                       // -> [{ id, name, active }]
+partwright.createPalette('PLA basics')          // -> { id }  (then setActivePalette to switch)
+partwright.setActivePalette(id)
+partwright.addFilament({ name: 'Teal', hex: '#1fa89a', td: 1 })   // -> { id, name, hex, td }
+partwright.updateFilament(slotId, { hex: '#0e7d72' })
+partwright.removeFilament(slotId)
+partwright.setPaletteCapacity(4)                // AMS with 4 slots
+partwright.setPaletteConstrained(true)          // snap paint to the loaded slots
+```
+
+Aim for a region count within `capacity` for a single-pass multi-material print; beyond it the UI flags the model over-budget.
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,7 +129,12 @@ import { DEFAULT_RELIEF_OPTIONS, type ReliefOptions, type ReliefImportMode, type
 import { computeReliefTriColors, getSwapGuideFor, setPreviewMode as ctlSetReliefPreviewMode, getPreviewMode as ctlGetReliefPreviewMode, isPreviewActive as isReliefPreviewActive } from './relief/reliefController';
 import { setReliefSettings, getReliefSettings, updateReliefSettings, isReliefSession, getPreviewModeFor } from './relief/reliefSettings';
 import { saveReliefSource, getReliefSource } from './relief/reliefSource';
-import { listFilaments, hexToRgb, getPaletteCapacity } from './relief/filaments';
+import {
+  listFilaments, hexToRgb, getPaletteCapacity, setPaletteCapacity,
+  isPaletteConstrained, setPaletteConstrained,
+  addFilament, updateFilament, removeFilament,
+  listPalettes, createPalette, setActivePalette, getActivePaletteId, getActivePaletteName,
+} from './color/palette';
 import { meshBounds } from './color/slabPaint';
 import { openReliefImportModal } from './ui/reliefImportModal';
 import { mountReliefStudio, type ReliefStudioHandle } from './ui/reliefStudio';
@@ -180,7 +185,7 @@ import {
 import { setColor as setAnnotateColor, setWidth as setAnnotateWidth, getWidth as getAnnotateWidth } from './annotations/annotateMode';
 import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontSize as getAnnotateFontSize } from './annotations/textMode';
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
-import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, setRegionTriangles, buildTriColors, createEmptyTriColors, overlayPainted, setModelColorRegions, hasModelColorRegions, clearModelColorRegions, getModelRegions, getDistinctRegionColors, type SerializedColorRegion, type RegionDescriptor } from './color/regions';
+import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, setRegionTriangles, buildTriColors, createEmptyTriColors, overlayPainted, setModelColorRegions, hasModelColorRegions, clearModelColorRegions, getModelRegions, getDistinctRegionColors, replaceRegionColors, type SerializedColorRegion, type RegionDescriptor } from './color/regions';
 import { setPaintLabels } from './color/labels';
 import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as getPaintBucketTolerance, setBucketColorTolerance as setPaintBucketColorTolerance, getBucketColorTolerance as getPaintBucketColorTolerance, setBucketMode as setPaintBucketMode, getBucketMode as getPaintBucketMode, setBrushRadius as setPaintBrushRadius, getBrushRadius as getPaintBrushRadius, setBrushSmooth as setPaintBrushSmooth, isBrushSmooth as isPaintBrushSmooth, setBrushSmoothDivisor as setPaintBrushSmoothDivisor, getBrushSmoothDivisor as getPaintBrushSmoothDivisor, setBrushSurface as setPaintBrushSurface, getBrushSurface as getPaintBrushSurface, setBrushPaintDepth as setPaintBrushDepth, getBrushPaintDepth as getPaintBrushDepth, setBrushWrapAngle as setPaintBrushWrapAngle, getBrushWrapAngle as getPaintBrushWrapAngle, SMOOTH_DIVISOR_MIN, SMOOTH_DIVISOR_MAX, WRAP_ANGLE_MIN, WRAP_ANGLE_MAX } from './color/paintMode';
 import { buildStrokeMesh, buildRefinedMesh, buildRefinedMeshFromSet, brushRefineRegion, strokeFootprintTriangles, deriveSampleNormals, buildGeodesicField, tangentBasis, wrapAngleGate, childrenByParent, type BrushStroke, type BrushShape, type RefineRegion } from './color/subdivide';
@@ -11293,6 +11298,123 @@ async function main() {
       return { cleared: true };
     },
 
+    /** Recolor every paint region whose color matches `from` (within
+     *  `tolerance`) to `to` — the programmatic Replace-color tool. Colors are
+     *  [r,g,b] in 0..1 (the range paintFaces/paintRegion use). `tolerance`
+     *  defaults to 0.01. Returns `{ replaced: count }`. */
+    replaceColor(opts: { from: [number, number, number]; to: [number, number, number]; tolerance?: number }) {
+      const check = guard(() => {
+        assertObject(opts, 'replaceColor(opts)');
+        const from = assertNumberTuple(opts?.from, 3, 'replaceColor(opts.from)');
+        from.forEach((n, i) => assertNumber(n, `replaceColor(opts.from[${i}])`, { min: 0, max: 1 }));
+        const to = assertNumberTuple(opts?.to, 3, 'replaceColor(opts.to)');
+        to.forEach((n, i) => assertNumber(n, `replaceColor(opts.to[${i}])`, { min: 0, max: 1 }));
+        if (opts?.tolerance !== undefined) assertNumber(opts.tolerance, 'replaceColor(opts.tolerance)', { min: 0 });
+      });
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      const count = replaceRegionColors(opts.from, opts.to, opts.tolerance ?? 0.01);
+      if (count > 0) scheduleColorRefresh();
+      return { replaced: count };
+    },
+
+    // --- Filament palette (the print-color slots paint regions map onto) ------
+
+    /** Read the active filament palette — the slots a multi-color model maps onto
+     *  a printer's AMS/MMU. Returns `{ id, name, capacity, constrained, slots:
+     *  [{id, name, hex, td}] }`. `td` is the slot's transmission distance (used
+     *  by the relief optical preview). Paint with palette hex values (via
+     *  hexToRgb) so a model's colors land on real, loadable filament slots. */
+    getPalette() {
+      return {
+        id: getActivePaletteId(),
+        name: getActivePaletteName(),
+        capacity: getPaletteCapacity(),
+        constrained: isPaletteConstrained(),
+        slots: listFilaments().map(f => ({ id: f.id, name: f.name, hex: f.hex, td: f.td })),
+      };
+    },
+
+    /** List all saved palettes (spool sets). Returns `[{id, name, active}]`. */
+    listPalettes() { return listPalettes(); },
+
+    /** Create a new (empty) palette and return its id. Does not switch to it —
+     *  call setActivePalette(id) to make it active. */
+    createPalette(name: string) {
+      const check = guard(() => assertString(name, 'createPalette(name)', { allowEmpty: false }));
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      return { id: createPalette(name) };
+    },
+
+    /** Switch the active palette by id (from listPalettes()). */
+    setActivePalette(id: string) {
+      const check = guard(() => assertString(id, 'setActivePalette(id)', { allowEmpty: false }));
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      if (!listPalettes().some(p => p.id === id)) return { error: `No palette with id "${id}". Use listPalettes() to see valid ids.` };
+      setActivePalette(id);
+      return { ok: true };
+    },
+
+    /** Add a filament slot to the active palette. `hex` is "#rrggbb"; `td`
+     *  (transmission distance, default 1) tunes the relief preview. Returns the
+     *  new slot `{ id, name, hex, td }`. */
+    addFilament(opts: { name: string; hex: string; td?: number }) {
+      const check = guard(() => {
+        assertObject(opts, 'addFilament(opts)');
+        assertString(opts?.name, 'addFilament(opts.name)', { allowEmpty: false });
+        assertString(opts?.hex, 'addFilament(opts.hex)', { allowEmpty: false });
+        if (!/^#[0-9a-fA-F]{6}$/.test(opts.hex)) throw new ValidationError('addFilament(opts.hex) must be a "#rrggbb" hex color');
+        if (opts?.td !== undefined) assertNumber(opts.td, 'addFilament(opts.td)', { min: 0 });
+      });
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      const slot = addFilament({ name: opts.name, hex: opts.hex, td: opts.td ?? 1 });
+      return { id: slot.id, name: slot.name, hex: slot.hex, td: slot.td };
+    },
+
+    /** Update a filament slot's name/hex/td by id (from getPalette().slots). */
+    updateFilament(id: string, patch: { name?: string; hex?: string; td?: number }) {
+      const check = guard(() => {
+        assertString(id, 'updateFilament(id)', { allowEmpty: false });
+        assertObject(patch, 'updateFilament(patch)');
+        if (patch?.name !== undefined) assertString(patch.name, 'updateFilament(patch.name)', { allowEmpty: false });
+        if (patch?.hex !== undefined) {
+          assertString(patch.hex, 'updateFilament(patch.hex)', { allowEmpty: false });
+          if (!/^#[0-9a-fA-F]{6}$/.test(patch.hex)) throw new ValidationError('updateFilament(patch.hex) must be a "#rrggbb" hex color');
+        }
+        if (patch?.td !== undefined) assertNumber(patch.td, 'updateFilament(patch.td)', { min: 0 });
+      });
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      if (!listFilaments().some(f => f.id === id)) return { error: `No filament slot with id "${id}". Use getPalette().slots to see valid ids.` };
+      updateFilament(id, patch);
+      return { ok: true };
+    },
+
+    /** Remove a filament slot from the active palette by id. */
+    removeFilament(id: string) {
+      const check = guard(() => assertString(id, 'removeFilament(id)', { allowEmpty: false }));
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      if (!listFilaments().some(f => f.id === id)) return { error: `No filament slot with id "${id}". Use getPalette().slots to see valid ids.` };
+      removeFilament(id);
+      return { ok: true };
+    },
+
+    /** Set how many filament slots the printer can load at once (the AMS/MMU
+     *  budget). Regions beyond it are flagged over-budget in the UI. */
+    setPaletteCapacity(n: number) {
+      const check = guard(() => assertNumber(n, 'setPaletteCapacity(n)', { min: 1, integer: true }));
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      setPaletteCapacity(n);
+      return { ok: true, capacity: getPaletteCapacity() };
+    },
+
+    /** Toggle whether paint is constrained to the palette's slots (snap to the
+     *  nearest filament) versus free RGB. */
+    setPaletteConstrained(on: boolean) {
+      const check = guard(() => assertBoolean(on, 'setPaletteConstrained(on)'));
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      setPaletteConstrained(on);
+      return { ok: true, constrained: isPaletteConstrained() };
+    },
+
     /** Remove a single color region by id. Reverses one paint operation
      *  without nuking the rest. Returns `{ removed: true, id }` on success
      *  or `{ error }` if no region matches. */
@@ -12609,6 +12731,16 @@ async function main() {
         'getMeshSummary':  { signature: 'getMeshSummary({tolerance?, minTriangles?, maxTrianglesPerGroup?, maxGroups?}?) -- List coplanar face groups with centroid/normal/area/bbox', docs: '/ai/colors.md' },
         'listRegions':     { signature: 'listRegions() -- List all color regions with bbox + centroid for each', docs: '/ai/colors.md' },
         'clearColors':     { signature: 'clearColors() -- Remove ALL color regions (use undoLastPaint to reverse just one)', docs: '/ai/colors.md' },
+        'replaceColor':    { signature: 'replaceColor({from:[r,g,b], to:[r,g,b], tolerance?}) -- Recolor every region matching `from` (0..1 colors) -> {replaced}', docs: '/ai/colors.md' },
+        'getPalette':      { signature: 'getPalette() -- Active filament palette {id, name, capacity, constrained, slots:[{id,name,hex,td}]}', docs: '/ai/colors.md' },
+        'listPalettes':    { signature: 'listPalettes() -- All saved palettes [{id, name, active}]', docs: '/ai/colors.md' },
+        'createPalette':   { signature: 'createPalette(name) -- Create an empty palette -> {id} (call setActivePalette to switch)', docs: '/ai/colors.md' },
+        'setActivePalette':{ signature: 'setActivePalette(id) -- Switch active palette by id from listPalettes() -> {ok} or {error}', docs: '/ai/colors.md' },
+        'addFilament':     { signature: 'addFilament({name, hex:"#rrggbb", td?}) -- Add a slot to the active palette -> {id,name,hex,td}', docs: '/ai/colors.md' },
+        'updateFilament':  { signature: 'updateFilament(id, {name?, hex?, td?}) -- Edit a slot -> {ok} or {error}', docs: '/ai/colors.md' },
+        'removeFilament':  { signature: 'removeFilament(id) -- Remove a slot from the active palette -> {ok} or {error}', docs: '/ai/colors.md' },
+        'setPaletteCapacity': { signature: 'setPaletteCapacity(n) -- Set the AMS/MMU slot budget -> {ok, capacity}', docs: '/ai/colors.md' },
+        'setPaletteConstrained': { signature: 'setPaletteConstrained(on) -- Constrain paint to palette slots (snap) vs free RGB -> {ok, constrained}', docs: '/ai/colors.md' },
         'listComponents':  { signature: 'listComponents() -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- Decompose the manifold into boolean-distinct parts. For "paint each feature" workflows (e.g. unioned head + eyes + mouth).', docs: '/ai/colors.md' },
         'paintComponent':  { signature: 'paintComponent({index, color, name?, topOnly?}) -- One-call shortcut: listComponents + paintInBox for the Nth piece.', docs: '/ai/colors.md' },
         'listLabels':      { signature: 'listLabels() -> {count, labels: [{name, triangleCount, bbox, centroid}]} -- Labels registered in the current run via api.label(shape, name). Survives boolean ops; the cleanest paint primitive on agent-authored geometry.', docs: '/ai/colors.md' },


### PR DESCRIPTION
## Summary

Third PR from the feature audit. Closes the **clean** paint/color-management parity gaps so the console / external AI agent can target real print-filament slots, and folds in the parity-guideline doc work (per your note).

1. **Filament palette API** — `getPalette`, `listPalettes`, `createPalette`, `setActivePalette`, `addFilament`, `updateFilament`, `removeFilament`, `setPaletteCapacity`, `setPaletteConstrained`. Thin, validated wrappers over the pure localStorage-backed `src/color/palette.ts`. This lets an AI read and manage the print-filament slots a multi-color model maps onto (AMS/MMU) — the audit's highest-value clean paint gap. (Migrated main.ts's palette import to the `color/palette` source of truth.)
2. **`replaceColor({from, to, tolerance?})`** — bulk-recolor every region matching `from` (colors are `[r,g,b]` 0..1, matching the rest of the paint API), wrapping `replaceRegionColors` + a color refresh.
3. **Docs/process** (rolled in per your message): the **UI ↔ JS-API parity** development guideline in `CLAUDE.md` (the same-PR norm + an honest note on why a static lint can't enforce it) and a matching **parity check** added to the `work-reviewer` agent so it flags future UI affordances that land without an API method / `help()` entry / docs. Plus `ai.md` + `colors.md` + the `help()` table for the new methods.

## Deliberately deferred: `paintImage` (image-stamp)

The image-stamp engine (`stampImageOntoMesh`) exists, but its **commit path** is a large inline closure in `main()` (~`main.ts` 6300–6520) tightly coupled to paint state — confined subdivision, per-region remapping, `suspendReconcile`, and a stamp commit hook. A faithful programmatic `paintImage` needs that closure refactored into a callable (taking imageData + hitPoint/hitNormal/size/rotation) plus an image-based browser verification — too much to fold in safely here. Recommend its own PR.

## Test plan

- ✅ `npm run build` (tsc) · `npm run test:unit` (800) · `npm run lint:deps` (no cycles)
- ✅ Browser-verified via a throwaway Playwright spec driving `window.partwright`: add/update/remove filament, capacity + constrain setters, **hex validation rejecting `"not-a-hex"`**, create/list palette, and `replaceColor` recoloring a painted cube **`[1,0,0] → [0,0,1]`** (screenshot showed the cube turn blue) — no console errors.
- PR-checks will run the full e2e shards on this draft.

https://claude.ai/code/session_01Qv19e5UnM7HzMvaDuh512k

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv19e5UnM7HzMvaDuh512k)_