### PR TITLE
refactor: lazy-load catalog thumbnails, drop thumbs.json aggregate

### DIFF
--- a/prompts/20260609-131500-catalog-lazy-thumbnails.md
+++ b/prompts/20260609-131500-catalog-lazy-thumbnails.md
@@ -1,0 +1,47 @@
+---
+session: "5c6e31e7"
+timestamp: "2026-06-09T13:15:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 5
+---
+
+## Human
+
+"Then create a new PR we remove any concept of thumbs.json. That approach won't
+scale anyway I don't think once our catalog gets sufficiently large. Also in the
+PR to remove the thumbs.json let's lazily load the images once they come close
+to the fold line."
+
+## Assistant
+
+## Key decisions
+
+**Removed the `thumbs.json` aggregate entirely.** It was never generated (the
+fetch always 404'd to the per-file fallback), and it doesn't scale: one file
+bundling every base64 thumbnail grows unbounded with the catalog and blocks the
+whole page on a single multi-MB download even for tiles far below the fold.
+Dropped the fetch and the `CatalogThumbs` interface.
+
+**Lazy-load per tile via IntersectionObserver.** Each tile's thumbnail (the
+base64 data URL inside its entry JSON) is now fetched only when the tile nears
+the viewport — `rootMargin: '300px 0px'` so the image is usually ready by the
+time it scrolls on screen — and the observer unobserves after the first hit so a
+tile loads exactly once. Falls back to loading all tiles when
+`IntersectionObserver` is unavailable (ancient browsers). Kept the `no-cache`
+fetch from the stacked cache-fix PR so an updated thumbnail is never masked by a
+stale copy.
+
+**Stacked on PR #537** (the cache-mode fix) rather than branching from main, so
+this branch already contains the `no-cache` change and won't conflict when #537
+merges first.
+
+**Verified the laziness, didn't just assume it.** A throwaway Playwright spec
+loaded `/catalog` (97 tiles): only **4** thumbnails fetched initially (above the
+fold + the 300px margin), and after scrolling through, all **97** had loaded —
+proving on-demand loading works and the page no longer pulls every thumbnail up
+front. Filter pills (e.g. VOXEL 13) still reflect the full set. Scratch spec
+deleted after.
+
+The cross-tab/filter interaction is sound: the observer watches every tile from
+the start; a filter-hidden tile simply never intersects until shown, then loads.

--- a/src/content/catalogEntry.ts
+++ b/src/content/catalogEntry.ts
@@ -13,48 +13,55 @@
 import { wireCatalogFilter } from './catalogFilter';
 import { initTooltips } from '../ui/tooltip';
 
