### PR TITLE
fix: stop Voxel Studio menu taps from painting the model behind it

### DIFF
--- a/prompts/voxel-studio-menu-passthrough.md
+++ b/prompts/voxel-studio-menu-passthrough.md
@@ -1,0 +1,38 @@
+---
+date: 2026-06-09
+branch: claude/voxel-studio-menu-paint-bug-ogaliz
+files_changed:
+  - src/color/voxelPaint.ts
+  - tests/voxel-studio-menu-passthrough.spec.ts
+---
+
+## Human
+
+In Voxel Studio on mobile, interacting with the menu (with the paint tool
+selected) turns finger presses into paint splotches on the model behind the
+menu. Presses on the menu shouldn't pass through and edit the model. Please fix.
+
+## Assistant
+
+Root cause: `voxelPaint.ts`'s `onPointerDown`/`onPointerMove` are registered on
+the viewport *container* in the CAPTURE phase (so they beat OrbitControls'
+suppressor). That means they also fire for presses on the floating Voxel Studio
+panel, which is an overlay sibling of the canvas inside the same container.
+`onPointerDown` went straight to `pickFace(event)`, which raycasts purely from
+`clientX/clientY` against the canvas rect — ignoring which DOM element was
+actually pressed — so a tap on a menu button raycast onto the model behind it
+and painted. `setPointerCapture` then bound the pointer to the canvas, so a drag
+across menu buttons kept stamping.
+
+`paintMode.ts` already had the correct guard for the identical overlay problem
+(`if (event.target !== getRenderer().domElement) return;`). The fix mirrors it:
+bail out of the voxel `onPointerDown` when the press didn't land on the canvas.
+`onPointerMove` needs no separate guard — it only edits while `strokeActive`,
+which is only set by a stroke that started on the canvas, so a press that bailed
+early can never begin one.
+
+Verified with a Playwright spec that dispatches a `pointerdown` whose target is
+a panel button but whose coordinates are over the model: the live grid size is
+unchanged after the menu tap, and a positive control (same gesture targeting the
+canvas) still adds a voxel. Confirmed the spec fails (9261 → 9262) when the guard
+is removed, so it's a real regression guard. All 19 existing voxel specs pass.

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -562,6 +562,13 @@ let capturedPointerId: number | null = null;
 
 function onPointerDown(event: PointerEvent): void {
   if (!active || event.button !== 0) return;
+  // This listener is on the container in the CAPTURE phase, so it also sees
+  // pointerdowns on the floating Voxel Studio panel (and other overlays) that
+  // sit in front of the 3D view. Only start an edit when the press landed on
+  // the canvas itself — otherwise a tap on the panel raycasts a hit on the
+  // model behind it and paints, and setPointerCapture binds the pointer to the
+  // canvas so a drag across menu buttons keeps stamping. See paintMode.ts.
+  if (event.target !== getRenderer().domElement) return;
   const hit = pickFace(event);
   if (!hit) return;
   clearPreview(); // the action commits; the preview rebuilds on the next move

--- a/tests/voxel-studio-menu-passthrough.spec.ts
+++ b/tests/voxel-studio-menu-passthrough.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, type Page } from 'playwright/test';
+
+// Regression for the mobile bug where tapping the Voxel Studio menu painted/
+// added voxels on the model behind it. The studio's pointerdown handler runs on
+// the viewport container in the CAPTURE phase, so it sees presses on the
+// overlaid panel too; it must ignore any press whose target isn't the canvas.
+
+async function setup(page: Page) {
+  await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', new Date().toISOString()));
+  await page.goto('/editor');
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    undefined,
+    { timeout: 30_000 },
+  );
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.setActiveLanguage('voxel');
+    await pw.run(`return api.voxels().fillBox([0,0,0],[20,20,20], '#cc4444');`);
+  });
+  await page.waitForTimeout(1000);
+  await page.locator('#voxel-paint-toggle').dispatchEvent('click');
+  await page.waitForSelector('#voxel-paint-panel:not(.hidden)');
+  await page.waitForTimeout(500);
+}
+
+// Read the LIVE in-memory voxel grid size (getGeometryData only reflects baked
+// state). An errant edit changes this immediately.
+const voxelCount = (page: Page) =>
+  page.evaluate(() => import('/src/color/voxelPaint.ts').then((m) => m.voxelCount()));
+
+test('tapping the Voxel Studio menu does not edit the model behind it', async ({ page }) => {
+  await setup(page);
+  // Use the "add" tool so any errant edit is measurable as a voxel-count change.
+  await page.locator('#voxel-paint-panel button[data-tool="add"]').dispatchEvent('click');
+  await page.waitForTimeout(150);
+
+  const canvas = await page.locator('#viewport').boundingBox();
+  if (!canvas) throw new Error('viewport missing');
+  const cx = canvas.x + canvas.width / 2;
+  const cy = canvas.y + canvas.height / 2;
+
+  const before = await voxelCount(page);
+  expect(before).toBeGreaterThan(0);
+
+  // Simulate the bug: a press whose DOM target is a menu button, but whose
+  // screen coordinates land over the model. Before the fix this raycast and
+  // added a voxel; now the canvas-target guard rejects it.
+  await page.evaluate(({ x, y }) => {
+    const btn = document.querySelector('#voxel-paint-panel button[data-tool="add"]') as HTMLElement;
+    btn.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, cancelable: true, composed: true,
+      pointerId: 1, isPrimary: true, button: 0, buttons: 1, clientX: x, clientY: y,
+    }));
+    window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1, button: 0 }));
+  }, { x: cx, y: cy });
+  await page.waitForTimeout(400);
+
+  const afterMenuTap = await voxelCount(page);
+  expect(afterMenuTap).toBe(before); // menu tap must NOT edit the model
+
+  await page.screenshot({ path: 'test-results/voxel-menu-passthrough.png' });
+
+  // Positive control: the same gesture targeting the canvas itself DOES edit.
+  await page.evaluate(({ x, y }) => {
+    const canvasEl = document.querySelector('#viewport') as HTMLElement;
+    canvasEl.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, cancelable: true, composed: true,
+      pointerId: 2, isPrimary: true, button: 0, buttons: 1, clientX: x, clientY: y,
+    }));
+    window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 2, button: 0 }));
+  }, { x: cx, y: cy });
+  await page.waitForTimeout(400);
+
+  const afterCanvasTap = await voxelCount(page);
+  expect(afterCanvasTap).toBeGreaterThan(before); // canvas tap still works
+});


