### PR TITLE
fix: stop ResizeObserver loop notice from hints ticker

### DIFF
--- a/prompts/20260609-140027-resizeobserver-loop-fix.md
+++ b/prompts/20260609-140027-resizeobserver-loop-fix.md
@@ -1,0 +1,40 @@
+---
+date: 2026-06-09
+prefix: fix
+---
+
+## Human
+
+"I sometimes see an error: 'ResizeObserver loop completed with undelivered
+notifications.' can you investigate and fix?"
+
+## Assistant
+
+Investigated the two app-level `ResizeObserver` instances. The viewport
+observer (`src/renderer/viewport.ts`) only resizes the WebGL drawing buffer
+via `renderer.setSize(w, h, false)` (`updateStyle=false`), so it never changes
+the observed element's box and can't loop. The culprit is the hints ticker
+(`src/ui/hints/hintsTicker.ts`): its observer callback synchronously mutates
+layout — toggling `display`, reparenting/restyling between single- and two-row
+arrangements, and reading `offsetWidth` in `measureSingleNeeded()`. When that
+work doesn't settle in one frame the browser raises the "undelivered
+notifications" notice. That intermittency matches the "sometimes" in the report.
+
+Two changes:
+
+1. **Source fix** — the ticker's `ResizeObserver` now coalesces to one
+   `requestAnimationFrame`-deferred `relayout()` per frame instead of mutating
+   layout inside the observer's delivery tick. Running the mutation outside the
+   tick is the standard way to break the loop. The rAF handle is cancelled in
+   `teardownStrip()` so a torn-down strip can't relayout.
+
+2. **Defense-in-depth** — this notice is a benign, unpreventable browser
+   message that can also originate from observers we don't own (CodeMirror,
+   Three.js helpers) and carries no stack. Filtered it out of the global
+   `window 'error'` handler in `src/diagnostics/errorLog.ts` so it stops
+   polluting the Diagnostic Log and raising the unseen-error badge over real
+   failures.
+
+Verified with `npm run build`, `npm run test:unit` (856 pass), and a scratch
+Playwright spec that thrashes the editor viewport width across seven sizes
+while listening for the message — zero occurrences.

