### PR TITLE
feat: persist computed api.surface.* textures across sessions (phase 3)

### DIFF
--- a/prompts/20260609-214500-surface-textures-phase3-persist.md
+++ b/prompts/20260609-214500-surface-textures-phase3-persist.md
@@ -1,0 +1,49 @@
+---
+session: "1kdce9"
+timestamp: "2026-06-09T21:45:00Z"
+model: claude-opus-4-8
+tools: [playwright, vitest, subagent]
+sequence: 5
+---
+
+## Human
+
+Asked to implement phases 3, 4, and 5 of the surface-textures-as-code plan as a
+series of stacked PRs (or independent if clean). This is phase 3 — persistence.
+
+## Assistant
+
+## Key decisions
+
+**Content-addressed persistent cache, not a Version field.** The plan suggested
+reusing the `importedMeshes` slot, but that's the wrong fit: `api.surface.*`
+models are non-baking and don't use `api.imports[0]`, so stuffing the textured
+mesh there would (a) leak it into the sandbox as a phantom import and (b) collide
+with models that genuinely use STL imports. Instead, a new IndexedDB store
+(`surfaceCache`, DB v9) keyed by the **same memo key** the in-memory cache uses —
+`hash(code + params + op-chain)`. This keeps the code as the artifact: the cache
+is derived and local, NOT part of a saved Version or session export, so a fresh
+machine simply recomputes. LRU-capped at 64 entries (savedAt index).
+
+**The key depends on the recorded ops, so seeding can't happen before the run.**
+Ops are only known after the code evaluates. So the persistent store is consulted
+inside the force path of `applySurfaceTextures`, on an in-memory miss: read
+IndexedDB by `fullChainKey(baseKey, ops)`; on a hit, seed the in-memory cache and
+use it; on a miss, compute and write back (fire-and-forget). Version loads are
+explicit (force) runs, so reopening a textured session hits this path and renders
+instantly.
+
+**Deterministic test via a compute counter.** A persistent hit and a recompute
+both yield a textured mesh, so timing isn't a reliable signal. Added
+`__surfaceComputeCalls()` (increments per op actually computed); the e2e runs a
+textured model, waits for the persistent write, clears the in-memory cache, re-
+runs the same code, and asserts the compute-call delta is **0** while the
+triangle count is unchanged — proving the persisted texture was reused, not
+recomputed.
+
+## Verification
+
+`tests/surface-persistence.spec.ts` (the round-trip above) + the existing
+surface-in-code e2e + 936 unit tests + build + lint:deps (acyclic) +
+lint:deadcode (no new) all green. New IDB store add is idempotent in
+`onupgradeneeded` and added to `clearAllData`.

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,7 +124,8 @@ import { getCompanionFiles, setCompanionFiles, addCompanionFile as addCompanionF
 import { applyFuzzy, applyFuzzyPatch, applyKnit, applyKnitAsync, applyKnitPatch, applyKnitPatchAsync, applyCable, applyCablePatch, applyWaffle, applyWafflePatch, applyFur, applyFurPatch, applyWoven, applyWovenPatch, applyVoronoi, applyVoronoiPatch, applyVoronoiLamp, applySmooth, applySmoothPatch, applyVoxelize, applyScale, defaultFuzzyOptions, defaultKnitOptions, defaultCableOptions, defaultWaffleOptions, defaultFurOptions, defaultWovenOptions, defaultVoronoiOptions, defaultVoronoiLampOptions, defaultSmoothOptions, modelDiagonal, applyTransform, type ModifierResult } from './surface/modifiers';
 import { buildTransformCode, computePlacementDelta, isNoopDelta, isNoopRotation, placementLabel, rotationLabel, rotateAboutCenterSteps, bestFlatDownRotation, applySteps, meshBox, type PlacementBox, type PlacementOps, type TransformStep, type Vec3 } from './surface/placement';
 import { nearestTriangleMap } from './surface/colorTransfer';
-import { surfaceCacheStatus, computeChain, type SurfaceOp } from './surface/surfaceOps';
+import { surfaceCacheStatus, computeChain, fullChainKey, seedCache, type SurfaceOp } from './surface/surfaceOps';
+import { getPersistedSurface, putPersistedSurface } from './storage/surfaceCacheStore';
 import { initSurfaceUI } from './ui/surfaceModal';
 import { initResizeUI } from './ui/resizeModal';
 import { initPlaceUI } from './ui/placeModal';
@@ -13677,6 +13678,20 @@ async function main() {
       return;
     }
     if (force) {
+      // Persisted (cross-session) cache: a reopened textured session seeds the
+      // in-memory cache from IndexedDB and renders instantly instead of
+      // recomputing. Keyed by the same memo key as the in-memory cache.
+      const persistKey = fullChainKey(baseKey, ops);
+      if (persistKey) {
+        const persisted = await getPersistedSurface(persistKey);
+        if (persisted) {
+          seedCache(persistKey, persisted);
+          result.mesh = persisted;
+          result.manifold = null;
+          hideSurfaceReapplyPill();
+          return;
+        }
+      }
       const progressId = startProgress({
         title: ops.length > 1 ? `Applying ${ops.length} surface textures…` : 'Applying surface texture…',
         indeterminate: false,
@@ -13686,6 +13701,8 @@ async function main() {
         result.mesh = textured;
         result.manifold = null;
         hideSurfaceReapplyPill();
+        // Persist for future sessions (best-effort, fire-and-forget).
+        if (persistKey) void putPersistedSurface(persistKey, textured);
       } catch (e) {
         // Compute failed — keep the base mesh and raise the pill so the user can
         // retry; surface the reason in the log.

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -177,7 +177,7 @@ const DB_NAME = 'partwright';
 const LEGACY_DB_NAME = 'mainifold';
 const LEGACY_MIGRATION_KEY = 'partwright-migrated-mainifold-db';
 const PARTS_MIGRATION_KEY = 'partwright-migrated-parts';
-const DB_VERSION = 8;
+const DB_VERSION = 9;
 
 /** Opens the partwright IndexedDB. Exposed so the AI subsystem can attach
  *  its own stores (`aiKeys`, `aiChats`) without duplicating the connection. */
@@ -276,6 +276,17 @@ function openDB(): Promise<IDBDatabase> {
       }
       if (!db.objectStoreNames.contains('exportInbox')) {
         db.createObjectStore('exportInbox', { keyPath: 'id' });
+      }
+      // v9: content-addressed cache for computed `api.surface.*` textures. Keyed
+      // by hash(code + params + op-chain) — the same memo key the in-memory cache
+      // (src/surface/surfaceOps.ts) uses — so reopening a textured session seeds
+      // the cache and renders instantly instead of recomputing the (slow)
+      // texture. NOT part of a Version/export: the code stays the artifact; this
+      // is a derived local cache that recomputes on a fresh machine. The
+      // `savedAt` index drives LRU pruning (src/storage/surfaceCacheStore.ts).
+      if (!db.objectStoreNames.contains('surfaceCache')) {
+        const store = db.createObjectStore('surfaceCache', { keyPath: 'key' });
+        store.createIndex('savedAt', 'savedAt', { unique: false });
       }
     };
     req.onsuccess = () => {
@@ -1008,6 +1019,7 @@ export async function clearAllData(): Promise<void> {
   const stores = ['sessions', 'versions', 'notes', 'parts', 'aiChats'];
   if (db.objectStoreNames.contains('drafts')) stores.push('drafts');
   if (db.objectStoreNames.contains('reliefSources')) stores.push('reliefSources');
+  if (db.objectStoreNames.contains('surfaceCache')) stores.push('surfaceCache');
   const txn = db.transaction(stores, 'readwrite');
   txn.objectStore('sessions').clear();
   txn.objectStore('versions').clear();
@@ -1019,6 +1031,7 @@ export async function clearAllData(): Promise<void> {
   txn.objectStore('aiChats').clear();
   if (db.objectStoreNames.contains('drafts')) txn.objectStore('drafts').clear();
   if (db.objectStoreNames.contains('reliefSources')) txn.objectStore('reliefSources').clear();
+  if (db.objectStoreNames.contains('surfaceCache')) txn.objectStore('surfaceCache').clear();
   await txComplete(txn);
 }
 

--- a/src/storage/surfaceCacheStore.ts
+++ b/src/storage/surfaceCacheStore.ts
@@ -1,0 +1,115 @@
+// Persistent, content-addressed cache for computed `api.surface.*` textures.
+//
+// The in-memory memo cache (`src/surface/surfaceOps.ts`) avoids recomputing a
+// texture within a session; this store extends that across reloads/sessions. It
+// is keyed by the same `hash(code + params + op-chain)` memo key, so a reopened
+// textured session can seed the in-memory cache from here and render instantly
+// instead of recomputing the (potentially slow) texture.
+//
+// It is deliberately NOT part of a saved Version or session export — the code
+// stays the artifact; this is a derived local cache. On a fresh machine (or
+// after a "clear all data") it simply recomputes. An LRU cap keeps it bounded.
+
+import { openPartwrightDB } from './db';
+import type { MeshData } from '../geometry/types';
+
+const STORE = 'surfaceCache';
+const MAX_ENTRIES = 64;
+
+interface SurfaceCacheRow {
+  key: string;
+  mesh: { vertProperties: Float32Array; triVerts: Uint32Array; numVert: number; numTri: number; numProp: number };
+  savedAt: number;
+}
+
+/** Look up a previously-computed textured mesh by its memo key. Returns null on
+ *  a miss or any error (the caller just recomputes). */
+export async function getPersistedSurface(key: string): Promise<MeshData | null> {
+  try {
+    const db = await openPartwrightDB();
+    if (!db.objectStoreNames.contains(STORE)) return null;
+    return await new Promise<MeshData | null>((resolve) => {
+      const txn = db.transaction(STORE, 'readonly');
+      const req = txn.objectStore(STORE).get(key);
+      req.onsuccess = () => {
+        const row = req.result as SurfaceCacheRow | undefined;
+        resolve(row ? row.mesh : null);
+      };
+      req.onerror = () => resolve(null);
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Persist a computed textured mesh under its memo key, then prune to the cap.
+ *  Best-effort: storage failures are swallowed (the in-memory cache still
+ *  serves this session). */
+export async function putPersistedSurface(key: string, mesh: MeshData): Promise<void> {
+  try {
+    const db = await openPartwrightDB();
+    if (!db.objectStoreNames.contains(STORE)) return;
+    const row: SurfaceCacheRow = {
+      key,
+      mesh: {
+        vertProperties: mesh.vertProperties,
+        triVerts: mesh.triVerts,
+        numVert: mesh.numVert,
+        numTri: mesh.numTri,
+        numProp: mesh.numProp,
+      },
+      savedAt: Date.now(),
+    };
+    await new Promise<void>((resolve) => {
+      const txn = db.transaction(STORE, 'readwrite');
+      txn.objectStore(STORE).put(row);
+      txn.oncomplete = () => resolve();
+      txn.onerror = () => resolve();
+    });
+    await pruneSurfaceCache(db);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Evict the oldest rows beyond MAX_ENTRIES (LRU by savedAt). Runs in a single
+ *  readwrite transaction — no awaits between the count and the cursor deletes,
+ *  per the IndexedDB transaction rules in CLAUDE.md. */
+function pruneSurfaceCache(db: IDBDatabase): Promise<void> {
+  return new Promise((resolve) => {
+    const txn = db.transaction(STORE, 'readwrite');
+    const store = txn.objectStore(STORE);
+    const countReq = store.count();
+    countReq.onsuccess = () => {
+      const excess = countReq.result - MAX_ENTRIES;
+      if (excess <= 0) return;
+      let removed = 0;
+      const cursorReq = store.index('savedAt').openCursor(); // ascending → oldest first
+      cursorReq.onsuccess = () => {
+        const cursor = cursorReq.result;
+        if (!cursor || removed >= excess) return;
+        cursor.delete();
+        removed++;
+        cursor.continue();
+      };
+    };
+    txn.oncomplete = () => resolve();
+    txn.onerror = () => resolve();
+  });
+}
+
+/** Diagnostic/test hook — number of rows in the persistent surface cache. */
+export async function surfaceCacheCount(): Promise<number> {
+  try {
+    const db = await openPartwrightDB();
+    if (!db.objectStoreNames.contains(STORE)) return 0;
+    return await new Promise<number>((resolve) => {
+      const txn = db.transaction(STORE, 'readonly');
+      const req = txn.objectStore(STORE).count();
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => resolve(0);
+    });
+  } catch {
+    return 0;
+  }
+}

--- a/src/surface/surfaceOps.ts
+++ b/src/surface/surfaceOps.ts
@@ -106,15 +106,40 @@ export async function computeChain(
   const remaining = ops.length - start;
   for (let i = start; i < ops.length; i++) {
     mesh = await applyOne(mesh, ops[i]);
+    computeCalls++;
     remember(prefixKey(baseKey, ops, i), mesh);
     onProgress?.(remaining > 0 ? (i - start + 1) / remaining : 1);
   }
   return mesh;
 }
 
+/** Cumulative count of ops actually computed (not served from cache). Tests use
+ *  the delta across runs to prove a cache hit avoided recompute. */
+let computeCalls = 0;
+export function __surfaceComputeCalls(): number {
+  return computeCalls;
+}
+
 /** Test/diagnostic hook — clears the memo cache. */
 export function __clearSurfaceCache(): void {
   cache.clear();
+}
+
+/** The memo key for the *full* op chain against a base identity. Persistence
+ *  (phase 3) stores this alongside the textured mesh so a reopened version can
+ *  seed the cache and hit instantly instead of recomputing. Returns null for an
+ *  empty chain (nothing to persist). */
+export function fullChainKey(baseKey: string, ops: SurfaceOp[]): string | null {
+  if (ops.length === 0) return null;
+  return prefixKey(baseKey, ops, ops.length - 1);
+}
+
+/** Insert a precomputed textured mesh under a known key (e.g. one persisted on a
+ *  saved version). The subsequent run recomputes the same key and hits this
+ *  entry, so reopening a textured session is instant. No-op on a falsy key. */
+export function seedCache(key: string | null | undefined, mesh: MeshData): void {
+  if (!key) return;
+  remember(key, mesh);
 }
 
 // Re-export the spec types so callers can import everything surface-op from here.

--- a/tests/surface-persistence.spec.ts
+++ b/tests/surface-persistence.spec.ts
@@ -1,0 +1,62 @@
+// Phase 3 — persistence of computed api.surface.* textures across the in-memory
+// cache being lost (e.g. a reload). A computed texture is written to a
+// content-addressed IndexedDB store (src/storage/surfaceCacheStore.ts); when the
+// in-memory memo cache is empty, an explicit run seeds from IndexedDB and
+// renders the textured mesh WITHOUT recomputing. Proven via the compute counter:
+// the second run's count is unchanged.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+test('a computed surface texture persists and is reused without recompute', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  await page.goto('/editor');
+  await waitForEngine(page);
+
+  const code = [
+    'const { Manifold } = api;',
+    'api.surface.cable({ cableWidth: 1.6, amplitude: 0.5 });',
+    'return Manifold.sphere(10, 48);',
+  ].join('\n');
+
+  // First explicit run: computes the texture and persists it.
+  const first = await page.evaluate(async (src) => {
+    const pw = (window as unknown as { partwright: { createSession: (n?: string) => Promise<unknown>; run: (c: string) => Promise<{ triangleCount?: number }> } }).partwright;
+    await pw.createSession('surface-persist');
+    const ops = await import('/src/surface/surfaceOps.ts');
+    const r = await pw.run(src);
+    return { tris: r.triangleCount ?? 0, computeCalls: ops.__surfaceComputeCalls() };
+  }, code);
+  expect(first.tris).toBeGreaterThan(0);
+  expect(first.computeCalls).toBeGreaterThan(0); // it actually computed
+
+  // Wait for the (fire-and-forget) persistent write to land.
+  await page.waitForFunction(async () => {
+    const store = await import('/src/storage/surfaceCacheStore.ts');
+    return (await store.surfaceCacheCount()) > 0;
+  }, { timeout: 10_000 });
+
+  // Drop the in-memory cache (simulates a reload), then run the SAME code again.
+  const second = await page.evaluate(async (src) => {
+    const ops = await import('/src/surface/surfaceOps.ts');
+    ops.__clearSurfaceCache();
+    const before = ops.__surfaceComputeCalls();
+    const pw = (window as unknown as { partwright: { run: (c: string) => Promise<{ triangleCount?: number }> } }).partwright;
+    const r = await pw.run(src);
+    return { tris: r.triangleCount ?? 0, delta: ops.__surfaceComputeCalls() - before };
+  }, code);
+
+  // Still textured (same triangle count) ...
+  expect(second.tris).toBe(first.tris);
+  // ... but served from the persistent store — zero new compute.
+  expect(second.delta).toBe(0);
+  // No "Re-apply" pill: the explicit run applied the (persisted) texture.
+  await expect(page.getByRole('button', { name: /Re-apply/ })).toBeHidden();
+});


### PR DESCRIPTION
## Summary

**Phase 3** of surface-textures-as-code (follows the merged #543). Reopening a textured session no longer recomputes the (potentially slow) texture — it's served from a persistent cache.

Adds a **content-addressed IndexedDB cache** (`surfaceCache`, DB bumped to v9) keyed by the *same* `hash(code + params + op-chain)` memo key the in-memory cache uses. On an explicit run with a cold in-memory cache (e.g. reopening a session, or after a reload), `applySurfaceTextures` seeds from IndexedDB and renders the textured mesh **instantly** instead of recomputing; freshly computed textures are written back (fire-and-forget, LRU-capped at 64 entries).

### Why a separate store, not a Version field
The plan floated reusing the `importedMeshes` slot, but `api.surface.*` models are non-baking and don't use `api.imports[0]` — stuffing the textured mesh there would leak it into the sandbox as a phantom import and collide with models that genuinely use STL imports. The content-addressed cache instead:
- keeps **the code as the artifact** — the cache is *derived* and *local*, NOT part of a saved Version or session export, so a fresh machine simply recomputes;
- is shared across versions/sessions automatically (same inputs → same key);
- is consulted inside the **force path** on an in-memory miss (the key depends on the recorded `ops`, which only exist after the run, so it can't be pre-seeded before running).

## Files
- `src/storage/db.ts` — DB v9: new `surfaceCache` object store (key = memo key, `savedAt` index for LRU); added to `clearAllData`.
- `src/storage/surfaceCacheStore.ts` (new) — `getPersistedSurface` / `putPersistedSurface` / `pruneSurfaceCache` / `surfaceCacheCount`, best-effort with the IndexedDB single-transaction discipline.
- `src/surface/surfaceOps.ts` — `fullChainKey` / `seedCache` (persist + warm), plus `__surfaceComputeCalls` test counter.
- `src/main.ts` — consult the persistent store on a force-path miss; write back on compute.

## Test plan
- **E2e** `tests/surface-persistence.spec.ts`: run a textured model (computes), wait for the persistent write, **clear the in-memory cache**, re-run the same code → asserts identical triangle count with a **zero** compute-call delta (proves it was reused from IndexedDB, not recomputed) and no Re-apply pill.
- Green locally: `tsc`, full unit tier (936), `npm run build`, `lint:deps` (acyclic), `lint:deadcode` (no new). Existing `surface-in-code` e2e still passes.

## Stacked-PR note
First of three stacked PRs (3 → 4 → 5). This one targets `main` and gets full pr-checks. Phases 4 (Surface panel emits `api.surface.*`) and 5 (per-region textures) will stack on top; I'll retarget each to `main` as the one below merges.

https://claude.ai/code/session_01NHdsUwyEAsrjGaHVLYTbrm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHdsUwyEAsrjGaHVLYTbrm)_