### PR TITLE
feat: configurable voxel rounding + Voxel Studio rounding controls

### DIFF
--- a/prompts/20260609-voxel-rounding-controls.md
+++ b/prompts/20260609-voxel-rounding-controls.md
@@ -70,3 +70,29 @@ lockBox; the panel only owns strength/flatBottom/baseLayers). Added an e2e test
 asserting a slider change keeps the source's `algorithm:'taubin', iterations:6,
 detail:2`. (The unrelated `editor-hints` ticker-layout e2e flake on the first CI
 run is pre-existing and untouched by this diff.)
+
+## User feedback round 2
+
+Two issues from hands-on use:
+
+**(1) Duplicate `__voxStudio` declaration on repeated rounding edits.** Adjusting
+the slider + "Update code" twice produced `const __voxStudio = __voxStudio;`
+("Identifier '__voxStudio' has already been declared"), because
+`appendVoxelEditsToCode` re-wrapped its own prior output. Made it re-entrant: when
+the input already ends `return __voxStudio;` with a `const __voxStudio = …`, it
+reuses that block — keeps the first declaration + prior edit ops + any custom
+lines the user added with the var, drops only the auto surfacing call and any
+duplicate declarations (so it also self-heals already-corrupted code), then
+appends the new edits/surfacing. Unit tests cover re-apply, custom-code
+preservation, and self-heal.
+
+**(2) Live rounding preview in the viewport.** Folded a preview into `setRounding`:
+when surfacing is smooth it pushes `meshGrid(grid)` (the rounded mesh) to the
+viewport, coalesced per-frame; hard blocks shows the blocky mesh. Picking needs
+the blocky provenance mesh, so `onPointerDown` reverts the preview the instant the
+user presses *inside* the model (an edit) — a press outside keeps the preview so
+they can orbit the rounded result. `remeshAndPush`/`deactivate` keep the flag in
+sync. E2E reads the live `meshGroup` (imported as `/src/renderer/viewport.ts` to
+hit the app's module singleton) and asserts the displayed extent shrinks when
+rounding is applied and returns to blocky after an edit — triangle count is a
+non-signal here since smoothing moves vertices without changing the count.

--- a/prompts/20260609-voxel-rounding-controls.md
+++ b/prompts/20260609-voxel-rounding-controls.md
@@ -58,3 +58,15 @@ surfacing call (incl. surfacing-only, no edits). 911 unit pass. E2E: voxel-engin
 Browser: screenshotted the Rounding panel; drove the slider + flat-bottom +
 Update code and confirmed the emitted `.smooth({ strength: 0.6, flatBottom: true })`
 and a rounded, flat-bottomed rendered result.
+
+## Review fix
+
+work-reviewer caught a data-loss path: `setRounding` called `grid.smooth({ strength,
+flatBottom, baseLayers })`, which reset the *unspecified* fields
+(iterations/detail/algorithm/lockBox) to defaults — so touching the slider on a
+model authored with `.smooth({ iterations: 6, detail: 2, … })` dropped them. Fixed
+by MERGING onto the grid's current surfacing (preserve iterations/detail/algorithm/
+lockBox; the panel only owns strength/flatBottom/baseLayers). Added an e2e test
+asserting a slider change keeps the source's `algorithm:'taubin', iterations:6,
+detail:2`. (The unrelated `editor-hints` ticker-layout e2e flake on the first CI
+run is pre-existing and untouched by this diff.)

--- a/prompts/20260609-voxel-rounding-controls.md
+++ b/prompts/20260609-voxel-rounding-controls.md
@@ -1,0 +1,60 @@
+---
+session: "kfva7f"
+timestamp: "2026-06-09T15:50:00Z"
+model: claude-opus-4-8
+tools: [explore]
+---
+
+## Human
+
+Follow-on to the merged Surface Nets PR: (1) make the amount of rounding
+configurable; (2) make it so some layers aren't rounded (e.g. the bottom layer
+for a flat bottom); (3) add rounding options to Voxel Studio, applying them as
+code if possible, otherwise to the baked version.
+
+User confirmed: single 0–100% rounding slider (0 = blocky), and let Voxel Studio
+open on already-smoothed models. "create a new pr".
+
+## Assistant
+
+## Key decisions
+
+**Rounding amount = a `strength` (0–1) on `smooth()`.** Implemented in
+`taubinSmooth` by scaling the λ/μ step sizes uniformly (ratio preserved, so
+anti-shrink still holds; `strength === 0` is a no-op). It tunes roundness without
+changing the pass count, and works for both algorithms — for Surface Nets it
+scales the post-relaxation that runs on the SN base. The UI's 0% slider position
+maps to `.blocky()` (true hard cubes), 1–100% to `.smooth({ strength })`, which
+gives a continuous blocky→round dial.
+
+**"Keep layers un-rounded" reuses the existing pins.** `flatBottom` (plane-Z pin,
+exact) and `baseLayers` (keep bottom N layers blocky) already existed for the
+Taubin path and already apply to Surface Nets via the post-relaxation pins — so
+the Studio just exposes them. (baseLayers lands within ~0.5 voxel on SN since its
+surface sits half a voxel inward; documented.)
+
+**Voxel Studio Rounding section.** Added an amount slider + Flat-bottom toggle +
+Flat-base-layers field to `voxelPaintUI.ts`, prefilled from the grid's surfacing.
+The editing preview stays blocky (per-voxel picking needs the hard-faced
+provenance mesh — `gridToMeshWithProvenance` ignores surfacing), so rounding is
+applied on commit, with a hint saying so. Dropped the old "refuses smooth grids"
+guard in `voxelPaint.activate` so the Studio opens on already-smoothed models;
+added `getSurfacing`/`setRounding`/`roundingChanged` to drive the panel.
+
+**Applied "as code, else baked."** Centralized surfacing→source in a new
+`formatSurfacingCall(surf)` (editCodegen.ts), reused by all three emitters:
+- "Update code" — `appendVoxelEditsToCode` gained a `surfacingCall` arg, so a
+  `.smooth({ … })` / `.blocky()` lands after the edits (only when rounding
+  actually changed; an untouched model keeps its source).
+- "Save as raw" / image-import / voxelize codegen now emit the *full* options
+  (algorithm/strength/baseLayers/flatBottom), not just iterations+detail.
+
+## Verification
+
+Unit: strength storage/validation/scaling (taubin 0=no-move, monotonic; SN
+post-relax), `formatSurfacingCall` round-trip, `appendVoxelEditsToCode` with a
+surfacing call (incl. surfacing-only, no edits). 911 unit pass. E2E: voxel-engine
++ voxel-paint green, including the rewritten "opens on a smooth grid" test.
+Browser: screenshotted the Rounding panel; drove the slider + flat-bottom +
+Update code and confirmed the emitted `.smooth({ strength: 0.6, flatBottom: true })`
+and a rounded, flat-bottomed rendered result.

--- a/public/ai/voxel.md
+++ b/public/ai/voxel.md
@@ -133,6 +133,11 @@ return voxels()
 - **`iterations`** (1–8, default 2) — more passes = rounder. For `taubin` these
   are the relaxation passes; for `surfaceNets` they're a light cleanup on top
   (and what makes the base pins below take effect).
+- **`strength`** (0–1, default 1) — the rounding *amount*. Scales how far each
+  smoothing pass moves vertices, so it dials roundness continuously without
+  changing the pass count: `1` is fully rounded, `0.3` is a gentle bevel, `0`
+  leaves the mesh un-rounded. (For perfectly hard cubes use `.blocky()` / no
+  smooth call.) Works for both algorithms.
 - **`detail`** (1–4, default 1) — **`taubin` only.** Supersamples the grid
   ×`detail` before smoothing for finer rounding on coarse shapes (at more
   triangles), then scales back to original size. Ignored by `surfaceNets`.
@@ -368,6 +373,20 @@ Two ways to commit when you're done:
 > rotatable shape gizmo, and named color regions) don't apply to voxels —
 > color lives per-cell in the grid and undo/redo replaces region history.
 
+#### Rounding controls
+
+The Studio's **Rounding** section sets the model's surfacing without leaving the
+editor: a **0–100% amount slider** (0 = hard blocks, higher = smoother — the
+`strength` knob above), a **Flat bottom** toggle (keep the build-plate face
+flat), and a **Flat base … layers** field (keep the bottom N layers blocky). The
+editing preview stays blocky so per-voxel picking still works; the rounding is
+applied to the rendered model when you commit. It rides both commit paths: a
+**Update code** commit appends `.smooth({ … })` / `.blocky()` to your code, and
+**Save as raw voxel data** bakes the surfacing into the emitted call. The Studio
+now also opens on an already-smoothed model (the controls prefill from its
+current setting). This is the UI equivalent of calling `.smooth({ strength, … })`
+in code.
+
 ### Editing an imported voxel
 
 Image-import (and `.vox`) sessions open as `voxels.decode("…")` code. That
@@ -420,9 +439,9 @@ await partwright.bakeVoxelsToCode({ label: 'castle' });  // replace with voxels.
 ```
 
 - `activateVoxelPaint()` re-runs the current code locally to capture the grid
