### PR TITLE
feat: import and export MagicaVoxel scene graphs (multi-object .vox)

### DIFF
--- a/prompts/vox-scene-graph-support.md
+++ b/prompts/vox-scene-graph-support.md
@@ -60,3 +60,27 @@ bypass, a 90°-about-Z `_r` rotation (line in x → line in y), and malformed-no
 fallback. Ran the full unit tier (1050 pass) + typecheck, and a throwaway
 Playwright spec that imports a hand-built two-cube scene through the real
 import→voxel-render path and screenshots both cubes at their offset positions.
+
+## Review follow-ups (work-reviewer pass)
+
+A read-only review (which brute-forced the rotation composition against 1M
+cases and confirmed no DoS vector in the bounds-checked reader) flagged two
+should-fix items; both applied:
+
+**Reject improper (mirroring) `_r` rotations.** 48 of 256 `_r` byte values
+decode to a determinant-−1 reflection. MagicaVoxel only ever writes proper
+rotations, so a reflection means a corrupt/crafted file — `decodeRotation` now
+computes the determinant (sign of the column permutation × product of the row
+signs) and falls back to identity on −1, consistent with the existing
+malformed-byte fallback, rather than silently mirroring geometry. New test
+covers `_r=20` keeping identity.
+
+**Documented the single-model z-normalization change.** MagicaVoxel writes a
+scene graph even for one model, so real single-model files now take the scene
+path, which grounds the model on z=0 and centers it horizontally (the same
+"land it in view" framing the legacy path used) instead of preserving the
+file's authored world origin. Intentional and consistent across import sources;
+an explicit `modelIndex` still gives the legacy per-model centering. Added a
+code comment so it isn't mistaken for a regression. The reviewer's nits
+(global cycle-guard over-prunes a true DAG, which MV never emits; duplicate
+node ids last-write-wins) were left as acceptable for malformed/non-MV input.

--- a/prompts/vox-scene-graph-support.md
+++ b/prompts/vox-scene-graph-support.md
@@ -1,0 +1,62 @@
+---
+session: "i9i55h"
+timestamp: "2026-06-10T22:40:00Z"
+tools: [subagent, websearch, playwright, vitest]
+---
+
+## Human
+
+Research question about MagicaVoxel / MagicaCSG: how they work, whether the
+source was published, and whether techniques could be adopted into Partwright.
+After establishing that the only openly-licensed asset is the MIT-licensed
+`.vox` format spec (the apps themselves are closed freeware), and that the SDF
+smooth-CSG capability MagicaCSG embodies already exists in Partwright via
+`api.sdf`, the actionable gap was `.vox` round-trip fidelity. Instruction:
+"Do the VOX fixes."
+
+## Assistant
+
+## Key decisions
+
+**Scoped to the real fidelity gap: scene-graph (multi-object) import.** The
+importer previously walked only MAIN's direct children and parsed
+`SIZE/XYZI/RGBA`, picking model 0 and silently dropping every other model — so
+any multi-object MagicaVoxel scene (the common case; MV emits one model per
+object) collapsed to a single piece at the origin. Added full `nTRN/nGRP/nSHP`
++ `DICT`/`STRING` parsing and a graph traversal that composes each node's
+translation **and** rotation (the `_r` signed-permutation byte) and assembles
+every shape's model into one grid at its world position. Models are positioned
+by their center (`floor(size/2)`), matching MV's transform convention and the
+existing single-model centering.
+
+**Kept a legacy fallback rather than changing behavior for old files.** When no
+explicit `modelIndex` is requested *and* a scene graph is present, assemble the
+whole scene; otherwise (no graph, or an explicit `modelIndex` picking one
+model) keep the prior center-one-model path. This preserves every existing
+test and the `modelIndex` escape hatch, and means hand-built `SIZE/XYZI`-only
+files are untouched.
+
+**Defensive parsing — a malformed scene node degrades, never throws.** Scene
+chunks are read through a bounds-checked `ChunkReader` that throws past the
+chunk end; each node parse is wrapped so a truncated/garbage node is skipped
+and the file falls back to the legacy path. A cyclic graph is guarded with a
+`seen` set. A scene that yields no shapes also falls back.
+
+**Export now emits a canonical scene graph** (`nTRN`→`nGRP`→`nTRN`→`nSHP`) so
+our output matches the structure MagicaVoxel itself writes, and the export
+round-trip tests now exercise the new import path. The shape transform
+translates by the model center so the round-trip reproduces the same occupancy
+the old center-on-corner layout produced.
+
+**Deliberately did NOT emit `MATL`.** A Partwright voxel grid carries only RGBA
+color — there is no metal/glass/emissive/roughness data to serialize — so a
+`MATL` chunk would be fabricated defaults: bytes, not fidelity. Documented the
+omission in the export header comment. (Likewise left the 256/axis single-model
+limit in place; multi-model tiling to lift it would be a separate, larger
+change.)
+
+**Verification.** Added unit tests for two-model placement, the `modelIndex`
+bypass, a 90°-about-Z `_r` rotation (line in x → line in y), and malformed-node
+fallback. Ran the full unit tier (1050 pass) + typecheck, and a throwaway
+Playwright spec that imports a hand-built two-cube scene through the real
+import→voxel-render path and screenshots both cubes at their offset positions.

