### PR TITLE
feat: let voxel depth accept a typed value past the slider max

### DIFF
--- a/prompts/voxel-depth-typed-input.md
+++ b/prompts/voxel-depth-typed-input.md
@@ -1,0 +1,42 @@
+---
+session: "01EDqE"
+timestamp: "2026-06-09T10:00:00Z"
+---
+
+## Human
+
+I just merged a voxel studio update but I want the depth slider to accept a
+typed number. Even though the slider goes up to 16 I don't want a hard max on
+the typed in value. Make a PR.
+
+## Assistant
+
+## Key decisions
+
+**Split the convenience range from the allowed range.** The depth slider stays
+a 0..16 range input (a comfortable drag for the common case), but the *stored*
+value is no longer clamped to 16. `setAddDepth` in `voxelPaint.ts` dropped its
+`Math.min(MAX_ADD_DEPTH, …)` (and the now-unused `MAX_ADD_DEPTH` const) so it
+keeps any non-negative integer. The lower bound (`Math.max(0, …)`) is kept —
+negative depth is meaningless.
+
+**Typed input mirrors the existing paint-depth pattern.** Rather than invent a
+new control, I followed the precedent already in `paintUI.ts` (the brush
+paint-depth row: a range slider beside a `type="number"` input with `min=0` and
+*no* `max`, commented "type past the slider"). The voxel depth section now has
+the same slider + number-input row. The number input commits on `change`/Enter,
+rejects negatives/NaN by reverting to the current value, and has no `max`.
+
+**Keep the slider and input in sync without fighting the user.** On refresh the
+slider clamps its displayed value to its own max (`Math.min(16, depth)`) so its
+thumb pins at the right edge for deeper values, while the number input shows the
+true stored depth — but only when it isn't the active element, so typing isn't
+clobbered mid-edit.
+
+**Parity + docs.** The console/AI path (`setVoxelBrush({ depth })` in `main.ts`)
+already delegated to `setAddDepth` and validated only `depth >= 0`, so it
+inherits the no-max behavior for free — I updated its JSDoc and the
+`public/ai/voxel.md` entry, both of which still said `0..16`. Added a
+`voxel-studio.spec.ts` golden-path test that drives both the API and the panel's
+number input with values past 16 and asserts neither re-clamps (slider thumb
+pins at ≤ 16, stored depth is the typed value).

--- a/public/ai/voxel.md
+++ b/public/ai/voxel.md
@@ -323,7 +323,8 @@ await partwright.bakeVoxelsToCode({ label: 'castle' });  // replace with voxels.
   16); `shape` is `'sphere' | 'cube' | 'diamond'`; `spray` scatters a random
   subset; `sprayDensity` 0.05..1. For the `add` tool: `block` is the `[x,y,z]`
   size in voxels (1..32 each) and the block is anchored to the clicked face so a