-  + per-triangle voxel/normal provenance. Returns `{ error }` outside voxel
-  sessions, on a `.smooth()` grid (call `.blocky()` first), or if the code
-  doesn't return a grid.
+  + per-triangle voxel/normal provenance. Works on smooth-surfaced grids too
+  (editing happens on the blocky preview; the rounding is preserved). Returns
+  `{ error }` outside voxel sessions or if the code doesn't return a grid.
 - `setVoxelTool(tool)` — `'paint' | 'add' | 'remove' | 'bucket' | 'level' |
   'boxAdd' | 'boxRemove'`. Returns `{ tool }` or `{ error }`.
 - `setVoxelBrush({ radius?, shape?, spray?, sprayDensity?, block?, depth? })` —

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -17,7 +17,7 @@
 
 import * as THREE from 'three';
 import type { MeshData } from '../geometry/types';
-import { normalizeColor, type VoxelGrid, type Surfacing } from '../geometry/voxel/grid';
+import { normalizeColor, type VoxelGrid, type Surfacing, type Vec3 } from '../geometry/voxel/grid';
 import { gridToMeshWithProvenance } from '../geometry/voxel/mesher';
 import { runVoxelForPaint, type VoxelPaintRun } from '../geometry/engines/voxel';
 import { bucketRecolor, clearBox, fillBoxRecolor, addBlock, addBlockCells, extrudeBox, brushApply, levelRecolor, inBrush, type BrushShape } from '../geometry/voxel/edits';
@@ -182,12 +182,27 @@ export type RoundingOpts = { strength?: number; iterations?: number; algorithm?:
 export function getSurfacing(): Surfacing | null { return run?.grid.surfacing() ?? null; }
 
 /** Set the grid's surfacing from the Rounding panel — `null` = hard blocks,
- *  otherwise smooth with the given options. Does not change the (blocky) editing
- *  preview; the rounding is baked into the rendered model on save. */
+ *  otherwise smooth with the given options. The panel only owns
+ *  `strength`/`flatBottom`/`baseLayers`, so we MERGE onto the grid's current
+ *  surfacing to preserve source-declared fields the panel doesn't expose
+ *  (`iterations`/`detail`/`algorithm`/`lockBox`) — otherwise touching the slider
+ *  would reset them to defaults. Does not change the (blocky) editing preview;
+ *  the rounding is baked into the rendered model on save. Not routed through
+ *  `mutate()` on purpose: a surfacing tweak isn't an undo-able grid edit (the
+ *  slider is its own revert affordance), and it's reflected live by
+ *  refreshControls. */
 export function setRounding(opts: RoundingOpts | null): void {
   if (!run) return;
-  if (opts === null) run.grid.blocky();
-  else run.grid.smooth(opts);
+  if (opts === null) { run.grid.blocky(); cbStateChange?.(); return; }
+  const cur = run.grid.surfacing();
+  const merged: RoundingOpts & { detail?: number; lockBox?: [Vec3, Vec3] } = {
+    algorithm: cur.algorithm,
+    iterations: cur.iterations,
+    detail: cur.detail,
+    ...opts, // strength / flatBottom / baseLayers from the panel
+  };
+  if (cur.lockBox) merged.lockBox = [cur.lockBox.min, cur.lockBox.max];
+  run.grid.smooth(merged);
   cbStateChange?.();
 }
 

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -17,7 +17,7 @@
 
 import * as THREE from 'three';
 import type { MeshData } from '../geometry/types';
-import { normalizeColor, type VoxelGrid } from '../geometry/voxel/grid';
+import { normalizeColor, type VoxelGrid, type Surfacing } from '../geometry/voxel/grid';
 import { gridToMeshWithProvenance } from '../geometry/voxel/mesher';
 import { runVoxelForPaint, type VoxelPaintRun } from '../geometry/engines/voxel';
 import { bucketRecolor, clearBox, fillBoxRecolor, addBlock, addBlockCells, extrudeBox, brushApply, levelRecolor, inBrush, type BrushShape } from '../geometry/voxel/edits';
