### PR TITLE
feat: PR 520 retro follow-ups — model:preview introspection, compare, sweepArc, cylinder paint axis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,16 @@ npm run model:preview -- model.js --png out.png -p turns=6      # override api.p
 
 **`componentCount` is the instrument for print-in-place mechanisms.** A model that returns separate moving parts (screw, spinner, hinge, captive ball, two-tone spiral) must report `componentCount === N`. If it fuses to `1`, the clearance gap is too small or parts collide. The reliable recipe for splitting one solid into interleaved colored parts: subtract a clearance-thick cutter (e.g. a full-diameter helical **slab** for a spiral), then `manifold.decompose()` and color each component. Verify topological/geometric claims with `model:preview`, not from memory.
 
+When the count is wrong, **inspect the islands instead of tuning blindly**:
+
+```bash
+npm run model:preview -- model.js --explain-components   # per-island vol/tris/size/center (to stderr)
+npm run model:preview -- model.js --expect-components 3   # assert; exits non-zero on mismatch (CI gate)
+node bin/partwright.mjs compare a.js b.js c.js --png out.png   # tile each model's iso view into one contact sheet
+```
+
+`--explain-components` prints the per-island breakdown (already in the JSON's `stats.components`, capped at the top 16 by volume) to stderr so the stdout JSON stays parseable. `--expect-components N` compares against the uncapped `stats.componentCount` and exits 1 on mismatch — the escape hatch for "this mechanism MUST stay N parts." `compare` runs several variants and lays one iso view of each side-by-side, for A/B param sweeps or before/after checks.
+
 > **CLI agents vs in-app/extension AI.** `model:preview` is for agents running in *this repo* (you). The in-app and chrome-extension AI cannot run a CLI — they verify with the in-browser `renderViews()` / `runAndSave(code, label, {maxComponents})` and read `public/ai/*.md` subdocs (e.g. `mechanisms`). Keep tool-specific instructions in `CLAUDE.md`/`docs/` (this audience) and in-browser instructions in `ai.md`/subdocs (that audience).
 
 ## AI Agent Workflow & API Reference

--- a/prompts/20260609-110000-pr520-retro-followups.md
+++ b/prompts/20260609-110000-pr520-retro-followups.md
@@ -1,0 +1,73 @@
+---
+session: "sji7ys"
+timestamp: "2026-06-09T11:00:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+I have a retro PR 520 that has follow up items. read it and propose fixes.
+
+(After proposing, the user chose: "do all the cheap ones as well as the
+heavier model preview task" — i.e. the four contained items plus the
+`compare` contact-sheet.)
+
+## Assistant
+
+## Key decisions
+
+**Scope picked from the retro backlog.** PR 520's backlog had 8 items; I
+grounded each in the code first, which shrank several. Implemented five:
+①`model:preview --explain-components`/`--expect-components`, ②`compare`
+contact-sheet, ④SCAD for-loop label-drop warning, ⑤`api.loft` flat alias +
+`Curves.sweepArc`, ⑥`paintInCylinder({ axis })`. Deferred ⑧ (catalog
+triangle-budget CI gate — heavy: WASM per entry), ③ (`--palette` mismatch,
+vague), and ⑦ (tile-camera, large renderer change).
+
+**① Per-component data was already computed.** `previewModel.ts` already
+decomposes and returns `stats.components` (top 16 by volume). I added a `center`
+field (bbox center — honest cheap locator, not mass centroid) and two CLI flags
+in both `scripts/model-preview.mjs` and `scripts/cli/main.mjs`.
+`--explain-components` prints the per-island table to **stderr** so the stdout
+JSON contract stays parseable; `--expect-components N` asserts against the
+**uncapped** `stats.componentCount` (not `components.length`, which tops at 16)
+and exits 1 on mismatch. Caught a bug in testing: `Number(null) === 0`, so the
+default (no flag) wrongly asserted 0 components — guarded null/undefined/'' first.
+
+**② Contact sheet reuses the rasterizer.** New `composeContactSheet` in
+`preview.mjs` tiles one iso view per model in a near-square grid, each fit to
+its own bbox; failed models get a distinct pink tile. Extracted a shared `blit`
++ `fit` helper so `composePng` and the new function don't duplicate the
+tile-placement math. Exposed as `partwright compare a.js b.js …`.
+
+**④ Promoted a swallowed INFO to a warning.** The SCAD for-loop label drop
+pushed an `INFO:` line onto `stderr`, which is only surfaced on the *error*
+path — so on a successful compile it vanished. Mirrored the existing
+`hasNestedLabels` diagnostic: when labels were written but didn't reach the
+labelMap (`lostLabels` non-empty) and it's not the nested-block case, emit a
+`severity:'warning'` `SourceDiagnostic` with for-loop-specific detail when the
+statement/object count mismatched. Verified via an SSR probe that all three
+cases (for-loop drop / nested-block / clean) produce the right output.
+
+**⑤ Loft already existed — the gap was discoverability.** `Curves.loft`/`sweep`
+were present but only under the namespace; agents reach for `api.loft(...)`.
+Added flat `api.loft`/`sweep`/`sweepArc` aliases. New `Curves.sweepArc(profile,
+{radius, angle?, plane?, …})` builds a circular arc spine and delegates to the
+existing `sweep` (auto-closes at 360°) — the common elbow/pipe case without
+hand-building a 3D path.
+
+**⑥ paintInCylinder axis via coordinate projection.** Rather than rewrite the
+radial/height math, added a `projectAxis` permutation (cyclic x→y→z) to
+`findCylinderTriangles` + `cylinderRefineRegion`. `axis` defaults to `'z'` and
+the descriptor field is omitted when `'z'`, so old saved sessions round-trip
+unchanged. Also deduped `main.ts`'s copy-pasted `collectTrianglesByCylinder`
+closure to delegate to the canonical exported function (the projection logic
+can't drift now), and **fixed a parity bug**: `paintInCylinder` was missing from
+the `help()` table entirely. Closed the UI↔API parity loop: `help()` row,
+`tools.ts` schema, `ai.md`/`colors.md` docs.
+
+**Verification.** `npm run build` clean; `npm run test:unit` 818/818 (added
+`tests/unit/cylinderPaint.test.ts` for axis selection); `lint:deps` acyclic;
+`lint:deadcode` shows only pre-existing advisory items. CLI features exercised
+end-to-end (explain/expect/compare PNGs viewed); SCAD diagnostic and elbow
+sweep confirmed via SSR probes.

--- a/public/ai.md
+++ b/public/ai.md
@@ -342,6 +342,7 @@ partwright.paintInBox({box, normalCone?, color, name?})                   // AAB
 partwright.paintInOrientedBox({box: {center, size, quaternion?}, color, smooth?, resolution?, maxEdge?})  // rotated box selector (same as UI Box tool); SMOOTH edges by default
 partwright.paintFaces({triangleIds, color, name?})                        // explicit triangle ids
 partwright.paintSlab({axis|normal, offset, thickness, color, name?, smooth?, resolution?, maxEdge?})  // planar range; SMOOTH edges by default
+partwright.paintInCylinder({rMin, rMax, zMin, zMax, center?, axis?, normalCone?, color, name?, smooth?})  // cylindrical/annular shell (rMin=0 = solid); axis x|y|z (default z)
 partwright.paintByLabel({label, color, name?})                            // by api.label() name (manifold-js) or top-level `label("name")` (SCAD)
 partwright.paintByLabels([{label, color, name?}, ...])                    // batch sibling
 partwright.paintComponent({index, color, name?, topOnly?})                // by listComponents() index

--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -511,6 +511,8 @@ partwright.paintInOrientedBox({
 
 **Painting a feature that sticks out past a round body — select by radius, not a box plane.** A flat box face cutting across a curved junction (e.g. a handle meeting a cylindrical mug wall) leaves a ragged, stair-stepped boundary, because the box plane and the curved surface disagree. Select by *radial distance from the part's axis* instead — `paintInCylinder({ rMin, rMax, zMin, zMax })` (or a `normalCone` to grab only the outward-facing skin) — so the boundary follows the curve cleanly. Radius-based selection is the canonical tool for inner/outer walls of mugs, vases, and any revolved shape.
 
+> **Non-Z cylinders — `axis`.** `paintInCylinder` runs along **Z** by default (radius in XY, the `zMin..zMax` band along Z). For a part whose round axis points along X or Y, pass `axis: 'x'` or `axis: 'y'` (mirrors `paintSlab`'s axis shorthand) instead of rotating the model: radius is then measured in the plane normal to that axis and the band runs along it. `center` is the `[a,b]` pair in the radial plane (for `axis:'x'` that's `[y,z]`, for `'y'` it's `[z,x]`). The same `axis` field works in `paintPreview({ cylinder: { …, axis } })`.
+
 **Verifying paint before you commit it.** `paintPreview` accepts the same selectors as `paintInBox` / `paintNear` / `paintFaces` *and* the analytic `cylinder` / `slab` forms, *without* adding a region. Default: count-only (free sanity check). Pass `withImage: true` to also get a thumbnail with the candidate triangles tinted bright yellow on top of any existing paint. The `cylinder` / `slab` previews show the **unsmoothed** selection (preview never subdivides) — use it to validate a radial shell or slab offset/thickness in one cheap call before committing the real smoothing paint:
 
 ```js

--- a/public/ai/curves.md
+++ b/public/ai/curves.md
@@ -120,7 +120,25 @@ return Curves.sweep(profile, path);
 `closed: true` treats the path as a loop (no end caps, last segment wraps to
 first). Use this for torus-like sweeps.
 
-`Curves.sweep` (and `loft` / `revolveAxis`) return a **regular `Manifold`** —
+> **Shorthand:** `loft`, `sweep`, and `sweepArc` are also exposed as flat
+> aliases on `api`, so `api.loft(...)` / `api.sweep(...)` / `api.sweepArc(...)`
+> work without the `Curves.` prefix (same as `api.text`).
+
+### `Curves.sweepArc(profile, {radius, angle?, startAngle?, plane?, center?, segments?, refine?})`
+The common "curved pipe / elbow / torus section" case without hand-building a 3D
+path: traces a circular arc spine of `radius` in the chosen `plane` (`'xy'`,
+`'xz'` (default), or `'yz'`) and sweeps `profile` along it. `angle` is the sweep
+in degrees (default `90`); `startAngle` rotates where the arc begins; `center`
+moves the arc center (default `[0,0,0]`). A full `angle: 360` closes the loop
+automatically (a torus).
+
+```js
+// A 90deg elbow — a circular tube curving up in Z.
+const profile = CrossSection.circle(3, 32);
+return api.sweepArc(profile, { radius: 14, angle: 90, plane: 'xz' });
+```
+
+`Curves.sweep` (and `loft` / `sweepArc` / `revolveAxis`) return a **regular `Manifold`** —
 not some special curve type. So you can union it, subtract it, and crucially
 **`api.label()` it**: `const handle = api.label(Curves.sweep(profile, path),
 "handle")`. Label it before unioning it into the body and you can recolor the

--- a/scripts/cli/main.mjs
+++ b/scripts/cli/main.mjs
@@ -3,7 +3,7 @@
 // docs/headless-cli.md.
 import { resolve, dirname, basename, join } from 'node:path';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { runPreview, composePng } from './preview.mjs';
+import { runPreview, composePng, composeContactSheet, explainComponents, checkExpectComponents } from './preview.mjs';
 import { runPhoto, meshToPng, loadPalette } from './photo.mjs';
 import { runDaemon } from './daemon.mjs';
 import { startDaemon, stopDaemon, statusDaemon, rpc, evalInPage, resetPage } from './client.mjs';
@@ -32,9 +32,9 @@ function writeDataUrl(dataUrl, outPath) {
 const json = (v) => JSON.stringify(v, (_k, val) => (ArrayBuffer.isView(val) ? undefined : val), 2);
 
 async function cmdPreview(argv, { pngDefault }) {
-  const a = parse(argv, ['json']);
+  const a = parse(argv, ['json', 'explain-components']);
   const file = a._[0];
-  if (!file) { console.error('usage: partwright preview <file.js> [--lang manifold-js|voxel] [--png out] [--json] [--size N] [-p k=v]'); process.exit(2); }
+  if (!file) { console.error('usage: partwright preview <file.js> [--lang manifold-js|voxel] [--png out] [--json] [--size N] [--explain-components] [--expect-components N] [-p k=v]'); process.exit(2); }
   const abs = resolve(file);
   const result = await runPreview(abs, { params: a.params, lang: a.lang || 'manifold-js' });
   if (!result.ok) { console.log(json({ ok: false, error: result.error, diagnostics: result.diagnostics })); process.exit(1); }
@@ -46,6 +46,31 @@ async function cmdPreview(argv, { pngDefault }) {
     await img.toFile(pngPath);
   }
   console.log(json({ ok: true, png: pngPath, stats: result.stats }));
+
+  if (a['explain-components']) console.error(explainComponents(result.stats));
+  const expectErr = checkExpectComponents(result.stats, a['expect-components']);
+  if (expectErr) { console.error(expectErr); process.exit(1); }
+}
+
+// Contact sheet — run N model files and tile one iso view of each into a single
+// PNG for side-by-side comparison (variant sweeps, before/after, A/B params).
+async function cmdCompare(argv) {
+  const a = parse(argv, ['json']);
+  const files = a._;
+  if (files.length < 2) { console.error('usage: partwright compare <a.js> <b.js> [more.js …] [--lang manifold-js|voxel|scad] [--png out] [--size N] [--json] [-p k=v]'); process.exit(2); }
+  const results = [];
+  for (const f of files) {
+    const r = await runPreview(resolve(f), { params: a.params, lang: a.lang || 'manifold-js' });
+    results.push({ file: f, ok: r.ok, error: r.error, stats: r.stats, render: r.render });
+  }
+  let pngPath = null;
+  if (!a.json) {
+    pngPath = a.png ? resolve(a.png) : resolve('compare.png');
+    await composeContactSheet(results, Number(a.size) || 360).toFile(pngPath);
+  }
+  // Drop the heavy render buffers from the JSON; the PNG carries the pixels.
+  const models = results.map((r, i) => ({ cell: i, file: r.file, ok: r.ok, error: r.error, stats: r.stats }));
+  console.log(json({ ok: true, png: pngPath, models }));
 }
 
 // Photo → palette-constrained voxel model. Stateless (no daemon): decode +
@@ -218,8 +243,11 @@ async function cmdMethods(argv) {
 const USAGE = `partwright — headless Partwright CLI for driving model creation + feedback
 
 Phase 1 (stateless, no browser — fast inner loop):
-  partwright preview <file.js> [--lang manifold-js|voxel] [--png out] [--json] [--size N] [-p k=v]
+  partwright preview <file.js> [--lang manifold-js|voxel] [--png out] [--json] [--size N]
+                               [--explain-components] [--expect-components N] [-p k=v]
   partwright run     <file.js> [--lang …] [-p k=v]       stats JSON only
+  partwright compare <a.js> <b.js> [more.js …] [--png out] [--size N] [-p k=v]
+                                                         tile each model's iso view into one contact-sheet PNG
   partwright photo   <image>   [--palette p.json] [--max N] [--mode billboard|heightmap]
                                [--depth N] [--bg] [--crop x,y,w,h] [--out model.js] [--png out]
                                photo → palette-snapped voxel model + preview
@@ -240,6 +268,7 @@ export async function main(argv) {
   switch (cmd) {
     case 'preview': return cmdPreview(rest, { pngDefault: true });
     case 'run': return cmdPreview(rest, { pngDefault: false });
+    case 'compare': return cmdCompare(rest);
     case 'photo': return cmdPhoto(rest);
     case 'iterate': return cmdIterate(rest);
     case 'daemon': return cmdDaemon(rest);

--- a/scripts/cli/preview.mjs
+++ b/scripts/cli/preview.mjs
@@ -157,7 +157,9 @@ export function explainComponents(stats) {
 export function checkExpectComponents(stats, expected) {
   if (expected === null || expected === undefined || expected === '') return null;
   const n = Number(expected);
-  if (!Number.isFinite(n)) return null;
+  // The flag was given but the value isn't a number (typo / missing arg) — surface
+  // it rather than silently treating the assertion as a no-op.
+  if (!Number.isFinite(n)) return `--expect-components expects a number, got "${expected}".`;
   if (!stats || stats.componentCount !== n) {
     return `--expect-components ${n} failed: model has ${stats ? stats.componentCount : 'no'} component(s).`;
   }

--- a/scripts/cli/preview.mjs
+++ b/scripts/cli/preview.mjs
@@ -70,30 +70,98 @@ function renderTile(positions, triVerts, triColors, center, scale, size, view, b
   return px;
 }
 
-// Compose the 4-view grid PNG. Returns a sharp instance (caller writes/toBuffer).
-export function composePng(positions, triVerts, triColors, bbox, size) {
+// Copy one RGBA `size`×`size` tile into the RGB `out` buffer of width `W` at
+// pixel offset (ox, oy). Shared by composePng (4-view grid) and
+// composeContactSheet (one tile per model).
+function blit(out, W, tile, size, ox, oy) {
+  for (let y = 0; y < size; y++) for (let x = 0; x < size; x++) {
+    const s = (y * size + x) * 4, d = ((oy + y) * W + (ox + x)) * 3;
+    out[d] = tile[s]; out[d + 1] = tile[s + 1]; out[d + 2] = tile[s + 2];
+  }
+}
+
+// Center + uniform scale that fits a model's bbox into a `size`-px tile.
+function fit(bbox, size) {
   const center = bbox ? [(bbox.min[0] + bbox.max[0]) / 2, (bbox.min[1] + bbox.max[1]) / 2, (bbox.min[2] + bbox.max[2]) / 2] : [0, 0, 0];
   const diag = bbox ? Math.hypot(bbox.max[0] - bbox.min[0], bbox.max[1] - bbox.min[1], bbox.max[2] - bbox.min[2]) : 1;
-  const scale = (size * 0.42) / (diag / 2 || 1);
+  return { center, scale: (size * 0.42) / (diag / 2 || 1) };
+}
+
+const BG = [244, 244, 246];
+
+// Compose the 4-view grid PNG. Returns a sharp instance (caller writes/toBuffer).
+export function composePng(positions, triVerts, triColors, bbox, size) {
+  const { center, scale } = fit(bbox, size);
   const views = [
     { name: 'front', az: -90, el: 0 },
     { name: 'right', az: 0, el: 0 },
     { name: 'top', az: -90, el: 90 },
     { name: 'iso', az: -50, el: 28 },
   ];
-  const bg = [244, 244, 246];
-  const tiles = views.map((v) => renderTile(positions, triVerts, triColors, center, scale, size, basis(v.az, v.el), bg));
+  const tiles = views.map((v) => renderTile(positions, triVerts, triColors, center, scale, size, basis(v.az, v.el), BG));
   const g = 2, W = size * 2 + g, H = size * 2 + g;
   const out = Buffer.alloc(W * H * 3, 220);
-  const place = (px, ox, oy) => {
-    for (let y = 0; y < size; y++) for (let x = 0; x < size; x++) {
-      const s = (y * size + x) * 4, d = ((oy + y) * W + (ox + x)) * 3;
-      out[d] = px[s]; out[d + 1] = px[s + 1]; out[d + 2] = px[s + 2];
-    }
-  };
-  place(tiles[0], 0, 0); place(tiles[1], size + g, 0);
-  place(tiles[2], 0, size + g); place(tiles[3], size + g, size + g);
+  blit(out, W, tiles[0], size, 0, 0); blit(out, W, tiles[1], size, size + g, 0);
+  blit(out, W, tiles[2], size, 0, size + g); blit(out, W, tiles[3], size, size + g, size + g);
   return sharp(out, { raw: { width: W, height: H, channels: 3 } }).png();
+}
+
+// Compose a contact sheet — one iso tile per model, laid out in a near-square
+// grid (left-to-right, top-to-bottom matching the input order). Each model is
+// fit to its own bbox so all are visible regardless of relative size. Models
+// that failed to run get a distinct pink tile so a broken variant stands out.
+// `results` is an array of `{ render }` (render may be null on failure).
+export function composeContactSheet(results, size, view = { az: -50, el: 28 }) {
+  const n = Math.max(1, results.length);
+  const cols = Math.ceil(Math.sqrt(n));
+  const rows = Math.ceil(n / cols);
+  const g = 2;
+  const W = cols * size + (cols - 1) * g;
+  const H = rows * size + (rows - 1) * g;
+  const out = Buffer.alloc(W * H * 3, 220);
+  results.forEach((res, i) => {
+    const r = res && res.render;
+    let tile;
+    if (r && r.positions && r.triVerts && r.triVerts.length) {
+      const { center, scale } = fit(r.bbox, size);
+      tile = renderTile(r.positions, r.triVerts, r.triColors, center, scale, size, basis(view.az, view.el), BG);
+    } else {
+      tile = new Uint8ClampedArray(size * size * 4);
+      for (let p = 0; p < tile.length; p += 4) { tile[p] = 250; tile[p + 1] = 224; tile[p + 2] = 224; tile[p + 3] = 255; }
+    }
+    const ox = (i % cols) * (size + g), oy = Math.floor(i / cols) * (size + g);
+    blit(out, W, tile, size, ox, oy);
+  });
+  return sharp(out, { raw: { width: W, height: H, channels: 3 } }).png();
+}
+
+// Human-readable per-island breakdown for `--explain-components` (printed to
+// stderr so the stdout JSON contract stays clean). `stats.components` is capped
+// at the top 16 by volume; the header notes when more islands exist.
+export function explainComponents(stats) {
+  if (!stats || !Array.isArray(stats.components) || stats.components.length === 0) {
+    return `componentCount=${stats ? stats.componentCount : '?'} — no per-component data (render-only or single solid).`;
+  }
+  const capped = stats.components.length < stats.componentCount;
+  const f = (a) => (Array.isArray(a) ? a.map((n) => (+n).toFixed(2)).join(', ') : '');
+  const lines = [`componentCount=${stats.componentCount}${capped ? ` (showing top ${stats.components.length} by volume)` : ''}`];
+  for (const c of stats.components) {
+    lines.push(`  #${c.index}: vol=${(+c.volume).toFixed(2)} tris=${c.triangleCount} size=[${f(c.bbox && c.bbox.size)}] center=[${f(c.center)}]`);
+  }
+  return lines.join('\n');
+}
+
+// `--expect-components N` assertion. Returns null when the count matches (or N
+// isn't a finite number), otherwise an error string. Compares against the
+// uncapped `stats.componentCount`, NOT `components.length` (which tops out at 16).
+export function checkExpectComponents(stats, expected) {
+  if (expected === null || expected === undefined || expected === '') return null;
+  const n = Number(expected);
+  if (!Number.isFinite(n)) return null;
+  if (!stats || stats.componentCount !== n) {
+    return `--expect-components ${n} failed: model has ${stats ? stats.componentCount : 'no'} component(s).`;
+  }
+  return null;
 }
 
 // Run a model file through the real engine via a throwaway in-process Vite SSR

--- a/scripts/model-preview.mjs
+++ b/scripts/model-preview.mjs
@@ -12,16 +12,18 @@
 // scripts/cli/preview.mjs and is also exposed as `partwright preview`
 // (bin/partwright.mjs). See docs/headless-cli.md.
 import { resolve, dirname, basename, join } from 'node:path';
-import { runPreview, composePng } from './cli/preview.mjs';
+import { runPreview, composePng, explainComponents, checkExpectComponents } from './cli/preview.mjs';
 
 function parseArgs(argv) {
-  const a = { params: {}, size: 480, json: false, png: null, file: null, lang: 'manifold-js' };
+  const a = { params: {}, size: 480, json: false, png: null, file: null, lang: 'manifold-js', explain: false, expect: null };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
     if (t === '--json') a.json = true;
     else if (t === '--size') a.size = parseInt(argv[++i], 10);
     else if (t === '--png') a.png = argv[++i];
     else if (t === '--lang') a.lang = argv[++i];
+    else if (t === '--explain-components') a.explain = true;
+    else if (t === '--expect-components') a.expect = argv[++i];
     else if (t === '-p' || t === '--param') { const [k, ...v] = argv[++i].split('='); a.params[k] = coerce(v.join('=')); }
     else if (!a.file && !t.startsWith('-')) a.file = t;
   }
@@ -31,7 +33,7 @@ function coerce(s) { if (s === 'true') return true; if (s === 'false') return fa
 
 async function main() {
   const a = parseArgs(process.argv.slice(2));
-  if (!a.file) { console.error('Usage: npm run model:preview -- <file.js> [--png out.png] [--json] [--size N] [-p k=v]'); process.exit(2); }
+  if (!a.file) { console.error('Usage: npm run model:preview -- <file.js> [--png out.png] [--json] [--size N] [--explain-components] [--expect-components N] [-p k=v]'); process.exit(2); }
   const file = resolve(a.file);
   const result = await runPreview(file, { params: a.params, lang: a.lang });
 
@@ -47,5 +49,9 @@ async function main() {
     await img.toFile(pngPath);
   }
   console.log(JSON.stringify({ ok: true, png: pngPath, stats: result.stats }, (_k, v) => (ArrayBuffer.isView(v) ? undefined : v), 2));
+
+  if (a.explain) console.error(explainComponents(result.stats));
+  const expectErr = checkExpectComponents(result.stats, a.expect);
+  if (expectErr) { console.error(expectErr); process.exit(1); }
 }
 main().catch((e) => { console.error('model:preview failed:', e?.stack || e?.message || e); process.exit(1); });

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -924,7 +924,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintInCylinder',
-    description: 'Paint triangles whose centroids fall within a cylindrical shell: rMin ≤ dist(centroid, axis) ≤ rMax AND zMin ≤ centroid.z ≤ zMax. The canonical tool for inner walls of hollow cylinders, mugs, vases, and any revolved shape where paintInBox catches too many faces. Set rMin > 0 to exclude the axis core; set rMax to the inner radius to select only the inner surface. Optional normalCone/topOnly for further filtering.',
+    description: 'Paint triangles whose centroids fall within a cylindrical shell: rMin ≤ dist(centroid, axis) ≤ rMax AND zMin ≤ height ≤ zMax. The canonical tool for inner walls of hollow cylinders, mugs, vases, and any revolved shape where paintInBox catches too many faces. Set rMin > 0 to exclude the axis core; set rMax to the inner radius to select only the inner surface. The shell runs along the chosen axis (default z); for an x- or y-aligned cylinder pass axis. Optional normalCone/topOnly for further filtering.',
     input_schema: {
       type: 'object',
       properties: {
@@ -933,12 +933,17 @@ const ALL_TOOLS: ToolDefinition[] = [
           items: { type: 'number' },
           minItems: 2,
           maxItems: 2,
-          description: 'Center of the cylinder axis in the XY plane [cx, cy]. Use [0, 0] for Z-centered models.',
+          description: 'Center of the cylinder axis in the radial plane [a, b]. For axis="z" this is [x, y]; for "x" it is [y, z]; for "y" it is [z, x]. Use [0, 0] for an axis-centered model.',
+        },
+        axis: {
+          type: 'string',
+          enum: ['x', 'y', 'z'],
+          description: 'World axis the shell runs along (default z). Radius is measured in the plane normal to it and the zMin..zMax band runs along it.',
         },
         rMin: { type: 'number', description: 'Minimum radial distance from axis (0 to include everything up to rMax).' },
         rMax: { type: 'number', description: 'Maximum radial distance from axis.' },
-        zMin: { type: 'number', description: 'Bottom of the cylindrical band.' },
-        zMax: { type: 'number', description: 'Top of the cylindrical band.' },
+        zMin: { type: 'number', description: 'Start of the band along the chosen axis.' },
+        zMax: { type: 'number', description: 'End of the band along the chosen axis.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[r, g, b] in 0..1.' },
         name: { type: 'string', description: 'Optional region name.' },
         normalCone: {

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -379,7 +379,7 @@ const ALL_TOOLS: ToolDefinition[] = [
       type: 'object',
       properties: {
         box: { type: 'object', description: '{min: [x,y,z], max: [x,y,z]}' },
-        cylinder: { type: 'object', description: 'Radial-shell selector: {rMin, rMax, zMin, zMax, center?: [x,y]}. Previews the same triangles paintInCylinder would select (unsmoothed).' },
+        cylinder: { type: 'object', description: 'Radial-shell selector: {rMin, rMax, zMin, zMax, center?: [a,b], axis?: "x"|"y"|"z"}. axis (default z) picks the shell axis; radius is measured in the plane normal to it. Previews the same triangles paintInCylinder would select (unsmoothed).' },
         slab: { type: 'object', description: 'Slab selector: {axis: "x"|"y"|"z" OR normal: [nx,ny,nz], offset, thickness}. Previews the same triangles paintSlab would select (unsmoothed).' },
         point: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         radius: { type: 'number' },

--- a/src/color/cylinderPaint.ts
+++ b/src/color/cylinderPaint.ts
@@ -16,10 +16,26 @@ import type { RefineRegion, TriClass, Aabb } from './subdivide';
 
 export type CylinderCoverage = 'centroid' | 'fully_inside' | 'any_vertex_inside';
 
+/** Which world axis the cylindrical shell runs along. `'z'` (the default and
+ *  the only legacy behaviour) measures radius in XY and the band along Z;
+ *  `'x'` measures radius in YZ with the band along X; `'y'` measures radius in
+ *  ZX with the band along Y. The two radial coordinates follow cyclic order
+ *  (x→y→z→x), so `center` is interpreted in that plane. */
+export type CylinderAxis = 'x' | 'y' | 'z';
+
+/** Project a world point onto [radialA, radialB, height] for the chosen axis. */
+function projectAxis(axis: CylinderAxis, x: number, y: number, z: number): [number, number, number] {
+  if (axis === 'x') return [y, z, x];
+  if (axis === 'y') return [z, x, y];
+  return [x, y, z];
+}
+
 /** Collect triangle ids whose centroids (or every vertex, depending on
  *  `coverage`) fall inside a cylindrical shell. Mirrors `findSlabTriangles`
  *  / `findBoxTriangles` in shape — top-level so the post-refine descriptor
- *  resolver can call it without going through `main.ts`'s closure scope. */
+ *  resolver can call it without going through `main.ts`'s closure scope.
+ *  `axis` selects the shell's axis (default `'z'` = the legacy XY-radius
+ *  behaviour). */
 export function findCylinderTriangles(
   mesh: MeshData,
   center: [number, number],
@@ -30,6 +46,7 @@ export function findCylinderTriangles(
   cone?: { axis: [number, number, number]; angleDeg: number },
   coverage: CylinderCoverage = 'centroid',
   maxArea?: number,
+  axis: CylinderAxis = 'z',
 ): Set<number> {
   const adjacency = cone ? buildAdjacency(mesh) : null;
   let coneAxis: [number, number, number] | null = null;
@@ -45,9 +62,10 @@ export function findCylinderTriangles(
   const { triVerts, vertProperties, numProp, numTri } = mesh;
 
   const inShell = (x: number, y: number, z: number): boolean => {
-    const dx = x - cx, dy = y - cy;
+    const [rA, rB, h] = projectAxis(axis, x, y, z);
+    const dx = rA - cx, dy = rB - cy;
     const r2 = dx * dx + dy * dy;
-    return r2 >= rMin2 && r2 <= rMax2 && z >= zMin && z <= zMax;
+    return r2 >= rMin2 && r2 <= rMax2 && h >= zMin && h <= zMax;
   };
 
   for (let t = 0; t < numTri; t++) {
@@ -100,15 +118,19 @@ export function cylinderRefineRegion(
   zMin: number,
   zMax: number,
   maxEdge: number,
+  axis: CylinderAxis = 'z',
 ): RefineRegion {
   const [cx, cy] = center;
   const rMin2 = rMin * rMin;
   const rMax2 = rMax * rMax;
   const classify = (a: number[], b: number[], c: number[]): TriClass => {
-    const ra2 = (a[0] - cx) * (a[0] - cx) + (a[1] - cy) * (a[1] - cy);
-    const rb2 = (b[0] - cx) * (b[0] - cx) + (b[1] - cy) * (b[1] - cy);
-    const rc2 = (c[0] - cx) * (c[0] - cx) + (c[1] - cy) * (c[1] - cy);
-    const az = a[2], bz = b[2], cz = c[2];
+    const pa = projectAxis(axis, a[0], a[1], a[2]);
+    const pb = projectAxis(axis, b[0], b[1], b[2]);
+    const pc = projectAxis(axis, c[0], c[1], c[2]);
+    const ra2 = (pa[0] - cx) * (pa[0] - cx) + (pa[1] - cy) * (pa[1] - cy);
+    const rb2 = (pb[0] - cx) * (pb[0] - cx) + (pb[1] - cy) * (pb[1] - cy);
+    const rc2 = (pc[0] - cx) * (pc[0] - cx) + (pc[1] - cy) * (pc[1] - cy);
+    const az = pa[2], bz = pb[2], cz = pc[2];
 
     // Outside on any single side — all three vertices fail the same test.
     // This is conservative: a thin triangle that happens to lie tangent to
@@ -128,12 +150,19 @@ export function cylinderRefineRegion(
     return 'straddle';
   };
   // Cheap outer-AABB reject: anything fully outside the [cx±rMax, cy±rMax,
-  // zMin..zMax] box can't be in the shell at all. The inner hole (rMin) is
-  // unbounded by a single AABB so we live with the false positives — the
-  // classify catches them.
+  // zMin..zMax] box (in the shell's own projected frame) can't be in the shell
+  // at all. The inner hole (rMin) is unbounded by a single AABB so we live with
+  // the false positives — the classify catches them. The box is built in
+  // projected coords then permuted back to world for the chosen axis (the
+  // projection is a pure axis permutation, so min/max map componentwise).
+  const unproject = (p: [number, number, number]): [number, number, number] => {
+    if (axis === 'x') return [p[2], p[0], p[1]];
+    if (axis === 'y') return [p[1], p[2], p[0]];
+    return p;
+  };
   const aabb: Aabb = {
-    min: [cx - rMax, cy - rMax, zMin],
-    max: [cx + rMax, cy + rMax, zMax],
+    min: unproject([cx - rMax, cy - rMax, zMin]),
+    max: unproject([cx + rMax, cy + rMax, zMax]),
   };
   return { aabb, maxEdge, classify };
 }

--- a/src/color/cylinderPaint.ts
+++ b/src/color/cylinderPaint.ts
@@ -88,9 +88,9 @@ export function findCylinderTriangles(
       if (coneAxis[0] * nx + coneAxis[1] * ny + coneAxis[2] * nz < coneCos) continue;
     }
     if (maxArea !== undefined) {
-      // Inline 2× triangle area via the cross product magnitude so we don't
-      // need a buildAdjacency() call when the cone branch didn't already
-      // build one. The factor of 2 is consistent on both sides of the test.
+      // Inline the true triangle area via the cross-product magnitude so we
+      // don't need a buildAdjacency() call when the cone branch didn't already
+      // build one. Matches `triangleArea`'s real-area semantics (0.5·|cross|).
       const ex1 = bx - ax, ey1 = by - ay, ez1 = bz - az;
       const ex2 = cx2 - ax, ey2 = cy2 - ay, ez2 = cz2 - az;
       const nx = ey1 * ez2 - ez1 * ey2;

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -40,6 +40,10 @@ export type RegionDescriptor =
   // `maxEdge`, giving crisp painted edges that follow the analytic cylinder
   // rather than the coarse base tessellation.
   | { kind: 'cylinder'; center: [number, number]; rMin: number; rMax: number; zMin: number; zMax: number;
+      // World axis the shell runs along — radius measured in the plane normal
+      // to it, the zMin..zMax band along it. Omitted = 'z' (the legacy XY-radius
+      // behaviour), so descriptors saved before axis support round-trip cleanly.
+      axis?: 'x' | 'y' | 'z';
       normalCone?: { axis: [number, number, number]; angleDeg: number };
       // Coverage mode literal — kept as a string union (not an imported type)
       // so this descriptor stays serializable without pulling in main.ts.

--- a/src/geometry/curves.ts
+++ b/src/geometry/curves.ts
@@ -32,6 +32,7 @@ type CurvesAPI = {
   // 3D constructors
   loft: (profiles: any[], heights: number[], opts?: LoftOptions) => any;
   sweep: (profile: any, path: Vec3[], opts?: SweepOptions) => any;
+  sweepArc: (profile: any, opts: SweepArcOptions) => any;
   revolveAxis: (profile: any, axis: Vec3, opts?: RevolveOptions) => any;
 
   // Mesh smoothing wrappers
@@ -71,6 +72,23 @@ interface LoftOptions {
 
 interface SweepOptions {
   closed?: boolean;
+  refine?: number;
+}
+
+interface SweepArcOptions {
+  /** Arc radius (the spine the profile is swept along). Required. */
+  radius: number;
+  /** Sweep angle in degrees. Default 90. */
+  angle?: number;
+  /** Starting angle in degrees (where on the circle the sweep begins). Default 0. */
+  startAngle?: number;
+  /** Number of path segments along the arc. Default 32. */
+  segments?: number;
+  /** Plane the arc spine lies in. Default 'xz' (the pipe curves up in Z). */
+  plane?: 'xy' | 'xz' | 'yz';
+  /** Arc center in world space. Default [0,0,0]. */
+  center?: Vec3;
+  /** refine factor passed through to the underlying sweep. */
   refine?: number;
 }
 
@@ -574,6 +592,43 @@ function makeSweep(module: any) {
 }
 
 // ---------------------------------------------------------------------------
+// Sweep a 2D profile along a circular arc — the common "curved pipe / elbow /
+// torus section" case, without the caller hand-building a 3D path. Traces an
+// arc spine of `radius` in the chosen plane and delegates to `sweep`.
+// ---------------------------------------------------------------------------
+
+function makeSweepArc(sweep: (profile: any, path: Vec3[], opts?: SweepOptions) => any) {
+  return function sweepArc(profile: any, opts: SweepArcOptions): any {
+    need(opts && typeof opts === 'object', 'sweepArc requires an options object');
+    need(isFiniteNum(opts.radius) && opts.radius > 0, 'sweepArc.radius must be a positive number');
+    const angle = opts.angle ?? 90;
+    const startAngle = opts.startAngle ?? 0;
+    const segments = opts.segments ?? 32;
+    const plane = opts.plane ?? 'xz';
+    const center = opts.center ?? [0, 0, 0];
+    need(isFiniteNum(angle) && angle !== 0, 'sweepArc.angle must be a non-zero number');
+    need(isFiniteNum(startAngle), 'sweepArc.startAngle must be a number');
+    need(Number.isInteger(segments) && segments >= 2, 'sweepArc.segments must be an integer >= 2');
+    need(plane === 'xy' || plane === 'xz' || plane === 'yz', "sweepArc.plane must be 'xy', 'xz', or 'yz'");
+    need(isVec3(center), 'sweepArc.center must be a [x,y,z] point');
+
+    const path: Vec3[] = [];
+    for (let i = 0; i <= segments; i++) {
+      const t = i / segments;
+      const a = ((startAngle + angle * t) * Math.PI) / 180;
+      const c = Math.cos(a) * opts.radius, s = Math.sin(a) * opts.radius;
+      if (plane === 'xy') path.push([center[0] + c, center[1] + s, center[2]]);
+      else if (plane === 'yz') path.push([center[0], center[1] + c, center[2] + s]);
+      else path.push([center[0] + c, center[1], center[2] + s]);
+    }
+    // A full 360° sweep wraps onto itself — close the path so the seam fuses.
+    const closed = Math.abs(angle) >= 360 - 1e-6;
+    if (closed) path.pop(); // drop the duplicate end point that coincides with the start
+    return sweep(profile, path, { closed, refine: opts.refine });
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Revolve a profile around an arbitrary 3D axis (not just Y).
 // Internally: rotate so the axis aligns with Y, revolve, then rotate back.
 // ---------------------------------------------------------------------------
@@ -751,6 +806,7 @@ export function createCurvesNamespace(module: any): CurvesAPI {
   const { CrossSection } = module;
   const patterns = makePatterns(module);
   const textHelpers = makeTextHelpers(module);
+  const sweep = makeSweep(module);
   return {
     arc,
     bezier,
@@ -759,7 +815,8 @@ export function createCurvesNamespace(module: any): CurvesAPI {
     text: textHelpers.text,
     textSection: textHelpers.textSection,
     loft: makeLoft(module),
-    sweep: makeSweep(module),
+    sweep,
+    sweepArc: makeSweepArc(sweep),
     revolveAxis: makeRevolveAxis(module),
     fillet,
     chamfer,

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -261,6 +261,12 @@ export const manifoldJsEngine: Engine = {
       // Text helpers — flat aliases so agents can write api.text(...) directly.
       text: curvesNamespace.text,
       textSection: curvesNamespace.textSection,
+      // 3D constructors — flat aliases so agents reach api.loft(...) /
+      // api.sweep(...) / api.sweepArc(...) directly (they consistently try the
+      // short name before the Curves namespace).
+      loft: curvesNamespace.loft,
+      sweep: curvesNamespace.sweep,
+      sweepArc: curvesNamespace.sweepArc,
       // Flat aliases for the most-used meshOps verbs — agents reach for shorter
       // names like `api.intersects(a,b)` and `api.placeOn(part, table)` much more
       // often than they reach for the namespace, so we promote those to api.* too.

--- a/src/geometry/engines/openscad.ts
+++ b/src/geometry/engines/openscad.ts
@@ -452,7 +452,12 @@ async function runLabelAwareAsync(
   // order. When the counts disagree (for-loop expansion, conditional
   // statements, runtime-computed names), fall back to auto-named regions
   // for unmatched objects rather than producing wrong labels.
-  const names = resolveLabelNames(objects.length, labelScan, stderr);
+  // When the scanner's top-level statement count diverges from the AMF object
+  // count, lazy-union expanded a for-loop / conditional at runtime and every
+  // object was auto-named — so any label() the user wrote can't reach
+  // paintByLabel. Capture it here to drive a warning diagnostic below.
+  const labelCountMismatch = labelScan.topLevelStatements.length !== objects.length;
+  const names = resolveLabelNames(objects.length, labelScan);
 
   const module = getManifoldModule();
   if (!module) {
@@ -530,6 +535,26 @@ async function runLabelAwareAsync(
         'Apply label() OUTSIDE the boolean to tag the whole result, or refactor the operands ' +
         'into separate top-level statements.',
     });
+  } else if (lostLabels && lostLabels.length > 0) {
+    // Labels were written in source but didn't reach paintByLabel, and it's not
+    // the nested-block case above. The usual cause is a for-loop / conditional
+    // expanding at runtime so the objects got auto-named (labelCountMismatch).
+    // Promote this from the old INFO-on-stderr line (swallowed on success) to a
+    // warning the editor panel and the AI both see.
+    diagnostics.push({
+      message:
+        `These label() names won't reach paintByLabel: ${lostLabels.join(', ')}. ` +
+        (labelCountMismatch
+          ? `The label scanner counted ${labelScan.topLevelStatements.length} top-level statement(s) but ` +
+            `OpenSCAD emitted ${objects.length} object(s) — a for-loop or conditional expanded at runtime, ` +
+            'so those objects were auto-named.'
+          : 'They were declared in source but no matching object came back from OpenSCAD.'),
+      severity: 'warning',
+      source: 'OpenSCAD',
+      hint:
+        'Apply label() to a single top-level statement that wraps the loop/conditional result, ' +
+        'or unroll the loop so each labelled object is its own top-level statement.',
+    });
   }
   return {
     mesh: canonical,
@@ -546,17 +571,14 @@ async function runLabelAwareAsync(
 function resolveLabelNames(
   amfCount: number,
   labelScan: ReturnType<typeof scanScadLabels>,
-  stderr: string[],
 ): (string | null)[] {
   const stmts = labelScan.topLevelStatements;
   if (stmts.length !== amfCount) {
     // The scanner's view of top-level statements diverges from what
     // lazy-union actually emitted — common when for-loops or conditionals
-    // expand at runtime. Log once for diagnostics, then auto-name.
-    stderr.push(
-      `INFO: label scanner counted ${stmts.length} top-level statement(s) but ` +
-      `OpenSCAD emitted ${amfCount} object(s); using auto names for unmatched objects.`,
-    );
+    // expand at runtime. Auto-name; the caller surfaces a warning-level
+    // diagnostic (promoted from the old swallowed INFO-on-stderr line) when
+    // labels were actually dropped as a result.
     return new Array<string | null>(amfCount).fill(null);
   }
   return stmts.map(s => s.labelName);

--- a/src/main.ts
+++ b/src/main.ts
@@ -199,7 +199,7 @@ import { openShareModal, renderSharedBanner, renderSharedOverlay } from './share
 import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, findColorRegion, resolveSeed, findNearestTriangle, type AdjacencyGraph } from './color/adjacency';
 import { findSlabTriangles, slabRefineRegion, smoothEdgeForResolution } from './color/slabPaint';
 import { findBoxTriangles, findShapeTriangles, shapeRefineRegion } from './color/boxPaint';
-import { cylinderRefineRegion, findCylinderTriangles } from './color/cylinderPaint';
+import { cylinderRefineRegion, findCylinderTriangles, type CylinderAxis } from './color/cylinderPaint';
 import { computeFaceGroups } from './color/faceGroups';
 import {
   getSessionIdFromURL,
@@ -896,7 +896,7 @@ function collectRefineRegions(descriptors: RegionDescriptor[]): RefineRegion[] {
     } else if (d.kind === 'box' && descriptorRefines(d)) {
       regions.push(shapeRefineRegion(d.shape ?? 'box', { center: d.center, size: d.size, quaternion: d.quaternion }, d.maxEdge!));
     } else if (d.kind === 'cylinder' && descriptorRefines(d)) {
-      regions.push(cylinderRefineRegion(d.center, d.rMin, d.rMax, d.zMin, d.zMax, d.maxEdge!));
+      regions.push(cylinderRefineRegion(d.center, d.rMin, d.rMax, d.zMin, d.zMax, d.maxEdge!, d.axis ?? 'z'));
     }
   }
   return regions;
@@ -1008,8 +1008,8 @@ function resolveDescriptorTriangles(
       // Same triangle collector `paintInCylinder` uses for the live call —
       // re-resolves the shell against the (possibly subdivided) current mesh
       // so smoothing-driven refinement carries forward across re-runs.
-      const { center, rMin, rMax, zMin, zMax, normalCone, coverageMode, maxTriangleArea } = descriptor;
-      return { triangles: findCylinderTriangles(mesh, center, rMin, rMax, zMin, zMax, normalCone, coverageMode ?? 'centroid', maxTriangleArea) };
+      const { center, rMin, rMax, zMin, zMax, normalCone, coverageMode, maxTriangleArea, axis } = descriptor;
+      return { triangles: findCylinderTriangles(mesh, center, rMin, rMax, zMin, zMax, normalCone, coverageMode ?? 'centroid', maxTriangleArea, axis ?? 'z') };
     }
     case 'byLabel': {
       // Labels are runtime state — manifold-3d assigns fresh originalIDs on
@@ -10957,6 +10957,11 @@ async function main() {
       zMax: number;
       color: [number, number, number];
       name?: string;
+      /** World axis the shell runs along (default 'z'). Mirrors `paintSlab`'s
+       *  axis shorthand: 'x' measures radius in YZ with the band along X, 'y'
+       *  in ZX along Y, 'z' (default) in XY along Z. `center` is the [a,b] pair
+       *  in the radial plane and zMin/zMax are the band along the chosen axis. */
+      axis?: CylinderAxis;
       normalCone?: { axis: [number, number, number]; angleDeg: number };
       topOnly?: boolean;
       coverageMode?: CoverageMode;
@@ -10981,6 +10986,7 @@ async function main() {
       if (typeof opts.zMin !== 'number' || typeof opts.zMax !== 'number') return { error: 'zMin and zMax must be numbers' };
       if (opts.rMin < 0 || opts.rMax <= opts.rMin) return { error: 'paintInCylinder requires rMin >= 0 and rMax > rMin' };
       if (opts.zMax <= opts.zMin) return { error: 'paintInCylinder requires zMax > zMin' };
+      if (opts.axis !== undefined && opts.axis !== 'x' && opts.axis !== 'y' && opts.axis !== 'z') return { error: "paintInCylinder axis must be 'x', 'y', or 'z'" };
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] in 0..1' };
       const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
       const coneErr = validateNormalCone(cone);
@@ -10991,6 +10997,7 @@ async function main() {
       if (smoothErr) return { error: smoothErr };
 
       const center = opts.center ?? [0, 0];
+      const axis = opts.axis ?? 'z';
       const coverageMode = opts.coverageMode;
       const { smooth, maxEdge } = resolveShapeSmoothFields(opts);
 
@@ -11007,9 +11014,10 @@ async function main() {
         cone,
         coverageMode,
         opts.maxTriangleArea,
+        axis,
       );
       if (triangles.size === 0) {
-        return { error: `paintInCylinder: no triangles in cylindrical shell (rMin=${opts.rMin}, rMax=${opts.rMax}, z=${opts.zMin}..${opts.zMax})${cone ? ' with normalCone filter' : ''}. Try widening the shell, checking the center, or dry-running paintPreview({ cylinder: { rMin, rMax, zMin, zMax } }) to locate the geometry.` };
+        return { error: `paintInCylinder: no triangles in cylindrical shell (axis=${axis}, rMin=${opts.rMin}, rMax=${opts.rMax}, band=${opts.zMin}..${opts.zMax})${cone ? ' with normalCone filter' : ''}. Try widening the shell, checking the center, or dry-running paintPreview({ cylinder: { rMin, rMax, zMin, zMax } }) to locate the geometry.` };
       }
 
       const regionName = opts.name ?? `Region ${getRegions().length + 1}`;
@@ -11027,6 +11035,7 @@ async function main() {
           rMax: opts.rMax,
           zMin: opts.zMin,
           zMax: opts.zMax,
+          ...(axis !== 'z' ? { axis } : {}),
           ...(cone ? { normalCone: cone } : {}),
           ...(coverageMode ? { coverageMode } : {}),
           ...(opts.maxTriangleArea !== undefined ? { maxTriangleArea: opts.maxTriangleArea } : {}),
@@ -11037,7 +11046,7 @@ async function main() {
       ));
       scheduleColorRefresh();
       syncLockState();
-      return { id: region.id, name: region.name, triangles: region.triangles.size, smooth, maxEdge };
+      return { id: region.id, name: region.name, triangles: region.triangles.size, axis, smooth, maxEdge };
     },
 
     /** Render a preview of the current model with a candidate region tinted
@@ -11063,7 +11072,7 @@ async function main() {
      *  `view` is forwarded to `renderView` (elevation/azimuth/ortho/size). */
     paintPreview(opts: {
       box?: { min: [number, number, number]; max: [number, number, number] };
-      cylinder?: { center?: [number, number]; rMin: number; rMax: number; zMin: number; zMax: number };
+      cylinder?: { center?: [number, number]; rMin: number; rMax: number; zMin: number; zMax: number; axis?: CylinderAxis };
       slab?: { axis?: 'x' | 'y' | 'z'; normal?: [number, number, number]; offset: number; thickness: number };
       normalCone?: { axis: [number, number, number]; angleDeg: number };
       /** Cylinder selector only — mirrors `paintInCylinder.topOnly`. Keeps just
@@ -11120,12 +11129,13 @@ async function main() {
         if (c.rMin < 0 || c.rMax <= c.rMin) return { error: 'cylinder requires rMin >= 0 and rMax > rMin' };
         if (c.zMax <= c.zMin) return { error: 'cylinder requires zMax > zMin' };
         if (c.center !== undefined && (!Array.isArray(c.center) || c.center.length !== 2)) return { error: 'cylinder.center must be [x, y]' };
+        if (c.axis !== undefined && c.axis !== 'x' && c.axis !== 'y' && c.axis !== 'z') return { error: "cylinder.axis must be 'x', 'y', or 'z'" };
         // Resolve topOnly into a cone the same way paintInCylinder does, so the
         // preview's selection matches a topOnly commit instead of over-reporting.
         const cone = resolvePaintCone(opts.normalCone, opts.topOnly);
         const coneErr = validateNormalCone(cone);
         if (coneErr) return { error: coneErr };
-        triangles = collectTrianglesByCylinder(mesh, c.center ?? [0, 0], c.rMin, c.rMax, c.zMin, c.zMax, cone, opts.coverageMode, opts.maxTriangleArea);
+        triangles = collectTrianglesByCylinder(mesh, c.center ?? [0, 0], c.rMin, c.rMax, c.zMin, c.zMax, cone, opts.coverageMode, opts.maxTriangleArea, c.axis ?? 'z');
       } else if (opts.slab !== undefined) {
         const s = opts.slab;
         if (typeof s !== 'object' || s === null) return { error: 'slab must be { axis|normal, offset, thickness }' };
@@ -12789,6 +12799,7 @@ async function main() {
         'paintInOrientedBox': { signature: 'paintInOrientedBox({box: {center, size, quaternion?}, color, name?}) -- Paint triangles whose centroid is inside a rotated oriented box. Same selector as the UI Box tool.', docs: '/ai/colors.md' },
         'paintFaces':      { signature: 'paintFaces({triangleIds, color, name?}) -- Paint specific triangle indices', docs: '/ai/colors.md' },
         'paintSlab':       { signature: 'paintSlab({axis|normal, offset, thickness, color, name?}) -- Paint planar slab range', docs: '/ai/colors.md' },
+        'paintInCylinder': { signature: 'paintInCylinder({rMin, rMax, zMin, zMax, center?, axis?, color, name?}) -- Paint a cylindrical/annular shell (rMin=0 = solid cylinder). axis (x|y|z, default z) picks the shell axis; band runs zMin..zMax along it.', docs: '/ai/colors.md' },
         'paintPreview':    { signature: 'paintPreview({box?|point+radius?|triangleIds?, normalCone?, withImage?, view?}) -- DRY-RUN -> {triangleCount, bbox, centroid, [thumbnail]}. Default count-only; pass withImage:true for the yellow-highlighted thumbnail.', docs: '/ai/colors.md' },
         'paintExplain':    { signature: 'paintExplain({region, withImage?, view?}) -- Diagnose a committed region -> {triangleCount, area, bbox, centroid, normalHistogram, [thumbnail]}.', docs: '/ai/colors.md' },
         'assertPaint':     { signature: 'assertPaint({region, expectedTriangleCount?, expectedBoundingBox?, expectedCentroid?}) -- Verify a previously-painted region -> {passed, failures?}', docs: '/ai/colors.md' },
@@ -13402,52 +13413,12 @@ async function main() {
     cone: { axis: [number, number, number]; angleDeg: number } | undefined,
     coverage: CoverageMode = 'centroid',
     maxArea: number | undefined = undefined,
+    axis: CylinderAxis = 'z',
   ): Set<number> {
-    const adjacency = cone ? buildAdjacency(mesh) : null;
-    let coneAxis: [number, number, number] | null = null;
-    let coneCos = -1;
-    if (cone) {
-      const len = Math.hypot(cone.axis[0], cone.axis[1], cone.axis[2]);
-      coneAxis = [cone.axis[0] / len, cone.axis[1] / len, cone.axis[2] / len];
-      coneCos = Math.cos(cone.angleDeg * Math.PI / 180);
-    }
-    const rMin2 = rMin * rMin, rMax2 = rMax * rMax;
-    const [cx, cy] = center;
-    const result = new Set<number>();
-    const { triVerts, vertProperties, numProp, numTri } = mesh;
-
-    function radial2(x: number, y: number): number {
-      const dx = x - cx, dy = y - cy;
-      return dx * dx + dy * dy;
-    }
-    function inShell(x: number, y: number, z: number): boolean {
-      const r2 = radial2(x, y);
-      return r2 >= rMin2 && r2 <= rMax2 && z >= zMin && z <= zMax;
-    }
-
-    for (let t = 0; t < numTri; t++) {
-      const v0 = triVerts[t * 3], v1 = triVerts[t * 3 + 1], v2 = triVerts[t * 3 + 2];
-      const ax = vertProperties[v0 * numProp], ay = vertProperties[v0 * numProp + 1], az = vertProperties[v0 * numProp + 2];
-      const bx = vertProperties[v1 * numProp], by = vertProperties[v1 * numProp + 1], bz = vertProperties[v1 * numProp + 2];
-      const cx2 = vertProperties[v2 * numProp], cy2 = vertProperties[v2 * numProp + 1], cz2 = vertProperties[v2 * numProp + 2];
-
-      if (coverage === 'fully_inside') {
-        if (!inShell(ax, ay, az) || !inShell(bx, by, bz) || !inShell(cx2, cy2, cz2)) continue;
-      } else if (coverage === 'any_vertex_inside') {
-        if (!inShell(ax, ay, az) && !inShell(bx, by, bz) && !inShell(cx2, cy2, cz2)) continue;
-      } else {
-        const ccx = (ax + bx + cx2) / 3, ccy = (ay + by + cy2) / 3, ccz = (az + bz + cz2) / 3;
-        if (!inShell(ccx, ccy, ccz)) continue;
-      }
-
-      if (coneAxis && adjacency) {
-        const nx = adjacency.normals[t * 3], ny = adjacency.normals[t * 3 + 1], nz = adjacency.normals[t * 3 + 2];
-        if (coneAxis[0] * nx + coneAxis[1] * ny + coneAxis[2] * nz < coneCos) continue;
-      }
-      if (maxArea !== undefined && triangleArea(t, mesh) > maxArea) continue;
-      result.add(t);
-    }
-    return result;
+    // Delegate to the canonical shell collector (src/color/cylinderPaint.ts) so
+    // the live paint call, the preview, and the post-refine descriptor resolver
+    // all share one implementation — the projection/axis logic can't drift.
+    return findCylinderTriangles(mesh, center, rMin, rMax, zMin, zMax, cone, coverage, maxArea, axis);
   }
 
   /** Produce advisory warnings for geometry that was saved or queried.

--- a/src/tools/previewModel.ts
+++ b/src/tools/previewModel.ts
@@ -14,6 +14,10 @@ export interface PreviewComponent {
   triangleCount: number;
   volume: number;
   bbox: { min: number[]; max: number[]; size: number[] };
+  /** Bounding-box center of this island ((min+max)/2) — the cheap "where is
+   *  it" locator surfaced by `--explain-components`. Empty when the part had
+   *  no measurable bounding box. */
+  center: number[];
 }
 
 export interface PreviewStats {
@@ -199,7 +203,11 @@ export async function previewModel(
         .map((p: any, index: number) => ({ index, vol: safeNum(() => p.volume()), tri: safeNum(() => p.numTri()), box: safeBox(p) }))
         .sort((a, b) => b.vol - a.vol)
         .slice(0, 16);
-      for (const p of ranked) components.push({ index: p.index, triangleCount: p.tri, volume: p.vol, bbox: p.box ? bb(p.box) : { min: [], max: [], size: [] } });
+      for (const p of ranked) {
+        const box = p.box ? bb(p.box) : { min: [], max: [], size: [] };
+        const center = box.min.length === 3 ? box.min.map((m, i) => (m + box.max[i]) / 2) : [];
+        components.push({ index: p.index, triangleCount: p.tri, volume: p.vol, bbox: box, center });
+      }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       for (const p of parts) try { (p as any).delete(); } catch { /* exit cleans up */ }
     } catch { /* decompose unsupported */ }

--- a/tests/unit/cylinderPaint.test.ts
+++ b/tests/unit/cylinderPaint.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { findCylinderTriangles } from '../../src/color/cylinderPaint';
+import type { MeshData } from '../../src/geometry/types';
+
+// Build a MeshData from a flat list of triangle centroids. Each triangle gets
+// three vertices clustered tightly around its centroid (the 'centroid' coverage
+// mode only reads the centroid, so the exact spread is irrelevant).
+function meshFromCentroids(centroids: [number, number, number][]): MeshData {
+  const vertProperties: number[] = [];
+  const triVerts: number[] = [];
+  centroids.forEach(([x, y, z], t) => {
+    // Three verts whose average is exactly (x, y, z).
+    vertProperties.push(x + 1, y, z, x - 0.5, y + 0.5, z, x - 0.5, y - 0.5, z);
+    triVerts.push(t * 3, t * 3 + 1, t * 3 + 2);
+  });
+  return {
+    vertProperties: new Float32Array(vertProperties),
+    triVerts: new Uint32Array(triVerts),
+    numProp: 3,
+    numVert: centroids.length * 3,
+    numTri: centroids.length,
+  } as MeshData;
+}
+
+describe('findCylinderTriangles — axis', () => {
+  // T0 sits 10 units out in XY at z=5  → in a z-axis shell, out of an x-axis one.
+  // T1 sits 10 units out in YZ at x=5  → in an x-axis shell, out of a z-axis one.
+  const mesh = meshFromCentroids([
+    [10, 0, 5],
+    [5, 0, 10],
+  ]);
+
+  it("defaults to the z axis (radius in XY, band along Z)", () => {
+    const sel = findCylinderTriangles(mesh, [0, 0], 8, 12, 0, 10);
+    expect([...sel]).toEqual([0]);
+  });
+
+  it("axis 'x' measures radius in YZ with the band along X", () => {
+    const sel = findCylinderTriangles(mesh, [0, 0], 8, 12, 0, 10, undefined, 'centroid', undefined, 'x');
+    expect([...sel]).toEqual([1]);
+  });
+
+  it("axis 'z' explicitly matches the default", () => {
+    const zDefault = findCylinderTriangles(mesh, [0, 0], 8, 12, 0, 10);
+    const zExplicit = findCylinderTriangles(mesh, [0, 0], 8, 12, 0, 10, undefined, 'centroid', undefined, 'z');
+    expect([...zExplicit]).toEqual([...zDefault]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements five of the backlog items from the **PR #520** weekly retro (the four "cheap" ones plus the heavier `compare` contact-sheet). Grounding each item in the code first shrank several of them — loft already existed, per-component data was already computed, `lint:catalog` already exists.

| # | Item (retro votes) | What shipped |
|---|---|---|
| ① | per-component introspection (~4 agents) | `model:preview --explain-components` (per-island vol/tris/size/center → stderr) + `--expect-components N` (CI assert, exits 1 on mismatch). Added a `center` field to `PreviewComponent`. |
| ② | `--compare` contact-sheet (2 agents) | `partwright compare a.js b.js …` tiles one iso view per model into a single PNG. New `composeContactSheet`; shared `blit`/`fit` helpers with `composePng`. |
| ④ | loud SCAD for-loop label drop (2 agents) | The for-loop/conditional label drop now emits a **warning-level** `SourceDiagnostic` (visible in the editor panel + `geometry-data`) instead of a swallowed `INFO:` line on stderr. |
| ⑤ | sweep/loft primitive (2 agents) | Flat `api.loft` / `api.sweep` / `api.sweepArc` aliases; new `Curves.sweepArc(profile, {radius, angle?, plane?, …})` for elbow/pipe sweeps. |
| ⑥ | `paintInCylinder({ axis })` (1 agent) | `axis: 'x'|'y'|'z'` (default `'z'`) via coordinate projection. Deduped the copy-pasted cylinder collector in `main.ts`; **fixed a parity bug** — `paintInCylinder` was missing from the `help()` table. |

**Deferred** (left on the backlog): ⑧ catalog triangle-budget CI gate (heavy — WASM per entry), ③ `--palette` mismatch (vague), ⑦ tile-camera control (large renderer change).

### Back-compat notes
- `paintInCylinder` `axis` defaults to `'z'` and the descriptor field is **omitted** when `'z'`, so old saved sessions round-trip byte-identically.
- `--expect-components` correctly treats "flag absent" as no assertion (guards `Number(null) === 0`).

## Test plan
- `npm run build` — clean (tsc type-check).
- `npm run test:unit` — 818/818 (added `tests/unit/cylinderPaint.test.ts` covering axis selection).
- `npm run lint:deps` — acyclic; `npm run lint:deadcode` — only pre-existing advisory items.
- CLI exercised end-to-end: `--explain-components`/`--expect-components` (pass + fail exit codes), `compare` contact-sheet PNG (viewed — 3 models + sweepArc elbow render correctly).
- SCAD for-loop / nested-block / clean diagnostics confirmed via SSR probe.

Parity closed in the same PR: `help()` table, `tools.ts` schema, `public/ai.md`, `public/ai/colors.md`, `public/ai/curves.md`, `CLAUDE.md`.

https://claude.ai/code/session_015yrAV2GPRVc1ciJL6wd3Mj

---
_Generated by [Claude Code](https://claude.ai/code/session_015yrAV2GPRVc1ciJL6wd3Mj)_