### PR TITLE
feat: window-anchored draggable panels + Customize in Tools dropdown

### DIFF
--- a/prompts/20260609-181500-draggable-window-fixed-panels.md
+++ b/prompts/20260609-181500-draggable-window-fixed-panels.md
@@ -1,0 +1,57 @@
+---
+session: "ibcg08"
+timestamp: "2026-06-09T18:15:00Z"
+model: claude-opus-4-8
+tools: [subagent, playwright]
+sequence: 1
+---
+
+## Human
+
+When dragging a tool modal, wanted to be able to move it anywhere within the
+window, and for it NOT to move around when panes are closed/resized. Same for
+the other modals like Customize. Also: put Customize in the Tools dropdown, and
+when a parameterizable model is opened for the first time, auto-open the
+Customize panel together with the Tools dropdown (the tool list that sits just
+above it by default).
+
+## Assistant
+
+## Key decisions
+
+**Window-anchored, not pane-anchored.** The viewport overlay panels (Customize
++ every `createToolPanelShell` tool: Surface, Resize, Place, Quality, …) were
+`position: absolute` inside the viewport pane and the drag math clamped them to
+the *parent pane*. Switched `viewportPanelDrag.ts` to `position: fixed`
+(window-relative): the drag now uses raw `clientX/clientY` and `clampIntoView`
+clamps to `window.innerWidth/innerHeight`. This delivers both asks at once —
+the panel can be dragged anywhere in the window, and a pane open/close/resize
+no longer shifts it (those reflow the pane but fire no `window resize`, so a
+window-anchored box stays put). The resize listener is kept only to pull a
+panel back on-screen when the *window itself* shrinks. `setInitialPanelPosition`
+now docks via window coords (right edge aligned to the toolbar's right edge so
+it still tucks under correctly when a side panel insets the toolbar). I set
+`style.position = 'fixed'` inline in the drag module so every caller inherits it
+without touching their Tailwind classes.
+
+**Customize moved into the Tools dropdown.** It was a standalone top-level pill;
+now it's appended into `#viewport-tools-menu` via `viewportToolsMount`, restyled
+with the shared `TOOL_TOGGLE_IDLE/ACTIVE` so it reads as one of the editing
+tools. The command-palette action and `getParams/setParams` API are unchanged
+(no API-parity surface changed — this is pure UI placement + drag behavior).
+
+**Auto-open both on first open of a param model.** `paramsPanel.update()`
+already re-opened the panel on a schema change; added an `onAutoReveal` callback
+fired in that same branch (and only then — not on manual reopen), wired in
+`main.ts` to `openPopoverGroupById('viewport-tools')` (new helper in
+`popoverMenu.ts` that calls a live group's `open()`). Ordered it *before*
+`applyVisibility()` so the panel docks beneath the now-open menu rather than the
+bare toolbar.
+
+**Consistency consequence, accepted:** because the Customize panel lives outside
+the Tools popover wrapper, interacting with it (or closing it) lands a
+click-outside that collapses the dropdown — identical to every other docked tool
+panel. The "way back in" after closing is reopen-dropdown → Customize (plus the
+command palette). Updated `customizer.spec.ts` to assert this model, added a
+test that a dragged panel is `position: fixed` and stays put across an editor-
+pane collapse, and verified both behaviors with screenshots.

--- a/prompts/20260609-182500-panel-review-fixes.md
+++ b/prompts/20260609-182500-panel-review-fixes.md
@@ -1,0 +1,35 @@
+---
+session: "ibcg08"
+timestamp: "2026-06-09T18:25:00Z"
+model: claude-opus-4-8
+tools: [subagent]
+sequence: 2
+---
+
+## Human
+
+(Follow-up on PR #540, after the work-reviewer pass.) Address the reviewer's
+should-fix and nit findings on the window-anchored draggable panels.
+
+## Assistant
+
+## Key decisions
+
+**Clamp tool panels on open.** `position: fixed` made `max-h-[calc(100%-…)]`
+resolve against the window, so on the short stacked mobile layout a tall tool
+panel docked near the top could extend off-screen, and `createToolPanelShell`
+(unlike the params panel) never clamped on open — only on a later drag/resize.
+Added a `requestAnimationFrame(() => drag.clampIntoView())` after
+`setInitialPanelPosition`, mirroring `paramsPanel`'s open path, so the panel is
+pulled fully into the window immediately.
+
+**Doc + class cleanup.** Corrected `openPopoverGroupById`'s docstring (re-opening
+an already-open group is idempotent, not a no-op) and switched the two flagged
+class strings (`TOOL_PANEL_CLASS`, the params-panel root) from `absolute` to
+`fixed` so the source reflects the actual positioning model instead of relying
+purely on the inline `style.position` override. Left the percentage `max-h`
+values as-is: under fixed positioning `100%` already resolves to the window, so
+they're equivalent to `vh` and the on-open clamp keeps panels on-screen.
+
+Verified: build + unit (909) green; `customizer`, `viewport-toolbar-groups`,
+and `place-model` (docked tool panel) e2e specs all green.

--- a/prompts/20260609-190000-panels-dock-over-ai-pane.md
+++ b/prompts/20260609-190000-panels-dock-over-ai-pane.md
@@ -1,0 +1,38 @@
+---
+session: "ibcg08"
+timestamp: "2026-06-09T19:00:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 3
+---
+
+## Human
+
+(Follow-up on PR #540.) When the AI pane is open, have the tool/Customize panel
+appear over top of it by default rather than aligning to the right of the
+interactive viewport pane — people using tools manually don't need the AI pane
+visible.
+
+## Assistant
+
+## Key decisions
+
+**Dock to the window's right edge, not the viewport pane's.** `setInitialPanelPosition`
+was aligning the panel's right edge to `#clip-controls`' right edge, which is
+inset to the left of the docked AI column when it's open — so panels tucked
+*beside* the AI pane. Changed it to dock at `right: PANEL_EDGE_GAP` from the
+window edge. When the AI pane is closed this is unchanged (the viewport pane
+already reaches the window edge); when it's open, the panel now overlays the AI
+column.
+
+**Z-order already works — no layering change needed.** The desktop docked AI
+panel (`#ai-panel`) is a normal flex child with `position: relative` and no
+`z-index`, so it does *not* establish a stacking context; the `fixed z-10/z-20`
+tool panels paint on top of it. (The mobile full-screen AI overlay is
+`fixed inset-0 z-40`, but that's a distinct mode where manual tool use over the
+drawer isn't the scenario, and the stacked mobile layout docks at the window
+edge anyway.) Confirmed visually with a screenshot.
+
+Added an e2e test (`customizer.spec.ts`) that opens the AI panel, runs a param
+model, and asserts the Customize panel's right edge hugs the window edge and
+extends over the AI column. All 11 customizer specs green.

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,8 @@ import { formatEngineMemory } from './geometry/engineMemory';
 import { onQualitySettingsChange } from './geometry/qualitySettings';
 import { resolveParamValues, pruneParamValues, type ParamSpec, type ParamValue } from './geometry/params';
 import { createParamsPanel, type ParamsPanelController } from './ui/paramsPanel';
+import { viewportToolsMount, openPopoverGroupById } from './ui/popoverMenu';
+import { TOOL_TOGGLE_IDLE, TOOL_TOGGLE_ACTIVE } from './ui/toolPanel';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
 import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCameraPose, setCameraPose, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange, resetView, onOrbitEnd } from './renderer/viewport';
 // Side-effect import: registers the phantom/annotation/session-plane viewport
@@ -5696,21 +5698,21 @@ async function main() {
   // re-runs (live preview); Reset clears all overrides back to model defaults.
   // Hidden until a run reports a parameter schema.
   //
-  // A "Customize" toggle pill in the viewport toolbar (created below) is the
-  // discoverable open/reopen affordance: it appears only when the active model
-  // declares parameters, shows the count, and mirrors the panel's open state —
-  // so closing the panel never strands the user without a way back in.
+  // A "Customize" toggle button lives in the viewport Tools dropdown (one of the
+  // model-editing tools) and is the discoverable open/reopen affordance: it
+  // appears in the menu only when the active model declares parameters, shows the
+  // count, and mirrors the panel's open state — so closing the panel never
+  // strands the user without a way back in. When a parameterizable model is first
+  // opened, the panel auto-reveals and pops the Tools dropdown open with it (see
+  // onAutoReveal), so the tool list sits just above the freshly-docked panel.
   const customizeBtn = document.createElement('button');
   customizeBtn.id = 'customize-toggle';
   customizeBtn.title = 'Tweak this model’s parameters';
-  customizeBtn.className = 'hidden'; // shown by syncCustomizeBtn once a run reports params
+  customizeBtn.className = `hidden ${TOOL_TOGGLE_IDLE}`; // shown by syncCustomizeBtn once a run reports params
   customizeBtn.addEventListener('click', () => paramsPanel?.toggle());
-  const CUSTOMIZE_BTN_BASE = 'md:px-2 md:py-1 px-3 py-2 rounded text-sm md:text-xs backdrop-blur transition-colors border';
-  const CUSTOMIZE_BTN_OPEN = `${CUSTOMIZE_BTN_BASE} bg-blue-500/30 text-blue-300 border-blue-500/50`;
-  const CUSTOMIZE_BTN_CLOSED = `${CUSTOMIZE_BTN_BASE} bg-zinc-800/80 text-zinc-400 [@media(hover:hover)]:hover:text-zinc-200 [@media(hover:hover)]:hover:bg-zinc-700/80 border-zinc-600/50`;
   const syncCustomizeBtn = (state: { hasParams: boolean; open: boolean; count: number }) => {
     customizeBtn.textContent = state.count > 0 ? `🎛 Customize (${state.count})` : '🎛 Customize';
-    customizeBtn.className = state.open ? CUSTOMIZE_BTN_OPEN : CUSTOMIZE_BTN_CLOSED;
+    customizeBtn.className = state.open ? TOOL_TOGGLE_ACTIVE : TOOL_TOGGLE_IDLE;
     // No declared parameters → no button at all (matches the panel being hidden).
     customizeBtn.classList.toggle('hidden', !state.hasParams);
   };
@@ -5725,14 +5727,16 @@ async function main() {
       runCode();
     },
     onVisibilityChange: syncCustomizeBtn,
+    // First open of a parameterizable model: surface the Tools dropdown the
+    // Customize button sits in, so the tool list shows just above the panel.
+    onAutoReveal: () => openPopoverGroupById('viewport-tools'),
   });
   viewportPane.appendChild(paramsPanel.element);