@@ -174,6 +174,31 @@ export function pendingBoxCorner(): [number, number, number] | null {
  *  (e.g. `.vox` export) capture unbaked edits without re-running the code. */
 export function getGrid(): VoxelGrid | null { return run?.grid ?? null; }
 
+/** Options the Rounding panel can set (a subset of `VoxelGrid.smooth`'s opts;
+ *  `lockBox`/`detail` aren't exposed in the studio). */
+export type RoundingOpts = { strength?: number; iterations?: number; algorithm?: 'taubin' | 'surfaceNets'; flatBottom?: boolean; baseLayers?: number };
+
+/** Current surfacing of the edited grid, for the Rounding panel to prefill. */
+export function getSurfacing(): Surfacing | null { return run?.grid.surfacing() ?? null; }
+
+/** Set the grid's surfacing from the Rounding panel — `null` = hard blocks,
+ *  otherwise smooth with the given options. Does not change the (blocky) editing
+ *  preview; the rounding is baked into the rendered model on save. */
+export function setRounding(opts: RoundingOpts | null): void {
+  if (!run) return;
+  if (opts === null) run.grid.blocky();
+  else run.grid.smooth(opts);
+  cbStateChange?.();
+}
+
+/** Whether the user changed surfacing since activation — drives whether the
+ *  "Update code" commit appends an explicit `.smooth(...)`/`.blocky()` call (so
+ *  an untouched model keeps whatever its source already declared). */
+export function roundingChanged(): boolean {
+  if (!run || !baselineGrid) return false;
+  return JSON.stringify(run.grid.surfacing()) !== JSON.stringify(baselineGrid.surfacing());
+}
+
 /** The delta from the code's own output to the current edited grid — what the
  *  "Update code" action appends to the source. Empty when nothing changed. */
 export function getEditOps(): VoxelEditOps {
@@ -216,13 +241,11 @@ export function activate(code: string, callbacks: VoxelPaintCallbacks, paramOver
   if (active) deactivate();
   const r = runVoxelForPaint(code, paramOverrides);
   if (!r.ok) return r.error;
-  // Smooth surfacing moves vertices off the voxel grid, so a clicked
-  // triangle's coords no longer map cleanly to a single source voxel. Refuse
-  // here with a clear, actionable message rather than silently dropping the
-  // user's `.smooth()` and showing them a blocky model.
-  if (r.data.grid.surfacing().mode === 'smooth') {
-    return 'Voxel Studio cannot edit a smooth-surfaced grid (per-voxel picking only works on hard cube faces). Call `.blocky()` before returning, edit, then re-apply `.smooth()` afterward.';
-  }
+  // A smooth grid is editable: per-voxel picking runs on the hard-faced
+  // provenance mesh (gridToMeshWithProvenance ignores surfacing), so the studio
+  // preview shows blocks while editing. The grid keeps its surfacing setting —
+  // the Rounding panel reads/updates it and it's re-applied to the rendered
+  // model on save (see getSurfacing / setRounding and commitVoxelEdits).
   // Soft cap: edits re-mesh on every click on the main thread, so very large
   // grids tank interactivity. The blocky-art / image-import range is far below
   // this; refuse at the door with a useful number.

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -18,7 +18,7 @@
 import * as THREE from 'three';
 import type { MeshData } from '../geometry/types';
 import { normalizeColor, type VoxelGrid, type Surfacing, type Vec3 } from '../geometry/voxel/grid';
-import { gridToMeshWithProvenance } from '../geometry/voxel/mesher';
+import { gridToMeshWithProvenance, meshGrid } from '../geometry/voxel/mesher';
 import { runVoxelForPaint, type VoxelPaintRun } from '../geometry/engines/voxel';
 import { bucketRecolor, clearBox, fillBoxRecolor, addBlock, addBlockCells, extrudeBox, brushApply, levelRecolor, inBrush, type BrushShape } from '../geometry/voxel/edits';
 import { diffGrids, type VoxelEditOps } from '../geometry/voxel/editCodegen';
@@ -186,24 +186,63 @@ export function getSurfacing(): Surfacing | null { return run?.grid.surfacing() 
  *  `strength`/`flatBottom`/`baseLayers`, so we MERGE onto the grid's current
  *  surfacing to preserve source-declared fields the panel doesn't expose
  *  (`iterations`/`detail`/`algorithm`/`lockBox`) — otherwise touching the slider
- *  would reset them to defaults. Does not change the (blocky) editing preview;
- *  the rounding is baked into the rendered model on save. Not routed through
- *  `mutate()` on purpose: a surfacing tweak isn't an undo-able grid edit (the
- *  slider is its own revert affordance), and it's reflected live by
- *  refreshControls. */
+ *  would reset them to defaults. Live-previews the result in the viewport (see
+ *  {@link showRoundingPreview}); the preview reverts to the blocky, pickable
+ *  mesh the moment the user edits on the canvas. Not routed through `mutate()`
+ *  on purpose: a surfacing tweak isn't an undo-able grid edit (the slider is its
+ *  own revert affordance), and it's reflected live by refreshControls. */
 export function setRounding(opts: RoundingOpts | null): void {
   if (!run) return;
-  if (opts === null) { run.grid.blocky(); cbStateChange?.(); return; }
-  const cur = run.grid.surfacing();
-  const merged: RoundingOpts & { detail?: number; lockBox?: [Vec3, Vec3] } = {
-    algorithm: cur.algorithm,
-    iterations: cur.iterations,
-    detail: cur.detail,
-    ...opts, // strength / flatBottom / baseLayers from the panel
-  };
-  if (cur.lockBox) merged.lockBox = [cur.lockBox.min, cur.lockBox.max];
-  run.grid.smooth(merged);
+  if (opts === null) {
+    run.grid.blocky();
+  } else {
+    const cur = run.grid.surfacing();
+    const merged: RoundingOpts & { detail?: number; lockBox?: [Vec3, Vec3] } = {
+      algorithm: cur.algorithm,
+      iterations: cur.iterations,
+      detail: cur.detail,
+      ...opts, // strength / flatBottom / baseLayers from the panel
+    };
+    if (cur.lockBox) merged.lockBox = [cur.lockBox.min, cur.lockBox.max];
+    run.grid.smooth(merged);
+  }
+  showRoundingPreview();
   cbStateChange?.();
+}
+
+// ── Rounding live preview ────────────────────────────────────────────────────
+// The studio edits on the blocky provenance mesh (picking maps a clicked
+// triangle back to a voxel via run.triVoxel). To preview rounding without
+// breaking that, we *temporarily* show the smoothed mesh while the Rounding
+// panel is in use and swap back to the blocky mesh the instant the user edits.
+let roundingPreview = false; // true while the smoothed preview mesh is displayed
+let previewRaf = 0;          // pending rebuild handle (coalesces slider drags)
+
+/** Show the smoothed mesh for the current surfacing (or the blocky mesh when
+ *  surfacing is hard blocks), coalesced to one rebuild per frame so a slider
+ *  drag stays responsive. Re-meshing reads the live grid at flush time, so
+ *  coalescing never shows a stale preview. */
+function showRoundingPreview(): void {
+  if (!active || !cbMeshUpdate || previewRaf) return;
+  previewRaf = requestAnimationFrame(() => {
+    previewRaf = 0;
+    if (!active || !run || !cbMeshUpdate) return;
+    if (run.grid.surfacing().mode === 'smooth') {
+      cbMeshUpdate(meshGrid(run.grid));
+      roundingPreview = true;
+    } else if (roundingPreview) {
+      cbMeshUpdate(run.mesh);
+      roundingPreview = false;
+    }
+  });
+}
+
+/** Drop the rounded preview and restore the blocky provenance mesh so picking
+ *  and editing operate on voxel-accurate triangles again. Also cancels any
+ *  pending preview rebuild so it can't flash back over an edit. */
+function endRoundingPreview(): void {
+  if (previewRaf) { cancelAnimationFrame(previewRaf); previewRaf = 0; }
+  if (roundingPreview && run) { cbMeshUpdate?.(run.mesh); roundingPreview = false; }
 }
 
 /** Whether the user changed surfacing since activation — drives whether the
@@ -302,6 +341,8 @@ export function activate(code: string, callbacks: VoxelPaintCallbacks, paramOver
 export function deactivate(): void {
   if (!active) return;
   active = false;
+  if (previewRaf) { cancelAnimationFrame(previewRaf); previewRaf = 0; }
+  roundingPreview = false;
   detachPointerHandler();
   cbLockChange?.(false);
   cbLockChange = null;
@@ -471,6 +512,9 @@ function remeshAndPush(): void {
   if (!run) return;
   const { mesh, triVoxel, triNormal } = gridToMeshWithProvenance(run.grid);
   run = { ...run, mesh, triVoxel, triNormal };
+  // Any edit/undo/redo pushes the blocky provenance mesh, so a rounded preview
+  // is no longer what's on screen — keep the flag in sync.
+  roundingPreview = false;
   cbMeshUpdate?.(mesh);
 }
 
@@ -600,6 +644,14 @@ let capturedPointerId: number | null = null;
 
 function onPointerDown(event: PointerEvent): void {
   if (!active || event.button !== 0) return;
+  // A rounded preview (showing or scheduled) means the canvas shows the smooth
+  // mesh, which isn't pickable per-voxel. A press inside the model is an edit:
+  // restore the blocky pickable mesh first, then pick against it. A press
+  // outside the model is an orbit and keeps the preview.
+  if (roundingPreview || previewRaf) {
+    if (!isPointerWithinModelBounds(event)) return;
+    endRoundingPreview();
+  }
   const hit = pickFace(event);
   if (!hit) return;
   clearPreview(); // the action commits; the preview rebuilds on the next move
@@ -619,6 +671,9 @@ function onPointerDown(event: PointerEvent): void {
 function onPointerMove(event: PointerEvent): void {
   if (!active || !run) return;
   lastHoverEvent = { clientX: event.clientX, clientY: event.clientY };
+  // While the rounded preview is up, the displayed mesh isn't voxel-pickable, so
+  // don't draw a (misplaced) brush footprint over it; just orbit/hover.
+  if (roundingPreview) { clearPreview(); return; }
   // One raycast feeds both the hover preview and the active stroke.
   const hit = isBrushTool(tool) ? pickFace(event) : null;
   renderPreviewFromHit(hit);

--- a/src/color/voxelPaintUI.ts
+++ b/src/color/voxelPaintUI.ts
@@ -556,8 +556,9 @@ function buildLevelSection(): HTMLElement {
 }
 
 /** Rounding (surfacing) controls: an amount slider (0 = hard blocks, 1–100% =
- *  smooth) plus "keep flat" pins. These don't change the blocky editing preview;
- *  they're applied to the grid's surfacing and baked into the saved model. */
+ *  smooth) plus "keep flat" pins. The result previews live in the viewport as
+ *  you drag; editing on the canvas snaps back to blocks. Applied to the grid's
+ *  surfacing and baked into the saved model. */
 function buildRoundingSection(): HTMLElement {
   const sec = document.createElement('div');
   sec.className = 'flex flex-col gap-1 pt-1 border-t border-zinc-700/60';
@@ -611,7 +612,7 @@ function buildRoundingSection(): HTMLElement {
 
   const hint = document.createElement('p');
   hint.className = 'text-[10px] text-zinc-500 leading-tight';
-  hint.textContent = 'Editing preview stays blocky; rounding shows after you save.';
+  hint.textContent = 'Rounding previews live; click the model to edit (snaps back to blocks).';
   sec.appendChild(hint);
   return sec;
 }

--- a/src/color/voxelPaintUI.ts
+++ b/src/color/voxelPaintUI.ts
@@ -77,6 +77,11 @@ let blockSizeLabel: HTMLElement | null = null;
 let depthSlider: HTMLInputElement | null = null;
 let depthInput: HTMLInputElement | null = null;
 let depthLabel: HTMLElement | null = null;
+let roundSlider: HTMLInputElement | null = null;
+let roundValueLabel: HTMLElement | null = null;
+let flatBottomBtn: HTMLButtonElement | null = null;
+let baseLayersInput: HTMLInputElement | null = null;
+let flatBottomState = false;
 
 export interface VoxelPaintUICallbacks {
   /** Called when the user clicks the toggle button to enter the studio. The
@@ -208,6 +213,21 @@ function refreshControls(): void {
     else depthLabel.textContent = isBox ? `+${d} layers` : `${d} deep`;
   }
 
+  // Rounding section reflects the grid's current surfacing.
+  const surf = voxelPaint.getSurfacing();
+  const smooth = surf?.mode === 'smooth';
+  flatBottomState = smooth && !!surf?.flatBottom;
+  if (roundSlider && document.activeElement !== roundSlider) {
+    roundSlider.value = String(smooth ? Math.round((surf?.strength ?? 1) * 100) : 0);
+  }
+  const amt = Number(roundSlider?.value ?? '0');
+  if (roundValueLabel) roundValueLabel.textContent = amt <= 0 ? 'Off (blocky)' : `${amt}%`;
+  if (flatBottomBtn) { setActive(flatBottomBtn, flatBottomState); flatBottomBtn.disabled = amt <= 0; }
+  if (baseLayersInput) {
+    baseLayersInput.disabled = amt <= 0;
+    if (document.activeElement !== baseLayersInput) baseLayersInput.value = String(smooth ? (surf?.baseLayers ?? 0) : 0);
+  }
+
   if (undoBtn) undoBtn.disabled = !voxelPaint.canUndo();
   if (redoBtn) redoBtn.disabled = !voxelPaint.canRedo();
   if (statusEl) {
@@ -272,6 +292,7 @@ function createPanel(): HTMLElement {
   content.appendChild(depthSection);
   levelSection = buildLevelSection();
   content.appendChild(levelSection);
+  content.appendChild(buildRoundingSection());
   content.appendChild(buildHistoryRow());
   content.appendChild(buildActions());
   p.appendChild(content);
@@ -532,6 +553,83 @@ function buildLevelSection(): HTMLElement {
   }
   sec.appendChild(row);
   return sec;
+}
+
+/** Rounding (surfacing) controls: an amount slider (0 = hard blocks, 1–100% =
+ *  smooth) plus "keep flat" pins. These don't change the blocky editing preview;
+ *  they're applied to the grid's surfacing and baked into the saved model. */
+function buildRoundingSection(): HTMLElement {
+  const sec = document.createElement('div');
+  sec.className = 'flex flex-col gap-1 pt-1 border-t border-zinc-700/60';
+
+  const head = document.createElement('div');
+  head.className = 'flex items-center justify-between';
+  const h = document.createElement('span');
+  h.className = 'text-[10px] uppercase tracking-wider text-zinc-500';
+  h.textContent = 'Rounding';
+  head.appendChild(h);
+  roundValueLabel = document.createElement('span');
+  roundValueLabel.className = 'text-[11px] text-zinc-400';
+  head.appendChild(roundValueLabel);
+  sec.appendChild(head);
+
+  roundSlider = document.createElement('input');
+  roundSlider.type = 'range';
+  roundSlider.min = '0'; roundSlider.max = '100'; roundSlider.step = '5'; roundSlider.value = '0';
+  roundSlider.className = 'w-full accent-blue-500';
+  roundSlider.title = 'Rounding amount (0 = hard blocks, 100% = fully smooth)';
+  roundSlider.addEventListener('input', applyRounding);
+  sec.appendChild(roundSlider);
+
+  const row = document.createElement('div');
+  row.className = 'flex items-center gap-2';
+  flatBottomBtn = document.createElement('button');
+  flatBottomBtn.type = 'button';
+  flatBottomBtn.className = 'flex-1 px-1 py-1 rounded text-[11px] border border-zinc-600/60 hover:bg-zinc-700/60 transition-colors';
+  flatBottomBtn.textContent = 'Flat bottom';
+  flatBottomBtn.title = 'Keep the build-plate face flat while edges round';
+  flatBottomBtn.addEventListener('click', () => { flatBottomState = !flatBottomState; applyRounding(); });
+  row.appendChild(flatBottomBtn);
+
+  const baseWrap = document.createElement('label');
+  baseWrap.className = 'flex items-center gap-1 text-[11px] text-zinc-400';
+  const baseSpan = document.createElement('span');
+  baseSpan.textContent = 'Flat base';
+  baseWrap.appendChild(baseSpan);
+  baseLayersInput = document.createElement('input');
+  baseLayersInput.type = 'number';
+  baseLayersInput.min = '0'; baseLayersInput.max = '64'; baseLayersInput.value = '0';
+  baseLayersInput.className = 'w-12 px-1 py-0.5 text-[11px] bg-zinc-900/70 border border-zinc-600/60 rounded text-zinc-200 text-right tabular-nums';
+  baseLayersInput.title = 'Keep the bottom N voxel layers fully blocky (0 = none)';
+  baseLayersInput.addEventListener('input', applyRounding);
+  baseWrap.appendChild(baseLayersInput);
+  const baseUnit = document.createElement('span');
+  baseUnit.textContent = 'layers';
+  baseWrap.appendChild(baseUnit);
+  row.appendChild(baseWrap);
+  sec.appendChild(row);
+
+  const hint = document.createElement('p');
+  hint.className = 'text-[10px] text-zinc-500 leading-tight';
+  hint.textContent = 'Editing preview stays blocky; rounding shows after you save.';
+  sec.appendChild(hint);
+  return sec;
+}
+
+/** Read the rounding controls and push the resulting surfacing to the grid. */
+function applyRounding(): void {
+  const amount = Number(roundSlider?.value ?? '0');
+  if (amount <= 0) {
+    voxelPaint.setRounding(null);
+  } else {
+    const base = Math.max(0, Math.floor(Number(baseLayersInput?.value ?? '0')));
+    voxelPaint.setRounding({
+      strength: amount / 100,
+      flatBottom: flatBottomState || undefined,
+      baseLayers: base > 0 ? base : undefined,
+    });
+  }
+  refreshControls();
 }
 
 function buildHistoryRow(): HTMLElement {

--- a/src/geometry/voxel/editCodegen.ts
+++ b/src/geometry/voxel/editCodegen.ts
@@ -10,7 +10,7 @@
 //
 // Pure logic (no DOM/engine) so it unit-tests in the vitest tier.
 
-import type { VoxelGrid } from './grid';
+import type { VoxelGrid, Surfacing } from './grid';
 
 /** The grid delta between the baseline (the code's own output) and the edited
  *  grid: cells to set (added or recolored) and cells to remove. */
@@ -52,14 +52,36 @@ export function formatEditOps(ops: VoxelEditOps, varName: string): string {
   return lines.join('\n');
 }
 
+/** The chained surfacing method for a grid's setting, as source you append to
+ *  the returned-grid expression — e.g. `.smooth({ strength: 0.5, baseLayers: 2 })`
+ *  or `.blocky()`. Only non-default options are emitted. For the default blocky
+ *  surfacing it returns `''` unless `explicitBlocky` is set (the Voxel Studio
+ *  "update code" path passes it so a `.blocky()` deterministically overrides any
+ *  `.smooth()` the original code applied). */
+export function formatSurfacingCall(surf: Surfacing, explicitBlocky = false): string {
+  if (surf.mode !== 'smooth') return explicitBlocky ? '.blocky()' : '';
+  const o: string[] = [];
+  if (surf.algorithm && surf.algorithm !== 'surfaceNets') o.push(`algorithm: '${surf.algorithm}'`);
+  if (surf.iterations !== 2) o.push(`iterations: ${surf.iterations}`);
+  if (surf.detail !== undefined && surf.detail !== 1) o.push(`detail: ${surf.detail}`);
+  if (surf.strength !== undefined && surf.strength !== 1) o.push(`strength: ${surf.strength}`);
+  if (surf.flatBottom) o.push('flatBottom: true');
+  if (surf.baseLayers !== undefined) o.push(`baseLayers: ${surf.baseLayers}`);
+  if (surf.lockBox) o.push(`lockBox: [[${surf.lockBox.min.join(', ')}], [${surf.lockBox.max.join(', ')}]]`);
+  return o.length ? `.smooth({ ${o.join(', ')} })` : '.smooth()';
+}
+
 /** Append the edit ops to the user's procedural code, just before its final
  *  `return`. Binds the returned grid to a local so the ops apply to whatever
  *  expression the code returns (a bare `v`, a `voxels().…` chain, etc.), then
- *  returns that local. Returns null if there's no trailing `return …;` to hook
- *  onto (the caller then falls back to a full replace). A no-op delta returns
- *  the code unchanged. */
-export function appendVoxelEditsToCode(code: string, ops: VoxelEditOps): string | null {
-  if (editOpCount(ops) === 0) return code;
+ *  returns that local. `surfacingCall` (from {@link formatSurfacingCall}) is
+ *  applied to that local after the edits, so Voxel Studio's rounding settings
+ *  land as code. Returns null if there's no trailing `return …;` to hook onto
+ *  (the caller then falls back to a full replace). A no-op (no edits and no
+ *  surfacing change) returns the code unchanged. */
+export function appendVoxelEditsToCode(code: string, ops: VoxelEditOps, surfacingCall = ''): string | null {
+  const hasEdits = editOpCount(ops) > 0;
+  if (!hasEdits && !surfacingCall) return code;
   const trimmed = code.replace(/\s+$/, '');
   // Greedy prefix forces the match onto the LAST `return …;` in the source.
   const m = /^([\s\S]*)\breturn\b([\s\S]*?);\s*$/.exec(trimmed);
@@ -67,5 +89,7 @@ export function appendVoxelEditsToCode(code: string, ops: VoxelEditOps): string 
   const prefix = m[1].replace(/\s+$/, '');
   const expr = m[2].trim();
   const VAR = '__voxStudio';
-  return `${prefix}\n\nconst ${VAR} = ${expr};\n// --- Voxel Studio edits ---\n${formatEditOps(ops, VAR)}\nreturn ${VAR};\n`;
+  const editBlock = hasEdits ? `// --- Voxel Studio edits ---\n${formatEditOps(ops, VAR)}\n` : '';
+  const surfBlock = surfacingCall ? `${VAR}${surfacingCall};\n` : '';
+  return `${prefix}\n\nconst ${VAR} = ${expr};\n${editBlock}${surfBlock}return ${VAR};\n`;
 }

--- a/src/geometry/voxel/editCodegen.ts
+++ b/src/geometry/voxel/editCodegen.ts
@@ -78,7 +78,16 @@ export function formatSurfacingCall(surf: Surfacing, explicitBlocky = false): st
  *  applied to that local after the edits, so Voxel Studio's rounding settings
  *  land as code. Returns null if there's no trailing `return …;` to hook onto
  *  (the caller then falls back to a full replace). A no-op (no edits and no
- *  surfacing change) returns the code unchanged. */
+ *  surfacing change) returns the code unchanged.
+ *
+ *  Re-entrant: when the input is itself a previous Voxel Studio output (it
+ *  declares `const __voxStudio = …` and ends `return __voxStudio;`), it reuses
+ *  that block instead of wrapping it again — otherwise a second pass emits a
+ *  duplicate `const __voxStudio = __voxStudio;` ("Identifier '__voxStudio' has
+ *  already been declared"). It keeps the first declaration plus any edit ops and
+ *  custom lines, drops only the auto-generated surfacing call (and any duplicate
+ *  declarations from older buggy output), and appends the new edits + surfacing.
+ */
 export function appendVoxelEditsToCode(code: string, ops: VoxelEditOps, surfacingCall = ''): string | null {
   const hasEdits = editOpCount(ops) > 0;
   if (!hasEdits && !surfacingCall) return code;
@@ -89,6 +98,33 @@ export function appendVoxelEditsToCode(code: string, ops: VoxelEditOps, surfacin
   const prefix = m[1].replace(/\s+$/, '');
   const expr = m[2].trim();
   const VAR = '__voxStudio';
+
+  // Re-applying onto a previous Voxel Studio output: reuse the existing block.
+  if (expr === VAR) {
+    const declRe = new RegExp(`^[ \\t]*const[ \\t]+${VAR}[ \\t]*=[ \\t]*([\\s\\S]*?);[ \\t]*$`, 'm');
+    const decl = declRe.exec(prefix);
+    if (decl && decl[1].trim() !== VAR) {
+      const head = prefix.slice(0, decl.index).replace(/\s+$/, '');
+      const base = decl[1].trim();
+      // Everything after the first declaration is the prior edit ops + any
+      // custom lines the user added. Drop duplicate declarations (from older
+      // buggy output) and the prior auto surfacing call; keep the rest.
+      const body = prefix.slice(decl.index + decl[0].length)
+        .replace(new RegExp(`^[ \\t]*const[ \\t]+${VAR}[ \\t]*=.*;[ \\t]*$\\n?`, 'gm'), '')
+        .replace(new RegExp(`^[ \\t]*${VAR}\\.(?:smooth|blocky)\\([^\\n]*\\);[ \\t]*$\\n?`, 'gm'), '')
+        .replace(/^\s*\n/, '')
+        .replace(/\s+$/, '');
+      const parts: string[] = [];
+      if (head) parts.push(head, '');
+      parts.push(`const ${VAR} = ${base};`);
+      if (body) parts.push(body);
+      if (hasEdits) parts.push(formatEditOps(ops, VAR));
+      if (surfacingCall) parts.push(`${VAR}${surfacingCall};`);
+      parts.push(`return ${VAR};`);
+      return parts.join('\n').replace(/\n{3,}/g, '\n\n') + '\n';
+    }
+  }
+
   const editBlock = hasEdits ? `// --- Voxel Studio edits ---\n${formatEditOps(ops, VAR)}\n` : '';
   const surfBlock = surfacingCall ? `${VAR}${surfacingCall};\n` : '';
   return `${prefix}\n\nconst ${VAR} = ${expr};\n${editBlock}${surfBlock}return ${VAR};\n`;

--- a/src/geometry/voxel/grid.ts
+++ b/src/geometry/voxel/grid.ts
@@ -130,6 +130,10 @@ export interface Surfacing {
   algorithm?: 'taubin' | 'surfaceNets';
   iterations: number;
   detail: number;
+  /** Rounding amount, 0–1 (default 1). Scales how far each smoothing pass moves
+   *  vertices, so lower = gentler rounding. 0 leaves the mesh un-rounded (the
+   *  smoother is skipped); for a fully hard-faced model use `mode: 'blocks'`. */
+  strength?: number;
   /** Pin the Z of the bottom-most plane so the build-plate face stays flat. */
   flatBottom?: boolean;
   /** Keep the bottom N voxel layers fully blocky (a solid, sharp pedestal). */
@@ -569,8 +573,8 @@ export class VoxelGrid {
    *    - `lockBox` — keep the voxels in `[[x0,y0,z0],[x1,y1,z1]]` (voxel coords)
    *      blocky, for a custom base region.
    *  Chainable. */
-  smooth(opts: number | { iterations?: number; detail?: number; algorithm?: 'taubin' | 'surfaceNets'; flatBottom?: boolean; baseLayers?: number; lockBox?: [Vec3, Vec3] } = {}): this {
-    let iterations = 2, detail = 1;
+  smooth(opts: number | { iterations?: number; detail?: number; strength?: number; algorithm?: 'taubin' | 'surfaceNets'; flatBottom?: boolean; baseLayers?: number; lockBox?: [Vec3, Vec3] } = {}): this {
+    let iterations = 2, detail = 1, strength = 1;
     let algorithm: 'taubin' | 'surfaceNets' = DEFAULT_SMOOTH_ALGORITHM;
     let flatBottom: boolean | undefined;
     let baseLayers: number | undefined;
@@ -579,15 +583,16 @@ export class VoxelGrid {
       iterations = assertNumber(opts, 'smooth(iterations)', { integer: true, min: 1, max: 8 })!;
     } else {
       const o = assertObject(opts, 'smooth(opts)')!;
-      assertNoUnknownKeys(o, ['iterations', 'detail', 'algorithm', 'flatBottom', 'baseLayers', 'lockBox'], 'smooth(opts)');
+      assertNoUnknownKeys(o, ['iterations', 'detail', 'strength', 'algorithm', 'flatBottom', 'baseLayers', 'lockBox'], 'smooth(opts)');
       if (o.iterations !== undefined) iterations = assertNumber(o.iterations, 'smooth.iterations', { integer: true, min: 1, max: 8 })!;
       if (o.detail !== undefined) detail = assertNumber(o.detail, 'smooth.detail', { integer: true, min: 1, max: 4 })!;
+      if (o.strength !== undefined) strength = assertNumber(o.strength, 'smooth.strength', { min: 0, max: 1 })!;
       if (o.algorithm !== undefined) algorithm = assertEnum(o.algorithm, ['taubin', 'surfaceNets'] as const, 'smooth.algorithm');
       if (o.flatBottom !== undefined) flatBottom = assertBoolean(o.flatBottom, 'smooth.flatBottom')!;
       if (o.baseLayers !== undefined) baseLayers = assertNumber(o.baseLayers, 'smooth.baseLayers', { integer: true, min: 1, max: HALF })!;
       if (o.lockBox !== undefined) lockBox = normalizeLockBox(o.lockBox);
     }
-    this._surfacing = { mode: 'smooth', algorithm, iterations, detail, flatBottom, baseLayers, lockBox };
+    this._surfacing = { mode: 'smooth', algorithm, iterations, detail, strength, flatBottom, baseLayers, lockBox };
     return this;
   }
 

--- a/src/geometry/voxel/mesher.ts
+++ b/src/geometry/voxel/mesher.ts
@@ -279,14 +279,14 @@ export function meshGrid(grid: VoxelGrid): MeshData {
     // exactly; `baseLayers`/`lockBox` are coordinate-based and the SN surface
     // sits ~half a voxel inward of the blocky extent, so those pin the intended
     // region only to within ~0.5 voxel (fine for a "keep this base blocky" hint).
-    mesh = taubinSmooth(mesh, surf.iterations, resolveSmoothPins(surf, 1));
+    mesh = taubinSmooth(mesh, surf.iterations, resolveSmoothPins(surf, 1), surf.strength ?? 1);
     return mesh;
   }
 
   const detail = surf.detail;
   const dense = detail > 1 ? grid.supersample(detail) : grid;
   let mesh = gridToMeshData(dense);
-  mesh = taubinSmooth(mesh, surf.iterations, resolveSmoothPins(surf, detail));
+  mesh = taubinSmooth(mesh, surf.iterations, resolveSmoothPins(surf, detail), surf.strength ?? 1);
   if (detail > 1) scaleMeshPositions(mesh, 1 / detail);
   return mesh;
 }

--- a/src/geometry/voxel/smooth.ts
+++ b/src/geometry/voxel/smooth.ts
@@ -106,12 +106,17 @@ function relaxPass(src: Float32Array, dst: Float32Array, adj: number[][], factor
 }
 
 /** Taubin-smooth a mesh's vertex positions. `iterations` is the number of
- *  λ/μ pass pairs (more = rounder). Returns a NEW MeshData sharing the input's
- *  triangle and color arrays (topology is untouched). Assumes `numProp === 3`
- *  (voxel meshes are position-only), which all callers satisfy. */
-export function taubinSmooth(mesh: MeshData, iterations = 2, pins?: SmoothPins): MeshData {
+ *  λ/μ pass pairs (more = rounder). `strength` (0–1, default 1) scales the λ/μ
+ *  step sizes uniformly, so it tunes the *amount* of rounding without changing
+ *  the pass count — `strength === 0` is a no-op. The ratio |μ| > λ is preserved,
+ *  so the anti-shrink behavior holds at every strength. Returns a NEW MeshData
+ *  sharing the input's triangle and color arrays (topology is untouched).
+ *  Assumes `numProp === 3` (voxel meshes are position-only), which all callers
+ *  satisfy. */
+export function taubinSmooth(mesh: MeshData, iterations = 2, pins?: SmoothPins, strength = 1): MeshData {
   const n = Math.max(0, Math.floor(iterations));
-  if (n === 0 || mesh.numVert === 0) return mesh;
+  const s = Math.max(0, Math.min(1, strength));
+  if (n === 0 || s === 0 || mesh.numVert === 0) return mesh;
 
   const adj = buildAdjacency(mesh.triVerts, mesh.numVert);
   let pos = Float32Array.from(mesh.vertProperties);
@@ -119,9 +124,9 @@ export function taubinSmooth(mesh: MeshData, iterations = 2, pins?: SmoothPins):
   const mask = buildPinMask(pos, mesh.numVert, pins);
 
   for (let i = 0; i < n; i++) {
-    relaxPass(pos, scratch, adj, LAMBDA, mask);
+    relaxPass(pos, scratch, adj, LAMBDA * s, mask);
     [pos, scratch] = [scratch, pos];
-    relaxPass(pos, scratch, adj, MU, mask);
+    relaxPass(pos, scratch, adj, MU * s, mask);
     [pos, scratch] = [scratch, pos];
   }
 

--- a/src/import/imageToVoxel.ts
+++ b/src/import/imageToVoxel.ts
@@ -6,6 +6,7 @@
 // ImageData); the DOM step that turns a `File` into pixels lives in main.ts.
 
 import { VoxelGrid, encodeGrid, COORD_MIN, COORD_MAX } from '../geometry/voxel/grid';
+import { formatSurfacingCall } from '../geometry/voxel/editCodegen';
 import { preprocessRgb, quantizeColors, detectBackgroundMask, bgMaskFromColor, rgbToLab, nearestPalette } from '../relief/imageToRelief';
 
 /** Minimal shape of the browser `ImageData` we consume (also satisfiable by a
@@ -561,10 +562,8 @@ export function generateVoxelImportCode(grid: VoxelGrid, filename: string, opts:
   // smooth-surfaced model that's baked (e.g. via the voxel paint flow) keeps
   // its rounded edges after the next run, instead of silently reverting to
   // hard blocks. The default (blocks) needs no call.
-  const surf = grid.surfacing();
-  const surfaceCall = surf.mode === 'smooth'
-    ? `\nv.smooth({ iterations: ${surf.iterations}, detail: ${surf.detail} });`
-    : '';
+  const call = formatSurfacingCall(grid.surfacing());
+  const surfaceCall = call ? `\nv${call};` : '';
   const header = `// Imported from ${filename} on ${date}\n`;
 
   if (opts.style === 'calls') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,7 +115,7 @@ import { imageDataToVoxelGrid, generateVoxelImportCode, type ImageToVoxelOptions
 import { runVoxelForPaint } from './geometry/engines/voxel';
 import type { VoxelGrid } from './geometry/voxel/grid';
 import { greedyMeshGrid } from './geometry/voxel/mesher';
-import { appendVoxelEditsToCode, editOpCount } from './geometry/voxel/editCodegen';
+import { appendVoxelEditsToCode, editOpCount, formatSurfacingCall } from './geometry/voxel/editCodegen';
 import * as voxelPaint from './color/voxelPaint';
 import { setActiveImports, getActiveImports, type ImportedMesh } from './import/importedMesh';
 import { getCompanionFiles, setCompanionFiles, addCompanionFile as addCompanionFileToRegistry, removeCompanionFile as removeCompanionFileFromRegistry, updateCompanionFile, detectMissingIncludes, normalizeCompanionPath, companionFilesEqual } from './import/companionFiles';
@@ -6626,8 +6626,15 @@ async function main() {
     let code: string | null;
     if (mode === 'update') {
       const ops = voxelPaint.getEditOps();
-      if (editOpCount(ops) === 0) return { error: 'No edits to apply — paint, add, or remove some voxels first.' };
-      code = appendVoxelEditsToCode(getValue(), ops);
+      const roundingChanged = voxelPaint.roundingChanged();
+      if (editOpCount(ops) === 0 && !roundingChanged) {
+        return { error: 'No edits to apply — paint/add/remove voxels or adjust Rounding first.' };
+      }
+      // Append an explicit surfacing call only when the user changed rounding;
+      // otherwise leave whatever the source already declared intact.
+      const surf = voxelPaint.getSurfacing();
+      const surfacingCall = roundingChanged && surf ? formatSurfacingCall(surf, true) : '';
+      code = appendVoxelEditsToCode(getValue(), ops, surfacingCall);
       // No trailing `return …;` to hook onto — fall back to a clean replace.
       if (code === null) code = voxelPaint.bakeToCode('painted');
     } else {

--- a/src/surface/modifiers.ts
+++ b/src/surface/modifiers.ts
@@ -23,6 +23,7 @@ import { smoothSurface, type SmoothOptions } from './smoothSurface';
 import { voxelizeMesh, type VoxelizeOptions } from './voxelizeMesh';
 import { extractPositions, bboxOf, subdivideWithMask } from './meshSubdivide';
 import { encodeGrid } from '../geometry/voxel/grid';
+import { formatSurfacingCall } from '../geometry/voxel/editCodegen';
 import { scaleMesh } from './scaleMesh';
 import { applySteps, type TransformStep } from './placement';
 import { meshGrid } from '../geometry/voxel/mesher';
@@ -542,7 +543,8 @@ export function applyVoxelize(mesh: MeshData, opts: VoxelizeModifierOptions): Mo
   // mesh below matches what the emitted `v.smooth()` produces at runtime.
   const encoded = encodeGrid(grid);
   if (opts.smooth) grid.smooth();
-  const smoothCall = opts.smooth ? `\nv.smooth();` : '';
+  const call = formatSurfacingCall(grid.surfacing());
+  const smoothCall = call ? `\nv${call};` : '';
   const code = `// Voxelized from the current model on ${today()} (resolution ${opts.resolution ?? 32}).
 // Edit below — toggle "Smooth voxels" for rounded corners, or v.fillBox(...) to extend.
 const { voxels } = api;

--- a/tests/unit/voxelEditCodegen.test.ts
+++ b/tests/unit/voxelEditCodegen.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { VoxelGrid } from '../../src/geometry/voxel/grid';
-import { diffGrids, editOpCount, formatEditOps, appendVoxelEditsToCode } from '../../src/geometry/voxel/editCodegen';
+import { diffGrids, editOpCount, formatEditOps, appendVoxelEditsToCode, formatSurfacingCall } from '../../src/geometry/voxel/editCodegen';
 
 describe('diffGrids', () => {
   it('captures added, recolored, and removed cells', () => {
@@ -34,6 +34,37 @@ describe('formatEditOps', () => {
   });
 });
 
+describe('formatSurfacingCall', () => {
+  const surf = (over: Partial<ReturnType<VoxelGrid['surfacing']>> = {}) =>
+    ({ mode: 'smooth', algorithm: 'surfaceNets', iterations: 2, detail: 1, strength: 1, ...over }) as ReturnType<VoxelGrid['surfacing']>;
+
+  it('emits an empty call for default smooth', () => {
+    expect(formatSurfacingCall(surf())).toBe('.smooth()');
+  });
+
+  it('emits only non-default options', () => {
+    expect(formatSurfacingCall(surf({ strength: 0.5, baseLayers: 2, flatBottom: true })))
+      .toBe('.smooth({ strength: 0.5, flatBottom: true, baseLayers: 2 })');
+    expect(formatSurfacingCall(surf({ algorithm: 'taubin', iterations: 4, detail: 2 })))
+      .toBe(".smooth({ algorithm: 'taubin', iterations: 4, detail: 2 })");
+  });
+
+  it('blocky surfacing emits nothing unless explicit', () => {
+    const blocks = { mode: 'blocks', iterations: 2, detail: 1 } as ReturnType<VoxelGrid['surfacing']>;
+    expect(formatSurfacingCall(blocks)).toBe('');
+    expect(formatSurfacingCall(blocks, true)).toBe('.blocky()');
+  });
+
+  it('round-trips through smooth(): emitted opts reproduce the surfacing', () => {
+    const g = new VoxelGrid().fillBox([0, 0, 0], [3, 3, 3], '#888').smooth({ strength: 0.4, baseLayers: 2, flatBottom: true });
+    const call = formatSurfacingCall(g.surfacing());
+    const g2 = new VoxelGrid().fillBox([0, 0, 0], [3, 3, 3], '#888');
+    // eslint-disable-next-line no-eval
+    (new Function('g', `g${call}`))(g2);
+    expect(g2.surfacing()).toEqual(g.surfacing());
+  });
+});
+
 describe('appendVoxelEditsToCode', () => {
   const ops = { set: [[1, 0, 0, 0xff0000]] as [number, number, number, number][], remove: [[2, 0, 0]] as [number, number, number][] };
 
@@ -63,6 +94,23 @@ describe('appendVoxelEditsToCode', () => {
 
   it('returns null when there is no trailing return to hook onto', () => {
     expect(appendVoxelEditsToCode(`const v = api.voxels(); v.set(0,0,0,'#fff');`, ops)).toBeNull();
+  });
+
+  it('appends a surfacing call after the edits', () => {
+    const code = `const v = api.voxels();\nv.fillBox([0,0,0],[3,3,3],'#888');\nreturn v;`;
+    const out = appendVoxelEditsToCode(code, ops, '.smooth({ strength: 0.5, baseLayers: 2 })')!;
+    expect(out).toContain('__voxStudio.smooth({ strength: 0.5, baseLayers: 2 });');
+    // Surfacing comes after the edit ops, before the return.
+    expect(out.indexOf("__voxStudio.set(1, 0, 0, '#ff0000');")).toBeLessThan(out.indexOf('__voxStudio.smooth('));
+    expect(out.trimEnd().endsWith('return __voxStudio;')).toBe(true);
+  });
+
+  it('applies a surfacing-only change even with no edit ops', () => {
+    const code = `return api.voxels().sphere([0,0,0],4,'#e7b');`;
+    const out = appendVoxelEditsToCode(code, { set: [], remove: [] }, '.blocky()')!;
+    expect(out).toContain('__voxStudio.blocky();');
+    expect(out).not.toContain('Voxel Studio edits'); // no edit-op block when there are none
+    expect(out.trimEnd().endsWith('return __voxStudio;')).toBe(true);
   });
 
   it('round-trips: appended code reproduces the edited grid', () => {

--- a/tests/unit/voxelEditCodegen.test.ts
+++ b/tests/unit/voxelEditCodegen.test.ts
@@ -113,6 +113,53 @@ describe('appendVoxelEditsToCode', () => {
     expect(out.trimEnd().endsWith('return __voxStudio;')).toBe(true);
   });
 
+  it('re-applying a surfacing change reuses the prior block (no duplicate const)', () => {
+    // First pass: a rounding-only change wraps the code.
+    const code = `const v = api.voxels();\nv.fillBox([0,0,0],[5,5,5],'#6cf');\nreturn v;`;
+    const first = appendVoxelEditsToCode(code, { set: [], remove: [] }, '.smooth({ flatBottom: true })')!;
+    // Second pass: adjust rounding again on the already-generated code.
+    const second = appendVoxelEditsToCode(first, { set: [], remove: [] }, '.smooth({ strength: 0.45, flatBottom: true })')!;
+    // Exactly one declaration — the old "Identifier already declared" bug.
+    expect(second.match(/const __voxStudio\b/g)).toHaveLength(1);
+    expect(second).not.toContain('const __voxStudio = __voxStudio;');
+    // The new surfacing replaced the old one (not both).
+    expect(second).toContain('__voxStudio.smooth({ strength: 0.45, flatBottom: true });');
+    expect(second).not.toContain('__voxStudio.smooth({ flatBottom: true });');
+    // The user's original procedural code survives, and base is the real expr.
+    expect(second).toContain("v.fillBox([0,0,0],[5,5,5],'#6cf');");
+    expect(second).toContain('const __voxStudio = v;');
+    expect(second.trimEnd().endsWith('return __voxStudio;')).toBe(true);
+  });
+
+  it('preserves custom follow-up code and prior edit ops on re-apply', () => {
+    const first = `const v = api.voxels();\nreturn v;`;
+    const wrapped = appendVoxelEditsToCode(first, { set: [[1, 0, 0, 0xff0000]], remove: [] }, '.smooth({ strength: 0.5 })')!;
+    // User hand-adds a line using the studio var, then re-rounds.
+    const customized = wrapped.replace('return __voxStudio;', "__voxStudio.set(9, 9, 9, '#0f0');\nreturn __voxStudio;");
+    const out = appendVoxelEditsToCode(customized, { set: [], remove: [] }, '.smooth({ strength: 0.8 })')!;
+    expect(out.match(/const __voxStudio\b/g)).toHaveLength(1);
+    expect(out).toContain("__voxStudio.set(1, 0, 0, '#ff0000');"); // prior edit op kept
+    expect(out).toContain("__voxStudio.set(9, 9, 9, '#0f0');");     // custom line kept
+    expect(out).toContain('__voxStudio.smooth({ strength: 0.8 });'); // new surfacing
+    expect(out).not.toContain('strength: 0.5');                       // old surfacing dropped
+  });
+
+  it('self-heals already-duplicated declarations from older buggy output', () => {
+    const broken = [
+      'const __voxStudio = v;',
+      '__voxStudio.smooth({ flatBottom: true });',
+      '',
+      'const __voxStudio = __voxStudio;',
+      '__voxStudio.smooth({ strength: 0.45, flatBottom: true });',
+      'return __voxStudio;',
+    ].join('\n');
+    const out = appendVoxelEditsToCode(broken, { set: [], remove: [] }, '.smooth({ strength: 0.6 })')!;
+    expect(out.match(/const __voxStudio\b/g)).toHaveLength(1);
+    expect(out).toContain('const __voxStudio = v;');
+    expect(out).toContain('__voxStudio.smooth({ strength: 0.6 });');
+    expect(out.trimEnd().endsWith('return __voxStudio;')).toBe(true);
+  });
+
   it('round-trips: appended code reproduces the edited grid', () => {
     // Baseline procedural grid.
     const before = new VoxelGrid();

--- a/tests/unit/voxelEdits.test.ts
+++ b/tests/unit/voxelEdits.test.ts
@@ -14,7 +14,7 @@ describe('VoxelGrid.clone', () => {
     g.smooth({ algorithm: 'taubin', iterations: 3, detail: 2 });
     const c = g.clone();
     expect(c.size).toBe(g.size);
-    expect(c.surfacing()).toEqual({ mode: 'smooth', algorithm: 'taubin', iterations: 3, detail: 2, flatBottom: undefined, baseLayers: undefined, lockBox: undefined });
+    expect(c.surfacing()).toEqual({ mode: 'smooth', algorithm: 'taubin', iterations: 3, detail: 2, strength: 1, flatBottom: undefined, baseLayers: undefined, lockBox: undefined });
     // Mutating the clone must not touch the original.
     c.remove(0, 0, 0);
     c.set(9, 9, 9, '#fff');

--- a/tests/unit/voxelSmooth.test.ts
+++ b/tests/unit/voxelSmooth.test.ts
@@ -152,3 +152,41 @@ describe('voxel smooth — algorithm selection (Surface Nets default)', () => {
     expect(m.numVert).toBe(0);
   });
 });
+
+describe('voxel smooth — rounding amount (strength)', () => {
+  function totalDelta(a: MeshData, b: MeshData): number {
+    let d = 0;
+    for (let i = 0; i < a.vertProperties.length; i++) d += Math.abs(a.vertProperties[i] - b.vertProperties[i]);
+    return d;
+  }
+
+  it('stores strength (default 1) and rejects out-of-range', () => {
+    expect(new VoxelGrid().smooth().surfacing().strength).toBe(1);
+    expect(new VoxelGrid().smooth({ strength: 0.3 }).surfacing().strength).toBe(0.3);
+    expect(() => new VoxelGrid().smooth({ strength: 1.5 } as never)).toThrow();
+    expect(() => new VoxelGrid().smooth({ strength: -0.1 } as never)).toThrow();
+  });
+
+  it('taubin strength 0 leaves the block mesh un-rounded; 1 rounds fully', () => {
+    const block = meshGrid(box(5)); // blocky
+    const s0 = meshGrid(box(5).smooth({ algorithm: 'taubin', strength: 0 }));
+    const s1 = meshGrid(box(5).smooth({ algorithm: 'taubin', strength: 1 }));
+    expect(totalDelta(s0, block)).toBeCloseTo(0, 4); // strength 0 = no movement
+    expect(totalDelta(s1, block)).toBeGreaterThan(1); // strength 1 = clearly rounded
+  });
+
+  it('higher strength rounds more (monotonic displacement from blocky)', () => {
+    const block = meshGrid(box(6));
+    const lo = meshGrid(box(6).smooth({ algorithm: 'taubin', strength: 0.25 }));
+    const hi = meshGrid(box(6).smooth({ algorithm: 'taubin', strength: 1 }));
+    expect(totalDelta(lo, block)).toBeGreaterThan(0);
+    expect(totalDelta(hi, block)).toBeGreaterThan(totalDelta(lo, block));
+  });
+
+  it('strength tunes Surface Nets post-relaxation (same topology, different positions)', () => {
+    const sn0 = meshGrid(box(6).smooth({ strength: 0 }));
+    const sn1 = meshGrid(box(6).smooth({ strength: 1 }));
+    expect(sn0.numVert).toBe(sn1.numVert); // same SN base topology
+    expect(totalDelta(sn0, sn1)).toBeGreaterThan(0); // relaxation amount differs
+  });
+});

--- a/tests/voxel-paint.spec.ts
+++ b/tests/voxel-paint.spec.ts
@@ -128,6 +128,55 @@ test.describe('voxel paint mode', () => {
     expect(result.voxelCount).toBe(64); // 4×4×4 box
   });
 
+  test('Rounding slider previews live in the viewport, edits snap back to blocks', async ({ page }) => {
+    // The displayed solid mesh's extent is our window into what the studio shows
+    // without baking: Surface Nets pulls the surface inward (~0.5 voxel), so the
+    // max X of the rounded preview is smaller than the blocky mesh's. Reading the
+    // live meshGroup (same module singleton the app uses) avoids depending on any
+    // stat that only tracks committed runs.
+    const maxX = () => page.evaluate(async () => {
+      const { getMeshGroup } = await import('/src/renderer/viewport.ts');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const solid = getMeshGroup().children[0] as any;
+      const pos = solid?.geometry?.getAttribute('position');
+      if (!pos) return NaN;
+      let mx = -Infinity;
+      for (let i = 0; i < pos.count; i++) mx = Math.max(mx, pos.getX(i));
+      return mx;
+    });
+    const blockyMax = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.setActiveLanguage('voxel');
+      await pw.run(`return api.voxels().sphere([0,0,0],6,'#6cf');`);
+      pw.activateVoxelPaint();
+      await new Promise((r) => setTimeout(r, 200));
+      const { getMeshGroup } = await import('/src/renderer/viewport.ts');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pos = (getMeshGroup().children[0] as any).geometry.getAttribute('position');
+      let mx = -Infinity;
+      for (let i = 0; i < pos.count; i++) mx = Math.max(mx, pos.getX(i));
+      return mx;
+    });
+    expect(blockyMax).toBeGreaterThan(6.9); // blocky sphere extent (voxel corner at 7)
+    // Drag the rounding slider up — the displayed mesh re-meshes smooth (the
+    // surface pulls inward) without baking anything yet.
+    await page.evaluate(() => {
+      const slider = document.querySelector('#voxel-paint-panel input[title^="Rounding amount"]') as HTMLInputElement;
+      slider.value = '100';
+      slider.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await expect.poll(maxX).toBeLessThan(blockyMax - 0.1);
+    // Editing on the model snaps the preview back to the blocky provenance mesh.
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      pw.setVoxelTool('paint');
+      pw.voxelStudioApply({ faceIndex: 0, color: [255, 0, 0] });
+    });
+    await expect.poll(maxX).toBe(blockyMax);
+  });
+
   test('Rounding panel preserves source-declared smooth options', async ({ page }) => {
     // Touching the rounding slider must merge onto the grid's surfacing, not
     // reset iterations/detail/algorithm to defaults.

--- a/tests/voxel-paint.spec.ts
+++ b/tests/voxel-paint.spec.ts
@@ -113,15 +113,19 @@ test.describe('voxel paint mode', () => {
     expect(result.code).not.toContain('voxels.decode(');
   });
 
-  test('refuses smooth-surfaced grids with a clear message', async ({ page }) => {
+  test('opens on a smooth-surfaced grid (edits on the blocky preview)', async ({ page }) => {
+    // The studio now opens on smooth grids: per-voxel picking runs on the
+    // hard-faced provenance mesh while the grid keeps its surfacing for the
+    // Rounding panel to read and re-apply on save.
     const result = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const pw = (window as any).partwright;
       await pw.setActiveLanguage('voxel');
-      await pw.run(`return api.voxels().fillBox([0,0,0],[3,3,3],'#fff').smooth();`);
+      await pw.run(`return api.voxels().fillBox([0,0,0],[3,3,3],'#fff').smooth({ strength: 0.5 });`);
       return pw.activateVoxelPaint();
     });
-    expect(result.error).toMatch(/smooth-surfaced/);
+    expect(result.error).toBeFalsy();
+    expect(result.voxelCount).toBe(64); // 4×4×4 box
   });
 
   test('cross-session: loading a different version cancels active paint', async ({ page }) => {

--- a/tests/voxel-paint.spec.ts
+++ b/tests/voxel-paint.spec.ts
@@ -128,6 +128,30 @@ test.describe('voxel paint mode', () => {
     expect(result.voxelCount).toBe(64); // 4×4×4 box
   });
 
+  test('Rounding panel preserves source-declared smooth options', async ({ page }) => {
+    // Touching the rounding slider must merge onto the grid's surfacing, not
+    // reset iterations/detail/algorithm to defaults.
+    const code = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.setActiveLanguage('voxel');
+      await pw.run(`return api.voxels().fillBox([0,0,0],[5,5,5],'#6cf').smooth({ algorithm: 'taubin', iterations: 6, detail: 2 });`);
+      pw.activateVoxelPaint();
+      await new Promise((r) => setTimeout(r, 300));
+      const slider = document.querySelector('#voxel-paint-panel input[title^="Rounding amount"]') as HTMLInputElement;
+      slider.value = '40';
+      slider.dispatchEvent(new Event('input', { bubbles: true }));
+      const upd = [...document.querySelectorAll('#voxel-paint-panel button')].find((b) => b.textContent === 'Update code') as HTMLButtonElement;
+      upd.click();
+      await new Promise((r) => setTimeout(r, 1500));
+      return pw.getCode();
+    });
+    expect(code).toContain("algorithm: 'taubin'"); // preserved
+    expect(code).toContain('iterations: 6');         // preserved
+    expect(code).toContain('detail: 2');             // preserved
+    expect(code).toContain('strength: 0.4');         // the panel's change
+  });
+
   test('cross-session: loading a different version cancels active paint', async ({ page }) => {
     const result = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/voxel-studio.spec.ts
+++ b/tests/voxel-studio.spec.ts
@@ -128,7 +128,7 @@ test.describe('voxel studio', () => {
 
     // Now the panel's number input: typing 50 and committing keeps 50, while the
     // range slider pins its thumb at its own max of 16.
-    const input = page.locator('#voxel-paint-panel input[type="number"]').last();
+    const input = page.locator('#voxel-paint-panel input[title^="Depth in layers"]');
     await input.fill('50');
     await input.press('Enter');
     await expect(input).toHaveValue('50');
@@ -138,8 +138,7 @@ test.describe('voxel studio', () => {
     );
     expect(storedDepth).toBe(50);
     const sliderVal = await page
-      .locator('#voxel-paint-panel input[type="range"]')
-      .last()
+      .locator('#voxel-paint-panel input[title^="Add: layers the block sinks"]')
       .inputValue();
     expect(Number(sliderVal)).toBeLessThanOrEqual(16);
   });


### PR DESCRIPTION
## Summary

Follow-on to the merged Surface Nets PR (#531). Three requests: configurable rounding amount, keep some layers un-rounded, and rounding controls in Voxel Studio (applied as code, else baked).

### 1. Rounding amount — `smooth({ strength })`
- New `strength` (0–1, default 1) on `VoxelGrid.smooth()` / `Surfacing`. Implemented in `taubinSmooth` by scaling the λ/μ step sizes uniformly (ratio preserved → anti-shrink still holds; `0` = no-op). Tunes roundness continuously for **both** algorithms — for Surface Nets it scales the post-relaxation over the SN base.

### 2. Keep layers un-rounded
- Reuses the existing `flatBottom` (exact plane pin) and `baseLayers` (keep bottom N layers blocky) pins, which already apply to Surface Nets via its post-relaxation pass. No new mechanism — just surfaced in the UI.

### 3. Voxel Studio "Rounding" section
- Amount slider (**0% = hard blocks**, 1–100% = smoother), **Flat bottom** toggle, **Flat base … layers** field — prefilled from the grid's current surfacing.
- The blocky editing preview is unchanged (per-voxel picking needs the hard-faced provenance mesh), so rounding is applied **on commit**, with an in-panel hint.
- The Studio now **opens on already-smoothed models** (previously refused) — edits run on the blocky preview, rounding preserved.

### Applied as code, else baked
- A shared `formatSurfacingCall(surf)` (editCodegen.ts) centralizes surfacing → source. **Update code** appends `.smooth({ … })` / `.blocky()` after the edits (only when rounding actually changed). **Save as raw** / image-import / voxelize codegen now emit the *full* options (algorithm/strength/baseLayers/flatBottom), not just iterations+detail.

## Test plan
- **Unit (911 pass):** `strength` storage/validation/scaling (taubin 0 = no movement, monotonic; SN post-relax differs); `formatSurfacingCall` round-trip through `smooth()`; `appendVoxelEditsToCode` with a surfacing call incl. the surfacing-only/no-edits case.
- **E2E:** `voxel-engine` + `voxel-paint` green, including the rewritten "opens on a smooth-surfaced grid" test (replaces the old refusal).
- **Browser:** screenshotted the Rounding panel; drove the slider + flat-bottom + Update code → confirmed emitted `.smooth({ strength: 0.6, flatBottom: true })` and a rounded, flat-bottomed rendered result.
- `npm run build`, `lint:deps` (acyclic), `lint:deadcode` clean for the diff.

## Docs
`public/ai/voxel.md`: documented `strength`, the Studio Rounding controls, and the now-supported open-on-smooth behavior.

🤖 https://claude.ai/code/session_016pTn8ytmVbH4piJpWPbVox

---
_Generated by [Claude Code](https://claude.ai/code/session_016pTn8ytmVbH4piJpWPbVox)_