### PR TITLE
feat: tile-camera control, clearance warning, partwright fetch (W23 retro follow-ups)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,10 +157,12 @@ When you're iterating on a **model snippet** (catalog entries, `examples/`, mech
 npm run model:preview -- .plans/fidgets/spiral-cone.js          # writes <file>.preview.png + prints JSON
 npm run model:preview -- model.js --json                        # stats only, no PNG
 npm run model:preview -- model.js --png out.png -p turns=6      # override api.params, custom PNG path
+npm run model:preview -- model.js --view 130,35                 # ONE custom-angle tile (peek behind a feature)
+npm run model:preview -- model.js --views front,iso,back        # pick/reorder named views (front,back,right,left,top,bottom,iso)
 ```
 
-- **JSON stat block** (stdout): `isManifold`, `componentCount`, per-component `{volume, bbox, triangleCount}`, `volume`, `surfaceArea`, `genus`, `bbox`, `aspectRatio`, `minEdgeLength`/`meanEdgeLength`, model-declared `labels` (name + color), `paramsSchema`, and a `warnings[]` array (fused parts, tri-count over the ~200k catalog budget, sub-0.4 mm detail, …).
-- **4-view PNG** (front / right / top / iso), shaded by face normal with the model's own label colors — enough to judge proportions, spirals, and color at a glance. `Read` it like a thumbnail.
+- **JSON stat block** (stdout): `isManifold`, `componentCount`, per-component `{volume, bbox, triangleCount, center}`, `volume`, `surfaceArea`, `genus`, `bbox`, `aspectRatio`, `minEdgeLength`/`meanEdgeLength`, model-declared `labels` (name + color), `paramsSchema`, and a `warnings[]` array (fused parts, **interpenetrating components / clearance**, tri-count over the ~200k catalog budget, sub-0.4 mm detail, …).
+- **4-view PNG** (front / right / top / iso by default; override with `--view`/`--views`), shaded by face normal with the model's own label colors — enough to judge proportions, spirals, and color at a glance. `Read` it like a thumbnail. Use `--view az,el` to rotate to an occluded feature when the four default angles hide it.
 - Implementation: `scripts/model-preview.mjs` (CLI + pure-JS rasterizer → `sharp`) + `src/tools/previewModel.ts` (the faithful engine call). No WebGL needed.
 
 **`componentCount` is the instrument for print-in-place mechanisms.** A model that returns separate moving parts (screw, spinner, hinge, captive ball, two-tone spiral) must report `componentCount === N`. If it fuses to `1`, the clearance gap is too small or parts collide. The reliable recipe for splitting one solid into interleaved colored parts: subtract a clearance-thick cutter (e.g. a full-diameter helical **slab** for a spiral), then `manifold.decompose()` and color each component. Verify topological/geometric claims with `model:preview`, not from memory.
@@ -172,10 +174,12 @@ npm run model:preview -- model.js --png out.png -p turns=6      # override api.p
 ```bash
 npm run model:preview -- model.js --explain-components   # per-island vol/tris/size/center (to stderr)
 npm run model:preview -- model.js --expect-components 3   # assert; exits non-zero on mismatch (CI gate)
