### PR TITLE
feat: default custom AI endpoint to the CLI bridge URL

### DIFF
--- a/prompts/20260610-022055-custom-endpoint-default-url.md
+++ b/prompts/20260610-022055-custom-endpoint-default-url.md
@@ -1,0 +1,52 @@
+---
+session: "upbeat-carson-e6lhoy"
+timestamp: "2026-06-10T02:20:55Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+Since the local model instructions are for the CLI API proxy, let's default the
+local (Custom OpenAI-compatible) endpoint to `http://localhost:8317/v1` so the
+user doesn't have to enter it.
+
+## Assistant
+
+## Key decisions
+
+**Single source of truth for the default URL.** The Custom provider's onboarding
+card (`cliBridgeSetup.tsx`) already hardcoded `http://localhost:8317/v1` as
+CLIProxyAPI's default endpoint for its "Use this endpoint" button. Promoted that
+to an exported `DEFAULT_CUSTOM_BASE_URL` in `src/ai/settings.ts` (the ai-layer
+config home; ui imports down into ai, never the reverse, so no cycle) and made
+`cliBridgeSetup.tsx` import it — so the pre-filled field and the button can't
+drift.
+
+**Pre-fill, two ways, for new and existing users.** Set
+`DEFAULT_TOGGLES.customBaseUrl` to the constant so brand-new users get it in
+stored toggles. For existing users (whose saved blob already holds `''`, which
+`mergeWithDefaults`' `??` leaves untouched), the Custom tab's Base URL input now
+seeds from `settings.toggles.customBaseUrl || DEFAULT_CUSTOM_BASE_URL`; the
+modal's existing `pendingFlush` persists it on close. Deliberately did NOT
+migrate stored `''` → default, to avoid overwriting a URL a user intentionally
+cleared.
+
+**Scoped `aiConnectionMode` to the custom provider.** This was the one global
+side effect: it returned `'cloud'` whenever `customBaseUrl` was non-empty,
+regardless of the active provider. With the URL now shipping pre-filled, that
+would have made every fresh user (default provider `anthropic`, no key) falsely
+report "connected", suppressing the auto-open-settings flow and lighting the
+toolbar chip. Added `provider === 'custom' &&` to the check so a non-empty URL
+only counts as connected when the user actually selected the custom provider —
+which is also the more honest signal. All other `customBaseUrl` reads were
+already gated on `provider === 'custom'` and/or a non-empty `customModel`, so no
+regression there (e.g. the cross-provider review modal still won't offer Custom
+until a model is set).
+
+**Tests.** Updated the two e2e specs that asserted the old empty-start behavior:
+`ai-cli-bridge-setup.spec.ts` now expects the Base URL pre-filled and
+"Save & activate" enabled out of the box (clicking "Use this endpoint" is
+idempotent); `ai-providers.spec.ts`'s gate test now verifies the URL ships
+pre-filled and ready, then clears it to confirm the gate still flips to disabled
+and back. Verified via build, unit tier (981 pass), the two affected e2e specs,
+and an eyes-on screenshot of the pre-filled Custom tab.

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -89,6 +89,14 @@ export interface LocalContextSettings {
 const DEFAULT_OPENAI_MODEL: OpenaiModelId = 'gpt-5-mini';
 const DEFAULT_GEMINI_MODEL: GeminiModelId = 'gemini-flash-latest';
 
+/** Default Base URL for the Custom (OpenAI-compatible) provider. Points at
+ *  CLIProxyAPI's default localhost port (:8317) — the subscription bridge the
+ *  Custom tab's onboarding card walks the user through — so the endpoint is
+ *  pre-filled and the common case (driving Partwright from a Claude/Codex
+ *  plan via the bridge) needs no typing. The single source of truth for this
+ *  URL; `cliBridgeSetup.tsx` imports it for its "Use this endpoint" button. */
+export const DEFAULT_CUSTOM_BASE_URL = 'http://localhost:8317/v1';
+
 const DEFAULT_TOGGLES_BY_PRESET: Record<Exclude<Preset, 'custom'>, Omit<ChatToggles, 'provider' | 'anthropicModel' | 'localModel' | 'openaiModel' | 'geminiModel' | 'customModel' | 'customModels' | 'customBaseUrl'> & { anthropicModel: AnthropicModelId }> = {
   minimal: {
     vision: { views: false, resolution: 'low', angles: 'auto' },
@@ -152,7 +160,7 @@ const DEFAULT_TOGGLES: ChatToggles = {
   geminiModel: DEFAULT_GEMINI_MODEL,
   customModel: '',
   customModels: [],
-  customBaseUrl: '',
+  customBaseUrl: DEFAULT_CUSTOM_BASE_URL,
 };
 
 const DEFAULT_SETTINGS: AiSettings = {
@@ -270,7 +278,10 @@ export async function aiConnectionMode(): Promise<'disconnected' | 'cloud' | 'lo
   // A configured custom endpoint counts as connected even with no key — the
   // base URL is the real "is it set up" signal (auth is optional). Treated as
   // 'cloud' since, like the hosted providers, it's a remote HTTP endpoint.
-  if (settings.toggles.customBaseUrl.trim().length > 0) return 'cloud';
+  // Scoped to the custom provider: the base URL now ships pre-filled with the
+  // bridge default (see DEFAULT_CUSTOM_BASE_URL), so a non-empty URL alone no
+  // longer implies the user picked this provider.
+  if (settings.toggles.provider === 'custom' && settings.toggles.customBaseUrl.trim().length > 0) return 'cloud';
   const [anthropic, openai, gemini, custom] = await Promise.all([
     getKey('anthropic'),
     getKey('openai'),

--- a/src/ui/preact/cliBridgeSetup.tsx
+++ b/src/ui/preact/cliBridgeSetup.tsx
@@ -25,10 +25,13 @@
 import type { ComponentChildren } from 'preact';
 import { useSignal } from '@preact/signals';
 
+import { DEFAULT_CUSTOM_BASE_URL } from '../../ai/settings';
 import { Section, Pill, PrimaryButton } from './primitives';
 
-/** CLIProxyAPI's default OpenAI-compatible base URL. */
-const CLI_BRIDGE_ENDPOINT = 'http://localhost:8317/v1';
+/** CLIProxyAPI's default OpenAI-compatible base URL — shared with the Custom
+ *  provider's default so the "Use this endpoint" button and the pre-filled
+ *  Base URL field can never drift. */
+const CLI_BRIDGE_ENDPOINT = DEFAULT_CUSTOM_BASE_URL;
 /** Where CLIProxyAPI serves its status / config-error page. */
 const CLI_BRIDGE_STATUS_URL = 'http://localhost:8317';
 

--- a/src/ui/preact/settingsModal.tsx
+++ b/src/ui/preact/settingsModal.tsx
@@ -36,6 +36,7 @@ import {
   setCustomModel,
   setCustomModels,
   setCustomBaseUrl,
+  DEFAULT_CUSTOM_BASE_URL,
   providerLabel,
   AUTO_COMPACT_OPTIONS,
   ANTHROPIC_MODEL_OPTIONS,
@@ -575,7 +576,11 @@ function CustomTab(props: { cb: AiSettingsCallbacks; close: () => void }) {
   const { cb, close } = props;
   const settings = settingsSignal.value;
 
-  const url = useSignal(settings.toggles.customBaseUrl);
+  // Pre-fill with the bridge default for existing users whose stored URL is
+  // still empty (their settings predate the default); new users already get it
+  // from DEFAULT_TOGGLES. The pendingFlush below persists this on close so the
+  // endpoint is configured without the user typing it.
+  const url = useSignal(settings.toggles.customBaseUrl || DEFAULT_CUSTOM_BASE_URL);
   const model = useSignal(settings.toggles.customModel);
   const keyVal = useSignal('');
   // One example key per modal open — shown in the bridge setup's "set an API

--- a/tests/ai-cli-bridge-setup.spec.ts
+++ b/tests/ai-cli-bridge-setup.spec.ts
@@ -27,17 +27,17 @@ test.describe('AI CLI bridge setup', () => {
     await expect(page.getByText('Set an API key (required)')).toBeVisible();
     await expect(page.getByText('Log in with your subscription')).toBeVisible();
 
-    // Footer shows Close, Save, and a disabled "Save & activate" until the
-    // endpoint is set.
+    // Footer shows Close, Save, and "Save & activate" — already enabled because
+    // the Base URL ships pre-filled with the bridge default (no typing needed).
     await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
     const enableBtn = page.getByRole('button', { name: 'Save & activate Custom endpoint' });
-    await expect(enableBtn).toBeDisabled();
 
-    // The Base URL starts empty; clicking "Use this endpoint" fills it and,
-    // in turn, enables the footer's "Save & activate".
+    // The Base URL is pre-filled with CLIProxyAPI's default endpoint; clicking
+    // "Use this endpoint" is idempotent and keeps "Save & activate" enabled.
     const baseUrl = page.locator('input[placeholder="http://localhost:8080/v1"]');
-    await expect(baseUrl).toHaveValue('');
+    await expect(baseUrl).toHaveValue('http://localhost:8317/v1');
+    await expect(enableBtn).toBeEnabled();
     await page.getByRole('button', { name: /Use this endpoint/ }).click();
     await expect(baseUrl).toHaveValue('http://localhost:8317/v1');
     await expect(enableBtn).toBeEnabled();

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -810,12 +810,20 @@ test.describe('Multi-provider AI', () => {
     await expect(modal.locator('button:has-text("Test connection")')).toBeVisible();
     await expect(modal.locator('button:has-text("Fetch models")')).toBeVisible();
 
-    // Enable is gated on the endpoint URL (the API key is optional), so it's
-    // disabled until a URL is set, then flips on — no key required.
-    await expect(modal.getByRole('button', { name: 'Enable Custom endpoint', exact: true })).toBeDisabled();
+    // Enable is gated on the endpoint URL (the API key is optional). The URL
+    // ships pre-filled with the bridge default, so Enable starts ready;
+    // clearing the URL gates it off, and refilling flips it back on — no key
+    // required.
+    const enableBtn = modal.getByRole('button', { name: 'Enable Custom endpoint', exact: true });
+    await expect(urlInput).toHaveValue('http://localhost:8317/v1');
+    await expect(enableBtn).toBeEnabled();
+    await urlInput.fill('');
+    await urlInput.blur();
+    await expect(enableBtn).toBeDisabled();
     await urlInput.fill('http://localhost:8080/v1');
+    await urlInput.blur();
     await modal.locator('input[placeholder^="e.g. llama"]').fill('my-model');
-    await expect(modal.getByRole('button', { name: 'Enable Custom endpoint', exact: true })).toBeEnabled();
+    await expect(enableBtn).toBeEnabled();
   });
 
   test('Custom tab: fetched models surface in the panel dropdown; Save & activate flushes the typed key', async ({ page }) => {


### PR DESCRIPTION
## Summary

The Custom (OpenAI-compatible) provider's onboarding card walks the user through running **CLIProxyAPI** — the local subscription bridge that serves a Claude/Codex plan as an OpenAI-compatible endpoint on `localhost:8317`. Since that's the dominant use case for the Custom provider, this pre-fills the **Base URL** field with the bridge default (`http://localhost:8317/v1`) so the user doesn't have to type it or click "Use this endpoint".

### Changes
- **`DEFAULT_CUSTOM_BASE_URL`** — new exported constant in `src/ai/settings.ts`, now the single source of truth for the bridge URL. `cliBridgeSetup.tsx` imports it for its "Use this endpoint" button so the field and the button can't drift.
- **Pre-fill, new + existing users** — `DEFAULT_TOGGLES.customBaseUrl` ships the constant for new users; the Custom tab input seeds from `customBaseUrl || DEFAULT_CUSTOM_BASE_URL` for existing users whose saved blob still holds `''` (the modal's existing `pendingFlush` persists it on close). Stored `''` is *not* migrated to the default, so a deliberately-cleared URL is left alone.
- **`aiConnectionMode` scoped to `provider === 'custom'`** — previously a non-empty `customBaseUrl` reported `'cloud'` regardless of provider; with the URL now pre-filled that would falsely report every fresh user as connected. Now it only counts when the custom provider is actually selected (also the more honest signal). All other `customBaseUrl` reads were already provider-scoped, so no regression.

### Test plan
- `npm run build` ✅, `npm run lint:deps` ✅ (acyclic), `npm run test:unit` ✅ (981 pass)
- Updated + passing e2e: `ai-cli-bridge-setup.spec.ts` (Base URL pre-filled, Save & activate enabled out of the box) and `ai-providers.spec.ts` (gate test now starts ready, clears URL to confirm the gate still flips disabled↔enabled)
- Eyes-on: screenshot of the Custom tab shows `http://localhost:8317/v1` pre-filled and "Save & activate Custom endpoint" enabled

https://claude.ai/code/session_01KXDJMSuGR75ovLW4HuKLAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXDJMSuGR75ovLW4HuKLAz)_