### PR TITLE
feat: add per-bubble copy button to AI panel transcript

### DIFF
--- a/prompts/20260610-030552-ai-bubble-copy-button.md
+++ b/prompts/20260610-030552-ai-bubble-copy-button.md
@@ -1,0 +1,48 @@
+---
+session: "t568pi"
+timestamp: "2026-06-10T03:05:52Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+every chat bubble in the AI pane has to have a copy button next to it so I can
+quickly copy ai responses
+
+## Assistant
+
+## Key decisions
+
+**Scope**: Added a copy button to the textual *response* bubbles in the AI panel
+transcript — user text, assistant text, and cross-provider review bubbles. Left
+tool-call chips, thinking boxes, image bubbles, and tool-result bubbles alone:
+they aren't "responses" worth copying and a button on each would clutter the
+transcript. This satisfies the intent ("copy ai responses") while reading as
+"every chat bubble."
+
+**Where**: A new `withCopyButton(bubble, align, getText)` helper in
+`src/ui/aiPanel.ts` wraps a bubble in a flex row and appends `makeCopyButton`.
+The button sits on the bubble's *outer* edge — `flex-row-reverse` for
+right-aligned user bubbles (button on the left), normal row for left-aligned
+assistant/review bubbles (button on the right). The bubble's own `max-w-[90%]`
+is moved onto the row so the width cap still measures against the panel, not a
+nested 90%-of-90%.
+
+**Live-streaming bubble left bare**: The empty assistant placeholder that streams
+via `onAssistantText` rewriting `textContent` (and is the insertion anchor for
+the live thinking box) is intentionally *not* wrapped — wrapping it would break
+both the `textContent` rewrite and the thinking-box `parentElement` insertion.
+It picks up a copy button automatically on the persist re-render
+(`renderTranscript`), once it actually has text worth copying.
+
+**Feedback**: The button is always visible but faint (`opacity-60`, brightens on
+hover/focus) rather than hover-only, so it stays tappable on touch devices with
+no hover state. On click it swaps `⧉` → `✓` (emerald) for 1.2s; a failure routes
+through `showToast(..., { variant: 'warn', source: 'ai' })`. No success toast —
+the icon swap is enough and avoids logging every copy to the Diagnostic Log.
+
+**Verification**: Added `tests/ai-copy-button.spec.ts` (golden path): seeds a
+user+assistant turn, asserts one button per text bubble, clicks the assistant's
+button, and reads `navigator.clipboard` back to confirm it copies the bubble
+text verbatim. Manually screenshotted in the browser. `npm run build` and
+`npm run test:unit` (981) pass.

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1998,16 +1998,22 @@ function renderMessage(msg: ChatMessage): HTMLElement {
       const isEmpty = b.text.length === 0;
       if (isEmpty && msg.role !== 'assistant') continue;
       const bubble = renderTextBubble(msg.role, b.text, msg.compacted);
-      if (isEmpty && msg.role === 'assistant') bubble.dataset.liveBubble = msg.id;
-      if (b.text.trim().length > 0 || (isEmpty && msg.role === 'assistant')) {
+      if (isEmpty && msg.role === 'assistant') {
+        // Live streaming placeholder: kept bare (no copy wrapper) so
+        // onAssistantText can rewrite its textContent and the thinking-box
+        // insertion can target its parent wrap. It picks up a copy button on
+        // the persist re-render, once it actually has text worth copying.
+        bubble.dataset.liveBubble = msg.id;
         wrap.appendChild(bubble);
+      } else if (b.text.trim().length > 0) {
+        wrap.appendChild(withCopyButton(bubble, msg.role, () => bubble.textContent ?? ''));
       }
     } else if (b.type === 'image') {
       wrap.appendChild(renderImageBubble(b.source));
     } else if (b.type === 'thinking') {
       if (b.text.trim().length > 0) wrap.appendChild(renderThinkingBox(b.text));
     } else if (b.type === 'review') {
-      wrap.appendChild(renderReviewBubble(b.provider, b.model, b.text));
+      wrap.appendChild(withCopyButton(renderReviewBubble(b.provider, b.model, b.text), 'assistant', () => b.text));
     }
   }
 
@@ -2306,6 +2312,47 @@ function renderTextBubble(role: 'user' | 'assistant', text: string, compacted?: 
   }
   bubble.textContent = text;
   return bubble;
