### PR TITLE
feat: per-region surface textures via api.surface.*({ region }) (phase 5)

### DIFF
--- a/prompts/20260609-220500-surface-textures-phase5-region.md
+++ b/prompts/20260609-220500-surface-textures-phase5-region.md
@@ -1,0 +1,58 @@
+---
+session: "1kdce9"
+timestamp: "2026-06-09T22:05:00Z"
+model: claude-opus-4-8
+tools: [playwright, vitest]
+sequence: 7
+---
+
+## Human
+
+Phase 5 of surface-textures-as-code (stacked on phase 4): per-region textures —
+texture only part of the model, so different regions can carry different
+textures.
+
+## Assistant
+
+## Key decisions
+
+**`api.surface.<id>({ region })` resolves to a patch apply.** The sandbox builds
+a RegionDescriptor from a `region` selector that mirrors `api.paint.*`: a label
+name (string / `{label}`), `{box}`, `{slab}`, or `{cylinder}` (exactly one). The
+descriptor rides on the SurfaceOp; the main thread resolves it to a triangle set
+and `computeChain` routes to the `apply*Patch` variant instead of the whole-model
+modifier.
+
+**Region resolution happens per-op against the op's INPUT mesh, on the main
+thread.** computeChain gained a `RegionResolver` callback (the resolver lives in
+main.ts, which owns `resolveDescriptorTriangles` + the label map). Resolving
+against each op's input mesh keeps geometric selectors (box/slab/cylinder) exact
+even when chained after a prior texture that subdivided the mesh.
+
+**byLabel is guarded, not silently wrong.** A `byLabel` region depends on the
+run's label map, whose triangle ids are only valid on the un-textured base. So
+the resolver throws an actionable error if a byLabel region would run on an
+already-subdivided mesh (i.e. it's not the first surface op) — telling the user to
+reorder or use a geometric selector. Single-region byLabel (the common case) and
+geometric multi-region chaining both work; the broken case fails loudly.
+
+**Two correctness fixes caught by reasoning, not types:**
+- `prefixKey` (the memo key) omitted `region`, so a region change wouldn't
+  re-key the cache — added `region` to the serialized chain.
+- `currentLabelMap` is set by the run handler *after* applySurfaceTextures, so
+  byLabel regions would resolve against the previous run's labels — the resolver
+  factory now sets it early (idempotent with the later assignment).
+
+**Scope boundary:** region is code-authored (write `api.surface.knit({region})`
+in runAndSave). The phase-4 `surfaceTexture` tool / panel stay whole-model and
+reject a `region` option with a message pointing to code — because the panel's
+raw-triangle selection isn't a durable descriptor, and the tool's codegen only
+serializes scalars.
+
+## Verification
+
+`tests/surface-region.spec.ts`: a box region produces base < region < whole-model
+triangle counts (proves it's a patch, not whole-model); a `region: 'body'` label
+textures the labeled region; a two-selector region errors. Browser-confirmed —
+top hemisphere knit, bottom smooth (screenshot). All 8 surface e2e + unit tier +
+build + lint:deps/consistency/deadcode green.

--- a/public/ai/textures.md
+++ b/public/ai/textures.md
@@ -65,6 +65,28 @@ return body;
   (see [colors](/ai/colors.md)). Use it when you want the texture to live with
   the code; use the `apply*` tools when you want a one-shot baked result.
 
+**Per-region textures (`region`):** pass a `region` selector to texture only part
+of the model — so different regions can carry different textures:
+
+```js
+const { Manifold } = api;
+const body = api.label(Manifold.sphere(12, 48), 'body');
+api.surface.knit({ stitchWidth: 1.4, region: 'body' });                  // by api.label name
+api.surface.fuzzy({ region: { box: { min: [-12,-12,0], max: [12,12,12] } } }); // upper half only
+return body;
+```
+
+`region` accepts exactly one selector, mirroring `api.paint.*`: a label name
+(string, or `{ label }`), `{ box: { min, max } }`, `{ slab: { axis|normal,
+offset, thickness } }`, or `{ cylinder: { center, rMin?, rMax, zMin, zMax } }`.
+It textures just the matching triangles (a "patch"), so the rest of the surface
+stays as-is. Chain several to give regions different textures. Geometric
+selectors (box/slab/cylinder) stay exact even when chained after another texture;
+a `byLabel` region must be the **first** surface op (label ids are only valid on
+the un-textured mesh — use a geometric selector for a region after another
+texture). This is code-authored (write it in `runAndSave`); the `surfaceTexture`
+tool/panel apply whole-model.
+
 **Driving it without writing the call yourself:** the `surfaceTexture(id, opts)`
 tool / `partwright.surfaceTexture(id, opts)` console method applies a texture *as
 code* — it appends the `api.surface.<id>(...)` call to the current model and

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -349,6 +349,71 @@ export const manifoldJsEngine: Engine = {
       x: [1, 0, 0], y: [0, 1, 0], z: [0, 0, 1],
     };
 
+    // Build a RegionDescriptor from an `api.surface.*({ region })` selector. The
+    // forms mirror the api.paint.* selectors so "texture this region" reads the
+    // same as "paint this region". The descriptor is resolved to triangles on
+    // the main thread (against the actual mesh), reusing the paint resolver.
+    const buildRegionDescriptor = (region: unknown): RegionDescriptor => {
+      if (typeof region === 'string') {
+        if (region.length === 0) throw new Error('api.surface region: a string region must be a non-empty api.label(...) name.');
+        return { kind: 'byLabel', label: region };
+      }
+      const o = paintObj(region, 'api.surface region');
+      const { label, box, slab, cylinder, ...rest } = o;
+      paintRejectUnknown('api.surface region', rest);
+      const provided = [label, box, slab, cylinder].filter(v => v !== undefined).length;
+      if (provided !== 1) {
+        throw new Error("api.surface region: provide exactly one of label, box, slab, or cylinder (e.g. region: 'body' or region: { box: { min, max } }).");
+      }
+      if (label !== undefined) {
+        if (typeof label !== 'string' || label.length === 0) throw new Error('api.surface region.label: must be a non-empty api.label(...) name.');
+        return { kind: 'byLabel', label };
+      }
+      if (box !== undefined) {
+        const b = paintObj(box, 'api.surface region.box({ min, max })');
+        const { min, max, ...brest } = b;
+        paintRejectUnknown('api.surface region.box', brest);
+        const lo = paintVec3(min, 'api.surface region.box min');
+        const hi = paintVec3(max, 'api.surface region.box max');
+        const center: [number, number, number] = [(lo[0] + hi[0]) / 2, (lo[1] + hi[1]) / 2, (lo[2] + hi[2]) / 2];
+        const size: [number, number, number] = [Math.abs(hi[0] - lo[0]), Math.abs(hi[1] - lo[1]), Math.abs(hi[2] - lo[2])];
+        return { kind: 'box', center, size, quaternion: [0, 0, 0, 1], shape: 'box' };
+      }
+      if (slab !== undefined) {
+        const s = paintObj(slab, 'api.surface region.slab({ axis, offset, thickness })');
+        const { axis, normal, offset, thickness, ...srest } = s;
+        paintRejectUnknown('api.surface region.slab', srest);
+        let nrm: [number, number, number];
+        if (axis !== undefined) {
+          if (typeof axis !== 'string' || !(axis in AXIS_NORMAL)) throw new Error("api.surface region.slab axis: expected 'x', 'y' or 'z' (or pass an explicit normal).");
+          nrm = AXIS_NORMAL[axis];
+        } else if (normal !== undefined) {
+          nrm = paintVec3(normal, 'api.surface region.slab normal');
+        } else {
+          throw new Error("api.surface region.slab: provide either axis ('x'|'y'|'z') or an explicit normal [x, y, z].");
+        }
+        const off = paintNum(offset, 'api.surface region.slab offset');
+        const thk = paintNum(thickness, 'api.surface region.slab thickness');
+        if (thk <= 0) throw new Error('api.surface region.slab thickness: must be > 0.');
+        return { kind: 'slab', normal: nrm, offset: off, thickness: thk };
+      }
+      // cylinder
+      const c = paintObj(cylinder, 'api.surface region.cylinder({ center, rMin, rMax, zMin, zMax })');
+      const { center, rMin, rMax, zMin, zMax, ...crest } = c;
+      paintRejectUnknown('api.surface region.cylinder', crest);
+      if (!Array.isArray(center) || center.length !== 2 || center.some(n => typeof n !== 'number' || !Number.isFinite(n))) {
+        throw new Error('api.surface region.cylinder center: expected [x, y] (two finite numbers).');
+      }
+      const cc = center as [number, number];
+      const r0 = rMin === undefined ? 0 : paintNum(rMin, 'api.surface region.cylinder rMin');
+      const r1 = paintNum(rMax, 'api.surface region.cylinder rMax');
+      const z0 = paintNum(zMin, 'api.surface region.cylinder zMin');
+      const z1 = paintNum(zMax, 'api.surface region.cylinder zMax');
+      if (r0 < 0 || r1 <= r0) throw new Error('api.surface region.cylinder: require 0 <= rMin < rMax.');
+      if (z1 <= z0) throw new Error('api.surface region.cylinder: require zMin < zMax.');
+      return { kind: 'cylinder', center: cc, rMin: r0, rMax: r1, zMin: z0, zMax: z1 };
+    };
+
     const paint = {
       /** Paint every triangle inside an axis-aligned box. `min`/`max` are world-space corners. */
       box(opts: unknown): void {
@@ -436,11 +501,14 @@ export const manifoldJsEngine: Engine = {
         }
         opts = params as Record<string, unknown>;
       }
+      // `region` is handled separately (it's an object selector, not a scalar
+      // option): texture only the matching triangles instead of the whole mesh.
+      const { region, ...scalarOpts } = opts;
       const allowed = SURFACE_OP_FIELDS[id];
       const clean: Record<string, number | boolean | string> = {};
-      for (const [k, v] of Object.entries(opts)) {
+      for (const [k, v] of Object.entries(scalarOpts)) {
         if (!allowed.includes(k)) {
-          throw new Error(`api.surface.${id}: unknown option "${k}". Accepted: ${allowed.join(', ')}.`);
+          throw new Error(`api.surface.${id}: unknown option "${k}". Accepted: ${allowed.join(', ')}${allowed.length ? ', ' : ''}region.`);
         }
         if (typeof v === 'number') {
           if (!Number.isFinite(v)) throw new Error(`api.surface.${id}.${k}: must be a finite number.`);
@@ -449,7 +517,9 @@ export const manifoldJsEngine: Engine = {
         }
         clean[k] = v;
       }
-      surfaceOps.push({ id, params: clean });
+      const op: SurfaceOp = { id, params: clean };
+      if (region !== undefined && region !== null) op.region = buildRegionDescriptor(region);
+      surfaceOps.push(op);
     };
     const makeSurfaceFn = (id: SurfaceOpId) => (params?: unknown): void => recordSurfaceOp(id, params);
     const surface: Record<SurfaceOpId, (params?: unknown) => void> & { apply(id: unknown, params?: unknown): void } = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7206,6 +7206,9 @@ async function main() {
     if (getActiveLanguage() !== 'manifold-js') {
       return { error: 'api.surface.* textures are manifold-js only. Use the bake tool (applyKnitTexture, applyFuzzySkin, …) for this engine, or switch the session to manifold-js.' };
     }
+    if ('region' in opts) {
+      return { error: 'surfaceTexture applies whole-model. For a region texture, write api.surface.' + id + "({ region: 'label' | { box|slab|cylinder } }) directly in your model code (runAndSave) — see /ai/textures.md." };
+    }
     if (!currentMeshData) return { error: 'No model loaded — run the model first.' };
     const newCode = appendSurfaceCall(getValue(), id, opts);
     setValue(newCode);
@@ -13693,6 +13696,27 @@ async function main() {
    *     sticky Re-apply pill, keeping keystroke renders snappy.
    *  Returns true unless a forced compute failed (caller treats failure as a
    *  non-fatal "base shown" run). */
+  /** Build the region resolver passed to computeChain for `api.surface.*({ region })`
+   *  (phase 5). Resolves each op's region descriptor to a triangle set against
+   *  the mesh that op runs on, reusing the paint resolver. Geometric selectors
+   *  (box/slab/cylinder) are exact on any mesh; a `byLabel` region depends on the
+   *  run's label map (valid only on the un-textured base), so it's rejected when
+   *  it would run on an already-subdivided mesh — with an actionable message. */
+  function makeSurfaceRegionResolver(result: MeshResult, base: MeshData) {
+    // The run handler sets currentLabelMap later; set it now so byLabel regions
+    // resolve against THIS run's labels (idempotent with the later assignment).
+    if (result.surfaceOps?.some(o => o.region != null)) currentLabelMap = result.labelMap ?? null;
+    return (descriptor: unknown, mesh: MeshData): Set<number> => {
+      const d = descriptor as RegionDescriptor;
+      if (d.kind === 'byLabel' && mesh.numTri !== base.numTri) {
+        throw new Error(`api.surface region "${d.label}": a byLabel region must be the first surface op — label triangle ids are only valid on the un-textured mesh. Texture this region first, or use a geometric selector (box/slab/cylinder) to texture a region after another texture.`);
+      }
+      let adjacency: AdjacencyGraph | null = null;
+      if (d.kind === 'coplanar' || d.kind === 'connectedFromSeed' || d.kind === 'colorFlood') adjacency = buildAdjacency(mesh);
+      return resolveDescriptorTriangles(d, mesh, adjacency, null).triangles;
+    };
+  }
+
   async function applySurfaceTextures(result: MeshResult, src: string, force: boolean): Promise<void> {
     const ops = result.surfaceOps;
     if (!ops || ops.length === 0 || !result.mesh) {
@@ -13731,7 +13755,7 @@ async function main() {
         indeterminate: false,
       });
       try {
-        const textured = await computeChain(base, baseKey, ops, (f) => updateProgress(progressId, f));
+        const textured = await computeChain(base, baseKey, ops, (f) => updateProgress(progressId, f), makeSurfaceRegionResolver(result, base));
         result.mesh = textured;
         result.manifold = null;
         hideSurfaceReapplyPill();

--- a/src/surface/surfaceOpSpec.ts
+++ b/src/surface/surfaceOpSpec.ts
@@ -30,6 +30,12 @@ export type SurfaceOpId =
 export interface SurfaceOp {
   id: SurfaceOpId;
   params: Record<string, number | boolean | string>;
+  /** Optional region selector — when present, only the matching triangles are
+   *  textured (a "patch" apply) instead of the whole mesh. A `RegionDescriptor`
+   *  (built from the `region` option in `api.surface.*`), kept `unknown` here so
+   *  this leaf stays import-free; the main thread casts it back and resolves it
+   *  to triangles against the mesh. */
+  region?: unknown;
 }
 
 /** Accepted option keys per modifier — mirrors the `Required<…Options>` field

--- a/src/surface/surfaceOps.ts
+++ b/src/surface/surfaceOps.ts
@@ -17,9 +17,15 @@ import { simpleHash } from '../geometry/statsComputation';
 import type { SurfaceOp, SurfaceOpId } from './surfaceOpSpec';
 import {
   applyFuzzy, applyKnitAsync, applyCable, applyWaffle, applyFur, applyWoven, applyVoronoi, applySmooth,
+  applyFuzzyPatch, applyKnitPatchAsync, applyCablePatch, applyWafflePatch, applyFurPatch, applyWovenPatch, applyVoronoiPatch, applySmoothPatch,
   defaultFuzzyOptions, defaultKnitOptions, defaultCableOptions, defaultWaffleOptions,
   defaultFurOptions, defaultWovenOptions, defaultVoronoiOptions, defaultSmoothOptions,
 } from './modifiers';
+
+/** Resolves an op's `region` descriptor to the triangle set to texture, against
+ *  the mesh that op will run on. Supplied by the main thread (it owns the
+ *  descriptor resolver + label map). Returns an empty set for "no match". */
+export type RegionResolver = (descriptor: unknown, mesh: MeshData) => Set<number>;
 
 /** Memo cache: prefix key → textured mesh after that prefix of the chain.
  *  Bounded so a long editing session can't grow it without limit (insertion
@@ -43,23 +49,26 @@ function remember(key: string, mesh: MeshData): void {
  *  caller), so the same code+params+ops always maps to the same key — and any
  *  geometry-affecting change shifts it (→ a miss → the Re-apply pill). */
 function prefixKey(baseKey: string, ops: SurfaceOp[], upTo: number): string {
-  const chain = ops.slice(0, upTo + 1).map(o => ({ id: o.id, params: o.params }));
+  const chain = ops.slice(0, upTo + 1).map(o => ({ id: o.id, params: o.params, region: o.region ?? null }));
   return simpleHash(`${baseKey}|${JSON.stringify(chain)}`);
 }
 
 /** Apply one op to `mesh`, filling size-relative defaults from the actual mesh
- *  and reusing the modifier math. The async knit path uses the GPU when present. */
-async function applyOne(mesh: MeshData, op: SurfaceOp): Promise<MeshData> {
+ *  and reusing the modifier math. When `region` is a non-empty triangle set the
+ *  *patch* variant textures only those triangles. The async knit path uses the
+ *  GPU when present. */
+async function applyOne(mesh: MeshData, op: SurfaceOp, region: Set<number> | null): Promise<MeshData> {
   const p = op.params;
+  const r = region && region.size > 0 ? region : null;
   switch (op.id) {
-    case 'fuzzy':   return applyFuzzy(mesh, { ...defaultFuzzyOptions(mesh), ...p }).mesh;
-    case 'knit':    return (await applyKnitAsync(mesh, { ...defaultKnitOptions(mesh), ...p })).mesh;
-    case 'cable':   return applyCable(mesh, { ...defaultCableOptions(mesh), ...p }).mesh;
-    case 'waffle':  return applyWaffle(mesh, { ...defaultWaffleOptions(mesh), ...p }).mesh;
-    case 'fur':     return applyFur(mesh, { ...defaultFurOptions(mesh), ...p }).mesh;
-    case 'woven':   return applyWoven(mesh, { ...defaultWovenOptions(mesh), ...p }).mesh;
-    case 'voronoi': return applyVoronoi(mesh, { ...defaultVoronoiOptions(mesh), ...p }).mesh;
-    case 'smooth':  return applySmooth(mesh, { ...defaultSmoothOptions(), ...p }).mesh;
+    case 'fuzzy':   return r ? applyFuzzyPatch(mesh, { ...defaultFuzzyOptions(mesh), ...p }, r).mesh : applyFuzzy(mesh, { ...defaultFuzzyOptions(mesh), ...p }).mesh;
+    case 'knit':    return r ? (await applyKnitPatchAsync(mesh, { ...defaultKnitOptions(mesh), ...p }, r)).mesh : (await applyKnitAsync(mesh, { ...defaultKnitOptions(mesh), ...p })).mesh;
+    case 'cable':   return r ? applyCablePatch(mesh, { ...defaultCableOptions(mesh), ...p }, r).mesh : applyCable(mesh, { ...defaultCableOptions(mesh), ...p }).mesh;
+    case 'waffle':  return r ? applyWafflePatch(mesh, { ...defaultWaffleOptions(mesh), ...p }, r).mesh : applyWaffle(mesh, { ...defaultWaffleOptions(mesh), ...p }).mesh;
+    case 'fur':     return r ? applyFurPatch(mesh, { ...defaultFurOptions(mesh), ...p }, r).mesh : applyFur(mesh, { ...defaultFurOptions(mesh), ...p }).mesh;
+    case 'woven':   return r ? applyWovenPatch(mesh, { ...defaultWovenOptions(mesh), ...p }, r).mesh : applyWoven(mesh, { ...defaultWovenOptions(mesh), ...p }).mesh;
+    case 'voronoi': return r ? applyVoronoiPatch(mesh, { ...defaultVoronoiOptions(mesh), ...p }, r).mesh : applyVoronoi(mesh, { ...defaultVoronoiOptions(mesh), ...p }).mesh;
+    case 'smooth':  return r ? applySmoothPatch(mesh, { ...defaultSmoothOptions(), ...p }, r).mesh : applySmooth(mesh, { ...defaultSmoothOptions(), ...p }).mesh;
     default: {
       // Exhaustiveness guard — a new SurfaceOpId must add a case above.
       const _never: never = op.id;
@@ -91,6 +100,7 @@ export async function computeChain(
   baseKey: string,
   ops: SurfaceOp[],
   onProgress?: (fraction: number) => void,
+  resolveRegion?: RegionResolver,
 ): Promise<MeshData> {
   if (ops.length === 0) return base;
 
@@ -105,7 +115,11 @@ export async function computeChain(
 
   const remaining = ops.length - start;
   for (let i = start; i < ops.length; i++) {
-    mesh = await applyOne(mesh, ops[i]);
+    const op = ops[i];
+    // Region selectors resolve against the mesh this op runs on (so geometric
+    // selectors stay exact even after a prior op subdivided the mesh).
+    const region = op.region != null && resolveRegion ? resolveRegion(op.region, mesh) : null;
+    mesh = await applyOne(mesh, op, region);
     computeCalls++;
     remember(prefixKey(baseKey, ops, i), mesh);
     onProgress?.(remaining > 0 ? (i - start + 1) / remaining : 1);

--- a/tests/surface-region.spec.ts
+++ b/tests/surface-region.spec.ts
@@ -1,0 +1,94 @@
+// Phase 5 — per-region surface textures: api.surface.<id>({ region }) textures
+// only the triangles matching a selector (label / box / slab / cylinder) via the
+// patch modifier variants, resolved against the mesh on the main thread.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    { timeout: 20_000 },
+  );
+}
+
+type PW = {
+  createSession: (n?: string) => Promise<unknown>;
+  run: (code: string) => Promise<{ error?: string | null; triangleCount?: number; isManifold?: boolean } | unknown>;
+};
+
+const SPHERE = 'const { Manifold } = api;\nreturn Manifold.sphere(12, 48);';
+
+test.describe('api.surface.* per-region textures', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('a box region textures only part of the mesh (patch, not whole-model)', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+
+    const out = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('surface-region');
+      const base = await pw.run('const { Manifold } = api;\nreturn Manifold.sphere(12, 48);') as { triangleCount?: number };
+      const whole = await pw.run([
+        'const { Manifold } = api;',
+        'api.surface.knit({ stitchWidth: 1.6, amplitude: 0.6 });',
+        'return Manifold.sphere(12, 48);',
+      ].join('\n')) as { triangleCount?: number };
+      const region = await pw.run([
+        'const { Manifold } = api;',
+        'api.surface.knit({ stitchWidth: 1.6, amplitude: 0.6, region: { box: { min: [-12, -12, 0], max: [12, 12, 12] } } });',
+        'return Manifold.sphere(12, 48);',
+      ].join('\n')) as { triangleCount?: number; isManifold?: boolean };
+      return {
+        base: base.triangleCount ?? 0,
+        whole: whole.triangleCount ?? 0,
+        region: region.triangleCount ?? 0,
+        regionManifold: region.isManifold,
+      };
+    });
+
+    // The region patch subdivides only its triangles: more than the base, but
+    // fewer than texturing the whole sphere.
+    expect(out.region).toBeGreaterThan(out.base);
+    expect(out.region).toBeLessThan(out.whole);
+    await page.screenshot({ path: 'test-results/surface-region-box.png' });
+  });
+
+  test('a labeled region textures by api.label name', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    const out = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('surface-region-label');
+      const base = await pw.run('const { Manifold } = api;\nreturn Manifold.sphere(12, 48);') as { triangleCount?: number };
+      const r = await pw.run([
+        'const { Manifold } = api;',
+        "const body = api.label(Manifold.sphere(12, 48), 'body');",
+        "api.surface.knit({ stitchWidth: 1.6, amplitude: 0.6, region: 'body' });",
+        'return body;',
+      ].join('\n')) as { triangleCount?: number; error?: string | null };
+      return { base: base.triangleCount ?? 0, tris: r.triangleCount ?? 0, error: r.error ?? null };
+    });
+    expect(out.error).toBeNull();
+    expect(out.tris).toBeGreaterThan(out.base); // body region got textured/subdivided
+  });
+
+  test('rejects a region with more than one selector', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    const err = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: PW }).partwright;
+      await pw.createSession('surface-region-err');
+      const r = await pw.run([
+        'const { Manifold } = api;',
+        "api.surface.knit({ region: { label: 'a', box: { min: [0,0,0], max: [1,1,1] } } });",
+        'return Manifold.cube([10, 10, 10]);',
+      ].join('\n')) as { error?: string | null };
+      return r?.error ?? '';
+    });
+    expect(err.toLowerCase()).toContain('exactly one');
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 5** of surface-textures-as-code — the headline "different textures on different regions" capability. `api.surface.<id>({ region })` textures only the triangles matching a selector, so e.g. the body can be knit and a handle smoothed.

```js
const { Manifold } = api;
const body = api.label(Manifold.sphere(12, 48), 'body');
api.surface.knit({ stitchWidth: 1.4, region: 'body' });                        // by label
api.surface.fuzzy({ region: { box: { min: [-12,-12,0], max: [12,12,12] } } }); // upper half
return body;
```

`region` accepts exactly one selector, mirroring `api.paint.*`: a label name (string / `{ label }`), `{ box: { min, max } }`, `{ slab: { axis|normal, offset, thickness } }`, or `{ cylinder: { center, rMin?, rMax, zMin, zMax } }`. It routes to the `apply*Patch` modifier variants (only the matched triangles subdivide/displace).

### How it works
- The sandbox builds a `RegionDescriptor` from the selector (reusing the `api.paint.*` validators) and stores it on the `SurfaceOp`.
- `computeChain` gained a `RegionResolver` callback (resolution lives on the main thread, which owns `resolveDescriptorTriangles` + the label map). **Each op's region resolves against that op's input mesh**, so geometric selectors (box/slab/cylinder) stay exact even when chained after a texture that already subdivided the mesh.
- **byLabel is guarded, not silently wrong:** a `byLabel` region depends on the run's label map (valid only on the un-textured base), so the resolver throws an actionable error if it would run on an already-subdivided mesh — i.e. a byLabel region must be the *first* surface op; use a geometric selector for a region after another texture. Single-region byLabel and geometric multi-region chaining both work.

### Two correctness fixes (caught by reasoning, not types)
- `prefixKey` (the memo key) omitted `region` → a region change wouldn't re-key the cache. Now included.
- `currentLabelMap` is set by the run handler *after* `applySurfaceTextures`, so byLabel regions would resolve against the *previous* run's labels. The resolver factory now sets it early (idempotent with the later assignment).

### Scope boundary
`region` is **code-authored** (write it in `runAndSave`). The phase-4 `surfaceTexture` tool/panel stay whole-model and reject a `region` option with a message pointing to code — the panel's raw-triangle selection isn't a durable descriptor, and the tool's codegen only serializes scalars.

## Files
- `src/geometry/engines/manifoldJs.ts` — `buildRegionDescriptor` + `region` handling in `recordSurfaceOp`.
- `src/surface/surfaceOpSpec.ts` — `SurfaceOp.region`.
- `src/surface/surfaceOps.ts` — `RegionResolver`, patch dispatch in `applyOne`, region in `computeChain` + memo key.
- `src/main.ts` — `makeSurfaceRegionResolver` (byLabel guard + early labelMap), region guard in `commitSurfaceCode`.
- `public/ai/textures.md` — docs.

## Test plan
- **E2e** `tests/surface-region.spec.ts`: a box region gives base < region < whole-model triangle counts (proves patch, not whole-model); `region: 'body'` textures a labeled region; a two-selector region errors. Browser-confirmed: top hemisphere knit, bottom smooth (screenshot in session).
- Green locally: `tsc`, unit tier, `build`, `lint:deps`/`consistency`/`deadcode`. All 8 surface e2e specs pass on this branch.

## Stacked-PR note
Top of the stack (3 → 4 → 5), based on #554. I'll retarget down the stack to `main` as each lower PR merges (which triggers full pr-checks at each level).

https://claude.ai/code/session_01NHdsUwyEAsrjGaHVLYTbrm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHdsUwyEAsrjGaHVLYTbrm)_