### PR TITLE
feat: voxel studio delete fixes + keep voxel colors after regular paint

### DIFF
--- a/prompts/voxel-colors-survive-regular-paint.md
+++ b/prompts/voxel-colors-survive-regular-paint.md
@@ -1,0 +1,53 @@
+---
+session: "01TLwb"
+timestamp: "2026-06-08T15:55:00Z"
+---
+
+## Human
+
+When using the regular (mesh) Paint tool on an imported voxel tile, the voxel
+colourisation disappears — but reopening Voxel Studio brings the colours back.
+The user wants the voxel colours kept all the time, even after a regular paint
+operation. (Asked to investigate and recommend among: keep colours / warn it
+converts to mesh / disable paint on voxel sessions.) Chose **keep the colours**.
+
+## Assistant
+
+## Key decisions
+
+**Root cause: paint's colour compositing blanks everything it didn't paint.**
+`buildTriColors` (regions.ts) allocates a fresh all-zero buffer and a `_painted`
+sidecar that's `1` only on user-painted triangles, then hands it to the viewport.
+The renderer shows the default shade wherever `_painted[t] === 0`, so every
+triangle the user didn't paint loses the voxel mesh's per-triangle colour.
+Reopening Voxel Studio re-runs the code, regenerating the mesh with full voxel
+colours — which is why the colours "came back". This would hit any pre-coloured
+import (coloured STL, relief), not just voxels.
+
+**Fix part 1 — seed the composite from the base mesh's own colours.** Added an
+optional `baseColors` arg to `buildTriColors`; when present it pre-seeds the
+buffer (and marks those triangles painted) before the region layers composite on
+top. `applyTriColors` (export) and `applyTriColorsIfVisible` (viewport) now pass
+`mesh.triColors`. Plain manifold sessions have no `triColors`, so they're
+unaffected — verified the "no base colours" path keeps the prior behaviour.
+
+**Fix part 2 — carry colours through paint's mesh subdivision.** The smooth
+brush subdivides the rim triangles, and the subdivision built new meshes without
+`triColors`, so colours would still vanish there. Added `propagateTriColors` in
+subdivide.ts and applied it at the two refine chokepoints (`buildRefinedMesh`,
+`buildRefinedMeshFromSet`) so each child triangle inherits its parent's colour
+and painted flag via the already-computed `childToParent` map. Both paint paths
+(`refineMeshForRegions` full rebuild and `buildStrokeMesh` incremental append)
+route through these, so colours survive every brush.
+
+**Scope.** Left the analysis-only `buildTriColors` callers (bucket seed match,
+surface modal, optical preview) unchanged — they want the region-only composite.
+Did not add a convert-to-mesh warning or disable paint on voxel sessions; the
+user picked "keep the colours", and the seed fix makes regular paint additive
+over the voxel colours, which is the least-surprising behaviour.
+
+**Verification.** Reproduced end-to-end: painted a two-colour voxel slab with
+the regular Paint tool and confirmed the green/orange voxel colours survive
+(previously the model reverted to default blue except the painted patch). Added
+unit tests for the seeding (base colour preserved on unpainted tris; plain mesh
+unchanged). Full unit tier (802) + paint/voxel/smooth-brush e2e pass.