--- a/src/export/vox.ts
+++ b/src/export/vox.ts
@@ -9,13 +9,19 @@
 //   MAIN { contentSize = 0, childrenSize } wrapping, in order:
 //     SIZE { x, y, z : uint32 }
 //     XYZI { count : uint32, count × (x, y, z, colorIndex : uint8) }
+//     nTRN/nGRP/nTRN/nSHP — the scene graph that positions the model
 //     RGBA { 256 × (r, g, b, a : uint8) }   — file slot k holds palette index k+1
 //
 // XYZI coordinates are single bytes (0–255), so one model spans at most 256³,
 // and color indices are 1-based into a 255-color palette (slot 0 is reserved /
 // transparent). We translate the grid's min corner to the origin, build a
 // palette from its distinct colors (reducing to the 255 most-frequent, with
-// nearest-color snapping, when a grid has more), and emit a single model.
+// nearest-color snapping, when a grid has more), and emit a single model wrapped
+// in a canonical root-transform → group → transform → shape scene graph (the
+// same structure MagicaVoxel itself writes), so the file round-trips through
+// any conforming reader. Materials (MATL) are intentionally omitted: a voxel
+// grid carries only RGBA color, so there is no metal/glass/emissive data to
+// serialize — a MATL chunk of fabricated defaults would add bytes, not fidelity.
 //
 // `encodeVox` is pure logic (no DOM, no WASM) so it's unit-tested in the vitest
 // tier and round-tripped against `parseVox`; `buildVOX` / `exportVOX` wrap it
