### PR TITLE
fix: stabilize code editor scroll against re-measure snaps near the bottom

### DIFF
--- a/prompts/editor-blur-scroll-pin.md
+++ b/prompts/editor-blur-scroll-pin.md
@@ -1,0 +1,61 @@
+---
+session: "01AhYR"
+timestamp: "2026-06-09T19:15:00Z"
+---
+
+## Human
+
+When I scroll all the way down in the code pane (with a lot of code — my model
+has 170 lines) and then click to drag a tool modal, the code in the editor
+shifts up about 1 to 3 lines. It only seems to happen when scrolled all the way
+to the bottom (couldn't repro at other line numbers); feels like a stutter, as
+if the code updated when it didn't. Make sure scrolling to the bottom and using
+other parts of the app doesn't cause that stutter. (Clarified: it happens any
+time focus leaves the editor pane, in Chrome, with a clean model and no error
+panel.)
+
+## Assistant
+
+## Key decisions
+
+**Diagnosed it as a CodeMirror focus-change re-measure that re-clamps
+max-scroll.** Built faithful headless reproductions of every interaction —
+opening/dragging the tool modal, blurring the editor, window resizes, the error
+panel appearing (shrinking the pane 605→319px) — across device pixel ratios
+1/1.25/1.5/2 and both caret positions. In headless Chromium the editor's
+`scrollTop` stayed pinned at the bottom in every case (zero swing). The symptom
+profile — only at the very bottom, only real Chrome, on any blur, never in
+automation — points to real headed Chrome running CodeMirror's deferred
+focus-change pass (`observers.blur → updateForFocusChange → view.update([])`),
+which re-measures and lets the browser re-clamp `scrollTop` at exact max-scroll,
+nudging the visible lines. Ruled out browser scroll-anchoring (CodeMirror
+already sets `overflow-anchor: none` on `.cm-scroller`) and the app's
+onBlur work (`surfacePendingError` is a no-op for a clean model; `autosaveDraft`
+is an IndexedDB write).
+
+**Fixed it with a targeted scroll-pin guard rather than chasing the exact
+trigger.** Since the nudge can't be reproduced in this sandbox, I made the
+symptom impossible regardless of source: `pinScrollAfterBlur` in
+`src/editor/codeEditor.ts` snapshots the scroll offset when the editor loses
+focus and holds it for a short window, re-applying it if something moves it by
+less than a few lines — so the nudge never paints. It is deliberately narrow:
+
+- **Engages only at the very bottom** (within one line-height of max-scroll),
+  where the bug lives — inert everywhere else, so mid-document focus changes are
+  untouched.
+- **Bails out on any genuine scroll** — user wheel / touch / pointer gesture, or
+  a large programmatic jump (> 4 line-heights, e.g. reveal-diagnostic) — so it
+  can never block real navigation.
+- Thresholds are **line-height-relative** (`view.defaultLineHeight`), not magic
+  pixels.
+
+**Made the window a tunable config knob, not a hardcoded constant** (per the
+repo rule): `ui.codeEditorBlurScrollPinMs` (default 180 ms) in `appConfig.ts`,
+surfaced in the advanced settings modal, with `0` disabling the guard.
+
+**Verification.** Couldn't reproduce the original jump headlessly (it's
+real-display-specific), so I verified the *guard* instead with three e2e tests
+(`tests/editor-blur-scroll.spec.ts`): a simulated small post-blur nudge at the
+bottom is reverted; a large programmatic scroll after blur is honored; and away
+from the bottom the guard stays inert. Build + full unit tier green. The user
+should confirm the stutter is gone in their real Chrome.

--- a/prompts/editor-blur-scroll-pin.md
+++ b/prompts/editor-blur-scroll-pin.md
@@ -16,6 +16,32 @@ panel.)
 
 ## Assistant
 