--- a/prompts/20260609-141500-editor-hints-flake-fix.md
+++ b/prompts/20260609-141500-editor-hints-flake-fix.md
@@ -1,0 +1,27 @@
+---
+date: 2026-06-09
+prefix: test
+---
+
+## Human
+
+(PR #534 CI follow-up) The `editor-hints.spec.ts` "a coach CTA pulses an arrow
+at the target control" e2e test failed on the PR (initial + retry).
+
+## Assistant
+
+Diagnosed it as a pre-existing flake, not a regression from the ResizeObserver
+fix. The ticker's rotation order is shuffled (`buildOrder` → Fisher–Yates), and
+there are 24 hints, but the test only clicked "Next hint" 12 times looking for
+the BREP hint — so it found it only ~50% of the time (and the retry could miss
+too, ~25% of runs fail). The commit history already shows this test being
+re-triggered as a known flake (`a4cfb90`).
+
+The ResizeObserver change only touches the observer-driven relayout path;
+`advance()` → `showCurrent()` sets the hint text synchronously and is untouched,
+so text stepping isn't affected.
+
+Made the test deterministic: step through a full cycle (cap 40) instead of a
+fixed 12, stop early once a hint text repeats (a complete loop), and poll for
+the text to actually change after each "Next" click before re-reading. Verified
+with `--repeat-each=3` — 12/12 green.

--- a/src/diagnostics/errorLog.ts
+++ b/src/diagnostics/errorLog.ts
@@ -87,6 +87,13 @@ class ErrorLogStore {
   /** Wire up global error handlers and console interception. Call once at startup. */
   install(): void {
     window.addEventListener('error', (e) => {
+      // "ResizeObserver loop completed with undelivered notifications" is a
+      // benign, unpreventable browser notice fired when an observer's callback
+      // doesn't settle in a single frame. It can come from any observer on the
+      // page (ours, CodeMirror, Three.js helpers), carries no stack, and is not
+      // an actual fault — keep it out of the log so it doesn't raise the
+      // unseen-error badge over real failures.
+      if (e.message && e.message.includes('ResizeObserver loop')) return;
       const where = e.filename ? `at ${e.filename}:${e.lineno}:${e.colno}` : undefined;
       this.capture({
         level: 'error',

--- a/src/ui/hints/hintsTicker.ts
+++ b/src/ui/hints/hintsTicker.ts
@@ -38,6 +38,12 @@ let paused = false;
 let configUnsub: (() => void) | null = null;
 let sessionUnsub: (() => void) | null = null;
 let resizeObs: ResizeObserver | null = null;
+/** Pending rAF handle for the resize-driven relayout (0 = none). The observer
+ *  defers relayout to the next frame so its layout mutations (display toggles,
+ *  reparenting, offsetWidth reads) don't re-enter the observer in the same tick
+ *  — that re-entrancy is what raises "ResizeObserver loop completed with
+ *  undelivered notifications". */
+let resizeRaf = 0;
 let desktopMqCleanup: (() => void) | null = null;
 /** Re-evaluate single-vs-two-row layout for the current width + hint text.
  *  Set while a strip is mounted (closure over its elements), cleared on
@@ -167,6 +173,7 @@ function teardownStrip(): void {
   rotateTimer = 0;
   resizeObs?.disconnect();
   resizeObs = null;
+  if (resizeRaf) { cancelAnimationFrame(resizeRaf); resizeRaf = 0; }
   desktopMqCleanup?.();
   desktopMqCleanup = null;
   dismissCoachmark();
@@ -304,7 +311,16 @@ function renderStrip(): void {
   relayoutFn = relayout;
 
   resizeObs?.disconnect();
-  resizeObs = new ResizeObserver(relayout);
+  resizeObs = new ResizeObserver(() => {
+    // Coalesce to one relayout per frame and run it outside the observer's
+    // delivery tick, so the layout changes it makes don't trip the
+    // "undelivered notifications" loop.
+    if (resizeRaf) return;
+    resizeRaf = requestAnimationFrame(() => {
+      resizeRaf = 0;
+      relayout();
+    });
+  });
   resizeObs.observe(host);
   // Re-evaluate on breakpoint crossings: resizing the window across 768px may
   // not shift the host's own width enough to trip the ResizeObserver.

--- a/tests/editor-hints.spec.ts
+++ b/tests/editor-hints.spec.ts
@@ -88,12 +88,20 @@ test.describe('editor hints ticker', () => {
     await expect(strip).toBeVisible({ timeout: 15_000 });
 
     // Step to the BREP-engine hint, whose CTA coaches the language toggle.
+    // The rotation order is shuffled (buildOrder), so the brep hint can sit
+    // anywhere in the cycle — step through the whole cycle, not a fixed count,
+    // and stop once a hint text repeats (a full loop with nothing left to see).
     const hintText = page.locator('#editor-hints-text');
     let found = false;
-    for (let i = 0; i < 12; i++) {
-      const t = (await hintText.textContent())?.toLowerCase() ?? '';
+    const seen = new Set<string>();
+    for (let i = 0; i < 40; i++) {
+      const t = (await hintText.textContent())?.trim().toLowerCase() ?? '';
       if (t.includes('brep')) { found = true; break; }
+      if (t && seen.has(t)) break;   // completed a full cycle without a match
+      if (t) seen.add(t);
       await strip.getByRole('button', { name: 'Next hint' }).click();
+      // Wait for the text to actually change before reading again.
+      await expect.poll(async () => (await hintText.textContent())?.trim().toLowerCase()).not.toBe(t);
     }
     expect(found).toBe(true);
 


### PR DESCRIPTION
## Summary

Fixes the intermittent `ResizeObserver loop completed with undelivered notifications` browser notice.

**Root cause.** Of the two app-level `ResizeObserver`s, the viewport one (`src/renderer/viewport.ts`) only resizes the WebGL drawing buffer via `renderer.setSize(w, h, false)` (`updateStyle=false`), so it never changes the observed box and can't loop. The culprit is the editor **hints ticker** (`src/ui/hints/hintsTicker.ts`): its observer callback synchronously mutated layout — toggling `display`, reparenting/restyling between the single- and two-row arrangements, and reading `offsetWidth` in `measureSingleNeeded()`. When that work doesn't settle in one frame, the browser raises the notice (hence "sometimes").

**Changes:**
1. **Source fix** — the ticker's `ResizeObserver` now coalesces to one `requestAnimationFrame`-deferred `relayout()` per frame, so its layout mutations run *outside* the observer's delivery tick (the standard way to break the loop). The rAF handle is cancelled in `teardownStrip()`.
2. **Defense-in-depth** — this notice is a benign, stackless browser message that can also come from observers we don't own (CodeMirror, Three.js helpers). Filtered it out of the global `window 'error'` handler in `src/diagnostics/errorLog.ts` so it stops polluting the Diagnostic Log and raising the unseen-error badge over real failures.

## Test plan
- [x] `npm run build` (type-check) — clean
- [x] `npm run test:unit` — 856 pass
- [x] Scratch Playwright spec thrashing editor viewport width across 7 sizes while listening for the message — zero occurrences; app renders correctly (screenshot posted in session)
- [ ] PR-checks shards green

https://claude.ai/code/session_01VBMG959eU6YmjhJvZ8Ud6j

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBMG959eU6YmjhJvZ8Ud6j)_