+}
+
+/** Small copy-to-clipboard button that swaps to a check on success. Kept
+ *  always-visible-but-faint (not hover-only) so it stays tappable on touch
+ *  devices that have no hover state. */
+function makeCopyButton(getText: () => string): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.title = 'Copy to clipboard';
+  btn.setAttribute('aria-label', 'Copy message to clipboard');
+  btn.className = 'shrink-0 mt-0.5 px-1.5 py-1 rounded text-zinc-500 hover:text-zinc-200 hover:bg-zinc-700/60 opacity-60 hover:opacity-100 focus-visible:opacity-100 transition-opacity text-xs leading-none';
+  btn.textContent = '⧉';
+  btn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(getText());
+      btn.textContent = '✓';
+      btn.classList.add('text-emerald-400');
+      window.setTimeout(() => {
+        btn.textContent = '⧉';
+        btn.classList.remove('text-emerald-400');
+      }, 1200);
+    } catch {
+      showToast('Copy failed — clipboard unavailable', { variant: 'warn', source: 'ai' });
+    }
+  });
+  return btn;
+}
+
+/** Wrap a response bubble in a row carrying a copy button on its outer edge —
+ *  left of right-aligned user bubbles, right of left-aligned assistant ones —
+ *  so any message can be copied with one click. The bubble's own `max-w-[90%]`
+ *  is moved onto the row so the cap still measures against the panel. */
+function withCopyButton(bubble: HTMLElement, align: 'user' | 'assistant', getText: () => string): HTMLElement {
+  bubble.classList.remove('max-w-[90%]');
+  bubble.classList.add('max-w-full', 'min-w-0');
+  const row = document.createElement('div');
+  row.className = `group flex items-start gap-1 max-w-[90%] min-w-0 ${align === 'user' ? 'flex-row-reverse' : 'flex-row'}`;
+  row.appendChild(bubble);
+  row.appendChild(makeCopyButton(getText));
+  return row;
 }
 
 function renderImageBubble(source: ImageSource): HTMLElement {

--- a/tests/ai-copy-button.spec.ts
+++ b/tests/ai-copy-button.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from 'playwright/test';
+import { openAiPanel, waitForEditorReady, waitForChatSessionId } from './helpers/aiPanel';
+
+// Golden path for the per-bubble copy button: every text/response bubble in the
+// AI panel carries a small copy-to-clipboard button on its outer edge, so a
+// user can grab any message (especially AI replies) in one click. We seed a
+// user + assistant turn, then assert one button per text bubble and that the
+// assistant button copies that bubble's text verbatim.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+  });
+});
+
+test('each chat bubble has a copy button that copies its text', async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.goto('/editor');
+  await page.waitForSelector('#ai-panel', { state: 'attached' });
+  // Seed against the restored session bucket so the post-reload restore reads it
+  // back (a bare /editor creates the session only after WASM init).
+  const sid = await waitForChatSessionId(page);
+
+  await page.evaluate(async (sid) => {
+    const db = await import('/src/ai/db.ts');
+    await db.putMessages([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 'm-user-1', sessionId: sid, role: 'user', blocks: [{ type: 'text', text: 'Make me a gear.' }], createdAt: Date.now(), seq: 1 } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 'm-asst-1', sessionId: sid, role: 'assistant', blocks: [{ type: 'text', text: 'Done — created a 20-tooth spur gear.' }], createdAt: Date.now(), seq: 2 } as any,
+    ]);
+  }, sid);
+
+  await page.reload();
+  await waitForEditorReady(page);
+  await openAiPanel(page);
+
+  await expect(page.locator('#ai-panel').getByText('Done — created a 20-tooth spur gear.'))
+    .toBeVisible({ timeout: 15_000 });
+
+  // One copy button per text bubble (the seeded user turn + assistant reply).
+  const copyBtns = page.locator('#ai-panel button[aria-label="Copy message to clipboard"]');
+  await expect(copyBtns).toHaveCount(2);
+
+  // The assistant button (second) puts that bubble's exact text on the clipboard.
+  await copyBtns.nth(1).click();
+  const clip = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clip).toBe('Done — created a 20-tooth spur gear.');
+});


### PR DESCRIPTION
## Summary

Adds a small copy-to-clipboard button next to every **response bubble** in the AI panel transcript, so AI replies (and your own messages) can be grabbed in one click.

- Applies to the textual response bubbles: **user text, assistant text, and cross-provider review bubbles**. Tool-call chips, thinking boxes, image bubbles, and tool-result bubbles are intentionally left alone — they aren't "responses" worth copying and a button on each would clutter the transcript.
- The button sits on the bubble's **outer edge** — left of right-aligned user bubbles, right of left-aligned assistant/review bubbles — and reveals on hover/focus while staying faintly visible (so it's tappable on touch devices with no hover).
- Click swaps `⧉` → `✓` (emerald) for ~1.2s as feedback; a clipboard failure routes through `showToast(warn, source: 'ai')`. No success toast — the icon swap is enough and avoids logging every copy to the Diagnostic Log.

### Implementation notes

- New `makeCopyButton(getText)` + `withCopyButton(bubble, align, getText)` helpers in `src/ui/aiPanel.ts`. `withCopyButton` wraps the bubble in a flex row (reversed for user bubbles) and moves the bubble's `max-w-[90%]` onto the row so the width cap still measures against the panel.
- The **live streaming placeholder** is left bare (not wrapped): `onAssistantText` rewrites its `textContent` and the live thinking box inserts relative to its parent, so wrapping it would break both. It picks up a copy button automatically on the persist re-render, once it has text.

## Test plan

- [x] `npm run build` (type-check) passes
- [x] `npm run test:unit` — 981 pass
- [x] New `tests/ai-copy-button.spec.ts` golden path: seeds a user+assistant turn, asserts one copy button per text bubble, clicks the assistant's button, and reads `navigator.clipboard` back to confirm verbatim copy
- [x] Manual browser check (screenshot below) — buttons render correctly on both sides

https://claude.ai/code/session_014CeX3tjUJ22dNCJ78KwTxh

---
_Generated by [Claude Code](https://claude.ai/code/session_014CeX3tjUJ22dNCJ78KwTxh)_