+## Follow-up (after user testing)
+
+The first fix (a blur-only pin) didn't fully solve it. The user reported the
+stutter **persists** and clarified it happens "any time focus changes away from
+the editor pane" *and* while clicking around tool menus — "not just on a blur" —
+and described it precisely: a line of clear space below the last line snaps shut
+so the pane bottom aligns with the last line of code (a one-line jump). That's
+CodeMirror reconciling its line-height model against real Chrome's fractional,
+device-pixel-rounded line boxes; the re-measure fires on **any** trigger (focus
+change, layout reflow from a menu/panel, its own measure loop), not only blur.
+
+**Replaced the blur hook with a persistent, input-aware bottom-scroll
+stabilizer** (`installBottomScrollStabilizer`, installed once on the editor
+view). It listens for scroll events and reverts an *unsolicited* small
+(≤ 3 line-heights) scroll change while the editor is parked near the bottom —
+the measure snap — before the browser paints. It stays out of the way of every
+genuine scroll by tracking user intent: a recent wheel/keydown (within the
+`codeEditorScrollPinMs` grace window) or a held pointer (scrollbar drag / touch
+pan) marks the scroll as the user's and it's always honored; a large jump
+(reveal-diagnostic / jump-to-match) is adopted as real navigation. "Near the
+bottom" is anchored to the user's intended offset, not the post-snap position,
+so a snap right at the threshold is still caught. Renamed the config knob to
+`ui.codeEditorScrollPinMs` (default 250 ms, 0 disables) and broadened the e2e
+suite to five cases (revert after blur, revert focused-idle, honor-after-keys,
+honor-large-nav, inert-mid-document).
+
 ## Key decisions
 
 **Diagnosed it as a CodeMirror focus-change re-measure that re-clamps

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -156,6 +156,12 @@ export interface AppConfig {
     tooltipDelayMs: number;
     /** Idle delay (ms) after the last keystroke before error annotations appear in the code editor. */
     codeEditorErrorIdleMs: number;
+    /** How long (ms) to pin the code editor's scroll offset after it loses focus
+     *  while scrolled to the very bottom. Real Chrome can nudge the scroll by a
+     *  line or two on blur (a deferred focus-change re-measure re-clamps the
+     *  max-scroll position); pinning for this window absorbs that without
+     *  blocking real scrolling (any user scroll disengages it immediately). */
+    codeEditorBlurScrollPinMs: number;
     /** Debounce delay (ms) after the last companion-file keystroke before the
      *  draft is autosaved, so companion edits survive a reload without writing
      *  to IndexedDB on every keystroke. */
@@ -269,6 +275,7 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     toastDurationMs: 2200,
     tooltipDelayMs: 150,
     codeEditorErrorIdleMs: 800,
+    codeEditorBlurScrollPinMs: 180,
     companionDraftDebounceMs: 600,
     workCameraSaveDebounceMs: 500,
     surfacePreviewDebounceMs: 250,

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -156,12 +156,13 @@ export interface AppConfig {
     tooltipDelayMs: number;
     /** Idle delay (ms) after the last keystroke before error annotations appear in the code editor. */
     codeEditorErrorIdleMs: number;
-    /** How long (ms) to pin the code editor's scroll offset after it loses focus
-     *  while scrolled to the very bottom. Real Chrome can nudge the scroll by a
-     *  line or two on blur (a deferred focus-change re-measure re-clamps the
-     *  max-scroll position); pinning for this window absorbs that without
-     *  blocking real scrolling (any user scroll disengages it immediately). */
-    codeEditorBlurScrollPinMs: number;
+    /** Input-grace window (ms) for the code editor's bottom-scroll stabilizer.
+     *  When the editor is parked near the very bottom, a programmatic one-line
+     *  re-measure snap (real Chrome reconciling fractional line heights on a
+     *  focus change / layout reflow) is reverted so the code doesn't stutter —
+     *  unless a real scroll happened within this window (wheel, scrollbar drag,
+     *  touch, keyboard/typing), which is always honored. Set to 0 to disable. */
+    codeEditorScrollPinMs: number;
     /** Debounce delay (ms) after the last companion-file keystroke before the
      *  draft is autosaved, so companion edits survive a reload without writing
      *  to IndexedDB on every keystroke. */
@@ -275,7 +276,7 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     toastDurationMs: 2200,
     tooltipDelayMs: 150,
     codeEditorErrorIdleMs: 800,
-    codeEditorBlurScrollPinMs: 180,
+    codeEditorScrollPinMs: 250,
     companionDraftDebounceMs: 600,
     workCameraSaveDebounceMs: 500,
     surfacePreviewDebounceMs: 250,

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -205,54 +205,78 @@ export interface EditorHooks {
   onBlur?: () => void;
 }
 
-/** Hold the editor's scroll offset steady for a short window after it loses
- *  focus while scrolled to the very bottom.
+/** Keep the code editor's scroll position from drifting when CodeMirror
+ *  re-measures while the editor is parked at (or near) the very bottom.
  *
- *  In real Chrome, blurring the editor while it's scrolled flush against the
- *  bottom nudges the visible code up by a line or two: CodeMirror runs a
- *  deferred focus-change pass that re-measures the height model, and at exact
- *  max-scroll the browser re-clamps `scrollTop`, shifting which lines are in
- *  view. It only manifests at the bottom (anywhere else the offset is preserved
- *  exactly) and only on a real display, which is why it reads as a "stutter"
- *  when you click away to drag a tool panel.
+ *  On a real display, CodeMirror's line-height model never perfectly matches
+ *  Chrome's fractional, device-pixel-rounded line boxes, so over a long
+ *  document the modelled content height drifts from the real DOM height by
+ *  ~a line. Whenever something makes CodeMirror re-measure — a focus change, a
+ *  layout reflow from opening a tool menu/panel, or its own measure loop — it
+ *  reconciles the two and the browser re-clamps `scrollTop` at max-scroll,
+ *  snapping the visible code by a line. It only shows at the bottom (anywhere
+ *  else the offset is preserved exactly) and only on a real display, so it reads
+ *  as a one-line "stutter" when you click around with the editor scrolled down.
  *
- *  This pins the offset for `codeEditorBlurScrollPinMs` and re-applies it if
- *  something moves it by less than a couple of lines, so the nudge never paints.
- *  It bails out immediately on any genuine scroll — a user wheel/touch/pointer
- *  gesture, or a large programmatic jump like reveal-diagnostic — so it can
- *  never block real navigation. Thresholds are line-height-relative, not magic
- *  pixels. */
-function pinScrollAfterBlur(view: EditorView): void {
-  const pinMs = getConfig().ui.codeEditorBlurScrollPinMs;
-  if (pinMs <= 0) return; // disabled
+ *  This installs a persistent stabilizer: when a *programmatic* scroll nudges
+ *  the editor by less than a couple of lines while it's resting near the bottom,
+ *  it reverts to the last user-intended offset before the browser paints, so the
+ *  snap is invisible. It stays out of the way of every genuine scroll — wheel,
+ *  trackpad/momentum, scrollbar drag, touch, and keyboard/typing are all tracked
+ *  as user intent and always honored — and a large jump (reveal-diagnostic,
+ *  jump-to-match) is treated as real navigation. Thresholds are
+ *  line-height-relative, not magic pixels. */
+function installBottomScrollStabilizer(view: EditorView): void {
   const sc = view.scrollDOM;
-  const lineH = view.defaultLineHeight || 18;
-  const top = sc.scrollTop;
-  // The bug is specific to resting at the very bottom; ignore every other
-  // scroll position so we never interfere with mid-document focus changes.
-  if (sc.scrollHeight - (top + sc.clientHeight) > lineH) return;
+  // The grace window (ms) during which recent user input means a scroll is the
+  // user's own intent and must never be reverted.
+  const inputGraceMs = (): number => getConfig().ui.codeEditorScrollPinMs;
 
-  let active = true;
-  const stop = (): void => {
-    if (!active) return;
-    active = false;
-    sc.removeEventListener('scroll', onScroll);
-    sc.removeEventListener('wheel', stop);
-    sc.removeEventListener('pointerdown', stop);
-    sc.removeEventListener('touchstart', stop);
+  let intendedTop = sc.scrollTop; // the offset we believe the user wants
+  let lastWheel = -Infinity;
+  let lastKey = -Infinity;
+  let pointerDown = false; // covers scrollbar drag + touch pan
+  let reverting = false;
+
+  const lineH = (): number => view.defaultLineHeight || 18;
+  const userActive = (): boolean => {
+    const now = performance.now();
+    const grace = inputGraceMs();
+    return pointerDown || now - lastWheel < grace || now - lastKey < grace;
   };
-  const onScroll = (): void => {
-    if (!active) return;
-    // A move larger than a few lines is real navigation (jump-to-match /
-    // reveal-diagnostic) — let it stand and stop pinning.
-    if (Math.abs(sc.scrollTop - top) > lineH * 4) { stop(); return; }
-    if (sc.scrollTop !== top) sc.scrollTop = top;
-  };
-  sc.addEventListener('scroll', onScroll);
-  sc.addEventListener('wheel', stop, { passive: true });
-  sc.addEventListener('pointerdown', stop);
-  sc.addEventListener('touchstart', stop, { passive: true });
-  window.setTimeout(stop, pinMs);
+
+  // Track user-driven scroll intent. Capture phase so we see input even when the
+  // editor isn't focused (e.g. dragging the scrollbar).
+  sc.addEventListener('wheel', () => { lastWheel = performance.now(); }, { capture: true, passive: true });
+  sc.addEventListener('keydown', () => { lastKey = performance.now(); }, true);
+  // Pointer down/up is tracked on the document: a scrollbar drag holds the
+  // pointer down on the scroller without firing wheel/keydown.
+  const onPointerDown = (): void => { pointerDown = true; };
+  const onPointerUp = (): void => { pointerDown = false; };
+  document.addEventListener('pointerdown', onPointerDown, true);
+  document.addEventListener('pointerup', onPointerUp, true);
+  document.addEventListener('pointercancel', onPointerUp, true);
+
+  sc.addEventListener('scroll', () => {
+    if (reverting) return;
+    if (getConfig().ui.codeEditorScrollPinMs <= 0) { intendedTop = sc.scrollTop; return; } // disabled
+    const lh = lineH();
+    const maxScroll = sc.scrollHeight - sc.clientHeight;
+    // Anchor "near the bottom" to where the user *wanted* to be (intendedTop),
+    // not the post-snap position — the snap moves us a line off the bottom, so
+    // testing the current offset would miss it right at the boundary.
+    const wasNearBottom = maxScroll - intendedTop <= lh * 2;
+    const delta = sc.scrollTop - intendedTop;
+    // Revert only an unsolicited, small, near-bottom nudge — the measure snap.
+    if (!userActive() && wasNearBottom && delta !== 0 && Math.abs(delta) <= lh * 3) {
+      reverting = true;
+      sc.scrollTop = intendedTop;
+      reverting = false;
+      return;
+    }
+    // Otherwise this is the user's intent (or real navigation): adopt it.
+    intendedTop = sc.scrollTop;
+  }, { passive: true });
 }
 
 export function initEditor(
@@ -288,7 +312,7 @@ export function initEditor(
         }
       }),
       EditorView.domEventHandlers({
-        blur: (_event, view) => { pinScrollAfterBlur(view); hooks.onBlur?.(); return false; },
+        blur: () => { hooks.onBlur?.(); return false; },
       }),
       EditorView.theme({
         '&': { height: '100%', fontSize: '13px' },
@@ -303,6 +327,8 @@ export function initEditor(
     state,
     parent: container,
   });
+
+  installBottomScrollStabilizer(editorView);
 
   onThemeChange((theme) => {
     if (!editorView) return;

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -205,6 +205,56 @@ export interface EditorHooks {
   onBlur?: () => void;
 }
 
+/** Hold the editor's scroll offset steady for a short window after it loses
+ *  focus while scrolled to the very bottom.
+ *
+ *  In real Chrome, blurring the editor while it's scrolled flush against the
+ *  bottom nudges the visible code up by a line or two: CodeMirror runs a
+ *  deferred focus-change pass that re-measures the height model, and at exact
+ *  max-scroll the browser re-clamps `scrollTop`, shifting which lines are in
+ *  view. It only manifests at the bottom (anywhere else the offset is preserved
+ *  exactly) and only on a real display, which is why it reads as a "stutter"
+ *  when you click away to drag a tool panel.
+ *
+ *  This pins the offset for `codeEditorBlurScrollPinMs` and re-applies it if
+ *  something moves it by less than a couple of lines, so the nudge never paints.
+ *  It bails out immediately on any genuine scroll — a user wheel/touch/pointer
+ *  gesture, or a large programmatic jump like reveal-diagnostic — so it can
+ *  never block real navigation. Thresholds are line-height-relative, not magic
+ *  pixels. */
+function pinScrollAfterBlur(view: EditorView): void {
+  const pinMs = getConfig().ui.codeEditorBlurScrollPinMs;
+  if (pinMs <= 0) return; // disabled
+  const sc = view.scrollDOM;
+  const lineH = view.defaultLineHeight || 18;
+  const top = sc.scrollTop;
+  // The bug is specific to resting at the very bottom; ignore every other
+  // scroll position so we never interfere with mid-document focus changes.
+  if (sc.scrollHeight - (top + sc.clientHeight) > lineH) return;
+
+  let active = true;
+  const stop = (): void => {
+    if (!active) return;
+    active = false;
+    sc.removeEventListener('scroll', onScroll);
+    sc.removeEventListener('wheel', stop);
+    sc.removeEventListener('pointerdown', stop);
+    sc.removeEventListener('touchstart', stop);
+  };
+  const onScroll = (): void => {
+    if (!active) return;
+    // A move larger than a few lines is real navigation (jump-to-match /
+    // reveal-diagnostic) — let it stand and stop pinning.
+    if (Math.abs(sc.scrollTop - top) > lineH * 4) { stop(); return; }
+    if (sc.scrollTop !== top) sc.scrollTop = top;
+  };
+  sc.addEventListener('scroll', onScroll);
+  sc.addEventListener('wheel', stop, { passive: true });
+  sc.addEventListener('pointerdown', stop);
+  sc.addEventListener('touchstart', stop, { passive: true });
+  window.setTimeout(stop, pinMs);
+}
+
 export function initEditor(
   container: HTMLElement,
   initialCode: string,
@@ -238,7 +288,7 @@ export function initEditor(
         }
       }),
       EditorView.domEventHandlers({
-        blur: () => { hooks.onBlur?.(); return false; },
+        blur: (_event, view) => { pinScrollAfterBlur(view); hooks.onBlur?.(); return false; },
       }),
       EditorView.theme({
         '&': { height: '100%', fontSize: '13px' },

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -781,13 +781,13 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           onChange={v => set('ui', 'codeEditorErrorIdleMs', v)}
         />
         <Field
-          label="Code editor blur scroll-pin window"
+          label="Code editor bottom-scroll stabilizer"
           unit="ms"
-          tooltip="When the code editor is scrolled to the very bottom and you click away (e.g. to drag a tool panel), real Chrome can nudge the visible code up by a line or two. For this long after focus leaves the editor, its scroll position is held steady so the code doesn't stutter. Any real scroll (wheel/touch/drag) cancels the hold immediately. Set to 0 to disable."
-          defaultValue={APP_CONFIG_DEFAULTS.ui.codeEditorBlurScrollPinMs}
-          value={c.ui.codeEditorBlurScrollPinMs}
+          tooltip="When the code editor is scrolled near the very bottom, real Chrome can snap the visible code by a line whenever CodeMirror re-measures (a focus change, opening a tool menu/panel, etc.). The stabilizer reverts that one-line snap so the code doesn't stutter, while always honoring real scrolling. This is the input-grace window: a wheel/scrollbar/touch/keyboard scroll within this window is treated as your intent and never reverted. Set to 0 to disable."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.codeEditorScrollPinMs}
+          value={c.ui.codeEditorScrollPinMs}
           min={0} max={1_000} integer
-          onChange={v => set('ui', 'codeEditorBlurScrollPinMs', v)}
+          onChange={v => set('ui', 'codeEditorScrollPinMs', v)}
         />
         <Field
           label="Companion draft autosave debounce"

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -781,6 +781,15 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           onChange={v => set('ui', 'codeEditorErrorIdleMs', v)}
         />
         <Field
+          label="Code editor blur scroll-pin window"
+          unit="ms"
+          tooltip="When the code editor is scrolled to the very bottom and you click away (e.g. to drag a tool panel), real Chrome can nudge the visible code up by a line or two. For this long after focus leaves the editor, its scroll position is held steady so the code doesn't stutter. Any real scroll (wheel/touch/drag) cancels the hold immediately. Set to 0 to disable."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.codeEditorBlurScrollPinMs}
+          value={c.ui.codeEditorBlurScrollPinMs}
+          min={0} max={1_000} integer
+          onChange={v => set('ui', 'codeEditorBlurScrollPinMs', v)}
+        />
+        <Field
           label="Companion draft autosave debounce"
           unit="ms"
           tooltip="After you stop typing in a SCAD companion file, the editor waits this long before autosaving the draft so the edit survives a reload. Coalesces keystrokes so IndexedDB isn't written on every key. Lower it to capture edits sooner; raise it to write less often."

--- a/tests/editor-blur-scroll.spec.ts
+++ b/tests/editor-blur-scroll.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from 'playwright/test';
+
+// When the code editor is scrolled to the very bottom and loses focus (e.g. the
+// user clicks away to drag a tool panel), real Chrome can nudge the visible code
+// up by a line or two — a deferred focus-change re-measure re-clamps max-scroll.
+// `pinScrollAfterBlur` (src/editor/codeEditor.ts) holds the scroll offset steady
+// for a short window after blur so the code doesn't stutter, while still letting
+// any genuine scroll through. These tests pin down that behaviour.
+
+function longCode(): string {
+  const lines: string[] = [];
+  lines.push('const { Manifold } = api;');
+  lines.push('let m = Manifold.cube([10, 10, 10], true);');
+  for (let i = 0; i < 160; i++) lines.push(`// filler comment line ${i} ----------------------------------`);
+  lines.push('return m;');
+  return lines.join('\n');
+}
+
+async function setupScrolledToBottom(page: import('playwright/test').Page): Promise<void> {
+  await page.goto('/editor');
+  await page.waitForFunction(() => !!(window as unknown as { partwright?: unknown }).partwright, null, { timeout: 30000 });
+  await page.waitForTimeout(2000);
+  await page.evaluate(async (code: string) => {
+    const pw = (window as unknown as { partwright: { createSession?: (n: string) => Promise<unknown>; run: (c: string) => Promise<unknown> } }).partwright;
+    if (pw.createSession) { try { await pw.createSession('blur-scroll'); } catch { /* a session may already be open */ } }
+    await pw.run(code);
+  }, longCode());
+  await page.waitForTimeout(1200);
+  await page.evaluate(() => (document.querySelector('.cm-content') as HTMLElement)?.focus());
+  await page.waitForTimeout(80);
+  await page.keyboard.press('Control+End');
+  await page.waitForTimeout(100);
+  await page.evaluate(() => { const sc = document.querySelector('.cm-scroller') as HTMLElement; sc.scrollTop = sc.scrollHeight; });
+  await page.waitForTimeout(150);
+}
+
+const scrollTop = (page: import('playwright/test').Page): Promise<number> =>
+  page.evaluate(() => Math.round((document.querySelector('.cm-scroller') as HTMLElement).scrollTop));
+
+const blur = (page: import('playwright/test').Page): Promise<void> =>
+  page.evaluate(() => (document.activeElement as HTMLElement)?.blur());
+
+const nudgeScroll = (page: import('playwright/test').Page, by: number): Promise<void> =>
+  page.evaluate((d) => { (document.querySelector('.cm-scroller') as HTMLElement).scrollTop += d; }, by);
+
+const setScroll = (page: import('playwright/test').Page, to: number): Promise<void> =>
+  page.evaluate((t) => { (document.querySelector('.cm-scroller') as HTMLElement).scrollTop = t; }, to);
+
+test.describe('editor blur scroll pin', () => {
+  test('reverts a small post-blur scroll nudge at the bottom', async ({ page }) => {
+    await setupScrolledToBottom(page);
+    const atBottom = await scrollTop(page);
+
+    await blur(page);
+    await page.waitForTimeout(20);
+    await nudgeScroll(page, -40); // simulate Chrome's 2-line nudge
+    await page.waitForTimeout(140);
+
+    expect(await scrollTop(page)).toBe(atBottom);
+  });
+
+  test('does not block a large programmatic scroll after blur', async ({ page }) => {
+    await setupScrolledToBottom(page);
+
+    await blur(page);
+    await page.waitForTimeout(20);
+    await setScroll(page, 200); // a real jump (e.g. reveal-diagnostic)
+    await page.waitForTimeout(160);
+
+    expect(await scrollTop(page)).toBeLessThan(400);
+  });
+
+  test('does not engage when the editor is not at the bottom', async ({ page }) => {
+    await setupScrolledToBottom(page);
+    await setScroll(page, 1000);
+    await page.waitForTimeout(100);
+
+    await blur(page);
+    await page.waitForTimeout(20);
+    await nudgeScroll(page, -40);
+    await page.waitForTimeout(140);
+
+    expect(await scrollTop(page)).toBe(960); // nudge stands; guard inert away from bottom
+  });
+});

--- a/tests/editor-blur-scroll.spec.ts
+++ b/tests/editor-blur-scroll.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect } from 'playwright/test';
 
-// When the code editor is scrolled to the very bottom and loses focus (e.g. the
-// user clicks away to drag a tool panel), real Chrome can nudge the visible code
-// up by a line or two — a deferred focus-change re-measure re-clamps max-scroll.
-// `pinScrollAfterBlur` (src/editor/codeEditor.ts) holds the scroll offset steady
-// for a short window after blur so the code doesn't stutter, while still letting
-// any genuine scroll through. These tests pin down that behaviour.
+// When the code editor is parked near the very bottom, real Chrome snaps the
+// visible code by a line whenever CodeMirror re-measures (a focus change, a
+// layout reflow from opening a tool menu/panel, or its own measure loop). The
+// bottom-scroll stabilizer (`installBottomScrollStabilizer` in
+// src/editor/codeEditor.ts) reverts that unsolicited one-line snap while always
+// honoring genuine scrolling. These tests pin down that behaviour by simulating
+// the programmatic snap (which is what we can't get headless Chrome to produce
+// on its own) and by exercising the user-intent escape hatches.
 
 function longCode(): string {
   const lines: string[] = [];
@@ -31,7 +33,9 @@ async function setupScrolledToBottom(page: import('playwright/test').Page): Prom
   await page.keyboard.press('Control+End');
   await page.waitForTimeout(100);
   await page.evaluate(() => { const sc = document.querySelector('.cm-scroller') as HTMLElement; sc.scrollTop = sc.scrollHeight; });
-  await page.waitForTimeout(150);
+  // Wait past the stabilizer's input-grace window so a subsequent programmatic
+  // nudge counts as "unsolicited" (the setup's own scroll/keys don't bleed in).
+  await page.waitForTimeout(450);
 }
 
 const scrollTop = (page: import('playwright/test').Page): Promise<number> =>
@@ -40,46 +44,72 @@ const scrollTop = (page: import('playwright/test').Page): Promise<number> =>
 const blur = (page: import('playwright/test').Page): Promise<void> =>
   page.evaluate(() => (document.activeElement as HTMLElement)?.blur());
 
-const nudgeScroll = (page: import('playwright/test').Page, by: number): Promise<void> =>
+// Simulate the engine/browser snap: a small programmatic scrollTop change with
+// no preceding user-input event (no wheel/key/pointer).
+const programmaticNudge = (page: import('playwright/test').Page, by: number): Promise<void> =>
   page.evaluate((d) => { (document.querySelector('.cm-scroller') as HTMLElement).scrollTop += d; }, by);
 
-const setScroll = (page: import('playwright/test').Page, to: number): Promise<void> =>
+const programmaticSet = (page: import('playwright/test').Page, to: number): Promise<void> =>
   page.evaluate((t) => { (document.querySelector('.cm-scroller') as HTMLElement).scrollTop = t; }, to);
 
-test.describe('editor blur scroll pin', () => {
-  test('reverts a small post-blur scroll nudge at the bottom', async ({ page }) => {
+test.describe('editor bottom-scroll stabilizer', () => {
+  test('reverts an unsolicited one-line snap at the bottom (after blur)', async ({ page }) => {
     await setupScrolledToBottom(page);
     const atBottom = await scrollTop(page);
 
     await blur(page);
     await page.waitForTimeout(20);
-    await nudgeScroll(page, -40); // simulate Chrome's 2-line nudge
-    await page.waitForTimeout(140);
+    await programmaticNudge(page, -40); // the measure snap
+    await page.waitForTimeout(120);
 
     expect(await scrollTop(page)).toBe(atBottom);
   });
 
-  test('does not block a large programmatic scroll after blur', async ({ page }) => {
+  test('reverts an unsolicited snap even while the editor stays focused', async ({ page }) => {
+    await setupScrolledToBottom(page);
+    const atBottom = await scrollTop(page);
+
+    // No blur, no user input — e.g. a re-measure from a background reflow/timer.
+    await programmaticNudge(page, -36);
+    await page.waitForTimeout(120);
+
+    expect(await scrollTop(page)).toBe(atBottom);
+  });
+
+  test('honors a scroll that follows a real keystroke (typing at the bottom)', async ({ page }) => {
+    await setupScrolledToBottom(page);
+    const atBottom = await scrollTop(page);
+
+    // A keystroke marks user intent; a scroll right after must be left alone
+    // (otherwise typing/paging at the bottom would fight the stabilizer).
+    await page.keyboard.press('ArrowUp');
+    await programmaticNudge(page, -36);
+    await page.waitForTimeout(120);
+
+    expect(await scrollTop(page)).toBeLessThan(atBottom); // the move stood
+  });
+
+  test('does not block a large programmatic scroll (real navigation)', async ({ page }) => {
     await setupScrolledToBottom(page);
 
     await blur(page);
     await page.waitForTimeout(20);
-    await setScroll(page, 200); // a real jump (e.g. reveal-diagnostic)
-    await page.waitForTimeout(160);
+    await programmaticSet(page, 200); // a jump, e.g. reveal-diagnostic
+    await page.waitForTimeout(140);
 
     expect(await scrollTop(page)).toBeLessThan(400);
   });
 
-  test('does not engage when the editor is not at the bottom', async ({ page }) => {
+  test('does not engage away from the bottom', async ({ page }) => {
     await setupScrolledToBottom(page);
-    await setScroll(page, 1000);
+    await programmaticSet(page, 1000);
     await page.waitForTimeout(100);
 
     await blur(page);
     await page.waitForTimeout(20);
-    await nudgeScroll(page, -40);
-    await page.waitForTimeout(140);
+    await programmaticNudge(page, -40);
+    await page.waitForTimeout(120);
 
-    expect(await scrollTop(page)).toBe(960); // nudge stands; guard inert away from bottom
+    expect(await scrollTop(page)).toBe(960); // nudge stands; stabilizer inert mid-document
   });
 });


### PR DESCRIPTION
## Summary

When the code editor is parked **near the very bottom** of a long document, the visible code jumps by a line — a stutter — whenever the user does something unrelated (clicks away to drag a tool panel, opens a tool menu, any focus change off the editor). The reporter described it precisely: a line of clear space below the last line snaps shut so the pane's bottom aligns with the last line of code.

### Diagnosis

CodeMirror's line-height model never perfectly matches real Chrome's **fractional, device-pixel-rounded** line boxes, so over a long document the modelled content height drifts from the real DOM height by ~a line. Whenever something makes CodeMirror **re-measure** — a focus change, a layout reflow from opening a tool menu/panel, or its own measure loop — it reconciles the two and the browser re-clamps `scrollTop` at max-scroll, snapping the visible code by a line. It only shows **at the bottom** (anywhere else the offset is preserved exactly) and only on a **real display**, which is why it never reproduces in headless Chromium (DPR 1, integer metrics — verified across DPR 1/1.25/1.5/2 and both caret positions, `scrollTop` never moved).

Ruled out: browser scroll-anchoring (CodeMirror already sets `overflow-anchor: none` on `.cm-scroller`); app `onBlur` work (`surfacePendingError` is a no-op for a clean model, `autosaveDraft` is just an IndexedDB write).

> The first iteration of this PR hooked only `blur` — but the reporter confirmed it's **not just blur** (it also fires clicking around menus), so the fix had to cover re-measures from any trigger.

### Fix

A persistent, input-aware **bottom-scroll stabilizer** (`installBottomScrollStabilizer` in `src/editor/codeEditor.ts`, installed once on the editor view). It reverts an *unsolicited*, small (≤ 3 line-heights) scroll change while the editor is parked near the bottom — the measure snap — **before the browser paints**, so the snap is invisible. It stays out of the way of every genuine scroll by tracking user intent:

- A recent **wheel / keydown** (within the `codeEditorScrollPinMs` grace window) or a **held pointer** (scrollbar drag, touch pan) marks the scroll as the user's — always honored.
- A **large jump** (reveal-diagnostic, jump-to-match) is adopted as real navigation.
- "Near the bottom" is anchored to the user's *intended* offset, not the post-snap position, so a snap right at the threshold is still caught.
- Thresholds are **line-height-relative**, not magic pixels.

The grace window is a tunable config knob (`ui.codeEditorScrollPinMs`, default **250 ms**, `0` disables) in `appConfig.ts`, surfaced in the advanced settings modal — per the repo's no-hardcoded-constants rule.

## Test plan

- **New e2e:** `tests/editor-blur-scroll.spec.ts` — five cases, all green:
  1. reverts an unsolicited snap after blur;
  2. reverts an unsolicited snap while the editor stays focused (background reflow/timer);
  3. honors a scroll that follows a real keystroke (typing/paging at the bottom isn't fought);
  4. does not block a large programmatic scroll (real navigation);
  5. inert away from the bottom.
- `npm run build` ✓ · `npm run test:unit` ✓ (909 passing).
- ⚠️ The original stutter is **real-display-specific** and does not reproduce in headless Chromium, so the e2e suite verifies the *stabilizer's* behaviour by simulating the snap. **@kemper — please confirm in your real Chrome** that the stutter is gone and that scrolling at the bottom (wheel + scrollbar drag) still feels normal.

https://claude.ai/code/session_01AhYR9yodHm1nPUubL4vQsq