-interface CatalogThumbs {
-  /** Map of catalog file name → latest-version thumbnail data URL. */
-  [file: string]: string;
+/** Fetch one tile's thumbnail from its entry JSON and apply it. Each tile loads
+ *  at most once. `no-cache` revalidates (cheap 304 when unchanged) so an updated
+ *  thumbnail is never masked by a stale cached copy. */
+async function loadThumbnail(tile: HTMLElement): Promise<void> {
+  const file = tile.getAttribute('data-pw-thumb');
+  if (!file) return;
+  const img = tile.querySelector<HTMLImageElement>('img');
+  if (!img) return;
+  try {
+    const res = await fetch(`/catalog/${file}`, { cache: 'no-cache' });
+    if (!res.ok) return;
+    const payload = await res.json() as { versions?: { thumbnail?: string | null }[] };
+    const versions = payload.versions ?? [];
+    const src = versions.length > 0 ? (versions[versions.length - 1].thumbnail ?? null) : null;
+    if (src) {
+      img.src = src;
+      img.style.opacity = '1';
+    }
+  } catch { /* leave placeholder */ }
 }
 
 async function hydrateThumbnails(): Promise<void> {
   const tiles = Array.from(document.querySelectorAll<HTMLElement>('[data-pw-thumb]'));
   if (tiles.length === 0) return;
 
-  // One request for all thumbnails (emitted at build time), with a graceful
-  // fallback to per-file fetches if it isn't present. Use `no-cache` (revalidate
-  // with the server, cheap 304 when unchanged) rather than `force-cache`: a
-  // stale entry must never blank a tile after a thumbnail update — `force-cache`
-  // returns a cached copy without revalidating, so a visitor who loaded the page
-  // before a thumbnail existed would keep seeing the blank indefinitely.
-  let thumbs: CatalogThumbs | null = null;
-  try {
-    const res = await fetch('/catalog/thumbs.json', { cache: 'no-cache' });
-    if (res.ok) thumbs = await res.json() as CatalogThumbs;
-  } catch { /* fall through to per-file */ }
+  // Lazy, per-tile: a tile's thumbnail (a base64 data URL embedded in its entry
+  // JSON) is fetched only as the tile nears the viewport. There is intentionally
+  // no aggregate `thumbs.json` — bundling every thumbnail into one file doesn't
+  // scale: it grows unbounded with the catalog and blocks the whole page on a
+  // single multi-MB download even for tiles far below the fold. Loading on demand
+  // keeps the page fast no matter how large the catalog grows.
+  if (typeof IntersectionObserver === 'undefined') {
+    // Ancient browser with no IO: just load everything (old behavior).
+    await Promise.all(tiles.map(loadThumbnail));
+    return;
+  }
 
-  await Promise.all(tiles.map(async (tile) => {
-    const file = tile.getAttribute('data-pw-thumb');
-    if (!file) return;
-    const img = tile.querySelector<HTMLImageElement>('img');
-    if (!img) return;
-    let src = thumbs?.[file] ?? null;
-    if (!src) {
-      try {
-        const res = await fetch(`/catalog/${file}`, { cache: 'no-cache' });
-        if (res.ok) {
-          const payload = await res.json() as { versions?: { thumbnail?: string | null }[] };
-          const versions = payload.versions ?? [];
-          src = versions.length > 0 ? (versions[versions.length - 1].thumbnail ?? null) : null;
-        }
-      } catch { /* leave placeholder */ }
+  // Start fetching ~300px before a tile scrolls into view so the image is
+  // usually ready by the time it's on screen; unobserve after the first hit so
+  // each tile loads exactly once.
+  const observer = new IntersectionObserver((entries, obs) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue;
+      const tile = entry.target as HTMLElement;
+      obs.unobserve(tile);
+      void loadThumbnail(tile);
     }
-    if (src) {
-      img.src = src;
-      img.style.opacity = '1';
-    }
-  }));
+  }, { rootMargin: '300px 0px' });
+  for (const tile of tiles) observer.observe(tile);
 }
 
 function init(): void {


### PR DESCRIPTION
## Summary

Removes the `thumbs.json` aggregate concept and lazy-loads catalog thumbnails as tiles approach the fold.

**Why drop `thumbs.json`:** it was never generated (the fetch always 404'd to the per-file fallback), and the approach doesn't scale — one file bundling every base64 thumbnail grows unbounded with the catalog and would block the whole page on a single multi-MB download even for tiles far below the fold.

**What replaces it:** each tile's thumbnail (the base64 data URL already embedded in its entry JSON) is fetched **only when the tile nears the viewport**, via `IntersectionObserver` with `rootMargin: '300px 0px'` so the image is usually ready by the time it scrolls on screen. The observer unobserves after the first hit, so each tile loads exactly once. Falls back to loading all tiles where `IntersectionObserver` is unavailable. Keeps the `no-cache` fetch so an updated thumbnail is never masked by a stale copy.

> **Stacked on #537** (the cache-mode fix). Base is that branch so this diff shows only the lazy-load change; GitHub will retarget it to `main` automatically once #537 merges.

## Test plan
- `npm run build` clean; `lint:deadcode` shows no `catalogEntry`/`CatalogThumbs` orphans.
- **Browser-verified laziness** (throwaway Playwright spec, deleted): on `/catalog` with 97 tiles, only **4** thumbnails fetched up front (above the fold + the 300px margin); after scrolling through, all **97** loaded. Filter pills (VOXEL 13, etc.) still reflect the full set.
- No e2e assertions touch this path (catalog spec only navigates/filters), so lazy loading doesn't regress them.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_019nSNrMeHCBvoLkrZs4Yeyi

---
_Generated by [Claude Code](https://claude.ai/code/session_019nSNrMeHCBvoLkrZs4Yeyi)_