-  // Customize is a contextual primary: hidden until a model declares params,
-  // then surfaced top-level (just before the Inspect popover) as a strong "this
-  // model is tweakable" signal — not buried inside the Tools popover.
-  const customizeAnchor = clipControls.querySelector('#viewport-inspect-group');
-  if (customizeAnchor) clipControls.insertBefore(customizeBtn, customizeAnchor);
-  else clipControls.appendChild(customizeBtn);
+  // Customize joins the other model-editing tools inside the Tools popover, hidden
+  // until a model declares params. The Customize panel docks beneath the open
+  // Tools menu (see viewportPanelDrag's dockUnderBottom), so the two read as one
+  // unit when auto-revealed.
+  viewportToolsMount(clipControls).appendChild(customizeBtn);
 
   // Init measure tool
   initMeasureTool(getCanvas(), getCamera(), getMeshGroup(), viewportPane);
@@ -6693,8 +6697,8 @@ async function main() {
   reliefViewportBtn.textContent = '✦ Relief';
   reliefViewportBtn.title = 'Edit colors for this relief';
   reliefViewportBtn.addEventListener('click', () => toggleReliefStudio());
-  // Relief edit is a contextual primary too (shown only in relief sessions), so
-  // it sits top-level alongside Customize rather than inside the Tools popover.
+  // Relief edit is a contextual primary (shown only in relief sessions), so it
+  // sits top-level on the bar rather than inside the Tools popover.
   const reliefAnchor = clipControls.querySelector('#viewport-inspect-group');
   if (reliefAnchor) clipControls.insertBefore(reliefViewportBtn, reliefAnchor);
   else clipControls.appendChild(reliefViewportBtn);

--- a/src/ui/paramsPanel.ts
+++ b/src/ui/paramsPanel.ts
@@ -61,7 +61,7 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
   // Bottom-left of the viewport — clear of the status pill (top-left), the
   // clip/tool bar (top-right) and the Z slider (right). pointer-events-auto so
   // widgets work; the panel itself is small so it doesn't block orbit much.
-  root.className = 'hidden absolute z-10 w-60 max-w-[calc(100%-1rem)] flex flex-col rounded-lg bg-zinc-900/85 backdrop-blur border border-zinc-700 shadow-lg text-zinc-200 pointer-events-auto';
+  root.className = 'hidden fixed z-10 w-60 max-w-[calc(100%-1rem)] flex flex-col rounded-lg bg-zinc-900/85 backdrop-blur border border-zinc-700 shadow-lg text-zinc-200 pointer-events-auto';
 
   // Header: a "Customize" title, a Reset button, and a close (×) button. Closing
   // hides the whole panel; the viewport "Customize" toggle pill reopens it (see

--- a/src/ui/paramsPanel.ts
+++ b/src/ui/paramsPanel.ts
@@ -22,6 +22,11 @@ export interface ParamsPanelOptions {
    *  Lets an external toggle button (the viewport "Customize" pill) mirror the
    *  panel's state and show a parameter count. */
   onVisibilityChange?: (state: { hasParams: boolean; open: boolean; count: number }) => void;
+  /** Fired when a new/changed parameter schema auto-opens the panel (i.e. a
+   *  parameterizable model is opened for the first time). Lets the host also
+   *  reveal the Tools dropdown the Customize button lives in, so the tool list
+   *  sits just above the freshly-docked panel. Not fired on manual re-opens. */
+  onAutoReveal?: () => void;
 }
 
 export interface ParamsPanelController {
@@ -163,7 +168,8 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
       return;
     }
     const sig = schemaSignature(schema);
-    if (sig !== currentSig) {
+    const schemaChanged = sig !== currentSig;
+    if (schemaChanged) {
       currentSig = sig;
       rebuild(schema);
       // A new or changed parameter set re-opens the panel so its knobs are seen.
@@ -172,6 +178,9 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
     paramCount = schema.length;
     updateValues(values);
     title.textContent = schema.length === 1 ? 'Customize (1)' : `Customize (${schema.length})`;
+    // Reveal the Tools dropdown *before* positioning the panel, so applyVisibility
+    // docks the panel beneath the now-open menu rather than the bare toolbar.
+    if (schemaChanged && isOpen()) opts.onAutoReveal?.();
     applyVisibility();
   }
 

--- a/src/ui/popoverMenu.ts
+++ b/src/ui/popoverMenu.ts
@@ -133,8 +133,9 @@ export function createPopoverGroup(opts: PopoverGroupOptions): PopoverGroup {
 
 /**
  * Open a live popover group by the base `id` passed to {@link createPopoverGroup}
- * (e.g. `'viewport-tools'`). No-op when no such group exists or it is already
- * open. Used to programmatically surface the Tools dropdown (e.g. when a
+ * (e.g. `'viewport-tools'`). No-op when no such group exists; if the group is
+ * already open, re-opening it is idempotent (it just re-closes any siblings).
+ * Used to programmatically surface the Tools dropdown (e.g. when a
  * parameterizable model auto-reveals its Customize panel).
  */
 export function openPopoverGroupById(id: string): void {

--- a/src/ui/popoverMenu.ts
+++ b/src/ui/popoverMenu.ts
@@ -132,6 +132,16 @@ export function createPopoverGroup(opts: PopoverGroupOptions): PopoverGroup {
 }
 
 /**
+ * Open a live popover group by the base `id` passed to {@link createPopoverGroup}
+ * (e.g. `'viewport-tools'`). No-op when no such group exists or it is already
+ * open. Used to programmatically surface the Tools dropdown (e.g. when a
+ * parameterizable model auto-reveals its Customize panel).
+ */
+export function openPopoverGroupById(id: string): void {
+  liveGroups.find((g) => g.menu.id === `${id}-menu`)?.open();
+}
+
+/**
  * The mount point for an injected viewport tool button: the Tools popover's menu
  * if present, else the given container (graceful fallback before the group exists
  * or in any non-grouped layout). Tool modules append their button here while

--- a/src/ui/toolPanel.ts
+++ b/src/ui/toolPanel.ts
@@ -13,7 +13,7 @@ import { openViewportPanel, closeViewportPanel, type ViewportPanel } from './vie
  *  above the model (z-20) but below centered dialogs. Does NOT include `hidden`:
  *  singleton panels that toggle visibility prepend it themselves. */
 export const TOOL_PANEL_CLASS =
-  'absolute z-20 flex flex-col overflow-hidden bg-zinc-800/95 backdrop-blur border border-zinc-600/60 rounded-lg shadow-xl';
+  'fixed z-20 flex flex-col overflow-hidden bg-zinc-800/95 backdrop-blur border border-zinc-600/60 rounded-lg shadow-xl';
 
 /** Drag-handle header bar (title + close ×). Pass to attachViewportPanelDrag. */
 export const TOOL_PANEL_HEADER =
@@ -124,6 +124,11 @@ export function createToolPanelShell(opts: {
   host.appendChild(panel);
   const drag = attachViewportPanelDrag(header, panel);
   setInitialPanelPosition(panel);
+  // The panel is now window-anchored (position: fixed), so a tall panel docked
+  // near the bottom of a short window (e.g. the stacked mobile layout) could
+  // extend off-screen. Pull it fully back into view once it has measured,
+  // mirroring the params panel's open path.
+  requestAnimationFrame(() => drag.clampIntoView());
   document.addEventListener('keydown', onEsc);
   openViewportPanel(entry); // close any other open tool panel
 

--- a/src/ui/viewportPanelDrag.ts
+++ b/src/ui/viewportPanelDrag.ts
@@ -26,18 +26,18 @@ function dockUnderBottom(controls: HTMLElement): number {
 }
 
 /** Position the panel below the #clip-controls toolbar buttons (or below the
- *  open Tools menu), with its right edge aligned to the toolbar's right edge.
- *  Coordinates are window-relative (the panel is `position: fixed`), so the dock
- *  lands correctly regardless of which pane the toolbar currently lives in. */
+ *  open Tools menu), docked against the window's right edge.
+ *  Coordinates are window-relative (the panel is `position: fixed`). Docking to
+ *  the *window* edge (rather than the viewport pane's right edge) means that
+ *  when the AI panel is docked open, the tool panel sits *over* it by default —
+ *  manual tool use doesn't need the AI column visible, and the panel is still
+ *  draggable anywhere if the user wants it elsewhere. */
 export function setInitialPanelPosition(panel: HTMLElement): void {
   panel.style.position = 'fixed';
   const controls = document.getElementById('clip-controls');
   if (controls) {
-    const cr = controls.getBoundingClientRect();
     panel.style.top = `${Math.round(dockUnderBottom(controls) + PANEL_EDGE_GAP / 2)}px`;
-    // `right` is the gap from the window's right edge to the toolbar's right edge,
-    // so the panel tucks under the toolbar even when a docked side panel insets it.
-    panel.style.right = `${Math.round(Math.max(PANEL_EDGE_GAP, window.innerWidth - cr.right))}px`;
+    panel.style.right = `${PANEL_EDGE_GAP}px`;
     panel.style.left = 'auto';
     panel.style.bottom = 'auto';
     return;

--- a/src/ui/viewportPanelDrag.ts
+++ b/src/ui/viewportPanelDrag.ts
@@ -1,13 +1,20 @@
 // Shared drag-handle logic for viewport overlay panels. Attaches pointer-event
 // drag tracking to a handle element and keeps the panel clamped inside the
-// visible area of its offset parent. Position resets on each open (not
-// persisted) — the panel always starts below the clip-controls toolbar.
+// visible browser window. Panels are positioned `fixed` (window-relative) rather
+// than absolute within the viewport pane: that lets the user drag them *anywhere*
+// in the window, and — crucially — keeps them put when surrounding panes open,
+// close, or resize (those reflow the pane but don't move a window-anchored box).
+// Position resets on each fresh open (not persisted) — the panel always starts
+// docked below the clip-controls toolbar.
 
 // px gap between a docked panel and the bar/menu above it (mirrors the toolbar's
 // own right-2 inset, reused as the vertical breathing room under the menu).
 const PANEL_EDGE_GAP = 8;
 
-/** The bottom edge (viewport-relative px) that a docked panel should sit under:
+// Keep a dragged panel at least this far from the window edges when re-clamping.
+const CLAMP_PAD = 8;
+
+/** The bottom edge (window-relative px) that a docked panel should sit under:
  *  normally the toolbar, but the open horizontal Tools menu when it's showing,
  *  so the panel drops *beneath* the menu row rather than under it. */
 function dockUnderBottom(controls: HTMLElement): number {
@@ -19,23 +26,21 @@ function dockUnderBottom(controls: HTMLElement): number {
 }
 
 /** Position the panel below the #clip-controls toolbar buttons (or below the
- *  open Tools menu), docked to the right edge.
- *  Prefers the panel's own offset parent as the coordinate reference so
- *  top/right values land in the correct space. Falls back to clip-controls'
- *  positioned ancestor for callers that position while the panel is hidden
- *  (display:none elements have offsetParent=null). */
+ *  open Tools menu), with its right edge aligned to the toolbar's right edge.
+ *  Coordinates are window-relative (the panel is `position: fixed`), so the dock
+ *  lands correctly regardless of which pane the toolbar currently lives in. */
 export function setInitialPanelPosition(panel: HTMLElement): void {
+  panel.style.position = 'fixed';
   const controls = document.getElementById('clip-controls');
   if (controls) {
-    const host = (panel.offsetParent ?? controls.offsetParent ?? controls.parentElement) as HTMLElement | null;
-    if (host) {
-      const hr = host.getBoundingClientRect();
-      panel.style.top = `${Math.round(dockUnderBottom(controls) - hr.top + PANEL_EDGE_GAP / 2)}px`;
-      panel.style.right = `${PANEL_EDGE_GAP}px`;
-      panel.style.left = 'auto';
-      panel.style.bottom = 'auto';
-      return;
-    }
+    const cr = controls.getBoundingClientRect();
+    panel.style.top = `${Math.round(dockUnderBottom(controls) + PANEL_EDGE_GAP / 2)}px`;
+    // `right` is the gap from the window's right edge to the toolbar's right edge,
+    // so the panel tucks under the toolbar even when a docked side panel insets it.
+    panel.style.right = `${Math.round(Math.max(PANEL_EDGE_GAP, window.innerWidth - cr.right))}px`;
+    panel.style.left = 'auto';
+    panel.style.bottom = 'auto';
+    return;
   }
   // Fallback when clip-controls isn't in the DOM yet.
   panel.style.top = '48px';
@@ -64,6 +69,9 @@ export function attachViewportPanelDrag(
   panel: HTMLElement,
 ): PanelDragHandle {
   handle.classList.add('cursor-move', 'select-none', 'touch-none');
+  // Window-relative so the panel can be dragged anywhere and stays put when the
+  // surrounding panes reflow (see file header).
+  panel.style.position = 'fixed';
 
   let dragPointerId: number | null = null;
   let startX = 0, startY = 0, startLeft = 0, startTop = 0;
@@ -75,26 +83,18 @@ export function attachViewportPanelDrag(
     panel.style.bottom = 'auto';
   }
 
+  // Pull the panel back inside the window if it would sit (partly) off-screen —
+  // e.g. after the window itself is resized smaller. Clamps to the full window,
+  // not a parent pane, so the panel is free to live anywhere on screen.
   function clampIntoView(): void {
-    const parent = panel.offsetParent as HTMLElement | null;
-    if (!parent || panel.classList.contains('hidden')) return;
-    const pad = 8;
-    const pr = parent.getBoundingClientRect();
+    if (panel.classList.contains('hidden')) return;
     const rr = panel.getBoundingClientRect();
     if (rr.width === 0 || rr.height === 0) return;
-    const visTop = Math.max(pr.top, 0);
-    const visBottom = Math.min(pr.bottom, window.innerHeight);
-    const visLeft = Math.max(pr.left, 0);
-    const visRight = Math.min(pr.right, window.innerWidth);
-    const minLeft = (visLeft - pr.left) + pad;
-    const minTop = (visTop - pr.top) + pad;
-    const maxLeft = (visRight - pr.left) - rr.width - pad;
-    const maxTop = (visBottom - pr.top) - rr.height - pad;
-    const curLeft = rr.left - pr.left;
-    const curTop = rr.top - pr.top;
-    const left = Math.max(minLeft, Math.min(curLeft, maxLeft));
-    const top = Math.max(minTop, Math.min(curTop, maxTop));
-    if (Math.abs(left - curLeft) > 0.5 || Math.abs(top - curTop) > 0.5) {
+    const maxLeft = window.innerWidth - rr.width - CLAMP_PAD;
+    const maxTop = window.innerHeight - rr.height - CLAMP_PAD;
+    const left = Math.max(CLAMP_PAD, Math.min(rr.left, maxLeft));
+    const top = Math.max(CLAMP_PAD, Math.min(rr.top, maxTop));
+    if (Math.abs(left - rr.left) > 0.5 || Math.abs(top - rr.top) > 0.5) {
       applyPos(left, top);
     }
   }
@@ -102,12 +102,9 @@ export function attachViewportPanelDrag(
   handle.addEventListener('pointerdown', (e) => {
     if (e.pointerType === 'mouse' && e.button !== 0) return;
     if ((e.target as HTMLElement).closest('button')) return;
-    const parent = panel.offsetParent as HTMLElement | null;
-    if (!parent) return;
-    const pr = parent.getBoundingClientRect();
     const rr = panel.getBoundingClientRect();
-    startLeft = rr.left - pr.left;
-    startTop = rr.top - pr.top;
+    startLeft = rr.left;
+    startTop = rr.top;
     startX = e.clientX;
     startY = e.clientY;
     dragPointerId = e.pointerId;

--- a/tests/customizer.spec.ts
+++ b/tests/customizer.spec.ts
@@ -210,32 +210,43 @@ return v;`;
     await expect(page.locator('#customize-toggle')).toContainText('Customize (2)');
   });
 
-  test('Customize toolbar pill toggles the panel, and close → reopen always works', async ({ page }) => {
+  test('Customize button toggles the panel, and close → reopen always works', async ({ page }) => {
     const pill = page.locator('#customize-toggle');
     const panel = page.locator('#params-panel');
+    const toolsMenu = page.locator('#viewport-tools-menu');
 
-    // Plain model: no parameters → neither the pill nor the panel show.
+    // The Customize button lives inside the Tools dropdown alongside the other
+    // model-editing tools (not as a standalone toolbar pill).
+    await expect(toolsMenu.locator('#customize-toggle')).toHaveCount(1);
+
+    // Plain model: no parameters → neither the button nor the panel show.
     await page.evaluate((code) => (window as unknown as { partwright: PW }).partwright.run(code), PLAIN_MODEL);
     await expect(pill).toBeHidden();
     await expect(panel).toBeHidden();
 
-    // Parametric model: pill appears (with the count) and the panel opens.
+    // Parametric model: the panel opens AND the Tools dropdown auto-opens with
+    // it, surfacing the Customize button (with its count) just above the panel.
     await page.evaluate((code) => (window as unknown as { partwright: PW }).partwright.run(code), PARAM_MODEL);
+    await expect(toolsMenu).toBeVisible();
     await expect(pill).toBeVisible();
     await expect(pill).toContainText('Customize (4)');
     await expect(panel).toBeVisible();
 
-    // The panel's × closes it; the pill stays visible as the way back in.
+    // The panel's × closes it. As with every docked tool panel, that click lands
+    // outside the Tools popover and collapses the dropdown too — so the way back
+    // in is to reopen the Tools dropdown, where the Customize button still waits.
     await panel.locator('button[aria-label="Close parameters"]').click();
     await expect(panel).toBeHidden();
+    await page.locator('#viewport-tools-group-btn').click();
     await expect(pill).toBeVisible();
+    await expect(pill).toContainText('Customize (4)');
 
     // Re-running the SAME model (e.g. a code edit) must NOT re-pop a panel the
     // user deliberately closed.
     await page.evaluate((code) => (window as unknown as { partwright: PW }).partwright.run(code), PARAM_MODEL);
     await expect(panel).toBeHidden();
 
-    // Clicking the pill reopens it — the discoverable reopen affordance.
+    // Clicking the Customize button reopens it — the discoverable reopen affordance.
     await pill.click();
     await expect(panel).toBeVisible();
 
@@ -334,5 +345,40 @@ return v;`;
     expect(after.x).toBeLessThan(before.x - 10);
     expect(after.y).toBeGreaterThanOrEqual(0);
     expect(after.x).toBeGreaterThanOrEqual(0);
+    // It is window-anchored (position: fixed), so it can roam the whole window.
+    await expect(panel).toHaveCSS('position', 'fixed');
+  });
+
+  test('a dragged panel stays put when a surrounding pane is collapsed', async ({ page }) => {
+    await page.evaluate((code) => (window as unknown as { partwright: PW }).partwright.run(code), PARAM_MODEL);
+    const panel = page.locator('#params-panel');
+    await expect(panel).toBeVisible();
+
+    // Drag it well into the middle so a pane reflow would visibly shift an
+    // absolutely-positioned (pane-relative) panel.
+    const title = panel.locator('text=Customize').first();
+    const titleBox = await title.boundingBox();
+    if (!titleBox) throw new Error('no title box');
+    await page.mouse.move(titleBox.x + titleBox.width / 2, titleBox.y + titleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(titleBox.x - 120, titleBox.y + 140, { steps: 8 });
+    await page.mouse.up();
+
+    const before = await panel.boundingBox();
+    if (!before) throw new Error('no panel box');
+
+    // Collapse the code editor pane — the viewport pane grows, but a
+    // window-anchored panel must not budge. Fire the collapse directly (the
+    // dragged panel may overlap the header button) and let the layout settle.
+    await page.evaluate(() => {
+      const btn = [...document.querySelectorAll('button')].find((b) => b.textContent?.trim() === 'Hide code');
+      (btn as HTMLButtonElement | undefined)?.click();
+    });
+    await page.waitForTimeout(200);
+
+    const after = await panel.boundingBox();
+    if (!after) throw new Error('no panel box after collapse');
+    expect(Math.abs(after.x - before.x)).toBeLessThan(2);
+    expect(Math.abs(after.y - before.y)).toBeLessThan(2);
   });
 });

--- a/tests/customizer.spec.ts
+++ b/tests/customizer.spec.ts
@@ -5,6 +5,7 @@
 // real browser (the sandbox + worker round-trip can't run in the unit tier).
 
 import { test, expect, type Page } from 'playwright/test';
+import { openAiPanel } from './helpers/aiPanel';
 
 const PARAM_MODEL = `const { Manifold } = api;
 const p = api.params({
@@ -380,5 +381,25 @@ return v;`;
     if (!after) throw new Error('no panel box after collapse');
     expect(Math.abs(after.x - before.x)).toBeLessThan(2);
     expect(Math.abs(after.y - before.y)).toBeLessThan(2);
+  });
+
+  test('with the AI panel open, the Customize panel docks over it (window right edge)', async ({ page }) => {
+    await openAiPanel(page);
+    const ai = page.locator('#ai-panel');
+    await expect(ai).toBeVisible();
+
+    await page.evaluate((code) => (window as unknown as { partwright: PW }).partwright.run(code), PARAM_MODEL);
+    const panel = page.locator('#params-panel');
+    await expect(panel).toBeVisible();
+
+    const box = await panel.boundingBox();
+    const aiBox = await ai.boundingBox();
+    if (!box || !aiBox) throw new Error('missing box');
+    const vw = await page.evaluate(() => window.innerWidth);
+
+    // The panel hugs the window's right edge rather than tucking to the left of
+    // the AI column, so it overlays the AI panel by default.
+    expect(vw - (box.x + box.width)).toBeLessThan(24); // right edge ~PANEL_EDGE_GAP from window edge
+    expect(box.x + box.width).toBeGreaterThan(aiBox.x); // and extends over the AI column
   });
 });


### PR DESCRIPTION
## Summary

Reworks the viewport overlay panels (the Customize panel and every `createToolPanelShell` tool — Surface, Resize, Place, Quality, …) so they behave the way the user asked:

- **Drag anywhere in the window.** Panels were `position: absolute` inside the viewport pane and the drag math clamped them to that *parent pane*. They're now `position: fixed` (window-relative) — the drag uses raw `clientX/clientY` and `clampIntoView` clamps to the full window, so a panel can roam the entire screen.
- **Stay put when panes change.** Because the panels are now window-anchored, opening/closing/resizing a surrounding pane (e.g. hiding the code editor, docking the AI panel) reflows the pane but no longer shifts the panel. The only re-clamp left fires on a genuine *window* resize, to pull a panel back on-screen.
- **Dock over the AI pane when it's open.** Panels dock to the window's right edge rather than the viewport pane's right edge, so an open AI column is overlaid by default (manual tool use doesn't need the AI pane visible). Unchanged when the AI pane is closed; the panel is still draggable anywhere. Z-order needs no change — the desktop AI panel is a normal flex child with no stacking context, so the `fixed` tool panels paint on top.
- **Customize lives in the Tools dropdown.** The standalone top-level Customize pill moved into `#viewport-tools-menu` alongside the other editing tools, restyled with the shared `TOOL_TOGGLE_IDLE/ACTIVE` chrome.
- **Auto-open on first open of a parameterizable model.** When a model declares a new/changed parameter schema, the Customize panel auto-reveals *and* pops the Tools dropdown open with it, so the tool list sits just above the freshly-docked panel. Fires only on a genuine schema change, not on manual reopen.

### Notes / trade-offs

- Because the Customize panel sits *outside* the Tools popover wrapper, interacting with it (or closing it) lands a click-outside that collapses the dropdown — identical to every other docked tool panel. After closing, the way back in is reopen-the-dropdown → Customize (plus the command palette `Customize parameters`).
- Tool panels now clamp into the window on open (matching the params panel) so a tall panel can't dock off-screen on the short stacked mobile layout.

## Implementation

- `src/ui/viewportPanelDrag.ts` — `fixed` positioning + window-bounds clamp; docks to the window's right edge.
- `src/ui/paramsPanel.ts` — new `onAutoReveal` callback, fired on schema-change auto-open before the panel is positioned.
- `src/ui/popoverMenu.ts` — `openPopoverGroupById(id)` helper.
- `src/ui/toolPanel.ts` — clamp-into-view on open.
- `src/main.ts` — Customize button mounted into the Tools menu, restyled, `onAutoReveal` → open Tools dropdown.

## Test plan

- `npm run build` ✅ · `npm run test:unit` (909) ✅ · `npm run lint:deps` ✅
- `npx playwright test customizer` (11) ✅ — updated the close→reopen flow to the new dropdown model; added "window-anchored, stays put across editor-pane collapse", "docks over the AI pane when open", and a `position: fixed` assertion on the drag test.
- `npx playwright test viewport-toolbar-groups` (5) ✅ · `place-model` (7) ✅
- Manual browser verification (screenshots): param model auto-opens Tools dropdown + Customize panel; panel drags freely; Customize docks over the open AI pane.

https://claude.ai/code/session_01DA5U9NbPJbsxjTiruVP2yQ