### PR TITLE
chore: upgrade agent search tooling to Serena MCP + ast-grep search ladder

### DIFF
--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -6,7 +6,7 @@ description: >-
   conventions, and cross-file references. Returns conclusions (file:line), not
   file dumps. It locates and explains; it does not edit or audit (use
   work-reviewer for review).
-tools: Read, Grep, Glob, Bash, mcp__typescript__*
+tools: Read, Grep, Glob, Bash, mcp__serena__*
 model: sonnet
 ---
 
@@ -19,11 +19,14 @@ This codebase's hardest questions are **cross-file reference** questions —
 `applyVoxelize`", "does this exported symbol have any importers". String search
 answers those imprecisely. Reach for the most precise tool available:
 
-1. **Symbol-aware first (when available).** If the `typescript` MCP tools
-   (`mcp__typescript__*`) are present, use them for find-references,
-   go-to-definition, hover types, and diagnostics — they query the type graph,
-   so no false positives from string collisions. If the MCP isn't loaded, say
-   so briefly and fall back to the tools below.
+1. **Symbol-aware first (when available).** If the Serena MCP tools
+   (`mcp__serena__*`) are present, use them for reference questions:
+   `find_symbol`, `find_referencing_symbols`, `get_symbols_overview`,
+   `find_declaration`, and `find_implementations` query the real
+   language-server graph, so no false positives from string collisions — and
+   they return compact symbol chunks, not file dumps. If the MCP isn't loaded
+   (e.g. `uv` missing from the environment), say so briefly and fall back to
+   the tools below.
 2. **Structural search.** For "find UI that doesn't match the shared pattern"
    or other shape-based queries, use ast-grep:
    `npx --package @ast-grep/cli ast-grep run -p '<pattern>' -l ts src`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(npx ast-grep:*)",
