### PR TITLE
fix: reconstruct _painted mask across the paint-subdivision worker

### DIFF
--- a/prompts/voxel-paint-review-followups.md
+++ b/prompts/voxel-paint-review-followups.md
@@ -1,0 +1,35 @@
+---
+session: "01TLwb"
+timestamp: "2026-06-08T16:15:00Z"
+---
+
+## Human
+
+(work-reviewer follow-up on PR #511.) The reviewer flagged that the `_painted`
+sidecar — a JS expando on the triColors `Uint8Array` — doesn't survive the
+paint-subdivision Web Worker boundary, so on the worker path a legitimately
+black base triangle could be misread as unpainted and render as the default
+material, diverging from the synchronous path.
+
+## Assistant
+
+## Key decisions
+
+**Reconstruct the `_painted` mask on the main thread after the worker returns.**
+The worker transfers the colour BYTES of `triColors` but not the expando mask.
+The main thread still holds the input mesh (mask intact) and the worker returns
+`childToParent`, so `reattachPaintedMask` (subdivisionClient.ts) rebuilds the
+mask as `painted[i] = inputPainted[childToParent[i]]` — exactly mirroring the
+synchronous `propagateTriColors`. Wired it into the resolve path of
+`refineInWorker` so every worker result is normalised. No-op when the input has
+no mask, so the renderer's nonzero-channel fallback still governs both paths
+identically; strictly improves consistency with zero downside.
+
+**Left the brush-preview `inRange` nit alone.** `grid.has()` already
+bounds-checks, so the paint/remove previews are correct; only the `add` preview
+at the absolute coordinate extremes is affected, which is unreachable in
+practice. Exporting a private helper just for that would be churn for no
+real-world gain.
+
+**Verification.** Build + 802 unit tests pass; the smooth-brush e2e suite (which
+drives the subdivision worker) passes.

--- a/src/color/subdivisionClient.ts
+++ b/src/color/subdivisionClient.ts
@@ -101,6 +101,28 @@ function toRefinedResult(msg: RefineDone): RefinedResult {
   };
 }
 
+/** The `_painted` mask is a JS expando on the triColors `Uint8Array`, so it
+ *  doesn't survive structured-clone/transfer across the worker boundary: the
+ *  worker returns the correct colour BYTES but no mask. Reconstruct it on the
+ *  main thread from the (intact) input mesh's mask via `childToParent`, so the
+ *  worker path matches the synchronous one — e.g. a legitimately black base
+ *  triangle stays painted instead of being misread as the default material.
+ *  No-op when the input carries no mask (the renderer's nonzero-channel
+ *  fallback then governs both paths identically). */
+function reattachPaintedMask(result: RefinedResult, input: MeshData): RefinedResult {
+  const out = result.mesh.triColors as (Uint8Array & { _painted?: Uint8Array }) | undefined;
+  const srcPainted = (input.triColors as (Uint8Array & { _painted?: Uint8Array }) | undefined)?._painted;
+  if (!out || !srcPainted) return result;
+  const n = result.childToParent.length;
+  const painted = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    const p = result.childToParent[i];
+    if (p >= 0) painted[i] = srcPainted[p];
+  }
+  out._painted = painted;
+  return result;
+}
+
 /** Dispatch one refine job to the worker. Rejects if a prior job is still
  *  running — callers are expected to coalesce / queue at the reconcile layer.
  *  Abort terminates the worker; the next call spins a fresh one up. */
@@ -115,7 +137,12 @@ export function refineInWorker(input: RefineJobInput): Promise<RefinedResult> {
   const id = nextJobId++;
 
   return new Promise<RefinedResult>((resolve, reject) => {
-    const job: PendingJob = { id, resolve, reject, signal: input.signal };
+    const job: PendingJob = {
+      id,
+      resolve: (result) => resolve(reattachPaintedMask(result, input.input)),
+      reject,
+      signal: input.signal,
+    };
     if (input.signal) {
       job.onAbort = () => {
         if (!inFlight || inFlight.id !== id) return;


### PR DESCRIPTION
## Summary

Follow-up to #511 (already merged). The `work-reviewer` pass on #511 flagged one should-fix that landed just **after** you merged, so it's not in `main` yet.

The `_painted` mask is a JS expando on the `triColors` `Uint8Array`, so it doesn't survive the paint-subdivision Web Worker's structured-clone/transfer boundary: the worker returns correct color **bytes** but no mask. With the new `triColors` propagation from #511, that meant a legitimately **black** base triangle (e.g. a black voxel) could be misread as *unpainted* on the worker path and render as the default material — diverging from the synchronous path, which preserves the mask in-process.

Fix: reconstruct the mask on the main thread in `subdivisionClient.ts` after the worker returns. The input mesh's mask is intact on the main thread and the worker returns `childToParent`, so rebuild it as `painted[i] = inputPainted[childToParent[i]]`, mirroring `propagateTriColors`. No-op when the input carries no mask (the renderer's nonzero-channel fallback then governs both paths identically), so it's a strict consistency improvement with no downside.

## Test plan

- [x] `npm run build` (tsc + vite)
- [x] `npm run test:unit` — 802 pass
- [x] `paint-smooth-brush` e2e (drives the subdivision worker) — 24 pass

https://claude.ai/code/session_01TLwbKg6AuMfit15FdcKpqo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLwbKg6AuMfit15FdcKpqo)_