### PR TITLE
docs: update GitHub repo references to kemper/partwright

### DIFF
--- a/Formula/partwright.rb
+++ b/Formula/partwright.rb
@@ -14,7 +14,7 @@ class Partwright < Formula
   desc "Headless CLI to drive the Partwright CAD engine + app for AI agents"
   homepage "https://www.partwrightstudio.com"
   # TODO(release): point at a tagged tarball and fill in the checksum.
-  url "https://github.com/kemper/mainifold/archive/refs/tags/v0.0.0.tar.gz"
+  url "https://github.com/kemper/partwright/archive/refs/tags/v0.0.0.tar.gz"
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   license "LicenseRef-PolyForm-Noncommercial-1.0.0"
   version "0.0.0"

--- a/index.html
+++ b/index.html
@@ -361,7 +361,7 @@ Then navigate to https://www.partwrightstudio.com/editor and use the window.part
           <a href="/help" style="color:#71717a;text-decoration:none">How it works</a>
           <a href="/legal" style="color:#71717a;text-decoration:none">Legal</a>
           <a href="/ai.md" style="color:#71717a;text-decoration:none">AI agent docs</a>
-          <a href="https://github.com/kemper/mainifold" target="_blank" rel="noopener noreferrer" style="color:#71717a;text-decoration:none">GitHub</a>
+          <a href="https://github.com/kemper/partwright" target="_blank" rel="noopener noreferrer" style="color:#71717a;text-decoration:none">GitHub</a>
         </div>
         <div>&copy; 2026 Partwright Studio. Source-available &middot; free for non-commercial use.</div>
       </footer>

--- a/prompts/20260608-repo-rename-mainifold-to-partwright.md
+++ b/prompts/20260608-repo-rename-mainifold-to-partwright.md
@@ -1,0 +1,42 @@
+---
+date: 2026-06-08
+title: Update GitHub repo references after mainifold → partwright rename
+prefix: docs
+---
+
+## Human
+
+Renamed the GitHub repo from `kemper/mainifold` to `kemper/partwright`. Asked
+whether the old name redirects (it does, gracefully) and whether a new
+Cloudflare Pages application is needed (it is not — the Pages project binds to
+the repo by internal ID, keeps its `mainifold` name, and its `*.pages.dev`
+URLs are unchanged). Then asked for a PR updating all docs/references to the old
+repo name.
+
+## Assistant
+
+Key decision was **scoping** the rename. The string "mainifold" plays five
+distinct roles in this repo, and only one is the GitHub repo path:
+
+1. **GitHub repo path** `kemper/mainifold` — the only thing the rename affects.
+   Updated to `kemper/partwright`.
+2. **Cloudflare `*.mainifold.pages.dev` URLs** — tied to the Cloudflare Pages
+   *project* name, NOT the GitHub repo. The project keeps its name after a repo
+   rename, so these URLs stay valid. Left untouched.
+3. **`window.mainifold` legacy JS API alias** — deliberate back-compat alias for
+   `window.partwright`. Renaming it would break older agent prompts/tools. Left
+   untouched.
+4. **`data.mainifold` import-schema brand field** — back-compat for loading old
+   exported sessions. Left untouched.
+5. **Legacy IndexedDB name `mainifold`** (`db.ts` migration) — back-compat for
+   pre-rebrand local data. Left untouched.
+
+So the diff only touches category 1: the hardcoded repo-slug fallbacks in
+`src/buildInfo.ts` and `vite.config.ts` (production gets the real value from
+`GITHUB_REPOSITORY`/git remote, now `kemper/partwright`), their unit-test
+expectations, the landing-page footer GitHub link, and the Homebrew formula
+tarball URL. Historical `prompts/*.md` logs were left as-is (immutable record).
+
+Verified with `npm run test:unit` (800 pass) and `npm run build` (tsc + vite
+clean). No browser screenshot — the only UI-visible change is a footer link
+href, no visual difference.

--- a/src/buildInfo.ts
+++ b/src/buildInfo.ts
@@ -25,7 +25,7 @@ const FALLBACK: BuildInfo = {
   commit: 'unknown',
   branch: 'unknown',
   buildTime: 'unknown',
-  repo: 'kemper/mainifold',
+  repo: 'kemper/partwright',
   dirty: false,
 };
 

