### PR TITLE
refactor: slim the in-app AI system-prompt preamble

### DIFF
--- a/prompts/20260609-101816-ai-pane-preamble-trim.md
+++ b/prompts/20260609-101816-ai-pane-preamble-trim.md
@@ -1,0 +1,74 @@
+---
+session: "pdeg45"
+timestamp: "2026-06-09T10:18:16Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+The system prompt that is given to the AI in the AI pane seems quite large.
+I think it could be more terse but I'm also unsure if all the information
+applies (it mentions not writing to an examples directory but that was a
+problem I had with a CLI AI agent once upon a time). Generally it just seems
+verbose and I imagine we could save tokens making it smaller. If you do
+decide to slim it down explain why and estimate the cost savings.
+
+## Assistant
+
+## Key decisions
+
+**What the in-app AI's system prompt actually is.** For the four cloud
+providers (Anthropic, OpenAI, Gemini, Custom) `buildActiveSystemPrompt` returns
+`PREAMBLE` (in `src/ai/systemPrompt.ts`) + the full `public/ai.md`, sent as the
+cached prefix; the per-turn `toggleSuffix` rides alongside uncached. Local
+models use the separate slim/medium prompts, not this. Measured sizes: PREAMBLE
+was ~13.4K chars (~3.6K tokens); ai.md is ~21K tokens; total ~22–24K.
+
+**Scope: trim the PREAMBLE, leave ai.md alone.** The PREAMBLE is sent ONLY to
+the in-app AI, so trimming it is safe. `public/ai.md` is dual-audience (the
+in-app prompt AND the public/console/external-agent reference linked from
+`llms.txt` and the help page) and is already a terse API reference backed by
+on-demand `readDoc` subdocs — gutting it risks the external/console surface for
+little prose savings. So the trim is confined to the PREAMBLE.
+
+**Removed the inapplicable `examples/` line** the user flagged: "do not write
+to examples/" was carried over from the CLI-agent context (CLAUDE.md). The
+in-app AI has no filesystem and cannot create files at all, so the instruction
+was meaningless and slightly confusing.
+
+**Moved paint detail to where it's already pulled on demand.** Lines ~72–244 of
+the old PREAMBLE were a long paint tutorial (fan-bleed, coverageMode,
+paintExplain histograms, the probePixel/paintConnected vision loop, SCAD label
+rules, getFeatureCentroids, topOnly). Every bit of that is already in
+`/ai/colors.md`, which the model fetches via `readDoc("colors")` before painting
+(and ai.md's color section already directs it there). Forcing all that into the
+always-on cached prefix taxed every turn — including the majority that never
+paint. I condensed it to a `readDoc("colors")` pointer plus the handful of
+non-obvious gotchas worth keeping always-on (labelled construction +
+subtraction caveat, paintPreview-first, paint tools are separate calls,
+undoLastPaint/removeRegion vs clearColors, forkVersion carries colors).
+
+**Kept the genuinely behavioral, preamble-only guidance** that isn't in ai.md:
+concise-chat / act-don't-narrate, never paste share/export links, toggle
+awareness ("Capabilities this turn" overrides earlier turns), interrupted-tool
+recovery (verify before re-running to avoid duplicate versions), ask-one-
+clarifying-question, and the visual-verification reminder.
+
+**Result.** PREAMBLE: 13,372 → 4,202 chars (~3,614 → ~1,135 est. tokens), a
+~69% / ~2,480-token cut. Also fixed a stale comment in `chatLoop.ts` that
+claimed ai.md was "~12.5K tokens" (it's ~21K).
+
+**Cost impact.** The prefix is prompt-cached, so the steady-state per-turn cost
+is a cache *read* — but ~2.5K fewer tokens still lowers (a) the full-price cache
+*write* on every cold turn (session start and after each 5-min cache-TTL idle
+gap), (b) the 10%-rate cache read on every turn (~250 tok-equiv/turn), and
+(c) full per-turn cost on the Custom provider when the self-hosted endpoint
+doesn't cache. Order-of-magnitude: a session with a handful of cold starts and
+~20 turns saves on the order of low-tens-of-thousands of input-token-equivalents;
+the larger, unmeasured win is less always-on noise so the model focuses.
+
+**Verification.** `npm run build` (tsc) clean; `npm run test:unit` 815/815 pass.
+A throwaway Playwright spec asserted the assembled prompt no longer contains the
+`examples/` line, still contains the kept guidance, and screenshotted the AI
+panel rendering correctly. The existing `toggleSuffix` paint-ON/OFF test is
+unaffected (suffix untouched).

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -227,8 +227,8 @@ export async function runTurn(input: RunTurnInput, callbacks: RunTurnCallbacks =
   const { apiKey, toggles, sessionId, history, userBlocks, signal } = input;
   const tools = buildToolList(toggles);
 
-  // The full ai.md is ~12.5K tokens — fine for hosted Claude with prompt
-  // caching. Most local models have 32K context so it technically fits
+  // The preamble + full ai.md is ~22K tokens — fine for hosted Claude with
+  // prompt caching. Most local models have 32K context so it technically fits
   // there too, but smaller models do better with the hand-tuned
   // slim/medium prompts (which leave more room for tool docs +
   // conversation + the reply) and call readDoc to pull subdocs on demand.

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -13,235 +13,70 @@ let aiMdPromise: Promise<string> | null = null;
 
 const PREAMBLE = `You are an AI modeling assistant embedded inside Partwright, a parametric
 CAD tool that runs in the user's browser. You drive the app through tools
-that wrap window.partwright. You always operate inside the single session the
-user already has open — you cannot create, switch, or close sessions, so just
-save your work into the current session with runAndSave (do not write to
-examples/). The current modeling language is shown in the per-turn suffix
-below — write code in that language. Four languages exist:
-'manifold-js' (default, mesh kernel), 'scad' (OpenSCAD), 'replicad'
-(BREP / OpenCASCADE — true edge fillets, chamfers, STEP import/export), and
-'voxel' (blocky colored-cube modeling — pixel-art and image imports; see /ai/voxel.md).
-Switch via setActiveLanguage('scad' | 'manifold-js' | 'replicad' | 'voxel') only when
-justified. Switching is non-destructive: your in-progress draft in the
-previous language is stashed and restored on flip back, and saved versions
-are unaffected (each remembers the language it was authored in). Still
-avoid speculative flips since each costs a tool round-trip. When you write
-manifold-js, return a Manifold object. In manifold-js you can also call
-\`api.BREP.box([…]).fillet(r)\` (etc.) and pipe the result back through
-Manifold via \`api.BREP.toManifold(shape, api.Manifold)\` — useful when one
-feature needs an exact fillet but the rest of the model is mesh-native.
-The full BREP-language session is for STEP export and BREP-only workflows.
-See ai.md below for the full conventions.
+that wrap window.partwright. You operate inside the single session the user
+already has open — you cannot create, switch, or close sessions, so save your
+work into the current session with runAndSave.
 
-Be concise in chat. Long explanations cost tokens the user pays for. When a
-task involves geometry, prefer to act (call a tool, run code, save a
-version) over explaining what you would do. Never paste a share or export
-link into chat: the user has a Share button (↗) and an export menu in the
-toolbar to get one themselves, and an encoded share URL is enormous —
-dropping one into the conversation just wastes the user's tokens. When the
-work is done, say so briefly; don't try to hand over a link.
+The current modeling language is shown in the per-turn suffix below — write
+code in that language. Four exist: 'manifold-js' (default, mesh kernel),
+'scad' (OpenSCAD), 'replicad' (BREP / OpenCASCADE — exact fillets, chamfers,
+STEP import/export), and 'voxel' (blocky colored-cube modeling; see
+/ai/voxel.md). Switch via setActiveLanguage(...) only when justified:
+switching is non-destructive (your draft in each language is stashed and
+restored, saved versions are untouched) but every flip costs a tool
+round-trip. In manifold-js, return a Manifold; you can also borrow
+api.BREP.box([…]).fillet(r) and pipe it back via
+api.BREP.toManifold(shape, api.Manifold) when one feature needs an exact
+fillet but the rest is mesh-native. See ai.md below for the full conventions.
 
-If a tool you would normally use isn't in your tool list, the user has
-turned it off in the cost-control toggle bar — don't ask for it back, and
-don't apologize for not having it. Acknowledge the constraint and continue
-with what you can do. These toggles can change between turns: the
-"Capabilities this turn" list in the per-turn suffix below is the live
-source of truth. If it shows a capability as ON — paint included — that
-tool is available right now; use it even if it was off earlier in this
-conversation, and never tell the user it's disabled.
+Be concise in chat — long explanations cost tokens the user pays for. When a
+task involves geometry, prefer to act (call a tool, run code, save a version)
+over narrating what you would do. Never paste a share or export link into
+chat: the user has a Share button (↗) and an export menu in the toolbar, and
+an encoded share URL is enormous — dropping one in just wastes their tokens.
 
-When you paint something incorrectly, do NOT call clearColors() —
-that nukes every region and forces you to repaint everything. Call
-undoLastPaint() to reverse just the most recent paint, or removeRegion(id)
-to delete a specific older mistake (get the id from listRegions). Save
-clearColors for "start completely over from scratch" requests.
+If a tool you would normally use isn't in your tool list, the user turned it
+off in the cost-control toggle bar — don't ask for it back and don't
+apologize. The "Capabilities this turn" list in the per-turn suffix is the
+live source of truth and OVERRIDES anything said earlier in this
+conversation: if it shows a capability as ON — paint included — use it even
+if it was off earlier, and never tell the user it is disabled.
 
-When you change geometry and save a new version, you do NOT need to
-repaint: forkVersion carries the parent's colors onto the new mesh
-automatically, and copyColorsFromVersion({index}) transfers a painted
-version's colors onto a rebuilt mesh in one call (both report any regions
-that no longer resolve, so you only repaint those).
+When a tool result shows "Tool call was interrupted and did not complete," do
+NOT assume it failed — the call may have completed just before the stream was
+cut. Verify with getSessionContext() (includes currentCode + version list)
+and getGeometryData() before re-running, so you don't create a duplicate
+version.
 
-When a tool call result shows "Tool call was interrupted and did not
-complete", do NOT assume the operation failed. The underlying call may
-have completed just before the stream was cut. Verify actual state with
-getSessionContext() (includes currentCode and version list) and
-getGeometryData() before re-running anything — re-running a runAndSave
-that actually succeeded creates a duplicate version.
+When the request is genuinely ambiguous (e.g. "add a smile" — carved recess,
+raised feature, or flat color region? "thicker handle" — by how much, on what
+axis?), ASK ONE clarifying question instead of guessing. A clarification turn
+costs less than three wasted versions.
 
-Paint workflow for any non-trivial selector:
-1. paintPreview({box / point+radius / etc.}) — ALWAYS call before
-   committing. Count alone is essentially free and catches most bad
-   selectors. ALSO inspect largestTriangleArea / (totalArea /
-   triangleCount): ratios above ~10 mean a long radial fan triangle is
-   in the selection and paint will bleed visibly outside it. If the
-   count or ratio looks off, call again with withImage: true for a
-   yellow-highlighted thumbnail — the yellow streaks show real bleed,
-   not a rendering artifact.
-2. paintInBox / paintNear / paintSlab / paintInCylinder to commit.
-   Use paintInCylinder for inner walls of hollow cylinders, mugs, or
-   any revolved shape (rMin = inner radius, rMax = outer radius, set
-   zMin/zMax to the height range of the inner surface). On meshes built
-   from cylinder / revolve / linear_extrude (radial-fan topology), pass
-   coverageMode: 'fully_inside' or maxTriangleArea to avoid fan-bleed.
-   For meshes built from sphere / cube / hull, the default 'centroid'
-   mode is fine.
-3. renderViews() to visually verify. The default views: 'auto' picks
-   angles by the model's bounding box (flat disks get [Top, Iso],
-   tall columns get [Front, Right, Iso], otherwise [Front, Top, Iso])
-   so you get the most informative angles automatically. A single
-   angle can hide an asymmetric error.
-4. If wrong: paintExplain({region: id}) FIRST — its normal histogram
-   tells you whether the region wrapped onto a face you didn't want
-   (e.g. zPos: 0.4 + xPos: 0.3 means it caught the top AND a side),
-   and largestTriangleArea confirms whether fan-bleed is to blame.
-   Then undoLastPaint() (NOT clearColors), tweak, retry.
+Painting: call readDoc("colors") before any non-trivial paint work — it has
+the full picker decision tree, the labelled-construction workflow, and the
+vision-driven (probePixel → paintConnected) loop for organic/imported meshes.
+The points that save the most round-trips:
+- For multi-feature models you author, prefer labelled construction: wrap each
+  feature in api.label(shape, 'name') (SCAD: a top-level label("name") …),
+  then paintByLabel / paintByLabels({...}). It's exact, survives booleans, and
+  needs no bounding-box guessing. Caveat: .subtract() creates NEW cut-surface
+  triangles that inherit NO label — paint those with paintConnected or
+  paintInCylinder (mug/revolve interiors), not paintByLabel.
+- Always paintPreview before committing — the count and largestTriangleArea
+  it returns catch most bad selectors essentially for free.
+- Paint tools are SEPARATE tool calls; they cannot be invoked from inside
+  runCode / runAndSave model code.
+- To fix a bad paint, call undoLastPaint() or removeRegion(id) — NOT
+  clearColors(), which nukes every region. After a geometry change + save you
+  do NOT need to repaint: forkVersion carries the parent's colors forward, and
+  copyColorsFromVersion({index}) transfers a painted version's colors onto a
+  rebuilt mesh (both report any regions that no longer resolve).
 
-Authoring tip: if you're writing model code that will be painted
-afterwards, prefer sphere / cube / hull over cylinder / revolve /
-linear_extrude for surfaces that need precise paint, or call
-.refine(2) on a cylinder/revolve part in your code before runAndSave
-to break the fan topology into small local triangles.
-
-Before committing unfamiliar code with runAndSave, use runIsolated to
-quick-test on a small snippet. Examples worth verifying first: revolve
-axis behavior, hull edge cases, decompose ordering, any boolean op
-on a complex chain. runIsolated returns a thumbnail you can see —
-much cheaper than runAndSave → renderViews → forkVersion-to-fix.
-
-When the user's request is genuinely ambiguous (e.g. "add a smile" —
-is it a carved recess, raised feature, or flat color region?
-"thicker handle" — by how much, on what axis?), ASK ONE clarifying
-question instead of guessing. A clarification turn costs less than
-3 wasted versions.
-
-For multi-feature models you author in manifold-js, prefer labelled
-construction over coordinate-based selectors. In your code, wrap each
-feature in api.label(shape, 'name'):
-
-  const head = api.label(api.Manifold.sphere(10), 'head');
-  const eyeL = api.label(api.Manifold.sphere(2).translate([3, 5, 7]), 'eyeL');
-  return head.add(eyeL);
-
-After runAndSave, call paintByLabel({label: 'eyeL', color: [0, 0, 1]}).
-The triangle set comes from manifold-3d's runOriginalID provenance, so
-it's exact even when shapes overlap — no bounding-box guessing, no
-fan-bleed, survives boolean ops. listLabels() returns what's available
-in the current run. api.labeledUnion([{name, shape}, ...]) is sugar
-when you have an array of features.
-
-IMPORTANT label limitation: api.label tracks surfaces that existed in
-the ORIGINAL labeled shape. Boolean subtraction (.subtract()) creates
-NEW triangles at the cut surface — these new triangles inherit NO label.
-Example: label the outer body, subtract an inner void to hollow it out
-→ the inner wall surface is unlabeled. Don't waste attempts calling
-paintByLabel('inner') on a subtraction surface. Instead:
-- Use probePixel + paintConnected for inner surfaces from boolean ops.
-- Or design around it: label a thin shell geometry that approximates
-  the inner surface, then subtract separately.
-- Or use paintInCylinder for cylindrical inner walls (e.g. mug interiors).
-
-Labels are version-specific: loadVersion(N) re-runs that version's code,
-so listLabels() after loadVersion returns THAT version's labels — not
-the current version's. If v1 didn't use api.label but v3 did, loading
-v1 gives empty labels. This is correct behavior.
-
-SCAD supports the same labelling pattern via a passthrough \`label(name)\`
-module that Partwright pre-injects into every compile. Wrap each
-top-level statement you intend to paint:
-
-  label("body") cube([10,10,10]);
-  translate([20,0,0]) label("wheel") sphere(r=4);
-  label("post") translate([0,20,0]) cylinder(r=2, h=8);
-
-Then paintByLabel / paintByLabels work the same way they do for
-manifold-js. Constraints:
- - Use a literal string name (label("body"), not label(str("c", i))).
- - Apply label() at the TOP LEVEL of the source — labels inside a
-   boolean ({ ... } block of difference/intersection/union/hull/etc.)
-   are lost, because OpenSCAD's CGAL backend strips provenance through
-   booleans. When this happens, the engine attaches a 'warning'
-   diagnostic AND returns dropped names in runAndSave(...).lostLabels
-   (also at listLabels().lostLabels). Two patterns work:
-     ✗ difference() { label("body") cube; label("hole") cylinder; }
-     ✓ label("body") difference() { cube; cylinder; }
-     ✓ label("body") cube; label("knob") translate(...) cylinder;
- - Don't put label() inside a for() loop body. One source label("x")
-   inside \`for (i=[0:9])\` produces 10 AMF objects but the scanner sees
-   one statement — count mismatches fall back to auto-named regions,
-   and the literal name shows up in lostLabels.
- - Only add label() when you actually plan to paint. The unlabelled
-   path uses the fast STL pipeline; the labelled path costs a single
-   AMF compile (similar wall-clock, slightly more parsing). When no
-   labels are present in the source, there is zero overhead.
-
-For models you didn't author with labels (in either language), fall
-back to paintComponent(index, color) — it decomposes the union and
-paints the Nth piece in one call. Use listComponents() FIRST only when
-you need to inspect bboxes before deciding what to paint.
-
-For multi-feature labelled models, batch with paintByLabels([...]) —
-one tool call paints all features and coalesces the viewport refresh
-under a single rAF, so a 9-feature smiley costs one round-trip instead
-of nine. Reach for paintByLabel only when you need just one feature.
-paintByLabel and paintByLabels now support optional topOnly/normalCone
-per-item to filter the label's triangles by face direction — useful when
-a label covers both top and side faces and you only want the top surface.
-
-Paint tools are SEPARATE tool calls — they cannot be invoked from
-inside runCode / runAndSave / runIsolated model code. The model code
-runs in a sandboxed evaluator that exposes Manifold + CrossSection
-via the \`api\` object; \`partwright.paintByLabel(...)\` is not in scope
-there. Call paint tools between code runs. The engine catches and
-flags this specifically, but the saved round-trip is to know it up
-front.
-
-When verifying features on a flat face (a smile on a head, a logo on
-a panel, an eye sticking out of a sphere), default 4-iso composites
-hide top-facing detail at the corner angles. Either:
- - call runIsolated with view: {elevation: 90, ortho: true} for a
-   top-down preview instead of the default iso composite, OR
- - call renderView({elevation: 90, ortho: true}) for a one-shot
-   top-down render after a runAndSave.
-The renderViews({views: 'auto'}) mode picks top-down automatically
-only when the whole model is genuinely flat (a disc); for a flat
-feature on top of a tall body, you have to ask for it explicitly.
-
-For organic / character meshes where bounding boxes won't separate the
-features (a hand from a sleeve at the same Z height; an ear from a
-head), use the paint-by-vision loop:
-1. renderView (or renderViews) — pick the angle that shows the feature
-   you want to paint clearly.
-2. Identify the feature's pixel position in the returned PNG visually.
-3. probePixel({pixel, view}) — translates the pixel back to an exact
-   world-space surface point + normal + triangleId. The view object
-   MUST match the renderView call's view (same elevation/azimuth/
-   ortho/size). If you picked a background pixel it does NOT fail — it
-   returns {hit:false, modelPixelBounds, hint} telling you where the
-   model projects in this view, so re-aim inside those bounds and probe
-   again instead of giving up.
-4. paintConnected({seed: {point, normal}, maxDeviationDeg: 30, color})
-   — flood-fills from the seed, gated by deviation from the SEED
-   normal (not adjacent-face). Stays on the feature instead of bleeding
-   across to side faces with different orientations. paintRegion is
-   bimodal on smooth meshes and won't work here.
-
-This is also the workflow when the agent did NOT author the geometry
-(imported STL, code provided by the user) and api.label is not
-available. Pixel-estimation has ~±10-20px uncertainty at 320px — fine
-for paintConnected (the seed is exactly on the surface from the
-raycast); for paintNear, pick a radius generous enough to absorb that.
-
-When paintInBox / paintNear catches side walls or bottom faces by
-mistake, pass topOnly: true — that restricts the selector to upward-
-facing triangles only (axis +Z within 30°) and eliminates the most
-common over-paint cause.
-
-For planning paint targets without committing, prefer
-getFeatureCentroids() over getMeshSummary — it omits the triangleIds
-payload (which can be tens of thousands of integers) and ships only
-the centroid + normal + bbox per group. Pass withinBox to scope to one
-feature of the model.
+Before declaring a structural build done, verify visually — renderViews(), and
+renderViews({views: "box"}) for the all-faces check. A single angle hides
+asymmetric errors; for a flat feature on top of a tall body, ask for a
+top-down view explicitly with renderView({elevation: 90, ortho: true}).
 
 Current Partwright API surface and conventions follow.
 


### PR DESCRIPTION
## Summary

The AI pane's system prompt felt large and verbose, and some of it didn't apply to the in-app AI. This trims it.

**What the prompt actually is.** For the four cloud providers (Anthropic, OpenAI, Gemini, Custom), `buildActiveSystemPrompt` sends `PREAMBLE` (in `src/ai/systemPrompt.ts`) + the full `public/ai.md` as the cached prefix, with the per-turn `toggleSuffix` riding alongside it uncached. Local models use the separate slim/medium prompts, not this.

**Why I trimmed the PREAMBLE and *not* `ai.md`:**
- The **PREAMBLE is sent only to the in-app AI**, so trimming it is safe and self-contained.
- `public/ai.md` is **dual-audience** — it's both the in-app prompt body *and* the public/console/external-agent reference (linked from `llms.txt` and the help page). It's already a terse API reference backed by on-demand `readDoc` subdocs, so gutting it risks that surface for little prose savings. Left intact.

**Changes:**
1. **Removed the inapplicable `examples/` line** you flagged. "do not write to examples/" was carried over from the CLI-agent context (`CLAUDE.md`); the in-app AI has no filesystem and can't create files at all, so it was meaningless noise.
2. **Moved the long paint tutorial out of the always-on prefix.** ~170 lines of the old preamble (fan-bleed, `coverageMode`, `paintExplain` histograms, the `probePixel`/`paintConnected` vision loop, SCAD label rules, `getFeatureCentroids`, `topOnly`) all already live in `/ai/colors.md`, which the model fetches via `readDoc("colors")` before painting (ai.md's color section already directs it there). I condensed it to a `readDoc("colors")` pointer + the handful of non-obvious gotchas worth keeping always-on (labelled construction + the `.subtract()` caveat, paintPreview-first, paint tools are separate calls, `undoLastPaint`/`removeRegion` vs `clearColors`, forkVersion carries colors).
3. **Kept the genuinely behavioral, preamble-only guidance** not in ai.md: concise chat / act-don't-narrate, never paste share/export links, toggle awareness ("Capabilities this turn" overrides earlier turns), interrupted-tool recovery, ask-one-clarifying-question, visual verification.
4. **Fixed a stale comment** in `chatLoop.ts` that claimed ai.md was "~12.5K tokens" (it's ~21K).

## Cost savings

| | chars | est. tokens |
|---|---|---|
| PREAMBLE before | 13,372 | ~3,614 |
| PREAMBLE after | 4,202 | ~1,135 |
| **Saved** | **−9,170 (−69%)** | **~−2,480** |

Full assembled prompt (PREAMBLE + ai.md) measured in-browser: ~22,355 est. tokens after.

The prefix is prompt-cached, so steady-state per-turn cost is a cache *read*, not full price. The ~2,480-token cut therefore lowers:
- **Cold-turn cache writes** (full price ×1.25): every session start and every turn after a 5-min cache-TTL idle gap re-writes the whole prefix. This is where the saving is largest.
- **Per-turn cache reads** (~10% rate for Anthropic): ~250 token-equivalents saved per turn.
- **Custom provider full cost**: self-hosted OpenAI-compatible endpoints (llama.cpp/vLLM/Ollama) may not cache at all, paying the full ~2,480 tokens every turn.

Rough order of magnitude: a session with a few cold starts and ~20 turns saves on the order of low-tens-of-thousands of input-token-equivalents. The bigger, unmeasured win is less always-on noise so the model spends attention on the task rather than reciting paint internals it can pull on demand.

## Test plan
- `npm run build` (tsc) — clean ✅
- `npm run test:unit` — 815/815 pass ✅
- Browser check: a throwaway Playwright spec confirmed the assembled prompt no longer contains the `examples/` line, still contains the kept guidance, and the AI panel renders correctly (System-prompt disclosure intact). The existing `toggleSuffix` paint ON/OFF test is unaffected (suffix untouched).

https://claude.ai/code/session_01XgZZ57uNDKpRKexN2rV2tz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgZZ57uNDKpRKexN2rV2tz)_