### PR TITLE
feat: add paintImage (image-stamp) to window.partwright

### DIFF
--- a/prompts/20260608-145000-ai-api-paint-image.md
+++ b/prompts/20260608-145000-ai-api-paint-image.md
@@ -1,0 +1,50 @@
+---
+session: "qvftq5"
+timestamp: "2026-06-08T14:50:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+---
+
+## Human
+
+Let's do paintImage as its own PR. (The last open paint parity gap from the
+feature audit — image-stamp painting reachable only by clicking.)
+
+## Assistant
+
+## Key decisions
+
+**The refactor was smaller than feared.** The heavy compute (footprint BFS +
+confined subdivision + region remap) was already a reusable callback
+(`smoothStampCb`, set from main.ts). The only UI-coupled piece was
+`executeStamp`, which read panel state (picked image, size, rotation, detail,
+preprocess, bg options) and committed the region. So I extracted a param-
+explicit core `runStamp(StampRun)` in `imagePaintUI.ts`; `executeStamp` now
+builds a `StampRun` from UI state and calls it, and a new exported
+`stampImageProgrammatic(imageData, params)` builds one from explicit params.
+Behaviour for the UI path is unchanged (the one latent inconsistency — the
+descriptor keyed `entries`/smooth-params off the `stampSmooth` toggle while the
+compute branch used the fuller `smooth && maxEdge>0 && cb` condition — is now
+consistent via a single `useSmooth`, which only differs in a path unreachable
+with the default detail=96 + always-set callback).
+
+**`window.partwright.paintImage({imageUrl, at, normal, size, rotationDeg?,
+detail?, removeBackground?, name?})`** — loads the image via the existing
+`loadImageDataFromUrl`, then calls `stampImageProgrammatic`. `at`/`normal` are
+the stamp centre + outward face direction (agent gets them from `probeRay` /
+`measureAt` / a known face centre); only forward-facing footprint triangles are
+painted. Returns `{ ok, name, triangles, avgColor }` or a clear `{ error }` when
+the footprint is empty. Validated with guard/assert*; deferred the in-app AI
+tool (consistent with the prior PRs — the chat AI would need an attached image's
+data URL; noted as follow-up).
+
+**Docs**: `public/ai.md` console list + a "Stamping an image" section in
+`public/ai/colors.md` (incl. how to get `at`/`normal` and the saveVersion
+reminder) + the `help()` table.
+
+**Verification**: build (tsc) + 800 unit tests + `lint:deps` pass. A throwaway
+Playwright spec generated a data-URL image (red disc on white), ran a 40mm cube,
+and `paintImage`'d it onto the +Z face: 7,452 triangles painted (white bg
+removed), exactly one region created, avgColor red; an off-surface stamp
+correctly returned the "nothing painted" error. Screenshot showed the red disc
+on the cube's top face.

--- a/public/ai.md
+++ b/public/ai.md
@@ -357,6 +357,7 @@ partwright.undoLastPaint() / redoLastPaint()                              // sin
 partwright.removeRegion(id) / setRegionVisibility(id, visible)            // per-region edits
 partwright.hideRegion(id) / showRegion(id) / clearColors()
 partwright.replaceColor({from:[r,g,b], to:[r,g,b], tolerance?})           // bulk-recolor matching regions (0..1 colors) -> {replaced}
+await partwright.paintImage({imageUrl, at:[x,y,z], normal:[nx,ny,nz], size, rotationDeg?, detail?, removeBackground?, name?}) // stamp an image onto the surface as a region -> {ok, name, triangles, avgColor}; get at/normal from probeRay; see /ai/colors.md
 // Filament palette — the print slots (AMS/MMU) regions map onto; see /ai/colors.md
 partwright.getPalette()                                                   // -> {id, name, capacity, constrained, slots:[{id,name,hex,td}]}
 partwright.listPalettes() / setActivePalette(id) / createPalette(name)

--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -588,6 +588,29 @@ partwright.replaceColor({ from: [1, 0, 0], to: [0, 0, 1] })  // -> { replaced: 3
 
 This only changes region *colors*, not which triangles they cover — to repaint different triangles, use the paint selectors.
 
