### PR TITLE
feat: apply surface textures as editable api.surface.* code (phase 4)

### DIFF
--- a/prompts/20260609-215500-surface-textures-phase4-panel.md
+++ b/prompts/20260609-215500-surface-textures-phase4-panel.md
@@ -1,0 +1,51 @@
+---
+session: "1kdce9"
+timestamp: "2026-06-09T21:55:00Z"
+model: claude-opus-4-8
+tools: [playwright, vitest]
+sequence: 6
+---
+
+## Human
+
+Phase 4 of surface-textures-as-code (stacked on phase 3): make the Surface panel
+emit `api.surface.*` code instead of baking, with a console method + AI tool.
+
+## Assistant
+
+## Key decisions
+
+**Code is now the default panel output, bake is the escape hatch.** The Surface
+panel grew an "Apply as editable code (api.surface.*)" checkbox (on by default)
+for the eight code-expressible textures (fuzzy/knit/cable/waffle/fur/woven/
+voronoi/smooth). Checked → the texture is appended to the model source as a
+parametric call and re-run (force-applies the phase-1/2 memoized texture);
+unchecked → the existing destructive bake. The toggle is hidden for
+voronoiLamp/voxelize (engine-changing → bake only) and bypassed when a region is
+selected (per-region code is phase 5 — the patch still bakes).
+
+**Single emit path for panel + console + AI.** All three route through one new
+`commitSurfaceCode(id, opts)` in main.ts → `partwright.surfaceTexture(id, opts)`
+console method + `surfaceTexture` AI tool (SAVE_GATED) + help() entry. Parity in
+one place. It guards manifold-js-only and returns `{ error }` otherwise.
+
+**Codegen mirrors the api.paint.* migration wrapper.** `surfaceCodegen.ts`
+(pure, unit-tested) appends `api.surface.<id>({...})` before the IIFE wrapper's
+`return __pwModel;`, wrapping the body on first use and inserting before the
+existing return on subsequent applies — so repeated textures compose without
+nesting, and it interoperates with the paint-in-code wrapper. `surfaceOptsLiteral`
+filters to the op's valid fields (drops `selectedTriangles`, unknown keys) and
+rounds numbers to 4dp for a tidy literal.
+
+**Why this is the right default:** it directly fixes the user's earlier finding
+(an AI baked because it couldn't get a parametric texture). Now the AI's natural
+tool (`surfaceTexture`) and the human's panel both produce editable models;
+baking is opt-in.
+
+## Verification
+
+`tests/surface-code-emit.spec.ts` (emit → code contains the call + textured
+render; unknown-id error) + `tests/unit/surfaceCodegen.test.ts` (literal
+filtering, IIFE wrap, compose-without-nesting). Panel toggle confirmed in the
+browser (screenshot). All three surface e2e specs + 941 unit tests + build +
+lint:deps/consistency/deadcode green.

--- a/prompts/20260609-220500-surface-textures-phase5-region.md
+++ b/prompts/20260609-220500-surface-textures-phase5-region.md
@@ -1,0 +1,58 @@
+---
+session: "1kdce9"
+timestamp: "2026-06-09T22:05:00Z"
+model: claude-opus-4-8
+tools: [playwright, vitest]
+sequence: 7
+---
+
+## Human
+
+Phase 5 of surface-textures-as-code (stacked on phase 4): per-region textures —
+texture only part of the model, so different regions can carry different
+textures.
+
+## Assistant
+
+## Key decisions
+
+**`api.surface.<id>({ region })` resolves to a patch apply.** The sandbox builds
+a RegionDescriptor from a `region` selector that mirrors `api.paint.*`: a label
+name (string / `{label}`), `{box}`, `{slab}`, or `{cylinder}` (exactly one). The
+descriptor rides on the SurfaceOp; the main thread resolves it to a triangle set
+and `computeChain` routes to the `apply*Patch` variant instead of the whole-model
+modifier.
+
+**Region resolution happens per-op against the op's INPUT mesh, on the main
+thread.** computeChain gained a `RegionResolver` callback (the resolver lives in
+main.ts, which owns `resolveDescriptorTriangles` + the label map). Resolving
+against each op's input mesh keeps geometric selectors (box/slab/cylinder) exact
+even when chained after a prior texture that subdivided the mesh.
+
+**byLabel is guarded, not silently wrong.** A `byLabel` region depends on the
+run's label map, whose triangle ids are only valid on the un-textured base. So
+the resolver throws an actionable error if a byLabel region would run on an
+already-subdivided mesh (i.e. it's not the first surface op) — telling the user to
+reorder or use a geometric selector. Single-region byLabel (the common case) and
+geometric multi-region chaining both work; the broken case fails loudly.
+
+**Two correctness fixes caught by reasoning, not types:**
+- `prefixKey` (the memo key) omitted `region`, so a region change wouldn't
+  re-key the cache — added `region` to the serialized chain.
+- `currentLabelMap` is set by the run handler *after* applySurfaceTextures, so
+  byLabel regions would resolve against the previous run's labels — the resolver
+  factory now sets it early (idempotent with the later assignment).
+
+**Scope boundary:** region is code-authored (write `api.surface.knit({region})`
+in runAndSave). The phase-4 `surfaceTexture` tool / panel stay whole-model and
+reject a `region` option with a message pointing to code — because the panel's
+raw-triangle selection isn't a durable descriptor, and the tool's codegen only
+serializes scalars.
+
+## Verification
+
+`tests/surface-region.spec.ts`: a box region produces base < region < whole-model
+triangle counts (proves it's a patch, not whole-model); a `region: 'body'` label
+textures the labeled region; a two-selector region errors. Browser-confirmed —
+top hemisphere knit, bottom smooth (screenshot). All 8 surface e2e + unit tier +
+build + lint:deps/consistency/deadcode green.

--- a/public/ai/textures.md
+++ b/public/ai/textures.md
@@ -65,6 +65,28 @@ return body;
   (see [colors](/ai/colors.md)). Use it when you want the texture to live with
   the code; use the `apply*` tools when you want a one-shot baked result.
 
+**Per-region textures (`region`):** pass a `region` selector to texture only part
+of the model — so different regions can carry different textures:
+
+```js
+const { Manifold } = api;
+const body = api.label(Manifold.sphere(12, 48), 'body');
+api.surface.knit({ stitchWidth: 1.4, region: 'body' });                  // by api.label name
+api.surface.fuzzy({ region: { box: { min: [-12,-12,0], max: [12,12,12] } } }); // upper half only
+return body;
+```
+
+`region` accepts exactly one selector, mirroring `api.paint.*`: a label name
+(string, or `{ label }`), `{ box: { min, max } }`, `{ slab: { axis|normal,
+offset, thickness } }`, or `{ cylinder: { center, rMin?, rMax, zMin, zMax } }`.
+It textures just the matching triangles (a "patch"), so the rest of the surface
+stays as-is. Chain several to give regions different textures. Geometric
+selectors (box/slab/cylinder) stay exact even when chained after another texture;
+a `byLabel` region must be the **first** surface op (label ids are only valid on
+the un-textured mesh — use a geometric selector for a region after another
+texture). This is code-authored (write it in `runAndSave`); the `surfaceTexture`
+tool/panel apply whole-model.
+
 **Driving it without writing the call yourself:** the `surfaceTexture(id, opts)`
 tool / `partwright.surfaceTexture(id, opts)` console method applies a texture *as
 code* — it appends the `api.surface.<id>(...)` call to the current model and

--- a/public/ai/textures.md
+++ b/public/ai/textures.md
@@ -65,6 +65,17 @@ return body;
   (see [colors](/ai/colors.md)). Use it when you want the texture to live with
   the code; use the `apply*` tools when you want a one-shot baked result.
 
+**Driving it without writing the call yourself:** the `surfaceTexture(id, opts)`
+tool / `partwright.surfaceTexture(id, opts)` console method applies a texture *as
+code* — it appends the `api.surface.<id>(...)` call to the current model and
+re-runs, so you get the editable result in one step (`id` = `fuzzy` / `knit` /
+`cable` / `waffle` / `fur` / `woven` / `voronoi` / `smooth`; `opts` = the same
+options as the matching `apply*` tool). The Surface panel does the same: its
+**"Apply as editable code (api.surface.*)"** checkbox (on by default for these
+textures) emits the call instead of baking; unchecking it bakes a fixed mesh.
+manifold-js + whole-model only — pick the baking `apply*` tools for other engines
+or a region selection.
+
 ---
 
 ## When to apply textures

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1618,6 +1618,42 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'surfaceTexture',
+    description: `Apply a surface texture as PARAMETRIC, EDITABLE code (api.surface.*) instead of baking it into a fixed mesh. This is the non-destructive counterpart of applyFuzzySkin / applyKnitTexture / applyCableKnit / etc.: it appends an api.surface.<id>(...) call to the model's code and re-runs, so the texture stays tunable (edit a param, re-run) and the model code remains the source of truth. Saves a new version.
+
+**When to use:** prefer this over the baking apply* tools when you want the textured model to stay editable — e.g. you may retune the stitch size later, or keep painting/booleaning the parametric base. Use the baking apply* tools only when you specifically want a flattened mesh.
+
+**Parameters:** id (required) = which texture; the remaining options are the SAME as the matching apply* tool (e.g. for 'knit': stitchWidth, amplitude, …) — see /ai/textures.md. Unset options use size-relative defaults. Only options valid for the chosen id are used.
+
+**Limits:** manifold-js sessions only (returns { error } otherwise), and whole-model only (no region selection yet). Returns { ok, label, mode:'code', geometry } or { error }.`,
+    input_schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', enum: ['fuzzy', 'knit', 'cable', 'waffle', 'fur', 'woven', 'voronoi', 'smooth'], description: 'Which texture to apply as code.' },
+        amplitude: { type: 'number', description: 'Displacement depth (world units). Texture-specific default if omitted.' },
+        scale: { type: 'number', description: 'fuzzy: feature size.' },
+        octaves: { type: 'integer', description: 'fuzzy/fur: noise octaves (1–5).' },
+        stitchWidth: { type: 'number', description: 'knit: horizontal stitch repeat.' },
+        stitchHeight: { type: 'number', description: 'knit: vertical stitch repeat.' },
+        cableWidth: { type: 'number', description: 'cable: cable column width.' },
+        cablePitch: { type: 'number', description: 'cable: twist pitch.' },
+        cellWidth: { type: 'number', description: 'waffle: cell width.' },
+        cellHeight: { type: 'number', description: 'waffle: cell height.' },
+        cellSize: { type: 'number', description: 'voronoi: cell size.' },
+        wallWidth: { type: 'number', description: 'voronoi: ridge wall width fraction.' },
+        fiberSpacing: { type: 'number', description: 'fur: fiber spacing.' },
+        fiberLength: { type: 'number', description: 'fur: fiber length.' },
+        threadSpacing: { type: 'number', description: 'woven: thread spacing.' },
+        threadWidth: { type: 'number', description: 'woven: thread width fraction.' },
+        grainAngleDeg: { type: 'number', description: 'Rotate the texture grain in the XY plane (degrees).' },
+        iterations: { type: 'integer', description: 'smooth: number of Taubin passes.' },
+        seed: { type: 'integer', description: 'Pattern seed (different seeds → different patterns).' },
+        quality: { type: 'integer', description: 'Mesh detail 1 (draft) – 5 (ultra).', minimum: 1, maximum: 5 },
+      },
+      required: ['id'],
+    },
+  },
+  {
     name: 'scaleModel',
     description: `Resize the current model by per-axis multiplicative factors and save a new version. 1 = unchanged, 2 = double, 0.5 = half. For a uniform resize pass the same factor for sx, sy, and sz.
 
@@ -1777,7 +1813,7 @@ export const RETRY_SAFE_TOOLS = new Set([
 ]);
 
 const RUN_GATED = new Set(['runCode', 'setParams']);
-const SAVE_GATED = new Set(['runAndSave', 'loadVersion', 'saveVersion', 'applyFuzzySkin', 'applyKnitTexture', 'applyCableKnit', 'applyWaffleStitch', 'applyFurVelvet', 'applyWovenFabric', 'applyVoronoiShell', 'applyVoronoiLamp', 'smoothModel', 'voxelizeModel', 'scaleModel', 'placeModel', 'rotateModel', 'layFlatModel']);
+const SAVE_GATED = new Set(['runAndSave', 'loadVersion', 'saveVersion', 'applyFuzzySkin', 'applyKnitTexture', 'applyCableKnit', 'applyWaffleStitch', 'applyFurVelvet', 'applyWovenFabric', 'applyVoronoiShell', 'applyVoronoiLamp', 'smoothModel', 'voxelizeModel', 'surfaceTexture', 'scaleModel', 'placeModel', 'rotateModel', 'layFlatModel']);
 const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);
 /** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
@@ -2289,6 +2325,10 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.smoothModel(input);
     case 'voxelizeModel':
       return api.voxelizeModel(input);
+    case 'surfaceTexture': {
+      const { id, ...rest } = input;
+      return api.surfaceTexture(id as string, rest);
+    }
     case 'scaleModel':
       return api.scaleModel(input.sx as number, input.sy as number, input.sz as number, { preserveColor: input.preserveColor as boolean | undefined });
     case 'placeModel':

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -349,6 +349,71 @@ export const manifoldJsEngine: Engine = {
       x: [1, 0, 0], y: [0, 1, 0], z: [0, 0, 1],
     };
 
+    // Build a RegionDescriptor from an `api.surface.*({ region })` selector. The
+    // forms mirror the api.paint.* selectors so "texture this region" reads the
+    // same as "paint this region". The descriptor is resolved to triangles on
+    // the main thread (against the actual mesh), reusing the paint resolver.
+    const buildRegionDescriptor = (region: unknown): RegionDescriptor => {
+      if (typeof region === 'string') {
+        if (region.length === 0) throw new Error('api.surface region: a string region must be a non-empty api.label(...) name.');
+        return { kind: 'byLabel', label: region };
+      }
+      const o = paintObj(region, 'api.surface region');
+      const { label, box, slab, cylinder, ...rest } = o;
+      paintRejectUnknown('api.surface region', rest);
+      const provided = [label, box, slab, cylinder].filter(v => v !== undefined).length;
+      if (provided !== 1) {
+        throw new Error("api.surface region: provide exactly one of label, box, slab, or cylinder (e.g. region: 'body' or region: { box: { min, max } }).");
+      }
+      if (label !== undefined) {
+        if (typeof label !== 'string' || label.length === 0) throw new Error('api.surface region.label: must be a non-empty api.label(...) name.');
+        return { kind: 'byLabel', label };
+      }
+      if (box !== undefined) {
+        const b = paintObj(box, 'api.surface region.box({ min, max })');
+        const { min, max, ...brest } = b;
+        paintRejectUnknown('api.surface region.box', brest);
+        const lo = paintVec3(min, 'api.surface region.box min');
+        const hi = paintVec3(max, 'api.surface region.box max');
+        const center: [number, number, number] = [(lo[0] + hi[0]) / 2, (lo[1] + hi[1]) / 2, (lo[2] + hi[2]) / 2];
+        const size: [number, number, number] = [Math.abs(hi[0] - lo[0]), Math.abs(hi[1] - lo[1]), Math.abs(hi[2] - lo[2])];
+        return { kind: 'box', center, size, quaternion: [0, 0, 0, 1], shape: 'box' };
+      }
+      if (slab !== undefined) {
+        const s = paintObj(slab, 'api.surface region.slab({ axis, offset, thickness })');
+        const { axis, normal, offset, thickness, ...srest } = s;
+        paintRejectUnknown('api.surface region.slab', srest);
+        let nrm: [number, number, number];
+        if (axis !== undefined) {
+          if (typeof axis !== 'string' || !(axis in AXIS_NORMAL)) throw new Error("api.surface region.slab axis: expected 'x', 'y' or 'z' (or pass an explicit normal).");
+          nrm = AXIS_NORMAL[axis];
+        } else if (normal !== undefined) {
+          nrm = paintVec3(normal, 'api.surface region.slab normal');
+        } else {
+          throw new Error("api.surface region.slab: provide either axis ('x'|'y'|'z') or an explicit normal [x, y, z].");
+        }
+        const off = paintNum(offset, 'api.surface region.slab offset');
+        const thk = paintNum(thickness, 'api.surface region.slab thickness');
+        if (thk <= 0) throw new Error('api.surface region.slab thickness: must be > 0.');
+        return { kind: 'slab', normal: nrm, offset: off, thickness: thk };
+      }
+      // cylinder
+      const c = paintObj(cylinder, 'api.surface region.cylinder({ center, rMin, rMax, zMin, zMax })');
+      const { center, rMin, rMax, zMin, zMax, ...crest } = c;
+      paintRejectUnknown('api.surface region.cylinder', crest);
+      if (!Array.isArray(center) || center.length !== 2 || center.some(n => typeof n !== 'number' || !Number.isFinite(n))) {
+        throw new Error('api.surface region.cylinder center: expected [x, y] (two finite numbers).');
+      }
+      const cc = center as [number, number];
+      const r0 = rMin === undefined ? 0 : paintNum(rMin, 'api.surface region.cylinder rMin');
+      const r1 = paintNum(rMax, 'api.surface region.cylinder rMax');
+      const z0 = paintNum(zMin, 'api.surface region.cylinder zMin');
+      const z1 = paintNum(zMax, 'api.surface region.cylinder zMax');
+      if (r0 < 0 || r1 <= r0) throw new Error('api.surface region.cylinder: require 0 <= rMin < rMax.');
+      if (z1 <= z0) throw new Error('api.surface region.cylinder: require zMin < zMax.');
+      return { kind: 'cylinder', center: cc, rMin: r0, rMax: r1, zMin: z0, zMax: z1 };
+    };
+
     const paint = {
       /** Paint every triangle inside an axis-aligned box. `min`/`max` are world-space corners. */
       box(opts: unknown): void {
@@ -436,11 +501,14 @@ export const manifoldJsEngine: Engine = {
         }
         opts = params as Record<string, unknown>;
       }
+      // `region` is handled separately (it's an object selector, not a scalar
+      // option): texture only the matching triangles instead of the whole mesh.
+      const { region, ...scalarOpts } = opts;
       const allowed = SURFACE_OP_FIELDS[id];
       const clean: Record<string, number | boolean | string> = {};
-      for (const [k, v] of Object.entries(opts)) {
+      for (const [k, v] of Object.entries(scalarOpts)) {
         if (!allowed.includes(k)) {
-          throw new Error(`api.surface.${id}: unknown option "${k}". Accepted: ${allowed.join(', ')}.`);
+          throw new Error(`api.surface.${id}: unknown option "${k}". Accepted: ${allowed.join(', ')}${allowed.length ? ', ' : ''}region.`);
         }
         if (typeof v === 'number') {
           if (!Number.isFinite(v)) throw new Error(`api.surface.${id}.${k}: must be a finite number.`);
@@ -449,7 +517,9 @@ export const manifoldJsEngine: Engine = {
         }
         clean[k] = v;
       }
-      surfaceOps.push({ id, params: clean });
+      const op: SurfaceOp = { id, params: clean };
+      if (region !== undefined && region !== null) op.region = buildRegionDescriptor(region);
+      surfaceOps.push(op);
     };
     const makeSurfaceFn = (id: SurfaceOpId) => (params?: unknown): void => recordSurfaceOp(id, params);
     const surface: Record<SurfaceOpId, (params?: unknown) => void> & { apply(id: unknown, params?: unknown): void } = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7206,6 +7206,9 @@ async function main() {
     if (getActiveLanguage() !== 'manifold-js') {
       return { error: 'api.surface.* textures are manifold-js only. Use the bake tool (applyKnitTexture, applyFuzzySkin, …) for this engine, or switch the session to manifold-js.' };
     }
+    if ('region' in opts) {
+      return { error: 'surfaceTexture applies whole-model. For a region texture, write api.surface.' + id + "({ region: 'label' | { box|slab|cylinder } }) directly in your model code (runAndSave) — see /ai/textures.md." };
+    }
     if (!currentMeshData) return { error: 'No model loaded — run the model first.' };
     const newCode = appendSurfaceCall(getValue(), id, opts);
     setValue(newCode);
@@ -13693,6 +13696,27 @@ async function main() {
    *     sticky Re-apply pill, keeping keystroke renders snappy.
    *  Returns true unless a forced compute failed (caller treats failure as a
    *  non-fatal "base shown" run). */
+  /** Build the region resolver passed to computeChain for `api.surface.*({ region })`
+   *  (phase 5). Resolves each op's region descriptor to a triangle set against
+   *  the mesh that op runs on, reusing the paint resolver. Geometric selectors
+   *  (box/slab/cylinder) are exact on any mesh; a `byLabel` region depends on the
+   *  run's label map (valid only on the un-textured base), so it's rejected when
+   *  it would run on an already-subdivided mesh — with an actionable message. */
+  function makeSurfaceRegionResolver(result: MeshResult, base: MeshData) {
+    // The run handler sets currentLabelMap later; set it now so byLabel regions
+    // resolve against THIS run's labels (idempotent with the later assignment).
+    if (result.surfaceOps?.some(o => o.region != null)) currentLabelMap = result.labelMap ?? null;
+    return (descriptor: unknown, mesh: MeshData): Set<number> => {
+      const d = descriptor as RegionDescriptor;
+      if (d.kind === 'byLabel' && mesh.numTri !== base.numTri) {
+        throw new Error(`api.surface region "${d.label}": a byLabel region must be the first surface op — label triangle ids are only valid on the un-textured mesh. Texture this region first, or use a geometric selector (box/slab/cylinder) to texture a region after another texture.`);
+      }
+      let adjacency: AdjacencyGraph | null = null;
+      if (d.kind === 'coplanar' || d.kind === 'connectedFromSeed' || d.kind === 'colorFlood') adjacency = buildAdjacency(mesh);
+      return resolveDescriptorTriangles(d, mesh, adjacency, null).triangles;
+    };
+  }
+
   async function applySurfaceTextures(result: MeshResult, src: string, force: boolean): Promise<void> {
     const ops = result.surfaceOps;
     if (!ops || ops.length === 0 || !result.mesh) {
@@ -13731,7 +13755,7 @@ async function main() {
         indeterminate: false,
       });
       try {
-        const textured = await computeChain(base, baseKey, ops, (f) => updateProgress(progressId, f));
+        const textured = await computeChain(base, baseKey, ops, (f) => updateProgress(progressId, f), makeSurfaceRegionResolver(result, base));
         result.mesh = textured;
         result.manifold = null;
         hideSurfaceReapplyPill();

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,6 +125,8 @@ import { applyFuzzy, applyFuzzyPatch, applyKnit, applyKnitAsync, applyKnitPatch,
 import { buildTransformCode, computePlacementDelta, isNoopDelta, isNoopRotation, placementLabel, rotationLabel, rotateAboutCenterSteps, bestFlatDownRotation, applySteps, meshBox, type PlacementBox, type PlacementOps, type TransformStep, type Vec3 } from './surface/placement';
 import { nearestTriangleMap } from './surface/colorTransfer';
 import { surfaceCacheStatus, computeChain, fullChainKey, seedCache, type SurfaceOp } from './surface/surfaceOps';
+import { isSurfaceOpId } from './surface/surfaceOpSpec';
+import { appendSurfaceCall } from './surface/surfaceCodegen';
 import { getPersistedSurface, putPersistedSurface } from './storage/surfaceCacheStore';
 import { initSurfaceUI } from './ui/surfaceModal';
 import { initResizeUI } from './ui/resizeModal';
@@ -7194,6 +7196,26 @@ async function main() {
     return null;
   }
 
+  /** Apply a texture as parametric `api.surface.*` code (phase 4): append the
+   *  call to the model's source, re-run (force-applies the memoized texture), and
+   *  save a version. The non-baking counterpart of commitSurfaceModifier. */
+  async function commitSurfaceCode(id: string, opts: Record<string, unknown>): Promise<Record<string, unknown>> {
+    if (!isSurfaceOpId(id)) {
+      return { error: `surfaceTexture: unknown texture "${id}". Use one of: fuzzy, knit, cable, waffle, fur, woven, voronoi, smooth.` };
+    }
+    if (getActiveLanguage() !== 'manifold-js') {
+      return { error: 'api.surface.* textures are manifold-js only. Use the bake tool (applyKnitTexture, applyFuzzySkin, …) for this engine, or switch the session to manifold-js.' };
+    }
+    if (!currentMeshData) return { error: 'No model loaded — run the model first.' };
+    const newCode = appendSurfaceCall(getValue(), id, opts);
+    setValue(newCode);
+    const ok = await runCodeSync(newCode);
+    if (!ok) return { error: `Failed to apply ${id} texture` };
+    const thumbnail = await captureThumbnail();
+    await saveVersion(newCode, enrichGeometryDataWithColors(getGeometryDataObj()), thumbnail, `${id} texture (code)`, undefined, { force: true });
+    return { ok: true, label: `${id} texture (code)`, mode: 'code', geometry: getGeometryDataObj() };
+  }
+
   async function commitSurfaceModifier(result: ModifierResult, preserveColor: boolean, opts?: { warnOnBake?: boolean }): Promise<Record<string, unknown>> {
     // Capture the language *before* the commit switches it, so we can warn when a
     // SCAD/BREP session is silently baked to a mesh. The transform path
@@ -7851,6 +7873,16 @@ async function main() {
       try {
         const preserve = opts?.preserveColor ?? true;
         return await commitSurfaceModifier(buildSurfaceModifier('voxelize', opts, preserve), preserve);
+      } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
+    },
+    /** Apply a surface texture as parametric `api.surface.*` code (phase 4) —
+     *  the editable, non-baking counterpart of applyFuzzySkin / applyKnitTexture
+     *  / etc. Appends the call to the model's code and re-runs (force-applies),
+     *  saving a version. manifold-js + whole-model only. Returns `{ error }` on a
+     *  non-manifold-js engine or an unknown id. */
+    async surfaceTexture(id: string, opts?: Record<string, unknown>) {
+      try {
+        return await commitSurfaceCode(id, opts ?? {});
       } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
     },
     /** Non-destructive viewport preview of a scale operation (no version saved). */
@@ -12920,6 +12952,8 @@ async function main() {
         'setBucketMode': { signature: "setBucketMode(mode) -- Set the bucket flood-fill mode: 'color' (magic-wand by RGB) or 'geometry' (coplanar by bend angle).", docs: '/ai/colors.md' },
         'getBrushSize':    { signature: 'getBrushSize() -- Read the UI brush radius (mesh units). 0 = single triangle.', docs: '/ai/colors.md' },
         'setBrushSize':    { signature: 'setBrushSize(radius) -- Set the UI brush radius (mesh units, >= 0). Affects only the interactive brush tool; programmatic painting uses paintNear / paintFaces.', docs: '/ai/colors.md' },
+        // Surface textures
+        'surfaceTexture':  { signature: "surfaceTexture(id, opts?) -- Apply a texture as parametric api.surface.* code (id: fuzzy|knit|cable|waffle|fur|woven|voronoi|smooth) instead of baking. Edits the model code + re-runs. manifold-js, whole-model. -> {ok, label, geometry} or {error}", docs: '/ai/textures.md#textures-as-code--apisurface-non-baking-in-a-manifold-js-session' },
         // Annotations
         'listAnnotations':    { signature: 'listAnnotations() -- List freehand strokes -> [{id, color, width, points}]', docs: '/ai/annotations.md' },
         'listTextAnnotations':{ signature: 'listTextAnnotations() -- List pinned text labels -> [{id, text, color, fontSizePx, anchor}]', docs: '/ai/annotations.md' },

--- a/src/surface/surfaceCodegen.ts
+++ b/src/surface/surfaceCodegen.ts
@@ -1,0 +1,54 @@
+// Emit `api.surface.*` calls into a manifold-js model's source (phase 4: the
+// Surface panel / console can apply a texture as editable, parametric code
+// instead of baking it into a mesh). Pure string transform — unit-testable.
+
+import { SURFACE_OP_FIELDS, type SurfaceOpId } from './surfaceOpSpec';
+
+// Marker for the IIFE wrapper this (and the api.paint.* migration) uses, so
+// repeated applies append another line before the same return instead of
+// nesting wrappers.
+const WRAP_RETURN = 'return __pwModel;';
+
+function roundNum(n: number): string {
+  // Compact literal: round to 4 decimals, drop trailing zeros.
+  return Number(n.toFixed(4)).toString();
+}
+
+/** Serialize chosen opts to a compact object literal, keeping only keys valid
+ *  for this op and JSON-serializable scalars (numbers/booleans/strings). */
+export function surfaceOptsLiteral(id: SurfaceOpId, opts: Record<string, unknown>): string {
+  const allowed = new Set(SURFACE_OP_FIELDS[id]);
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(opts)) {
+    if (!allowed.has(k)) continue;
+    if (typeof v === 'number') { if (Number.isFinite(v)) parts.push(`${k}: ${roundNum(v)}`); }
+    else if (typeof v === 'boolean') parts.push(`${k}: ${v}`);
+    else if (typeof v === 'string') parts.push(`${k}: ${JSON.stringify(v)}`);
+  }
+  return parts.length > 0 ? `{ ${parts.join(', ')} }` : '';
+}
+
+/** Append an `api.surface.<id>(...)` call to a model's code. If the code is
+ *  already wrapped (carries `return __pwModel;` — from a prior surface/paint
+ *  emit), insert the call before that return so emits compose; otherwise wrap
+ *  the body in an IIFE so any return shape keeps working. */
+export function appendSurfaceCall(code: string, id: SurfaceOpId, opts: Record<string, unknown>): string {
+  const lit = surfaceOptsLiteral(id, opts);
+  const call = `api.surface.${id}(${lit});`;
+  const body = code.replace(/\s+$/, '');
+  if (body.includes(WRAP_RETURN)) {
+    // Insert before the LAST occurrence of the return marker.
+    const idx = body.lastIndexOf(WRAP_RETURN);
+    return `${body.slice(0, idx)}${call}\n${WRAP_RETURN}${body.slice(idx + WRAP_RETURN.length)}`;
+  }
+  return [
+    '// Surface texture applied as parametric code — edit the params, or remove',
+    '// this line to drop the texture. See /ai/textures.md#textures-as-code.',
+    'const __pwModel = (() => {',
+    body,
+    '})();',
+    call,
+    WRAP_RETURN,
+    '',
+  ].join('\n');
+}

--- a/src/surface/surfaceOpSpec.ts
+++ b/src/surface/surfaceOpSpec.ts
@@ -30,6 +30,12 @@ export type SurfaceOpId =
 export interface SurfaceOp {
   id: SurfaceOpId;
   params: Record<string, number | boolean | string>;
+  /** Optional region selector — when present, only the matching triangles are
+   *  textured (a "patch" apply) instead of the whole mesh. A `RegionDescriptor`
+   *  (built from the `region` option in `api.surface.*`), kept `unknown` here so
+   *  this leaf stays import-free; the main thread casts it back and resolves it
+   *  to triangles against the mesh. */
+  region?: unknown;
 }
 
 /** Accepted option keys per modifier — mirrors the `Required<…Options>` field

--- a/src/surface/surfaceOps.ts
+++ b/src/surface/surfaceOps.ts
@@ -17,9 +17,15 @@ import { simpleHash } from '../geometry/statsComputation';
 import type { SurfaceOp, SurfaceOpId } from './surfaceOpSpec';
 import {
   applyFuzzy, applyKnitAsync, applyCable, applyWaffle, applyFur, applyWoven, applyVoronoi, applySmooth,
+  applyFuzzyPatch, applyKnitPatchAsync, applyCablePatch, applyWafflePatch, applyFurPatch, applyWovenPatch, applyVoronoiPatch, applySmoothPatch,
   defaultFuzzyOptions, defaultKnitOptions, defaultCableOptions, defaultWaffleOptions,
   defaultFurOptions, defaultWovenOptions, defaultVoronoiOptions, defaultSmoothOptions,
 } from './modifiers';
+
+/** Resolves an op's `region` descriptor to the triangle set to texture, against
+ *  the mesh that op will run on. Supplied by the main thread (it owns the
+ *  descriptor resolver + label map). Returns an empty set for "no match". */
+export type RegionResolver = (descriptor: unknown, mesh: MeshData) => Set<number>;
 
 /** Memo cache: prefix key → textured mesh after that prefix of the chain.
  *  Bounded so a long editing session can't grow it without limit (insertion
@@ -43,23 +49,26 @@ function remember(key: string, mesh: MeshData): void {
  *  caller), so the same code+params+ops always maps to the same key — and any
  *  geometry-affecting change shifts it (→ a miss → the Re-apply pill). */
 function prefixKey(baseKey: string, ops: SurfaceOp[], upTo: number): string {
-  const chain = ops.slice(0, upTo + 1).map(o => ({ id: o.id, params: o.params }));
+  const chain = ops.slice(0, upTo + 1).map(o => ({ id: o.id, params: o.params, region: o.region ?? null }));
   return simpleHash(`${baseKey}|${JSON.stringify(chain)}`);
 }
 
 /** Apply one op to `mesh`, filling size-relative defaults from the actual mesh
- *  and reusing the modifier math. The async knit path uses the GPU when present. */
-async function applyOne(mesh: MeshData, op: SurfaceOp): Promise<MeshData> {
+ *  and reusing the modifier math. When `region` is a non-empty triangle set the
+ *  *patch* variant textures only those triangles. The async knit path uses the
+ *  GPU when present. */
+async function applyOne(mesh: MeshData, op: SurfaceOp, region: Set<number> | null): Promise<MeshData> {
   const p = op.params;
+  const r = region && region.size > 0 ? region : null;
   switch (op.id) {
-    case 'fuzzy':   return applyFuzzy(mesh, { ...defaultFuzzyOptions(mesh), ...p }).mesh;
-    case 'knit':    return (await applyKnitAsync(mesh, { ...defaultKnitOptions(mesh), ...p })).mesh;
-    case 'cable':   return applyCable(mesh, { ...defaultCableOptions(mesh), ...p }).mesh;
-    case 'waffle':  return applyWaffle(mesh, { ...defaultWaffleOptions(mesh), ...p }).mesh;
-    case 'fur':     return applyFur(mesh, { ...defaultFurOptions(mesh), ...p }).mesh;
-    case 'woven':   return applyWoven(mesh, { ...defaultWovenOptions(mesh), ...p }).mesh;
-    case 'voronoi': return applyVoronoi(mesh, { ...defaultVoronoiOptions(mesh), ...p }).mesh;
-    case 'smooth':  return applySmooth(mesh, { ...defaultSmoothOptions(), ...p }).mesh;
+    case 'fuzzy':   return r ? applyFuzzyPatch(mesh, { ...defaultFuzzyOptions(mesh), ...p }, r).mesh : applyFuzzy(mesh, { ...defaultFuzzyOptions(mesh), ...p }).mesh;
+    case 'knit':    return r ? (await applyKnitPatchAsync(mesh, { ...defaultKnitOptions(mesh), ...p }, r)).mesh : (await applyKnitAsync(mesh, { ...defaultKnitOptions(mesh), ...p })).mesh;
+    case 'cable':   return r ? applyCablePatch(mesh, { ...defaultCableOptions(mesh), ...p }, r).mesh : applyCable(mesh, { ...defaultCableOptions(mesh), ...p }).mesh;
+    case 'waffle':  return r ? applyWafflePatch(mesh, { ...defaultWaffleOptions(mesh), ...p }, r).mesh : applyWaffle(mesh, { ...defaultWaffleOptions(mesh), ...p }).mesh;
+    case 'fur':     return r ? applyFurPatch(mesh, { ...defaultFurOptions(mesh), ...p }, r).mesh : applyFur(mesh, { ...defaultFurOptions(mesh), ...p }).mesh;
+    case 'woven':   return r ? applyWovenPatch(mesh, { ...defaultWovenOptions(mesh), ...p }, r).mesh : applyWoven(mesh, { ...defaultWovenOptions(mesh), ...p }).mesh;
+    case 'voronoi': return r ? applyVoronoiPatch(mesh, { ...defaultVoronoiOptions(mesh), ...p }, r).mesh : applyVoronoi(mesh, { ...defaultVoronoiOptions(mesh), ...p }).mesh;
+    case 'smooth':  return r ? applySmoothPatch(mesh, { ...defaultSmoothOptions(), ...p }, r).mesh : applySmooth(mesh, { ...defaultSmoothOptions(), ...p }).mesh;
     default: {
       // Exhaustiveness guard — a new SurfaceOpId must add a case above.
       const _never: never = op.id;
@@ -91,6 +100,7 @@ export async function computeChain(
   baseKey: string,
   ops: SurfaceOp[],
   onProgress?: (fraction: number) => void,
+  resolveRegion?: RegionResolver,
 ): Promise<MeshData> {
   if (ops.length === 0) return base;
 
@@ -105,7 +115,11 @@ export async function computeChain(
 
   const remaining = ops.length - start;
   for (let i = start; i < ops.length; i++) {
-    mesh = await applyOne(mesh, ops[i]);
+    const op = ops[i];
+    // Region selectors resolve against the mesh this op runs on (so geometric
+    // selectors stay exact even after a prior op subdivided the mesh).
+    const region = op.region != null && resolveRegion ? resolveRegion(op.region, mesh) : null;
+    mesh = await applyOne(mesh, op, region);
     computeCalls++;
     remember(prefixKey(baseKey, ops, i), mesh);
     onProgress?.(remaining > 0 ? (i - start + 1) / remaining : 1);

--- a/src/ui/surfaceModal.ts
+++ b/src/ui/surfaceModal.ts
@@ -40,9 +40,19 @@ export interface SurfaceApi {
   clearSurfacePreview(): { ok: true };
   modelHasColor(): boolean;
   getGeometryData(): { boundingBox?: { min?: number[]; max?: number[] } | null } | Record<string, unknown>;
+  /** Apply a texture as parametric `api.surface.*` code (phase 4) instead of
+   *  baking it into a mesh. manifold-js only; whole-model only (per-region is a
+   *  later phase). Returns `{ error }` when it can't (non-manifold-js engine). */
+  surfaceTexture(id: string, opts?: Record<string, unknown>): Promise<ApplyResult>;
 }
 
 type Tab = ModId;
+
+/** Tabs that can be expressed as `api.surface.*` code (a subset of the modifier
+ *  list — voronoiLamp/voxelize change the engine, so they only bake). */
+const CODE_EMITTABLE: ReadonlySet<Tab> = new Set<Tab>([
+  'fuzzy', 'knit', 'cable', 'waffle', 'fur', 'woven', 'voronoi', 'smooth',
+]);
 
 const BTN_BASE =
   'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur border border-zinc-700 text-zinc-200 hover:bg-zinc-700';
@@ -210,6 +220,12 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
   // Default to preserve; the toggle lets the user clear instead. The warning
   // only shows when the model is actually painted.
   let preserveColor = true;
+
+  // --- Output mode: parametric code (api.surface.*) vs destructive bake ---
+  // Default to code for the emittable textures so the result stays editable; the
+  // user can opt into baking. Forced to bake for non-emittable tabs or a region
+  // selection (per-region code is a later phase).
+  let applyAsCode = true;
 
   // --- Region selector state (persists across tab switches) ---
   let regionSelection: Set<number> | null = null;
@@ -414,6 +430,15 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
     // keep reference so the checkbox closure can find `warn` (defined above via hoist).
   }
 
+  // Output-mode toggle: parametric api.surface.* code vs destructive bake.
+  // Shown only for code-emittable tabs; hidden (forced bake) otherwise.
+  const codeRow = el('div', 'mb-3');
+  const codeBox = checkbox('Apply as editable code (api.surface.*)', true, () => {
+    applyAsCode = codeBox.get();
+  });
+  const codeNote = el('p', 'text-[11px] text-zinc-500 mt-1', 'Keeps the texture parametric in your code — edit the params and re-run. Uncheck to bake into a fixed mesh.');
+  codeRow.append(codeBox.wrap, codeNote);
+
   // Shared detail slider — persists across texture-tab switches so the user's
   // chosen quality level is preserved when comparing different textures.
   // Not shown for smooth/voxelize (those have their own quality controls).
@@ -426,6 +451,8 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
   function renderTab() {
     body.innerHTML = '';
     regionSection.style.display = (active === 'voxelize' || active === 'voronoiLamp') ? 'none' : '';
+    // The code-output toggle only applies to the api.surface.*-expressible tabs.
+    codeRow.style.display = CODE_EMITTABLE.has(active) ? '' : 'none';
     if (active === 'fuzzy') {
       const amp = slider('Amplitude (depth)', 0, span * 0.1, span * 0.03, span * 0.001, n => n.toFixed(3), schedulePreview);
       const scale = slider('Feature size', span * 0.005, span * 0.25, span * 0.04, span * 0.005, n => n.toFixed(3), schedulePreview);
@@ -653,6 +680,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
 
   scrollBody.append(regionSection, tabRow, body);
   if (painted) scrollBody.append(colorRow);
+  scrollBody.append(codeRow);
   scrollBody.append(status);
 
   // Footer: Cancel | Preview | Apply.
@@ -692,7 +720,12 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
     status.textContent = 'Working…';
     try {
       const opts = { ...currentOpts(), preserveColor };
-      const result = active === 'fuzzy' ? await api.applyFuzzySkin(opts)
+      // Parametric path: emit api.surface.* code instead of baking. Only for the
+      // code-expressible textures, manifold-js, and a whole-model apply (a region
+      // selection still bakes the patch — per-region code is a later phase).
+      const asCode = applyAsCode && CODE_EMITTABLE.has(active) && !activeSelection();
+      const result = asCode ? await api.surfaceTexture(active, opts)
+        : active === 'fuzzy' ? await api.applyFuzzySkin(opts)
         : active === 'knit' ? await api.applyKnitTexture(opts)
         : active === 'cable' ? await api.applyCableKnit(opts)
         : active === 'waffle' ? await api.applyWaffleStitch(opts)

--- a/tests/surface-code-emit.spec.ts
+++ b/tests/surface-code-emit.spec.ts
@@ -1,0 +1,68 @@
+// Phase 4 — applying a surface texture as parametric api.surface.* code instead
+// of baking. The Surface panel's "Apply as editable code" path and the
+// partwright.surfaceTexture(id, opts) console method / AI tool all route through
+// commitSurfaceCode, which appends the call to the model source and re-runs.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+type PW = {
+  createSession: (n?: string) => Promise<unknown>;
+  run: (code: string) => Promise<{ triangleCount?: number } | unknown>;
+  surfaceTexture: (id: string, opts?: Record<string, unknown>) => Promise<{ ok?: boolean; mode?: string; error?: string }>;
+  getCode: () => string;
+  getGeometryData: () => { triangleCount?: number };
+};
+
+test.describe('surfaceTexture (apply as api.surface.* code)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('emits api.surface.* into the code and renders textured', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const out = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('surface-code-emit');
+      const plain = await pw.run('const { Manifold } = api;\nreturn Manifold.sphere(10, 48);') as { triangleCount?: number };
+      const res = await pw.surfaceTexture('knit', { stitchWidth: 1.4, amplitude: 0.6 });
+      return {
+        plainTris: plain.triangleCount ?? 0,
+        res,
+        code: pw.getCode(),
+        tris: pw.getGeometryData().triangleCount ?? 0,
+      };
+    });
+
+    expect(out.res.ok).toBe(true);
+    expect(out.res.mode).toBe('code');
+    // The texture now lives in the editor source as a parametric call.
+    expect(out.code).toContain('api.surface.knit(');
+    expect(out.code).toContain('stitchWidth: 1.4');
+    // ...and the rendered model is textured (subdivided → more triangles).
+    expect(out.tris).toBeGreaterThan(out.plainTris);
+    await page.screenshot({ path: 'test-results/surface-code-emit.png' });
+  });
+
+  test('rejects an unknown texture id', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    const err = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('surface-code-emit-err');
+      await pw.run('const { Manifold } = api;\nreturn Manifold.cube([10,10,10]);');
+      const r = await pw.surfaceTexture('bogus', {});
+      return r.error ?? '';
+    });
+    expect(err).toContain('bogus');
+  });
+});

--- a/tests/surface-region.spec.ts
+++ b/tests/surface-region.spec.ts
@@ -1,0 +1,94 @@
+// Phase 5 — per-region surface textures: api.surface.<id>({ region }) textures
+// only the triangles matching a selector (label / box / slab / cylinder) via the
+// patch modifier variants, resolved against the mesh on the main thread.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+type PW = {
+  createSession: (n?: string) => Promise<unknown>;
+  run: (code: string) => Promise<{ error?: string | null; triangleCount?: number; isManifold?: boolean } | unknown>;
+};
+
+const SPHERE = 'const { Manifold } = api;\nreturn Manifold.sphere(12, 48);';
+
+test.describe('api.surface.* per-region textures', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('a box region textures only part of the mesh (patch, not whole-model)', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const out = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('surface-region');
+      const base = await pw.run('const { Manifold } = api;\nreturn Manifold.sphere(12, 48);') as { triangleCount?: number };
+      const whole = await pw.run([
+        'const { Manifold } = api;',
+        'api.surface.knit({ stitchWidth: 1.6, amplitude: 0.6 });',
+        'return Manifold.sphere(12, 48);',
+      ].join('\n')) as { triangleCount?: number };
+      const region = await pw.run([
+        'const { Manifold } = api;',
+        'api.surface.knit({ stitchWidth: 1.6, amplitude: 0.6, region: { box: { min: [-12, -12, 0], max: [12, 12, 12] } } });',
+        'return Manifold.sphere(12, 48);',
+      ].join('\n')) as { triangleCount?: number; isManifold?: boolean };
+      return {
+        base: base.triangleCount ?? 0,
+        whole: whole.triangleCount ?? 0,
+        region: region.triangleCount ?? 0,
+        regionManifold: region.isManifold,
+      };
+    });
+
+    // The region patch subdivides only its triangles: more than the base, but
+    // fewer than texturing the whole sphere.
+    expect(out.region).toBeGreaterThan(out.base);
+    expect(out.region).toBeLessThan(out.whole);
+    await page.screenshot({ path: 'test-results/surface-region-box.png' });
+  });
+
+  test('a labeled region textures by api.label name', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    const out = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('surface-region-label');
+      const base = await pw.run('const { Manifold } = api;\nreturn Manifold.sphere(12, 48);') as { triangleCount?: number };
+      const r = await pw.run([
+        'const { Manifold } = api;',
+        "const body = api.label(Manifold.sphere(12, 48), 'body');",
+        "api.surface.knit({ stitchWidth: 1.6, amplitude: 0.6, region: 'body' });",
+        'return body;',
+      ].join('\n')) as { triangleCount?: number; error?: string | null };
+      return { base: base.triangleCount ?? 0, tris: r.triangleCount ?? 0, error: r.error ?? null };
+    });
+    expect(out.error).toBeNull();
+    expect(out.tris).toBeGreaterThan(out.base); // body region got textured/subdivided
+  });
+
+  test('rejects a region with more than one selector', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    const err = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('surface-region-err');
+      const r = await pw.run([
+        'const { Manifold } = api;',
+        "api.surface.knit({ region: { label: 'a', box: { min: [0,0,0], max: [1,1,1] } } });",
+        'return Manifold.cube([10, 10, 10]);',
+      ].join('\n')) as { error?: string | null };
+      return r?.error ?? '';
+    });
+    expect(err.toLowerCase()).toContain('exactly one');
+  });
+});

--- a/tests/unit/surfaceCodegen.test.ts
+++ b/tests/unit/surfaceCodegen.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { surfaceOptsLiteral, appendSurfaceCall } from '../../src/surface/surfaceCodegen';
+
+describe('surfaceOptsLiteral', () => {
+  it('keeps only keys valid for the op and serializes scalars', () => {
+    const lit = surfaceOptsLiteral('knit', {
+      stitchWidth: 1.23456, amplitude: 0.5, algorithm: 'bfs', subdivide: true,
+      selectedTriangles: new Set([1, 2]), // not a knit field → dropped
+      bogus: 99,                          // not a knit field → dropped
+    });
+    expect(lit).toContain('stitchWidth: 1.2346'); // rounded to 4 dp
+    expect(lit).toContain('amplitude: 0.5');
+    expect(lit).toContain('algorithm: "bfs"');
+    expect(lit).toContain('subdivide: true');
+    expect(lit).not.toContain('selectedTriangles');
+    expect(lit).not.toContain('bogus');
+  });
+
+  it('drops non-finite numbers and returns empty literal when nothing valid', () => {
+    expect(surfaceOptsLiteral('smooth', { iterations: NaN })).toBe('');
+    expect(surfaceOptsLiteral('fuzzy', {})).toBe('');
+  });
+});
+
+describe('appendSurfaceCall', () => {
+  it('IIFE-wraps plain code and appends the call before the return', () => {
+    const out = appendSurfaceCall('const { Manifold } = api;\nreturn Manifold.sphere(10);', 'knit', { stitchWidth: 1.4 });
+    expect(out).toContain('const __pwModel = (() => {');
+    expect(out).toContain('return Manifold.sphere(10);');
+    expect(out).toContain('api.surface.knit({ stitchWidth: 1.4 });');
+    expect(out.trim().endsWith('return __pwModel;')).toBe(true);
+    // The texture call sits before the wrapper return.
+    expect(out.indexOf('api.surface.knit')).toBeLessThan(out.lastIndexOf('return __pwModel;'));
+  });
+
+  it('composes: a second apply inserts before the existing wrapper return, no nesting', () => {
+    const once = appendSurfaceCall('return api.Manifold.cube([1,1,1]);', 'fuzzy', { amplitude: 0.2 });
+    const twice = appendSurfaceCall(once, 'smooth', { iterations: 3 });
+    // Only one IIFE wrapper.
+    expect(twice.match(/const __pwModel = \(\(\) => \{/g)?.length).toBe(1);
+    // Both calls present, fuzzy before smooth, both before the single return.
+    expect(twice.indexOf('api.surface.fuzzy')).toBeLessThan(twice.indexOf('api.surface.smooth'));
+    expect(twice.indexOf('api.surface.smooth')).toBeLessThan(twice.lastIndexOf('return __pwModel;'));
+    expect(twice.match(/return __pwModel;/g)?.length).toBe(1);
+  });
+
+  it('emits an empty-arg call when no options are supplied', () => {
+    const out = appendSurfaceCall('return api.Manifold.sphere(5);', 'fuzzy', {});
+    expect(out).toContain('api.surface.fuzzy();');
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 4** of surface-textures-as-code. The Surface panel (and the AI/console) now apply textures as **parametric `api.surface.*` code** instead of baking — so the textured model stays editable.

- **Panel:** a new **"Apply as editable code (api.surface.*)"** checkbox, on by default for the eight code-expressible textures (fuzzy/knit/cable/waffle/fur/woven/voronoi/smooth). Checked → appends the call to the model source and re-runs (force-applies the memoized texture from phases 1–2); unchecked → the existing destructive bake. Hidden for voronoiLamp/voxelize (engine-changing → bake only); a region selection still bakes the patch (per-region code is phase 5).
- **Console + AI:** one shared path — `partwright.surfaceTexture(id, opts)` console method + a `surfaceTexture` AI tool (SAVE_GATED) + a `help()` entry. This directly fixes the earlier finding where an AI *baked* because it had no way to produce a parametric texture: now `surfaceTexture` is the natural editable choice.

### How it works
`commitSurfaceCode(id, opts)` (manifold-js only) → `appendSurfaceCall` (pure `surfaceCodegen.ts`) inserts `api.surface.<id>({…})` before the IIFE wrapper's `return __pwModel;` (wrapping on first use, inserting before the existing return after that), so repeated textures compose without nesting and interoperate with the `api.paint.*` migration wrapper → `setValue` + `runCodeSync` (force-applies) + `saveVersion`. `surfaceOptsLiteral` filters to the op's valid fields and rounds numbers for a tidy literal.

## Files
- `src/ui/surfaceModal.ts` — code/bake toggle (`CODE_EMITTABLE` gating) routing apply to `api.surfaceTexture`.
- `src/surface/surfaceCodegen.ts` (new) — `surfaceOptsLiteral` + `appendSurfaceCall` (pure).
- `src/main.ts` — `commitSurfaceCode` + `partwright.surfaceTexture` + `help()` entry.
- `src/ai/tools.ts` — `surfaceTexture` tool def + dispatch + SAVE_GATED.
- `public/ai/textures.md` — docs.

## Test plan
- **E2e** `tests/surface-code-emit.spec.ts`: `surfaceTexture('knit', …)` emits `api.surface.knit(` into the code and renders textured; unknown id → error. Panel toggle confirmed in the browser (screenshot in session).
- **Unit** `tests/unit/surfaceCodegen.test.ts`: literal filtering/rounding, IIFE wrap, compose-without-nesting.
- Green locally: `tsc`, full unit tier, `build`, `lint:deps`/`consistency`/`deadcode`. All three surface e2e specs pass on this branch.

## Stacked-PR note
Stacked on #551 (phase 3) — base is the phase-3 branch so the diff is just phase 4. I'll retarget this to `main` once #551 merges (which also triggers full pr-checks). Phase 5 (per-region textures) will stack on this.

https://claude.ai/code/session_01NHdsUwyEAsrjGaHVLYTbrm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHdsUwyEAsrjGaHVLYTbrm)_