### PR TITLE
feat: voxel add-block size + depth, with box-tool extrude

### DIFF
--- a/prompts/voxel-add-block-fix-test.md
+++ b/prompts/voxel-add-block-fix-test.md
@@ -1,0 +1,28 @@
+---
+session: "01TLwb"
+timestamp: "2026-06-08T17:10:00Z"
+---
+
+## Human
+
+#519 has test failures I think.
+
+## Assistant
+
+## Key decisions
+
+- The failing e2e (`tests/voxel-studio.spec.ts` "brush size stamps a
+  footprint") asserted the *old* behavior where the `add` tool's footprint came
+  from the paint brush radius/shape. The voxel-add-block feature on this branch
+  deliberately reassigns the `add` tool to the new **Block size (X/Y/Z) +
+  Depth** controls (`addBlock`), and the UI now shows the brush radius/shape
+  section only for `paint`/`remove`. So the test was exercising intentionally
+  removed behavior, not a regression in the new code.
+
+- Fixed by updating the test to the new contract: drive the add stamp via
+  `setVoxelBrush({ block: [3,3,3], depth: 1 })`. `depth: 1` sinks the block's
+  near layer into the clicked voxel so the 3×3×3 block overlaps the origin,
+  yielding the same 27-voxel total the test verifies. The brush radius/shape
+  path remains covered by the paint/remove tests, so no coverage was lost.
+
+- Verified locally: the single spec passes against the sandbox Chromium.

--- a/prompts/voxel-add-block-size-depth.md
+++ b/prompts/voxel-add-block-size-depth.md
@@ -1,0 +1,59 @@
+---
+session: "01TLwb"
+timestamp: "2026-06-08T17:00:00Z"
+---
+
+## Human
+
+In Voxel Studio, let people control the **XYZ size** of a large voxel block
+when *adding* voxels, and control the **depth** of how they're added. The
+problem: adding a 5×5 block onto a 1-thick imported tile landed it halfway, so
+2–3 layers stuck out both the front and the back. They want it to attach to the
+*front-most* surface by default, but also be able to embed it / set a general
+depth so it feels like "painting" new voxels onto a model. Then, separately:
+make the size and depth settings work for the **box fill** and **box subtract**
+tools too.
+
+## Assistant
+
+## Key decisions
+
+**Add tool → an anchored block instead of a centered round brush.** The old
+`add` stamped a sphere/cube/diamond brush centered on `clickedVoxel + normal`,
+so a thick brush straddled a thin tile and poked out both sides. New
+`addBlockCells(voxel, normal, size, depth)` (edits.ts) lays a world-axis
+`[x,y,z]` box that is **centered on the two axes tangent to the clicked face**
+but **anchored along the normal** — its near layer sits flush against the
+surface and it grows outward. That structurally prevents back-poke. `depth`
+sinks it inward (0 = on top / front-attach; `size`-along-normal = fully
+embedded). Crucially, the default `[1,1,1]` + depth 0 reduces *exactly* to the
+legacy `addTarget` single-voxel add, so existing behavior/tests are unchanged.
+
+**Box tools → depth extrudes the selection; size is already the two corners.**
+The box tools are two-click region ops, so the two corners already fix the X/Y/Z
+extent — a separate "block size" has no meaning there. What they lacked is
+*thickness* perpendicular to a flat (coplanar) selection. New `extrudeBox(a, b,
+normal, depth, into)` extends the box `depth` extra layers along the completing
+click's face normal: `boxAdd` grows a slab outward, `boxRemove` carves inward.
+`depth 0` returns the corners unchanged (legacy behavior preserved). Threaded
+the completing click's `triNormal` into `applyBox`. I deliberately did **not**
+wire the XYZ sliders to the box tools (they'd be redundant/confusing); the panel
+shows only Depth for box, and I flagged this choice to the user.
+
+**UI.** Split the brush panel: paint/remove keep radius/shape/spray; `add` shows
+a Block-size section (X/Y/Z sliders, 1..16) ; a shared Depth section shows for
+`add` + both box tools, with tool-aware labels ("on surface"/"N deep" for add,
+"flat"/"+N layers" for box). The hover/delete preview overlay now draws the full
+add-block footprint (via `addBlockCells`) so size/depth are visible before
+committing.
+
+**Parity.** Extended the `setVoxelBrush` console/AI API with `block` and
+`depth` (validated, returns resolved settings) and documented both in
+`public/ai/voxel.md`, keeping the UI↔JS-API parity rule.
+
+**Verification.** Build clean; unit tier 815 pass (added `addBlockCells` /
+`addBlock` / `extrudeBox` coverage incl. the thin-tile front-attach and the
+non-coplanar extrude-axis edge case). Browser-verified both flows with throwaway
+Playwright specs + screenshots: a 3×3×4 block front-attaching to a 5×5×1 tile
+(25→61 voxels, none overlapping) and a box-fill extruding a raised slab
+(depth +3, 25→37). Scratch specs deleted before commit.

--- a/public/ai/voxel.md
+++ b/public/ai/voxel.md
@@ -285,6 +285,8 @@ partwright.paintVoxelFace({ faceIndex: 12, erase: true });
 partwright.setVoxelTool('add');                                  // -> { tool }
 partwright.setVoxelBrush({ radius: 2, shape: 'sphere' });        // wider brush
 partwright.voxelStudioApply({ faceIndex: 0, color: [80,160,255] }); // sculpt a blob
+partwright.setVoxelBrush({ block: [5,5,1], depth: 0 });          // add a 5×5×1 plate flush to the clicked face
+partwright.voxelStudioApply({ faceIndex: 0, color: '#cc8844' });    // stamp the block
 partwright.setVoxelTool('bucket');
 partwright.voxelStudioApply({ faceIndex: 4, color: '#33cc55' });    // flood recolor
 partwright.setVoxelTool('level');
@@ -316,10 +318,16 @@ await partwright.bakeVoxelsToCode({ label: 'castle' });  // replace with voxels.
   doesn't return a grid.
 - `setVoxelTool(tool)` — `'paint' | 'add' | 'remove' | 'bucket' | 'level' |
   'boxAdd' | 'boxRemove'`. Returns `{ tool }` or `{ error }`.
-- `setVoxelBrush({ radius?, shape?, spray?, sprayDensity? })` — brush for the
-  paint/add/remove tools. `radius` in voxels (0 = single, max 16); `shape` is
-  `'sphere' | 'cube' | 'diamond'`; `spray` scatters a random subset;
-  `sprayDensity` 0.05..1. Returns the resolved settings.
+- `setVoxelBrush({ radius?, shape?, spray?, sprayDensity?, block?, depth? })` —
+  brush/block settings. For paint/remove: `radius` in voxels (0 = single, max
+  16); `shape` is `'sphere' | 'cube' | 'diamond'`; `spray` scatters a random
+  subset; `sprayDensity` 0.05..1. For the `add` tool: `block` is the `[x,y,z]`
+  size in voxels (1..32 each) and the block is anchored to the clicked face so a
+  thick block never pokes out the far side of a thin tile. `depth` (0..16) sinks
+  the add block into the surface, and for the box tools extrudes the
+  fill/subtract along the clicked face (a `boxAdd` grows a slab that many extra
+  layers, a `boxRemove` carves that many deeper); `0` = flush to the face.
+  Returns the resolved settings.
 - `setVoxelLevelAxis(axis)` — `0`/`1`/`2` (x/y/z) for the `level` tool.
 - `voxelStudioBeginStroke()` / `voxelStudioEndStroke()` — bracket a run of
   `voxelStudioApply` calls so they collapse into one undo step (the

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -20,7 +20,7 @@ import type { MeshData } from '../geometry/types';
 import { normalizeColor, type VoxelGrid } from '../geometry/voxel/grid';
 import { gridToMeshWithProvenance } from '../geometry/voxel/mesher';
 import { runVoxelForPaint, type VoxelPaintRun } from '../geometry/engines/voxel';
-import { bucketRecolor, clearBox, fillBoxRecolor, addTarget, brushApply, levelRecolor, inBrush, type BrushShape } from '../geometry/voxel/edits';
+import { bucketRecolor, clearBox, fillBoxRecolor, addBlock, addBlockCells, extrudeBox, brushApply, levelRecolor, inBrush, type BrushShape } from '../geometry/voxel/edits';
 import { diffGrids, type VoxelEditOps } from '../geometry/voxel/editCodegen';
 import { generateVoxelImportCode } from '../import/imageToVoxel';
 import { addPointerSuppressor, isPointerWithinModelBounds, getRenderer, getScene, requestRender } from '../renderer/viewport';
@@ -62,6 +62,10 @@ let boxCorner: [number, number, number] | null = null;
 // Brush settings (shared by the paint/add/remove tools).
 let brushRadius = 0;            // 0 = single voxel (preserves click-to-paint)
 let brushShape: BrushShape = 'sphere';
+// Add-block settings (the `add` tool only): a world-axis box laid against the
+// clicked face. [1,1,1] + depth 0 reduces to the legacy single-voxel add.
+let blockSize: [number, number, number] = [1, 1, 1];
+let addDepth = 0;              // layers the block sinks into the surface (0 = on top)
 let spray = false;             // scatter a random subset of the footprint
 let sprayDensity = 0.5;        // 0..1, fraction kept when spraying
 let levelAxis: 0 | 1 | 2 = 2;  // axis for the "level" tool (x/y/z)
@@ -112,6 +116,23 @@ export function setBrushRadius(r: number): void {
 }
 export function getBrushShape(): BrushShape { return brushShape; }
 export function setBrushShape(s: BrushShape): void { brushShape = s; refreshPreview(); cbStateChange?.(); }
+
+// Add-block dimensions (X/Y/Z, in voxels) and how deep the block sinks into the
+// clicked surface. Used only by the `add` tool; the preview reflects them live.
+const MAX_BLOCK_SIZE = 32;
+const MAX_ADD_DEPTH = 16;
+export function getBlockSize(): [number, number, number] { return [...blockSize]; }
+export function setBlockSize(axis: 0 | 1 | 2, n: number): void {
+  blockSize[axis] = Math.max(1, Math.min(MAX_BLOCK_SIZE, Math.round(n) || 1));
+  refreshPreview();
+  cbStateChange?.();
+}
+export function getAddDepth(): number { return addDepth; }
+export function setAddDepth(n: number): void {
+  addDepth = Math.max(0, Math.min(MAX_ADD_DEPTH, Math.round(n) || 0));
+  refreshPreview();
+  cbStateChange?.();
+}
 export function isSpray(): boolean { return spray; }
 export function setSpray(on: boolean): void { spray = !!on; cbStateChange?.(); }
 export function getSprayDensity(): number { return sprayDensity; }
@@ -282,7 +303,8 @@ export function applyAtTriangle(triangleIndex: number): boolean {
   if (idx < 0 || idx + 2 >= run.triVoxel.length) return false;
   if (tool === 'boxAdd' || tool === 'boxRemove') {
     const x = run.triVoxel[idx], y = run.triVoxel[idx + 1], z = run.triVoxel[idx + 2];
-    return applyBox(x, y, z);
+    const nx = run.triNormal[idx], ny = run.triNormal[idx + 1], nz = run.triNormal[idx + 2];
+    return applyBox(x, y, z, [nx, ny, nz]);
   }
   if (strokeActive) {
     const changed = runOp(triangleIndex);
@@ -307,11 +329,10 @@ function runOp(triangleIndex: number): boolean {
       return brushApply(run.grid, [x, y, z], brushRadius, brushShape, 'paint', color, density) > 0;
     case 'remove':
       return brushApply(run.grid, [x, y, z], brushRadius, brushShape, 'remove', color, density) > 0;
-    case 'add': {
-      const target = addTarget([x, y, z], [nx, ny, nz]);
-      if (!target) return false;
-      return brushApply(run.grid, target, brushRadius, brushShape, 'add', color, density) > 0;
-    }
+    case 'add':
+      // A block laid against the clicked face: per-axis size, anchored along
+      // the normal so it won't poke out the far side of a thin tile.
+      return addBlock(run.grid, [x, y, z], [nx, ny, nz], blockSize, addDepth, color) > 0;
     case 'bucket':
       return bucketRecolor(run.grid, [x, y, z], color) > 0;
     case 'level':
@@ -369,8 +390,11 @@ function mutate(fn: () => boolean): boolean {
 }
 
 /** Two-click box: the first click banks a corner (no mutation); the second
- *  fills (boxAdd) or clears (boxRemove) the inclusive box between them. */
-function applyBox(x: number, y: number, z: number): boolean {
+ *  fills (boxAdd) or clears (boxRemove) the inclusive box between them. The
+ *  `addDepth` setting extrudes the box along the second click's face normal —
+ *  a fill grows a slab outward, a subtract carves inward (see {@link extrudeBox}).
+ *  The completing click's `normal` sets the extrusion direction. */
+function applyBox(x: number, y: number, z: number, normal: [number, number, number]): boolean {
   if (!run) return false;
   if (!boxCorner) {
     boxCorner = [x, y, z];
@@ -379,9 +403,11 @@ function applyBox(x: number, y: number, z: number): boolean {
   }
   const a = boxCorner;
   boxCorner = null;
-  return mutate(() => tool === 'boxRemove'
-    ? clearBox(run!.grid, a, [x, y, z]) > 0
-    : fillBoxRecolor(run!.grid, a, [x, y, z], color) > 0);
+  const remove = tool === 'boxRemove';
+  const [c0, c1] = extrudeBox(a, [x, y, z], normal, addDepth, remove);
+  return mutate(() => remove
+    ? clearBox(run!.grid, c0, c1) > 0
+    : fillBoxRecolor(run!.grid, c0, c1, color) > 0);
 }
 
 function remeshAndPush(): void {
@@ -397,6 +423,15 @@ function triangleVoxel(triangleIndex: number): [number, number, number] | null {
   const idx = triangleIndex * 3;
   if (idx < 0 || idx + 2 >= run.triVoxel.length) return null;
   return [run.triVoxel[idx], run.triVoxel[idx + 1], run.triVoxel[idx + 2]];
+}
+
+/** The integer face-normal baked for a triangle (a unit axis vector), or null.
+ *  Preferred over the raycast normal for the add block since it's exact. */
+function triangleNormal(triangleIndex: number): [number, number, number] | null {
+  if (!run) return null;
+  const idx = triangleIndex * 3;
+  if (idx < 0 || idx + 2 >= run.triNormal.length) return null;
+  return [run.triNormal[idx], run.triNormal[idx + 1], run.triNormal[idx + 2]];
 }
 
 function sameVoxel(a: [number, number, number] | null, b: [number, number, number] | null): boolean {
@@ -443,9 +478,9 @@ function ensurePreviewCapacity(n: number): void {
   previewCapacity = cap;
 }
 
-/** The voxel cells the active brush tool would affect at `center`: occupied
- *  cells in the footprint for paint/remove (what gets recolored/deleted), empty
- *  cells for add (the new voxels). */
+/** The occupied voxel cells the paint/remove brush would affect at `center` —
+ *  what gets recolored or deleted. (The `add` tool previews a block instead;
+ *  see {@link previewCells}.) */
 function brushFootprintCells(center: [number, number, number]): [number, number, number][] {
   const cells: [number, number, number][] = [];
   if (!run) return cells;
@@ -456,25 +491,30 @@ function brushFootprintCells(center: [number, number, number]): [number, number,
       for (let dz = -ri; dz <= ri; dz++) {
         if (!inBrush(brushShape, dx, dy, dz, ri)) continue;
         const x = cx + dx, y = cy + dy, z = cz + dz;
-        const occupied = run.grid.has(x, y, z);
-        // add fills empty cells; paint/remove act on existing ones.
-        if (tool === 'add' ? occupied : !occupied) continue;
+        if (!run.grid.has(x, y, z)) continue; // paint/remove act on existing cells
         cells.push([x, y, z]);
       }
   return cells;
 }
 
-function previewCenter(hit: FacePickResult): [number, number, number] | null {
+/** Cells the active brush/block tool would touch at the hovered face — the
+ *  set the preview overlay draws. For `add` this is the anchored block (so the
+ *  user sees its size and how far it sinks in); for paint/remove it's the
+ *  occupied brush footprint. */
+function previewCells(hit: FacePickResult): [number, number, number][] {
+  if (!run) return [];
   const v = triangleVoxel(hit.triangleIndex);
-  if (!v) return null;
-  return tool === 'add' ? addTarget(v, hit.normal) : v;
+  if (!v) return [];
+  if (tool === 'add') {
+    const n = triangleNormal(hit.triangleIndex);
+    return n ? addBlockCells(v, n, blockSize, addDepth) : [];
+  }
+  return brushFootprintCells(v);
 }
 
 function renderPreviewFromHit(hit: FacePickResult | null): void {
   if (!active || !run || !isBrushTool(tool) || !hit) { clearPreview(); return; }
-  const center = previewCenter(hit);
-  if (!center) { clearPreview(); return; }
-  const cells = brushFootprintCells(center);
+  const cells = previewCells(hit);
   if (cells.length === 0) { clearPreview(); return; }
   ensurePreviewCapacity(cells.length);
   if (!previewMesh) return;

--- a/src/color/voxelPaintUI.ts
+++ b/src/color/voxelPaintUI.ts
@@ -19,7 +19,7 @@ const SWATCHES: string[] = [
 // Tool buttons, in panel order. `label` is the glyph shown; `title` the tooltip.
 const TOOLS: { tool: VoxelTool; label: string; title: string }[] = [
   { tool: 'paint',     label: '🖌', title: 'Brush — drag to recolor voxels (use Size for a wider brush)' },
-  { tool: 'add',       label: '➕', title: 'Add — drag to build cubes onto the clicked faces' },
+  { tool: 'add',       label: '➕', title: 'Add — build a block onto the clicked face (set its X/Y/Z size and how deep it sinks in)' },
   { tool: 'remove',    label: '⌫',  title: 'Remove — drag to delete voxels' },
   { tool: 'bucket',    label: '🪣', title: 'Bucket — recolor the connected same-color region' },
   { tool: 'level',     label: '🧱', title: 'Level — recolor a whole X/Y/Z layer through the clicked voxel' },
@@ -65,11 +65,17 @@ let undoBtn: HTMLButtonElement | null = null;
 let redoBtn: HTMLButtonElement | null = null;
 let statusEl: HTMLElement | null = null;
 let brushSection: HTMLElement | null = null;
+let blockSection: HTMLElement | null = null;
+let depthSection: HTMLElement | null = null;
 let levelSection: HTMLElement | null = null;
 let sizeSlider: HTMLInputElement | null = null;
 let sizeLabel: HTMLElement | null = null;
 let sprayBtn: HTMLButtonElement | null = null;
 let sprayRow: HTMLElement | null = null;
+const blockSliders: Partial<Record<0 | 1 | 2, HTMLInputElement>> = {};
+let blockSizeLabel: HTMLElement | null = null;
+let depthSlider: HTMLInputElement | null = null;
+let depthLabel: HTMLElement | null = null;
 
 export interface VoxelPaintUICallbacks {
   /** Called when the user clicks the toggle button to enter the studio. The
@@ -162,9 +168,13 @@ function refreshControls(): void {
   const tool = voxelPaint.getTool();
   for (const t of TOOLS) setActive(toolBtns[t.tool], t.tool === tool);
 
-  // Brush section shows only for the brush tools; level section only for level.
-  const brushy = tool === 'paint' || tool === 'add' || tool === 'remove';
-  brushSection?.classList.toggle('hidden', !brushy);
+  // Brush (radius/shape/spray) shows for paint/remove; the add tool gets the
+  // block (X/Y/Z) size controls; depth shows for add + the box tools; level
+  // gets the axis picker.
+  const isBox = tool === 'boxAdd' || tool === 'boxRemove';
+  brushSection?.classList.toggle('hidden', !(tool === 'paint' || tool === 'remove'));
+  blockSection?.classList.toggle('hidden', tool !== 'add');
+  depthSection?.classList.toggle('hidden', !(tool === 'add' || isBox));
   levelSection?.classList.toggle('hidden', tool !== 'level');
 
   for (const s of BRUSH_SHAPES) setActive(shapeBtns[s.shape], s.shape === voxelPaint.getBrushShape());
@@ -180,6 +190,20 @@ function refreshControls(): void {
     sprayBtn.textContent = on ? '◉ Spray: on' : '○ Spray: off';
     setActive(sprayBtn, on);
     sprayRow?.classList.toggle('hidden', !on);
+  }
+
+  // Add-block controls.
+  const size = voxelPaint.getBlockSize();
+  for (const axis of [0, 1, 2] as const) {
+    const s = blockSliders[axis];
+    if (s) s.value = String(size[axis]);
+  }
+  if (blockSizeLabel) blockSizeLabel.textContent = `${size[0]}×${size[1]}×${size[2]}`;
+  if (depthSlider) depthSlider.value = String(voxelPaint.getAddDepth());
+  if (depthLabel) {
+    const d = voxelPaint.getAddDepth();
+    if (d === 0) depthLabel.textContent = isBox ? 'flat' : 'on surface';
+    else depthLabel.textContent = isBox ? `+${d} layers` : `${d} deep`;
   }
 
   if (undoBtn) undoBtn.disabled = !voxelPaint.canUndo();
@@ -240,6 +264,10 @@ function createPanel(): HTMLElement {
   content.appendChild(buildColorRow());
   brushSection = buildBrushSection();
   content.appendChild(brushSection);
+  blockSection = buildBlockSection();
+  content.appendChild(blockSection);
+  depthSection = buildDepthSection();
+  content.appendChild(depthSection);
   levelSection = buildLevelSection();
   content.appendChild(levelSection);
   content.appendChild(buildHistoryRow());
@@ -376,6 +404,82 @@ function buildBrushSection(): HTMLElement {
   density.addEventListener('input', () => voxelPaint.setSprayDensity(Number(density.value) / 100));
   sprayRow.appendChild(density);
   sec.appendChild(sprayRow);
+
+  return sec;
+}
+
+function buildBlockSection(): HTMLElement {
+  const sec = document.createElement('div');
+  sec.className = 'hidden flex flex-col gap-1.5 pt-1 border-t border-zinc-700/60';
+
+  const head = document.createElement('div');
+  head.className = 'flex items-center justify-between';
+  const h = document.createElement('span');
+  h.className = 'text-[10px] uppercase tracking-wider text-zinc-500';
+  h.textContent = 'Block size';
+  head.appendChild(h);
+  blockSizeLabel = document.createElement('span');
+  blockSizeLabel.className = 'text-[11px] text-zinc-400';
+  head.appendChild(blockSizeLabel);
+  sec.appendChild(head);
+
+  // One X/Y/Z slider per axis (1…16). The block is centered on the clicked
+  // voxel across the face and grows outward along the normal.
+  const AXIS_META: { axis: 0 | 1 | 2; label: string }[] = [
+    { axis: 0, label: 'X' }, { axis: 1, label: 'Y' }, { axis: 2, label: 'Z' },
+  ];
+  for (const { axis, label } of AXIS_META) {
+    const row = document.createElement('label');
+    row.className = 'flex items-center gap-2 text-[11px] text-zinc-400';
+    const tag = document.createElement('span');
+    tag.className = 'w-3 text-zinc-300';
+    tag.textContent = label;
+    row.appendChild(tag);
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.min = '1';
+    slider.max = '16';
+    slider.step = '1';
+    slider.value = String(voxelPaint.getBlockSize()[axis]);
+    slider.className = 'flex-1 accent-blue-500';
+    slider.title = `Block ${label} size in voxels`;
+    slider.addEventListener('input', () => { voxelPaint.setBlockSize(axis, Number(slider.value)); refreshControls(); });
+    row.appendChild(slider);
+    blockSliders[axis] = slider;
+    sec.appendChild(row);
+  }
+
+  return sec;
+}
+
+// Depth control, shared by the add tool (how far the block sinks into the
+// surface) and the box tools (how many extra layers the fill/subtract extrudes
+// along the clicked face). 0 = flush to the surface in both cases.
+function buildDepthSection(): HTMLElement {
+  const sec = document.createElement('div');
+  sec.className = 'hidden flex flex-col gap-1 pt-1 border-t border-zinc-700/60';
+
+  const head = document.createElement('div');
+  head.className = 'flex items-center justify-between';
+  const dh = document.createElement('span');
+  dh.className = 'text-[10px] uppercase tracking-wider text-zinc-500';
+  dh.textContent = 'Depth';
+  head.appendChild(dh);
+  depthLabel = document.createElement('span');
+  depthLabel.className = 'text-[11px] text-zinc-400';
+  head.appendChild(depthLabel);
+  sec.appendChild(head);
+
+  depthSlider = document.createElement('input');
+  depthSlider.type = 'range';
+  depthSlider.min = '0';
+  depthSlider.max = '16';
+  depthSlider.step = '1';
+  depthSlider.value = String(voxelPaint.getAddDepth());
+  depthSlider.className = 'w-full accent-blue-500';
+  depthSlider.title = 'Add: layers the block sinks into the surface. Box: extra layers the fill grows / subtract carves (0 = flush to the clicked face).';
+  depthSlider.addEventListener('input', () => { voxelPaint.setAddDepth(Number(depthSlider!.value)); refreshControls(); });
+  sec.appendChild(depthSlider);
 
   return sec;
 }

--- a/src/geometry/voxel/edits.ts
+++ b/src/geometry/voxel/edits.ts
@@ -103,6 +103,83 @@ export function addTarget(voxel: Vec3, normal: Vec3): Vec3 | null {
   return inRange(nx, ny, nz) ? [nx, ny, nz] : null;
 }
 
+/** The cells an "add block" stamp covers — a `size`=[sx,sy,sz] world-voxel box
+ *  laid against the clicked face. The box is centered on `voxel` in the two
+ *  axes tangent to `normal`, and *anchored* along the normal so its near layer
+ *  sits flush against the clicked face (front-attach) instead of straddling it.
+ *  This is what stops a thick block from poking out the back of a thin tile.
+ *
+ *  `depth` (≥0) sinks the block into the surface along the normal: 0 = entirely
+ *  outside the clicked voxel (the default, front-attach); 1 = its near layer
+ *  overwrites the clicked voxel; `size`-along-normal = fully embedded, ending
+ *  flush at the clicked voxel. Out-of-range cells are dropped.
+ *
+ *  At the default size [1,1,1] with depth 0 this reduces to {@link addTarget} —
+ *  a single voxel one step out from the clicked face. */
+export function addBlockCells(voxel: Vec3, normal: Vec3, size: Vec3, depth = 0): Vec3[] {
+  // Normal axis = the dominant component; the other two are tangent.
+  const ax = Math.abs(normal[0]), ay = Math.abs(normal[1]), az = Math.abs(normal[2]);
+  if (ax === 0 && ay === 0 && az === 0) return [];
+  const a = ax >= ay && ax >= az ? 0 : ay >= az ? 1 : 2;
+  const d = normal[a] >= 0 ? 1 : -1;
+  const t0 = (a + 1) % 3, t1 = (a + 2) % 3;
+  const sa = Math.max(1, Math.floor(size[a]));
+  const s0 = Math.max(1, Math.floor(size[t0]));
+  const s1 = Math.max(1, Math.floor(size[t1]));
+  const e = Math.max(0, Math.floor(depth));
+  // Tangent axes center on the clicked voxel (odd sizes symmetric; even sizes
+  // bias one cell toward +).
+  const base0 = voxel[t0] - Math.floor((s0 - 1) / 2);
+  const base1 = voxel[t1] - Math.floor((s1 - 1) / 2);
+  const cells: Vec3[] = [];
+  for (let k = 0; k < sa; k++) {
+    const an = voxel[a] + d * (1 - e + k); // layer along the normal
+    for (let i = 0; i < s0; i++)
+      for (let j = 0; j < s1; j++) {
+        const cell: Vec3 = [0, 0, 0];
+        cell[a] = an;
+        cell[t0] = base0 + i;
+        cell[t1] = base1 + j;
+        if (inRange(cell[0], cell[1], cell[2])) cells.push(cell);
+      }
+  }
+  return cells;
+}
+
+/** Stamp an "add block" (see {@link addBlockCells}) into the grid, coloring
+ *  every covered cell. Returns the number of cells newly created or recolored.
+ *  Mutates `grid` in place. */
+export function addBlock(grid: VoxelGrid, voxel: Vec3, normal: Vec3, size: Vec3, depth: number, color: ColorInput): number {
+  const rgb = normalizeColor(color, 'addBlock(color)');
+  let changed = 0;
+  for (const [x, y, z] of addBlockCells(voxel, normal, size, depth)) {
+    if (grid.get(x, y, z) !== rgb) { grid.set(x, y, z, rgb); changed++; }
+  }
+  return changed;
+}
+
+/** Extrude the box spanned by corners `a`/`b` along the clicked face `normal`
+ *  by `depth` extra layers, returning the two corners of the extruded box.
+ *  This gives the two-click box tools a thickness perpendicular to a flat
+ *  (coplanar) selection: a box-fill grows a slab *outward* from the surface
+ *  (`into = false`), a box-subtract carves *inward* into the solid
+ *  (`into = true`). `depth = 0` returns `[a, b]` unchanged (legacy behavior). */
+export function extrudeBox(a: Vec3, b: Vec3, normal: Vec3, depth: number, into: boolean): [Vec3, Vec3] {
+  const e = Math.max(0, Math.floor(depth));
+  const ax = Math.abs(normal[0]), ay = Math.abs(normal[1]), az = Math.abs(normal[2]);
+  if (e === 0 || (ax === 0 && ay === 0 && az === 0)) return [[...a] as Vec3, [...b] as Vec3];
+  const axis = ax >= ay && ax >= az ? 0 : ay >= az ? 1 : 2;
+  const d = normal[axis] >= 0 ? 1 : -1;
+  const dir = into ? -d : d; // fill grows outward; subtract digs inward
+  const lo = Math.min(a[axis], b[axis]);
+  const hi = Math.max(a[axis], b[axis]);
+  const c0: Vec3 = [...a] as Vec3;
+  const c1: Vec3 = [...b] as Vec3;
+  c0[axis] = dir > 0 ? lo : lo - e;
+  c1[axis] = dir > 0 ? hi + e : hi;
+  return [c0, c1];
+}
+
 /** Voxel brush footprint shapes — the 3D analogues of the mesh paint brush's
  *  circle/square/diamond, as integer-voxel distance tests around a center. */
 export type BrushShape = 'sphere' | 'cube' | 'diamond';

--- a/src/main.ts
+++ b/src/main.ts
@@ -12285,8 +12285,13 @@ async function main() {
     /** Configure the brush used by the paint/add/remove tools. `radius` is in
      *  voxels (0 = a single voxel, max 16); `shape` is 'sphere' | 'cube' |
      *  'diamond'; `spray` scatters a random subset; `sprayDensity` is 0.05..1.
+     *
+     *  The `add` tool uses a block instead of a round brush: `block` is the
+     *  [x,y,z] size in voxels (1..32 each) and `depth` (0..16) is how far the
+     *  block sinks into the clicked surface — 0 attaches it flush to the face
+     *  (so a thick block never pokes out the far side of a thin tile).
      *  Returns the resolved brush settings or `{ error }`. */
-    setVoxelBrush(opts: { radius?: number; shape?: import('./color/voxelPaint').BrushShape; spray?: boolean; sprayDensity?: number } = {}) {
+    setVoxelBrush(opts: { radius?: number; shape?: import('./color/voxelPaint').BrushShape; spray?: boolean; sprayDensity?: number; block?: [number, number, number]; depth?: number } = {}) {
       if (!voxelPaint.isActive()) return { error: 'Voxel Studio is not active — call activateVoxelPaint() first.' };
       if (opts.radius !== undefined) {
         if (typeof opts.radius !== 'number' || opts.radius < 0) return { error: 'setVoxelBrush.radius must be a non-negative number' };
@@ -12302,8 +12307,23 @@ async function main() {
         if (typeof opts.sprayDensity !== 'number') return { error: 'setVoxelBrush.sprayDensity must be a number 0.05..1' };
         voxelPaint.setSprayDensity(opts.sprayDensity);
       }
+      if (opts.block !== undefined) {
+        const b = opts.block;
+        if (!Array.isArray(b) || b.length !== 3 || b.some((n) => typeof n !== 'number' || n < 1)) {
+          return { error: 'setVoxelBrush.block must be [x,y,z] with each ≥ 1' };
+        }
+        ([0, 1, 2] as const).forEach((axis) => voxelPaint.setBlockSize(axis, b[axis]));
+      }
+      if (opts.depth !== undefined) {
+        if (typeof opts.depth !== 'number' || opts.depth < 0) return { error: 'setVoxelBrush.depth must be a non-negative number' };
+        voxelPaint.setAddDepth(opts.depth);
+      }
       syncVoxelPaintUI();
-      return { radius: voxelPaint.getBrushRadius(), shape: voxelPaint.getBrushShape(), spray: voxelPaint.isSpray(), sprayDensity: voxelPaint.getSprayDensity() };
+      return {
+        radius: voxelPaint.getBrushRadius(), shape: voxelPaint.getBrushShape(),
+        spray: voxelPaint.isSpray(), sprayDensity: voxelPaint.getSprayDensity(),
+        block: voxelPaint.getBlockSize(), depth: voxelPaint.getAddDepth(),
+      };
     },
 
     /** Set the axis (0=x, 1=y, 2=z) the 'level' tool recolors. Returns `{ axis }`. */

--- a/tests/unit/voxelEdits.test.ts
+++ b/tests/unit/voxelEdits.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { VoxelGrid } from '../../src/geometry/voxel/grid';
 import { gridToMeshWithProvenance } from '../../src/geometry/voxel/mesher';
-import { bucketRecolor, clearBox, fillBoxRecolor, addTarget, brushApply, levelRecolor, inBrush } from '../../src/geometry/voxel/edits';
+import { bucketRecolor, clearBox, fillBoxRecolor, addTarget, addBlock, addBlockCells, extrudeBox, brushApply, levelRecolor, inBrush } from '../../src/geometry/voxel/edits';
 
 // Pure-logic tests for the Voxel Studio multi-voxel edit operations + the
 // provenance the "add" tool relies on. The DOM/raycast glue (voxelPaint.ts)
@@ -102,6 +102,114 @@ describe('addTarget + provenance triNormal', () => {
       expect(target).not.toBeNull();
       expect(g.has(target![0], target![1], target![2])).toBe(false);
     }
+  });
+});
+
+describe('addBlockCells (anchored block add)', () => {
+  const key = (c: [number, number, number]) => c.join(',');
+  const has = (cells: [number, number, number][], c: [number, number, number]) =>
+    cells.some((x) => x[0] === c[0] && x[1] === c[1] && x[2] === c[2]);
+
+  it('default size + depth reduces to a single voxel out from the face (addTarget)', () => {
+    const cells = addBlockCells([0, 0, 0], [0, 0, 1], [1, 1, 1], 0);
+    expect(cells).toEqual([[0, 0, 1]]);
+    // Matches the legacy single-voxel add target.
+    expect(cells[0]).toEqual(addTarget([0, 0, 0], [0, 0, 1]));
+  });
+
+  it('front-attaches a thick block: never pokes out the far side of a thin tile', () => {
+    // Click the +Z face of a 1-thick tile voxel at z=0 with a 1×1×3 block.
+    const cells = addBlockCells([0, 0, 0], [0, 0, 1], [1, 1, 3], 0);
+    // All three layers sit ABOVE the surface (z = 1,2,3) — none at or below 0.
+    expect(cells.map((c) => c[2]).sort((a, b) => a - b)).toEqual([1, 2, 3]);
+    expect(cells.every((c) => c[2] >= 1)).toBe(true);
+  });
+
+  it('centers the block across the two tangent axes', () => {
+    // 3×3 across X/Y on a +Z face at the origin → a 3×3 plate one above.
+    const cells = addBlockCells([0, 0, 0], [0, 0, 1], [3, 3, 1], 0);
+    expect(cells).toHaveLength(9);
+    expect(has(cells, [-1, -1, 1])).toBe(true);
+    expect(has(cells, [1, 1, 1])).toBe(true);
+    expect(cells.every((c) => c[2] === 1)).toBe(true);
+  });
+
+  it('depth sinks the block into the surface along the normal', () => {
+    // depth 1 → the near layer overwrites the clicked voxel (z=0), rest grow up.
+    const cells = addBlockCells([0, 0, 0], [0, 0, 1], [1, 1, 3], 1).map((c) => c[2]).sort((a, b) => a - b);
+    expect(cells).toEqual([0, 1, 2]);
+    // depth === thickness → fully embedded, ending flush at the clicked voxel.
+    const deep = addBlockCells([0, 0, 0], [0, 0, 1], [1, 1, 3], 3).map((c) => c[2]).sort((a, b) => a - b);
+    expect(deep).toEqual([-2, -1, 0]);
+  });
+
+  it('respects the clicked face direction (negative normal grows the other way)', () => {
+    const cells = addBlockCells([5, 5, 5], [-1, 0, 0], [3, 1, 1], 0).map((c) => c[0]).sort((a, b) => a - b);
+    expect(cells).toEqual([2, 3, 4]); // x = 5-1, 5-2, 5-3
+  });
+
+  it('drops out-of-range cells at the coordinate extreme', () => {
+    // At x=1023 a +X block would land at 1024+ which is out of range.
+    expect(addBlockCells([1023, 0, 0], [1, 0, 0], [3, 1, 1], 0)).toEqual([]);
+  });
+
+  it('addBlock stamps the block into the grid and counts changes', () => {
+    const g = new VoxelGrid();
+    g.set(0, 0, 0, '#fff'); // a 1-voxel tile
+    const changed = addBlock(g, [0, 0, 0], [0, 0, 1], [3, 3, 1], 0, '#00ff00');
+    expect(changed).toBe(9);
+    expect(g.get(0, 0, 1)).toBe(0x00ff00);
+    expect(g.get(1, 1, 1)).toBe(0x00ff00);
+    expect(g.has(0, 0, -1)).toBe(false); // nothing below the surface
+    // The original tile is untouched (the block sits on top, depth 0).
+    expect(g.get(0, 0, 0)).toBe(0xffffff);
+    expect(new Set(addBlockCells([0, 0, 0], [0, 0, 1], [3, 3, 1], 0).map(key)).size).toBe(9);
+  });
+});
+
+describe('extrudeBox (box-tool depth)', () => {
+  it('depth 0 returns the corners unchanged (legacy box behavior)', () => {
+    expect(extrudeBox([0, 0, 0], [4, 4, 0], [0, 0, 1], 0, false)).toEqual([[0, 0, 0], [4, 4, 0]]);
+    expect(extrudeBox([0, 0, 0], [4, 4, 0], [0, 0, 1], 0, true)).toEqual([[0, 0, 0], [4, 4, 0]]);
+  });
+
+  it('box-fill grows a slab outward along the clicked normal', () => {
+    // Flat 5×5 selection on a +Z face → fill extrudes UP into a 5×5×4 slab.
+    const [a, b] = extrudeBox([0, 0, 0], [4, 4, 0], [0, 0, 1], 3, false);
+    expect(a).toEqual([0, 0, 0]);
+    expect(b).toEqual([4, 4, 3]);
+  });
+
+  it('box-subtract carves inward along the clicked normal', () => {
+    // Click the +Z top face at z=5 → subtract digs DOWN, removing z 2..5.
+    const [a, b] = extrudeBox([0, 0, 5], [4, 4, 5], [0, 0, 1], 3, true);
+    expect(a).toEqual([0, 0, 2]);
+    expect(b).toEqual([4, 4, 5]);
+  });
+
+  it('respects a negative face normal', () => {
+    // -X face: a fill grows toward -X (outward from that face).
+    const [a, b] = extrudeBox([0, 0, 0], [0, 4, 4], [-1, 0, 0], 2, false);
+    expect(a).toEqual([-2, 0, 0]);
+    expect(b).toEqual([0, 4, 4]);
+  });
+
+  it('preserves a non-coplanar box extent on the extrude axis', () => {
+    // Corners already span z 0..2; extruding up by 2 → z 0..4, not lost to 2..4.
+    const [a, b] = extrudeBox([0, 0, 0], [4, 4, 2], [0, 0, 1], 2, false);
+    expect(Math.min(a[2], b[2])).toBe(0);
+    expect(Math.max(a[2], b[2])).toBe(4);
+  });
+
+  it('drives a real fill/clear when fed through fillBoxRecolor/clearBox', () => {
+    const g = new VoxelGrid();
+    g.fillBox([0, 0, 0], [4, 4, 0], '#888'); // 5×5 tile at z=0
+    const [fa, fb] = extrudeBox([0, 0, 0], [4, 4, 0], [0, 0, 1], 2, false);
+    // 5×5×3 slab (z 0..2): recolors the 25 tile cells + 50 new = 75 changed.
+    expect(fillBoxRecolor(g, fa, fb, '#0f0')).toBe(75);
+    expect(g.size).toBe(75);
+    expect(g.has(2, 2, 2)).toBe(true);
+    expect(g.has(2, 2, -1)).toBe(false); // never pokes below the surface
   });
 });
 

--- a/tests/voxel-studio.spec.ts
+++ b/tests/voxel-studio.spec.ts
@@ -90,7 +90,7 @@ test.describe('voxel studio', () => {
     expect(r.second.pendingBoxCorner).toBeNull();
   });
 
-  test('brush size stamps a footprint of voxels in one apply', async ({ page }) => {
+  test('add-block size stamps a footprint of voxels in one apply', async ({ page }) => {
     const r = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const pw = (window as any).partwright;
@@ -98,15 +98,17 @@ test.describe('voxel studio', () => {
       await pw.run(`return api.voxels().set(0,0,0,'#ffffff');`);
       pw.activateVoxelPaint();
       pw.setVoxelTool('add');
-      const brush = pw.setVoxelBrush({ radius: 1, shape: 'cube' });
-      // Add a 3×3×3 cube footprint onto the clicked face.
+      // The add tool stamps a block sized by X/Y/Z (not the paint brush radius);
+      // depth 1 sinks its near layer into the clicked voxel so the 3×3×3 block
+      // overlaps the origin.
+      const brush = pw.setVoxelBrush({ block: [3, 3, 3], depth: 1 });
       const added = pw.voxelStudioApply({ faceIndex: 0, color: [255, 0, 0] });
       return { brush, added };
     });
-    expect(r.brush.radius).toBe(1);
-    expect(r.brush.shape).toBe('cube');
+    expect(r.brush.block).toEqual([3, 3, 3]);
+    expect(r.brush.depth).toBe(1);
     expect(r.added.changed).toBe(true);
-    expect(r.added.voxelCount).toBe(27); // 1 original ∪ 3×3×3 stamp (overlaps the origin)
+    expect(r.added.voxelCount).toBe(27); // 3×3×3 block, near layer overlapping the origin
   });
 
   test('level tool recolors a whole axis layer without changing the count', async ({ page }) => {


### PR DESCRIPTION
## Summary

Voxel Studio additions, driven by user feedback:

### Add tool — per-axis block + depth
The `add` tool now places a **per-axis X/Y/Z block** anchored to the clicked face instead of a centered round brush.
- The block centers on the two axes **tangent** to the clicked face and grows **outward along the normal**, so a thick block can never poke out the far side of a thin (1-voxel) tile — it front-attaches by default.
- A new **Depth** control sinks the block into the surface (`0` = sits on top / front-attach; up to the block's normal-axis size = fully embedded), so it feels like "painting" voxels onto a model.
- **Backward compatible:** the default `1×1×1` + depth `0` reduces exactly to the legacy single-voxel `addTarget` add.

### Box fill / box subtract — depth extrude
The same **Depth** control now extrudes the two-click box selection along the completing click's face normal:
- `boxAdd` grows a slab that many extra layers **outward**;
- `boxRemove` carves that many layers **deeper inward**.
- Depth `0` preserves the legacy box behavior exactly.

> **Note on "size" for the box tools:** the two corners already fix the box's X/Y/Z extent, so the X/Y/Z **block-size** sliders don't apply there — the panel shows only **Depth** for box tools (the genuinely new knob: thickness perpendicular to a flat selection). If you actually wanted the XYZ sliders to *pad* the box beyond the two clicked corners, say the word and I'll add that.

### Preview, API, docs
- The hover/delete **preview overlay** now draws the full add-block footprint (via `addBlockCells`), so size/depth are visible before committing.
- `setVoxelBrush` (console/AI API) gains validated `block: [x,y,z]` and `depth` options and returns them; documented in `public/ai/voxel.md` (UI↔JS-API parity).

## Test plan
- `npm run build` — clean.
- `npm run test:unit` — **815 pass**, including new coverage for `addBlockCells` / `addBlock` / `extrudeBox` (thin-tile front-attach, depth embedding, negative normals, the non-coplanar extrude-axis edge case, and the fill driven end-to-end through `fillBoxRecolor`).
- Browser-verified both flows with throwaway Playwright specs + screenshots (deleted before commit):
  - a `3×3×4` block front-attaching to a `5×5×1` tile → 25→61 voxels, none overlapping (no poke-through);
  - a box-fill with depth `+3` extruding a flat selection into a raised slab → 25→37 voxels.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLwbKg6AuMfit15FdcKpqo)_