-node bin/partwright.mjs compare a.js b.js c.js --png out.png   # tile each model's iso view into one contact sheet
+node bin/partwright.mjs compare a.js b.js c.js --png out.png        # tile each model's iso view into one contact sheet
+node bin/partwright.mjs compare a.js b.js --view 130,35 --png o.png # …from a custom angle
+node bin/partwright.mjs fetch <image-url> --out ref.png            # pull a remote image to disk (then `photo` it)
 ```
 
-`--explain-components` prints the per-island breakdown (already in the JSON's `stats.components`, capped at the top 16 by volume) to stderr so the stdout JSON stays parseable. `--expect-components N` compares against the uncapped `stats.componentCount` and exits 1 on mismatch — the escape hatch for "this mechanism MUST stay N parts." `compare` runs several variants and lays one iso view of each side-by-side, for A/B param sweeps or before/after checks.
+`--explain-components` prints the per-island breakdown (already in the JSON's `stats.components`, capped at the top 16 by volume) to stderr so the stdout JSON stays parseable. `--expect-components N` compares against the uncapped `stats.componentCount` and exits 1 on mismatch — the escape hatch for "this mechanism MUST stay N parts." `compare` runs several variants and lays one view of each side-by-side (default iso, `--view az,el` to change it), for A/B param sweeps or before/after checks. `fetch` downloads a remote image to disk so the `photo` voxel-import flow can consume a URL (the env's network policy governs reachability).
 
 **Delegate multi-pass visual iteration to the `model-sculpt` subagent.** Each preview PNG you `Read` in the main context stays there and is re-billed every subsequent turn — image tokens compound. For 3+ render passes on the same model, delegate to `model-sculpt` (or `general-purpose` with its instructions): it owns the render→look→adjust loop in its own disposable context and returns only text. The main agent calls `SendUserFile` to ship the final PNG to the user **without** reading it.
 

--- a/docs/headless-cli.md
+++ b/docs/headless-cli.md
@@ -42,8 +42,12 @@ subsequent call.
 partwright preview <file.js> [--png out.png] [--json] [--size N] [-p k=v ...]
 partwright run     <file.js> [-p k=v ...]            # stats JSON only, no PNG
 
-partwright preview <file.js> [--lang manifold-js|voxel|scad] [--png out] [--json] [--size N] [-p k=v]
+partwright preview <file.js> [--lang manifold-js|voxel|scad] [--png out] [--json] [--size N]
+                   [--view az,el] [--views front,right,top,bottom,left,back,iso]
+                   [--explain-components] [--expect-components N] [-p k=v]
+partwright compare <a.js> <b.js> [more.js ...] [--png out] [--size N] [--view az,el] [-p k=v]  # one tile per model
 partwright photo <image> [--palette p.json] [--max N] [--mode billboard|heightmap] [--depth N] [--bg] [--crop x,y,w,h] [--out model.js] [--png out]
+partwright fetch <url> [--out file]                  # download a remote image to disk (for `photo`)
 
 partwright daemon start [--app-port N] [--control-port N]
 partwright daemon stop
@@ -88,6 +92,21 @@ here). It loads the file against the real engine via Vite SSR and prints the ric
 stat block (`isManifold`, `componentCount`, per-component volumes/bboxes, genus,
 edge stats, declared labels, `warnings[]`). Unless `--json` is passed it also
 writes a 4-view PNG (front/right/top/iso), software-rasterized — flat shading.
+Override the camera with `--view az,el` (a single custom-angle tile, to peek at
+a feature the four defaults occlude) or `--views a,b,c` (pick/reorder named
+angles: front,back,right,left,top,bottom,iso). `--explain-components` prints a
+per-island vol/tris/size/center breakdown to stderr; `--expect-components N`
+exits non-zero on a count mismatch (a CI gate for "this must stay N parts").
+
+**`compare`** runs several model files and tiles one view of each into a single
+contact-sheet PNG — for A/B parameter sweeps or before/after checks. Each model
+is fit to its own bbox; a failed variant gets a distinct pink tile. Default view
+is iso; `--view az,el` changes it for all tiles.
+
+**`fetch`** downloads a remote image (`http(s)` URL) to disk so the `photo`
+voxel-import flow can consume a URL — the literal "chat-attached image" isn't
+reachable from a Node CLI, so this is the URL-download equivalent. Reachability
+is governed by the environment's network policy.
 
 **Multi-engine (`--lang`).** `preview`/`run` dispatch across the engines that
 run without a browser: `manifold-js` (default), `voxel` (pure-JS grid mesher),

--- a/prompts/20260609-130000-retro-513-dropped-items.md
+++ b/prompts/20260609-130000-retro-513-dropped-items.md
@@ -53,3 +53,12 @@ features exercised via the CLI (custom-angle + named-views PNGs viewed, clearanc
 warning fires/silent as expected, fetch downloads + error paths). Docs updated:
 `CLAUDE.md` model:preview section and `docs/headless-cli.md` (which was also
 missing the #525 `compare` command).
+
+**Review follow-up (work-reviewer).** 0 blocking, 2 should-fix, 4 nits — all
+folded in: extracted `resolveViews`/`NAMED_VIEWS` to a pure `scripts/cli/views.mjs`
+and `componentsOverlap` to `src/tools/bboxOverlap.ts` (both now unit-tested —
+`resolveViews.test.ts`, `bboxOverlap.test.ts`); added a 50 MB content-length +
+buffer cap to `cmdFetch` (OOM guard); guarded `compare --views` with a clear
+error (it's single-view, use `--view`); softened the clearance message to
+"bounds overlap, so they may interpenetrate" and noted the top-16 cap. Unit
+suite 840/840.

--- a/prompts/20260609-130000-retro-513-dropped-items.md
+++ b/prompts/20260609-130000-retro-513-dropped-items.md
@@ -1,0 +1,55 @@
+---
+session: "retro513"
+timestamp: "2026-06-09T13:00:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+Compare PR #520's retro with the earlier W23 retro (PR #513) and see if we
+missed any fixes/ideas. Then: create a new PR for the items dropped from #513,
+and also do the tile-camera work in that PR.
+
+(After scoping, the user chose: tile-camera control, the model:preview clearance
+warning, and `partwright fetch` — BREP code-side color excluded.)
+
+## Assistant
+
+## Key decisions
+
+**Diffed #513's backlog against current state.** Three #513 backlog items had
+fallen off #520's radar and were still unbuilt: `partwright fetch`, a
+`model:preview` clearance/self-intersection warning, and `BREP.label({color})`.
+(The other #513 asks — compare, explain/expect-components, paintInCylinder axis —
+shipped in #525; the daemon and file-size `lint:catalog` already existed.) The
+user picked the first two plus tile-camera; BREP color was deferred.
+
+**Tile-camera control — cheap, not "large" as I'd first triaged.** The pure-JS
+rasterizer already renders any angle via `basis(az, el)`; `composePng` just
+hardcoded front/right/top/iso. Added a `NAMED_VIEWS` registry + `resolveViews`
+in `preview.mjs`, extracted a shared `tileGrid` (composePng + composeContactSheet
+now both use it, near-square layout), and threaded `--view az,el` (one custom
+tile) and `--views a,b,c` (named-angle grid) through `cmdPreview`,
+`model-preview.mjs`, and `compare` (which takes `--view`). Bad specs exit 2.
+
+**Clearance warning — implemented as a bbox-overlap heuristic.** manifold-3d
+guarantees non-self-intersecting output, so a literal self-intersection check is
+meaningless on a manifold result. Instead, `buildWarnings` now flags when an
+**unlabeled** model has `componentCount >= 2` AND two components' bounding boxes
+overlap — i.e. separate parts that interpenetrate (a boolean that didn't fuse, or
+an assembly whose clearance wants a sanity-check). Gated to the no-labels case so
+it doesn't double up with the existing FUSED-labels warning. Verified it fires on
+a captive nested-sphere model and stays silent on two disjoint balls.
+
+**`partwright fetch` — URL→disk, with the caveat stated.** "Chat-attached images
+to disk" isn't reachable from a Node CLI, so `fetch <url> --out <file>` downloads
+a remote image (Node global `fetch`) for the `photo` flow to consume. Handles
+HTTP errors, non-URL input, and missing args with the right exit codes;
+reachability is governed by the env network policy. Verified end-to-end (24 KB
+JPEG downloaded; 404/403/bad-input paths handled).
+
+**Verification.** `npm run build` clean; `npm run test:unit` 825/825. All three
+features exercised via the CLI (custom-angle + named-views PNGs viewed, clearance
+warning fires/silent as expected, fetch downloads + error paths). Docs updated:
+`CLAUDE.md` model:preview section and `docs/headless-cli.md` (which was also
+missing the #525 `compare` command).

--- a/scripts/cli/main.mjs
+++ b/scripts/cli/main.mjs
@@ -60,6 +60,7 @@ async function cmdCompare(argv) {
   const a = parse(argv, ['json']);
   const files = a._;
   if (files.length < 2) { console.error('usage: partwright compare <a.js> <b.js> [more.js …] [--lang manifold-js|voxel|scad] [--png out] [--size N] [--view az,el] [--json] [-p k=v]'); process.exit(2); }
+  if (a.views !== undefined) { console.error('compare renders one view per model — use --view az,el (not --views).'); process.exit(2); }
   const { views, error: viewErr } = resolveViews(a.view, undefined);
   if (viewErr) { console.error(viewErr); process.exit(2); }
   const results = [];
@@ -249,7 +250,15 @@ async function cmdFetch(argv) {
   let res;
   try { res = await fetch(url); } catch (e) { console.log(json({ ok: false, error: `fetch failed: ${e?.message || e}` })); process.exit(1); }
   if (!res.ok) { console.log(json({ ok: false, error: `HTTP ${res.status} ${res.statusText}` })); process.exit(1); }
+  // Guard against an oversized/hostile response OOMing the process. 50 MB is far
+  // larger than any reference image; reject up front on the advertised length.
+  const MAX_FETCH_BYTES = 50 * 1024 * 1024;
+  const declared = Number(res.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > MAX_FETCH_BYTES) {
+    console.log(json({ ok: false, error: `response is ${declared} bytes, over the ${MAX_FETCH_BYTES}-byte fetch cap` })); process.exit(1);
+  }
   const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.length > MAX_FETCH_BYTES) { console.log(json({ ok: false, error: `downloaded ${buf.length} bytes, over the ${MAX_FETCH_BYTES}-byte fetch cap` })); process.exit(1); }
   writeFileSync(out, buf);
   console.log(json({ ok: true, out, bytes: buf.length, contentType: res.headers.get('content-type') || 'unknown' }));
 }

--- a/scripts/cli/main.mjs
+++ b/scripts/cli/main.mjs
@@ -3,7 +3,7 @@
 // docs/headless-cli.md.
 import { resolve, dirname, basename, join } from 'node:path';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { runPreview, composePng, composeContactSheet, explainComponents, checkExpectComponents } from './preview.mjs';
+import { runPreview, composePng, composeContactSheet, explainComponents, checkExpectComponents, resolveViews } from './preview.mjs';
 import { runPhoto, meshToPng, loadPalette } from './photo.mjs';
 import { runDaemon } from './daemon.mjs';
 import { startDaemon, stopDaemon, statusDaemon, rpc, evalInPage, resetPage } from './client.mjs';
@@ -34,15 +34,17 @@ const json = (v) => JSON.stringify(v, (_k, val) => (ArrayBuffer.isView(val) ? un
 async function cmdPreview(argv, { pngDefault }) {
   const a = parse(argv, ['json', 'explain-components']);
   const file = a._[0];
-  if (!file) { console.error('usage: partwright preview <file.js> [--lang manifold-js|voxel] [--png out] [--json] [--size N] [--explain-components] [--expect-components N] [-p k=v]'); process.exit(2); }
+  if (!file) { console.error('usage: partwright preview <file.js> [--lang manifold-js|voxel] [--png out] [--json] [--size N] [--view az,el] [--views front,iso,…] [--explain-components] [--expect-components N] [-p k=v]'); process.exit(2); }
   const abs = resolve(file);
+  const { views, error: viewErr } = resolveViews(a.view, a.views);
+  if (viewErr) { console.error(viewErr); process.exit(2); }
   const result = await runPreview(abs, { params: a.params, lang: a.lang || 'manifold-js' });
   if (!result.ok) { console.log(json({ ok: false, error: result.error, diagnostics: result.diagnostics })); process.exit(1); }
 
   let pngPath = null;
   if (pngDefault && !a.json && result.render) {
     pngPath = a.png ? resolve(a.png) : join(dirname(abs), basename(abs).replace(/\.[^.]+$/, '') + '.preview.png');
-    const img = composePng(result.render.positions, result.render.triVerts, result.render.triColors, result.render.bbox, Number(a.size) || 480);
+    const img = composePng(result.render.positions, result.render.triVerts, result.render.triColors, result.render.bbox, Number(a.size) || 480, views || undefined);
     await img.toFile(pngPath);
   }
   console.log(json({ ok: true, png: pngPath, stats: result.stats }));
@@ -57,7 +59,9 @@ async function cmdPreview(argv, { pngDefault }) {
 async function cmdCompare(argv) {
   const a = parse(argv, ['json']);
   const files = a._;
-  if (files.length < 2) { console.error('usage: partwright compare <a.js> <b.js> [more.js …] [--lang manifold-js|voxel|scad] [--png out] [--size N] [--json] [-p k=v]'); process.exit(2); }
+  if (files.length < 2) { console.error('usage: partwright compare <a.js> <b.js> [more.js …] [--lang manifold-js|voxel|scad] [--png out] [--size N] [--view az,el] [--json] [-p k=v]'); process.exit(2); }
+  const { views, error: viewErr } = resolveViews(a.view, undefined);
+  if (viewErr) { console.error(viewErr); process.exit(2); }
   const results = [];
   for (const f of files) {
     const r = await runPreview(resolve(f), { params: a.params, lang: a.lang || 'manifold-js' });
@@ -66,7 +70,7 @@ async function cmdCompare(argv) {
   let pngPath = null;
   if (!a.json) {
     pngPath = a.png ? resolve(a.png) : resolve('compare.png');
-    await composeContactSheet(results, Number(a.size) || 360).toFile(pngPath);
+    await composeContactSheet(results, Number(a.size) || 360, views ? views[0] : undefined).toFile(pngPath);
   }
   // Drop the heavy render buffers from the JSON; the PNG carries the pixels.
   const models = results.map((r, i) => ({ cell: i, file: r.file, ok: r.ok, error: r.error, stats: r.stats }));
@@ -230,6 +234,26 @@ async function cmdIterate(argv) {
   console.log(json({ ok: true, png, stats }));
 }
 
+// Fetch a remote image (or any file) to disk so the stateless `photo` flow can
+// consume it — agents often have an image URL but `photo` needs a local path.
+// (The original "chat-attached image" ask isn't reachable from a Node CLI; a URL
+// download is the implementable equivalent. Honors the env's network policy.)
+async function cmdFetch(argv) {
+  const a = parse(argv);
+  const url = a._[0];
+  if (!url) { console.error('usage: partwright fetch <url> [--out file]'); process.exit(2); }
+  if (!/^https?:\/\//i.test(url)) { console.log(json({ ok: false, error: 'fetch needs an http(s) URL' })); process.exit(1); }
+  let out = a.out;
+  if (!out) { try { out = basename(new URL(url).pathname) || 'download'; } catch { out = 'download'; } }
+  out = resolve(out);
+  let res;
+  try { res = await fetch(url); } catch (e) { console.log(json({ ok: false, error: `fetch failed: ${e?.message || e}` })); process.exit(1); }
+  if (!res.ok) { console.log(json({ ok: false, error: `HTTP ${res.status} ${res.statusText}` })); process.exit(1); }
+  const buf = Buffer.from(await res.arrayBuffer());
+  writeFileSync(out, buf);
+  console.log(json({ ok: true, out, bytes: buf.length, contentType: res.headers.get('content-type') || 'unknown' }));
+}
+
 // Discovery — list the window.partwright methods reachable via `call`.
 async function cmdMethods(argv) {
   const a = parse(argv);
@@ -244,13 +268,15 @@ const USAGE = `partwright — headless Partwright CLI for driving model creation
 
 Phase 1 (stateless, no browser — fast inner loop):
   partwright preview <file.js> [--lang manifold-js|voxel] [--png out] [--json] [--size N]
