### PR TITLE
fix: harden editor scroll stabilizer (listener teardown + honor programmatic nav)

### DIFF
--- a/prompts/editor-scroll-stabilizer-followup.md
+++ b/prompts/editor-scroll-stabilizer-followup.md
@@ -1,0 +1,47 @@
+---
+session: "01AhYR"
+timestamp: "2026-06-09T21:50:00Z"
+---
+
+## Human
+
+(Follow-up to the merged #542 editor bottom-scroll stabilizer.) After merging,
+the user asked whether any cleanup was needed; a post-merge `work-reviewer` pass
+flagged two should-fix items. The user chose: open a small follow-up PR fixing
+both — the latent listener leak and the programmatic-scroll revert edge — with a
+test for the interaction.
+
+## Assistant
+
+## Key decisions
+
+**Gave the stabilizer a disposer so a re-init can't stack listeners.**
+`installBottomScrollStabilizer` adds three `document`-level pointer listeners
+(plus scroller wheel/scroll and an editor-root keydown). `initEditor` runs once
+today, but `editorView` is reassignable, so a future remount/HMR/reset path
+would orphan the old scroller's handlers and double-register the document ones —
+against the repo's listener-lifecycle rule. The function now stores a
+module-level `disposeScrollStabilizer` and calls any prior disposer at the top of
+a fresh install, removing every listener with matching capture flags.
+
+**Stopped the stabilizer from reverting a deliberate programmatic scroll.**
+`revealFirstDiagnostic` (jump-to-error on Run) and find-next dispatch a
+`scrollIntoView` with no preceding wheel/key/pointer, so `userActive()` was
+false; a diagnostic on one of the last lines while parked at the bottom produced
+a small (`<= 3 line`) near-bottom scroll that the stabilizer would revert,
+silently failing the reveal. Two-part fix:
+
+1. **`markEditorScrollIntent()`** — a module-private timestamp setter; `userActive()`
+   now also honors a scroll within the grace window of the last deliberate
+   navigation. `revealFirstDiagnostic` calls it right before its dispatch.
+2. **Keydown listener moved from `.cm-scroller` to `view.dom` (`.cm-editor`)** so
+   keystrokes in the search panel — which lives *outside* the scroller — count
+   as intent, covering the find-next-scrolls-to-match path without special-casing.
+
+Kept `markEditorScrollIntent` un-exported (only caller is in-file) to avoid a
+dead export.
+
+**Tests.** Added a sixth e2e case (`tests/editor-blur-scroll.spec.ts`): a
+keydown on the editor root followed by a small near-bottom scroll is honored, not
+reverted — proving the find-panel/intent path. All six pass; build + the unit
+tier green.

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -28,6 +28,22 @@ let debounceTimer: number | null = null;
 let idleTimer: number | null = null;
 let activeDiagnostics: Diagnostic[] = [];
 
+/** Teardown for the bottom-scroll stabilizer's listeners; replaced on re-install
+ *  so a re-init never stacks duplicate document-level listeners. */
+let disposeScrollStabilizer: (() => void) | null = null;
+/** Timestamp (performance.now) of the last *deliberate* programmatic editor
+ *  scroll — find-next, reveal-diagnostic. Lets the bottom-scroll stabilizer tell
+ *  an intended navigation from an unsolicited re-measure snap. */
+let scrollIntentAt = -Infinity;
+
+/** Mark that the editor is about to scroll itself on purpose (find / reveal /
+ *  caret nav), so the bottom-scroll stabilizer honors the resulting scroll
+ *  instead of reverting it as a measure snap. Call immediately before dispatching
+ *  the `EditorView.scrollIntoView` effect. */
+function markEditorScrollIntent(): void {
+  scrollIntentAt = performance.now();
+}
+
 let currentLanguage: EditorLanguage = 'manifold-js';
 // Per-tab (with a shared seed for fresh tabs) so toggling auto-format in one
 // window doesn't flip it in another open window.
@@ -223,10 +239,15 @@ export interface EditorHooks {
  *  it reverts to the last user-intended offset before the browser paints, so the
  *  snap is invisible. It stays out of the way of every genuine scroll — wheel,
  *  trackpad/momentum, scrollbar drag, touch, and keyboard/typing are all tracked
- *  as user intent and always honored — and a large jump (reveal-diagnostic,
- *  jump-to-match) is treated as real navigation. Thresholds are
- *  line-height-relative, not magic pixels. */
+ *  as user intent and always honored — as is a deliberate programmatic
+ *  navigation (find / reveal-diagnostic, which call `markEditorScrollIntent`)
+ *  and any large jump. Thresholds are line-height-relative, not magic pixels. */
 function installBottomScrollStabilizer(view: EditorView): void {
+  // Tear down a prior install first. `initEditor` runs once today, but
+  // `editorView` is reassignable (a future re-init / remount), and these
+  // document-level listeners would otherwise stack and orphan the old scroller.
+  disposeScrollStabilizer?.();
+
   const sc = view.scrollDOM;
   // The grace window (ms) during which recent user input means a scroll is the
   // user's own intent and must never be reverted.
@@ -242,22 +263,22 @@ function installBottomScrollStabilizer(view: EditorView): void {
   const userActive = (): boolean => {
     const now = performance.now();
     const grace = inputGraceMs();
-    return pointerDown || now - lastWheel < grace || now - lastKey < grace;
+    return pointerDown
+      || now - lastWheel < grace
+      || now - lastKey < grace
+      || now - scrollIntentAt < grace; // deliberate programmatic navigation
   };
 
   // Track user-driven scroll intent. Capture phase so we see input even when the
   // editor isn't focused (e.g. dragging the scrollbar).
-  sc.addEventListener('wheel', () => { lastWheel = performance.now(); }, { capture: true, passive: true });
-  sc.addEventListener('keydown', () => { lastKey = performance.now(); }, true);
-  // Pointer down/up is tracked on the document: a scrollbar drag holds the
-  // pointer down on the scroller without firing wheel/keydown.
+  const onWheel = (): void => { lastWheel = performance.now(); };
+  // Keydown is bound to the whole editor (`view.dom`), not just the scroller, so
+  // keystrokes in the search panel (find-next scrolls to the match) count as
+  // intent too — the panel lives outside `.cm-scroller`.
+  const onKey = (): void => { lastKey = performance.now(); };
   const onPointerDown = (): void => { pointerDown = true; };
   const onPointerUp = (): void => { pointerDown = false; };
-  document.addEventListener('pointerdown', onPointerDown, true);
-  document.addEventListener('pointerup', onPointerUp, true);
-  document.addEventListener('pointercancel', onPointerUp, true);
-
-  sc.addEventListener('scroll', () => {
+  const onScroll = (): void => {
     if (reverting) return;
     if (getConfig().ui.codeEditorScrollPinMs <= 0) { intendedTop = sc.scrollTop; return; } // disabled
     const lh = lineH();
@@ -276,7 +297,26 @@ function installBottomScrollStabilizer(view: EditorView): void {
     }
     // Otherwise this is the user's intent (or real navigation): adopt it.
     intendedTop = sc.scrollTop;
-  }, { passive: true });
+  };
+
+  sc.addEventListener('wheel', onWheel, { capture: true, passive: true });
+  view.dom.addEventListener('keydown', onKey, true);
+  // Pointer down/up is tracked on the document: a scrollbar drag holds the
+  // pointer down on the scroller without firing wheel/keydown.
+  document.addEventListener('pointerdown', onPointerDown, true);
+  document.addEventListener('pointerup', onPointerUp, true);
+  document.addEventListener('pointercancel', onPointerUp, true);
+  sc.addEventListener('scroll', onScroll, { passive: true });
+
+  disposeScrollStabilizer = (): void => {
+    sc.removeEventListener('wheel', onWheel, true);
+    view.dom.removeEventListener('keydown', onKey, true);
+    document.removeEventListener('pointerdown', onPointerDown, true);
+    document.removeEventListener('pointerup', onPointerUp, true);
+    document.removeEventListener('pointercancel', onPointerUp, true);
+    sc.removeEventListener('scroll', onScroll);
+    disposeScrollStabilizer = null;
+  };
 }
 
 export function initEditor(
@@ -447,6 +487,9 @@ export function clearEditorDiagnostics(): void {
 export function revealFirstDiagnostic(): void {
   if (!editorView || activeDiagnostics.length === 0) return;
   const first = activeDiagnostics[0];
+  // This is a deliberate jump — tell the bottom-scroll stabilizer not to revert
+  // it (e.g. a diagnostic on one of the last lines while parked at the bottom).
+  markEditorScrollIntent();
   editorView.dispatch({
     selection: { anchor: first.from, head: first.to },
     effects: EditorView.scrollIntoView(first.from, { y: 'center' }),

--- a/tests/editor-blur-scroll.spec.ts
+++ b/tests/editor-blur-scroll.spec.ts
@@ -89,6 +89,23 @@ test.describe('editor bottom-scroll stabilizer', () => {
     expect(await scrollTop(page)).toBeLessThan(atBottom); // the move stood
   });
 
+  test('honors a small scroll after a keystroke anywhere in the editor (find-next path)', async ({ page }) => {
+    await setupScrolledToBottom(page);
+    const atBottom = await scrollTop(page);
+
+    // The find panel lives outside .cm-scroller, so its keystrokes are caught on
+    // view.dom (.cm-editor). Simulate that: a keydown on the editor root marks
+    // intent, so a small near-bottom scroll right after it is left alone.
+    await page.evaluate(() => {
+      const ed = document.querySelector('.cm-editor') as HTMLElement;
+      ed.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    await programmaticNudge(page, -36);
+    await page.waitForTimeout(120);
+
+    expect(await scrollTop(page)).toBeLessThan(atBottom); // honored, not reverted
+  });
+
   test('does not block a large programmatic scroll (real navigation)', async ({ page }) => {
     await setupScrolledToBottom(page);
 


### PR DESCRIPTION
Follow-up to #542. A post-merge `work-reviewer` pass flagged two *should-fix* items in the bottom-scroll stabilizer; this addresses both.

## 1. Listener teardown (latent leak)

`installBottomScrollStabilizer` adds three `document`-level pointer listeners (plus scroller wheel/scroll and an editor-root keydown) with no teardown. `initEditor` runs exactly once today, but the module-level `editorView` is reassignable — a future remount / HMR / "reset editor" path would stack duplicate document listeners and orphan the old scroller's handlers, against the repo's listener-lifecycle rule.

Fix: a module-level `disposeScrollStabilizer` that a fresh install calls first, removing every listener with matching capture flags.

## 2. Don't revert a deliberate programmatic scroll near the bottom (the real bug)

`revealFirstDiagnostic` (jump-to-error on Run) and find-next dispatch a `scrollIntoView` with **no** preceding wheel/key/pointer, so `userActive()` was `false`. If the target is on one of the last lines while the editor is parked at the bottom, the resulting small (`≤ 3 line`) near-bottom scroll matched the revert condition and got snapped back — the reveal silently failed. (`revealFirstDiagnostic` uses `y:'center'`, which usually scrolls far enough to count as navigation, so the window is narrow — but real, and uncovered.)

Fix, two parts:
- **`markEditorScrollIntent()`** — a module-private timestamp; `userActive()` now also honors a scroll within the grace window of the last deliberate navigation. `revealFirstDiagnostic` calls it right before its dispatch.
- **Keydown intent moved from `.cm-scroller` to `view.dom` (`.cm-editor`)** so keystrokes in the **search panel** — which lives *outside* the scroller — count as intent, covering the find-next-scrolls-to-match path without special-casing.

Kept `markEditorScrollIntent` un-exported (only in-file caller) to avoid a dead export.

## Test plan

- `tests/editor-blur-scroll.spec.ts` — added a 6th case: a keydown on the editor root followed by a small near-bottom scroll is **honored, not reverted** (the find-panel/intent path). The original five still pass.
- `npm run build` ✓ · `npm run test:unit` ✓ (961) · `npm run lint:deadcode` shows only pre-existing advisory exports.

No behavior change for users beyond the two fixes; the merged stabilizer's core logic is unchanged.

https://claude.ai/code/session_01AhYR9yodHm1nPUubL4vQsq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhYR9yodHm1nPUubL4vQsq)_