+      "Bash(npx --package @ast-grep/cli ast-grep:*)",
+      "mcp__serena__find_symbol",
+      "mcp__serena__find_referencing_symbols",
+      "mcp__serena__get_symbols_overview",
+      "mcp__serena__find_declaration",
+      "mcp__serena__find_implementations",
+      "mcp__serena__get_diagnostics_for_file"
+    ]
+  },
   "hooks": {
     "Stop": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ playwright/.cache/
 
 # partwright CLI daemon state (pid/ports, logs, persistent Chromium profile)
 .partwright/
+
+# Serena MCP project metadata/cache
+.serena/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,18 @@
 {
   "$schema": "https://json.schemastore.org/mcp.json",
   "mcpServers": {
-    "typescript": {
-      "command": "npx",
-      "args": ["-y", "typescript-mcp@latest", "--project", "."],
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena@v1.5.3",
+        "serena",
+        "start-mcp-server",
+        "--context",
+        "ide-assistant",
+        "--project",
+        "."
+      ],
       "env": {}
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ See `docs/playwright-guide.md` for sandbox vs laptop Chromium binary detection a
 
 **Manually verify any UI-visible change in a real browser before pushing.**
 
-> **How to drive the browser in this environment: write and run a Playwright spec — there is no Playwright MCP.** The remote/web execution environment only configures the `typescript` MCP server (see `.mcp.json`); the `playwright_navigate` / `playwright_click` / `playwright_screenshot` tools do **not** exist here. Don't waste turns calling them. The real eyes-on check is a short `.spec.ts` that navigates, interacts, and writes a screenshot file you then view.
+> **How to drive the browser in this environment: write and run a Playwright spec — there is no Playwright MCP.** The remote/web execution environment only configures the `serena` MCP server (see `.mcp.json`); the `playwright_navigate` / `playwright_click` / `playwright_screenshot` tools do **not** exist here. Don't waste turns calling them. The real eyes-on check is a short `.spec.ts` that navigates, interacts, and writes a screenshot file you then view.
 
 The pattern:
 
@@ -399,7 +399,8 @@ Don't export functions unless they're imported elsewhere. When removing usage of
 This repo ships custom Claude Code subagents and a deterministic static-analysis layer they lean on — see `docs/agent-tooling.md` for the full reference. In short:
 
 - **`work-reviewer`** (`.claude/agents/work-reviewer.md`, Opus, read-only) reviews the branch diff vs `origin/main` for correctness, back-compat, security, and **UI consistency** against the shared component layer (`modalShell`, `styleConstants` `BUTTON_*`, `showToast`, `commandPalette` keyboard model). Launch it before marking a PR ready.
-- **`explore`** (`.claude/agents/explore.md`, Sonnet, read-only) overrides the built-in Haiku Explore agent for sharper codebase discovery, preferring the TypeScript LSP MCP (`mcp__typescript__*`, configured in `.mcp.json`) for reference/definition queries.
+- **`explore`** (`.claude/agents/explore.md`, Sonnet, read-only) overrides the built-in Haiku Explore agent for sharper codebase discovery, preferring the Serena LSP MCP (`mcp__serena__*`, configured in `.mcp.json`) for reference/definition queries.
+- **Search ladder** — match the search modality to the question (full guidance in `docs/agent-tooling.md`): `Grep` (ripgrep) for literals/strings → `npx ast-grep run -p '<pattern>' -l ts src` for code *shapes* (call-site sweeps, convention checks — `$X` matches one node, `$$$` any number; no comment/string false positives) → Serena (`find_symbol` / `find_referencing_symbols` / `get_symbols_overview`) for resolved references over the real type graph ("who actually uses this export"). Delegate broad multi-file discovery to the `explore` agent rather than running the fan-out in the main context.
 - **`lint:consistency`** (ast-grep), **`lint:deadcode`** (knip), and **`lint:deps`** (madge) run in CI (`code-quality.yml`). `lint:consistency` gates on `error`-severity ast-grep rules (`no-native-dialogs` is `error`; the rest are `warning`/`hint` — promote one to `error` once the codebase is clean for it). `lint:deadcode` gates on knip's trustworthy categories (`dependencies`/`unlisted`/`unresolved`/`files`) but keeps `exports`/`types` advisory (knip can't see exports used only via the e2e suite's dynamic `import('/src/…')`, and the dead-export backlog needs per-symbol triage). `lint:deps` (madge circular deps) is a **gate**: the module graph is acyclic, so any new cycle fails CI. Scope each advisory hit to the diff — they over-report by design. See `docs/agent-tooling.md`.
 
 ### Module Layering — keep the dependency graph acyclic

--- a/docs/agent-tooling.md
+++ b/docs/agent-tooling.md
@@ -1,8 +1,8 @@
 # Agent tooling — custom subagents, static analysis, LSP
 
 This repo configures the Claude Code harness for higher-quality automated work:
-two custom subagents, a deterministic static-analysis layer they lean on, and a
-TypeScript language-server MCP for symbol-aware discovery.
+custom subagents, a deterministic static-analysis layer they lean on, and a
+Serena (language-server) MCP for symbol-aware discovery.
 
 ## Custom subagents (`.claude/agents/`)
 
@@ -15,7 +15,7 @@ agents below can run on different model tiers.
 | Agent | File | Model | Tools | Role |
 |---|---|---|---|---|
 | `work-reviewer` | `.claude/agents/work-reviewer.md` | `opus` | read-only (`Read, Grep, Glob, Bash`) | Reviews the branch diff vs `origin/main` for correctness, back-compat, security, **and** UI consistency. Never edits. |
-| `explore` | `.claude/agents/explore.md` | `sonnet` | read-only + `mcp__typescript__*` | Codebase discovery / "where is X / who uses Y". Overrides the built-in Explore agent (which defaults to Haiku) with Sonnet + symbol-aware tools. |
+| `explore` | `.claude/agents/explore.md` | `sonnet` | read-only + `mcp__serena__*` | Codebase discovery / "where is X / who uses Y". Overrides the built-in Explore agent (which defaults to Haiku) with Sonnet + symbol-aware tools. |
 | `model-sculpt` | `.claude/agents/model-sculpt.md` | `sonnet` | `Read, Write, Edit, Bash` | Iterates a model snippet (photo→figurine, catalog toy, mechanical part) through the headless `model:preview` render→look→adjust loop until it matches a target *and* passes the printability gates. Engine-aware: **manifold-js / voxel / scad** (not replicad — see below). Returns **text only**. Driven by the `/sculpt` skill. |
 | `implementer` | `.claude/agents/implementer.md` | `sonnet` | `Read, Write, Edit, Bash, Grep, Glob` | Spec-driven implementation worker for parallelizable, well-bounded units (a new modifier/provider/export following an existing sibling). Runs build + unit + the targeted spec before reporting; asks the caller instead of guessing on ambiguity. Launch with `isolation: "worktree"` so parallel workers never share the checkout. |
 | `test-triage` | `.claude/agents/test-triage.md` | `sonnet` | `Read, Bash, Grep, Glob` | Runs vitest / Playwright (targeted, shard, or full) in its own context and returns only a digest: failing test → root-cause hypothesis → `file:line`. Diagnoses, never fixes. The log firewall for the e2e suite. |
@@ -81,7 +81,7 @@ and reasons about the hits against the diff.
 > Why override `explore`? The stock Explore agent runs on Haiku — fine for
 > locating a string, weaker for this codebase's cross-file reference questions
 > ("every reader of the `?notes` param", "does this export have importers").
-> Sonnet + the TS LSP makes that discovery precise.
+> Sonnet + the LSP-backed Serena tools make that discovery precise.
 
 ## Static analysis (`npm run lint:*`)
 
@@ -126,22 +126,65 @@ e2e). `lint:consistency` (ast-grep) and `lint:deadcode` (knip) are **gates**;
 circular deps are worked down. This job does **not** gate the `main → staging`
 promotion.
 
-## TypeScript LSP MCP (`.mcp.json`)
+## The search ladder — pick the right modality, not just grep
 
-`.mcp.json` configures a `typescript` MCP server (`typescript-mcp`) that wraps
-tsserver, giving agents find-references / go-to-definition / hover-types /
-diagnostics over the real type graph instead of string search. The `explore`
-agent allowlists `mcp__typescript__*` and prefers it for reference questions.
+Code search for agents has three modalities, each answering a different
+question. Use the cheapest rung that answers yours; escalate when the answer
+needs more precision than the rung can give:
+
+1. **Lexical — "where does this text appear?"** The built-in `Grep` tool
+   (ripgrep) and `Glob`. Zero setup, always available. Right for literals,
+   comments, error strings, and quick locating. Weakness: false positives from
+   comments/strings, and a common name like `update` drowns in noise.
+2. **Structural — "where does this code shape appear?"** ast-grep, already a
+   devDependency (`@ast-grep/cli`, the binary behind `lint:consistency`). It
+   matches parsed AST nodes, so formatting and comment/string collisions don't
+   produce false hits:
+   `npx ast-grep run -p 'showToast($$$)' -l ts src` — find every call shape;
+   `npx ast-grep run -p 'new Worker($$$)' -l ts src` — regardless of spacing.
+   Pattern syntax: `$X` one node, `$$$` any number. Right for call-site
+   sweeps, convention checks, "find code shaped like this sibling".
+3. **Symbol/graph — "who actually calls or uses this?"** The Serena MCP tools
+   (below): `find_symbol`, `find_referencing_symbols`, `get_symbols_overview`,
+   `find_declaration`, `find_implementations`. Resolved references over the
+   real type graph — no string-collision false positives at all, and compact
+   symbol-chunk output instead of file dumps. Right for "every importer of X",
+   rename-impact, "does this export have users" (cross-check with
+   `lint:deadcode`).
+
+The `explore` agent encodes this ladder; prefer delegating broad discovery to
+it so the main context gets conclusions, not search output. We deliberately do
+**not** run an embedding/vector code-search layer: the repo is single-language,
+well-mapped by `CLAUDE.md`, and the leading agent stacks get better results
+from the lexical/structural/graph trio than from semantic indexes at this
+scale. Revisit if the codebase grows past what these answer in a few calls.
+
+## Serena MCP — the symbol layer (`.mcp.json`)
+
+`.mcp.json` configures [Serena](https://github.com/oraios/serena) (pinned to a
+release tag), an MCP toolkit that wraps real language servers (tsserver for
+this repo) and exposes symbol-level retrieval: `find_symbol`,
+`find_referencing_symbols`, `get_symbols_overview`, `find_declaration`,
+`find_implementations` (plus symbol-anchored editing and per-file
+diagnostics). It runs entirely locally — no code leaves the machine. It replaced the earlier
+`typescript-mcp` server (TS-only, unstable upstream API). The `explore` agent
+allowlists `mcp__serena__*` and prefers it for reference questions;
+`.claude/settings.json` pre-allows the read-only retrieval tools so they don't
+prompt.
 
 Caveats:
 - **MCP servers load at session start.** Editing `.mcp.json` takes effect in a
   fresh session, not the current one.
-- **Managed/remote environments** gate MCP servers by their own config and
-  network policy; the server `npx`-installs `typescript-mcp` on first use, so
-  it needs registry access. If the server isn't loaded, `explore` says so and
-  falls back to ast-grep + grep.
-- `typescript-mcp` is marked under active development upstream — pin/replace it
-  if its API drifts.
+- **Serena is Python, launched via `uvx`** — the machine needs
+  [`uv`](https://docs.astral.sh/uv/) installed, and first run downloads Serena
+  from GitHub plus the TypeScript language server. In managed/remote
+  environments the setup script must install `uv` (and run `npm ci`), and the
+  network policy must allow `github.com`, `pypi.org`/`files.pythonhosted.org`,
+  `astral.sh`, and the npm registry. If the server isn't loaded, `explore`
+  says so and falls back to ast-grep + Grep — the ladder degrades gracefully.
+- **Pinned by tag** (`@vX.Y.Z` in `.mcp.json`). Bump deliberately; check the
+  tool-name surface hasn't drifted before bumping, since the permission
+  allowlist and agent docs name tools individually.
 
 ## Backlog surfaced by these tools (worth a follow-up)
 

--- a/prompts/20260610-160500-agent-search-ladder-serena.md
+++ b/prompts/20260610-160500-agent-search-ladder-serena.md
@@ -46,3 +46,6 @@ Key decisions and why:
 - Remote-env requirements (uv install, network-policy domains, `npm ci`)
   documented in docs/agent-tooling.md; the environment setup-script snippet
   was delivered in chat since that config lives outside the repo.
+
+- Post-PR: retro entry added (retros/inbox/20260610-162500); uv found preinstalled
+  in the remote image, so setup-script additions are pre-warm + policy only.

--- a/prompts/20260610-160500-agent-search-ladder-serena.md
+++ b/prompts/20260610-160500-agent-search-ladder-serena.md
@@ -1,0 +1,48 @@
+---
+session: "01UvAb"
+timestamp: "2026-06-10T16:05:00Z"
+---
+
+## Human
+
+I'd like to upgrade you and other agents' abilities to search without
+literally using the basic grep command/tool. I've seen a lot of new libraries
+recently that are better tools for AI agents than grep. Consider this space in
+relation to this codebase, recommend tools, and make a PR with the changes.
+Also tell me what to add to the remote-environment setup script.
+
+## Assistant
+
+Surveyed the 2025–26 agent-search space and applied the "three modalities"
+framing (lexical / structural / symbol-graph) rather than picking one
+grep-killer, because the repo already had partial coverage of all three.
+
+Key decisions and why:
+
+- **Replaced `typescript-mcp` with Serena MCP** (`.mcp.json`). Our own
+  agent-tooling doc already flagged typescript-mcp as unstable upstream.
+  Serena is the mature LSP toolkit for agents (find_symbol /
+  find_referencing_symbols / get_symbols_overview), runs fully locally, and
+  returns compact symbol chunks instead of file dumps. Pinned to `v1.5.3` by
+  git tag per the repo's own pin-or-replace guidance. Launched with
+  `--context ide-assistant` so it doesn't duplicate Claude Code's file tools.
+- **Promoted ast-grep from lint-only to a search tool.** `@ast-grep/cli` was
+  already a devDependency (lint:consistency); the change is guidance
+  (CLAUDE.md search-ladder section, docs/agent-tooling.md, explore agent) plus
+  settings permissions so `npx ast-grep …` doesn't prompt.
+- **Deliberately skipped embedding/vector search** (mgrep, Semble, ColGrep):
+  mgrep's index is cloud-backed (code leaves the environment), the local ones
+  are immature, and at this repo's scale the lexical/structural/graph trio
+  answers conceptual queries via CLAUDE.md + the explore agent. Documented the
+  skip and the revisit condition so the decision is visible.
+- **Tool names verified against the live server, not docs.** The
+  ide-assistant context exposes find_declaration / find_implementations /
+  get_diagnostics_for_file but NOT search_for_pattern; the settings allowlist
+  and docs name tools individually, so they were corrected to the actual
+  surface after the server connected.
+- Smoke-tested both new rungs in-session: Serena resolved `applyVoxelize` and
+  its single true call site (src/main.ts:7610) with zero false positives;
+  `npx ast-grep run -p 'showToast($$$)'` found call shapes in src/main.ts.
+- Remote-env requirements (uv install, network-policy domains, `npm ci`)
+  documented in docs/agent-tooling.md; the environment setup-script snippet
+  was delivered in chat since that config lives outside the repo.

--- a/retros/inbox/20260610-162500-agent-search-tooling-serena.md
+++ b/retros/inbox/20260610-162500-agent-search-tooling-serena.md
@@ -1,0 +1,42 @@
+---
+date: "2026-06-10T16:25:00Z"
+task: "chore: replace typescript-mcp with Serena MCP, promote ast-grep to a search tool, encode the Grep→ast-grep→Serena search ladder (PR #571)"
+areas: [tooling, agents, docs, mcp]
+cost: low
+---
+
+Research-then-implement task: surveyed the agent code-search space, recommended
+the three-modality ladder (lexical / structural / symbol-graph), then shipped
+the config + docs changes.
+
+## Liked / Worked
+- **The remote harness hot-loaded the edited `.mcp.json`** — the Serena server
+  connected mid-session, which let me verify the *actual* tool surface and
+  smoke-test `find_symbol` / `find_referencing_symbols` against the repo
+  before pushing. Zero-false-positive reference results on `applyVoxelize`
+  validated the whole premise in two calls.
+- The repo's own `docs/agent-tooling.md` had already flagged `typescript-mcp`
+  as "pin/replace if it drifts" — prior documented misgivings made the
+  replacement decision easy and defensible.
+
+## Learned
+- **Serena's `ide-assistant` context does NOT expose `search_for_pattern`**
+  (or `list_dir`/`find_file`); it does expose `find_declaration`,
+  `find_implementations`, `get_diagnostics_for_file`. Upstream docs/blog
+  posts list the full tool set — always verify tool names against the live
+  server before writing per-tool permission allowlists.
+- Serena drops a `.serena/` project-metadata dir in the repo root on first
+  connect — needs gitignoring (done in PR #571).
+- `uv`/`uvx` is preinstalled in the remote container image at
+  `/root/.local/bin`, so Serena worked without a setup-script change here;
+  the setup-script additions are pre-warm + network-policy belt-and-braces.
+
+## Lacked
+- No deterministic check that the per-tool names in `.claude/settings.json`
+  `permissions.allow` match what the pinned Serena version actually serves —
+  a tag bump could silently orphan the allowlist. A tiny CI probe (or a note
+  in the bump procedure, which I added to the docs) covers it for now.
+
+## Longed for
+- A `send_later`-style scheduler in this session to self-check the PR; not
+  available, so PR #571 babysitting rests on webhook events only.


### PR DESCRIPTION
## Summary

Upgrades agent code-search from "ripgrep for everything" to the three-modality model the agent-tooling space has converged on — lexical / structural / symbol-graph — using what the repo already had where possible:

- **`.mcp.json`: replace `typescript-mcp` with [Serena](https://github.com/oraios/serena)** (pinned `v1.5.3`, `ide-assistant` context, project-local). Serena wraps tsserver and exposes resolved-reference tools (`find_symbol`, `find_referencing_symbols`, `get_symbols_overview`, `find_declaration`, `find_implementations`) — no string-collision false positives, compact symbol-chunk output. `typescript-mcp` was already flagged in `docs/agent-tooling.md` as unstable upstream ("pin/replace it if its API drifts").
- **Promote ast-grep from lint-only to a search tool.** `@ast-grep/cli` was already a devDependency (behind `lint:consistency`); this documents `npx ast-grep run -p '<pattern>'` as the structural-search rung and pre-allows it in `.claude/settings.json`.
- **Encode the search ladder** (Grep → ast-grep → Serena) in `CLAUDE.md`, a new `docs/agent-tooling.md` section, and the `explore` agent (whose tools move from `mcp__typescript__*` to `mcp__serena__*`).
- **Deliberately skip embedding/vector search** (mgrep et al.) and document why: mgrep's index is cloud-backed, the local options are immature, and at this repo's scale the lexical/structural/graph trio plus the `explore` agent answers conceptual queries without index infrastructure.
- Gitignore `.serena/` (Serena's project metadata/cache).

Tool names in the settings allowlist and docs were verified against the **live** server surface (the `ide-assistant` context exposes `find_declaration`/`find_implementations`/`get_diagnostics_for_file` but not `search_for_pattern`), not upstream docs.

**Requires a remote-environment setup-script update** (install `uv`, allow `astral.sh`/`pypi.org`/`files.pythonhosted.org`/`github.com` in the network policy) — without it the Serena server won't start in fresh containers and agents fall back to ast-grep + Grep per the documented degradation path.

## Test plan

- [x] `.mcp.json` and `.claude/settings.json` validate as JSON
- [x] Serena server connects in this remote environment and `find_symbol` resolves `applyVoxelize` → `src/surface/modifiers.ts:647`
- [x] `find_referencing_symbols` returns exactly the import + the one true call site (`src/main.ts:7610`), no false positives
- [x] `npx ast-grep run -p 'showToast($$$)' -l ts src/main.ts` finds call shapes
- [ ] PR-checks shards green (config/docs-only change; no `src/` modifications)
- [ ] Fresh-session validation that the `explore` agent picks up `mcp__serena__*`

https://claude.ai/code/session_01UvAbmhkEjTRhwu3NzB8h2b

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvAbmhkEjTRhwu3NzB8h2b)_