+## Stamping an image onto the surface
+
+`paintImage({imageUrl, at, normal, size, ...})` projects an image onto the model as a color region — the programmatic Image-paint tool. Use it for logos, decals, faces, or photo decals on a surface.
+
+```js
+// stamp a logo on the +Z face of a 20mm cube, centred, 12mm across
+await partwright.paintImage({
+  imageUrl: logoDataUrl,     // a data: URL or a same-origin URL
+  at: [0, 0, 10],            // stamp centre, ON the surface (world coords)
+  normal: [0, 0, 1],         // the outward face direction there
+  size: 12,                  // stamp diameter in world units
+  rotationDeg: 0,            // spin around the normal (optional)
+  detail: 96,                // triangle rows across the stamp; higher = crisper. 0 = flat
+  removeBackground: true,    // drop the image's background (default true)
+})
+// -> { ok, name, triangles, avgColor } or { error }
+```
+
+- **Getting `at` / `normal`:** use `probeRay({origin, direction})` (returns the hit point + face normal), `measureAt([x,y])`, or a known face centre — `at` must lie on the surface and `normal` must face outward, or the footprint is empty and you get `{ error }`.
+- Only **forward-facing** triangles inside the stamp square are painted, so a stamp never bleeds onto the far side.
+- The stamp subdivides the footprint for crisp edges (smooth mode), so the model's triangle count rises locally — call `getGeometryData()` after if you care about the budget.
+- Call `saveVersion('stamped')` afterwards to persist it (paint isn't auto-saved).
+
 ## The filament palette — paint to real print slots
 
 A multi-color model prints by mapping its regions onto a printer's loaded **filament slots** (AMS / MMU). The palette is the shared set of those slots; painting with palette colors keeps a model printable on a known spool set. The palette is a cross-session user preference (localStorage), not part of the session.

--- a/src/color/imagePaintUI.ts
+++ b/src/color/imagePaintUI.ts
@@ -353,55 +353,86 @@ function updatePreviewLines(
 
 function executeStamp(hitPoint: [number, number, number], hitNormal: [number, number, number]): void {
   if (!pickedImageData) return;
-
-  const stampOpts: StampImageOptions = {
+  const maxEdge = stampDetail > 0 ? stampSize / stampDetail : 0;
+  runStamp({
+    imageData: pickedImageData,
     hitPoint,
     hitNormal,
     size: stampSize,
     rotationDeg: stampRotation,
-    preprocess: { ...opts.preprocess },
+    smooth: stampSmooth && maxEdge > 0,
+    maxEdge,
     removeBackground: opts.removeBackground,
-    manualBgColor: opts.manualBgColor ? [...opts.manualBgColor] as [number, number, number] : undefined,
+    manualBgColor: opts.manualBgColor,
+    preprocess: opts.preprocess,
+  });
+}
+
+interface StampRun {
+  imageData: ImageData;
+  hitPoint: [number, number, number];
+  hitNormal: [number, number, number];
+  size: number;
+  rotationDeg: number;
+  /** Subdivide the stamp footprint for crisp detail (uses the smooth callback). */
+  smooth: boolean;
+  /** Target triangle edge length when smoothing (stampSize / detail-rows). */
+  maxEdge: number;
+  removeBackground: boolean;
+  manualBgColor?: [number, number, number];
+  preprocess: PreprocessOptions;
+  name?: string;
+}
+
+/** Shared stamp core: compute the per-triangle colours (smooth-subdivided when
+ *  asked, else flat on the current mesh) and commit them as an `imagePaint`
+ *  region. Used by both the click-driven UI (executeStamp) and the programmatic
+ *  `stampImageProgrammatic` API. Returns the committed region summary, or null
+ *  when nothing was painted (empty footprint / no mesh). */
+function runStamp(r: StampRun): { name: string; triangles: number; avgColor: [number, number, number] } | null {
+  const stampOpts: StampImageOptions = {
+    hitPoint: r.hitPoint,
+    hitNormal: r.hitNormal,
+    size: r.size,
+    rotationDeg: r.rotationDeg,
+    preprocess: { ...r.preprocess },
+    removeBackground: r.removeBackground,
+    manualBgColor: r.manualBgColor ? [...r.manualBgColor] as [number, number, number] : undefined,
     bgTolerance: 36 * 36 * 3,
   };
 
   let result: ImagePaintResult;
-
-  // Convert the size-independent Detail level (triangle rows across the stamp)
-  // into an absolute target edge length for the subdivision. Stored on the
-  // descriptor so a reloaded session reproduces the same tessellation regardless
-  // of how the slider is later expressed.
-  const maxEdge = stampDetail > 0 ? stampSize / stampDetail : 0;
-
-  if (stampSmooth && maxEdge > 0 && smoothStampCb) {
+  const useSmooth = r.smooth && r.maxEdge > 0 && !!smoothStampCb;
+  if (useSmooth) {
     // Smooth mode: callback subdivides the stamp footprint to maxEdge (confined
     // to the stamp square), then stamps on the fine mesh — giving crisp detail.
-    const refined = smoothStampCb(pickedImageData, stampOpts, maxEdge);
-    if (!refined || refined.result.entries.length === 0) return;
+    const refined = smoothStampCb!(r.imageData, stampOpts, r.maxEdge);
+    if (!refined || refined.result.entries.length === 0) return null;
     result = refined.result;
   } else {
     const mesh = getPaintMesh();
-    if (!mesh) return;
-    result = stampImageOntoMesh(mesh, pickedImageData, stampOpts);
-    if (result.entries.length === 0) return;
+    if (!mesh) return null;
+    result = stampImageOntoMesh(mesh, r.imageData, stampOpts);
+    if (result.entries.length === 0) return null;
   }
 
   stampCounter++;
+  const name = r.name ?? `Stamp ${stampCounter}`;
   const triangles = new Set(result.perTriColors.keys());
   const commit = () => addRegion(
-    `Stamp ${stampCounter}`,
+    name,
     result.avgColor,
     'imagePaint',
     {
       kind: 'imagePaint',
-      entries: stampSmooth ? [] : result.entries,
+      entries: useSmooth ? [] : result.entries,
       avgColor: result.avgColor,
-      ...(stampSmooth ? {
-        smooth: true, maxEdge,
-        hitPoint, hitNormal, stampSize, rotationDeg: stampRotation,
-        imageDataUrl: compactImageDataUrl(pickedImageData!),
-        removeBackground: opts.removeBackground,
-        ...(opts.manualBgColor ? { manualBgColor: opts.manualBgColor } : {}),
+      ...(useSmooth ? {
+        smooth: true, maxEdge: r.maxEdge,
+        hitPoint: r.hitPoint, hitNormal: r.hitNormal, stampSize: r.size, rotationDeg: r.rotationDeg,
+        imageDataUrl: compactImageDataUrl(r.imageData),
+        removeBackground: r.removeBackground,
+        ...(r.manualBgColor ? { manualBgColor: r.manualBgColor } : {}),
         bgTolerance: 36 * 36 * 3,
       } : {}),
     },
@@ -414,6 +445,51 @@ function executeStamp(hitPoint: [number, number, number], hitNormal: [number, nu
   // so adding the stamp can't trigger a mesh rebuild that drops it or existing paint.
   if (stampCommitHook) stampCommitHook(commit);
   else commit();
+  return { name, triangles: triangles.size, avgColor: result.avgColor };
+}
+
+export interface ProgrammaticStampParams {
+  /** Stamp centre on the surface (world coords). */
+  hitPoint: [number, number, number];
+  /** Outward face direction at the stamp centre. */
+  hitNormal: [number, number, number];
+  /** Stamp diameter in world units. */
+  size: number;
+  rotationDeg?: number;
+  /** Triangle rows across the stamp; >0 subdivides for crisp detail (default
+   *  96, matching the UI). 0 = flat stamp on the existing tessellation. */
+  detail?: number;
+  removeBackground?: boolean;
+  manualBgColor?: [number, number, number];
+  preprocess?: PreprocessOptions;
+  /** Region label; defaults to "Stamp N". */
+  name?: string;
+}
+
+/** Stamp `imageData` onto the current mesh programmatically — the engine behind
+ *  the Image-paint tool, exposed so `window.partwright.paintImage` can drive it
+ *  without a click. Mirrors the UI's executeStamp but takes explicit params
+ *  instead of panel state. Returns the committed region summary or null. */
+export function stampImageProgrammatic(
+  imageData: ImageData,
+  params: ProgrammaticStampParams,
+): { name: string; triangles: number; avgColor: [number, number, number] } | null {
+  const size = params.size;
+  const detail = params.detail ?? 96;
+  const maxEdge = detail > 0 ? size / detail : 0;
+  return runStamp({
+    imageData,
+    hitPoint: params.hitPoint,
+    hitNormal: params.hitNormal,
+    size,
+    rotationDeg: params.rotationDeg ?? 0,
+    smooth: maxEdge > 0,
+    maxEdge,
+    removeBackground: params.removeBackground ?? true,
+    manualBgColor: params.manualBgColor,
+    preprocess: params.preprocess ?? defaultPreprocess(),
+    name: params.name,
+  });
 }
 
 // ─── Panel construction ───────────────────────────────────────────────────────

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,7 +155,7 @@ import { initTooltips } from './ui/tooltip';
 import { initTheme, getTheme, setTheme } from './ui/theme';
 import type { Theme } from './ui/theme';
 import { initPaintUI, isPaintOpen, forceDeactivate as closePaintMenu } from './color/paintUI';
-import { initImagePaintUI, setSmoothStampCallback, setStampCommitHook } from './color/imagePaintUI';
+import { initImagePaintUI, setSmoothStampCallback, setStampCommitHook, stampImageProgrammatic } from './color/imagePaintUI';
 import { stampImageOntoMesh, buildTangentFrame, entriesToPerTriColors, remapPerTriColors, loadImageDataFromUrl } from './color/imagePaint';
 import { initVoxelPaintUI, setVoxelPaintAvailable, syncActiveState as syncVoxelPaintUI } from './color/voxelPaintUI';
 import { initSimplifyUI, isSimplifyOpen, refreshSimplifyIfOpen, forceDeactivate as closeSimplifyMenu, notifyQualityLangChanged, setQualityRenderState, type SimplifyHandlers } from './ui/simplifyUI';
@@ -11317,6 +11317,52 @@ async function main() {
       return { replaced: count };
     },
 
+    /** Stamp an image onto the model surface as a color region — the
+     *  programmatic Image-paint tool. `imageUrl` is a `data:` URL or a
+     *  same-origin URL. `at` is the stamp centre on the surface (world coords)
+     *  and `normal` the outward face direction there — get them from probeRay /
+     *  measureAt / a face centroid. `size` is the stamp diameter in world units.
+     *  `detail` (default 96) is triangle rows across the stamp — higher = crisper
+     *  (0 = flat stamp on the existing tessellation). `removeBackground` (default
+     *  true) drops the image's background. Only forward-facing triangles inside
+     *  the footprint are painted. Returns `{ ok, name, triangles, avgColor }` or
+     *  `{ error }`. Call saveVersion() afterwards to persist. */
+    async paintImage(opts: { imageUrl: string; at: [number, number, number]; normal: [number, number, number]; size: number; rotationDeg?: number; detail?: number; removeBackground?: boolean; name?: string }) {
+      const check = guard(() => {
+        assertObject(opts, 'paintImage(opts)');
+        assertString(opts?.imageUrl, 'paintImage(opts.imageUrl)', { allowEmpty: false });
+        assertNumberTuple(opts?.at, 3, 'paintImage(opts.at)').forEach((n, i) => assertNumber(n, `paintImage(opts.at[${i}])`, {}));
+        assertNumberTuple(opts?.normal, 3, 'paintImage(opts.normal)').forEach((n, i) => assertNumber(n, `paintImage(opts.normal[${i}])`, {}));
+        assertNumber(opts?.size, 'paintImage(opts.size)', { min: 0 });
+        if (opts.size <= 0) throw new ValidationError('paintImage(opts.size) must be greater than 0');
+        if (opts?.rotationDeg !== undefined) assertNumber(opts.rotationDeg, 'paintImage(opts.rotationDeg)', {});
+        if (opts?.detail !== undefined) assertNumber(opts.detail, 'paintImage(opts.detail)', { min: 0, integer: true });
+        if (opts?.removeBackground !== undefined) assertBoolean(opts.removeBackground, 'paintImage(opts.removeBackground)');
+        if (opts?.name !== undefined) assertString(opts.name, 'paintImage(opts.name)', { allowEmpty: false });
+      });
+      if (typeof check === 'object' && check !== null && 'error' in check) return check;
+      if (!currentMeshData) return { error: 'No model loaded — run code first.' };
+      let imageData: ImageData;
+      try {
+        imageData = await loadImageDataFromUrl(opts.imageUrl);
+      } catch (e) {
+        return { error: `paintImage: could not load image — ${e instanceof Error ? e.message : String(e)}` };
+      }
+      const region = stampImageProgrammatic(imageData, {
+        hitPoint: opts.at,
+        hitNormal: opts.normal,
+        size: opts.size,
+        rotationDeg: opts.rotationDeg,
+        detail: opts.detail,
+        removeBackground: opts.removeBackground,
+        name: opts.name,
+      });
+      if (!region) {
+        return { error: 'paintImage: nothing was painted — the stamp footprint was empty. Check that `at` lies on the surface and `normal` faces outward, and that `size` is large enough to cover triangles.' };
+      }
+      return { ok: true, name: region.name, triangles: region.triangles, avgColor: region.avgColor };
+    },
+
     // --- Filament palette (the print-color slots paint regions map onto) ------
 
     /** Read the active filament palette — the slots a multi-color model maps onto
@@ -12732,6 +12778,7 @@ async function main() {
         'listRegions':     { signature: 'listRegions() -- List all color regions with bbox + centroid for each', docs: '/ai/colors.md' },
         'clearColors':     { signature: 'clearColors() -- Remove ALL color regions (use undoLastPaint to reverse just one)', docs: '/ai/colors.md' },
         'replaceColor':    { signature: 'replaceColor({from:[r,g,b], to:[r,g,b], tolerance?}) -- Recolor every region matching `from` (0..1 colors) -> {replaced}', docs: '/ai/colors.md' },
+        'paintImage':      { signature: 'await paintImage({imageUrl, at:[x,y,z], normal:[nx,ny,nz], size, rotationDeg?, detail?, removeBackground?, name?}) -- Stamp an image onto the surface as a color region -> {ok, name, triangles, avgColor} or {error}', docs: '/ai/colors.md' },
         'getPalette':      { signature: 'getPalette() -- Active filament palette {id, name, capacity, constrained, slots:[{id,name,hex,td}]}', docs: '/ai/colors.md' },
         'listPalettes':    { signature: 'listPalettes() -- All saved palettes [{id, name, active}]', docs: '/ai/colors.md' },
         'createPalette':   { signature: 'createPalette(name) -- Create an empty palette -> {id} (call setActivePalette to switch)', docs: '/ai/colors.md' },


### PR DESCRIPTION
## Summary

Closes the **last paint parity gap** from the feature audit: stamping an image onto the model surface (the 🖼️ Image tool) was reachable only by clicking. Now an AI/console caller can drive it.

### The refactor (smaller than expected)
The heavy compute — footprint BFS + confined subdivision + region remap — was *already* a reusable callback (`smoothStampCb`, set from main.ts). The only UI-coupled piece was `executeStamp`, which read panel state and committed the region. So I extracted a param-explicit core **`runStamp(StampRun)`** in `imagePaintUI.ts`:
- `executeStamp` (click path) now builds a `StampRun` from UI state and calls it — **behaviour unchanged**.
- A new exported **`stampImageProgrammatic(imageData, params)`** builds one from explicit params.

### `window.partwright.paintImage(...)`
```js
await partwright.paintImage({
  imageUrl,                // data: URL or same-origin URL
  at: [x, y, z],           // stamp centre on the surface
  normal: [nx, ny, nz],    // outward face direction (from probeRay / measureAt / a face centre)
  size, rotationDeg?, detail?, removeBackground?, name?,
})
// -> { ok, name, triangles, avgColor } or { error }
```
Loads the image via the existing `loadImageDataFromUrl`, stamps it as a color region (only forward-facing footprint triangles), and returns a clear `{ error }` when the footprint is empty. Validated with `guard`/`assert*`.

Docs: `public/ai.md` + a "Stamping an image" section in `public/ai/colors.md` (incl. how to obtain `at`/`normal` and the `saveVersion` reminder) + the `help()` table.

**Deferred** (consistent with the prior parity PRs): the in-app `src/ai/tools.ts` tool — the chat AI would need an attached image's data URL; noted as a follow-up.

## Test plan
- ✅ `npm run build` (tsc) · `npm run test:unit` (800) · `npm run lint:deps` (no cycles)
- ✅ Browser-verified via a throwaway Playwright spec: generated a data-URL image (red disc on white), ran a 40 mm cube, and `paintImage`'d it onto the +Z face — **7,452 triangles painted** (white background removed), exactly one region created, `avgColor` red; an off-surface stamp correctly returned the "nothing painted" error. Screenshot showed the red disc on the cube's top face.
- PR-checks will run the full e2e shards on this draft.

https://claude.ai/code/session_01Qv19e5UnM7HzMvaDuh512k

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv19e5UnM7HzMvaDuh512k)_