### PR TITLE
fix: register getModelColors as in-app AI chat tool

### DIFF
--- a/prompts/20260609-203612-getmodelcolors-chat-tool.md
+++ b/prompts/20260609-203612-getmodelcolors-chat-tool.md
@@ -1,0 +1,35 @@
+---
+date: 2026-06-09
+prefix: fix
+---
+
+## Human
+
+In a test on a PR branch the in-app AI tried a tool that failed with
+"Unknown tool: getModelColors".
+
+## Assistant
+
+`getModelColors` existed on `window.partwright` (src/main.ts) and was
+documented across `public/ai.md`, `public/ai/colors.md`, and
+`public/ai/replicad.md` as the way to read the model-declared color
+underlay — but it was never registered as an in-app chat tool. The chat
+agent, following those docs, called it; dispatch hit the default branch
+and returned "Unknown tool: getModelColors". Same parity gap class as the
+previously-fixed `listRegions` / `runAndExplain` / `saveVersion` tools.
+
+Decisions:
+
+- Registered `getModelColors` in `src/ai/tools.ts` as a parameterless tool
+  next to its siblings `listLabels` (uncolored label features) and
+  `listRegions` (manual paint regions).
+- Put it in `ALWAYS_AVAILABLE` (it's a pure read of declared colors, not a
+  paint mutation, so it stays listed even when `paintFaces` scope is off,
+  mirroring `listLabels`) and in `RETRY_SAFE_TOOLS`.
+- Added the dispatch case delegating to the existing `api.getModelColors()`.
+  No new console API or validation needed — the method already exists and
+  `PartwrightAPI` is the untyped record dispatch already uses.
+- Added `tests/ai-getmodelcolors-tool.spec.ts`, mirroring the
+  `ai-listregions-tool.spec.ts` regression guard: asserts the tool is
+  listed (with and without paint scope) and dispatches end-to-end against a
+  model that declares a color via `api.label(shape, name, {color})`.

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -199,6 +199,11 @@ const ALL_TOOLS: ToolDefinition[] = [
     input_schema: { type: 'object', properties: {} },
   },
   {
+    name: 'getModelColors',
+    description: 'Report the colors the current run declared in code via api.label(shape, name, {color}) (and api.labeledUnion entries with a color). These render and export automatically as a derived underlay — no paint step — and the editor stays editable; manual paint composites on top. Returns {count, colors: [{name, color, triangleCount}]}; an empty list means no colors were declared (or the labelled triangles vanished in a boolean — check listLabels().lostLabels). Sibling of listLabels (uncolored label features) and listRegions (manual paint regions).',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
     name: 'paintByLabel',
     description: 'Paint a labelled feature by name. The label must have been registered in the current run via api.label(shape, name) / api.labeledUnion (manifold-js) or label("name") <expr>; at the top level of the source (SCAD). This is the bullseye for "describe how to make and paint a model" workflows: write the geometry with labels, then paint by name — no coordinate guessing, no bounding-box estimation, no fan-bleed. For manifold-js it survives boolean ops because manifold-3d propagates originalID through runOriginalID. For SCAD it only survives at the top level — labels inside a CGAL boolean ({ ... } of difference/intersection/etc.) are lost; fall back to paintComponent / paintInBox there. For multi-feature models, batch with paintByLabels in one round-trip instead of N sequential paintByLabel calls. IMPORTANT: api.label only tracks surfaces that exist in the original labeled shape. Boolean subtraction creates NEW triangles at the cut surface (e.g. the inner wall of a mug after subtracting the void) — those new triangles have NO label. Use probePixel + paintConnected for inner surfaces created by boolean ops.',
     input_schema: {
@@ -1707,6 +1712,7 @@ const ALWAYS_AVAILABLE = new Set([
   'findFaces',
   'listComponents',
   'listLabels',
+  'getModelColors',
   // listRegions is a pure read, not a paint mutation, so it stays always-on
   // even when paintFaces is disabled — its consumers paintExplain/assertPaint
   // are always-available and need a region id to target.
@@ -1760,6 +1766,7 @@ export const RETRY_SAFE_TOOLS = new Set([
   'getActiveLanguage', 'getCode', 'getParams', 'getGeometryData', 'getMeshSummary',
   'getFeatureCentroids', 'getReferenceImages', 'getSessionContext', 'listVersions',
   'listSessionNotes', 'readDoc', 'findFaces', 'listComponents', 'listLabels',
+  'getModelColors',
   'listRegions', 'probePixel', 'paintPreview', 'paintExplain', 'query', 'probeRay',
   'listParts', 'getCurrentPart', 'assertPaint', 'sliceAtZVisual', 'checkPrintability',
   'getPrinterSettings', 'getReliefSwapGuide',
@@ -2137,6 +2144,8 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.paintComponent(input);
     case 'listLabels':
       return api.listLabels();
+    case 'getModelColors':
+      return api.getModelColors();
     case 'paintByLabel':
       return api.paintByLabel(input);
     case 'paintByLabels':

--- a/tests/ai-getmodelcolors-tool.spec.ts
+++ b/tests/ai-getmodelcolors-tool.spec.ts
@@ -1,0 +1,79 @@
+// Regression: ai.md and the colors/replicad subdocs all point the agent at
+// `partwright.getModelColors()` to read the model-declared color underlay, but
+// `getModelColors` was never registered as a chat tool. The call fell through
+// dispatch()'s default branch and came back as "Unknown tool: getModelColors",
+// leaving the in-app agent unable to inspect the colors its own labelled code
+// produced. This covers that the tool is now listed (always-available — it's a
+// pure read, sibling of listLabels/listRegions) and dispatches to the console
+// API end to end.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+test.describe('getModelColors chat tool', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('is always listed (even with paint paused) and dispatches to the console API', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const result = await page.evaluate(async () => {
+      const tools = await import('/src/ai/tools.ts');
+      const baseToggles = {
+        vision: { views: true, resolution: 'medium', angles: 'auto' },
+        scope: { runCode: true, saveVersions: true, paintFaces: true, sessionNotes: true },
+        autoRetry: 0,
+        maxIterations: 'medium',
+        maxSpend: 'high',
+        thinking: 'off',
+        provider: 'anthropic',
+        anthropicModel: 'claude-haiku-4-5',
+        localModel: null,
+        openaiModel: 'gpt-5-mini',
+        geminiModel: 'gemini-flash-latest',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const listFor = (t: any) => tools.buildToolList(t).map((d) => d.name);
+      const listedDefault = listFor(baseToggles).includes('getModelColors');
+      // Still listed when painting is paused — it reads colors declared in code,
+      // not manual paint, so it's a pure read like listLabels.
+      const listedWithPaintOff = listFor({ ...baseToggles, scope: { ...baseToggles.scope, paintFaces: false } }).includes('getModelColors');
+
+      // End-to-end dispatch: build geometry that declares a color via
+      // api.label(shape, name, {color}), then read it back.
+      const pw = (window as unknown as { partwright: {
+        createSession: (n?: string) => Promise<unknown>;
+        runAndSave: (code: string, label?: string) => Promise<unknown>;
+      } }).partwright;
+      await pw.createSession('getmodelcolors-tool-test');
+      await pw.runAndSave(
+        "const { Manifold } = api; return api.label(Manifold.cube([10, 10, 10], true), 'body', { color: [1, 0, 0] });",
+        'base',
+      );
+
+      const exec = await tools.executeTool('getModelColors', {});
+      return { listedDefault, listedWithPaintOff, exec };
+    });
+
+    // Always available — present with full scope and with painting paused.
+    expect(result.listedDefault).toBe(true);
+    expect(result.listedWithPaintOff).toBe(true);
+
+    // The call dispatched to window.partwright instead of throwing the old
+    // "Unknown tool" error, and returned the declared color.
+    expect(result.exec.isError).toBe(false);
+    expect(result.exec.content).not.toContain('Unknown tool');
+    const colors = JSON.parse(result.exec.content) as { count: number; colors: Array<{ name?: string }> };
+    expect(colors.count).toBe(1);
+    expect(colors.colors[0].name).toBe('body');
+  });
+});


### PR DESCRIPTION
## Summary

The in-app chat AI tried to call `getModelColors` and got back **"Unknown tool: getModelColors"**.

`getModelColors()` exists on `window.partwright` (`src/main.ts:12270`) and is documented across `public/ai.md`, `public/ai/colors.md`, and `public/ai/replicad.md` as the way to read the model-declared color underlay (colors declared in code via `api.label(shape, name, { color })`). But it was **never registered as an in-app chat tool** in `src/ai/tools.ts` — so when the chat agent followed those docs and called it, dispatch hit its default branch and returned the "Unknown tool" error. This is the same parity-gap class as the previously-fixed `listRegions` / `runAndExplain` / `saveVersion` tools (each has its own regression spec).

## Changes

- **Register `getModelColors`** as a parameterless tool, placed next to its siblings `listLabels` (uncolored label features) and `listRegions` (manual paint regions).
- Add it to **`ALWAYS_AVAILABLE`** — it's a pure read of declared colors, not a paint mutation, so it stays listed even when the `paintFaces` scope is off (mirrors `listLabels`).
- Add it to **`RETRY_SAFE_TOOLS`** (idempotent read).
- Add the **dispatch case** delegating to the existing `api.getModelColors()`. No new console API or validation needed — the method already exists.
- Add **`tests/ai-getmodelcolors-tool.spec.ts`**, mirroring `ai-listregions-tool.spec.ts`: asserts the tool is listed (with and without paint scope) and dispatches end-to-end against a model that declares a color via `api.label(shape, name, { color })`.

## Test plan

- `npm run build` (type-check) ✅
- `npm run test:unit` — 951 passed ✅
- `npx playwright test ai-getmodelcolors-tool` — 1 passed ✅

https://claude.ai/code/session_01URDH44c22paR1yDukncGmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01URDH44c22paR1yDukncGmB)_