--- a/prompts/voxel-studio-delete-no-rotate-and-preview.md
+++ b/prompts/voxel-studio-delete-no-rotate-and-preview.md
@@ -1,0 +1,52 @@
+---
+session: "01TLwb"
+timestamp: "2026-06-08T15:05:00Z"
+---
+
+## Human
+
+When opening the voxel studio, dragging/clicking on the model should not rotate
+the interactive view, the way the paint menu already behaves. On investigation
+the real trigger was the **voxel delete tool**. The user also asked for the
+delete tool to show a brush-size preview shape so they can tell what they're
+about to delete. (A third request — keeping voxel colours after a regular paint
+operation — is being investigated separately and is not part of this change.)
+
+## Assistant
+
+## Key decisions
+
+**Diagnosed the "voxel studio rotates" report as the delete tool carving holes,
+not a missing suppressor.** The studio already vetoed OrbitControls for
+on-model presses exactly like mesh paint (`isPointerOverModel`). Reproduced with
+a real-mouse Playwright drag: the default brush never rotates, but the delete
+tool does — because deleting punches holes through the mesh, and a *surface*
+raycast misses over a hole, so the press falls through to OrbitControls. Paint
+never hits this because painting can't remove geometry.
+
+**Fixed it with a bounds-based veto for the studio, not a surface-based one.**
+Added `isPointerWithinModelBounds` to the viewport (raycasts the model's AABB via
+`ray.intersectsBox`) and switched the voxel studio's pointer suppressor to it.
+Now any press within the model's footprint — including into a just-carved hole —
+counts as edit-intent and never rotates, while a drag that starts clearly
+outside the model still orbits. Surface-based veto would have required tracking a
+"pre-edit" silhouette; bounds is a simple, robust proxy. Trade-off: orbiting now
+needs a drag from outside the bounding box rather than just outside the
+silhouette — acceptable in an editing context, and verified that off-model orbit
+still works.
+
+**Added a brush-footprint hover preview for the brush tools.** A single
+`InstancedMesh` of slightly-oversized unit cubes (added to the scene like the
+mesh-paint brush ring) highlights the cells the active tool would touch at the
+hovered voxel: occupied cells for paint/remove, empty cells for add. Tinted red
+for delete ("this gets removed"), the paint colour otherwise. It follows the
+cursor (hover *and* during a stroke off one shared raycast), retints/resizes
+live when the tool or brush size/shape changes, clears on the press that commits
+the edit and on pointer-leave, and is disposed on deactivate. `onPointerMove`
+was previously stroke-only; it now also drives the hover preview.
+
+**Verification.** Repro'd the rotation bug and confirmed the fix with real-mouse
+drags (in-hole drag: 52° → 0°; off-model drag still ~85°). Screenshotted the
+delete (red sphere) and paint (cube) previews. Added
+`tests/voxel-studio-camera.spec.ts` as the regression guard. Full unit tier +
+all voxel e2e specs pass.

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -542,7 +542,7 @@ export function clearModelColorRegions(): void {
  *  region re-resolves by matching colors, so it must read the surface color
  *  *underneath* itself — without this, its own freshly-stamped color would mask
  *  the source color it's meant to follow and the flood would collapse to the seed. */
-export function buildTriColors(numTri: number, respectPerRegionVisibility = false, excludeRegionId?: number): Uint8Array | null {
+export function buildTriColors(numTri: number, respectPerRegionVisibility = false, excludeRegionId?: number, baseColors?: Uint8Array | null): Uint8Array | null {
   if (regions.length === 0 && modelRegions.length === 0) return null;
 
   const buf = new Uint8Array(numTri * 3); // default 0,0,0 — ignored for un-colored tris
@@ -550,6 +550,20 @@ export function buildTriColors(numTri: number, respectPerRegionVisibility = fals
   // from order so a region can legitimately paint pure black (and so the
   // model-color base layer counts as painted even though it sits below paint).
   const painted = new Uint8Array(numTri);
+
+  // Seed from the mesh's own per-triangle colours (e.g. a voxel grid's colours
+  // or an imported coloured model's) so painting a few regions doesn't blank the
+  // rest of the model back to the default shade — the regions composite on top.
+  if (baseColors && baseColors.length >= numTri * 3) {
+    buf.set(baseColors.subarray(0, numTri * 3));
+    const basePainted = (baseColors as Uint8Array & { _painted?: Uint8Array })._painted;
+    for (let t = 0; t < numTri; t++) {
+      const seeded = basePainted
+        ? basePainted[t] === 1
+        : (buf[t * 3] !== 0 || buf[t * 3 + 1] !== 0 || buf[t * 3 + 2] !== 0);
+      if (seeded) painted[t] = 1;
+    }
+  }
 
   // Stamp one layer of regions onto buf, higher `order` winning WITHIN the
   // layer. Layers are applied in call order, so a later layer overwrites an
@@ -644,7 +658,7 @@ export function serialize(): SerializedColorRegion[] {
 /** Apply triColors to a MeshData, returning a new object (non-destructive).
  *  Use for EXPORTS — all regions are baked in regardless of UI visibility flags. */
 export function applyTriColors(mesh: MeshData): MeshData {
-  const triColors = buildTriColors(mesh.numTri, false);
+  const triColors = buildTriColors(mesh.numTri, false, undefined, mesh.triColors);
   if (!triColors) return mesh;
   return { ...mesh, triColors };
 }
@@ -654,7 +668,7 @@ export function applyTriColors(mesh: MeshData): MeshData {
  *  `visible` flag is false (eye-icon toggles in the region list). */
 export function applyTriColorsIfVisible(mesh: MeshData): MeshData {
   if (!visible) return mesh;
-  const triColors = buildTriColors(mesh.numTri, true);
+  const triColors = buildTriColors(mesh.numTri, true, undefined, mesh.triColors);
   if (!triColors) return mesh;
   return { ...mesh, triColors };
 }

--- a/src/color/subdivide.ts
+++ b/src/color/subdivide.ts
@@ -1117,7 +1117,7 @@ export function buildRefinedMeshFromSet(
     mesh = nm;
   }
 
-  return { mesh, childToParent: comp };
+  return { mesh: propagateTriColors(base, mesh, comp), childToParent: comp };
 }
 
 /** Refine each region of a mesh until its boundary triangles fall below the
@@ -1151,7 +1151,7 @@ export function buildRefinedMesh(
       comp = composeMaps(comp, childToParent);
     }
   }
-  return { mesh, childToParent: comp };
+  return { mesh: propagateTriColors(base, mesh, comp), childToParent: comp };
 }
 
 /** Convenience wrapper: refine a base mesh under an ordered list of brush
@@ -1167,6 +1167,31 @@ function composeMaps(parentToBase: Int32Array, childToParent: Int32Array): Int32
   const out = new Int32Array(childToParent.length);
   for (let i = 0; i < out.length; i++) out[i] = parentToBase[childToParent[i]];
   return out;
+}
+
+/** Carry a base mesh's per-triangle colours onto a refined mesh: each output
+ *  triangle inherits the colour (and `_painted` flag) of the base triangle it
+ *  was split from. This lets a pre-coloured mesh (a voxel grid, an imported
+ *  coloured model) keep its colours through paint subdivision instead of the
+ *  refined triangles reverting to the default shade. No-op when the base carries
+ *  no `triColors`, or when nothing was refined (output === base). */
+function propagateTriColors(base: MeshData, refined: MeshData, childToParent: Int32Array): MeshData {
+  const src = base.triColors as (Uint8Array & { _painted?: Uint8Array }) | undefined;
+  if (!src || refined === base) return refined;
+  const n = refined.numTri;
+  const dst = new Uint8Array(n * 3);
+  const srcPainted = src._painted;
+  const dstPainted = srcPainted ? new Uint8Array(n) : undefined;
+  for (let i = 0; i < n; i++) {
+    const p = childToParent[i];
+    if (p < 0) continue;
+    dst[i * 3] = src[p * 3];
+    dst[i * 3 + 1] = src[p * 3 + 1];
+    dst[i * 3 + 2] = src[p * 3 + 2];
+    if (srcPainted && dstPainted) dstPainted[i] = srcPainted[p];
+  }
+  if (dstPainted) (dst as Uint8Array & { _painted?: Uint8Array })._painted = dstPainted;
+  return { ...refined, triColors: dst };
 }
 
 /** Invert a final→base triangle map into base→[final children]. Used to carry

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -15,15 +15,16 @@
 // code once on activate to get the grid + per-triangle voxel/normal
 // provenance, and all subsequent clicks are local — no Worker round-trip.
 
+import * as THREE from 'three';
 import type { MeshData } from '../geometry/types';
 import { normalizeColor, type VoxelGrid } from '../geometry/voxel/grid';
 import { gridToMeshWithProvenance } from '../geometry/voxel/mesher';
 import { runVoxelForPaint, type VoxelPaintRun } from '../geometry/engines/voxel';
-import { bucketRecolor, clearBox, fillBoxRecolor, addTarget, brushApply, levelRecolor, type BrushShape } from '../geometry/voxel/edits';
+import { bucketRecolor, clearBox, fillBoxRecolor, addTarget, brushApply, levelRecolor, inBrush, type BrushShape } from '../geometry/voxel/edits';
 import { diffGrids, type VoxelEditOps } from '../geometry/voxel/editCodegen';
 import { generateVoxelImportCode } from '../import/imageToVoxel';
-import { addPointerSuppressor, isPointerOverModel, getRenderer } from '../renderer/viewport';
-import { pickFace } from './facePicker';
+import { addPointerSuppressor, isPointerWithinModelBounds, getRenderer, getScene, requestRender } from '../renderer/viewport';
+import { pickFace, type FacePickResult } from './facePicker';
 import { registerExclusiveMode, deactivateMode } from '../ui/modeExclusion';
 
 export type { BrushShape } from '../geometry/voxel/edits';
@@ -97,6 +98,7 @@ export function setTool(t: VoxelTool): void {
   if (strokeActive) endStroke();
   tool = t;
   boxCorner = null;
+  refreshPreview();
   cbStateChange?.();
 }
 
@@ -105,10 +107,11 @@ const MAX_BRUSH_RADIUS = 16;
 export function getBrushRadius(): number { return brushRadius; }
 export function setBrushRadius(r: number): void {
   brushRadius = Math.max(0, Math.min(MAX_BRUSH_RADIUS, Math.round(r) || 0));
+  refreshPreview();
   cbStateChange?.();
 }
 export function getBrushShape(): BrushShape { return brushShape; }
-export function setBrushShape(s: BrushShape): void { brushShape = s; cbStateChange?.(); }
+export function setBrushShape(s: BrushShape): void { brushShape = s; refreshPreview(); cbStateChange?.(); }
 export function isSpray(): boolean { return spray; }
 export function setSpray(on: boolean): void { spray = !!on; cbStateChange?.(); }
 export function getSprayDensity(): number { return sprayDensity; }
@@ -400,6 +403,99 @@ function sameVoxel(a: [number, number, number] | null, b: [number, number, numbe
   return !!a && !!b && a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
 }
 
+// ── Brush hover preview ──────────────────────────────────────────────────────
+// A translucent overlay of the cells the active brush tool would touch at the
+// hovered voxel, so the user can judge brush size/shape before committing —
+// most useful for the delete tool, where it shows exactly which voxels will be
+// removed. Rendered as a single InstancedMesh of slightly-oversized unit cubes
+// added to the scene (a transient overlay, like the mesh-paint brush ring).
+const PREVIEW_TINT_REMOVE = 0xff4d4d; // red = "this gets deleted"
+const PREVIEW_CELL_SCALE = 1.06;      // a touch larger than a voxel → reads as a shell
+let previewMesh: THREE.InstancedMesh | null = null;
+let previewCapacity = 0;
+let lastHoverEvent: { clientX: number; clientY: number } | null = null;
+const previewMatrix = new THREE.Matrix4();
+
+function disposePreview(): void {
+  if (!previewMesh) return;
+  previewMesh.parent?.remove(previewMesh);
+  previewMesh.geometry.dispose();
+  (previewMesh.material as THREE.Material).dispose();
+  previewMesh = null;
+  previewCapacity = 0;
+}
+
+function clearPreview(): void {
+  if (previewMesh && previewMesh.count > 0) { previewMesh.count = 0; requestRender(); }
+}
+
+function ensurePreviewCapacity(n: number): void {
+  if (previewMesh && previewCapacity >= n) return;
+  disposePreview();
+  const cap = Math.max(8, n);
+  const geo = new THREE.BoxGeometry(PREVIEW_CELL_SCALE, PREVIEW_CELL_SCALE, PREVIEW_CELL_SCALE);
+  const mat = new THREE.MeshBasicMaterial({ transparent: true, opacity: 0.45, depthWrite: false });
+  previewMesh = new THREE.InstancedMesh(geo, mat, cap);
+  previewMesh.frustumCulled = false;
+  previewMesh.renderOrder = 1000;
+  previewMesh.count = 0;
+  getScene().add(previewMesh);
+  previewCapacity = cap;
+}
+
+/** The voxel cells the active brush tool would affect at `center`: occupied
+ *  cells in the footprint for paint/remove (what gets recolored/deleted), empty
+ *  cells for add (the new voxels). */
+function brushFootprintCells(center: [number, number, number]): [number, number, number][] {
+  const cells: [number, number, number][] = [];
+  if (!run) return cells;
+  const ri = Math.max(0, Math.floor(brushRadius));
+  const [cx, cy, cz] = center;
+  for (let dx = -ri; dx <= ri; dx++)
+    for (let dy = -ri; dy <= ri; dy++)
+      for (let dz = -ri; dz <= ri; dz++) {
+        if (!inBrush(brushShape, dx, dy, dz, ri)) continue;
+        const x = cx + dx, y = cy + dy, z = cz + dz;
+        const occupied = run.grid.has(x, y, z);
+        // add fills empty cells; paint/remove act on existing ones.
+        if (tool === 'add' ? occupied : !occupied) continue;
+        cells.push([x, y, z]);
+      }
+  return cells;
+}
+
+function previewCenter(hit: FacePickResult): [number, number, number] | null {
+  const v = triangleVoxel(hit.triangleIndex);
+  if (!v) return null;
+  return tool === 'add' ? addTarget(v, hit.normal) : v;
+}
+
+function renderPreviewFromHit(hit: FacePickResult | null): void {
+  if (!active || !run || !isBrushTool(tool) || !hit) { clearPreview(); return; }
+  const center = previewCenter(hit);
+  if (!center) { clearPreview(); return; }
+  const cells = brushFootprintCells(center);
+  if (cells.length === 0) { clearPreview(); return; }
+  ensurePreviewCapacity(cells.length);
+  if (!previewMesh) return;
+  (previewMesh.material as THREE.MeshBasicMaterial).color.setHex(tool === 'remove' ? PREVIEW_TINT_REMOVE : colorRgb());
+  for (let i = 0; i < cells.length; i++) {
+    const [x, y, z] = cells[i];
+    previewMatrix.makeTranslation(x + 0.5, y + 0.5, z + 0.5);
+    previewMesh.setMatrixAt(i, previewMatrix);
+  }
+  previewMesh.count = cells.length;
+  previewMesh.instanceMatrix.needsUpdate = true;
+  requestRender();
+}
+
+/** Re-evaluate the preview at the last hovered point — used when the brush
+ *  size/shape or the active tool changes while the cursor is stationary. */
+function refreshPreview(): void {
+  if (!active || !isBrushTool(tool) || !lastHoverEvent) { clearPreview(); return; }
+  renderPreviewFromHit(pickFace(lastHoverEvent as MouseEvent));
+}
+
 // Pointer Events (not mouse) so click-drag strokes work for mouse, touch, and
 // stylus alike. The active drag pointer is captured so moves keep flowing even
 // if it leaves the canvas.
@@ -409,6 +505,7 @@ function onPointerDown(event: PointerEvent): void {
   if (!active || event.button !== 0) return;
   const hit = pickFace(event);
   if (!hit) return;
+  clearPreview(); // the action commits; the preview rebuilds on the next move
   // Brush tools paint a drag stroke (one undo step); other tools are single
   // clicks. Box tools manage their own two-click state.
   if (isBrushTool(tool)) {
@@ -423,8 +520,12 @@ function onPointerDown(event: PointerEvent): void {
 }
 
 function onPointerMove(event: PointerEvent): void {
-  if (!active || !strokeActive || (event.buttons & 1) === 0) return;
-  const hit = pickFace(event);
+  if (!active || !run) return;
+  lastHoverEvent = { clientX: event.clientX, clientY: event.clientY };
+  // One raycast feeds both the hover preview and the active stroke.
+  const hit = isBrushTool(tool) ? pickFace(event) : null;
+  renderPreviewFromHit(hit);
+  if (!strokeActive || (event.buttons & 1) === 0) return;
   if (!hit) return;
   const v = triangleVoxel(hit.triangleIndex);
   // Skip if the cursor is still over the same source voxel (avoids redundant
@@ -434,12 +535,19 @@ function onPointerMove(event: PointerEvent): void {
   applyAtTriangle(hit.triangleIndex);
 }
 
+function onPointerLeave(): void {
+  lastHoverEvent = null;
+  clearPreview();
+}
+
 function onPointerUp(): void {
   if (capturedPointerId !== null) {
     try { getRenderer().domElement.releasePointerCapture(capturedPointerId); } catch { /* already released */ }
     capturedPointerId = null;
   }
   if (strokeActive) endStroke();
+  // The stroke may have changed which cells are occupied — refresh the preview.
+  refreshPreview();
 }
 
 function attachPointerHandler(): void {
@@ -453,14 +561,19 @@ function attachPointerHandler(): void {
   const container = canvas.parentElement ?? canvas;
   container.addEventListener('pointerdown', onPointerDown, { capture: true });
   container.addEventListener('pointermove', onPointerMove, { capture: true });
+  container.addEventListener('pointerleave', onPointerLeave);
   window.addEventListener('pointerup', onPointerUp, { capture: true });
   canvas.style.cursor = 'crosshair';
   canvas.style.touchAction = 'none'; // claim the gesture so touch-drag paints
-  // Veto OrbitControls on primary-button hits over the model so editing
-  // doesn't orbit. Off-model clicks fall through so the camera still rotates.
+  // Veto OrbitControls on primary-button presses within the model's bounds so
+  // editing doesn't orbit. We test the bounding box rather than the surface
+  // (unlike mesh paint) because the delete tool carves holes straight through
+  // the mesh — a surface-only test would let a click that lands in a just-made
+  // hole fall through and rotate the camera mid-edit. Presses clearly outside
+  // the model still fall through so the camera can rotate.
   removeSuppressor = addPointerSuppressor((event) => {
     if (event.button !== 0) return false;
-    return isPointerOverModel(event);
+    return isPointerWithinModelBounds(event);
   });
 }
 
@@ -469,6 +582,7 @@ function detachPointerHandler(): void {
   const container = canvas.parentElement ?? canvas;
   container.removeEventListener('pointerdown', onPointerDown, { capture: true } as EventListenerOptions);
   container.removeEventListener('pointermove', onPointerMove, { capture: true } as EventListenerOptions);
+  container.removeEventListener('pointerleave', onPointerLeave);
   window.removeEventListener('pointerup', onPointerUp, { capture: true } as EventListenerOptions);
   canvas.style.cursor = '';
   canvas.style.touchAction = '';
@@ -476,5 +590,7 @@ function detachPointerHandler(): void {
     try { canvas.releasePointerCapture(capturedPointerId); } catch { /* already released */ }
     capturedPointerId = null;
   }
+  lastHoverEvent = null;
+  disposePreview();
   if (removeSuppressor) { removeSuppressor(); removeSuppressor = null; }
 }

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -790,6 +790,28 @@ export function isPointerOverModel(event: { clientX: number; clientY: number }):
   return raycasterForHit.intersectObject(solid).length > 0;
 }
 
+const boundsForHit = new THREE.Box3();
+
+/** Like {@link isPointerOverModel}, but tests the model's axis-aligned bounding
+ *  box instead of its surface. The Voxel Studio uses this to veto OrbitControls
+ *  while editing: the delete tool carves holes straight through the mesh, so a
+ *  surface-only test lets a click that lands in a just-made hole fall through
+ *  and rotate the camera mid-edit. Testing the bounds keeps any click within the
+ *  model's footprint as edit-intent (never rotates), while a drag that starts
+ *  clearly outside the model still orbits. */
+export function isPointerWithinModelBounds(event: { clientX: number; clientY: number }): boolean {
+  if (!meshGroup || meshGroup.children.length === 0) return false;
+  const solid = meshGroup.children[0];
+  if (!(solid instanceof THREE.Mesh)) return false;
+  const rect = renderer.domElement.getBoundingClientRect();
+  ndcForHit.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  ndcForHit.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycasterForHit.setFromCamera(ndcForHit, camera);
+  boundsForHit.setFromObject(solid);
+  if (boundsForHit.isEmpty()) return false;
+  return raycasterForHit.ray.intersectsBox(boundsForHit);
+}
+
 function isVerticallyScrollable(el: HTMLElement): boolean {
   const style = getComputedStyle(el);
   const overflowY = style.overflowY;

--- a/tests/unit/regionsCompositing.test.ts
+++ b/tests/unit/regionsCompositing.test.ts
@@ -87,6 +87,31 @@ describe('model-declared color compositing (buildTriColors)', () => {
     expect(rgbAt(buf, 0)).toEqual(bytes);
   });
 
+  it('seeds unpainted triangles from the base mesh colors (voxel/import underlay)', () => {
+    // A pre-colored mesh (e.g. a voxel grid) passes its own per-triangle colors
+    // as `baseColors`. Painting one triangle must not blank the rest back to the
+    // default shade — they keep the base color and stay marked painted.
+    const base = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80, 90]); // 3 tris
+    (base as Uint8Array & { _painted?: Uint8Array })._painted = new Uint8Array([1, 1, 1]);
+    addRegion('accent', [0, 0, 1], 'paintbrush', { kind: 'triangles', ids: [1] }, new Set([1]));
+
+    const buf = buildTriColors(3, false, undefined, base)!;
+    expect(rgbAt(buf, 0)).toEqual([10, 20, 30]);  // base color preserved
+    expect(rgbAt(buf, 1)).toEqual([0, 0, 255]);   // user paint wins here
+    expect(rgbAt(buf, 2)).toEqual([70, 80, 90]);  // base color preserved
+    expect(painted(buf)[0]).toBe(1);
+    expect(painted(buf)[1]).toBe(1);
+    expect(painted(buf)[2]).toBe(1); // base-colored, so not the default material
+  });
+
+  it('without base colors, unpainted triangles stay unpainted (plain mesh unchanged)', () => {
+    addRegion('accent', [0, 0, 1], 'paintbrush', { kind: 'triangles', ids: [1] }, new Set([1]));
+    const buf = buildTriColors(3)!; // no baseColors → prior behavior
+    expect(rgbAt(buf, 0)).toEqual([0, 0, 0]);
+    expect(painted(buf)[0]).toBe(0); // untouched → renders default material
+    expect(painted(buf)[1]).toBe(1);
+  });
+
   it('replaces the whole model layer on each set, and clears on []', () => {
     setModelColorRegions([{ name: 'a', color: [1, 0, 0], triangles: new Set([0]) }]);
     setModelColorRegions([{ name: 'b', color: [0, 1, 0], triangles: new Set([1]) }]);

--- a/tests/voxel-studio-camera.spec.ts
+++ b/tests/voxel-studio-camera.spec.ts
@@ -1,0 +1,79 @@
+// Voxel Studio camera behavior. The studio vetoes OrbitControls for presses
+// within the model's bounds so editing doesn't rotate the view — and crucially,
+// because the delete tool carves holes straight through the mesh, the veto is
+// bounds-based (not surface-based like mesh paint): a click that lands in a
+// just-carved hole must NOT fall through and rotate the camera mid-edit. A drag
+// that starts clearly outside the model still orbits.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function getCamera(page: Page) {
+  return page.evaluate(() => (window as unknown as {
+    partwright: { getViewState(): { camera: { azimuth: number; elevation: number } } };
+  }).partwright.getViewState().camera);
+}
+
+async function setup(page: Page) {
+  await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', new Date().toISOString()));
+  await page.goto('/editor');
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    undefined,
+    { timeout: 30_000 },
+  );
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.setActiveLanguage('voxel');
+    // A thin slab so a wide-brush delete punches all the way through to the
+    // background, leaving a real hole to click into.
+    await pw.run(`return api.voxels().fillBox([0,0,0],[20,20,2], '#cc4444');`);
+  });
+  await page.waitForTimeout(1000);
+  await page.locator('#voxel-paint-toggle').dispatchEvent('click');
+  await page.waitForSelector('#voxel-paint-panel:not(.hidden)');
+  await page.waitForTimeout(500);
+}
+
+test.describe('voxel studio camera', () => {
+  test('delete tool does not rotate the view when clicking into a carved hole', async ({ page }) => {
+    await setup(page);
+    await page.locator('#voxel-paint-panel button[data-tool="remove"]').dispatchEvent('click');
+    await page.evaluate(() => (window as unknown as { partwright: { setVoxelBrush(o: object): void } }).partwright.setVoxelBrush({ radius: 5 }));
+    await page.waitForTimeout(150);
+
+    const canvas = await page.locator('#viewport').boundingBox();
+    if (!canvas) throw new Error('viewport missing');
+    const cx = canvas.x + canvas.width / 2;
+    const cy = canvas.y + canvas.height / 2;
+
+    const dragRot = async (x0: number, y0: number, x1: number, y1: number) => {
+      const b = await getCamera(page);
+      await page.mouse.move(x0, y0);
+      await page.mouse.down();
+      await page.mouse.move((x0 + x1) / 2, (y0 + y1) / 2, { steps: 6 });
+      await page.mouse.move(x1, y1, { steps: 6 });
+      await page.mouse.up();
+      await page.waitForTimeout(250);
+      const a = await getCamera(page);
+      return Math.abs(a.azimuth - b.azimuth) + Math.abs(a.elevation - b.elevation);
+    };
+
+    // Punch a hole through the slab at the centre.
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.up();
+    await page.waitForTimeout(300);
+
+    // Dragging starting inside that hole must NOT rotate the camera.
+    const inHole = await dragRot(cx, cy, cx + 50, cy + 30);
+    expect(inHole).toBeLessThan(1);
+
+    // A drag from the far corner, well outside the model bounds, still orbits.
+    const outside = await dragRot(
+      canvas.x + 6, canvas.y + 6,
+      canvas.x + canvas.width - 6, canvas.y + canvas.height - 6,
+    );
+    expect(outside).toBeGreaterThan(5);
+  });
+});


### PR DESCRIPTION
## Summary

Three fixes from one user report about the Voxel Studio / voxel painting.

### 1. Delete tool no longer rotates the view

The studio already vetoed OrbitControls for on-model presses like mesh paint (`isPointerOverModel`), but the **delete tool** still rotated: deleting carves holes straight through the mesh, and a *surface* raycast misses over a hole, so the press fell through to OrbitControls and orbited mid-edit. (Mesh paint never hits this because painting can't remove geometry — which is why the default brush behaved correctly.)

Fix: added `isPointerWithinModelBounds` (raycasts the model AABB via `ray.intersectsBox`) and switched the studio's pointer suppressor to it. Any press within the model's footprint — including into a just-carved hole — counts as edit-intent and never rotates, while a drag from clearly outside still orbits. Reproduced and verified: dragging inside a carved hole went **52° → 0°**, off-model drag still orbits (~85°).

### 2. Brush-footprint hover preview

Added a translucent preview overlay (a single `InstancedMesh` of slightly-oversized unit cubes, like the mesh-paint brush ring) showing exactly which cells the active brush tool would touch at the hovered voxel — **red for delete** (what gets removed), the paint color for paint, the empty cells for add. Follows the cursor (hover + during a stroke, off one shared raycast), retints/resizes live with the tool and brush size/shape, clears on the committing press and on pointer-leave, disposed on deactivate.

### 3. Keep voxel/imported colors after a regular paint operation

Painting with the regular Paint tool on an imported voxel tile wiped the voxel colors (they reappeared only on reopening Voxel Studio). Cause: `buildTriColors` built a fresh all-zero color buffer and marked only painted triangles, so the renderer showed the default shade everywhere else.

Fix: seed the composite from the mesh's own colors (`buildTriColors` takes an optional `baseColors`; `applyTriColors`/`applyTriColorsIfVisible` pass `mesh.triColors`) so paint layers *on top of* existing colors. Also carry per-triangle colors through paint's mesh subdivision (`propagateTriColors` in `subdivide.ts`, applied in `buildRefinedMesh`/`buildRefinedMeshFromSet`) so the smooth brush keeps them too. Plain manifold sessions have no `triColors` and are unaffected. Also fixes the same latent bug for colored STL / relief imports.

## Test plan

- [x] `npm run build` (tsc + vite)
- [x] `npm run test:unit` — 802 pass (incl. 2 new buildTriColors seeding tests)
- [x] e2e: paint / voxel / smooth-brush / relief specs pass (3 transient load-flakes confirmed green in isolation)
- [x] New regression: `tests/voxel-studio-camera.spec.ts` (delete-into-hole doesn't rotate; off-model still orbits)
- [x] Manual screenshots: delete preview (red sphere), paint preview (cube), two-color voxel keeps colors after paint

https://claude.ai/code/session_01TLwbKg6AuMfit15FdcKpqo