-  thick block never pokes out the far side of a thin tile. `depth` (0..16) sinks
+  thick block never pokes out the far side of a thin tile. `depth` (≥ 0; the
+  panel slider tops out at 16 but a typed value can go deeper) sinks
   the add block into the surface, and for the box tools extrudes the
   fill/subtract along the clicked face (a `boxAdd` grows a slab that many extra
   layers, a `boxRemove` carves that many deeper); `0` = flush to the face.

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -120,7 +120,6 @@ export function setBrushShape(s: BrushShape): void { brushShape = s; refreshPrev
 // Add-block dimensions (X/Y/Z, in voxels) and how deep the block sinks into the
 // clicked surface. Used only by the `add` tool; the preview reflects them live.
 const MAX_BLOCK_SIZE = 32;
-const MAX_ADD_DEPTH = 16;
 export function getBlockSize(): [number, number, number] { return [...blockSize]; }
 export function setBlockSize(axis: 0 | 1 | 2, n: number): void {
   blockSize[axis] = Math.max(1, Math.min(MAX_BLOCK_SIZE, Math.round(n) || 1));
@@ -128,8 +127,9 @@ export function setBlockSize(axis: 0 | 1 | 2, n: number): void {
   cbStateChange?.();
 }
 export function getAddDepth(): number { return addDepth; }
+// No upper clamp: the slider tops out at 16, but a typed value can go deeper.
 export function setAddDepth(n: number): void {
-  addDepth = Math.max(0, Math.min(MAX_ADD_DEPTH, Math.round(n) || 0));
+  addDepth = Math.max(0, Math.round(n) || 0);
   refreshPreview();
   cbStateChange?.();
 }

--- a/src/color/voxelPaintUI.ts
+++ b/src/color/voxelPaintUI.ts
@@ -75,6 +75,7 @@ let sprayRow: HTMLElement | null = null;
 const blockSliders: Partial<Record<0 | 1 | 2, HTMLInputElement>> = {};
 let blockSizeLabel: HTMLElement | null = null;
 let depthSlider: HTMLInputElement | null = null;
+let depthInput: HTMLInputElement | null = null;
 let depthLabel: HTMLElement | null = null;
 
 export interface VoxelPaintUICallbacks {
@@ -199,7 +200,8 @@ function refreshControls(): void {
     if (s) s.value = String(size[axis]);
   }
   if (blockSizeLabel) blockSizeLabel.textContent = `${size[0]}×${size[1]}×${size[2]}`;
-  if (depthSlider) depthSlider.value = String(voxelPaint.getAddDepth());
+  if (depthSlider) depthSlider.value = String(Math.min(16, voxelPaint.getAddDepth()));
+  if (depthInput && document.activeElement !== depthInput) depthInput.value = String(voxelPaint.getAddDepth());
   if (depthLabel) {
     const d = voxelPaint.getAddDepth();
     if (d === 0) depthLabel.textContent = isBox ? 'flat' : 'on surface';
@@ -470,16 +472,40 @@ function buildDepthSection(): HTMLElement {
   head.appendChild(depthLabel);
   sec.appendChild(head);
 
+  const row = document.createElement('div');
+  row.className = 'flex items-center gap-2';
+
   depthSlider = document.createElement('input');
   depthSlider.type = 'range';
   depthSlider.min = '0';
   depthSlider.max = '16';
   depthSlider.step = '1';
   depthSlider.value = String(voxelPaint.getAddDepth());
-  depthSlider.className = 'w-full accent-blue-500';
+  depthSlider.className = 'flex-1 min-w-0 accent-blue-500';
   depthSlider.title = 'Add: layers the block sinks into the surface. Box: extra layers the fill grows / subtract carves (0 = flush to the clicked face).';
   depthSlider.addEventListener('input', () => { voxelPaint.setAddDepth(Number(depthSlider!.value)); refreshControls(); });
-  sec.appendChild(depthSlider);
+  row.appendChild(depthSlider);
+
+  // Typed value: the slider tops out at 16, but the input has no max so you can
+  // sink a block deeper than the slider reaches.
+  depthInput = document.createElement('input');
+  depthInput.type = 'number';
+  depthInput.min = '0';
+  depthInput.step = '1';
+  depthInput.value = String(voxelPaint.getAddDepth());
+  depthInput.className = 'w-14 px-1 py-0.5 text-[11px] bg-zinc-900/70 border border-zinc-600/60 rounded text-zinc-200 text-right tabular-nums';
+  depthInput.title = 'Depth in layers. Type a value past the slider’s 16 to go deeper.';
+  const applyDepthInput = (): void => {
+    const raw = parseInt(depthInput!.value, 10);
+    if (!Number.isFinite(raw) || raw < 0) { depthInput!.value = String(voxelPaint.getAddDepth()); return; }
+    voxelPaint.setAddDepth(raw);
+    refreshControls();
+  };
+  depthInput.addEventListener('change', applyDepthInput);
+  depthInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') applyDepthInput(); });
+  row.appendChild(depthInput);
+
+  sec.appendChild(row);
 
   return sec;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12333,8 +12333,8 @@ async function main() {
      *  'diamond'; `spray` scatters a random subset; `sprayDensity` is 0.05..1.
      *
      *  The `add` tool uses a block instead of a round brush: `block` is the
-     *  [x,y,z] size in voxels (1..32 each) and `depth` (0..16) is how far the
-     *  block sinks into the clicked surface — 0 attaches it flush to the face
+     *  [x,y,z] size in voxels (1..32 each) and `depth` (≥ 0; no upper limit) is
+     *  how far the block sinks into the clicked surface — 0 attaches it flush to the face
      *  (so a thick block never pokes out the far side of a thin tile).
      *  Returns the resolved brush settings or `{ error }`. */
     setVoxelBrush(opts: { radius?: number; shape?: import('./color/voxelPaint').BrushShape; spray?: boolean; sprayDensity?: number; block?: [number, number, number]; depth?: number } = {}) {

--- a/tests/voxel-studio.spec.ts
+++ b/tests/voxel-studio.spec.ts
@@ -111,6 +111,39 @@ test.describe('voxel studio', () => {
     expect(r.added.voxelCount).toBe(27); // 3×3×3 block, near layer overlapping the origin
   });
 
+  test('depth accepts a typed value past the slider max (no hard upper clamp)', async ({ page }) => {
+    // The depth slider tops out at 16, but the typed number input has no max —
+    // setAddDepth keeps whatever you type (>= 0). Drive both the API and the
+    // panel's number input to prove neither re-clamps at 16.
+    const viaApi = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.setActiveLanguage('voxel');
+      await pw.run(`return api.voxels().set(0,0,0,'#ffffff');`);
+      pw.activateVoxelPaint();
+      pw.setVoxelTool('add');
+      return pw.setVoxelBrush({ depth: 40 }).depth;
+    });
+    expect(viaApi).toBe(40); // not clamped to 16
+
+    // Now the panel's number input: typing 50 and committing keeps 50, while the
+    // range slider pins its thumb at its own max of 16.
+    const input = page.locator('#voxel-paint-panel input[type="number"]').last();
+    await input.fill('50');
+    await input.press('Enter');
+    await expect(input).toHaveValue('50');
+    const storedDepth = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (window as any).partwright.setVoxelBrush({}).depth,
+    );
+    expect(storedDepth).toBe(50);
+    const sliderVal = await page
+      .locator('#voxel-paint-panel input[type="range"]')
+      .last()
+      .inputValue();
+    expect(Number(sliderVal)).toBeLessThanOrEqual(16);
+  });
+
   test('level tool recolors a whole axis layer without changing the count', async ({ page }) => {
     const r = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

The Voxel Studio **Depth** control had a hard upper clamp of 16, so even typing a larger number snapped back to 16. This adds a typed number input beside the slider and drops the clamp:

- **`setAddDepth` (`voxelPaint.ts`)** no longer clamps to `MAX_ADD_DEPTH` (removed that now-unused const). It keeps any non-negative integer — the lower `Math.max(0, …)` floor stays.
- **Depth section UI (`voxelPaintUI.ts`)** now has a `type="number"` input next to the range slider, mirroring the existing brush paint-depth pattern in `paintUI.ts` (slider with `max=16`, number input with **no max**). The slider stays a comfortable 0..16 drag; the typed input can go deeper. The slider thumb pins at its own max (`Math.min(16, depth)`) for larger values, and the input syncs only when it isn't being edited.
- **Parity:** the console/AI `setVoxelBrush({ depth })` path (`main.ts`) already delegated to `setAddDepth` and validated only `depth >= 0`, so it inherits the no-max behavior. Updated its JSDoc and the `public/ai/voxel.md` entry (both still said `0..16`).

## Test plan

- `npm run build` ✅ and `npm run test:unit` ✅ (815 passed)
- Added a `voxel-studio.spec.ts` golden-path test that drives both the API (`setVoxelBrush({ depth: 40 })`) and the panel's number input (typing `50`), asserting neither re-clamps: stored depth is the typed value, slider thumb pins at ≤ 16. ✅
- Manual browser check (screenshot): panel shows input `40`, label `40 deep`, slider pinned near its max.

https://claude.ai/code/session_01EDqENRVaL7gSaLKtRMUUUR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDqENRVaL7gSaLKtRMUUUR)_