### PR TITLE
feat: declare surface textures in code via api.surface.* (memoized, sticky)

### DIFF
--- a/prompts/20260609-193000-surface-textures-as-code.md
+++ b/prompts/20260609-193000-surface-textures-as-code.md
@@ -1,0 +1,71 @@
+---
+session: "1kdce9"
+timestamp: "2026-06-09T19:30:00Z"
+model: claude-opus-4-8
+tools: [playwright, vitest, node]
+sequence: 3
+---
+
+## Human
+
+After the `api.paint.*` work, asked to "proceed with the memoization idea" — make
+surface textures (`fuzzy`/`knit`/…) live in the model code as `api.surface.*`
+calls instead of destructive bakes, recomputing the expensive texture only on
+demand (memoized "sticky" nodes + a Re-apply control), single code buffer.
+Confirmed the plan, then: "Sounds good. Proceed with the plan."
+
+## Assistant
+
+## Key decisions
+
+**Mirror the `api.paint.*` architecture exactly.** Record ops in the Worker
+sandbox (they don't touch the mesh), cross the boundary as plain
+`MeshResult.surfaceOps`, and *apply on the main thread* after the run — reusing
+the existing modifier math (`src/surface/modifiers.ts`), which is already
+main-thread + WebGPU. Porting the modifiers into the Worker would have lost GPU
+acceleration and duplicated code.
+
+**A leaf spec module shared by both sides.** `src/surface/surfaceOpSpec.ts`
+(no imports) holds the `SurfaceOpId` union, the `SurfaceOp` type, and the
+per-modifier option allow-lists. The Worker sandbox imports it to *validate*
+`api.surface.*` calls; the main thread imports it to *apply* them. This keeps the
+heavy modifier math out of the Worker bundle and the graph acyclic (verified
+with `lint:deps`). Scope: the mesh-producing modifiers only (fuzzy/knit/cable/
+waffle/fur/woven/voronoi/smooth) — `voxelize`/`voronoiLamp(voxel)` change the
+engine, so they stay bake-only.
+
+**Memoization keyed by `hash(baseKey + op-chain prefix)`** where `baseKey =
+simpleHash(src + params)`. No mesh hashing: the base mesh is a deterministic
+function of code + customizer params, so any geometry-affecting edit re-keys the
+chain. Prefix memoization means editing op[i] reuses op[0..i-1]. A 32-entry LRU
+caps growth.
+
+**Sticky gating, button-driven (v1).** On a render, a fully-cached chain renders
+the textured mesh instantly; any miss renders the *base* mesh and raises a
+persistent "⟳ Textures stale — Re-apply" pill (a status indicator like the
+printability pill, not a toast). Pressing it computes the chain (async, with the
+progress modal), warms the cache, then re-runs.
+
+**The re-run must reuse the exact `src` string, not `getValue()`.** First attempt
+re-ran via `runCode()` (which reads the editor) and missed the cache — CodeMirror
+normalizes the buffer, so the recomputed base key differed. Fixed by storing the
+run's `src` in `pendingSurface` and calling `runCodeSync(src)` directly, so the
+key matches and the cache hits. (Caught in the browser, not by types.)
+
+**On a cache hit, swap `result.mesh` and null `result.manifold`** so the existing
+run-resolution path reconstructs the queryable Manifold from the textured mesh
+(falling back to render-only if a displaced mesh isn't watertight, exactly like
+the bake path's `Manifold.ofMesh`). Paint (`api.paint.*` / user regions) then
+resolves against the textured mesh, so colour follows the texture.
+
+**Scope = phases 1+2** (record→apply→memoize + sticky gating). Persistence on the
+version (phase 3) and wiring the Surface *panel* to emit `api.surface.*` instead
+of baking (phase 4) are follow-ups; an unchanged reopened session shows the pill
+until Re-apply, which is acceptable.
+
+**Verification.** Unit (`tests/unit/surfaceOps.test.ts`): spec invariants, memo
+hit/miss, base-key invalidation, prefix reuse, progress. E2e
+(`tests/surface-in-code.spec.ts`): base+pill → Re-apply → textured (1,152 →
+294,912 tris, pill clears) + option validation. Browser screenshots posted.
+`tsc`, full unit tier (936), `build`, `lint:deps` (acyclic), `lint:deadcode`
+(no new), `lint:consistency` (no new errors) all green.

--- a/prompts/20260609-205000-surface-textures-force-apply.md
+++ b/prompts/20260609-205000-surface-textures-force-apply.md
@@ -1,0 +1,50 @@
+---
+session: "1kdce9"
+timestamp: "2026-06-09T20:50:00Z"
+model: claude-opus-4-8
+tools: [playwright, vitest]
+sequence: 4
+---
+
+## Human
+
+Reported that an in-app AI used `api.surface.cable` and it "didn't appear to
+work" — the AI then fell back to the bake tool call, which looked right.
+
+## Assistant
+
+## Diagnosis
+
+`api.surface.cable` recorded correctly, but the texture was **gated behind the
+Re-apply pill** — a UI affordance only a human can click. The in-app AI drives
+via `runAndSave` + `renderViews()`; it has no way to press the pill, so its
+render showed the untextured base mesh and it concluded the call failed and used
+the baking `applyCableKnit` tool instead. This is a UI↔API parity violation
+(CLAUDE.md: "anything a user can do from the UI, an AI agent can do through the
+API").
+
+## Fix
+
+`surfaceErrors` already discriminates run kinds: the editor's live-typing
+auto-run passes `surfaceErrors: false`; every explicit path (Run button,
+`partwright.run`/`runAndSave`, version load) defaults `true`. So:
+
+- **Explicit/console runs force the (memoized) compute** — `applySurfaceTextures`
+  gained a `force` param; on a cache miss with `force` it computes the chain
+  inline (progress modal) and swaps in the textured mesh, so an AI/console caller
+  gets the real result with no extra step.
+- **Only live-typing stays gated** behind the pill, keeping keystrokes snappy.
+- Added a generation guard after the (awaitable) compute so a superseding run
+  abandons the stale one.
+- The Re-apply pill handler simplifies to "re-run the stored src" (which now
+  force-applies). Docs (`ai.md`, `textures.md`) updated to tell agents that
+  `run`/`runAndSave` apply textures automatically and the pill is human-only.
+
+## Verification
+
+E2e rewritten: a console run with `api.surface.cable` now returns a textured,
+subdivided mesh (triangle count jumps, no pill). Browser-confirmed (73,728 tris,
+no pill). Attempted to automate the human live-typing→pill path but CodeMirror
+focus/overlay friction in headless made it flaky; the pill DOM logic is unchanged
+and the gate trigger is covered by the unit memo tests + manual check. `tsc` +
+936 unit tests green.

--- a/public/ai.md
+++ b/public/ai.md
@@ -509,6 +509,18 @@ return part;
 
 `color` accepts the same hex string or `[r,g,b]` (0..1) as `api.label`. These selectors resolve **by triangle**, so a coarse mesh paints whole facets — `refine(n)` (or higher segment counts) gives crisp edges, exactly like the paint tools. Arguments are validated strictly (unknown keys rejected, bad color/axis throw an actionable error). This is a manifold-js-only sandbox API; the standalone paint tools (`partwright.paint*`) remain for click/coordinate painting and run between code runs.
 
+#### Surface textures in code — `api.surface.*`
+
+Just like paint, **surface textures** can live in the code instead of being baked: `api.surface.fuzzy / .knit / .cable / .waffle / .fur / .woven / .voronoi / .smooth` (or the generic `api.surface.apply('knit', {…})`). Each call records a texture op applied to the **final returned mesh**, in order — a parametric, non-baking counterpart of the `applyFuzzySkin` / `applyKnitTexture` / … tools (same options; size-relative defaults fill in omissions).
+
+```js
+const { Manifold } = api;
+api.surface.knit({ stitchWidth: 1.2, amplitude: 0.6 });
+return Manifold.sphere(10, 64);
+```
+
+Textures are expensive, so they're **memoized and gated**: an unchanged model renders the cached textured result instantly; after a code/param/op change the viewport shows the **base mesh** plus a **"⟳ Textures stale — Re-apply"** pill — press it to recompute on demand (geometry stays snappy; the slow texture only runs when asked). manifold-js-only. See [textures](/ai/textures.md#textures-as-code--apisurface-non-baking-in-a-manifold-js-session).
+
 ### Primitive origins and orientations
 
 ```

--- a/public/ai.md
+++ b/public/ai.md
@@ -519,7 +519,7 @@ api.surface.knit({ stitchWidth: 1.2, amplitude: 0.6 });
 return Manifold.sphere(10, 64);
 ```
 
-Textures are expensive, so they're **memoized and gated**: an unchanged model renders the cached textured result instantly; after a code/param/op change the viewport shows the **base mesh** plus a **"⟳ Textures stale — Re-apply"** pill — press it to recompute on demand (geometry stays snappy; the slow texture only runs when asked). manifold-js-only. See [textures](/ai/textures.md#textures-as-code--apisurface-non-baking-in-a-manifold-js-session).
+Textures are expensive, so they're **memoized**: an unchanged model renders the cached result instantly. An **explicit run computes the texture automatically** — `partwright.run` / `runAndSave` (and the Run button / version loads) force the compute and return the **textured** mesh, so you don't need to do anything special; the result you render/inspect is already textured. Only the editor's **live-typing** auto-run is gated (it shows the base mesh + a "⟳ Re-apply" pill so keystrokes stay snappy) — that never affects `run`/`runAndSave`. manifold-js-only. See [textures](/ai/textures.md#textures-as-code--apisurface-non-baking-in-a-manifold-js-session).
 
 ### Primitive origins and orientations
 

--- a/public/ai/textures.md
+++ b/public/ai/textures.md
@@ -29,6 +29,39 @@ apply→save→verify workflow:
 
 ---
 
+## Textures as code — `api.surface.*` (non-baking, in a manifold-js session)
+
+The tool calls above (`applyFuzzySkin`, …) **bake** the textured mesh into
+`api.imports[0]` and replace the editor code. As an alternative, in a
+**manifold-js** session you can declare the same textures **in the model code**
+so they stay parametric — edit a number, re-render, no lost source:
+
+```js
+const { Manifold } = api;
+const body = Manifold.sphere(10, 64);
+api.surface.knit({ stitchWidth: 1.2, amplitude: 0.6 });  // texture the returned mesh
+return body;
+```
+
+- Available ops: `api.surface.fuzzy`, `.knit`, `.cable`, `.waffle`, `.fur`,
+  `.woven`, `.voronoi`, `.smooth`. Each takes the **same options** as its
+  `apply*` tool (size-relative defaults fill in anything you omit). There's also
+  a generic `api.surface.apply('knit', { … })` form.
+- Calls are recorded, not applied during evaluation — they texture the **final
+  returned mesh** in the order called (a terminal skin; you can chain several).
+- Surface textures are **expensive**, so they're **memoized and gated**: a
+  render reuses the cached textured result when the code, params and ops are
+  unchanged. When they change, the viewport shows the **base (untextured) mesh**
+  and a **"⟳ Textures stale — Re-apply"** pill in the top-left corner. Press it
+  (or call the tool again from the panel) to recompute on demand. This keeps
+  editing snappy — geometry re-renders instantly, the slow texture only runs
+  when you ask.
+- This is the in-code counterpart of the bake tools, mirroring `api.paint.*`
+  (see [colors](/ai/colors.md)). Use it when you want the texture to live with
+  the code; use the `apply*` tools when you want a one-shot baked result.
+
+---
+
 ## When to apply textures
 
 Apply after the geometry is finalised and before the final paint pass (or after

--- a/public/ai/textures.md
+++ b/public/ai/textures.md
@@ -49,13 +49,18 @@ return body;
   a generic `api.surface.apply('knit', { … })` form.
 - Calls are recorded, not applied during evaluation — they texture the **final
   returned mesh** in the order called (a terminal skin; you can chain several).
-- Surface textures are **expensive**, so they're **memoized and gated**: a
-  render reuses the cached textured result when the code, params and ops are
-  unchanged. When they change, the viewport shows the **base (untextured) mesh**
-  and a **"⟳ Textures stale — Re-apply"** pill in the top-left corner. Press it
-  (or call the tool again from the panel) to recompute on demand. This keeps
-  editing snappy — geometry re-renders instantly, the slow texture only runs
-  when you ask.
+- Surface textures are **expensive**, so they're **memoized**: a render reuses
+  the cached textured result when the code, params and ops are unchanged.
+- **Explicit runs compute the texture automatically.** A `runCode` / `runAndSave`
+  / `run` call (and the editor's Run button + version loads) force the
+  (memoized) compute and return the **textured** mesh — so an AI/console caller
+  sees the real result with no extra step. The first compute shows a progress
+  modal; repeats are instant (cache hit).
+- **Only live-typing is gated.** While a human edits in the editor, keystroke
+  auto-runs show the **base (untextured) mesh** plus a **"⟳ Textures stale —
+  Re-apply"** pill (top-left) instead of recomputing on every keystroke. Press
+  the pill (or just hit Run) to apply. This keeps typing snappy; it does **not**
+  affect `run`/`runAndSave`, which always apply.
 - This is the in-code counterpart of the bake tools, mirroring `api.paint.*`
   (see [colors](/ai/colors.md)). Use it when you want the texture to live with
   the code; use the `apply*` tools when you want a one-shot baked result.

--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -351,6 +351,7 @@ function handleEngineWorkerMessage(event: MessageEvent): void {
         ? new Map(labelColorEntries)
         : undefined,
       paintOps: (msg.paintOps as MeshResult['paintOps']) ?? undefined,
+      surfaceOps: (msg.surfaceOps as MeshResult['surfaceOps']) ?? undefined,
       renderOnly: !!msg.renderOnly,
       lostLabels: lostLabels && lostLabels.length > 0 ? lostLabels : undefined,
       paramsSchema: (msg.paramsSchema as MeshResult['paramsSchema']) ?? undefined,

--- a/src/geometry/engineWorker.ts
+++ b/src/geometry/engineWorker.ts
@@ -21,7 +21,7 @@
 //
 // Protocol — Worker → Main:
 //   { type: 'ready' }
-//   { type: 'execute_result',          callId, mesh, error, diagnostics, labelMapEntries, labelColorEntries, paintOps, lostLabels, paramsSchema, workerMs }
+//   { type: 'execute_result',          callId, mesh, error, diagnostics, labelMapEntries, labelColorEntries, paintOps, surfaceOps, lostLabels, paramsSchema, workerMs }
 //   { type: 'validate_result',         callId, result }
 //   { type: 'detect_includes_result',  callId, result }
 //   { type: 'exportSTEP_result',       callId, blob, error }
@@ -209,6 +209,8 @@ self.onmessage = async (event: MessageEvent) => {
       // api.paint.* operations declared in code — already plain serialisable
       // objects ({ name, color, descriptor }), so they cross as-is.
       const paintOps = result.paintOps ?? null;
+      // api.surface.* ops — plain serialisable { id, params } objects, cross as-is.
+      const surfaceOps = result.surfaceOps ?? null;
       const paramsSchema = result.paramsSchema ?? null;
       // Heap high-water for manifold-js runs (other engines own separate heaps).
       const engineHeapBytes = effectiveLang === 'manifold-js' ? manifoldHeapBytes() : undefined;
@@ -230,7 +232,7 @@ self.onmessage = async (event: MessageEvent) => {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (self as any).postMessage(
-          { type: 'execute_result', callId, mesh, error: null, diagnostics: [], labelMapEntries, labelColorEntries, paintOps, lostLabels, paramsSchema, renderOnly: !!result.renderOnly, workerMs: Math.round(performance.now() - execStart), engineHeapBytes, voxelCount: result.voxelCount, voxelPieceCount: result.voxelPieceCount },
+          { type: 'execute_result', callId, mesh, error: null, diagnostics: [], labelMapEntries, labelColorEntries, paintOps, surfaceOps, lostLabels, paramsSchema, renderOnly: !!result.renderOnly, workerMs: Math.round(performance.now() - execStart), engineHeapBytes, voxelCount: result.voxelCount, voxelPieceCount: result.voxelPieceCount },
           transfer,
         );
       } else {

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -11,6 +11,7 @@ import { createPrintFitNamespace } from '../printFit';
 import { getBrepNamespace, consumeBrepAllocations, disposeBrepAllocationsExcept, consumeBrepToManifoldLabels, consumeBrepToManifoldLabelColors } from '../brepRuntime';
 import { parseLabelColor } from '../../color/labelColor';
 import type { RegionDescriptor } from '../../color/regions';
+import { SURFACE_OP_FIELDS, isSurfaceOpId, type SurfaceOp, type SurfaceOpId } from '../../surface/surfaceOpSpec';
 import { wasmFaultHint } from '../workerFaults';
 
 /** Marker the sandbox attaches to render-only proxies (see `renderMesh` below).
@@ -166,6 +167,16 @@ export const manifoldJsEngine: Engine = {
     // overlap, in declaration order. Cleared on every run.
     const paintOps: { name: string; color: [number, number, number]; descriptor: RegionDescriptor }[] = [];
     let paintSeq = 0;
+
+    // Surface textures declared in code via `api.surface.*` (fuzzy / knit / cable
+    // / waffle / fur / woven / voronoi / smooth). Like `api.paint.*`, these do
+    // NOT touch the mesh during evaluation — they record an ordered chain of
+    // ops that the MAIN thread applies to the final returned mesh after the run
+    // (reusing the existing modifier math, which is main-thread + WebGPU). The
+    // code is the source of truth, so the textured result is never baked into
+    // `api.imports[0]`; it's recomputed (and memoized) from these ops. Cleared
+    // on every run. See `src/surface/surfaceOps.ts`.
+    const surfaceOps: SurfaceOp[] = [];
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const label = (shape: any, name: unknown, options?: unknown): any => {
@@ -338,6 +349,53 @@ export const manifoldJsEngine: Engine = {
       },
     };
 
+    // === api.surface.* — surface textures declared in code (recorded, applied
+    // post-run on the main thread, memoized). Each call appends one op to the
+    // chain; the chain is applied to the final returned mesh. Unlike the Surface
+    // panel's destructive bake, the parametric op stays in the code — edit a
+    // param and press "Re-apply" to recompute. ===
+    const recordSurfaceOp = (id: SurfaceOpId, params: unknown): void => {
+      let opts: Record<string, unknown> = {};
+      if (params !== undefined && params !== null) {
+        if (typeof params !== 'object' || Array.isArray(params)) {
+          throw new Error(`api.surface.${id}(options): options must be a plain object, e.g. { amplitude: 0.5 }.`);
+        }
+        opts = params as Record<string, unknown>;
+      }
+      const allowed = SURFACE_OP_FIELDS[id];
+      const clean: Record<string, number | boolean | string> = {};
+      for (const [k, v] of Object.entries(opts)) {
+        if (!allowed.includes(k)) {
+          throw new Error(`api.surface.${id}: unknown option "${k}". Accepted: ${allowed.join(', ')}.`);
+        }
+        if (typeof v === 'number') {
+          if (!Number.isFinite(v)) throw new Error(`api.surface.${id}.${k}: must be a finite number.`);
+        } else if (typeof v !== 'boolean' && typeof v !== 'string') {
+          throw new Error(`api.surface.${id}.${k}: must be a number, boolean, or string.`);
+        }
+        clean[k] = v;
+      }
+      surfaceOps.push({ id, params: clean });
+    };
+    const makeSurfaceFn = (id: SurfaceOpId) => (params?: unknown): void => recordSurfaceOp(id, params);
+    const surface: Record<SurfaceOpId, (params?: unknown) => void> & { apply(id: unknown, params?: unknown): void } = {
+      fuzzy: makeSurfaceFn('fuzzy'),
+      knit: makeSurfaceFn('knit'),
+      cable: makeSurfaceFn('cable'),
+      waffle: makeSurfaceFn('waffle'),
+      fur: makeSurfaceFn('fur'),
+      woven: makeSurfaceFn('woven'),
+      voronoi: makeSurfaceFn('voronoi'),
+      smooth: makeSurfaceFn('smooth'),
+      /** Generic form: `api.surface.apply('knit', { … })` — handy for data-driven code. */
+      apply(id: unknown, params?: unknown): void {
+        if (!isSurfaceOpId(id)) {
+          throw new Error(`api.surface.apply(id): id must be one of ${Object.keys(SURFACE_OP_FIELDS).join(', ')}.`);
+        }
+        recordSurfaceOp(id, params);
+      },
+    };
+
     // Imported meshes (STL etc.) attached to the active version are exposed as
     // `api.imports[i]` — each entry is shaped to pass straight into
     // `Manifold.ofMesh()`. Metadata (filename/format) is kept off this object
@@ -418,6 +476,7 @@ export const manifoldJsEngine: Engine = {
       label,
       labeledUnion,
       paint,
+      surface,
       imports,
       renderMesh,
     };
@@ -541,6 +600,7 @@ export const manifoldJsEngine: Engine = {
         labelMap,
         labelColors: labelColors.size > 0 ? labelColors : undefined,
         paintOps: paintOps.length > 0 ? paintOps : undefined,
+        surfaceOps: surfaceOps.length > 0 ? surfaceOps : undefined,
         paramsSchema: paramCapture.collectSchema(),
         renderOnly,
       };

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -1,4 +1,5 @@
 import type { ParamSpec } from './params';
+import type { SurfaceOp } from '../surface/surfaceOpSpec';
 
 export interface MeshData {
   vertProperties: Float32Array;
@@ -60,6 +61,13 @@ export interface MeshResult {
    *  doesn't import the `color/` layer (that would close a module cycle); the
    *  main thread casts it back. Absent when no `api.paint.*` ran this turn. */
   paintOps?: { name: string; color: [number, number, number]; descriptor: unknown }[];
+  /** Surface texture ops declared in code via `api.surface.*` (fuzzy / knit /
+   *  cable / waffle / fur / woven / voronoi / smooth). An ordered chain applied
+   *  by the MAIN thread to the final returned mesh after the run (reusing the
+   *  existing modifier math) and memoized, so the parametric texture lives WITH
+   *  the code instead of being baked into `api.imports[0]`. Plain serializable.
+   *  Absent when no `api.surface.*` ran this turn. */
+  surfaceOps?: SurfaceOp[];
   /** True when the user code returned an `api.renderMesh(...)` proxy — the
    *  mesh isn't manifold (or wasn't validated as one) and the main thread
    *  must skip its Manifold.ofMesh fallback to avoid a "Not manifold" throw. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -13642,11 +13642,19 @@ async function main() {
     if (surfaceReapplyEl) surfaceReapplyEl.style.display = 'none';
   }
 
-  /** Resolve a run's `api.surface.*` chain against the memo cache. Mutates
-   *  `result` in place: on a hit, swaps in the textured mesh (and drops the
-   *  stale base Manifold so the downstream reconstructs from it); on a miss,
-   *  leaves the base mesh and raises the sticky Re-apply pill. */
-  function applySurfaceTextures(result: MeshResult, src: string): void {
+  /** Resolve a run's `api.surface.*` chain. Mutates `result` in place so the
+   *  downstream wiring sees the final mesh:
+   *   - cache hit → swap in the textured mesh (drop the stale base Manifold so
+   *     the run handler reconstructs from it).
+   *   - `force` (explicit/console runs — Run button, partwright.run/runAndSave,
+   *     version load) → compute the chain inline with the progress modal, so an
+   *     AI/console caller gets the real textured result instead of the gated
+   *     base (UI parity: agents can't press the pill).
+   *   - otherwise (live-typing auto-run) → leave the base mesh and raise the
+   *     sticky Re-apply pill, keeping keystroke renders snappy.
+   *  Returns true unless a forced compute failed (caller treats failure as a
+   *  non-fatal "base shown" run). */
+  async function applySurfaceTextures(result: MeshResult, src: string, force: boolean): Promise<void> {
     const ops = result.surfaceOps;
     if (!ops || ops.length === 0 || !result.mesh) {
       hideSurfaceReapplyPill();
@@ -13656,52 +13664,63 @@ async function main() {
     const baseKey = surfaceBaseKey(src);
     const status = surfaceCacheStatus(baseKey, ops);
     if (status.cached && status.mesh) {
-      result.mesh = status.mesh;
       // These displaced meshes round-trip through Manifold.ofMesh like the bake
       // path; clearing manifold makes the run handler rebuild from the textured
       // mesh (and fall back to render-only if it isn't watertight).
+      result.mesh = status.mesh;
       result.manifold = null;
       hideSurfaceReapplyPill();
-    } else {
-      pendingSurface = { base, ops, baseKey, src };
-      if (surfaceReapplyEl) {
-        surfaceReapplyEl.textContent = ops.length > 1
-          ? `⟳ ${ops.length} textures stale — Re-apply`
-          : '⟳ Texture stale — Re-apply';
-        surfaceReapplyEl.style.display = '';
+      return;
+    }
+    if (force) {
+      const progressId = startProgress({
+        title: ops.length > 1 ? `Applying ${ops.length} surface textures…` : 'Applying surface texture…',
+        indeterminate: false,
+      });
+      try {
+        const textured = await computeChain(base, baseKey, ops, (f) => updateProgress(progressId, f));
+        result.mesh = textured;
+        result.manifold = null;
+        hideSurfaceReapplyPill();
+      } catch (e) {
+        // Compute failed — keep the base mesh and raise the pill so the user can
+        // retry; surface the reason in the log.
+        const msg = e instanceof Error ? e.message : String(e);
+        showToast(`Surface texture failed: ${msg}`, { variant: 'warn', source: 'app' });
+        pendingSurface = { base, ops, baseKey, src };
+        if (surfaceReapplyEl) {
+          surfaceReapplyEl.textContent = '⟳ Texture failed — Re-apply';
+          surfaceReapplyEl.style.display = '';
+        }
+      } finally {
+        endProgress(progressId);
       }
+      return;
+    }
+    // Sticky miss (live-typing): keep the base mesh, remember what to compute.
+    pendingSurface = { base, ops, baseKey, src };
+    if (surfaceReapplyEl) {
+      surfaceReapplyEl.textContent = ops.length > 1
+        ? `⟳ ${ops.length} textures stale — Re-apply`
+        : '⟳ Texture stale — Re-apply';
+      surfaceReapplyEl.style.display = '';
     }
   }
 
-  /** Force-compute the pending surface chain (the Re-apply button), then re-run
-   *  the code so the resolution path picks up the now-cached textured mesh. */
-  async function reapplySurfaceTextures(): Promise<void> {
-    if (!pendingSurface || surfaceReapplyBusy) return;
+  /** The Re-apply pill (and the `partwright.applySurfaceTextures()` console
+   *  method): force-compute the pending chain by re-running the exact same
+   *  source — `runCodeSync` defaults to `surfaceErrors: true`, which force-
+   *  applies and clears the pill. Using the stored `src` (not `getValue()`)
+   *  keeps the base key identical so the compute is reused on the re-run. */
+  async function reapplySurfaceTextures(): Promise<boolean> {
+    if (!pendingSurface || surfaceReapplyBusy) return false;
     surfaceReapplyBusy = true;
-    const { base, ops, baseKey, src } = pendingSurface;
-    if (surfaceReapplyEl) surfaceReapplyEl.style.display = 'none';
-    const progressId = startProgress({
-      title: ops.length > 1 ? `Applying ${ops.length} surface textures…` : 'Applying surface texture…',
-      indeterminate: false,
-    });
+    const { src } = pendingSurface;
     try {
-      await computeChain(base, baseKey, ops, (f) => updateProgress(progressId, f));
-    } catch (e) {
-      endProgress(progressId);
+      return await runCodeSync(src, { preserveCamera: true });
+    } finally {
       surfaceReapplyBusy = false;
-      const msg = e instanceof Error ? e.message : String(e);
-      showToast(`Surface texture failed: ${msg}`, { variant: 'warn', source: 'app' });
-      // Re-raise the pill so the user can retry (if the run hasn't moved on).
-      if (surfaceReapplyEl && pendingSurface) surfaceReapplyEl.style.display = '';
-      return;
     }
-    endProgress(progressId);
-    surfaceReapplyBusy = false;
-    // Cache is warm — re-run the *exact same source* so the resolution path
-    // recomputes an identical base key and hits the cache (renders textured).
-    // Using the stored src (not getValue()) avoids any editor normalization
-    // shifting the key into a fresh miss.
-    void runCodeSync(src, { preserveCamera: true });
   }
 
   function runCode(code?: string, opts: { surfaceErrors?: boolean; preserveCamera?: boolean } = {}) {
@@ -13891,13 +13910,16 @@ async function main() {
       pendingEditorError = null;
       // === Surface textures declared in code (api.surface.*) ===
       // The Worker recorded an op chain but didn't touch the mesh. Apply it on
-      // this thread, but only from the memo cache — a slow texture must not run
-      // on every keystroke. On a cache hit, swap the textured mesh in so all the
-      // downstream wiring (currentManifold reconstruction, paint resolution,
-      // stats) sees the final geometry. On a miss, keep the base mesh and raise
-      // the "Re-apply" pill; the user computes it on demand. The base identity
-      // folds in code + customizer params so any geometry change re-stales it.
-      applySurfaceTextures(result, src);
+      // this thread. Explicit runs (`surfaceErrors` — Run button, console
+      // run/runAndSave, version load) force the (memoized) compute so the caller
+      // gets the real textured mesh; live-typing auto-runs only use a cache hit
+      // and otherwise raise the "Re-apply" pill, keeping keystrokes snappy. On a
+      // hit/force, the textured mesh is swapped in so all the downstream wiring
+      // (manifold reconstruction, paint resolution, stats) sees final geometry.
+      await applySurfaceTextures(result, src, surfaceErrors);
+      // A forced compute can take seconds; if a newer run started meanwhile,
+      // abandon this one rather than stamping a stale mesh over the new render.
+      if (myGen !== _runGeneration) return false;
       // Bump the paint generation so any in-flight subdivision worker — started
       // against the previous base mesh — discards its result instead of stamping
       // a refined mesh built from the OLD base over result.mesh.

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,6 +122,7 @@ import { getCompanionFiles, setCompanionFiles, addCompanionFile as addCompanionF
 import { applyFuzzy, applyFuzzyPatch, applyKnit, applyKnitAsync, applyKnitPatch, applyKnitPatchAsync, applyCable, applyCablePatch, applyWaffle, applyWafflePatch, applyFur, applyFurPatch, applyWoven, applyWovenPatch, applyVoronoi, applyVoronoiPatch, applyVoronoiLamp, applySmooth, applySmoothPatch, applyVoxelize, applyScale, defaultFuzzyOptions, defaultKnitOptions, defaultCableOptions, defaultWaffleOptions, defaultFurOptions, defaultWovenOptions, defaultVoronoiOptions, defaultVoronoiLampOptions, defaultSmoothOptions, modelDiagonal, applyTransform, type ModifierResult } from './surface/modifiers';
 import { buildTransformCode, computePlacementDelta, isNoopDelta, isNoopRotation, placementLabel, rotationLabel, rotateAboutCenterSteps, bestFlatDownRotation, applySteps, meshBox, type PlacementBox, type PlacementOps, type TransformStep, type Vec3 } from './surface/placement';
 import { nearestTriangleMap } from './surface/colorTransfer';
+import { surfaceCacheStatus, computeChain, type SurfaceOp } from './surface/surfaceOps';
 import { initSurfaceUI } from './ui/surfaceModal';
 import { initResizeUI } from './ui/resizeModal';
 import { initPlaceUI } from './ui/placeModal';
@@ -191,7 +192,7 @@ import { setPaintLabels } from './color/labels';
 import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as getPaintBucketTolerance, setBucketColorTolerance as setPaintBucketColorTolerance, getBucketColorTolerance as getPaintBucketColorTolerance, setBucketMode as setPaintBucketMode, getBucketMode as getPaintBucketMode, setBrushRadius as setPaintBrushRadius, getBrushRadius as getPaintBrushRadius, setBrushSmooth as setPaintBrushSmooth, isBrushSmooth as isPaintBrushSmooth, setBrushSmoothDivisor as setPaintBrushSmoothDivisor, getBrushSmoothDivisor as getPaintBrushSmoothDivisor, setBrushSurface as setPaintBrushSurface, getBrushSurface as getPaintBrushSurface, setBrushPaintDepth as setPaintBrushDepth, getBrushPaintDepth as getPaintBrushDepth, setBrushWrapAngle as setPaintBrushWrapAngle, getBrushWrapAngle as getPaintBrushWrapAngle, SMOOTH_DIVISOR_MIN, SMOOTH_DIVISOR_MAX, WRAP_ANGLE_MIN, WRAP_ANGLE_MAX } from './color/paintMode';
 import { buildStrokeMesh, buildRefinedMesh, buildRefinedMeshFromSet, brushRefineRegion, strokeFootprintTriangles, deriveSampleNormals, buildGeodesicField, tangentBasis, wrapAngleGate, childrenByParent, type BrushStroke, type BrushShape, type RefineRegion } from './color/subdivide';
 import { refineInWorker, SubdivisionAbortError, terminateSubdivisionWorker } from './color/subdivisionClient';
-import { startProgress, endProgress, __setProgressModalDelayForTests } from './ui/progressModal';
+import { startProgress, updateProgress, endProgress, __setProgressModalDelayForTests } from './ui/progressModal';
 import { syncLockState, disableRun, enableRun } from './color/editorLock';
 import { setReadOnlyReason } from './editor/editorAccess';
 import { asLanguage } from './storage/languageFallback';
@@ -457,6 +458,16 @@ const partMeshCache = new Map<string, PartMeshCacheEntry>();
 let geometryDataEl: HTMLElement;
 // Viewport overlay pill — shows printability issues after each successful run.
 let printabilityIndicatorEl: HTMLElement | null = null;
+// Viewport overlay pill — shown when a run's `api.surface.*` texture chain is
+// NOT in the memo cache (a "sticky" miss): we render the base mesh and let the
+// user press this to recompute the (potentially slow) texture on demand. See
+// the surfaceOps integration in runCodeSync.
+let surfaceReapplyEl: HTMLElement | null = null;
+// The base mesh + op-chain + base identity for the current run's pending
+// (uncomputed) surface textures. Set when a run leaves textures stale; consumed
+// by the Re-apply handler. Null when there's nothing pending.
+let pendingSurface: { base: MeshData; ops: SurfaceOp[]; baseKey: string; src: string } | null = null;
+let surfaceReapplyBusy = false;
 // The disconnected-components warning is surfaced as a transient toast (recorded
 // in the Diagnostic Log) rather than the persistent pill. Track the last one we
 // toasted so re-runs of an unchanged broken model don't re-spam the same toast;
@@ -4293,6 +4304,18 @@ async function main() {
   printabilityIndicatorEl.title = 'This model has structural issues that may prevent a clean 3D print. Open the ⚠ Diagnostic Log in the toolbar for details.';
   printabilityIndicatorEl.style.display = 'none';
   viewportPane.appendChild(printabilityIndicatorEl);
+
+  // Surface "Re-apply" pill — a persistent status indicator (not a transient
+  // toast) shown when the model declares `api.surface.*` textures whose result
+  // isn't cached for the current code/params. Until pressed, the viewport shows
+  // the untextured base mesh; pressing it computes the texture chain on demand.
+  surfaceReapplyEl = document.createElement('button');
+  surfaceReapplyEl.className = 'absolute top-2 left-2 z-20 text-xs text-sky-200 font-mono bg-zinc-900/85 px-2 py-0.5 rounded border border-sky-700/60 cursor-pointer hover:bg-zinc-800/90 transition-colors';
+  surfaceReapplyEl.textContent = '⟳ Textures stale — Re-apply';
+  surfaceReapplyEl.title = 'This model declares api.surface.* textures that haven’t been computed for the current code. The base shape is shown; click to apply the texture(s).';
+  surfaceReapplyEl.style.display = 'none';
+  surfaceReapplyEl.addEventListener('click', () => { void reapplySurfaceTextures(); });
+  viewportPane.appendChild(surfaceReapplyEl);
 
   // Parts rail — IDE-style list of the session's parts.
   createPartList(partsRail, {
@@ -13605,6 +13628,82 @@ async function main() {
     });
   }
 
+  // === api.surface.* — code-declared surface textures (memoized, sticky) ===
+
+  /** Base identity for the surface memo cache: code + customizer params. Any
+   *  change here re-keys the chain (→ a cache miss → the Re-apply pill), since
+   *  either changes the base geometry the textures sit on. */
+  function surfaceBaseKey(src: string): string {
+    return simpleHash(`${src} ${JSON.stringify(currentParamValues ?? {})}`);
+  }
+
+  function hideSurfaceReapplyPill(): void {
+    pendingSurface = null;
+    if (surfaceReapplyEl) surfaceReapplyEl.style.display = 'none';
+  }
+
+  /** Resolve a run's `api.surface.*` chain against the memo cache. Mutates
+   *  `result` in place: on a hit, swaps in the textured mesh (and drops the
+   *  stale base Manifold so the downstream reconstructs from it); on a miss,
+   *  leaves the base mesh and raises the sticky Re-apply pill. */
+  function applySurfaceTextures(result: MeshResult, src: string): void {
+    const ops = result.surfaceOps;
+    if (!ops || ops.length === 0 || !result.mesh) {
+      hideSurfaceReapplyPill();
+      return;
+    }
+    const base = result.mesh;
+    const baseKey = surfaceBaseKey(src);
+    const status = surfaceCacheStatus(baseKey, ops);
+    if (status.cached && status.mesh) {
+      result.mesh = status.mesh;
+      // These displaced meshes round-trip through Manifold.ofMesh like the bake
+      // path; clearing manifold makes the run handler rebuild from the textured
+      // mesh (and fall back to render-only if it isn't watertight).
+      result.manifold = null;
+      hideSurfaceReapplyPill();
+    } else {
+      pendingSurface = { base, ops, baseKey, src };
+      if (surfaceReapplyEl) {
+        surfaceReapplyEl.textContent = ops.length > 1
+          ? `⟳ ${ops.length} textures stale — Re-apply`
+          : '⟳ Texture stale — Re-apply';
+        surfaceReapplyEl.style.display = '';
+      }
+    }
+  }
+
+  /** Force-compute the pending surface chain (the Re-apply button), then re-run
+   *  the code so the resolution path picks up the now-cached textured mesh. */
+  async function reapplySurfaceTextures(): Promise<void> {
+    if (!pendingSurface || surfaceReapplyBusy) return;
+    surfaceReapplyBusy = true;
+    const { base, ops, baseKey, src } = pendingSurface;
+    if (surfaceReapplyEl) surfaceReapplyEl.style.display = 'none';
+    const progressId = startProgress({
+      title: ops.length > 1 ? `Applying ${ops.length} surface textures…` : 'Applying surface texture…',
+      indeterminate: false,
+    });
+    try {
+      await computeChain(base, baseKey, ops, (f) => updateProgress(progressId, f));
+    } catch (e) {
+      endProgress(progressId);
+      surfaceReapplyBusy = false;
+      const msg = e instanceof Error ? e.message : String(e);
+      showToast(`Surface texture failed: ${msg}`, { variant: 'warn', source: 'app' });
+      // Re-raise the pill so the user can retry (if the run hasn't moved on).
+      if (surfaceReapplyEl && pendingSurface) surfaceReapplyEl.style.display = '';
+      return;
+    }
+    endProgress(progressId);
+    surfaceReapplyBusy = false;
+    // Cache is warm — re-run the *exact same source* so the resolution path
+    // recomputes an identical base key and hits the cache (renders textured).
+    // Using the stored src (not getValue()) avoids any editor normalization
+    // shifting the key into a fresh miss.
+    void runCodeSync(src, { preserveCamera: true });
+  }
+
   function runCode(code?: string, opts: { surfaceErrors?: boolean; preserveCamera?: boolean } = {}) {
     // Never execute the sharer's untrusted code in a read-only preview. Fork first.
     if (isSharedPreview()) return;
@@ -13749,6 +13848,7 @@ async function main() {
       const diagnostics = result.diagnostics ?? [];
       setStatus(statusBar, 'error', summarizeDiagnostics(result.error, diagnostics));
       if (printabilityIndicatorEl) printabilityIndicatorEl.style.display = 'none';
+      hideSurfaceReapplyPill();
       lastDisconnectedWarning = null;
       geometryDataEl.textContent = JSON.stringify({
         status: 'error',
@@ -13789,6 +13889,15 @@ async function main() {
       clearEditorDiagnostics();
       clearEditorErrorPanel(editorErrorPanel);
       pendingEditorError = null;
+      // === Surface textures declared in code (api.surface.*) ===
+      // The Worker recorded an op chain but didn't touch the mesh. Apply it on
+      // this thread, but only from the memo cache — a slow texture must not run
+      // on every keystroke. On a cache hit, swap the textured mesh in so all the
+      // downstream wiring (currentManifold reconstruction, paint resolution,
+      // stats) sees the final geometry. On a miss, keep the base mesh and raise
+      // the "Re-apply" pill; the user computes it on demand. The base identity
+      // folds in code + customizer params so any geometry change re-stales it.
+      applySurfaceTextures(result, src);
       // Bump the paint generation so any in-flight subdivision worker — started
       // against the previous base mesh — discards its result instead of stamping
       // a refined mesh built from the OLD base over result.mesh.

--- a/src/surface/surfaceOpSpec.ts
+++ b/src/surface/surfaceOpSpec.ts
@@ -1,0 +1,54 @@
+// Shared, dependency-free spec for `api.surface.*` operations declared in model
+// code. This is the single source of truth for which surface modifiers can be
+// expressed as code and which option keys each one accepts.
+//
+// It is intentionally a leaf module (no imports): the Worker sandbox
+// (`engines/manifoldJs.ts`) imports it to *validate* `api.surface.*` calls, and
+// the main thread (`surfaceOps.ts`) imports it to *apply* them. Keeping the spec
+// here avoids pulling the heavy modifier math (which is main-thread + WebGPU)
+// into the Worker bundle, and avoids a module cycle.
+
+/** Surface modifiers that can be recorded in code as `api.surface.<id>(...)`.
+ *  A subset of `SurfaceModifierId` (`src/surface/modifiers.ts`): the ones that
+ *  produce a manifold-js mesh by displacing/smoothing the existing geometry.
+ *  `voxelize` / `voronoiLamp(voxel)` change the engine, so they stay
+ *  destructive bakes only. */
+export type SurfaceOpId =
+  | 'fuzzy'
+  | 'knit'
+  | 'cable'
+  | 'waffle'
+  | 'fur'
+  | 'woven'
+  | 'voronoi'
+  | 'smooth';
+
+/** One recorded surface operation. Ops form an ordered chain applied to the
+ *  final returned mesh (a terminal skin, like the current Surface-panel bake).
+ *  `params` carries only the user-supplied overrides — size-relative defaults
+ *  are filled in main-side from the actual mesh at apply time. */
+export interface SurfaceOp {
+  id: SurfaceOpId;
+  params: Record<string, number | boolean | string>;
+}
+
+/** Accepted option keys per modifier — mirrors the `Required<…Options>` field
+ *  sets in `src/surface/modifiers.ts` (the `default*Options` factories). Used to
+ *  reject unknown keys at record time so a typo surfaces as a clear sandbox
+ *  error instead of being silently dropped. */
+export const SURFACE_OP_FIELDS: Record<SurfaceOpId, readonly string[]> = {
+  fuzzy: ['amplitude', 'scale', 'octaves', 'seed', 'quality', 'subdivide'],
+  knit: ['amplitude', 'stitchWidth', 'stitchHeight', 'rowOffset', 'roundness', 'grainAngleDeg', 'variation', 'seed', 'quality', 'subdivide', 'algorithm'],
+  cable: ['amplitude', 'cableWidth', 'cablePitch', 'plyWidth', 'grainAngleDeg', 'variation', 'seed', 'quality', 'subdivide'],
+  waffle: ['amplitude', 'cellWidth', 'cellHeight', 'sharpness', 'rowOffset', 'grainAngleDeg', 'seed', 'quality', 'subdivide'],
+  fur: ['amplitude', 'fiberSpacing', 'fiberLength', 'octaves', 'grainAngleDeg', 'seed', 'quality', 'subdivide'],
+  woven: ['amplitude', 'threadSpacing', 'threadWidth', 'underDepth', 'grainAngleDeg', 'seed', 'quality', 'subdivide'],
+  voronoi: ['amplitude', 'cellSize', 'wallWidth', 'raised', 'jitter', 'grainAngleDeg', 'seed', 'quality', 'subdivide'],
+  smooth: ['iterations', 'subdivide'],
+};
+
+export const SURFACE_OP_IDS = Object.keys(SURFACE_OP_FIELDS) as SurfaceOpId[];
+
+export function isSurfaceOpId(v: unknown): v is SurfaceOpId {
+  return typeof v === 'string' && Object.prototype.hasOwnProperty.call(SURFACE_OP_FIELDS, v);
+}

--- a/src/surface/surfaceOps.ts
+++ b/src/surface/surfaceOps.ts
@@ -1,0 +1,121 @@
+// Main-thread application + memoization of `api.surface.*` ops.
+//
+// The Worker records an ordered chain of surface ops (`MeshResult.surfaceOps`)
+// during a run but never touches the mesh. Here, on the main thread, we apply
+// that chain to the run's base mesh by reusing the existing modifier math
+// (`src/surface/modifiers.ts`, which is main-thread + WebGPU). Each prefix of
+// the chain is memoized by `hash(baseKey + serialized op-chain)` so:
+//   - a cache hit is instant (no recompute), and
+//   - editing op[i] reuses op[0..i-1]'s cached result.
+//
+// "Sticky" gating lives in main.ts: on a miss we render the BASE mesh and raise
+// a "Re-apply" pill rather than recomputing on every keystroke. `computeChain`
+// is the explicit recompute the button triggers.
+
+import type { MeshData } from '../geometry/types';
+import { simpleHash } from '../geometry/statsComputation';
+import type { SurfaceOp, SurfaceOpId } from './surfaceOpSpec';
+import {
+  applyFuzzy, applyKnitAsync, applyCable, applyWaffle, applyFur, applyWoven, applyVoronoi, applySmooth,
+  defaultFuzzyOptions, defaultKnitOptions, defaultCableOptions, defaultWaffleOptions,
+  defaultFurOptions, defaultWovenOptions, defaultVoronoiOptions, defaultSmoothOptions,
+} from './modifiers';
+
+/** Memo cache: prefix key → textured mesh after that prefix of the chain.
+ *  Bounded so a long editing session can't grow it without limit (insertion
+ *  order = eviction order; the hot full-chain key is re-set on every hit so it
+ *  stays warm). */
+const cache = new Map<string, MeshData>();
+const MAX_CACHE_ENTRIES = 32;
+
+function remember(key: string, mesh: MeshData): void {
+  if (cache.has(key)) cache.delete(key);
+  cache.set(key, mesh);
+  while (cache.size > MAX_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+}
+
+/** Stable key for the chain prefix `ops[0..upTo]` against a given base identity.
+ *  `baseKey` already folds in the code + customizer params (computed by the
+ *  caller), so the same code+params+ops always maps to the same key — and any
+ *  geometry-affecting change shifts it (→ a miss → the Re-apply pill). */
+function prefixKey(baseKey: string, ops: SurfaceOp[], upTo: number): string {
+  const chain = ops.slice(0, upTo + 1).map(o => ({ id: o.id, params: o.params }));
+  return simpleHash(`${baseKey}|${JSON.stringify(chain)}`);
+}
+
+/** Apply one op to `mesh`, filling size-relative defaults from the actual mesh
+ *  and reusing the modifier math. The async knit path uses the GPU when present. */
+async function applyOne(mesh: MeshData, op: SurfaceOp): Promise<MeshData> {
+  const p = op.params;
+  switch (op.id) {
+    case 'fuzzy':   return applyFuzzy(mesh, { ...defaultFuzzyOptions(mesh), ...p }).mesh;
+    case 'knit':    return (await applyKnitAsync(mesh, { ...defaultKnitOptions(mesh), ...p })).mesh;
+    case 'cable':   return applyCable(mesh, { ...defaultCableOptions(mesh), ...p }).mesh;
+    case 'waffle':  return applyWaffle(mesh, { ...defaultWaffleOptions(mesh), ...p }).mesh;
+    case 'fur':     return applyFur(mesh, { ...defaultFurOptions(mesh), ...p }).mesh;
+    case 'woven':   return applyWoven(mesh, { ...defaultWovenOptions(mesh), ...p }).mesh;
+    case 'voronoi': return applyVoronoi(mesh, { ...defaultVoronoiOptions(mesh), ...p }).mesh;
+    case 'smooth':  return applySmooth(mesh, { ...defaultSmoothOptions(), ...p }).mesh;
+    default: {
+      // Exhaustiveness guard — a new SurfaceOpId must add a case above.
+      const _never: never = op.id;
+      throw new Error(`surfaceOps: unsupported op "${_never as SurfaceOpId}"`);
+    }
+  }
+}
+
+/** Cache lookup for a fully-applied chain. `cached: true` with `mesh` means the
+ *  textured result is ready to render; `cached: false` means at least the final
+ *  op must be recomputed (the sticky-pill case). An empty chain is trivially
+ *  "cached" with no mesh (caller keeps the base mesh). */
+export function surfaceCacheStatus(baseKey: string, ops: SurfaceOp[]): { cached: boolean; mesh: MeshData | null } {
+  if (ops.length === 0) return { cached: true, mesh: null };
+  const mesh = cache.get(prefixKey(baseKey, ops, ops.length - 1));
+  if (mesh) {
+    // Touch so the hot full-chain key resists eviction.
+    remember(prefixKey(baseKey, ops, ops.length - 1), mesh);
+    return { cached: true, mesh };
+  }
+  return { cached: false, mesh: null };
+}
+
+/** Force-apply the whole chain, reusing the deepest already-cached prefix and
+ *  caching every newly-computed prefix. `onProgress(fraction)` reports progress
+ *  across the uncached tail. Returns the final textured mesh. */
+export async function computeChain(
+  base: MeshData,
+  baseKey: string,
+  ops: SurfaceOp[],
+  onProgress?: (fraction: number) => void,
+): Promise<MeshData> {
+  if (ops.length === 0) return base;
+
+  // Resume from the deepest cached prefix so editing the last op doesn't redo
+  // the whole stack.
+  let mesh = base;
+  let start = 0;
+  for (let i = ops.length - 1; i >= 0; i--) {
+    const cached = cache.get(prefixKey(baseKey, ops, i));
+    if (cached) { mesh = cached; start = i + 1; break; }
+  }
+
+  const remaining = ops.length - start;
+  for (let i = start; i < ops.length; i++) {
+    mesh = await applyOne(mesh, ops[i]);
+    remember(prefixKey(baseKey, ops, i), mesh);
+    onProgress?.(remaining > 0 ? (i - start + 1) / remaining : 1);
+  }
+  return mesh;
+}
+
+/** Test/diagnostic hook — clears the memo cache. */
+export function __clearSurfaceCache(): void {
+  cache.clear();
+}
+
+// Re-export the spec types so callers can import everything surface-op from here.
+export type { SurfaceOp, SurfaceOpId } from './surfaceOpSpec';

--- a/tests/surface-in-code.spec.ts
+++ b/tests/surface-in-code.spec.ts
@@ -1,0 +1,79 @@
+// api.surface.* — surface textures declared in code. The op chain is recorded
+// during the run but applied (and memoized) on the MAIN thread. Because the
+// textures are expensive, a run with an uncached chain renders the BASE mesh and
+// raises a "Re-apply" pill; pressing it computes the texture on demand and the
+// next render serves the cached, textured mesh. See src/surface/surfaceOps.ts.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+type PW = {
+  createSession: (n?: string) => Promise<unknown>;
+  run: (code: string) => Promise<{ error?: string | null; triangleCount?: number } | unknown>;
+  getGeometryData: () => { triangleCount?: number };
+};
+
+test.describe('api.surface.* (textures declared in code)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('sticky gating: base mesh + Re-apply pill, then textured on demand', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const baseTris = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('surface-in-code');
+      const code = [
+        'const { Manifold } = api;',
+        'api.surface.knit({ stitchWidth: 1.4, amplitude: 0.6 });',
+        'return Manifold.sphere(10, 48);',
+      ].join('\n');
+      const r = await pw.run(code) as { triangleCount?: number };
+      return r.triangleCount ?? 0;
+    });
+    expect(baseTris).toBeGreaterThan(0);
+
+    // First run leaves the texture uncached → the pill is shown over the base mesh.
+    const pill = page.getByRole('button', { name: /Re-apply/ });
+    await expect(pill).toBeVisible();
+    await page.screenshot({ path: 'test-results/surface-in-code-stale.png' });
+
+    // Press it: compute the texture, then the re-run serves the cached textured
+    // mesh (more triangles — knit subdivides + displaces) and the pill clears.
+    await pill.click();
+    await expect(pill).toBeHidden({ timeout: 30_000 });
+
+    const texturedTris = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      return pw.getGeometryData().triangleCount ?? 0;
+    });
+    expect(texturedTris).toBeGreaterThan(baseTris);
+    await page.screenshot({ path: 'test-results/surface-in-code-textured.png' });
+  });
+
+  test('rejects unknown surface options with an actionable error', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const err = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('surface-in-code-errors');
+      const r = await pw.run([
+        'const { Manifold } = api;',
+        'api.surface.knit({ stitchWidth: 1, nope: 2 });',
+        'return Manifold.cube([10, 10, 10]);',
+      ].join('\n')) as { error?: string | null };
+      return r?.error ?? '';
+    });
+    expect(err).toContain('nope');
+  });
+});

--- a/tests/surface-in-code.spec.ts
+++ b/tests/surface-in-code.spec.ts
@@ -1,8 +1,11 @@
 // api.surface.* — surface textures declared in code. The op chain is recorded
-// during the run but applied (and memoized) on the MAIN thread. Because the
-// textures are expensive, a run with an uncached chain renders the BASE mesh and
-// raises a "Re-apply" pill; pressing it computes the texture on demand and the
-// next render serves the cached, textured mesh. See src/surface/surfaceOps.ts.
+// during the run but applied (and memoized) on the MAIN thread.
+//
+// Explicit/console runs (partwright.run / runAndSave, the Run button, version
+// loads) FORCE the memoized compute and return the textured mesh — so an
+// AI/console caller gets the real result with no extra step (it can't press the
+// in-UI pill). Only the editor's live-typing auto-run is gated behind the
+// "Re-apply" pill. See src/surface/surfaceOps.ts + applySurfaceTextures.
 
 import { test, expect, type Page } from 'playwright/test';
 
@@ -25,38 +28,34 @@ test.describe('api.surface.* (textures declared in code)', () => {
     await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
   });
 
-  test('sticky gating: base mesh + Re-apply pill, then textured on demand', async ({ page }) => {
+  test('a console run force-applies the texture and returns the textured mesh', async ({ page }) => {
     await page.goto('/editor');
     await waitForEngine(page);
 
-    const baseTris = await page.evaluate(async () => {
+    const out = await page.evaluate(async () => {
       const pw = (window as unknown as { partwright: PW }).partwright;
       await pw.createSession('surface-in-code');
-      const code = [
+      // Base sphere triangle count, no texture.
+      const plain = await pw.run([
         'const { Manifold } = api;',
-        'api.surface.knit({ stitchWidth: 1.4, amplitude: 0.6 });',
         'return Manifold.sphere(10, 48);',
-      ].join('\n');
-      const r = await pw.run(code) as { triangleCount?: number };
-      return r.triangleCount ?? 0;
+      ].join('\n')) as { triangleCount?: number };
+      // Same geometry + a cable texture: the console run must compute it inline
+      // (not gate) so the returned stats reflect the textured, subdivided mesh.
+      const textured = await pw.run([
+        'const { Manifold } = api;',
+        'api.surface.cable({ cableWidth: 1.6, amplitude: 0.5 });',
+        'return Manifold.sphere(10, 48);',
+      ].join('\n')) as { triangleCount?: number };
+      return { plainTris: plain.triangleCount ?? 0, texturedTris: textured.triangleCount ?? 0 };
     });
-    expect(baseTris).toBeGreaterThan(0);
 
-    // First run leaves the texture uncached → the pill is shown over the base mesh.
-    const pill = page.getByRole('button', { name: /Re-apply/ });
-    await expect(pill).toBeVisible();
-    await page.screenshot({ path: 'test-results/surface-in-code-stale.png' });
+    expect(out.plainTris).toBeGreaterThan(0);
+    // The texture subdivides + displaces, so triangle count grows substantially.
+    expect(out.texturedTris).toBeGreaterThan(out.plainTris);
 
-    // Press it: compute the texture, then the re-run serves the cached textured
-    // mesh (more triangles — knit subdivides + displaces) and the pill clears.
-    await pill.click();
-    await expect(pill).toBeHidden({ timeout: 30_000 });
-
-    const texturedTris = await page.evaluate(() => {
-      const pw = (window as unknown as { partwright: PW }).partwright;
-      return pw.getGeometryData().triangleCount ?? 0;
-    });
-    expect(texturedTris).toBeGreaterThan(baseTris);
+    // No "Re-apply" pill on a console/explicit run — the texture was applied.
+    await expect(page.getByRole('button', { name: /Re-apply/ })).toBeHidden();
     await page.screenshot({ path: 'test-results/surface-in-code-textured.png' });
   });
 

--- a/tests/unit/surfaceOps.test.ts
+++ b/tests/unit/surfaceOps.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { MeshData } from '../../src/geometry/types';
+import { SURFACE_OP_FIELDS, SURFACE_OP_IDS, isSurfaceOpId } from '../../src/surface/surfaceOpSpec';
+import { surfaceCacheStatus, computeChain, __clearSurfaceCache, type SurfaceOp } from '../../src/surface/surfaceOps';
+
+/** Axis-aligned cube from [0,s]^3 as an 8-vertex / 12-triangle MeshData. */
+function cube(s = 10): MeshData {
+  const vertProperties = new Float32Array([
+    0, 0, 0, s, 0, 0, s, s, 0, 0, s, 0,
+    0, 0, s, s, 0, s, s, s, s, 0, s, s,
+  ]);
+  const triVerts = new Uint32Array([
+    0, 2, 1, 0, 3, 2,
+    4, 5, 6, 4, 6, 7,
+    0, 1, 5, 0, 5, 4,
+    2, 3, 7, 2, 7, 6,
+    1, 2, 6, 1, 6, 5,
+    0, 4, 7, 0, 7, 3,
+  ]);
+  return { vertProperties, triVerts, numVert: 8, numTri: 12, numProp: 3 };
+}
+
+describe('surfaceOpSpec', () => {
+  it('every op id has a non-empty field allow-list', () => {
+    for (const id of SURFACE_OP_IDS) {
+      expect(SURFACE_OP_FIELDS[id].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('isSurfaceOpId accepts known ids and rejects others', () => {
+    expect(isSurfaceOpId('knit')).toBe(true);
+    expect(isSurfaceOpId('smooth')).toBe(true);
+    expect(isSurfaceOpId('voxelize')).toBe(false); // engine-changing → not a code op
+    expect(isSurfaceOpId('nope')).toBe(false);
+    expect(isSurfaceOpId(42)).toBe(false);
+  });
+});
+
+describe('surfaceOps memoization', () => {
+  beforeEach(() => __clearSurfaceCache());
+
+  const smooth: SurfaceOp = { id: 'smooth', params: { iterations: 1, subdivide: false } };
+
+  it('an empty chain is trivially cached with no mesh', () => {
+    const s = surfaceCacheStatus('k', []);
+    expect(s.cached).toBe(true);
+    expect(s.mesh).toBeNull();
+  });
+
+  it('misses before compute, hits the exact result after computeChain', async () => {
+    expect(surfaceCacheStatus('base1', [smooth]).cached).toBe(false);
+
+    const out = await computeChain(cube(), 'base1', [smooth]);
+    expect(out.numTri).toBeGreaterThan(0);
+
+    const after = surfaceCacheStatus('base1', [smooth]);
+    expect(after.cached).toBe(true);
+    expect(after.mesh).toBe(out); // same reference — served from cache, not recomputed
+  });
+
+  it('a different base identity (code/params change) re-stales the chain', async () => {
+    await computeChain(cube(), 'base1', [smooth]);
+    expect(surfaceCacheStatus('base1', [smooth]).cached).toBe(true);
+    // Same ops, different baseKey → cache miss (geometry it sits on changed).
+    expect(surfaceCacheStatus('base2', [smooth]).cached).toBe(false);
+  });
+
+  it('changing a later op param invalidates the full chain but reuses the prefix', async () => {
+    const a: SurfaceOp = { id: 'smooth', params: { iterations: 1, subdivide: false } };
+    const b1: SurfaceOp = { id: 'smooth', params: { iterations: 2, subdivide: false } };
+    const b2: SurfaceOp = { id: 'smooth', params: { iterations: 3, subdivide: false } };
+
+    await computeChain(cube(), 'k', [a, b1]);
+    // Editing the second op leaves the prefix [a] cached but the full chain stale.
+    expect(surfaceCacheStatus('k', [a, b2]).cached).toBe(false);
+    expect(surfaceCacheStatus('k', [a]).cached).toBe(true); // prefix preserved
+
+    // Recomputing the edited chain succeeds and becomes a hit.
+    await computeChain(cube(), 'k', [a, b2]);
+    expect(surfaceCacheStatus('k', [a, b2]).cached).toBe(true);
+  });
+
+  it('reports progress across the uncached tail', async () => {
+    const fractions: number[] = [];
+    await computeChain(cube(), 'k', [smooth, { id: 'smooth', params: { iterations: 2, subdivide: false } }], f => fractions.push(f));
+    expect(fractions.length).toBe(2);
+    expect(fractions[fractions.length - 1]).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Surface textures can now live **in the model code** as `api.surface.*` calls in a manifold-js session — parametric and non-baking — instead of the destructive bake the Surface panel does today. The expensive texture is **memoized**; an explicit run computes it automatically, while live editor typing is gated behind a "Re-apply" pill so keystrokes stay snappy.

This mirrors the `api.paint.*` architecture (#532): record in the Worker sandbox → cross as plain `MeshResult.surfaceOps` → apply on the main thread (reusing the existing modifier math, which is main-thread + WebGPU) → memoize.

```js
const { Manifold } = api;
api.surface.knit({ stitchWidth: 1.4, amplitude: 0.6 });
return Manifold.sphere(10, 48);
```

Available ops: `fuzzy`, `knit`, `cable`, `waffle`, `fur`, `woven`, `voronoi`, `smooth` (plus the generic `api.surface.apply('knit', {…})`). Same options as the `apply*` tools; size-relative defaults fill in omissions. `voxelize`/`voronoiLamp(voxel)` change the engine, so they stay bake-only.

### How it works
- **Record → apply-on-main → memoize.** Each op is keyed by `hash(simpleHash(src+params) + op-chain prefix)`. No mesh hashing — the base mesh is a deterministic function of code + customizer params, so any geometry-affecting edit re-keys the chain. Prefix memoization reuses op[0..i-1] when op[i] changes. 32-entry LRU caps growth.
- **Explicit runs force the (memoized) compute.** A `partwright.run`/`runAndSave`, the Run button, and version loads (anything with `surfaceErrors: true`) compute the texture inline (progress modal) and render/return the **textured** mesh — so an AI/console caller gets the real result with no extra step (UI↔API parity: agents can't press the pill).
- **Only live-typing is gated.** Keystroke auto-runs (`surfaceErrors: false`) render the **base** mesh + a persistent **"⟳ Textures stale — Re-apply"** pill (a status indicator like the printability pill, not a toast). Pressing it (or hitting Run) applies on demand.
- On apply, `result.mesh` is swapped and `result.manifold` nulled so the existing run-resolution path reconstructs the Manifold from the textured mesh (render-only fallback if not watertight, like the bake path). `api.paint.*`/user paint then resolves against the textured mesh.

### Scope
Phases **1 + 2** of `.plans/surface-textures-as-code.md` (record→apply→memoize + sticky gating + force-on-explicit-run). Follow-ups: **phase 3** persistence on the version (reopened session recomputes on first explicit run), **phase 4** wiring the Surface *panel* to emit `api.surface.*` instead of baking, **phase 5** per-region textures. Fully additive — existing baked sessions are untouched.

## Files
- `src/surface/surfaceOpSpec.ts` (new, leaf) — `SurfaceOpId`/`SurfaceOp` + per-modifier option allow-lists, shared by the Worker (validate) and main thread (apply).
- `src/surface/surfaceOps.ts` (new) — memo cache, key scheme, `surfaceCacheStatus`, `computeChain` (reuses `modifiers.ts`).
- `src/geometry/engines/manifoldJs.ts` — `api.surface.*` namespace (records ops, strict validation).
- `src/geometry/{types,engineWorker,engine}.ts` — `MeshResult.surfaceOps` plumbing.
- `src/main.ts` — apply/memo integration + force-on-explicit-run in the run path, the Re-apply pill + handler.
- `public/ai.md`, `public/ai/textures.md` — docs (incl. that `run`/`runAndSave` apply textures automatically).

## Test plan
- **Unit** `tests/unit/surfaceOps.test.ts`: spec invariants, memo hit/miss, base-key invalidation, prefix reuse, progress reporting.
- **E2e** `tests/surface-in-code.spec.ts`: a console run with `api.surface.cable` returns a textured, subdivided mesh with no pill (the AI path); + option-validation error.
- Green locally: `tsc`, full unit tier (936), `npm run build`, `lint:deps` (acyclic), `lint:deadcode` (no new), `lint:consistency` (no new errors). `paint-in-code` e2e re-run to confirm shared worker plumbing didn't regress.
- Browser-verified with screenshots posted in the session.

https://claude.ai/code/session_01NHdsUwyEAsrjGaHVLYTbrm