### PR TITLE
perf: serve catalog thumbnails as build-time content-hashed PNGs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,10 @@ playwright/.cache/
 # test_ prefix.
 /public/catalog/test_*.partwright.json
 
+# Build-time content-hashed catalog thumbnails — emitted by the prerender
+# plugin's buildStart from each entry's stored data-URL thumbnail. Generated,
+# never hand-edited.
+/public/catalog/thumbs/
+
 # partwright CLI daemon state (pid/ports, logs, persistent Chromium profile)
 .partwright/

--- a/prompts/20260609-140000-catalog-hashed-thumbnails.md
+++ b/prompts/20260609-140000-catalog-hashed-thumbnails.md
@@ -1,0 +1,64 @@
+---
+session: "5c6e31e7"
+timestamp: "2026-06-09T14:00:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+sequence: 6
+---
+
+## Human
+
+After shipping the catalog cache fix + lazy-load (#537), questioned whether
+`no-cache` was right: "Can't we use force-cache but add cache busting params to
+the links?" Agreed the instinct was right and that the best realization is
+content-hashed thumbnail files rather than a `?v=` query param. Chose: merge
+#537, do hashed PNGs as a follow-up. Clarified the mechanism: hashing happens
+**"during build time"**, so **"new builds bust the cache but regular refreshes
+don't."**
+
+## Assistant
+
+## Key decisions
+
+**Why hashed PNG files over `?v=` on the JSON fetch.** `no-cache` is correct but
+revalidates every thumbnail on every visit. A `?v=hash` query param on the
+entry-JSON fetch would cache better, but still downloads the whole session
+payload (code + geometryData + the base64 thumbnail) just to show a picture. The
+strictly-better move is to emit each thumbnail as its own content-hashed PNG and
+point the tile `<img>` straight at it: immutable caching for free, a binary PNG
+(not 33%-larger base64-in-JSON), native `loading="lazy"`, and no client fetch at
+all. Content hash = a *changed* thumbnail gets a new filename (new build busts
+only what changed), an *unchanged* one keeps its name (refreshes, and even
+unchanged tiles across deploys, hit cache).
+
+**Build-time emission via `buildStart`, written into a gitignored
+`public/catalog/thumbs/`.** Considered Vite `emitFile` (build) + a dev
+middleware (dev), but that splits the logic across two code paths. Writing the
+hashed PNGs into `public/` from the prerender plugin's `buildStart` (a Rollup
+hook Vite runs for *both* the dev server and the production build) means Vite's
+normal public-dir serving (dev) and public→dist copy (build) handle delivery
+with zero divergence — no middleware, no `emitFile`. The dir is cleared each run
+so stale hashes don't accumulate, and gitignored since it's generated.
+
+**Single-sourced hash.** `prepareCatalogThumbnails(publicDir)` in `render.ts`
+decodes each entry's stored data-URL thumbnail, hashes the bytes
+(`sha256` → 16 hex), writes `<id>.<hash>.png`, and records the URL in a
+module-level map. `catalogTileHtml` reads that map for the `<img src>`, so the
+file written and the URL rendered always agree (same module, same bytes).
+
+**Removed the client hydration entirely.** The tile `<img>` now ships a real
+`src` (dropped `data-pw-thumb` and the `opacity:0`→JS-fade), so
+`catalogEntry.ts` no longer fetches or hydrates anything — just the search/filter
+wiring + tooltips. The IntersectionObserver from #539 is replaced by native
+`loading="lazy"`. The entry JSON keeps its data-URL thumbnail as the build-time
+source of truth; the catalog page no longer downloads it.
+
+**Immutable headers.** Added a `public/_headers` rule giving
+`/catalog/thumbs/*` `Cache-Control: public, max-age=31536000, immutable` — safe
+because the names are content-hashed. This is what makes "refreshes don't
+re-fetch" real on Cloudflare Pages.
+
+**Verified:** `npm run build` emits 103 hashed PNGs to `dist/catalog/thumbs/`;
+`catalog.html` references the hashed paths and contains zero `data-pw-thumb`. In
+the browser, all 103 tiles carry a `/catalog/thumbs/<id>.<hash>.png` src and the
+above-fold image decodes. `lint:deadcode`/`lint:deps` clean; catalog e2e 8/8.

--- a/public/_headers
+++ b/public/_headers
@@ -11,6 +11,12 @@
   Cross-Origin-Embedder-Policy: require-corp
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' https: http://localhost:* http://127.0.0.1:* https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://huggingface.co https://*.huggingface.co https://*.xethub.hf.co https://raw.githubusercontent.com; worker-src 'self' blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'
 