+                               [--view az,el] [--views front,right,top,bottom,left,back,iso]
                                [--explain-components] [--expect-components N] [-p k=v]
   partwright run     <file.js> [--lang …] [-p k=v]       stats JSON only
-  partwright compare <a.js> <b.js> [more.js …] [--png out] [--size N] [-p k=v]
-                                                         tile each model's iso view into one contact-sheet PNG
+  partwright compare <a.js> <b.js> [more.js …] [--png out] [--size N] [--view az,el] [-p k=v]
+                                                         tile each model's view into one contact-sheet PNG
   partwright photo   <image>   [--palette p.json] [--max N] [--mode billboard|heightmap]
                                [--depth N] [--bg] [--crop x,y,w,h] [--out model.js] [--png out]
                                photo → palette-snapped voxel model + preview
+  partwright fetch   <url>     [--out file]              download a remote image to disk (for photo)
 
 Phase 2 (headless-browser daemon — full fidelity + state):
   partwright iterate <file.js> [--out png] [--views all] [-p k=v]
@@ -270,6 +296,7 @@ export async function main(argv) {
     case 'run': return cmdPreview(rest, { pngDefault: false });
     case 'compare': return cmdCompare(rest);
     case 'photo': return cmdPhoto(rest);
+    case 'fetch': return cmdFetch(rest);
     case 'iterate': return cmdIterate(rest);
     case 'daemon': return cmdDaemon(rest);
     case 'call': return cmdCall(rest);

--- a/scripts/cli/preview.mjs
+++ b/scripts/cli/preview.mjs
@@ -10,6 +10,12 @@
 import { createServer } from 'vite';
 import { readFileSync } from 'node:fs';
 import sharp from 'sharp';
+import { DEFAULT_VIEWS, resolveViews } from './views.mjs';
+
+// Re-export so existing importers (main.mjs, model-preview.mjs) can keep
+// pulling resolveViews from preview.mjs; the implementation lives in views.mjs
+// (pure, unit-testable).
+export { resolveViews };
 
 // ---------- pure-JS rasterizer ----------
 const sub = (a, b) => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
@@ -88,46 +94,6 @@ function fit(bbox, size) {
 }
 
 const BG = [244, 244, 246];
-
-// Named camera angles for `--views`. az/el are degrees in the rasterizer's own
-// frame (see `basis`); front/right/top/iso are the historical default grid.
-const NAMED_VIEWS = {
-  front: { az: -90, el: 0 },
-  back: { az: 90, el: 0 },
-  right: { az: 0, el: 0 },
-  left: { az: 180, el: 0 },
-  top: { az: -90, el: 90 },
-  bottom: { az: -90, el: -90 },
-  iso: { az: -50, el: 28 },
-};
-const DEFAULT_VIEWS = ['front', 'right', 'top', 'iso'].map((name) => ({ name, ...NAMED_VIEWS[name] }));
-
-/** Resolve the `--view` / `--views` CLI flags into an array of {name, az, el}.
- *  Returns `{ views: null }` when neither is set (caller uses DEFAULT_VIEWS),
- *  `{ views }` on success, or `{ error }` on a bad spec.
- *  - `--view "az,el"`  → one custom-angle tile (e.g. peek behind a feature).
- *  - `--views a,b,c`   → named angles, in order: front,back,right,left,top,bottom,iso. */
-export function resolveViews(view, views) {
-  if (view !== undefined && view !== null && view !== '') {
-    const parts = String(view).split(',').map((s) => Number(s.trim()));
-    if (parts.length !== 2 || parts.some((n) => !Number.isFinite(n))) {
-      return { error: `--view expects "az,el" (two numbers in degrees), got "${view}".` };
-    }
-    return { views: [{ name: `${parts[0]},${parts[1]}`, az: parts[0], el: parts[1] }] };
-  }
-  if (views !== undefined && views !== null && views !== '') {
-    const names = String(views).split(',').map((s) => s.trim()).filter(Boolean);
-    const out = [];
-    for (const nm of names) {
-      const v = NAMED_VIEWS[nm];
-      if (!v) return { error: `--views: unknown view "${nm}". Valid: ${Object.keys(NAMED_VIEWS).join(', ')}.` };
-      out.push({ name: nm, ...v });
-    }
-    if (!out.length) return { error: '--views needs at least one view name.' };
-    return { views: out };
-  }
-  return { views: null };
-}
 
 // Lay a list of pre-rendered RGBA tiles into a near-square grid PNG (the same
 // layout for the 4-view default, an N-view custom set, and the contact sheet).

--- a/scripts/cli/preview.mjs
+++ b/scripts/cli/preview.mjs
@@ -89,50 +89,90 @@ function fit(bbox, size) {
 
 const BG = [244, 244, 246];
 
-// Compose the 4-view grid PNG. Returns a sharp instance (caller writes/toBuffer).
-export function composePng(positions, triVerts, triColors, bbox, size) {
-  const { center, scale } = fit(bbox, size);
-  const views = [
-    { name: 'front', az: -90, el: 0 },
-    { name: 'right', az: 0, el: 0 },
-    { name: 'top', az: -90, el: 90 },
-    { name: 'iso', az: -50, el: 28 },
-  ];
-  const tiles = views.map((v) => renderTile(positions, triVerts, triColors, center, scale, size, basis(v.az, v.el), BG));
-  const g = 2, W = size * 2 + g, H = size * 2 + g;
-  const out = Buffer.alloc(W * H * 3, 220);
-  blit(out, W, tiles[0], size, 0, 0); blit(out, W, tiles[1], size, size + g, 0);
-  blit(out, W, tiles[2], size, 0, size + g); blit(out, W, tiles[3], size, size + g, size + g);
-  return sharp(out, { raw: { width: W, height: H, channels: 3 } }).png();
+// Named camera angles for `--views`. az/el are degrees in the rasterizer's own
+// frame (see `basis`); front/right/top/iso are the historical default grid.
+const NAMED_VIEWS = {
+  front: { az: -90, el: 0 },
+  back: { az: 90, el: 0 },
+  right: { az: 0, el: 0 },
+  left: { az: 180, el: 0 },
+  top: { az: -90, el: 90 },
+  bottom: { az: -90, el: -90 },
+  iso: { az: -50, el: 28 },
+};
+const DEFAULT_VIEWS = ['front', 'right', 'top', 'iso'].map((name) => ({ name, ...NAMED_VIEWS[name] }));
+
+/** Resolve the `--view` / `--views` CLI flags into an array of {name, az, el}.
+ *  Returns `{ views: null }` when neither is set (caller uses DEFAULT_VIEWS),
+ *  `{ views }` on success, or `{ error }` on a bad spec.
+ *  - `--view "az,el"`  → one custom-angle tile (e.g. peek behind a feature).
+ *  - `--views a,b,c`   → named angles, in order: front,back,right,left,top,bottom,iso. */
+export function resolveViews(view, views) {
+  if (view !== undefined && view !== null && view !== '') {
+    const parts = String(view).split(',').map((s) => Number(s.trim()));
+    if (parts.length !== 2 || parts.some((n) => !Number.isFinite(n))) {
+      return { error: `--view expects "az,el" (two numbers in degrees), got "${view}".` };
+    }
+    return { views: [{ name: `${parts[0]},${parts[1]}`, az: parts[0], el: parts[1] }] };
+  }
+  if (views !== undefined && views !== null && views !== '') {
+    const names = String(views).split(',').map((s) => s.trim()).filter(Boolean);
+    const out = [];
+    for (const nm of names) {
+      const v = NAMED_VIEWS[nm];
+      if (!v) return { error: `--views: unknown view "${nm}". Valid: ${Object.keys(NAMED_VIEWS).join(', ')}.` };
+      out.push({ name: nm, ...v });
+    }
+    if (!out.length) return { error: '--views needs at least one view name.' };
+    return { views: out };
+  }
+  return { views: null };
 }
 
-// Compose a contact sheet — one iso tile per model, laid out in a near-square
-// grid (left-to-right, top-to-bottom matching the input order). Each model is
-// fit to its own bbox so all are visible regardless of relative size. Models
-// that failed to run get a distinct pink tile so a broken variant stands out.
-// `results` is an array of `{ render }` (render may be null on failure).
-export function composeContactSheet(results, size, view = { az: -50, el: 28 }) {
-  const n = Math.max(1, results.length);
+// Lay a list of pre-rendered RGBA tiles into a near-square grid PNG (the same
+// layout for the 4-view default, an N-view custom set, and the contact sheet).
+function tileGrid(tiles, size) {
+  const n = Math.max(1, tiles.length);
   const cols = Math.ceil(Math.sqrt(n));
   const rows = Math.ceil(n / cols);
   const g = 2;
   const W = cols * size + (cols - 1) * g;
   const H = rows * size + (rows - 1) * g;
   const out = Buffer.alloc(W * H * 3, 220);
-  results.forEach((res, i) => {
-    const r = res && res.render;
-    let tile;
-    if (r && r.positions && r.triVerts && r.triVerts.length) {
-      const { center, scale } = fit(r.bbox, size);
-      tile = renderTile(r.positions, r.triVerts, r.triColors, center, scale, size, basis(view.az, view.el), BG);
-    } else {
-      tile = new Uint8ClampedArray(size * size * 4);
-      for (let p = 0; p < tile.length; p += 4) { tile[p] = 250; tile[p + 1] = 224; tile[p + 2] = 224; tile[p + 3] = 255; }
-    }
+  tiles.forEach((tile, i) => {
     const ox = (i % cols) * (size + g), oy = Math.floor(i / cols) * (size + g);
     blit(out, W, tile, size, ox, oy);
   });
   return sharp(out, { raw: { width: W, height: H, channels: 3 } }).png();
+}
+
+// Compose the multi-view grid PNG. Defaults to front/right/top/iso; pass a
+// custom `views` array (from resolveViews) to control the camera angles.
+// Returns a sharp instance (caller writes/toBuffer).
+export function composePng(positions, triVerts, triColors, bbox, size, views = DEFAULT_VIEWS) {
+  const { center, scale } = fit(bbox, size);
+  const tiles = views.map((v) => renderTile(positions, triVerts, triColors, center, scale, size, basis(v.az, v.el), BG));
+  return tileGrid(tiles, size);
+}
+
+// Compose a contact sheet — one tile per model, laid out in a near-square grid
+// (left-to-right, top-to-bottom matching the input order). Each model is fit to
+// its own bbox so all are visible regardless of relative size. Models that
+// failed to run get a distinct pink tile so a broken variant stands out.
+// `results` is an array of `{ render }` (render may be null on failure); `view`
+// is the shared camera angle (default iso, overridable via --view).
+export function composeContactSheet(results, size, view = { az: -50, el: 28 }) {
+  const tiles = results.map((res) => {
+    const r = res && res.render;
+    if (r && r.positions && r.triVerts && r.triVerts.length) {
+      const { center, scale } = fit(r.bbox, size);
+      return renderTile(r.positions, r.triVerts, r.triColors, center, scale, size, basis(view.az, view.el), BG);
+    }
+    const tile = new Uint8ClampedArray(size * size * 4);
+    for (let p = 0; p < tile.length; p += 4) { tile[p] = 250; tile[p + 1] = 224; tile[p + 2] = 224; tile[p + 3] = 255; }
+    return tile;
+  });
+  return tileGrid(tiles, size);
 }
 
 // Human-readable per-island breakdown for `--explain-components` (printed to

--- a/scripts/cli/views.mjs
+++ b/scripts/cli/views.mjs
@@ -1,0 +1,46 @@
+// Camera-view resolution for the headless preview CLI. Pure + dependency-free
+// (no vite/sharp), so it lives apart from preview.mjs and is unit-testable in
+// the fast vitest tier. Consumed by preview.mjs (composePng), main.mjs
+// (preview/compare), and the legacy model-preview.mjs wrapper.
+
+// Named camera angles for `--views`. az/el are degrees in the rasterizer's own
+// frame (see `basis` in preview.mjs); front/right/top/iso are the default grid.
+export const NAMED_VIEWS = {
+  front: { az: -90, el: 0 },
+  back: { az: 90, el: 0 },
+  right: { az: 0, el: 0 },
+  left: { az: 180, el: 0 },
+  top: { az: -90, el: 90 },
+  bottom: { az: -90, el: -90 },
+  iso: { az: -50, el: 28 },
+};
+
+export const DEFAULT_VIEWS = ['front', 'right', 'top', 'iso'].map((name) => ({ name, ...NAMED_VIEWS[name] }));
+
+/** Resolve the `--view` / `--views` CLI flags into an array of {name, az, el}.
+ *  Returns `{ views: null }` when neither is set (caller uses DEFAULT_VIEWS),
+ *  `{ views }` on success, or `{ error }` on a bad spec. `--view` wins if both
+ *  are passed.
+ *  - `--view "az,el"`  → one custom-angle tile (e.g. peek behind a feature).
+ *  - `--views a,b,c`   → named angles, in order: front,back,right,left,top,bottom,iso. */
+export function resolveViews(view, views) {
+  if (view !== undefined && view !== null && view !== '') {
+    const parts = String(view).split(',').map((s) => Number(s.trim()));
+    if (parts.length !== 2 || parts.some((n) => !Number.isFinite(n))) {
+      return { error: `--view expects "az,el" (two numbers in degrees), got "${view}".` };
+    }
+    return { views: [{ name: `${parts[0]},${parts[1]}`, az: parts[0], el: parts[1] }] };
+  }
+  if (views !== undefined && views !== null && views !== '') {
+    const names = String(views).split(',').map((s) => s.trim()).filter(Boolean);
+    const out = [];
+    for (const nm of names) {
+      const v = NAMED_VIEWS[nm];
+      if (!v) return { error: `--views: unknown view "${nm}". Valid: ${Object.keys(NAMED_VIEWS).join(', ')}.` };
+      out.push({ name: nm, ...v });
+    }
+    if (!out.length) return { error: '--views needs at least one view name.' };
+    return { views: out };
+  }
+  return { views: null };
+}

--- a/scripts/model-preview.mjs
+++ b/scripts/model-preview.mjs
@@ -12,16 +12,18 @@
 // scripts/cli/preview.mjs and is also exposed as `partwright preview`
 // (bin/partwright.mjs). See docs/headless-cli.md.
 import { resolve, dirname, basename, join } from 'node:path';
-import { runPreview, composePng, explainComponents, checkExpectComponents } from './cli/preview.mjs';
+import { runPreview, composePng, explainComponents, checkExpectComponents, resolveViews } from './cli/preview.mjs';
 
 function parseArgs(argv) {
-  const a = { params: {}, size: 480, json: false, png: null, file: null, lang: 'manifold-js', explain: false, expect: null };
+  const a = { params: {}, size: 480, json: false, png: null, file: null, lang: 'manifold-js', explain: false, expect: null, view: null, views: null };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
     if (t === '--json') a.json = true;
     else if (t === '--size') a.size = parseInt(argv[++i], 10);
     else if (t === '--png') a.png = argv[++i];
     else if (t === '--lang') a.lang = argv[++i];
+    else if (t === '--view') a.view = argv[++i];
+    else if (t === '--views') a.views = argv[++i];
     else if (t === '--explain-components') a.explain = true;
     else if (t === '--expect-components') a.expect = argv[++i];
     else if (t === '-p' || t === '--param') { const [k, ...v] = argv[++i].split('='); a.params[k] = coerce(v.join('=')); }
@@ -33,8 +35,10 @@ function coerce(s) { if (s === 'true') return true; if (s === 'false') return fa
 
 async function main() {
   const a = parseArgs(process.argv.slice(2));
-  if (!a.file) { console.error('Usage: npm run model:preview -- <file.js> [--png out.png] [--json] [--size N] [--explain-components] [--expect-components N] [-p k=v]'); process.exit(2); }
+  if (!a.file) { console.error('Usage: npm run model:preview -- <file.js> [--png out.png] [--json] [--size N] [--view az,el] [--views front,iso,…] [--explain-components] [--expect-components N] [-p k=v]'); process.exit(2); }
   const file = resolve(a.file);
+  const { views, error: viewErr } = resolveViews(a.view, a.views);
+  if (viewErr) { console.error(viewErr); process.exit(2); }
   const result = await runPreview(file, { params: a.params, lang: a.lang });
 
   if (!result.ok) {
@@ -45,7 +49,7 @@ async function main() {
   let pngPath = null;
   if (!a.json && result.render) {
     pngPath = a.png ? resolve(a.png) : join(dirname(file), basename(file).replace(/\.[^.]+$/, '') + '.preview.png');
-    const img = composePng(result.render.positions, result.render.triVerts, result.render.triColors, result.render.bbox, a.size);
+    const img = composePng(result.render.positions, result.render.triVerts, result.render.triColors, result.render.bbox, a.size, views || undefined);
     await img.toFile(pngPath);
   }
   console.log(JSON.stringify({ ok: true, png: pngPath, stats: result.stats }, (_k, v) => (ArrayBuffer.isView(v) ? undefined : v), 2));

--- a/src/tools/bboxOverlap.ts
+++ b/src/tools/bboxOverlap.ts
@@ -1,0 +1,25 @@
+// Pure AABB-overlap helper for the model:preview clearance heuristic. Kept apart
+// from previewModel.ts (which pulls the WASM engines) so it's unit-testable in
+// the fast vitest tier.
+
+interface HasBbox {
+  bbox: { min: number[]; max: number[] };
+}
+
+/** True when any two of the given components have overlapping axis-aligned
+ *  bounding boxes — a cheap interpenetration / clearance signal. Note that
+ *  overlapping AABBs do NOT prove the meshes intersect (nested or L-shaped
+ *  parts can share an AABB region without touching); it's an advisory cue, not
+ *  a proof. Components without a 3-D bbox are skipped. */
+export function componentsOverlap(components: HasBbox[]): boolean {
+  const boxes = components.map((c) => c.bbox).filter((b) => b && b.min.length === 3 && b.max.length === 3);
+  for (let i = 0; i < boxes.length; i++) {
+    for (let j = i + 1; j < boxes.length; j++) {
+      const a = boxes[i], b = boxes[j];
+      if (a.min[0] <= b.max[0] && b.min[0] <= a.max[0] &&
+          a.min[1] <= b.max[1] && b.min[1] <= a.max[1] &&
+          a.min[2] <= b.max[2] && b.min[2] <= a.max[2]) return true;
+    }
+  }
+  return false;
+}

--- a/src/tools/previewModel.ts
+++ b/src/tools/previewModel.ts
@@ -8,6 +8,7 @@ import { voxelEngine } from '../geometry/engines/voxel';
 import { openscadEngine, runScadAsync } from '../geometry/engines/openscad';
 import type { Language } from '../geometry/engines/types';
 import type { MeshResult } from '../geometry/engines/types';
+import { componentsOverlap } from './bboxOverlap';
 
 export interface PreviewComponent {
   index: number;
@@ -289,28 +290,13 @@ function buildWarnings(s: PreviewStats): string[] {
   // assembly it's a cue to sanity-check the clearance gap. Gated to the
   // no-labels case so it doesn't double up with the FUSED-labels warning above.
   if (!s.renderOnly && !s.empty && s.componentCount >= 2 && s.labels.length === 0 && componentsOverlap(s.components)) {
-    w.push(`componentCount=${s.componentCount} with overlapping component bounding boxes — separate parts that interpenetrate. If this should be ONE solid, a boolean didn't fuse (increase overlap ≥0.5 units); if it's an intentional multi-part / print-in-place assembly, verify the clearance gap. Inspect islands with model:preview --explain-components.`);
+    w.push(`componentCount=${s.componentCount} with overlapping component bounding boxes (top ${Math.min(s.componentCount, s.components.length)} by volume checked) — separate parts whose bounds overlap, so they may interpenetrate. If this should be ONE solid, a boolean didn't fuse (increase overlap ≥0.5 units); if it's an intentional multi-part / print-in-place assembly, verify the clearance gap. Inspect islands with model:preview --explain-components.`);
   }
   if (s.triangleCount > 200000) w.push(`High triangle count (${Math.round(s.triangleCount / 1000)}k) — exceeds the ~200k catalog budget; lower circular segments / nDivisions or feature density.`);
   if (s.aspectRatio > 12) w.push(`Extreme aspect ratio (${s.aspectRatio.toFixed(1)}:1) — tall/thin parts can be fragile or tip-droppy on FDM.`);
   if (s.minEdgeLength > 0 && s.minEdgeLength < 0.4) w.push(`Smallest edge ${s.minEdgeLength}mm (<0.4mm extrusion width) — sub-extrusion detail may vanish on the print.`);
   return w;
 }
-// True when any two of the (capped) decomposed components have overlapping
-// axis-aligned bounding boxes — a cheap interpenetration / clearance signal.
-function componentsOverlap(components: PreviewComponent[]): boolean {
-  const boxes = components.map((c) => c.bbox).filter((b) => b && b.min.length === 3 && b.max.length === 3);
-  for (let i = 0; i < boxes.length; i++) {
-    for (let j = i + 1; j < boxes.length; j++) {
-      const a = boxes[i], b = boxes[j];
-      if (a.min[0] <= b.max[0] && b.min[0] <= a.max[0] &&
-          a.min[1] <= b.max[1] && b.min[1] <= a.max[1] &&
-          a.min[2] <= b.max[2] && b.min[2] <= a.max[2]) return true;
-    }
-  }
-  return false;
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function safeBox(p: any): { min: number[]; max: number[] } | null {
   try { return toBox(p.boundingBox()); } catch { return null; }

--- a/src/tools/previewModel.ts
+++ b/src/tools/previewModel.ts
@@ -282,11 +282,35 @@ function buildWarnings(s: PreviewStats): string[] {
   if (distinctLabelColors >= 2 && s.componentCount === 1) {
     w.push('Multiple colors but a single component — separate moving parts should report componentCount ≥ 2.');
   }
+  // Clearance / unintended-fragmentation check: separate components whose
+  // bounding boxes overlap are interpenetrating-but-not-fused. For an unlabeled
+  // model that was meant to be ONE solid, that's a boolean that didn't take
+  // (insufficient overlap); for an intentional multi-part / print-in-place
+  // assembly it's a cue to sanity-check the clearance gap. Gated to the
+  // no-labels case so it doesn't double up with the FUSED-labels warning above.
+  if (!s.renderOnly && !s.empty && s.componentCount >= 2 && s.labels.length === 0 && componentsOverlap(s.components)) {
+    w.push(`componentCount=${s.componentCount} with overlapping component bounding boxes — separate parts that interpenetrate. If this should be ONE solid, a boolean didn't fuse (increase overlap ≥0.5 units); if it's an intentional multi-part / print-in-place assembly, verify the clearance gap. Inspect islands with model:preview --explain-components.`);
+  }
   if (s.triangleCount > 200000) w.push(`High triangle count (${Math.round(s.triangleCount / 1000)}k) — exceeds the ~200k catalog budget; lower circular segments / nDivisions or feature density.`);
   if (s.aspectRatio > 12) w.push(`Extreme aspect ratio (${s.aspectRatio.toFixed(1)}:1) — tall/thin parts can be fragile or tip-droppy on FDM.`);
   if (s.minEdgeLength > 0 && s.minEdgeLength < 0.4) w.push(`Smallest edge ${s.minEdgeLength}mm (<0.4mm extrusion width) — sub-extrusion detail may vanish on the print.`);
   return w;
 }
+// True when any two of the (capped) decomposed components have overlapping
+// axis-aligned bounding boxes — a cheap interpenetration / clearance signal.
+function componentsOverlap(components: PreviewComponent[]): boolean {
+  const boxes = components.map((c) => c.bbox).filter((b) => b && b.min.length === 3 && b.max.length === 3);
+  for (let i = 0; i < boxes.length; i++) {
+    for (let j = i + 1; j < boxes.length; j++) {
+      const a = boxes[i], b = boxes[j];
+      if (a.min[0] <= b.max[0] && b.min[0] <= a.max[0] &&
+          a.min[1] <= b.max[1] && b.min[1] <= a.max[1] &&
+          a.min[2] <= b.max[2] && b.min[2] <= a.max[2]) return true;
+    }
+  }
+  return false;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function safeBox(p: any): { min: number[]; max: number[] } | null {
   try { return toBox(p.boundingBox()); } catch { return null; }

--- a/tests/unit/bboxOverlap.test.ts
+++ b/tests/unit/bboxOverlap.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { componentsOverlap } from '../../src/tools/bboxOverlap';
+
+const box = (min: number[], max: number[]) => ({ bbox: { min, max } });
+
+describe('componentsOverlap', () => {
+  it('is false for fewer than two components', () => {
+    expect(componentsOverlap([])).toBe(false);
+    expect(componentsOverlap([box([0, 0, 0], [1, 1, 1])])).toBe(false);
+  });
+
+  it('is false for spatially disjoint components', () => {
+    // two boxes separated along X
+    expect(componentsOverlap([box([-10, -1, -1], [-2, 1, 1]), box([2, -1, -1], [10, 1, 1])])).toBe(false);
+  });
+
+  it('is true for a nested component (captive part)', () => {
+    expect(componentsOverlap([box([-10, -10, -10], [10, 10, 10]), box([-2, -2, -2], [2, 2, 2])])).toBe(true);
+  });
+
+  it('is true for partially overlapping boxes', () => {
+    expect(componentsOverlap([box([0, 0, 0], [5, 5, 5]), box([4, 4, 4], [9, 9, 9])])).toBe(true);
+  });
+
+  it('treats face-touching boxes (shared boundary) as overlapping', () => {
+    expect(componentsOverlap([box([0, 0, 0], [2, 2, 2]), box([2, 0, 0], [4, 2, 2])])).toBe(true);
+  });
+
+  it('finds an overlapping pair anywhere in the set, not just the first two', () => {
+    expect(componentsOverlap([
+      box([-20, 0, 0], [-18, 1, 1]),
+      box([0, 0, 0], [2, 2, 2]),
+      box([1, 1, 1], [3, 3, 3]), // overlaps the second
+    ])).toBe(true);
+  });
+
+  it('skips components without a 3-D bbox', () => {
+    expect(componentsOverlap([box([], []), box([0, 0, 0], [1, 1, 1])])).toBe(false);
+  });
+});

--- a/tests/unit/resolveViews.test.ts
+++ b/tests/unit/resolveViews.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs CLI helper, no type decls
+import { resolveViews, NAMED_VIEWS, DEFAULT_VIEWS } from '../../scripts/cli/views.mjs';
+
+describe('resolveViews', () => {
+  it('returns {views:null} when neither flag is set (caller uses defaults)', () => {
+    expect(resolveViews(undefined, undefined)).toEqual({ views: null });
+    expect(resolveViews('', '')).toEqual({ views: null });
+  });
+
+  it('parses a custom --view "az,el" into one tile', () => {
+    expect(resolveViews('130,35', undefined)).toEqual({ views: [{ name: '130,35', az: 130, el: 35 }] });
+  });
+
+  it('accepts negative angles and whitespace', () => {
+    expect(resolveViews(' -50 , 28 ', undefined)).toEqual({ views: [{ name: '-50,28', az: -50, el: 28 }] });
+  });
+
+  it('--view wins over --views when both are passed', () => {
+    const r = resolveViews('10,20', 'front,iso');
+    expect(r.views).toEqual([{ name: '10,20', az: 10, el: 20 }]);
+  });
+
+  it('rejects a --view that is not exactly two numbers', () => {
+    expect(resolveViews('a,b', undefined).error).toMatch(/two numbers/);
+    expect(resolveViews('1,2,3', undefined).error).toMatch(/two numbers/);
+    expect(resolveViews('5', undefined).error).toMatch(/two numbers/);
+  });
+
+  it('resolves named --views in order', () => {
+    const r = resolveViews(undefined, 'front,iso,back');
+    expect(r.views).toEqual([
+      { name: 'front', ...NAMED_VIEWS.front },
+      { name: 'iso', ...NAMED_VIEWS.iso },
+      { name: 'back', ...NAMED_VIEWS.back },
+    ]);
+  });
+
+  it('rejects an unknown named view and lists valid names', () => {
+    const r = resolveViews(undefined, 'front,nonsense');
+    expect(r.error).toMatch(/unknown view "nonsense"/);
+    expect(r.error).toContain('iso');
+  });
+
+  it('DEFAULT_VIEWS is the historical front/right/top/iso grid', () => {
+    expect(DEFAULT_VIEWS.map((v: { name: string }) => v.name)).toEqual(['front', 'right', 'top', 'iso']);
+  });
+});


### PR DESCRIPTION
## Summary

Picks up three backlog items that were raised in the **W23 retro (#513)** but fell off #520's radar and were never built. (The other #513 asks — `compare`, `--explain-components`/`--expect-components`, `paintInCylinder({axis})` — shipped in #525; the Phase-2 daemon and the file-size `lint:catalog` gate already existed.)

| Item (W23 votes) | What shipped |
|---|---|
| **Tile-camera control** (8+ agents, 3 cycles — the most-requested unresolved item) | `model:preview --view az,el` (one custom-angle tile) and `--views front,right,top,bottom,left,back,iso` (pick/reorder the grid). Threaded through `preview`, the legacy `model:preview` wrapper, and `compare` (via `--view`). |
| **`model:preview` clearance / self-intersection warning** (1 agent) | `buildWarnings` now flags an **unlabeled** model whose decomposed components have **overlapping bounding boxes** — interpenetrating-but-not-fused parts (a boolean that didn't take, or an assembly whose clearance wants a check). |
| **`partwright fetch`** (1 agent) | `partwright fetch <url> --out <file>` downloads a remote image to disk for the `photo` voxel-import flow. |

> **`BREP.label({color})`** (the 4th dropped item) was deliberately **excluded** from this PR per scoping.

### Notes / judgement calls
- **Tile-camera was much cheaper than #520's triage implied.** The pure-JS rasterizer already renders any `basis(az, el)`; `composePng` just hardcoded the four views. I extracted a shared `tileGrid` helper (now used by `composePng` *and* the contact sheet).
- **Clearance warning is a heuristic, by necessity.** manifold-3d guarantees non-self-intersecting output, so a literal self-intersection check is meaningless on a manifold result. The bbox-overlap heuristic is gated to the no-labels case so it doesn't double up with the existing FUSED-labels warning.
- **`fetch` is the URL-download equivalent** of the original "chat-attached image to disk" ask, which a Node CLI can't reach. Reachability is governed by the environment's network policy.

## Test plan
- `npm run build` — clean (tsc). `npm run test:unit` — 825/825.
- CLI exercised end-to-end:
  - `--view 130,35` → single custom-angle tile; `--views front,iso,back` → 3-tile grid; bad specs exit 2.
  - clearance warning **fires** on a captive nested-sphere model, **silent** on two disjoint balls.
  - `fetch` downloads a 24 KB JPEG (reports bytes/contentType); 404 / 403 / non-URL / no-args handled with correct exit codes.
- Docs updated: `CLAUDE.md` model:preview section + `docs/headless-cli.md` (also backfills the #525 `compare` command, which was undocumented there).

https://claude.ai/code/session_015yrAV2GPRVc1ciJL6wd3Mj

---
_Generated by [Claude Code](https://claude.ai/code/session_015yrAV2GPRVc1ciJL6wd3Mj)_