### PR TITLE
feat: add Save / Save & activate footer to AI Settings + custom model dropdown

### DIFF
--- a/prompts/20260608-164108-custom-provider-save-and-models.md
+++ b/prompts/20260608-164108-custom-provider-save-and-models.md
@@ -1,0 +1,83 @@
+---
+session: "QRjAG"
+timestamp: "2026-06-08T16:41:08Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+When configuring the local/custom provider via the AI settings menu, I pasted
+the API key, clicked "Fetch models", picked a model id, clicked "Use this
+endpoint", then Close — but I never clicked "Save key" next to the API key
+field, so the key was silently dropped. That's confusing.
+
+Two asks:
+
+1. Add footer buttons next to "Close": a "Save" that saves any pending changes,
+   and a "Save and activate" that saves, activates whatever provider is being
+   viewed, and closes — so people don't have to scroll back up to the inline
+   enable affordance. Make it consistent across all providers. (Noted the cloud
+   providers — Anthropic/OpenAI/Gemini — already have a "Done & enable" footer
+   button; it's really just the custom/local tab that was missing the parity.)
+2. When I fetch the model list via "Fetch models", make those models available
+   in the model-selection dropdown in the AI panel, the way they are for the
+   other providers.
+
+## Assistant
+
+## Key decisions
+
+**Root cause of the dropped key.** The Custom tab's API key lived only in a
+component-local `keyVal` signal and was persisted to IndexedDB *only* by its
+own "Save key" button. The shared modal footer ("Done & enable") could activate
+the provider but had no access to that local state, so closing — or even
+enabling — never flushed a typed-but-unsaved key. Base URL and model id already
+persist on the input's `onChange` (blur), so the key was the real gap.
+
+**Footer flush via a module-level registry, not lifted state.** Rather than
+hoist the Custom tab's `keyVal`/`url`/`model` signals up into the parent (which
+would touch the mount seam and every tab), the mounted tab registers a
+`pendingFlush` callback in a `useEffect` (cleared on unmount/tab-switch — only
+one tab is mounted at a time). The footer's new `commit(activate)` and
+EnableRow's Enable both `await runPendingFlush()` before acting. Only the Custom
+tab registers one today; cloud/local tabs persist immediately, so their flush is
+a no-op and "Save" there is effectively Save+close. This keeps the change
+contained to the modal and avoids a wider refactor.
+
+**Footer shape: Close / Save / Save & activate.** Replaced the single
+conditional "Done & enable {label}" with: always-present `Close` (cancel) and
+`Save` (flush + close, no provider switch), plus `Save & activate {label}`
+(flush + setProvider + close) shown only when the viewed tab isn't already
+active and gated on the same `useProviderReady` readiness as before. Renamed the
+primary from "Done & enable" to "Save & activate" per the request; updated the
+one e2e test (`ai-cli-bridge-setup.spec.ts`) that anchored the old string. Left
+the in-body EnableRow "Enable {label}" buttons untouched (separate affordance,
+still anchored by tests) but routed them through the same flush so the
+lost-key bug can't recur via that path either.
+
+**Persisting the fetched model list.** Added `customModels: string[]` to
+`ChatToggles` (per-tab, alongside `customModel`/`customBaseUrl`, so it stays out
+of cross-tab bleed and serializes with the rest of toggles). It's a *derived
+cache*, so `setCustomModels` deliberately does NOT flip `preset` to 'custom' the
+way the user-facing setters do. `fetchModels` writes the ids on success; the
+Custom tab also seeds its in-modal pills from this on open so reopening shows the
+last list without a re-fetch. Threaded the field through the usual choke points:
+`DEFAULT_TOGGLES`, `cloneToggles`, `applyPreset`, `setToggles`,
+`mergeWithDefaults` (filtered to strings for back-compat with old localStorage
+blobs), and the preset `Omit`.
+
+**DeepPartial fix.** `setToggles` takes a `DeepPartial<ChatToggles>`, whose
+mapped type would recurse into the new `string[]` and produce a sparse
+array-like not assignable back to `string[]`. Taught `DeepPartial` to pass
+arrays through wholesale (`T[K] extends ReadonlyArray<unknown>`), which is the
+correct behavior generally and only affects this one array-valued field.
+
+**AI panel dropdown.** For the custom provider, the panel header rendered a chip
+that just opened settings. Now, once `customModels` is non-empty, it renders a
+real `<select>` (mirroring the cloud providers' picker) populated from the
+fetched ids, with the current model appended as "… (custom)" if hand-typed and a
+disabled "Select a model…" placeholder when none is chosen. Before any fetch it
+falls back to the original chip; the ⚙ header button always remains the path to
+reconfigure the endpoint. No new `window.partwright` method needed — this only
+surfaces the already-settable `customModel`; fetching is a UI-only config action
+that needs the live endpoint.

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -89,7 +89,7 @@ export interface LocalContextSettings {
 const DEFAULT_OPENAI_MODEL: OpenaiModelId = 'gpt-5-mini';
 const DEFAULT_GEMINI_MODEL: GeminiModelId = 'gemini-flash-latest';
 
-const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatToggles, 'provider' | 'anthropicModel' | 'localModel' | 'openaiModel' | 'geminiModel' | 'customModel' | 'customBaseUrl'> & { anthropicModel: AnthropicModelId }> = {
+const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatToggles, 'provider' | 'anthropicModel' | 'localModel' | 'openaiModel' | 'geminiModel' | 'customModel' | 'customModels' | 'customBaseUrl'> & { anthropicModel: AnthropicModelId }> = {
   minimal: {
     vision: { views: false, resolution: 'low', angles: 'auto' },
     scope: { runCode: true, saveVersions: true, paintFaces: false, sessionNotes: false },
@@ -148,6 +148,7 @@ const DEFAULT_TOGGLES: ChatToggles = {
   openaiModel: DEFAULT_OPENAI_MODEL,
   geminiModel: DEFAULT_GEMINI_MODEL,
   customModel: '',
+  customModels: [],
   customBaseUrl: '',
 };
 
@@ -206,6 +207,7 @@ function cloneToggles(t: ChatToggles): ChatToggles {
     openaiModel: t.openaiModel,
     geminiModel: t.geminiModel,
     customModel: t.customModel,
+    customModels: [...t.customModels],
     customBaseUrl: t.customBaseUrl,
   };
 }
@@ -300,6 +302,7 @@ export function applyPreset(settings: AiSettings, preset: Preset): AiSettings {
       openaiModel: settings.toggles.openaiModel,
       geminiModel: settings.toggles.geminiModel,
       customModel: settings.toggles.customModel,
+      customModels: settings.toggles.customModels,
       customBaseUrl: settings.toggles.customBaseUrl,
     },
   };
@@ -429,6 +432,16 @@ export function setCustomModel(settings: AiSettings, model: string): AiSettings 
   };
 }
 
+/** Cache the list of model ids the custom endpoint advertised (from "Fetch
+ *  models"). Purely a derived list used to populate the AI panel's model
+ *  dropdown, so it does NOT flip the preset like the user-facing setters do. */
+export function setCustomModels(settings: AiSettings, models: string[]): AiSettings {
+  return {
+    ...settings,
+    toggles: { ...settings.toggles, customModels: models },
+  };
+}
+
 /** Set the base URL of the custom OpenAI-compatible endpoint (trimmed). */
 export function setCustomBaseUrl(settings: AiSettings, baseUrl: string): AiSettings {
   return {
@@ -455,13 +468,20 @@ export function setToggles(settings: AiSettings, partial: DeepPartial<ChatToggle
     openaiModel: partial.openaiModel ?? settings.toggles.openaiModel,
     geminiModel: partial.geminiModel ?? settings.toggles.geminiModel,
     customModel: partial.customModel ?? settings.toggles.customModel,
+    customModels: partial.customModels ?? settings.toggles.customModels,
     customBaseUrl: partial.customBaseUrl ?? settings.toggles.customBaseUrl,
   };
   return { ...settings, preset: 'custom', toggles: next };
 }
 
 type DeepPartial<T> = {
-  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+  // Arrays are replaced wholesale, never deep-partialled into a sparse
+  // array-like (which wouldn't be assignable back to the concrete field).
+  [K in keyof T]?: T[K] extends ReadonlyArray<unknown>
+    ? T[K]
+    : T[K] extends object
+      ? DeepPartial<T[K]>
+      : T[K];
 };
 
 /** Legacy shape — accepts the pre-provider single `model` field (v1 BYO-key
@@ -539,6 +559,9 @@ function mergeWithDefaults(partial: LegacyAiSettings): AiSettings {
       openaiModel: tgls.openaiModel ?? DEFAULT_SETTINGS.toggles.openaiModel,
       geminiModel: tgls.geminiModel ?? DEFAULT_SETTINGS.toggles.geminiModel,
       customModel: tgls.customModel ?? DEFAULT_SETTINGS.toggles.customModel,
+      customModels: Array.isArray(tgls.customModels)
+        ? tgls.customModels.filter((x): x is string => typeof x === 'string')
+        : DEFAULT_SETTINGS.toggles.customModels,
       customBaseUrl: tgls.customBaseUrl ?? DEFAULT_SETTINGS.toggles.customBaseUrl,
     },
     systemPromptOverrides: {

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -145,6 +145,12 @@ export interface ChatToggles {
    *  typed). Lives in toggles (not the key record) so it serializes into
    *  the agent Worker alongside `customBaseUrl`. */
   customModel: string;
+  /** Model ids the custom endpoint advertised the last time the user hit
+   *  "Fetch models" in AI Settings. Cached here (per-tab, like the rest of
+   *  toggles) purely so the AI panel's model picker can offer a real
+   *  dropdown for the custom provider — mirroring how the cloud providers
+   *  expose a `<select>`. Empty until the user fetches. */
+  customModels: string[];
   /** Base URL of the custom OpenAI-compatible endpoint, including any
    *  version path (e.g. `http://localhost:8080/v1`). We append
    *  `/chat/completions` and `/models` to it. Empty string = not configured.

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1178,16 +1178,57 @@ function renderModelPicker(): void {
     return;
   }
 
-  // Custom OpenAI-compatible endpoint: a chip showing the configured model
-  // (or a prompt to configure), opening AI Settings on the Custom tab — the
-  // endpoint URL + model live there, like the local model lives in its modal.
+  // Custom OpenAI-compatible endpoint. Once the user has fetched the
+  // endpoint's model list (AI Settings → Custom → Fetch models), surface it
+  // as a real <select> here — the same affordance the cloud providers get —
+  // so switching models doesn't require reopening settings. Before any models
+  // are fetched, fall back to a chip that opens settings (the ⚙ header button
+  // always stays available to reconfigure the endpoint).
   if (settings.toggles.provider === 'custom') {
+    const fetched = settings.toggles.customModels;
+    const current = settings.toggles.customModel.trim();
+    if (fetched.length > 0) {
+      const sel = document.createElement('select');
+      sel.className = 'h-6 px-2 rounded text-[11px] bg-zinc-800 border border-zinc-700 text-zinc-200 focus:outline-none';
+      sel.title = `Custom endpoint model (${settings.toggles.customBaseUrl || 'no URL set'}). Manage the endpoint + model list in ⚙ AI Settings → Custom.`;
+      if (!current) {
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Select a model…';
+        placeholder.disabled = true;
+        sel.appendChild(placeholder);
+      }
+      let foundCurrent = false;
+      for (const id of fetched) {
+        const o = document.createElement('option');
+        o.value = id;
+        o.textContent = id;
+        sel.appendChild(o);
+        if (id === current) foundCurrent = true;
+      }
+      if (current && !foundCurrent) {
+        const o = document.createElement('option');
+        o.value = current;
+        o.textContent = `${current} (custom)`;
+        sel.appendChild(o);
+      }
+      sel.value = current;
+      sel.addEventListener('change', () => {
+        saveSettings(setCustomModel(loadSettings(), sel.value));
+        recordSessionAiPreference();
+        renderToggleStrip();
+        renderCostMeter();
+        panelStatusUpdate();
+      });
+      modelPickerEl.appendChild(sel);
+      return;
+    }
     const customChip = document.createElement('button');
     customChip.type = 'button';
     customChip.className = 'h-6 px-2 inline-flex items-center rounded text-[11px] bg-sky-900/30 border border-sky-700/50 text-sky-200 hover:bg-sky-900/50';
-    customChip.textContent = settings.toggles.customModel.trim() || 'Configure endpoint';
+    customChip.textContent = current || 'Configure endpoint';
     customChip.title = settings.toggles.customBaseUrl.trim()
-      ? `Custom endpoint: ${settings.toggles.customBaseUrl} · model: ${settings.toggles.customModel || '(none set)'}. Click to configure.`
+      ? `Custom endpoint: ${settings.toggles.customBaseUrl} · model: ${current || '(none set)'}. Click to configure.`
       : 'No custom endpoint configured yet. Click to set the base URL and model.';
     customChip.addEventListener('click', () => {
       void showAiSettingsModal({ onChange: afterAiSettingsChange }, { initialTab: 'custom' });

--- a/src/ui/preact/settingsModal.tsx
+++ b/src/ui/preact/settingsModal.tsx
@@ -34,6 +34,7 @@ import {
   setOpenaiModel,
   setGeminiModel,
   setCustomModel,
+  setCustomModels,
   setCustomBaseUrl,
   providerLabel,
   AUTO_COMPACT_OPTIONS,
@@ -69,6 +70,16 @@ const TABS = [
  *  Cheaper than threading a refresh callback through 4 component layers. */
 const keyVersion = signal(0);
 function bumpKeyVersion(): void { keyVersion.value = keyVersion.value + 1; }
+
+/** The currently-mounted tab can register a flush for local, not-yet-persisted
+ *  edits — chiefly the Custom tab's typed-but-unsaved API key (whose own "Save
+ *  key" button is easy to miss). The footer's Save / Save & activate buttons,
+ *  and EnableRow's Enable, await this before acting so closing the modal no
+ *  longer silently drops a typed key. Only one tab is mounted at a time;
+ *  cleared on tab switch / unmount. */
+let pendingFlush: (() => Promise<void>) | null = null;
+function setPendingFlush(fn: (() => Promise<void>) | null): void { pendingFlush = fn; }
+async function runPendingFlush(): Promise<void> { if (pendingFlush) await pendingFlush(); }
 
 export function SettingsModalBody(props: {
   cb: AiSettingsCallbacks;
@@ -116,21 +127,32 @@ export function SettingsModalFooter(props: {
   const ready = useProviderReady(viewedTab);
   const label = providerLabel(viewedTab);
 
+  // Commit any pending edits (the Custom tab's typed-but-unsaved API key,
+  // base URL and model), optionally promote this provider to active, and
+  // close. Save persists without switching; Save & activate also switches.
+  async function commit(activate: boolean): Promise<void> {
+    await runPendingFlush();
+    if (activate) setSettings(setProvider(loadSettings(), viewedTab));
+    cb.onChange();
+    close();
+  }
+
   return (
     <>
       <SecondaryButton label="Close" onClick={close} />
+      <SecondaryButton
+        label="Save"
+        title="Save your changes and close. Doesn't switch the active provider."
+        onClick={() => { void commit(false); }}
+      />
       {!isActive && (
         <PrimaryButton
-          label={`Done & enable ${label}`}
+          label={`Save & activate ${label}`}
           disabled={!ready}
           title={ready
-            ? `Make ${label} the active provider and close. Edits above don't switch the active provider on their own.`
-            : `Finish configuring ${label} above before enabling it.`}
-          onClick={() => {
-            setSettings(setProvider(loadSettings(), viewedTab));
-            cb.onChange();
-            close();
-          }}
+            ? `Save your changes, make ${label} the active provider, and close.`
+            : `Finish configuring ${label} above before activating it.`}
+          onClick={() => { void commit(true); }}
         />
       )}
     </>
@@ -204,8 +226,11 @@ function EnableRow(props: { viewedTab: Provider; cb: AiSettingsCallbacks }) {
               ? 'Set the endpoint URL before enabling it.'
               : `Connect your ${label} key before enabling it.`}
           onClick={() => {
-            setSettings(setProvider(loadSettings(), viewedTab));
-            cb.onChange();
+            void (async () => {
+              await runPendingFlush();
+              setSettings(setProvider(loadSettings(), viewedTab));
+              cb.onChange();
+            })();
           }}
         />
       )}
@@ -558,7 +583,12 @@ function CustomTab(props: { cb: AiSettingsCallbacks; close: () => void }) {
   // the proxy is configured with matches the one Partwright sends.
   const genKey = useSignal(generateApiKey());
   const hasKey = useSignal<boolean | null>(null);
-  const models = useSignal<{ id: string; label: string }[]>([]);
+  // Seed from the last fetched list (persisted) so reopening the modal shows
+  // the endpoint's models without a re-fetch — and so the AI panel dropdown
+  // and these pills stay in sync.
+  const models = useSignal<{ id: string; label: string }[]>(
+    settings.toggles.customModels.map(id => ({ id, label: id })),
+  );
   const status = useSignal('');
   const statusErr = useSignal(false);
   const busy = useSignal(false);
@@ -568,6 +598,20 @@ function CustomTab(props: { cb: AiSettingsCallbacks; close: () => void }) {
     void getKey('custom').then(k => { if (!cancelled) hasKey.value = !!k; });
     return () => { cancelled = true; };
   }, [keyVersion.value]);
+
+  // Let the footer's Save / Save & activate (and EnableRow's Enable) commit
+  // the typed-but-unsaved API key + the latest URL/model before closing — the
+  // "Save key" button is easy to miss, which silently dropped the key before.
+  useEffect(() => {
+    setPendingFlush(async () => {
+      let s = setCustomBaseUrl(loadSettings(), url.value);
+      s = setCustomModel(s, model.value.trim());
+      setSettings(s);
+      if (keyVal.value.trim()) await saveKey();
+      cb.onChange();
+    });
+    return () => setPendingFlush(null);
+  }, []);
 
   // Effective key for test/fetch: the just-typed value wins, else the stored one.
   async function effectiveKey(): Promise<string> {
@@ -597,6 +641,10 @@ function CustomTab(props: { cb: AiSettingsCallbacks; close: () => void }) {
     try {
       const list = await listCustomModels(url.value, await effectiveKey());
       models.value = list;
+      // Persist the ids so the AI panel's model picker can offer them as a
+      // dropdown, the way the cloud providers do.
+      setSettings(setCustomModels(loadSettings(), list.map(m => m.id)));
+      cb.onChange();
       statusErr.value = false;
       status.value = list.length ? `${list.length} model(s) found.` : 'Endpoint reported no models.';
       // Auto-select when the server serves exactly one and nothing's chosen.

--- a/tests/ai-cli-bridge-setup.spec.ts
+++ b/tests/ai-cli-bridge-setup.spec.ts
@@ -27,13 +27,15 @@ test.describe('AI CLI bridge setup', () => {
     await expect(page.getByText('Set an API key (required)')).toBeVisible();
     await expect(page.getByText('Log in with your subscription')).toBeVisible();
 
-    // Footer shows Close, and a disabled "Done & enable" until the endpoint is set.
+    // Footer shows Close, Save, and a disabled "Save & activate" until the
+    // endpoint is set.
     await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
-    const enableBtn = page.getByRole('button', { name: 'Done & enable Custom endpoint' });
+    await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
+    const enableBtn = page.getByRole('button', { name: 'Save & activate Custom endpoint' });
     await expect(enableBtn).toBeDisabled();
 
     // The Base URL starts empty; clicking "Use this endpoint" fills it and,
-    // in turn, enables the footer's "Done & enable".
+    // in turn, enables the footer's "Save & activate".
     const baseUrl = page.locator('input[placeholder="http://localhost:8080/v1"]');
     await expect(baseUrl).toHaveValue('');
     await page.getByRole('button', { name: /Use this endpoint/ }).click();

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -769,6 +769,62 @@ test.describe('Multi-provider AI', () => {
     await expect(modal.getByRole('button', { name: 'Enable Custom endpoint', exact: true })).toBeEnabled();
   });
 
+  test('Custom tab: fetched models surface in the panel dropdown; Save & activate flushes the typed key', async ({ page }) => {
+    // Mock the OpenAI-compatible /models endpoint so "Fetch models" returns a list.
+    await page.route('**/v1/models', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [{ id: 'llama-3.3-70b-instruct' }, { id: 'qwen2.5-coder-32b' }] }),
+    }));
+
+    await page.goto('/editor');
+    await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch {} });
+    await page.reload();
+    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    await openAiPanel(page);
+
+    // Open settings via the panel's ⚙ button so the real onChange (which
+    // re-renders the model picker) is wired.
+    await page.locator('#ai-panel button[title^="AI settings"]').dispatchEvent('click');
+    await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
+    const modal = page.locator('.bg-zinc-800.rounded-xl').filter({ hasText: 'AI Settings' });
+    await page.locator('button:has-text("Custom (OpenAI)")').dispatchEvent('click');
+
+    const urlInput = modal.locator('input[placeholder="http://localhost:8080/v1"]');
+    await urlInput.fill('http://localhost:9911/v1');
+    await urlInput.blur(); // commit the URL (its onChange fires on blur)
+
+    // Footer parity with the cloud tabs: Close + Save + Save & activate.
+    await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Save & activate Custom endpoint' })).toBeEnabled();
+
+    // Fetch the endpoint's models → pills appear and a model is picked.
+    await modal.getByRole('button', { name: 'Fetch models' }).click();
+    await expect(modal.getByText('2 model(s) found.')).toBeVisible();
+    await modal.getByRole('button', { name: 'qwen2.5-coder-32b' }).click();
+
+    // Type an API key but DON'T click "Save key" — the original usability bug
+    // was that closing here silently dropped the typed key. Save & activate
+    // must flush it.
+    await modal.locator('input[placeholder="leave blank if the endpoint needs no auth"]').fill('pw-secret-token-123');
+    await page.getByRole('button', { name: 'Save & activate Custom endpoint' }).click();
+    await expect(page.getByRole('heading', { name: 'AI Settings' })).toHaveCount(0);
+
+    // The typed key was persisted to the aiKeys store despite never clicking "Save key".
+    const storedKey = await page.evaluate(async () => {
+      const db = await import('/src/ai/db.ts');
+      return (await db.getKey('custom'))?.apiKey ?? null;
+    });
+    expect(storedKey).toBe('pw-secret-token-123');
+
+    // The AI panel model picker is now a <select> populated with the fetched ids.
+    const sel = page.locator('#ai-panel select');
+    await expect(sel).toBeVisible();
+    await expect(sel).toHaveValue('qwen2.5-coder-32b');
+    const optionTexts = await sel.locator('option').allTextContents();
+    expect(optionTexts).toContain('llama-3.3-70b-instruct');
+  });
+
   test('Enable is gated on a connected key, except local', async ({ page }) => {
     await page.goto('/editor');
     await page.evaluate(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch {} });


### PR DESCRIPTION
## Summary

Two fixes for the **Custom (OpenAI-compatible)** provider in the AI Settings modal, prompted by a usability snag: configuring a custom endpoint, picking a model, and closing the modal **silently dropped the typed API key** because the key only saved via an easily-missed "Save key" button.

**1. Consistent footer: Close / Save / Save & activate (all tabs).**
- The Custom tab's typed-but-unsaved API key lived in component-local state, invisible to the shared modal footer. Now the mounted tab registers a `pendingFlush`; the footer's **Save** (persist + close) and **Save & activate** (persist + make this the active provider + close) both flush it first — so does EnableRow's inline **Enable**, so the lost-key path can't recur there either.
- The primary footer button was renamed from "Done & enable {label}" to **"Save & activate {label}"** per the request, and a new **"Save"** sits beside Close. Cloud/local tabs persist immediately, so their flush is a no-op (Save ≈ save-and-close there) — the footer is now uniform across providers.

**2. Fetched custom models populate the AI panel dropdown.**
- Added a per-tab `ChatToggles.customModels: string[]` cache. "Fetch models" now persists the endpoint's advertised ids, and the AI panel header renders a real `<select>` of them for the custom provider — mirroring the cloud providers — instead of a chip that only reopened settings. Before any fetch it falls back to the original chip; the ⚙ header button is always available to reconfigure. The Custom tab also seeds its in-modal pills from this cache so reopening shows the last list without a re-fetch.

`customModels` is a derived cache, so `setCustomModels` deliberately does **not** flip the preset to `custom` like the user-facing setters do. `DeepPartial<ChatToggles>` was taught to pass arrays through wholesale (the new array field would otherwise become an un-assignable sparse type).

No new `window.partwright` method: this only surfaces the already-settable `customModel`; fetching the list is a UI-only config action that needs the live endpoint.

## Test plan
- `npm run build` ✅ · `npm run test:unit` (802) ✅
- Updated `tests/ai-cli-bridge-setup.spec.ts` for the renamed footer button.
- New e2e in `tests/ai-providers.spec.ts`: mock `/v1/models` → Fetch models → pick a model → type a key **without** clicking "Save key" → **Save & activate**; asserts the key landed in the `aiKeys` store and the panel `<select>` is populated with the fetched ids. ✅
- Manual browser check (Playwright screenshots) confirmed the footer buttons, the in-settings model pills, and the new panel `<select>` showing the chosen model.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LroJbaMzLVFioZYZccKrHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LroJbaMzLVFioZYZccKrHm)_