### PR TITLE
feat: accept editor autocomplete with the Tab key

### DIFF
--- a/prompts/20260609-212100-editor-tab-accepts-autocomplete.md
+++ b/prompts/20260609-212100-editor-tab-accepts-autocomplete.md
@@ -1,0 +1,39 @@
+---
+session: "ggdpve"
+timestamp: "2026-06-09T21:21:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+---
+
+## Human
+
+Can we make it where, when the autocomplete shows in the editor, if somebody
+hits the Tab key, it accepts the autocomplete and automatically inserts the
+autocomplete code/text for them?
+
+## Assistant
+
+## Key decisions
+
+**Where**: The CodeMirror editor (`src/editor/codeEditor.ts`) builds on
+`basicSetup`, which wires the autocomplete tooltip to accept on Enter but
+leaves Tab unbound. The fix is a single keymap binding for Tab.
+
+**How**: Added `acceptCompletionWithTab` — a `Prec.highest`-wrapped
+`keymap.of([{ key: 'Tab', run: acceptCompletion }])` using `acceptCompletion`
+from `@codemirror/autocomplete`. `acceptCompletion` is a Command that returns
+`true` (consuming the key) only when a completion tooltip is open; otherwise it
+returns `false` so Tab falls through to its normal behavior. `Prec.highest`
+ensures it wins over the default Tab handlers basicSetup installs.
+
+**Scope**: Wired into `initEditor` only (the main code editor). The companion
+SCAD editor doesn't carry the manifold completions, so it's left untouched.
+
+**Verification**: Confirmed in a real browser via Playwright — typing
+`Manifold.cyli` opens the tooltip with `cylinder` highlighted, and Tab inserts
+`cylinder()` with the cursor inside the parens. Added a permanent golden-path
+test ("Tab accepts the highlighted completion") to
+`tests/editor-autocomplete.spec.ts`. The test needs a short settle wait after
+the tooltip appears before pressing Tab; `acceptCompletion` no-ops if the
+completion state hasn't fully activated even though an option already shows as
+aria-selected.

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -1,6 +1,7 @@
-import { EditorView } from '@codemirror/view';
-import { EditorState, Compartment, Transaction, type Extension } from '@codemirror/state';
+import { EditorView, keymap } from '@codemirror/view';
+import { EditorState, Compartment, Prec, Transaction, type Extension } from '@codemirror/state';
 import { openSearchPanel } from '@codemirror/search';
+import { acceptCompletion } from '@codemirror/autocomplete';
 import { javascript } from '@codemirror/lang-javascript';
 import { StreamLanguage } from '@codemirror/language';
 import { oneDark } from '@codemirror/theme-one-dark';
@@ -39,6 +40,14 @@ const themeCompartment = new Compartment();
 function themeExt(theme: Theme): Extension {
   return theme === 'dark' ? oneDark : [];
 }
+
+/** Tab accepts the active autocomplete option. `acceptCompletion` returns false
+ *  when no completion tooltip is open, so Tab falls through to its normal
+ *  indent/insert behavior otherwise. Prec.highest so it wins over the default
+ *  keymaps that basicSetup installs for Tab. */
+const acceptCompletionWithTab: Extension = Prec.highest(
+  keymap.of([{ key: 'Tab', run: acceptCompletion }]),
+);
 
 // Minimal OpenSCAD StreamLanguage — keyword/builtin/comment/string/number coloring.
 const SCAD_KEYWORDS = new Set([
@@ -216,6 +225,7 @@ export function initEditor(
     doc: initialCode,
     extensions: [
       basicSetup,
+      acceptCompletionWithTab,
       manifoldApiCompletion,
       languageCompartment.of(languageExt(initialLanguage)),
       lintGutter(),

--- a/tests/editor-autocomplete.spec.ts
+++ b/tests/editor-autocomplete.spec.ts
@@ -48,6 +48,23 @@ test.describe('editor autocomplete', () => {
       .toContain('Manifold.sphere(');
   });
 
+  test('Tab accepts the highlighted completion', async ({ page }) => {
+    await openEditor(page);
+    await replaceEditorWith(page, 'Manifold.cyli');
+    const tooltip = page.locator('.cm-tooltip-autocomplete');
+    await expect(tooltip).toBeVisible();
+    // Let the completion state settle so the highlighted option is acceptable.
+    await expect(tooltip.locator('[role="option"][aria-selected="true"]')).toBeVisible();
+    await page.waitForTimeout(400);
+    // Tab accepts the highlighted option (cylinder), inserting the call snippet.
+    await page.keyboard.press('Tab');
+    await expect
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .poll(() => page.evaluate(() => (window as any).partwright.getCode()))
+      .toContain('Manifold.cylinder(');
+    await expect(tooltip).not.toBeVisible();
+  });
+
   test('api. suggests injected sandbox members', async ({ page }) => {
     await openEditor(page);
     await replaceEditorWith(page, 'api.i');


### PR DESCRIPTION
## Summary

When the code editor's autocomplete tooltip is open, pressing **Tab** now accepts the highlighted completion and inserts it (e.g. `Manifold.cyli` + Tab → `Manifold.cylinder()` with the cursor inside the parens). Previously the tooltip only accepted on Enter.

Implementation: a single `Prec.highest` keymap in `src/editor/codeEditor.ts` binding `Tab` to `acceptCompletion` from `@codemirror/autocomplete`. `acceptCompletion` only consumes the key when a completion is open, so Tab falls through to its normal indent/insert behavior otherwise. Wired into `initEditor` (the main editor).

## Test plan

- [x] `npm run build` (type-check) — clean
- [x] `npm run test:unit` — 951 passed
- [x] `npm run test:e2e` (editor-autocomplete spec) — 4 passed, including a new golden-path test "Tab accepts the highlighted completion"
- [x] Manual browser verification via Playwright: typed `Manifold.cyli`, confirmed tooltip opens with `cylinder` highlighted, Tab inserts `cylinder()`

https://claude.ai/code/session_01S9HBV2SeSnsDHSQn3Y5zuL

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9HBV2SeSnsDHSQn3Y5zuL)_