### PR DESCRIPTION
## Summary

Fixes a mobile (and desktop) bug in **Voxel Studio**: tapping or dragging on the studio menu painted/added voxels on the model *behind* the panel, even though the user was only interacting with the menu.

**Root cause.** The studio's `onPointerDown`/`onPointerMove` (`src/color/voxelPaint.ts`) are registered on the viewport *container* in the **capture phase** (so they run before OrbitControls' suppressor). That means they also fire for presses on the floating Voxel Studio panel, which is an overlay sibling of the canvas inside the same container. `onPointerDown` went straight to `pickFace(event)`, which raycasts purely from the pointer's `clientX/clientY` against the canvas rect — ignoring which DOM element was actually pressed. So a tap on a menu button raycast onto the model behind it and painted; `setPointerCapture` then bound the pointer to the canvas, so a drag across menu buttons kept stamping. This is most visible on mobile, where the panel overlaps the model.

**Fix.** Mirror the guard `paintMode.ts` already uses for the identical overlay problem (`paintMode.ts:616`): bail out of `onPointerDown` when the press didn't land on the canvas (`event.target !== getRenderer().domElement`). `onPointerMove` needs no separate guard — it only edits while a stroke is active, and a stroke can now only start on the canvas.

## Test plan

- New regression spec `tests/voxel-studio-menu-passthrough.spec.ts`: dispatches a `pointerdown` whose target is a panel button but whose coordinates are over the model, asserts the live voxel grid is unchanged, and a positive control (same gesture on the canvas) still adds a voxel.
  - Confirmed it **fails** (9261 → 9262) when the guard is removed — a real regression guard.
- All 19 existing voxel specs pass (`voxel-studio*`, `voxel-paint`), including the existing mobile-touch path test.
- `npm run build` + `npm run test:unit` (951 tests) green.

https://claude.ai/code/session_013nY1rWcWDMdfzGwYrcpAJY

---
_Generated by [Claude Code](https://claude.ai/code/session_013nY1rWcWDMdfzGwYrcpAJY)_