@@ -51,6 +57,78 @@ function leafChunk(id: string, content: Uint8Array): Uint8Array {
   new DataView(out.buffer).setUint32(4, content.length, true); // contentSize; childrenSize stays 0
   out.set(content, 12);
   return out;
+}
+
+/** Growable little-endian byte writer for the scene-graph chunk encodings. */
+class ByteWriter {
+  private bytes: number[] = [];
+  int32(v: number): this {
+    this.bytes.push(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff);
+    return this;
+  }
+  /** STRING: int32 length + raw bytes (ASCII, no terminator). */
+  string(s: string): this {
+    this.int32(s.length);
+    for (let i = 0; i < s.length; i++) this.bytes.push(s.charCodeAt(i) & 0xff);
+    return this;
+  }
+  /** DICT: int32 pair count, then STRING key / STRING value pairs. */
+  dict(entries: [string, string][]): this {
+    this.int32(entries.length);
+    for (const [k, v] of entries) this.string(k).string(v);
+    return this;
+  }
+  done(): Uint8Array { return new Uint8Array(this.bytes); }
+}
+
+/** Build the canonical single-model scene graph: a root transform node feeds a
+ *  group, which holds one transform node positioning the shape's model. The
+ *  shape transform translates the model by its center (floor(size/2)) so a
+ *  conforming reader (including {@link parseVox}) reconstructs the same
+ *  occupancy the legacy center-on-corner layout produced. */
+function sceneGraphChunks(sx: number, sy: number, sz: number): Uint8Array[] {
+  const cx = Math.floor(sx / 2), cy = Math.floor(sy / 2), cz = Math.floor(sz / 2);
+  // nTRN(0): root, identity transform → group node 1.
+  const rootTrn = new ByteWriter()
+    .int32(0)          // node id
+    .dict([])          // node attributes
+    .int32(1)          // child = group node 1
+    .int32(-1)         // reserved
+    .int32(-1)         // layer id
+    .int32(1)          // 1 frame
+    .dict([])          // frame: identity (no _t / _r)
+    .done();
+  // nGRP(1): one child, the shape's transform node 2.
+  const grp = new ByteWriter()
+    .int32(1)          // node id
+    .dict([])          // node attributes
+    .int32(1)          // 1 child
+    .int32(2)          // child = transform node 2
+    .done();
+  // nTRN(2): positions the shape's model by its center → shape node 3.
+  const shapeTrn = new ByteWriter()
+    .int32(2)          // node id
+    .dict([])          // node attributes
+    .int32(3)          // child = shape node 3
+    .int32(-1)         // reserved
+    .int32(0)          // layer id
+    .int32(1)          // 1 frame
+    .dict([['_t', `${cx} ${cy} ${cz}`]])
+    .done();
+  // nSHP(3): references model 0.
+  const shp = new ByteWriter()
+    .int32(3)          // node id
+    .dict([])          // node attributes
+    .int32(1)          // 1 model
+    .int32(0)          // model id 0
+    .dict([])          // model attributes
+    .done();
+  return [
+    leafChunk('nTRN', rootTrn),
+    leafChunk('nGRP', grp),
+    leafChunk('nTRN', shapeTrn),
+    leafChunk('nSHP', shp),
+  ];
 }
 
 /** Serialize a grid to MagicaVoxel `.vox` bytes. Throws a clear, actionable
@@ -121,7 +199,9 @@ export function encodeVox(grid: VoxelGrid): Uint8Array {
   const sizeChunk = leafChunk('SIZE', size);
   const xyziChunk = leafChunk('XYZI', xyzi);
   const rgbaChunk = leafChunk('RGBA', rgba);
-  const childrenLen = sizeChunk.length + xyziChunk.length + rgbaChunk.length;
+  const sceneChunks = sceneGraphChunks(sx, sy, sz);
+  const children = [sizeChunk, xyziChunk, ...sceneChunks, rgbaChunk];
+  const childrenLen = children.reduce((sum, c) => sum + c.length, 0);
 
   // ── File header + MAIN wrapper (children follow MAIN's 12-byte header).
   const header = new Uint8Array(8);
@@ -138,9 +218,7 @@ export function encodeVox(grid: VoxelGrid): Uint8Array {
   let p = 0;
   out.set(header, p); p += header.length;
   out.set(main, p); p += main.length;
-  out.set(sizeChunk, p); p += sizeChunk.length;
-  out.set(xyziChunk, p); p += xyziChunk.length;
-  out.set(rgbaChunk, p);
+  for (const chunk of children) { out.set(chunk, p); p += chunk.length; }
   return out;
 }
 

--- a/src/import/parsers/vox.ts
+++ b/src/import/parsers/vox.ts
@@ -87,7 +87,10 @@ const IDENTITY_ROT: Rot = { cols: [0, 1, 2], signs: [1, 1, 1] };
 /** Decode a MagicaVoxel `_r` rotation byte into a {@link Rot}. Bits 0–1 and 2–3
  *  give the non-zero column of rows 0 and 1; row 2's column is whichever index
  *  remains. Bits 4–6 are the per-row signs (1 = negative). Falls back to
- *  identity for a malformed byte (rows 0 and 1 sharing a column). */
+ *  identity for a malformed byte (rows 0 and 1 sharing a column) or for an
+ *  improper rotation (determinant −1, a mirror): MagicaVoxel only ever writes
+ *  proper rotations, so a reflection means a corrupt/crafted file — we decline
+ *  to silently mirror the geometry. */
 function decodeRotation(byte: number): Rot {
   const c0 = byte & 0b11;
   const c1 = (byte >> 2) & 0b11;
@@ -96,6 +99,11 @@ function decodeRotation(byte: number): Rot {
   const s0 = (byte >> 4) & 1 ? -1 : 1;
   const s1 = (byte >> 5) & 1 ? -1 : 1;
   const s2 = (byte >> 6) & 1 ? -1 : 1;
+  // Determinant of a signed permutation matrix = sign(permutation) × ∏signs.
+  // sign([c0,c1,c2]) is +1 for an even permutation of (0,1,2), −1 for odd.
+  const even = (c0 === 0 && c1 === 1) || (c0 === 1 && c1 === 2) || (c0 === 2 && c1 === 0);
+  const det = (even ? 1 : -1) * s0 * s1 * s2;
+  if (det !== 1) return IDENTITY_ROT;
   return { cols: [c0, c1, c2], signs: [s0, s1, s2] };
 }
 
@@ -319,6 +327,13 @@ export function parseVox(bytes: Uint8Array, options: VoxParseOptions = {}): Voxe
 
   // Multi-object path: when no explicit model index was requested, assemble the
   // whole scene through its graph so every positioned part lands correctly.
+  //
+  // Note MagicaVoxel writes a scene graph even for a *single* model, so real
+  // single-model files take this path too — `assemblePlaced` grounds the scene
+  // on z=0 and centers it horizontally, the same "land it in view" framing the
+  // legacy path applies (rather than preserving the file's authored world
+  // origin). That's intentional and consistent across import sources; pass an
+  // explicit `modelIndex` to get the legacy per-model centering instead.
   if (options.modelIndex === undefined) {
     const placed: { x: number; y: number; z: number; c: number }[] = [];
     const place = (modelId: number, xform: Xform): void => {

--- a/src/import/parsers/vox.ts
+++ b/src/import/parsers/vox.ts
@@ -4,6 +4,7 @@
 //   MAIN chunk wrapping the rest as children:
 //     PACK   (optional)        — number of models in the file
 //     SIZE  + XYZI repeated    — one pair per model (dims + occupancy)
+//     nTRN / nGRP / nSHP       — scene graph: positions each model in the world
 //     RGBA  (optional)         — 256-entry palette; if absent use the default
 //
 // Each XYZI voxel is { x, y, z, i } with `i` a 1-based palette index.
@@ -13,7 +14,17 @@
 // so the model lands upright; users can `.mirror('x')` if they want the
 // opposite-handed view.
 //
+// Multi-object scenes: MagicaVoxel stores each object as its own SIZE/XYZI
+// model and positions it through a scene graph of transform (nTRN), group
+// (nGRP), and shape (nSHP) nodes. We traverse that graph from the root node,
+// compose each node's translation + rotation, and assemble every shape into one
+// grid at its world position — so a multi-part scene imports whole instead of
+// collapsing to model 0. Files with no scene graph (older single-model exports,
+// and the synthetic fixtures in our tests) fall back to the legacy single-model
+// path that centers one model around the origin.
+//
 // Reference: https://github.com/ephtracy/voxel-model/blob/master/MagicaVoxel-file-format-vox.txt
+//            https://github.com/ephtracy/voxel-model/blob/master/MagicaVoxel-file-format-vox-extension.txt
 //
 // Pure logic (no DOM/WASM): unit-tested in the vitest tier.
 
@@ -56,10 +67,143 @@ const DEFAULT_PALETTE: number[] = (() => {
 })();
 
 export interface VoxParseOptions {
-  /** When the file contains multiple models, this index picks one (default 0).
-   *  Other models are silently ignored — multi-model placement belongs at a
-   *  higher layer (where we'd want translation offsets / part-per-model). */
+  /** Force the legacy single-model path and pick this model by index, ignoring
+   *  any scene graph. When omitted (the default), a multi-object scene is
+   *  assembled whole via its scene graph; pass an index only to extract one
+   *  specific model from a multi-model file. */
   modelIndex?: number;
+}
+
+/** A signed-permutation rotation: row `i` of the matrix has its single non-zero
+ *  entry at column `cols[i]` with sign `signs[i]`. Applying it to a vector `v`
+ *  yields `[signs[0]*v[cols[0]], signs[1]*v[cols[1]], signs[2]*v[cols[2]]]`. */
+interface Rot {
+  cols: [number, number, number];
+  signs: [number, number, number];
+}
+
+const IDENTITY_ROT: Rot = { cols: [0, 1, 2], signs: [1, 1, 1] };
+
+/** Decode a MagicaVoxel `_r` rotation byte into a {@link Rot}. Bits 0–1 and 2–3
+ *  give the non-zero column of rows 0 and 1; row 2's column is whichever index
+ *  remains. Bits 4–6 are the per-row signs (1 = negative). Falls back to
+ *  identity for a malformed byte (rows 0 and 1 sharing a column). */
+function decodeRotation(byte: number): Rot {
+  const c0 = byte & 0b11;
+  const c1 = (byte >> 2) & 0b11;
+  if (c0 > 2 || c1 > 2 || c0 === c1) return IDENTITY_ROT;
+  const c2 = 3 - c0 - c1; // the remaining index of {0,1,2}
+  const s0 = (byte >> 4) & 1 ? -1 : 1;
+  const s1 = (byte >> 5) & 1 ? -1 : 1;
+  const s2 = (byte >> 6) & 1 ? -1 : 1;
+  return { cols: [c0, c1, c2], signs: [s0, s1, s2] };
+}
+
+/** Apply a rotation to an integer vector. */
+function applyRot(r: Rot, v: [number, number, number]): [number, number, number] {
+  return [r.signs[0] * v[r.cols[0]], r.signs[1] * v[r.cols[1]], r.signs[2] * v[r.cols[2]]];
+}
+
+/** Compose two rotations: `parent ∘ local` (apply local first, then parent). */
+function composeRot(parent: Rot, local: Rot): Rot {
+  const cols = [0, 1, 2].map((i) => local.cols[parent.cols[i]]) as [number, number, number];
+  const signs = [0, 1, 2].map((i) => parent.signs[i] * local.signs[parent.cols[i]]) as [number, number, number];
+  return { cols, signs };
+}
+
+/** A composed world transform (translation + rotation) for a scene-graph node. */
+interface Xform {
+  t: [number, number, number];
+  r: Rot;
+}
+
+const IDENTITY_XFORM: Xform = { t: [0, 0, 0], r: IDENTITY_ROT };
+
+/** Compose two transforms: place `local` inside `parent`'s frame. */
+function composeXform(parent: Xform, local: Xform): Xform {
+  const rt = applyRot(parent.r, local.t);
+  return {
+    t: [parent.t[0] + rt[0], parent.t[1] + rt[1], parent.t[2] + rt[2]],
+    r: composeRot(parent.r, local.r),
+  };
+}
+
+interface TrnNode { childId: number; xform: Xform }
+interface GrpNode { children: number[] }
+interface ShpNode { models: number[] }
+
+/** Cursor over a chunk's content for reading the extension chunk encodings.
+ *  Throws `RangeError` past `end` so a malformed scene node is caught and the
+ *  import falls back to the legacy single-model path rather than corrupting. */
+class ChunkReader {
+  private dv: DataView;
+  p: number;
+  private end: number;
+  constructor(dv: DataView, p: number, end: number) {
+    this.dv = dv;
+    this.p = p;
+    this.end = end;
+  }
+  private require(n: number): void {
+    if (this.p + n > this.end) throw new RangeError('scene-graph chunk truncated');
+  }
+  int32(): number { this.require(4); const v = this.dv.getInt32(this.p, true); this.p += 4; return v; }
+  uint32(): number { this.require(4); const v = this.dv.getUint32(this.p, true); this.p += 4; return v; }
+  /** STRING: int32 length + raw bytes (no terminator). */
+  string(): string {
+    const len = this.uint32();
+    this.require(len);
+    let s = '';
+    for (let i = 0; i < len; i++) s += String.fromCharCode(this.dv.getUint8(this.p + i));
+    this.p += len;
+    return s;
+  }
+  /** DICT: int32 pair count, then STRING key / STRING value pairs. */
+  dict(): Map<string, string> {
+    const n = this.uint32();
+    const m = new Map<string, string>();
+    for (let i = 0; i < n; i++) {
+      const k = this.string();
+      m.set(k, this.string());
+    }
+    return m;
+  }
+}
+
+/** Parse a `_t` translation string ("x y z") into a vector, or null. */
+function parseTranslation(s: string | undefined): [number, number, number] | null {
+  if (!s) return null;
+  const parts = s.trim().split(/\s+/).map(Number);
+  if (parts.length === 3 && parts.every(Number.isFinite)) {
+    return [parts[0], parts[1], parts[2]];
+  }
+  return null;
+}
+
+/** Walk the scene graph from the root and place every shape's model(s) into the
+ *  output via `place`. Returns false if the graph yielded no shapes (so the
+ *  caller can fall back to the legacy single-model path). */
+function traverseScene(
+  trn: Map<number, TrnNode>,
+  grp: Map<number, GrpNode>,
+  shp: Map<number, ShpNode>,
+  place: (modelId: number, xform: Xform) => void,
+): boolean {
+  if (trn.size === 0 && grp.size === 0 && shp.size === 0) return false;
+  let placedAny = false;
+  const seen = new Set<number>();
+  const visit = (nodeId: number, xform: Xform): void => {
+    if (seen.has(nodeId)) return; // guard against a cyclic/corrupt graph
+    seen.add(nodeId);
+    const t = trn.get(nodeId);
+    if (t) { visit(t.childId, composeXform(xform, t.xform)); return; }
+    const g = grp.get(nodeId);
+    if (g) { for (const child of g.children) visit(child, xform); return; }
+    const s = shp.get(nodeId);
+    if (s) { for (const modelId of s.models) { place(modelId, xform); placedAny = true; } }
+  };
+  visit(0, IDENTITY_XFORM); // MagicaVoxel's root node is always id 0
+  return placedAny;
 }
 
 /** Parse a MagicaVoxel `.vox` file into a {@link VoxelGrid}. Returns null and
@@ -70,13 +214,16 @@ export function parseVox(bytes: Uint8Array, options: VoxParseOptions = {}): Voxe
   }
   const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 
-  // Collect the model SIZE/XYZI pairs and the palette as we walk the chunk
-  // tree. MAIN's content lives between the header (12 bytes total) and EOF,
-  // skipping MAIN's own chunkContentSize/childrenSize.
+  // Collect the model SIZE/XYZI pairs, the palette, and the scene-graph nodes
+  // as we walk the chunk tree. MAIN's content lives between the header (12
+  // bytes total) and EOF, skipping MAIN's own chunkContentSize/childrenSize.
   if (bytes.length < 20) throw new Error('Truncated .vox file (no MAIN chunk).');
   const sizes: { x: number; y: number; z: number }[] = [];
   const voxels: { x: number; y: number; z: number; i: number }[][] = [];
   let palette: number[] | null = null;
+  const trn = new Map<number, TrnNode>();
+  const grp = new Map<number, GrpNode>();
+  const shp = new Map<number, ShpNode>();
 
   // Walk children of MAIN. MAIN's header occupies bytes [8, 20); its children
   // span [20, bytes.length).
@@ -120,6 +267,46 @@ export function parseVox(bytes: Uint8Array, options: VoxParseOptions = {}): Voxe
         pal[i + 1] = (r << 16) | (g << 8) | b;
       }
       palette = pal;
+    } else if (id === 'nTRN' || id === 'nGRP' || id === 'nSHP') {
+      // Scene-graph nodes. Parse defensively: a malformed node is skipped (the
+      // import then falls back to the legacy single-model path).
+      try {
+        const rd = new ChunkReader(dv, start, end);
+        const nodeId = rd.int32();
+        rd.dict(); // node attributes (_name, _hidden) — unused
+        if (id === 'nTRN') {
+          const childId = rd.int32();
+          rd.int32(); // reserved (-1)
+          rd.int32(); // layer id
+          const numFrames = rd.uint32();
+          let xform = IDENTITY_XFORM;
+          for (let f = 0; f < numFrames; f++) {
+            const frame = rd.dict();
+            if (f === 0) {
+              const t = parseTranslation(frame.get('_t')) ?? [0, 0, 0];
+              const rByte = frame.has('_r') ? parseInt(frame.get('_r')!, 10) : NaN;
+              const r = Number.isFinite(rByte) ? decodeRotation(rByte) : IDENTITY_ROT;
+              xform = { t, r };
+            }
+          }
+          trn.set(nodeId, { childId, xform });
+        } else if (id === 'nGRP') {
+          const numChildren = rd.uint32();
+          const children: number[] = [];
+          for (let c = 0; c < numChildren; c++) children.push(rd.int32());
+          grp.set(nodeId, { children });
+        } else {
+          const numModels = rd.uint32();
+          const models: number[] = [];
+          for (let m = 0; m < numModels; m++) {
+            models.push(rd.int32());
+            rd.dict(); // per-model attributes (_f frame index) — unused
+          }
+          shp.set(nodeId, { models });
+        }
+      } catch {
+        // Malformed scene node — ignore it; legacy fallback covers the file.
+      }
     }
     p = end;
   }
@@ -127,13 +314,42 @@ export function parseVox(bytes: Uint8Array, options: VoxParseOptions = {}): Voxe
   if (sizes.length === 0 || voxels.length === 0) {
     throw new Error('.vox file has no model (missing SIZE/XYZI chunks).');
   }
+  const pal = palette ?? DEFAULT_PALETTE;
+  const colorOf = (i: number): number => pal[i] ?? 0xffffff;
+
+  // Multi-object path: when no explicit model index was requested, assemble the
+  // whole scene through its graph so every positioned part lands correctly.
+  if (options.modelIndex === undefined) {
+    const placed: { x: number; y: number; z: number; c: number }[] = [];
+    const place = (modelId: number, xform: Xform): void => {
+      const size = sizes[modelId];
+      const cells = voxels[modelId];
+      if (!size || !cells) return; // shape references a model the file didn't ship
+      // MagicaVoxel's transform positions the model by its center; the center
+      // in local voxel space is floor(size/2) per axis.
+      const cx = Math.floor(size.x / 2), cy = Math.floor(size.y / 2), cz = Math.floor(size.z / 2);
+      for (const c of cells) {
+        const lv: [number, number, number] = [c.x - cx, c.y - cy, c.z - cz];
+        const rv = applyRot(xform.r, lv);
+        placed.push({
+          x: xform.t[0] + rv[0],
+          y: xform.t[1] + rv[1],
+          z: xform.t[2] + rv[2],
+          c: colorOf(c.i),
+        });
+      }
+    };
+    if (traverseScene(trn, grp, shp, place) && placed.length > 0) {
+      return assemblePlaced(placed);
+    }
+  }
+
+  // Legacy single-model path: no scene graph (or an explicit modelIndex). Pick
+  // one model and center it horizontally, sitting it on z=0 — so it lands where
+  // an image-import would, in a coordinate range likely to fit.
   const modelIndex = Math.max(0, Math.min(options.modelIndex ?? 0, voxels.length - 1));
   const cells = voxels[modelIndex];
   const size = sizes[modelIndex] ?? sizes[0];
-  const pal = palette ?? DEFAULT_PALETTE;
-
-  // Center the model horizontally and sit it on z=0, so it lands in the same
-  // place an image-import would and at a coordinate range likely to fit.
   const cx = Math.floor(size.x / 2);
   const cy = Math.floor(size.y / 2);
   const grid = new VoxelGrid();
@@ -141,13 +357,36 @@ export function parseVox(bytes: Uint8Array, options: VoxParseOptions = {}): Voxe
     const x = c.x - cx;
     const y = c.y - cy;
     const z = c.z;
-    if (x < COORD_MIN || x > COORD_MAX || y < COORD_MIN || y > COORD_MAX || z < COORD_MIN || z > COORD_MAX) {
-      // The model exceeds the grid range — silently drop the out-of-range
-      // voxels rather than fail the whole import. (The .vox spec allows up to
-      // 256³, comfortably inside ±1024 once centered.)
-      continue;
-    }
-    grid.set(x, y, z, pal[c.i] ?? 0xffffff);
+    if (!inRange(x, y, z)) continue; // drop out-of-range voxels rather than fail
+    grid.set(x, y, z, colorOf(c.i));
+  }
+  return grid;
+}
+
+/** True if a voxel coordinate sits inside the grid's addressable range. */
+function inRange(x: number, y: number, z: number): boolean {
+  return x >= COORD_MIN && x <= COORD_MAX
+    && y >= COORD_MIN && y <= COORD_MAX
+    && z >= COORD_MIN && z <= COORD_MAX;
+}
+
+/** Normalize a set of world-space voxels into a grid: center the whole scene
+ *  horizontally about the origin and sit its lowest layer on z=0, preserving
+ *  the relative placement of every part. Out-of-range voxels are dropped. */
+function assemblePlaced(placed: { x: number; y: number; z: number; c: number }[]): VoxelGrid {
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity, minZ = Infinity;
+  for (const v of placed) {
+    if (v.x < minX) minX = v.x; if (v.x > maxX) maxX = v.x;
+    if (v.y < minY) minY = v.y; if (v.y > maxY) maxY = v.y;
+    if (v.z < minZ) minZ = v.z;
+  }
+  const offX = Math.floor((minX + maxX) / 2);
+  const offY = Math.floor((minY + maxY) / 2);
+  const grid = new VoxelGrid();
+  for (const v of placed) {
+    const x = v.x - offX, y = v.y - offY, z = v.z - minZ;
+    if (!inRange(x, y, z)) continue;
+    grid.set(x, y, z, v.c);
   }
   return grid;
 }

--- a/tests/unit/vox.test.ts
+++ b/tests/unit/vox.test.ts
@@ -159,3 +159,146 @@ describe('parseVox', () => {
     expect(pal.slice(186).some((v) => v !== 0x000000)).toBe(true);
   });
 });
+
+// ── Scene-graph (multi-object) import ──────────────────────────────────────
+// MagicaVoxel positions each object through nTRN/nGRP/nSHP nodes. These tests
+// hand-build files with that graph to prove all models assemble at their world
+// positions (with rotation), instead of collapsing to model 0.
+
+/** Little-endian byte writer for the extension-chunk encodings. */
+class W {
+  b: number[] = [];
+  i32(v: number): this { this.b.push(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff); return this; }
+  str(s: string): this { this.i32(s.length); for (let i = 0; i < s.length; i++) this.b.push(s.charCodeAt(i) & 0xff); return this; }
+  dict(e: [string, string][]): this { this.i32(e.length); for (const [k, v] of e) this.str(k).str(v); return this; }
+  out(): Uint8Array { return new Uint8Array(this.b); }
+}
+
+function chunk(id: string, content: Uint8Array): Uint8Array {
+  const out = new Uint8Array(12 + content.length);
+  for (let i = 0; i < 4; i++) out[i] = id.charCodeAt(i);
+  new DataView(out.buffer).setUint32(4, content.length, true);
+  out.set(content, 12);
+  return out;
+}
+
+function sizeChunk(x: number, y: number, z: number): Uint8Array {
+  return chunk('SIZE', new W().i32(x).i32(y).i32(z).out());
+}
+function xyziChunk(voxels: XYZI[]): Uint8Array {
+  const w = new W().i32(voxels.length);
+  for (const v of voxels) w.b.push(v.x & 0xff, v.y & 0xff, v.z & 0xff, v.i & 0xff);
+  return chunk('XYZI', w.out());
+}
+function rgbaChunk(rgb: Record<number, number>): Uint8Array {
+  // rgb maps 1-based palette index → 0xRRGGBB; file slot k holds index k+1.
+  const w = new W();
+  for (let i = 0; i < 256; i++) {
+    const c = rgb[i + 1] ?? 0;
+    w.b.push((c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 0xff);
+  }
+  return chunk('RGBA', w.out());
+}
+function trnChunk(nodeId: number, childId: number, t?: [number, number, number], rByte?: number): Uint8Array {
+  const frame: [string, string][] = [];
+  if (t) frame.push(['_t', `${t[0]} ${t[1]} ${t[2]}`]);
+  if (rByte !== undefined) frame.push(['_r', String(rByte)]);
+  return chunk('nTRN', new W().i32(nodeId).dict([]).i32(childId).i32(-1).i32(0).i32(1).dict(frame).out());
+}
+function grpChunk(nodeId: number, children: number[]): Uint8Array {
+  const w = new W().i32(nodeId).dict([]).i32(children.length);
+  for (const c of children) w.i32(c);
+  return chunk('nGRP', w.out());
+}
+function shpChunk(nodeId: number, modelId: number): Uint8Array {
+  return chunk('nSHP', new W().i32(nodeId).dict([]).i32(1).i32(modelId).dict([]).out());
+}
+
+/** Wrap children under "VOX " + MAIN. */
+function voxFile(children: Uint8Array[]): Uint8Array {
+  const childrenLen = children.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(8 + 12 + childrenLen);
+  out[0] = 0x56; out[1] = 0x4f; out[2] = 0x58; out[3] = 0x20; // "VOX "
+  const dv = new DataView(out.buffer);
+  dv.setUint32(4, 150, true);
+  out[8] = 0x4d; out[9] = 0x41; out[10] = 0x49; out[11] = 0x4e; // "MAIN"
+  dv.setUint32(12, 0, true);
+  dv.setUint32(16, childrenLen, true);
+  let p = 20;
+  for (const c of children) { out.set(c, p); p += c.length; }
+  return out;
+}
+
+describe('parseVox scene graph', () => {
+  it('assembles two models at their scene-graph positions', () => {
+    // model0 (red) at origin, model1 (green) translated +10 in x.
+    const bytes = voxFile([
+      sizeChunk(1, 1, 1), xyziChunk([{ x: 0, y: 0, z: 0, i: 1 }]),
+      sizeChunk(1, 1, 1), xyziChunk([{ x: 0, y: 0, z: 0, i: 2 }]),
+      trnChunk(0, 1), // root → group 1
+      grpChunk(1, [2, 4]), // group → two shape transforms
+      trnChunk(2, 3, [0, 0, 0]), shpChunk(3, 0), // model 0 at origin
+      trnChunk(4, 5, [10, 0, 0]), shpChunk(5, 1), // model 1 at +10 x
+      rgbaChunk({ 1: 0xff0000, 2: 0x00ff00 }),
+    ]);
+    const grid = parseVox(bytes);
+    expect(grid.size).toBe(2);
+    // Scene spans x∈[0,10] → centered offset 5; both sit on z=0.
+    expect(grid.get(-5, 0, 0)).toBe(0xff0000);
+    expect(grid.get(5, 0, 0)).toBe(0x00ff00);
+  });
+
+  it('drops all-but-model-0 when an explicit modelIndex bypasses the graph', () => {
+    const bytes = voxFile([
+      sizeChunk(1, 1, 1), xyziChunk([{ x: 0, y: 0, z: 0, i: 1 }]),
+      sizeChunk(1, 1, 1), xyziChunk([{ x: 0, y: 0, z: 0, i: 2 }]),
+      trnChunk(0, 1), grpChunk(1, [2, 4]),
+      trnChunk(2, 3, [0, 0, 0]), shpChunk(3, 0),
+      trnChunk(4, 5, [10, 0, 0]), shpChunk(5, 1),
+      rgbaChunk({ 1: 0xff0000, 2: 0x00ff00 }),
+    ]);
+    // modelIndex picks exactly one model and ignores the scene graph.
+    expect(parseVox(bytes, { modelIndex: 1 }).size).toBe(1);
+    expect([...vals(parseVox(bytes, { modelIndex: 1 }))]).toEqual([0x00ff00]);
+  });
+
+  it('applies a 90°-about-Z rotation from the _r byte', () => {
+    // A 3-long line along local x; _r byte 17 maps (x,y,z) → (-y, x, z), so the
+    // line ends up along y. Proves the rotation matrix is decoded and applied.
+    const line: XYZI[] = [
+      { x: 0, y: 0, z: 0, i: 1 }, { x: 1, y: 0, z: 0, i: 1 }, { x: 2, y: 0, z: 0, i: 1 },
+    ];
+    const bytes = voxFile([
+      sizeChunk(3, 1, 1), xyziChunk(line),
+      trnChunk(0, 1), grpChunk(1, [2]),
+      trnChunk(2, 3, [0, 0, 0], 17), shpChunk(3, 0),
+      rgbaChunk({ 1: 0xffffff }),
+    ]);
+    const grid = parseVox(bytes);
+    expect(grid.size).toBe(3);
+    const b = grid.bounds()!;
+    // Originally a line in x (Δx=2, Δy=0); after the rotation it's a line in y.
+    expect(b.max[0] - b.min[0]).toBe(0); // collapsed in x
+    expect(b.max[1] - b.min[1]).toBe(2); // extended in y
+  });
+
+  it('falls back to the legacy path when a scene node is malformed', () => {
+    // A truncated nTRN (claims a frame but the content ends) must not throw —
+    // the importer ignores the bad node and centers model 0.
+    const badTrn = chunk('nTRN', new W().i32(0).dict([]).i32(1).i32(-1).i32(0).i32(1).out()); // missing frame DICT
+    const bytes = voxFile([
+      sizeChunk(1, 1, 1), xyziChunk([{ x: 0, y: 0, z: 0, i: 1 }]),
+      badTrn,
+      rgbaChunk({ 1: 0xff0000 }),
+    ]);
+    const grid = parseVox(bytes);
+    expect(grid.size).toBe(1);
+    expect(grid.get(0, 0, 0)).toBe(0xff0000);
+  });
+});
+
+function vals(grid: ReturnType<typeof parseVox>): number[] {
+  const out: number[] = [];
+  grid.forEach((_x, _y, _z, c) => out.push(c));
+  return out;
+}

--- a/tests/unit/vox.test.ts
+++ b/tests/unit/vox.test.ts
@@ -282,6 +282,23 @@ describe('parseVox scene graph', () => {
     expect(b.max[1] - b.min[1]).toBe(2); // extended in y
   });
 
+  it('ignores an improper (mirroring) _r rotation byte and keeps identity', () => {
+    // _r byte 20 decodes to a reflection (det = −1) — a mirror MagicaVoxel never
+    // writes. The importer must decline to mirror: red stays on the −x side.
+    const bytes = voxFile([
+      sizeChunk(3, 1, 1), xyziChunk([{ x: 0, y: 0, z: 0, i: 1 }, { x: 2, y: 0, z: 0, i: 2 }]),
+      trnChunk(0, 1), grpChunk(1, [2]),
+      trnChunk(2, 3, [0, 0, 0], 20), shpChunk(3, 0),
+      rgbaChunk({ 1: 0xff0000, 2: 0x00ff00 }),
+    ]);
+    const grid = parseVox(bytes);
+    expect(grid.size).toBe(2);
+    // Identity: local-centered red at x=−1, green at x=+1. A reflection would
+    // have swapped them; assert it did not.
+    expect(grid.get(-1, 0, 0)).toBe(0xff0000);
+    expect(grid.get(1, 0, 0)).toBe(0x00ff00);
+  });
+
   it('falls back to the legacy path when a scene node is malformed', () => {
     // A truncated nTRN (claims a frame but the content ends) must not throw —
     // the importer ignores the bad node and centers model 0.


### PR DESCRIPTION
## Summary

Closes a `.vox` fidelity gap surfaced while researching whether MagicaVoxel/MagicaCSG techniques could be adopted: the only openly-licensed asset from those (closed-source) apps is the MIT-licensed `.vox` format spec, and our import/export only implemented the minimal `SIZE`/`XYZI`/`RGBA` chunks.

**The bug:** multi-object MagicaVoxel scenes — the common case, since MV stores one model per object and positions them through a scene graph — imported as a *single* piece. The parser walked only `MAIN`'s direct children, picked model 0, and silently dropped every other model (no placement). A scene of, say, a character + a sword would lose the sword.

**Import** (`src/import/parsers/vox.ts`): parse the `nTRN` / `nGRP` / `nSHP` scene graph (with `DICT`/`STRING` and the `_r` signed-permutation rotation byte), traverse from the root node composing each node's translation **and** rotation, and assemble every shape's model into one grid at its world position. Models are positioned by their center (`floor(size/2)`), matching MagicaVoxel's transform convention.
- A malformed/truncated scene node is skipped (bounds-checked reader) and the file falls back to the legacy single-model path — old `SIZE/XYZI`-only files behave exactly as before.
- An explicit `modelIndex` still extracts one specific model and bypasses the graph.
- Cyclic graphs are guarded.

**Export** (`src/export/vox.ts`): emit a canonical `nTRN`→`nGRP`→`nTRN`→`nSHP` scene graph so our output matches the structure MagicaVoxel itself writes (and round-trips through the new importer). The shape transform translates by the model center so the round-trip reproduces the same occupancy.

**Deliberately not done:**
- **`MATL` (materials)** — a Partwright voxel grid carries only RGBA color; there's no metal/glass/emissive/roughness data to serialize, so a `MATL` chunk would be fabricated defaults (bytes, not fidelity). Noted in the export header comment.
- **Lifting the 256/axis single-model limit** via multi-model tiling — a separate, larger change.

## Test plan

- `npm run test:unit` — 1050 pass, including new cases: two-model scene-graph placement, `modelIndex` bypass, a 90°-about-Z `_r` rotation (a line in x ends up a line in y), and malformed-node fallback. Existing export round-trip tests now exercise the new import path.
- `npm run typecheck`, `npm run lint:deps` (acyclic), `lint:consistency` (only pre-existing hits in untouched files) — clean.
- **Manual browser check:** imported a hand-built two-cube `.vox` scene (red + green, offset +12 in x) through the real import → voxel render pipeline. Both cubes render at their distinct world positions with a gap between them (16-unit span), confirming scene-graph placement — previously only the red model-0 cube would have appeared. (Screenshot posted in the originating session.)

🤖 https://claude.ai/code/session_01YAvR5ZQTaUWPikt5dgpktF