### PR TITLE
feat: voxelPieceCount — trustworthy face-connected piece count for voxel models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,8 @@ npm run model:preview -- model.js --views front,iso,back        # pick/reorder n
 
 **When `componentCount` is wrong: decompose and inspect, don't tune blindly.** Call `Manifold.decompose()` on the result, iterate the parts, and check which one floated or fused — a 10-line diagnostic snippet beats 3 rounds of parameter-tweaking on the whole assembly. Note that many legitimate catalog subjects (assemblies, orreries, watch movements) intentionally have `componentCount > 1`; `isManifold: true` is the correctness gate, not the count. Pass `{ maxComponents: N }` to `runAndSave` when the model is intentionally multi-part.
 
+> **Voxel models: trust `voxelPieceCount`, not `componentCount`, for "is this one printable piece?"** `componentCount` comes from the meshed solid and over-reports voxel grids — an enclosed cavity counts as a second component, and voxels touching only at an edge/corner split apart. The stats also carry `voxelPieceCount`, a face-connected (6-neighbour) BFS over the grid that matches what actually fuses on an FDM plate. A one-piece hollow voxel shell reports `componentCount: 2` but `voxelPieceCount: 1`.
+
 `model:preview` can do that island inspection for you:
 
 ```bash

--- a/prompts/20260609-140000-voxel-face-component-count.md
+++ b/prompts/20260609-140000-voxel-face-component-count.md
@@ -1,0 +1,61 @@
+---
+session: "voxelpieces"
+timestamp: "2026-06-09T14:00:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+For the engine-level one-offs raised across both retros: start from the latest
+main, double-check they still need fixing, and if so implement and open a new PR.
+(Earlier turn established the two items: the BREP `fillet(r)` preflight clamp and
+the voxel `componentCount` over-count. The fillet one was deferred — already
+mitigated by `formatOcctError`'s clear "radius too large" message. So this PR is
+the voxel one.)
+
+## Assistant
+
+## Key decisions
+
+**Re-verified the voxel over-count on latest main — still present.** A
+face-connected hollow voxel shell (one printable piece with an enclosed cavity)
+reports `componentCount: 2` because the cavity's inner surface is a separate
+manifold component (`genus: -1`). `componentCount` comes from
+`Manifold.decompose()` on the meshed solid (`statsComputation.ts:80`), which is
+the wrong instrument for "how many separate printable pieces?" on a voxel grid.
+
+**Also found a concrete bug my own #530 clearance warning introduced:** it
+false-positived on that hollow shell ("separate parts whose bounds overlap, may
+interpenetrate") — it's one piece. So this work both adds the trustworthy
+measure and fixes that regression.
+
+**Fix: a face-connected (6-neighbour) BFS piece count.** Added
+`VoxelGrid.faceComponentCount()` (`grid.ts`) — pure, O(occupied), unit-tested —
+since FDM fuses only across shared faces (edge/corner touches and enclosed
+cavities don't make/break a single piece). Threaded it as `voxelPieceCount`
+through the same path `voxelCount` already uses: voxel engine →
+`MeshResult` (`types.ts`) → worker message (`engineWorker.ts`, `engine.ts`) →
+both the headless stats (`previewModel.ts`) and the browser geometry-data
+(`main.ts` `lastVoxelPieceCount` + `runIsolated`).
+
+**Did NOT override `componentCount`.** It's deeply wired into the
+printability/floating-parts logic (which already detects enclosed components via
+WASM `intersect`), and the per-component breakdown comes from the same
+decompose. Overriding it risked regressions for marginal benefit. Instead I
+surface `voxelPieceCount` alongside it and, in `buildWarnings`: (a) gate the
+clearance check on the real piece count (`pieces`, = voxelPieceCount for voxel)
+so the hollow-shell false positive is gone, and (b) add a clarifying note when
+`componentCount > voxelPieceCount` so the AI reads the right number.
+
+**Verification.** `npm run build` clean; `npm run test:unit` 864/864 (new
+`voxelFaceComponents.test.ts`, 8 cases incl. face/edge/corner/cavity). CLI:
+hollow shell now `voxelPieceCount: 1` + note, clearance false-positive gone;
+disjoint blobs `voxelPieceCount: 2`; the non-voxel (manifold-js) clearance
+warning still fires (no regression). A throwaway Playwright spec confirmed the
+browser worker path surfaces `voxelPieceCount: 1` in `runAndSave().geometry`.
+Docs: `public/ai/voxel.md` fragmentation section + `CLAUDE.md` componentCount
+discipline now point at `voxelPieceCount`.
+
+**Left as-is (per earlier decision):** the BREP `fillet(r)` preflight clamp —
+already mitigated, and a true clamp needs OCCT max-radius introspection
+replicad doesn't expose, for little gain.

--- a/prompts/20260609-140000-voxel-face-component-count.md
+++ b/prompts/20260609-140000-voxel-face-component-count.md
@@ -59,3 +59,11 @@ discipline now point at `voxelPieceCount`.
 **Left as-is (per earlier decision):** the BREP `fillet(r)` preflight clamp —
 already mitigated, and a true clamp needs OCCT max-radius introspection
 replicad doesn't expose, for little gain.
+
+**Review follow-up (work-reviewer).** 0 blocking, 0 should-fix, 2 nits. Fixed
+nit 1: the clearance warning was gated on voxel pieces but its message
+interpolated the mesh `componentCount` — self-contradictory next to the new
+note. Cleaner fix: skip the clearance warning entirely for voxel models (mesh
+bbox-overlap is meaningless given cavity over-reporting; voxelPieceCount is the
+right voxel cue). Nit 2 (lastVoxelCount staleness after Voxel-Studio paint
+edits) is pre-existing and not worsened here — left as a conscious non-goal.

--- a/public/ai/voxel.md
+++ b/public/ai/voxel.md
@@ -241,11 +241,17 @@ return voxels().sdf(sdf.union(shell, core), {
   over big bounds is capped (`import.voxelSdfMaxSamples`, default 8M) and throws,
   asking for a coarser `res` or tighter `bounds`, rather than freezing.
 - **Printability — fragmentation.** Open lattices can fragment into many
-  disconnected components (each a separate piece on the plate). Check
-  `componentCount`. Fixes, cheapest first: call **`v.keepLargest()`** to drop
-  stray specks; thicken walls so the lattice stays face-connected; weld a solid
-  core/skin through it (e.g. `lattice.union(smallSolidCore)`, or subtract an
-  inner shape from an outer solid and union the lattice inside).
+  disconnected pieces (each a separate piece on the plate). Check
+  **`voxelPieceCount`** — the face-connected (6-neighbour) piece count, which is
+  the trustworthy "how many separate printable pieces?" number for voxel models.
+  Do **not** judge this by `componentCount`: that comes from the meshed solid and
+  over-reports voxel models (an enclosed cavity counts as a second component, and
+  voxels touching only at an edge/corner split), so a one-piece hollow shell
+  shows `componentCount: 2` but `voxelPieceCount: 1`. Fixes, cheapest first: call
+  **`v.keepLargest()`** to drop stray specks; thicken walls so the lattice stays
+  face-connected; weld a solid core/skin through it (e.g.
+  `lattice.union(smallSolidCore)`, or subtract an inner shape from an outer solid
+  and union the lattice inside).
 - **Thin TPMS struts at `res: 1` can be non-manifold.** A lattice strut only one
   voxel wide tends to touch its neighbour along an *edge* (diagonal), not a face
   — a non-manifold edge. The fix is **resolution, not thickness**: a finer `res`

--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -355,6 +355,7 @@ function handleEngineWorkerMessage(event: MessageEvent): void {
       paramsSchema: (msg.paramsSchema as MeshResult['paramsSchema']) ?? undefined,
       engineHeapBytes: msg.engineHeapBytes as number | undefined,
       voxelCount: msg.voxelCount as number | undefined,
+      voxelPieceCount: msg.voxelPieceCount as number | undefined,
     };
     pending.resolve(result);
     // A WASM trap (OOM / abort) reported as a *result* leaves the Worker's

--- a/src/geometry/engineWorker.ts
+++ b/src/geometry/engineWorker.ts
@@ -227,7 +227,7 @@ self.onmessage = async (event: MessageEvent) => {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (self as any).postMessage(
-          { type: 'execute_result', callId, mesh, error: null, diagnostics: [], labelMapEntries, labelColorEntries, lostLabels, paramsSchema, renderOnly: !!result.renderOnly, workerMs: Math.round(performance.now() - execStart), engineHeapBytes, voxelCount: result.voxelCount },
+          { type: 'execute_result', callId, mesh, error: null, diagnostics: [], labelMapEntries, labelColorEntries, lostLabels, paramsSchema, renderOnly: !!result.renderOnly, workerMs: Math.round(performance.now() - execStart), engineHeapBytes, voxelCount: result.voxelCount, voxelPieceCount: result.voxelPieceCount },
           transfer,
         );
       } else {

--- a/src/geometry/engines/voxel.ts
+++ b/src/geometry/engines/voxel.ts
@@ -111,7 +111,7 @@ export const voxelEngine: Engine = {
 
     try {
       const mesh = meshGrid(grid);
-      return { mesh, manifold: null, error: null, paramsSchema: capture.collectSchema(), voxelCount: grid.size };
+      return { mesh, manifold: null, error: null, paramsSchema: capture.collectSchema(), voxelCount: grid.size, voxelPieceCount: grid.faceComponentCount() };
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       return { mesh: null, manifold: null, error: msg, diagnostics: runtimeDiagnostic(msg, undefined, 'JavaScript'), paramsSchema: capture.collectSchema() };

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -78,6 +78,11 @@ export interface MeshResult {
    *  geometry-data stats so agents can confirm a voxel model's size without
    *  re-decoding the grid themselves. */
   voxelCount?: number;
+  /** Count of face-connected (6-neighbour) voxel pieces — the trustworthy
+   *  "separate printable pieces?" measure for voxel models, which the mesh
+   *  `componentCount` over-reports (enclosed cavities + edge/corner touches).
+   *  Only set by the voxel engine. */
+  voxelPieceCount?: number;
 }
 
 export interface CrossSectionResult {

--- a/src/geometry/voxel/grid.ts
+++ b/src/geometry/voxel/grid.ts
@@ -157,6 +157,43 @@ export class VoxelGrid {
   /** Number of occupied voxels. */
   get size(): number { return this.cells.size; }
 
+  /** Count of **face-connected** voxel pieces (6-neighbour BFS). This is the
+   *  trustworthy "how many separate printable pieces?" measure for voxel
+   *  models — unlike the mesh `componentCount` (from `Manifold.decompose()`),
+   *  which over-counts: an enclosed cavity shows up as a second component, and
+   *  voxels touching only at an edge/corner can split apart. FDM prints fuse
+   *  only across shared faces, so face-connectivity is what determines whether
+   *  the model comes off the bed in one piece. O(occupied voxels). */
+  faceComponentCount(): number {
+    if (this.cells.size === 0) return 0;
+    const visited = new Set<number>();
+    const NEIGHBORS: Vec3[] = [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]];
+    let components = 0;
+    for (const startKey of this.cells.keys()) {
+      if (visited.has(startKey)) continue;
+      components++;
+      const stack = [startKey];
+      visited.add(startKey);
+      while (stack.length) {
+        const key = stack.pop()!;
+        // Inverse of packKey: decode the offset-packed (x,y,z).
+        const z = (key % DIM) - HALF;
+        const y = (Math.floor(key / DIM) % DIM) - HALF;
+        const x = Math.floor(key / (DIM * DIM)) - HALF;
+        for (const [dx, dy, dz] of NEIGHBORS) {
+          const nx = x + dx, ny = y + dy, nz = z + dz;
+          if (!inRange(nx, ny, nz)) continue;
+          const nKey = packKey(nx, ny, nz);
+          if (this.cells.has(nKey) && !visited.has(nKey)) {
+            visited.add(nKey);
+            stack.push(nKey);
+          }
+        }
+      }
+    }
+    return components;
+  }
+
   /** Set (occupy) a single voxel. */
   set(x: number, y: number, z: number, color: ColorInput): this {
     const cx = assertCoord(x, 'set(x)'), cy = assertCoord(y, 'set(y)'), cz = assertCoord(z, 'set(z)');

--- a/src/main.ts
+++ b/src/main.ts
@@ -461,6 +461,11 @@ let lastEngineHeapBytes: number | undefined;
  *  and the Data panel show it) without re-decoding the grid. Undefined for the
  *  non-voxel engines or before the first run. */
 let lastVoxelCount: number | undefined;
+/** Face-connected printable-piece count for the last voxel run (6-neighbour
+ *  BFS). Surfaced as `voxelPieceCount` in the geometry-data stats so agents
+ *  trust it over the mesh `componentCount`, which over-reports voxel models
+ *  (enclosed cavities + edge/corner touches). Undefined for non-voxel engines. */
+let lastVoxelPieceCount: number | undefined;
 /** The pristine mesh produced by the authored code, before any smooth brush
  *  subdivision. `currentMeshData` equals this until a `brushStroke` region
  *  exists, at which point it becomes the refined (subdivided) mesh rebuilt by
@@ -735,6 +740,11 @@ function withSessionContext(data: Record<string, unknown>): Record<string, unkno
   // size readout for direct (non-mesh) modeling.
   if (lastVoxelCount !== undefined) {
     data.voxelCount = lastVoxelCount;
+  }
+  // Trustworthy "separate printable pieces?" count for voxel models — the mesh
+  // componentCount over-reports them (enclosed cavities, edge/corner touches).
+  if (lastVoxelPieceCount !== undefined) {
+    data.voxelPieceCount = lastVoxelPieceCount;
   }
   return data;
 }
@@ -6993,6 +7003,7 @@ async function main() {
     const stats = computeGeometryStats(manifold, result.mesh!, elapsed, code);
     if (engineMemory !== undefined) stats.engineMemory = engineMemory;
     if (result.voxelCount !== undefined) stats.voxelCount = result.voxelCount;
+    if (result.voxelPieceCount !== undefined) stats.voxelPieceCount = result.voxelPieceCount;
     return {
       geometryData: stats,
       meshData: result.mesh,
@@ -13705,6 +13716,7 @@ async function main() {
     // Occupied-voxel count for voxel runs (undefined for other engines, which
     // resets the readout so a prior voxel session's count doesn't linger).
     lastVoxelCount = result.voxelCount;
+    lastVoxelPieceCount = result.voxelPieceCount;
 
     // Reconcile the Customizer with what the model declared this run. The
     // schema rides on the result for both success and error, so the panel

--- a/src/tools/previewModel.ts
+++ b/src/tools/previewModel.ts
@@ -295,18 +295,19 @@ function buildWarnings(s: PreviewStats): string[] {
   // chase a phantom "extra part", and use pieces (not componentCount) to gate
   // the clearance check below.
   const isVoxel = s.engine === 'voxel';
-  const pieces = isVoxel && typeof s.voxelPieceCount === 'number' ? s.voxelPieceCount : s.componentCount;
   if (isVoxel && typeof s.voxelPieceCount === 'number' && s.componentCount > s.voxelPieceCount) {
     w.push(`componentCount=${s.componentCount} counts enclosed cavities / edge-only touches, but this is ${s.voxelPieceCount} face-connected printable piece${s.voxelPieceCount === 1 ? '' : 's'} (voxelPieceCount). Trust voxelPieceCount for "is this one piece?".`);
   }
-  // Clearance / unintended-fragmentation check: separate pieces whose bounding
-  // boxes overlap are interpenetrating-but-not-fused. For an unlabeled model
-  // meant to be ONE solid, that's a boolean that didn't take (insufficient
-  // overlap); for an intentional multi-part / print-in-place assembly it's a
-  // cue to sanity-check the clearance gap. Gated to the no-labels case so it
-  // doesn't double up with the FUSED-labels warning, and to ≥2 actual pieces so
-  // a voxel model with a hollow cavity (one piece) doesn't false-positive.
-  if (!s.renderOnly && !s.empty && pieces >= 2 && s.labels.length === 0 && componentsOverlap(s.components)) {
+  // Clearance / unintended-fragmentation check: separate components whose
+  // bounding boxes overlap are interpenetrating-but-not-fused. For an unlabeled
+  // model meant to be ONE solid, that's a boolean that didn't take (insufficient
+  // overlap); for an intentional multi-part / print-in-place assembly it's a cue
+  // to sanity-check the clearance gap. Skipped for voxel models: their
+  // decompose-based components over-report (an enclosed cavity nests inside the
+  // shell's bbox), so the overlap signal is meaningless — voxelPieceCount above
+  // is the right cue there. Gated to no-labels so it doesn't double up with the
+  // FUSED-labels warning.
+  if (!s.renderOnly && !s.empty && !isVoxel && s.componentCount >= 2 && s.labels.length === 0 && componentsOverlap(s.components)) {
     w.push(`componentCount=${s.componentCount} with overlapping component bounding boxes (top ${Math.min(s.componentCount, s.components.length)} by volume checked) — separate parts whose bounds overlap, so they may interpenetrate. If this should be ONE solid, a boolean didn't fuse (increase overlap ≥0.5 units); if it's an intentional multi-part / print-in-place assembly, verify the clearance gap. Inspect islands with model:preview --explain-components.`);
   }
   if (s.triangleCount > 200000) w.push(`High triangle count (${Math.round(s.triangleCount / 1000)}k) — exceeds the ~200k catalog budget; lower circular segments / nDivisions or feature density.`);

--- a/src/tools/previewModel.ts
+++ b/src/tools/previewModel.ts
@@ -43,6 +43,11 @@ export interface PreviewStats {
   engine: Language;
   /** Occupied-voxel count — only set for the `voxel` engine. */
   voxelCount?: number;
+  /** Face-connected printable-piece count (6-neighbour) — only set for the
+   *  `voxel` engine. Trust this over `componentCount` for "is this one piece?":
+   *  the mesh componentCount over-reports voxel models (enclosed cavities count
+   *  as a second component, edge/corner-only touches split). */
+  voxelPieceCount?: number;
 }
 
 export interface PreviewRender {
@@ -186,7 +191,7 @@ export async function previewModel(
       vertexCount: mesh.numVert, volume: 0, surfaceArea: 0, genus: 0,
       bbox: null, aspectRatio: 0, minEdgeLength: edge.min, meanEdgeLength: edge.mean,
       components: [], labels, warnings: [], paramsSchema: r.paramsSchema, renderOnly: true,
-      engine, voxelCount: r.voxelCount,
+      engine, voxelCount: r.voxelCount, voxelPieceCount: r.voxelPieceCount,
     };
     stats.warnings = buildWarnings(stats);
   } else {
@@ -233,7 +238,7 @@ export async function previewModel(
       warnings: [],
       paramsSchema: r.paramsSchema,
       renderOnly: false,
-      engine, voxelCount: r.voxelCount,
+      engine, voxelCount: r.voxelCount, voxelPieceCount: r.voxelPieceCount,
     };
     stats.warnings = buildWarnings(stats);
   }
@@ -283,13 +288,25 @@ function buildWarnings(s: PreviewStats): string[] {
   if (distinctLabelColors >= 2 && s.componentCount === 1) {
     w.push('Multiple colors but a single component — separate moving parts should report componentCount ≥ 2.');
   }
-  // Clearance / unintended-fragmentation check: separate components whose
-  // bounding boxes overlap are interpenetrating-but-not-fused. For an unlabeled
-  // model that was meant to be ONE solid, that's a boolean that didn't take
-  // (insufficient overlap); for an intentional multi-part / print-in-place
-  // assembly it's a cue to sanity-check the clearance gap. Gated to the
-  // no-labels case so it doesn't double up with the FUSED-labels warning above.
-  if (!s.renderOnly && !s.empty && s.componentCount >= 2 && s.labels.length === 0 && componentsOverlap(s.components)) {
+  // For voxel models the mesh componentCount over-reports pieces (an enclosed
+  // cavity is a second component; edge/corner-only touches split), so the
+  // face-connected voxelPieceCount is the trustworthy "one printable piece?"
+  // number. Surface the distinction so the AI reads the right one and doesn't
+  // chase a phantom "extra part", and use pieces (not componentCount) to gate
+  // the clearance check below.
+  const isVoxel = s.engine === 'voxel';
+  const pieces = isVoxel && typeof s.voxelPieceCount === 'number' ? s.voxelPieceCount : s.componentCount;
+  if (isVoxel && typeof s.voxelPieceCount === 'number' && s.componentCount > s.voxelPieceCount) {
+    w.push(`componentCount=${s.componentCount} counts enclosed cavities / edge-only touches, but this is ${s.voxelPieceCount} face-connected printable piece${s.voxelPieceCount === 1 ? '' : 's'} (voxelPieceCount). Trust voxelPieceCount for "is this one piece?".`);
+  }
+  // Clearance / unintended-fragmentation check: separate pieces whose bounding
+  // boxes overlap are interpenetrating-but-not-fused. For an unlabeled model
+  // meant to be ONE solid, that's a boolean that didn't take (insufficient
+  // overlap); for an intentional multi-part / print-in-place assembly it's a
+  // cue to sanity-check the clearance gap. Gated to the no-labels case so it
+  // doesn't double up with the FUSED-labels warning, and to ≥2 actual pieces so
+  // a voxel model with a hollow cavity (one piece) doesn't false-positive.
+  if (!s.renderOnly && !s.empty && pieces >= 2 && s.labels.length === 0 && componentsOverlap(s.components)) {
     w.push(`componentCount=${s.componentCount} with overlapping component bounding boxes (top ${Math.min(s.componentCount, s.components.length)} by volume checked) — separate parts whose bounds overlap, so they may interpenetrate. If this should be ONE solid, a boolean didn't fuse (increase overlap ≥0.5 units); if it's an intentional multi-part / print-in-place assembly, verify the clearance gap. Inspect islands with model:preview --explain-components.`);
   }
   if (s.triangleCount > 200000) w.push(`High triangle count (${Math.round(s.triangleCount / 1000)}k) — exceeds the ~200k catalog budget; lower circular segments / nDivisions or feature density.`);

--- a/tests/unit/voxelFaceComponents.test.ts
+++ b/tests/unit/voxelFaceComponents.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { VoxelGrid } from '../../src/geometry/voxel/grid';
+
+describe('VoxelGrid.faceComponentCount', () => {
+  it('is 0 for an empty grid', () => {
+    expect(new VoxelGrid().faceComponentCount()).toBe(0);
+  });
+
+  it('is 1 for a single voxel', () => {
+    const v = new VoxelGrid().set(0, 0, 0, '#fff');
+    expect(v.faceComponentCount()).toBe(1);
+  });
+
+  it('counts face-adjacent voxels as ONE piece', () => {
+    const v = new VoxelGrid().set(0, 0, 0, '#fff').set(1, 0, 0, '#fff');
+    expect(v.faceComponentCount()).toBe(1);
+  });
+
+  it('counts edge-only (diagonal) touches as SEPARATE pieces', () => {
+    // (0,0,0) and (1,1,0) share only an edge, not a face → 2 pieces.
+    const v = new VoxelGrid().set(0, 0, 0, '#fff').set(1, 1, 0, '#fff');
+    expect(v.faceComponentCount()).toBe(2);
+  });
+
+  it('counts corner-only touches as SEPARATE pieces', () => {
+    const v = new VoxelGrid().set(0, 0, 0, '#fff').set(1, 1, 1, '#fff');
+    expect(v.faceComponentCount()).toBe(2);
+  });
+
+  it('reports ONE piece for a hollow shell with an enclosed cavity', () => {
+    // This is the case the mesh componentCount over-reports (cavity surface =
+    // a 2nd manifold component): the shell is fully face-connected → 1 piece.
+    const v = new VoxelGrid();
+    v.fillBox([0, 0, 0], [4, 4, 4], '#ccd');
+    v.remove(2, 2, 2);
+    expect(v.faceComponentCount()).toBe(1);
+  });
+
+  it('counts two disjoint blobs as two pieces', () => {
+    const v = new VoxelGrid();
+    v.fillBox([0, 0, 0], [2, 2, 2], '#f00');
+    v.fillBox([10, 0, 0], [12, 2, 2], '#00f');
+    expect(v.faceComponentCount()).toBe(2);
+  });
+
+  it('handles a face-connected L of voxels as one piece', () => {
+    const v = new VoxelGrid()
+      .set(0, 0, 0, '#fff').set(1, 0, 0, '#fff').set(2, 0, 0, '#fff')
+      .set(2, 1, 0, '#fff').set(2, 2, 0, '#fff');
+    expect(v.faceComponentCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the engine-level one-off raised in **both** the W23 (#513) and W24 (#520) retros: the voxel `componentCount` over-count. I re-verified it on latest `main` first — it's still present.

**The problem (reproduced on current main):** a face-connected hollow voxel shell — one printable piece with an enclosed cavity — reports `componentCount: 2`, because `componentCount` comes from `Manifold.decompose()` on the *meshed* solid and the cavity's inner surface is a separate manifold component (`genus: -1`). Voxels touching only at an edge/corner also split. That's the wrong instrument for "how many separate printable pieces?" on a voxel grid, and it's the misdiagnosis both retros flagged (agents "fix" geometry that's fine).

**The fix:** `VoxelGrid.faceComponentCount()` — a 6-neighbour BFS over the occupied grid (FDM fuses only across shared *faces*; edge/corner touches and enclosed cavities don't make or break a single piece). Surfaced as **`voxelPieceCount`** through the same plumbing `voxelCount` already uses:

`voxel engine → MeshResult → worker msg (engineWorker/engine) → headless stats (previewModel) + browser geometry-data (main.ts)`

`buildWarnings` now trusts the piece count: it adds a clarifying note when `componentCount > voxelPieceCount`, and **gates the clearance warning on real pieces** — which also fixes a **false positive** that my own #530 clearance warning hit on hollow voxel shells.

### Design note
I deliberately **did not override `componentCount`** — it's wired into the printability/floating-parts logic (which already detects enclosed components via WASM `intersect`) and the per-component breakdown. Overriding risked regressions for marginal benefit. `voxelPieceCount` sits alongside it as the trustworthy "one piece?" number.

### Not in scope
The other cross-retro one-off — the BREP `fillet(r)` preflight clamp — is left as-is (already mitigated by `formatOcctError`'s clear "radius too large" message; a true clamp needs OCCT max-radius introspection replicad doesn't cleanly expose).

## Test plan
- `npm run build` clean; `npm run test:unit` **864/864** (new `voxelFaceComponents.test.ts`: face/edge/corner/cavity/disjoint/L-shape).
- Headless CLI: hollow shell → `voxelPieceCount: 1` + clarifying note, clearance false-positive gone; two disjoint blobs → `voxelPieceCount: 2`; manifold-js captive (non-voxel) clearance warning **still fires** (no regression).
- Browser: a throwaway Playwright spec confirmed `runAndSave().geometry` surfaces `voxelPieceCount: 1` / `componentCount: 2` for the hollow shell (verifies the worker→main path).
- Docs: `public/ai/voxel.md` fragmentation section + `CLAUDE.md` componentCount discipline now point at `voxelPieceCount`.

https://claude.ai/code/session_015yrAV2GPRVc1ciJL6wd3Mj

---
_Generated by [Claude Code](https://claude.ai/code/session_015yrAV2GPRVc1ciJL6wd3Mj)_