+# Catalog thumbnails carry a content hash in their filename, so they're safe to
+# cache forever — a changed image gets a new name. Immutable = no revalidation
+# on refresh; only a new build (new hash) busts it.
+/catalog/thumbs/*
+  Cache-Control: public, max-age=31536000, immutable
+
 /*.md
   Content-Type: text/markdown; charset=utf-8
 

--- a/src/content/build/prerenderPlugin.ts
+++ b/src/content/build/prerenderPlugin.ts
@@ -9,7 +9,8 @@
 // behavior wired up by public/_redirects on Cloudflare Pages.
 
 import type { Plugin, Connect } from 'vite';
-import { renderContentBody, CONTENT_PAGES, type ContentPage } from './render';
+import { resolve } from 'node:path';
+import { renderContentBody, prepareCatalogThumbnails, CONTENT_PAGES, type ContentPage } from './render';
 import { contentHeaderHtml } from '../chrome';
 
 const PLACEHOLDER = '<!--PW-CONTENT-->';
@@ -51,6 +52,13 @@ function rewriteMiddleware(): Connect.NextHandleFunction {
 export function prerenderContentPages(): Plugin {
   return {
     name: 'partwright-prerender-content-pages',
+    // Emit each catalog entry's thumbnail as a content-hashed PNG under
+    // public/catalog/thumbs/ before anything renders, so the tiles (built in
+    // transformIndexHtml) can point <img src> straight at the hashed file. Runs
+    // for both the dev server and the production build.
+    buildStart() {
+      prepareCatalogThumbnails(resolve(process.cwd(), 'public'));
+    },
     transformIndexHtml: {
       order: 'pre',
       handler(html, ctx) {

--- a/src/content/build/render.ts
+++ b/src/content/build/render.ts
@@ -19,8 +19,9 @@ import {
   type CatalogLanguage,
   type CatalogManifestEntry,
 } from '../data/catalogCategories';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { createHash } from 'node:crypto';
 
 /** Production origin for absolute links baked into the static pages (e.g. the
  *  help page's example agent prompt). Mirrors the absoluteUrls plugin's env
@@ -146,6 +147,57 @@ interface BuiltTile {
   category: CategoryId;
 }
 
+// Per-entry hashed thumbnail URL (entry.file → "/catalog/thumbs/<id>.<hash>.png"),
+// filled by prepareCatalogThumbnails() and read by catalogTileHtml(). Empty until
+// the prerender plugin's buildStart runs (dev + build).
+const thumbSrcByFile = new Map<string, string>();
+
+/** Decode each catalog entry's stored thumbnail (a base64 PNG data URL in its
+ *  session JSON) into a **content-hashed** PNG under `<publicDir>/catalog/thumbs/`,
+ *  and remember the hashed URL per entry so the tiles can point `<img src>` at it.
+ *
+ *  Content-hashed filenames make these immutably cacheable (see `public/_headers`):
+ *  a refresh re-uses the cached image with no request, while a *changed* thumbnail
+ *  hashes to a new name — so a new build busts only what actually changed, never
+ *  the unchanged tiles. This replaces the old client-side per-entry JSON fetch.
+ *
+ *  Idempotent and deterministic; called once from the prerender plugin's
+ *  `buildStart` (so the files exist for both the dev server and the production
+ *  build). Failures for one entry just skip its thumbnail (the tile keeps its
+ *  placeholder glyph). */
+export function prepareCatalogThumbnails(publicDir: string): void {
+  thumbSrcByFile.clear();
+  const catalogDir = resolve(publicDir, 'catalog');
+  const thumbsDir = resolve(catalogDir, 'thumbs');
+  let entries: CatalogManifestEntry[];
+  try {
+    entries = (JSON.parse(readFileSync(resolve(catalogDir, 'manifest.json'), 'utf8')) as { entries: CatalogManifestEntry[] }).entries ?? [];
+  } catch {
+    return;
+  }
+  // Start clean so stale hashes (from removed or re-baked thumbnails) don't pile up.
+  try { rmSync(thumbsDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  mkdirSync(thumbsDir, { recursive: true });
+  for (const entry of entries) {
+    try {
+      const payload = JSON.parse(readFileSync(resolve(catalogDir, entry.file), 'utf8')) as {
+        versions?: { thumbnail?: string | null }[];
+      };
+      const versions = payload.versions ?? [];
+      const dataUrl = versions.length > 0 ? versions[versions.length - 1].thumbnail : null;
+      const m = dataUrl?.match(/^data:image\/png;base64,(.+)$/);
+      if (!m) continue;
+      const bytes = Buffer.from(m[1], 'base64');
+      const hash = createHash('sha256').update(bytes).digest('hex').slice(0, 16);
+      const fileName = `${entry.id}.${hash}.png`;
+      writeFileSync(resolve(thumbsDir, fileName), bytes);
+      thumbSrcByFile.set(entry.file, `/catalog/thumbs/${fileName}`);
+    } catch {
+      // No usable thumbnail for this entry — the tile falls back to its glyph.
+    }
+  }
+}
+
 /** Read the catalog manifest + each session file from public/catalog at build
  *  time, deriving each tile's language, traits, version count, and category.
  *  Failures degrade to an empty list (the page still renders its intro). */
@@ -195,10 +247,17 @@ function catalogTileHtml(tile: BuiltTile): string {
     ? `<span>${tile.versionCount} version${tile.versionCount !== 1 ? 's' : ''}</span>`
     : '';
   const haystack = [tile.entry.name, tile.entry.description ?? '', tile.entry.id, badge.label, print.search].join(' ').toLowerCase();
-  return `<a href="/editor?catalog=${encodeURIComponent(tile.entry.file)}" data-pw-thumb="${escAttr(tile.entry.file)}" data-catalog-tile data-language="${escAttr(tile.language)}" data-search="${escAttr(haystack)}" class="flex flex-col bg-zinc-800 rounded-lg border border-zinc-700 hover:border-zinc-500 transition-colors overflow-hidden no-underline">
+  // Thumbnail src is a content-hashed PNG emitted at build time (see
+  // prepareCatalogThumbnails); the browser lazy-loads it natively. Tiles with no
+  // thumbnail keep just the placeholder glyph.
+  const thumbSrc = thumbSrcByFile.get(tile.entry.file);
+  const thumbImg = thumbSrc
+    ? `<img src="${escAttr(thumbSrc)}" alt="${escAttr(tile.entry.name)}" loading="lazy" decoding="async" class="absolute inset-0 w-full h-full object-contain" />`
+    : '';
+  return `<a href="/editor?catalog=${encodeURIComponent(tile.entry.file)}" data-catalog-tile data-language="${escAttr(tile.language)}" data-search="${escAttr(haystack)}" class="flex flex-col bg-zinc-800 rounded-lg border border-zinc-700 hover:border-zinc-500 transition-colors overflow-hidden no-underline">
   <div class="relative w-full aspect-square bg-zinc-900 flex items-center justify-center overflow-hidden">
     <span class="text-3xl text-zinc-700">&#11041;</span>
-    <img alt="${escAttr(tile.entry.name)}" loading="lazy" class="absolute inset-0 w-full h-full object-contain" style="opacity:0;transition:opacity .2s" />
+    ${thumbImg}
   </div>
   <div class="px-3 py-2.5">
     <div class="text-sm font-medium text-zinc-100 truncate">${esc(tile.entry.name)}</div>

--- a/src/content/catalogEntry.ts
+++ b/src/content/catalogEntry.ts
@@ -1,10 +1,11 @@
 // The ONLY client script on any content page — and it runs only on /catalog.
-// The catalog tiles' text (name, description, language, category) are baked
-// into the static HTML at build time for crawlers; this hydrates each tile's
-// thumbnail lazily so the initial HTML stays small. Tiles are plain <a> links
-// to /editor?catalog=<file>, so the page is fully functional without it. It
-// also wires the search box + language filter pills (progressive enhancement —
-// the full catalog renders server-side; this just hides/shows on top).
+// The catalog tiles' text (name, description, language, category) AND their
+// thumbnails are baked into the static HTML at build time: each tile's <img>
+// points at a content-hashed PNG (/catalog/thumbs/<id>.<hash>.png) emitted by
+// the prerender plugin (see prepareCatalogThumbnails in build/render.ts) and is
+// lazy-loaded natively. So this script only wires the search box + language
+// filter pills and swaps the slow native tooltips — there's no thumbnail
+// hydration left to do.
 //
 // Keep the import graph empty: this must not pull in any app/engine code. The
 // imports below are dependency-free — wireCatalogFilter is pure DOM, and
@@ -13,57 +14,6 @@
 import { wireCatalogFilter } from './catalogFilter';
 import { initTooltips } from '../ui/tooltip';
 
-/** Fetch one tile's thumbnail from its entry JSON and apply it. Each tile loads
- *  at most once. `no-cache` revalidates (cheap 304 when unchanged) so an updated
- *  thumbnail is never masked by a stale cached copy. */
-async function loadThumbnail(tile: HTMLElement): Promise<void> {
-  const file = tile.getAttribute('data-pw-thumb');
-  if (!file) return;
-  const img = tile.querySelector<HTMLImageElement>('img');
-  if (!img) return;
-  try {
-    const res = await fetch(`/catalog/${file}`, { cache: 'no-cache' });
-    if (!res.ok) return;
-    const payload = await res.json() as { versions?: { thumbnail?: string | null }[] };
-    const versions = payload.versions ?? [];
-    const src = versions.length > 0 ? (versions[versions.length - 1].thumbnail ?? null) : null;
-    if (src) {
-      img.src = src;
-      img.style.opacity = '1';
-    }
-  } catch { /* leave placeholder */ }
-}
-
-async function hydrateThumbnails(): Promise<void> {
-  const tiles = Array.from(document.querySelectorAll<HTMLElement>('[data-pw-thumb]'));
-  if (tiles.length === 0) return;
-
-  // Lazy, per-tile: a tile's thumbnail (a base64 data URL embedded in its entry
-  // JSON) is fetched only as the tile nears the viewport. There is intentionally
-  // no aggregate `thumbs.json` — bundling every thumbnail into one file doesn't
-  // scale: it grows unbounded with the catalog and blocks the whole page on a
-  // single multi-MB download even for tiles far below the fold. Loading on demand
-  // keeps the page fast no matter how large the catalog grows.
-  if (typeof IntersectionObserver === 'undefined') {
-    // Ancient browser with no IO: just load everything (old behavior).
-    await Promise.all(tiles.map(loadThumbnail));
-    return;
-  }
-
-  // Start fetching ~300px before a tile scrolls into view so the image is
-  // usually ready by the time it's on screen; unobserve after the first hit so
-  // each tile loads exactly once.
-  const observer = new IntersectionObserver((entries, obs) => {
-    for (const entry of entries) {
-      if (!entry.isIntersecting) continue;
-      const tile = entry.target as HTMLElement;
-      obs.unobserve(tile);
-      void loadThumbnail(tile);
-    }
-  }, { rootMargin: '300px 0px' });
-  for (const tile of tiles) observer.observe(tile);
-}
-
 function init(): void {
   wireCatalogFilter(document);
   // Replace the slow native `title` tooltips on the catalog's tags/badges with
@@ -71,7 +21,6 @@ function init(): void {
   // The static catalog page never boots main.ts, so without this the tags fall
   // back to the browser's ~0.5–1.5s native tooltip delay.
   initTooltips();
-  void hydrateThumbnails();
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary

Follow-up to #537 (the cache fix + lazy-load). Replaces the client-side thumbnail hydration with **build-time content-hashed PNG files**, which is the clean realization of "force-cache + cache busting": hashing happens at build, so a new build busts only what changed and plain refreshes never re-fetch.

**Before:** each tile fetched its entire `*.partwright.json` (code + geometry stats + base64 thumbnail) via `IntersectionObserver` just to extract one image, with `no-cache` revalidation on every visit.

**After:**
- The prerender plugin's `buildStart` decodes each entry's stored data-URL thumbnail into a content-hashed PNG at `public/catalog/thumbs/<id>.<hash>.png` (`prepareCatalogThumbnails` in `render.ts`). Runs for both the dev server and the production build, so Vite's normal public-dir serving / public→dist copy delivers them — no `emitFile`, no dev middleware split.
- The tile `<img>` points straight at the hashed path with native `loading="lazy"` (`decoding="async"`). `data-pw-thumb` and the JS hydration are gone — `catalogEntry.ts` is now just search/filter + tooltips.
- `public/_headers` gives `/catalog/thumbs/*` `Cache-Control: public, max-age=31536000, immutable` — safe because the filename is a content hash.

**Wins:** immutable caching (refreshes re-use cache, only changed thumbnails bust), smaller transfers (binary PNG vs 33%-larger base64-in-JSON that also dragged along code+stats), and simpler (native lazy-load, no IO, no client fetch). The generated `public/catalog/thumbs/` is gitignored; the entry JSON keeps its data-URL thumbnail as the build-time source of truth.

## Test plan
- `npm run build` ✅ — emits 103 hashed PNGs to `dist/catalog/thumbs/`; `catalog.html` references the hashed paths and contains **0** `data-pw-thumb`.
- Browser-verified: all 103 tiles carry a `/catalog/thumbs/<id>.<hash>.png` src and the above-fold image decodes.
- `lint:deadcode` / `lint:deps` clean; **catalog e2e 8/8**.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_019nSNrMeHCBvoLkrZs4Yeyi

---
_Generated by [Claude Code](https://claude.ai/code/session_019nSNrMeHCBvoLkrZs4Yeyi)_