--- a/tests/unit/buildInfo.test.ts
+++ b/tests/unit/buildInfo.test.ts
@@ -15,7 +15,7 @@ const base: BuildInfo = {
   commit: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
   branch: 'main',
   buildTime: '2026-05-24T00:00:00.000Z',
-  repo: 'kemper/mainifold',
+  repo: 'kemper/partwright',
   dirty: false,
 };
 
@@ -31,7 +31,7 @@ describe('shortCommit', () => {
 
 describe('commitUrl', () => {
   test('links to the commit on GitHub', () => {
-    expect(commitUrl(base)).toBe(`https://github.com/kemper/mainifold/commit/${base.commit}`);
+    expect(commitUrl(base)).toBe(`https://github.com/kemper/partwright/commit/${base.commit}`);
   });
 
   test('returns null when the commit is unknown', () => {
@@ -48,12 +48,12 @@ describe('branchUrl', () => {
     // GitHub's /tree/<branch> 404s on a percent-encoded slash, so slashes in
     // slash-namespaced branch names must stay raw.
     expect(branchUrl({ ...base, branch: 'claude/laughing-davinci' }))
-      .toBe('https://github.com/kemper/mainifold/tree/claude/laughing-davinci');
+      .toBe('https://github.com/kemper/partwright/tree/claude/laughing-davinci');
   });
 
   test('encodes unsafe characters per segment but preserves slashes', () => {
     expect(branchUrl({ ...base, branch: 'feature/a b' }))
-      .toBe('https://github.com/kemper/mainifold/tree/feature/a%20b');
+      .toBe('https://github.com/kemper/partwright/tree/feature/a%20b');
   });
 
   test('returns null when the branch is unknown', () => {
@@ -64,7 +64,7 @@ describe('branchUrl', () => {
 describe('pullRequestsUrl', () => {
   test('builds a PR search scoped to the branch head', () => {
     expect(pullRequestsUrl({ ...base, branch: 'feature/x' }))
-      .toBe(`https://github.com/kemper/mainifold/pulls?q=${encodeURIComponent('is:pr head:feature/x')}`);
+      .toBe(`https://github.com/kemper/partwright/pulls?q=${encodeURIComponent('is:pr head:feature/x')}`);
   });
 
   test('returns null when the branch is unknown', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,7 +103,7 @@ function resolveBuildInfo() {
   const repo =
     process.env.GITHUB_REPOSITORY ||
     parseGitHubRepo(git('git config --get remote.origin.url')) ||
-    'kemper/mainifold';
+    'kemper/partwright';
   // "dirty" only means something for a local working tree; a fresh CI / CF
   // clone is always clean, so skip the (possibly slow) status call there.
   const dirty = !onCloudflare && git('git status --porcelain') !== '';


### PR DESCRIPTION
## Summary

The GitHub repo was renamed `kemper/mainifold` → `kemper/partwright`. This updates the hardcoded references to the **old repo path** so they point at the new one. GitHub redirects the old path indefinitely, so nothing was broken — this just keeps the source correct and forward-looking.

### What changed (the only role of "mainifold" that the rename affects)
- `src/buildInfo.ts` — repo-slug fallback `kemper/mainifold` → `kemper/partwright`
- `vite.config.ts` — same build-time fallback (production reads the real value from `GITHUB_REPOSITORY` / git remote, now `kemper/partwright`; this is only the local/unset fallback)
- `tests/unit/buildInfo.test.ts` — expectations for commit/branch/PR URLs
- `index.html` — landing-page footer "GitHub" link
- `Formula/partwright.rb` — Homebrew formula tarball URL

### Deliberately left untouched
"mainifold" plays four other roles that have nothing to do with the GitHub repo name and must stay for back-compat:
- **`*.mainifold.pages.dev` URLs** — tied to the Cloudflare Pages *project* name, which a repo rename does **not** change. These URLs are still live.
- **`window.mainifold`** — legacy console-API alias for `window.partwright` (older agent prompts/tools depend on it).
- **`data.mainifold`** — legacy import-schema brand field (old exported sessions must still load).
- **`mainifold` IndexedDB name** — legacy DB migration key (pre-rebrand local data).
- Historical `prompts/*.md` logs — immutable record, left as-is.

## Test plan
- `npm run test:unit` — 800 pass (incl. the updated `buildInfo` URL tests)
- `npm run build` — tsc + vite clean
- No browser screenshot: the only UI-visible change is a footer link `href`; no visual difference.

https://claude.ai/code/session_01QQ4jRjaJg1eQjKuvzJSdiX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQ4jRjaJg1eQjKuvzJSdiX)_