### PR TITLE
fix: keep viewport tool menu open when clicking the model to orbit

### DIFF
--- a/prompts/20260608-164600-toolmenu-stays-open-on-viewport-click.md
+++ b/prompts/20260608-164600-toolmenu-stays-open-on-viewport-click.md
@@ -1,0 +1,44 @@
+---
+session: "dzwl3a"
+timestamp: "2026-06-08T16:44:00Z"
+model: claude-opus-4-8
+tools: [explore, playwright]
+---
+
+## Human
+
+When painting or using a tool in the interactive view, clicking outside the
+model to move/rotate it hides the horizontal tool menu but leaves the
+individual tool panel open. Clicking away outside the model shouldn't close
+either — you might want to rotate the model while using tools on it. Make
+that update and open a PR.
+
+## Assistant
+
+## Key decisions
+
+**Root cause**: `createPopoverGroup` in `src/ui/popoverMenu.ts` registered a
+`document` `click` listener that called `close()` whenever the click target
+wasn't inside the popover `wrapper`. The 3D viewport `<canvas>` is not a DOM
+child of that wrapper, so an off-model click in the viewport (an orbit/rotate
+gesture, which OrbitControls handles on `pointerdown`) still produced a
+bubbling `click` that the listener treated as "click outside" — collapsing
+the Tools launcher row. The active tool's docked panel (e.g.
+`#paint-picker-panel`) is controlled separately and stays open, leaving the
+inconsistent state the user described.
+
+**Fix**: Guard the click-outside handler so clicks landing on the 3D viewport
+canvas (`.viewport-canvas`) are not treated as a dismiss. A viewport click is
+a camera/orbit/paint interaction, not a "close the menu" intent, so the menu
+(and the tool panel that docks beneath it) stays open. Genuine off-viewport
+UI clicks still dismiss the popover, and opening a sibling popover or Escape
+still closes it. Scoped the guard to the canvas element specifically (not the
+whole viewport container) so clicking other overlay buttons still dismisses,
+preserving single-popover-at-a-time behavior.
+
+**Verification**: Added a regression test to
+`tests/viewport-toolbar-groups.spec.ts` — opens Tools → Paint, clicks empty
+viewport-canvas space with a real mouse, and asserts both the Tools row and
+the paint panel remain visible. Used a real `page.mouse.click` (the tour is
+pre-dismissed) rather than `dispatchEvent('click')`, since the synthetic
+coordinate-less event isn't representative of an orbit click.

--- a/src/ui/popoverMenu.ts
+++ b/src/ui/popoverMenu.ts
@@ -112,7 +112,15 @@ export function createPopoverGroup(opts: PopoverGroupOptions): PopoverGroup {
   // Click-outside and Escape close the menu. Singleton bar — listeners persist
   // for the life of the page, matching the Import/Export dropdown pattern.
   document.addEventListener('click', (e) => {
-    if (isOpen() && !wrapper.contains(e.target as Node)) close();
+    if (!isOpen()) return;
+    const target = e.target as Node;
+    if (wrapper.contains(target)) return;
+    // Clicks on the 3D viewport canvas are camera/orbit/paint interactions, not a
+    // dismiss intent: the user may click empty space to rotate the model while a
+    // tool is active. Keep the menu (and the active tool's docked panel) open in
+    // that case — only genuine off-viewport UI clicks dismiss it.
+    if (target instanceof Element && target.closest('.viewport-canvas')) return;
+    close();
   });
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && isOpen()) close();

--- a/tests/viewport-toolbar-groups.spec.ts
+++ b/tests/viewport-toolbar-groups.spec.ts
@@ -80,6 +80,26 @@ test.describe('viewport toolbar groups', () => {
     await expect(page.locator('#measure-toggle')).toBeVisible();
   });
 
+  test('clicking the viewport canvas keeps the Tools menu and the open tool panel up', async ({ page }) => {
+    await openEditor(page);
+    await page.locator('#viewport-tools-group-btn').dispatchEvent('click');
+
+    // Open a tool so both the launcher row and its docked panel are showing.
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    // A click on empty space in the 3D viewport canvas is a camera/orbit intent
+    // (clicking away from the model to rotate it), NOT a dismiss — so it must leave
+    // both the Tools menu and the active tool's panel open. Regression for the bug
+    // where an off-model viewport click collapsed the Tools row but stranded the
+    // tool panel. The tour is pre-dismissed in openEditor, so a real click lands.
+    const box = await page.locator('#viewport').boundingBox();
+    if (!box) throw new Error('viewport canvas has no bounding box');
+    await page.mouse.click(box.x + 24, box.y + 24); // top-left corner — empty space
+    await expect(page.locator('#paint-toggle')).toBeVisible();
+    await expect(page.locator('#paint-picker-panel')).toBeVisible();
+  });
+
   test('grouped viewport tools are reachable from the command palette', async ({ page }) => {
     await openEditor(page);
     // Open the palette and search for the Paint tool command — the palette is the


### PR DESCRIPTION
## Summary

When painting or using a tool in the interactive viewport, clicking outside the model (to orbit/rotate the camera) hid the horizontal **Tools** launcher row but left the active tool's docked panel (e.g. the Paint picker) open — an inconsistent, half-collapsed state. You'd want to rotate the model *while* using a tool on it, so an off-model viewport click shouldn't dismiss either.

### Root cause

`createPopoverGroup` (`src/ui/popoverMenu.ts`) registered a `document` `click` listener that called `close()` on any click outside the popover wrapper. The 3D viewport `<canvas>` isn't a DOM child of that wrapper, so an off-model click in the viewport (an OrbitControls orbit gesture) still produced a bubbling `click` the listener treated as "click outside" — collapsing the Tools row while the separately-controlled tool panel stayed up.

### Fix

Guard the click-outside handler so clicks landing on the 3D viewport canvas (`.viewport-canvas`) are **not** treated as a dismiss — a viewport click is a camera/orbit/paint interaction, not a "close the menu" intent. Genuine off-viewport UI clicks, opening a sibling popover, and Escape all still close the menu, and the guard is scoped to the canvas element (not the whole viewport container) so other overlay buttons still dismiss.

## Test plan

- Added a regression test to `tests/viewport-toolbar-groups.spec.ts`: open Tools → Paint, click empty viewport-canvas space with a real mouse, assert both the Tools row and the Paint panel stay visible.
- `npm run build` ✅ · `npm run test:unit` ✅ (802 passing) · `viewport-toolbar-groups.spec.ts` ✅ (5/5)
- Manually verified in the browser (screenshot below): after clicking empty viewport space with Paint active, both the Tools row and the Paint panel remain open.

https://claude.ai/code/session_01TneUvdod5en9BB6wzBBkXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TneUvdod5en9BB6wzBBkXc)_