### PR TITLE
feat: start the AI panel closed by default

### DIFF
--- a/prompts/20260610-161531-ai-panel-closed-by-default.md
+++ b/prompts/20260610-161531-ai-panel-closed-by-default.md
@@ -1,0 +1,46 @@
+---
+date: 2026-06-10
+author: kriskemper@gmail.com
+title: AI panel starts closed by default
+---
+
+## Human
+
+When the app opens it auto opens the AI pane which I now find annoying in
+almost all circumstances. Leave that pane closed until someone opens it using
+the AI buttons. If someone had it opened and refreshed keep it open (and vice
+versa keep it closed if it was closed), but new sessions should start with it
+closed.
+
+## Assistant
+
+The open/close state was already persisted correctly: `showDrawer` writes
+`drawerOpen: true`, `hideDrawer` writes `drawerOpen: false`, and `initAiPanel`
+honors `settings.drawerOpen` on load. The only thing forcing auto-open was the
+**default** value of `drawerOpen` in `AiSettings` — it was `true` ("open on
+first visit for discoverability"). So the whole request reduces to flipping that
+default to `false`; the existing persistence handles "keep it open if it was
+open / closed if it was closed" across reloads for free.
+
+- `src/ai/settings.ts`: `DEFAULT_SETTINGS.drawerOpen = false`, with updated
+  JSDoc on both `drawerOpen` and `editorCollapsed`. `editorCollapsed` falls back
+  to `drawerOpen` (`editorCollapsed ?? drawerOpen` in `layout.ts`), so a fresh
+  visit now also shows the code editor pane instead of collapsing it — the
+  desired outcome when no AI panel is competing for space.
+
+Tests assumed default-open, so I updated `tests/smoke.spec.ts`:
+- `toolbar button toggles the drawer` — now asserts hidden-by-default, opens via
+  the rail, then toggles closed.
+- `connected: reopening via the rail …` — starts closed, opens once.
+- `code pane defaults hidden when the AI drawer is open` — seeds
+  `drawerOpen: true` (guarded so the `addInitScript` re-run on reload doesn't
+  clobber the persisted `editorCollapsed`) to keep exercising the
+  `editorCollapsed ?? drawerOpen` coupling.
+- renamed `drawer close state persists` → `drawer open/close state persists`,
+  now verifying both directions survive a reload.
+
+Updated the now-stale "panel opens by default" comment in
+`tests/helpers/aiPanel.ts` (the helper is idempotent, so it already worked for
+both defaults). Verified with a browser screenshot (panel closed, code editor
+shown on fresh load) plus the full smoke, ideas, persist, and diagnostics
+specs.

--- a/prompts/20260610-163919-fix-viewport-specs-after-editor-default.md
+++ b/prompts/20260610-163919-fix-viewport-specs-after-editor-default.md
@@ -1,0 +1,41 @@
+---
+date: 2026-06-10
+author: kriskemper@gmail.com
+title: Fix viewport specs broken by editor-shown-by-default
+---
+
+## Human
+
+(Continuation of "AI panel closed by default" — PR #570. CI shard 3 reported two
+real e2e failures after the change.)
+
+## Assistant
+
+The AI-panel-closed change flips `editorCollapsed`'s default too (it falls back
+to `drawerOpen` via `editorCollapsed ?? drawerOpen`), so a fresh `/editor` now
+shows the code pane and the viewport is narrower / shifted right. Two viewport
+specs that never open the AI panel relied on the old *AI-open + editor-collapsed*
+layout and broke. Both reproduced locally and deterministically; root-caused each
+with `elementFromPoint` / visibility probes rather than guessing:
+
+- **`viewport-toolbar-groups.spec.ts`** — "clicking the viewport canvas keeps the
+  Tools menu up" clicked `box.x+24, box.y+24` (viewport top-left). With the
+  narrower viewport the overlay toolbar's first row reaches down to that point,
+  so the probe showed it now lands on `#triangle-count`, not empty canvas — a UI
+  click that (correctly) dismisses the Tools menu. Moved the click to the
+  bottom-left corner (`box.y + box.height - 24`), confirmed via `elementFromPoint`
+  to be `CANVAS#viewport` in both wide and narrow layouts.
+
+- **`viewport-camera-persistence.spec.ts`** — "preserves the camera angle when
+  editing code" did `getByText('Show code').first().click()`. The `▶ Show code`
+  expander (`#expandEditorBtn`) is *always* in the DOM but `hidden` when the pane
+  is shown, so the probe showed `count: 1, visible: false`; clicking a hidden
+  element waited out the 30s test budget (surfacing as "Target page has been
+  closed"). Guarded the click on `isVisible()`.
+
+These are test-brittleness fixes, not product changes — the underlying behavior
+(toolbar click dismisses, empty-canvas click orbits; code pane shown by default)
+is correct. Verified all 10 tests in the two specs pass locally.
+
+Also confirmed the earlier shard-3 failure (run 1) was an unrelated transient
+`npm ci` ECONNRESET, re-kicked via an empty commit.

--- a/src/ai/settings.ts
+++ b/src/ai/settings.ts
@@ -13,15 +13,17 @@ const STORAGE_KEY = 'partwright-ai-settings-v1';
 export interface AiSettings {
   preset: Preset;
   toggles: ChatToggles;
-  /** Whether the chat drawer is shown. Defaults to open on a first visit so
-   *  the AI surface is discoverable; persists the user's choice thereafter, so
-   *  once they close it it stays closed on reload. */
+  /** Whether the chat drawer is shown. Defaults to closed on a first visit —
+   *  the panel only opens when the user reaches for it via the AI buttons.
+   *  Persists the user's choice thereafter, so once they open it it stays open
+   *  on reload (and once they close it it stays closed). */
   drawerOpen: boolean;
   /** Whether the code editor pane is collapsed. `null` means "no explicit
    *  preference yet" — layout.ts then defaults it to match `drawerOpen` so a
-   *  first-time visitor with the AI panel up doesn't see two competing surfaces
-   *  in the editor. Once the user clicks "Hide code" / "Show code" the choice
-   *  is persisted and respected on every subsequent load. */
+   *  visitor with the AI panel up doesn't see two competing surfaces in the
+   *  editor (and a visitor with it closed gets the code pane). Once the user
+   *  clicks "Hide code" / "Show code" the choice is persisted and respected on
+   *  every subsequent load. */
   editorCollapsed: boolean | null;
   /** Default for new sessions before the user has touched the toggle bar. */
   autoCompactMode: 'off' | 'conservative' | 'standard' | 'aggressive';
@@ -158,7 +160,7 @@ const DEFAULT_TOGGLES: ChatToggles = {
 const DEFAULT_SETTINGS: AiSettings = {
   preset: 'standard',
   toggles: DEFAULT_TOGGLES,
-  drawerOpen: true,
+  drawerOpen: false,
   editorCollapsed: null,
   autoCompactMode: 'off',
   systemPromptOverrides: { anthropic: null, local: null, openai: null, gemini: null, custom: null },

--- a/tests/helpers/aiPanel.ts
+++ b/tests/helpers/aiPanel.ts
@@ -3,12 +3,11 @@ import { waitFor } from './waitFor';
 
 /** Ensure the AI panel is open.
  *
- *  The panel now opens by default on a fresh visit, so the old "click #btn-ai
- *  to open it" no longer holds — a single click would *close* it. This helper
- *  is idempotent: it only clicks when the panel is hidden, and retries so it
- *  tolerates the brief window during editor init where `state.open` is already
- *  true but the drawer hasn't been un-hidden yet (a click then would race the
- *  init and toggle it shut).
+ *  The panel starts closed on a fresh visit, so it normally needs a click on
+ *  #btn-ai to open. This helper is idempotent: it only clicks when the panel
+ *  is hidden, and retries — so it also tolerates a session where the remembered
+ *  `drawerOpen` preference has it already open (a click then would toggle it
+ *  shut), and the brief window during editor init before the drawer is shown.
  *
  *  Opening the panel from the rail *while disconnected* also kicks off the
  *  connect flow, which auto-opens the AI Settings modal one tick later (after an

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -48,18 +48,19 @@ test.describe('AI chat panel', () => {
     // a COI service-worker reload / WASM boot on the default Interactive tab.
     await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
 
-    // The drawer opens by default on a fresh visit.
-    await expect(page.locator('#ai-panel')).toBeVisible();
-    // Close via the ✕, then reopen via the rail button.
-    await page.click('#ai-panel button:has-text("✕")');
+    // The drawer starts closed on a fresh visit — it only opens when the user
+    // reaches for it via the rail button.
     await expect(page.locator('#ai-panel')).toBeHidden();
     await page.click('#btn-ai');
     await expect(page.locator('#ai-panel')).toBeVisible();
-    // Disconnected → reopening via the rail also surfaces the AI Settings modal
+    // Disconnected → opening via the rail also surfaces the AI Settings modal
     // (the connect flow). Dismiss it to leave a clean state.
     await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeVisible();
     await page.keyboard.press('Escape');
     await expect(page.getByRole('heading', { name: 'AI Settings' })).toBeHidden();
+    // Toggling the rail again closes it.
+    await page.click('#btn-ai');
+    await expect(page.locator('#ai-panel')).toBeHidden();
   });
 
   test('connected: reopening via the rail opens the panel with no settings modal', async ({ page }) => {
@@ -84,9 +85,7 @@ test.describe('AI chat panel', () => {
         open.onerror = () => reject(open.error);
       });
     });
-    // Panel is open by default; close it, then reopen via the rail.
-    await expect(page.locator('#ai-panel')).toBeVisible();
-    await page.click('#ai-panel button:has-text("✕")');
+    // Panel starts closed; open it via the rail.
     await expect(page.locator('#ai-panel')).toBeHidden();
     await page.click('#btn-ai');
     await expect(page.locator('#ai-panel')).toBeVisible();
@@ -94,9 +93,21 @@ test.describe('AI chat panel', () => {
   });
 
   test('code pane defaults hidden when the AI drawer is open, and respects an explicit Show code', async ({ page }) => {
-    // First visit: drawer opens by default, so the code pane should NOT
-    // compete with it for screen real estate. The "▶ Show code" expand
-    // button only shows when the editor group is collapsed.
+    // With the AI drawer open, the code pane should NOT compete with it for
+    // screen real estate, so it defaults collapsed (`editorCollapsed ??
+    // drawerOpen`). The drawer no longer opens on a fresh visit, so seed the
+    // remembered-open preference to exercise that path. The "▶ Show code"
+    // expand button only shows when the editor group is collapsed.
+    // Seed only on the very first load — addInitScript re-runs on every
+    // navigation, so guard it or the reload below would clobber the
+    // editorCollapsed=false that the "Show code" click persists.
+    await page.addInitScript(() => {
+      try {
+        if (!localStorage.getItem('partwright-ai-settings-v1')) {
+          localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({ drawerOpen: true }));
+        }
+      } catch { /* ignore */ }
+    });
     await page.goto('/editor');
     await page.waitForSelector('#btn-ai');
     await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
@@ -117,18 +128,26 @@ test.describe('AI chat panel', () => {
     await expect(page.locator('.cm-content')).toBeVisible();
   });
 
-  test('drawer close state persists across reload', async ({ page }) => {
-    // The drawer opens by default, but the user's choice is remembered: once
-    // they close it, the stored drawerOpen=false keeps it closed on reload.
+  test('drawer open/close state persists across reload', async ({ page }) => {
+    // The drawer starts closed on a fresh visit, and the user's choice is
+    // remembered both ways: open it and the stored drawerOpen=true keeps it
+    // open on reload; close it and drawerOpen=false keeps it closed.
     await page.goto('/editor');
     await page.waitForSelector('#btn-ai');
     // Wait for full editor init (console API ready) so the click doesn't race
     // a COI service-worker reload / WASM boot on the default Interactive tab.
     await page.waitForFunction(() => !!(window as unknown as { partwright?: { help?: unknown } }).partwright?.help);
-    await expect(page.locator('#ai-panel')).toBeVisible();
-    await page.click('#ai-panel button:has-text("✕")');
     await expect(page.locator('#ai-panel')).toBeHidden();
 
+    // Open it; the remembered-open preference survives a reload.
+    await openAiPanel(page);
+    await page.reload();
+    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    await expect(page.locator('#ai-panel')).toBeVisible();
+
+    // Close it; the remembered-closed preference survives a reload.
+    await page.click('#ai-panel button:has-text("✕")');
+    await expect(page.locator('#ai-panel')).toBeHidden();
     await page.reload();
     await page.waitForSelector('#ai-panel', { state: 'attached' });
     await expect(page.locator('#ai-panel')).toBeHidden();

--- a/tests/viewport-camera-persistence.spec.ts
+++ b/tests/viewport-camera-persistence.spec.ts
@@ -94,8 +94,13 @@ test.describe('viewport camera persistence', () => {
 
     // Edit the code for real — replace it via the editor so the debounced
     // auto-run fires through the same runCode path a user hits while typing.
+    // The code pane is shown by default now, so the "▶ Show code" expander is in
+    // the DOM but hidden; only click it when it's actually visible (i.e. the pane
+    // is collapsed), otherwise the click waits on a hidden element until timeout.
     const showCode = page.getByText('Show code', { exact: false });
-    if (await showCode.count()) await showCode.first().click().catch(() => {});
+    if (await showCode.first().isVisible().catch(() => false)) {
+      await showCode.first().click().catch(() => {});
+    }
     const editor = page.locator('.cm-content').first();
     await editor.click();
     await page.keyboard.press('ControlOrMeta+a');

--- a/tests/viewport-toolbar-groups.spec.ts
+++ b/tests/viewport-toolbar-groups.spec.ts
@@ -95,7 +95,12 @@ test.describe('viewport toolbar groups', () => {
     // tool panel. The tour is pre-dismissed in openEditor, so a real click lands.
     const box = await page.locator('#viewport').boundingBox();
     if (!box) throw new Error('viewport canvas has no bounding box');
-    await page.mouse.click(box.x + 24, box.y + 24); // top-left corner — empty space
+    // Bottom-left corner — empty 3D canvas, clear of the centered model AND of the
+    // overlay toolbar that hugs the viewport's TOP edge. (A top corner is unsafe:
+    // when the code pane is shown the viewport narrows and the toolbar's first row
+    // reaches down into it, so a top-corner "canvas" click can land on a toolbar
+    // chip instead.)
+    await page.mouse.click(box.x + 24, box.y + box.height - 24);
     await expect(page.locator('#paint-toggle')).toBeVisible();
     await expect(page.locator('#paint-picker-panel')).toBeVisible();
   });


### PR DESCRIPTION
## Summary

The AI drawer auto-opened on every fresh visit, which is unwanted in almost all cases. It now starts **closed** and only opens when the user reaches for it via the AI buttons.

The open/close state was already persisted correctly (`showDrawer` → `drawerOpen: true`, `hideDrawer` → `drawerOpen: false`, and `initAiPanel` honors `settings.drawerOpen` on load). The only thing forcing auto-open was the **default** value, so the fix is a one-line flip of `DEFAULT_SETTINGS.drawerOpen` from `true` to `false`. Persistence then gives the requested behavior for free:

- **Fresh visit / new session** → closed.
- **Was open, then reload** → stays open.
- **Was closed, then reload** → stays closed.

`editorCollapsed` falls back to `drawerOpen` (`editorCollapsed ?? drawerOpen`), so a fresh visit with no AI panel competing for space now also shows the code editor pane — the sensible default.

## Changes

- `src/ai/settings.ts` — `drawerOpen` default `true` → `false`; updated JSDoc on `drawerOpen` and `editorCollapsed`.
- `tests/smoke.spec.ts` — updated the four tests that assumed default-open (toggle, connected-reopen, code-pane-default, open/close persistence). The code-pane test now seeds `drawerOpen: true` (guarded against the `addInitScript` reload re-run) to keep exercising the `editorCollapsed ?? drawerOpen` coupling.
- `tests/helpers/aiPanel.ts` — refreshed the now-stale "opens by default" comment (helper logic unchanged; it's idempotent).

## Test plan

- `npm run build` ✅
- `npm run test:unit` ✅ (1015 passed)
- `npx playwright test smoke.spec.ts` ✅ (18 passed)
- `npx playwright test ideas.spec.ts persist.spec.ts diagnostics-panel.spec.ts` ✅
- Manual browser check: fresh `/editor` load shows the code editor + viewport with the AI panel closed (screenshot captured during verification).

https://claude.ai/code/session_01LoyfoU6uTBtZUg7AWX8GSf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoyfoU6uTBtZUg7AWX8GSf)_