### PR TITLE
fix: voxel orbit rotation after Voxel Studio — restore touch-action (mobile) + frame-rate-independent damping

### DIFF
--- a/prompts/20260611-014752-voxel-studio-rotation-speed.md
+++ b/prompts/20260611-014752-voxel-studio-rotation-speed.md
@@ -1,0 +1,65 @@
+---
+session: "u0cvuk"
+timestamp: "2026-06-11T01:47:52Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+After using Voxel Studio on a voxel model (e.g. applying smoothing or other
+operations), the interactive rotation in the viewport became dramatically
+slower than before — the model rotates "incredibly slowly." Asked to
+investigate and, if confident, fix it. Follow-up answers: the rotation is
+"smooth but turns far less" (not choppy), it happens on *any* voxel model
+including a fresh sphere, and there was a vague memory of a past PR about a
+"different selected rotation speed."
+
+## Assistant
+
+## Key decisions
+
+**Ruled out an angular-speed regression.** OrbitControls rotation is
+`2π · pixels / canvasHeight` — invariant to model scale, distance, and triangle
+count. Confirmed empirically with instrumented browser runs: degrees-per-drag,
+camera distance, canvas clientHeight, and apparent on-screen size were all
+*identical* before opening the studio, in the studio (blocky), after smoothing,
+and after the full bake-and-commit path (at devicePixelRatio 2). A pickaxe over
+the entire git history of all branches showed `rotateSpeed` has **never** been
+set anywhere; the "rotation" PRs the user half-remembered rotate the starter
+*geometry's orientation*, not the camera. So there is no per-engine or
+voxel-specific rotation speed to "restore."
+
+**Found the real mechanism: frame-rate-dependent damping.** three.js
+OrbitControls applies damping once per `update()` (once per animation frame)
+with no time term: each frame it moves the camera by `sphericalDelta · factor`
+and decays the backlog by `(1 − factor)`. With a fixed factor the coast takes a
+fixed number of *frames*, so the wall-clock feel scales with frame rate. Measured
+the coast directly: at pointer-release only ~33° of an eventual ~47° had been
+applied — ~30% was still "coasting" out over the following frames. When the
+frame rate dips — exactly what heavy/smoothed voxel meshes cause — that backlog
+drips out over many more seconds and the model lags far behind the cursor, which
+reads as "smooth but turns far less / sluggish." This is consistent with the
+symptom being worse on voxel models (the app's heaviest meshes) and after
+smoothing (heavier still).
+
+**Fix:** re-derive the per-frame damping factor from the real frame delta so the
+decay stays constant *per second* instead of per frame:
+`f_eff = 1 − (1 − base)^(deltaSeconds · refFps)`, capped just under 1 for very
+long frames (backgrounded tab). At the reference rate (60 fps) it returns the
+configured factor unchanged — a no-op for anyone already at 60 fps — and only
+compensates when the frame rate drops. The total rotation eventually applied is
+unchanged; only its *timing* is made frame-rate independent.
+
+**Structure:** extracted the pure helper into a dependency-free leaf module
+`src/renderer/orbitDamping.ts` (so it unit-tests in the node tier without
+dragging in three.js), wired it into viewport.ts's animate loop using the
+`delta` already computed there. Added `orbitDampingReferenceFps` (default 60) to
+`appConfig.ts` per the no-hardcoded-tuning-constants rule, surfaced it in the
+advanced settings modal, and added `tests/unit/orbitDamping.test.ts` proving the
+constant-per-second property, the no-op at the reference rate, and the
+stability cap.
+
+**Verification:** unit tier (1052 passing), typecheck, production build, and
+`lint:deps` (acyclic) all green; the existing `voxel-studio-camera` e2e still
+passes. A browser check under 8× CPU throttle confirmed full rotation is
+preserved and the coast settles in ~0.8 s instead of dragging out.

--- a/prompts/20260611-020214-voxel-studio-touch-action.md
+++ b/prompts/20260611-020214-voxel-studio-touch-action.md
@@ -1,0 +1,37 @@
+---
+session: "u0cvuk"
+timestamp: "2026-06-11T02:02:14Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+(Follow-up on the slow-voxel-rotation investigation.) "I think the bug may only
+happen on mobile with touch screen drag effects."
+
+## Assistant
+
+## Key decisions
+
+**The mobile/touch clue pointed to `touch-action`, a different root cause than
+the frame-rate damping fix.** OrbitControls sets `domElement.style.touchAction =
+'none'` exactly once (on connect) and relies on it staying — that's what stops
+the browser from claiming a touch drag for scroll/pinch. Voxel Studio's
+`attachPointerHandler` overrides it with `'none'` (fine), but
+`detachPointerHandler` reset it to `''` on teardown instead of restoring it. So
+once you've used the studio, the canvas loses `touch-action: none`, and on a
+touch device the browser reclaims part of every subsequent orbit swipe — the
+model "turns far less." A mouse ignores `touch-action`, which is exactly why it's
+touch-only and why it was invisible in my earlier desktop measurements.
+
+**Fix:** capture the canvas's prior `cursor` / `touch-action` on attach and
+restore them on detach (instead of blanking to `''`), so OrbitControls' `'none'`
+survives a studio open/close. Verified in-browser: `touch-action` reads `'none'`
+before → during → after the studio, where before this change it was cleared to
+`''` afterwards. Added a permanent regression assertion to
+`tests/voxel-studio-camera.spec.ts`.
+
+This is the actual fix for the reported mobile symptom; the frame-rate-independent
+damping change from the first commit stays as a complementary robustness
+improvement (it helps the low-frame-rate "coast feels slow" case on any device,
+and is a no-op at 60 fps).

--- a/src/color/voxelPaint.ts
+++ b/src/color/voxelPaint.ts
@@ -657,6 +657,15 @@ function refreshPreview(): void {
 // if it leaves the canvas.
 let capturedPointerId: number | null = null;
 
+// The canvas's inline `cursor` / `touch-action` before the studio overrode them,
+// captured on attach and restored on detach. Critically, OrbitControls sets
+// `touch-action: none` once on connect and relies on it staying put; clearing it
+// to '' on detach (instead of restoring it) lets the browser reclaim touch
+// gestures, so on mobile a post-studio orbit drag only partially rotates ("turns
+// far less"). Restoring the captured value keeps OrbitControls' 'none' intact.
+let prevCanvasCursor: string | null = null;
+let prevCanvasTouchAction: string | null = null;
+
 function onPointerDown(event: PointerEvent): void {
   if (!active || event.button !== 0) return;
   // This listener is on the container in the CAPTURE phase, so it also sees
@@ -732,6 +741,8 @@ function attachPointerHandler(): void {
   container.addEventListener('pointermove', onPointerMove, { capture: true });
   container.addEventListener('pointerleave', onPointerLeave);
   window.addEventListener('pointerup', onPointerUp, { capture: true });
+  prevCanvasCursor = canvas.style.cursor;
+  prevCanvasTouchAction = canvas.style.touchAction;
   canvas.style.cursor = 'crosshair';
   canvas.style.touchAction = 'none'; // claim the gesture so touch-drag paints
   // Veto OrbitControls on primary-button presses within the model's bounds so
@@ -756,8 +767,13 @@ function detachPointerHandler(): void {
   container.removeEventListener('pointermove', onPointerMove, { capture: true } as EventListenerOptions);
   container.removeEventListener('pointerleave', onPointerLeave);
   window.removeEventListener('pointerup', onPointerUp, { capture: true } as EventListenerOptions);
-  canvas.style.cursor = '';
-  canvas.style.touchAction = '';
+  // Restore what was there before (OrbitControls' `touch-action: none`), not ''.
+  // Clearing touch-action would let the browser reclaim touch gestures, leaving a
+  // post-studio orbit drag only partially rotating on mobile. See above.
+  canvas.style.cursor = prevCanvasCursor ?? '';
+  canvas.style.touchAction = prevCanvasTouchAction ?? '';
+  prevCanvasCursor = null;
+  prevCanvasTouchAction = null;
   if (capturedPointerId !== null) {
     try { canvas.releasePointerCapture(capturedPointerId); } catch { /* already released */ }
     capturedPointerId = null;

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -103,6 +103,13 @@ export interface AppConfig {
     gizmoSnapDurationSec: number;
     /** OrbitControls damping factor — lower is snappier, higher is smoother. */
     orbitDampingFactor: number;
+    /** Frame rate (fps) that `orbitDampingFactor` is authored against. The orbit
+     *  coast is re-derived from the real frame delta so its decay-per-second
+     *  stays constant regardless of frame rate — otherwise a heavy mesh that
+     *  drops the frame rate makes the same drag "coast" for far longer and the
+     *  model lags behind the cursor (reads as sluggish, slow rotation). At this
+     *  rate the correction is a no-op. */
+    orbitDampingReferenceFps: number;
     /** Zoom-out limit as a multiple of the model's largest dimension. Caps how
      *  far the camera can dolly back (OrbitControls maxDistance) so the model
      *  can't shrink to a speck. Re-derived from the model size on each frame. */
@@ -252,6 +259,7 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     gizmoHitRadius: 0.4,
     gizmoSnapDurationSec: 0.4,
     orbitDampingFactor: 0.1,
+    orbitDampingReferenceFps: 60,
     maxZoomOutFactor: 12,
     ambientLightIntensity: 0.6,
     primaryLightIntensity: 0.8,

--- a/src/renderer/orbitDamping.ts
+++ b/src/renderer/orbitDamping.ts
@@ -1,0 +1,30 @@
+// Pure, dependency-free helper for frame-rate-independent OrbitControls damping.
+// Kept out of viewport.ts (which pulls in three.js) so it can be unit-tested in
+// the node tier. See the call site in viewport.ts's animate loop.
+
+/** Re-derive OrbitControls' per-frame damping factor from the real frame delta
+ *  so the orbit coast decays at a constant rate per *second* rather than per
+ *  *frame*.
+ *
+ *  OrbitControls applies damping once per `update()` (once per animation frame)
+ *  with no time term: each frame it moves the camera by `sphericalDelta * factor`
+ *  and decays the remaining backlog by `(1 - factor)`. With a fixed factor the
+ *  coast therefore takes a fixed number of *frames*, so when the frame rate dips
+ *  — exactly what a heavy/smoothed voxel mesh does — the same drag coasts for far
+ *  more wall-clock time and the model lags behind the cursor (reads as sluggish,
+ *  slow rotation).
+ *
+ *  `base` is the factor authored for `refFps`. At that frame rate this returns
+ *  `base` unchanged; below it the factor rises so each longer frame consumes
+ *  proportionally more of the backlog (constant decay-per-second); above it the
+ *  factor falls for the same reason. The total rotation eventually applied is
+ *  unchanged — only its timing is made frame-rate independent.
+ *
+ *  Capped just below 1 so the controls stay stable when a single frame is very
+ *  long (e.g. the first frame after the tab was backgrounded). Falls back to
+ *  `base` for non-positive / non-finite inputs. */
+export function frameRateAdjustedDamping(base: number, deltaSeconds: number, refFps: number): number {
+  if (!(deltaSeconds > 0) || !(refFps > 0) || !(base > 0)) return base;
+  const frames = deltaSeconds * refFps; // 1.0 at the reference frame rate
+  return Math.min(0.9, 1 - Math.pow(1 - base, frames));
+}

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -7,6 +7,7 @@ import { initMeasureOverlay } from './measureOverlay';
 import { initOrientationGizmo, renderGizmo, updateGizmo, isGizmoAnimating } from './orientationGizmo';
 import { initDimensionLines, updateDimensionLines, setDimensionsVisible as setDimensionsVisibleImpl, isDimensionsVisible } from './dimensionLines';
 import { runViewportInitHooks, runViewportResizeHooks } from './viewportRegistry';
+import { frameRateAdjustedDamping } from './orbitDamping';
 import { getTheme, onThemeChange, type Theme } from '../ui/theme';
 import { getConfig } from '../config/appConfig';
 
@@ -323,6 +324,18 @@ export function initViewport(container: HTMLElement): {
     const delta = timer.getDelta();
     updateGizmo(delta);
     syncOrbitState();
+    // OrbitControls applies damping once per frame with no time term, so a fixed
+    // dampingFactor makes the orbit "coast" decay per-frame instead of per-second.
+    // When the frame rate dips — exactly what heavy/smoothed voxel meshes do — the
+    // same rotation backlog drips out over many more wall-clock seconds and the
+    // model lags far behind the cursor: it reads as sluggish, slow rotation.
+    // Re-derive the per-frame factor from the real frame delta so the decay rate
+    // (and thus the feel) stays constant across frame rates. At the reference rate
+    // this returns the configured factor unchanged.
+    const rcfg = getConfig().renderer;
+    controls.dampingFactor = frameRateAdjustedDamping(
+      rcfg.orbitDampingFactor, delta, rcfg.orbitDampingReferenceFps,
+    );
     // controls.update() applies damping and synchronously fires 'change' (which
     // sets needsRender) whenever the camera actually moves, so inertia keeps the
     // loop painting until it settles.

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -545,6 +545,14 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           onChange={v => set('renderer', 'orbitDampingFactor', v)}
         />
         <Field
+          label="Orbit damping reference fps"
+          tooltip="The frame rate the orbit damping factor is tuned for. The coast is re-derived from the real frame delta so it decays at a constant rate per second — without this, a heavy mesh that drops the frame rate makes the same drag coast for far longer and the model lags behind the cursor (sluggish, slow rotation). Leave at 60 unless you target a different refresh rate."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.orbitDampingReferenceFps}
+          value={c.renderer.orbitDampingReferenceFps}
+          min={30} max={240} step={5}
+          onChange={v => set('renderer', 'orbitDampingReferenceFps', v)}
+        />
+        <Field
           label="Max zoom-out factor"
           tooltip="How far you can zoom the camera out, as a multiple of the model's largest dimension. The default framing sits at roughly 2× that dimension, so a value of 12 lets you pull back about 6× from the default before hitting the limit. Lower it to keep the model filling more of the view; raise it for more room. Re-applied each time the model is framed."
           defaultValue={APP_CONFIG_DEFAULTS.renderer.maxZoomOutFactor}

--- a/tests/unit/orbitDamping.test.ts
+++ b/tests/unit/orbitDamping.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { frameRateAdjustedDamping } from '../../src/renderer/orbitDamping';
+
+const BASE = 0.1;
+const REF = 60;
+
+describe('frameRateAdjustedDamping', () => {
+  it('is a no-op at the reference frame rate', () => {
+    expect(frameRateAdjustedDamping(BASE, 1 / 60, 60)).toBeCloseTo(BASE, 12);
+  });
+
+  it('raises the factor when frames are longer (lower fps)', () => {
+    // 30 fps -> a frame is 2 reference-frames long, so decay must be 1-(0.9)^2.
+    expect(frameRateAdjustedDamping(BASE, 1 / 30, REF)).toBeCloseTo(1 - 0.9 ** 2, 12);
+    // 15 fps -> 4 reference-frames long.
+    expect(frameRateAdjustedDamping(BASE, 1 / 15, REF)).toBeCloseTo(1 - 0.9 ** 4, 12);
+  });
+
+  it('lowers the factor when frames are shorter (higher fps)', () => {
+    // 120 fps -> half a reference-frame, so decay is 1-(0.9)^0.5 < base.
+    const f = frameRateAdjustedDamping(BASE, 1 / 120, REF);
+    expect(f).toBeCloseTo(1 - 0.9 ** 0.5, 12);
+    expect(f).toBeLessThan(BASE);
+  });
+
+  it('keeps the per-second decay constant across frame rates', () => {
+    // Composing the per-frame survival (1-f) over one second of frames must land
+    // on the same remaining fraction regardless of how that second is sliced.
+    const oneSecond = (fps: number) => {
+      const f = frameRateAdjustedDamping(BASE, 1 / fps, REF);
+      return (1 - f) ** fps; // survival after `fps` frames == 1 second
+    };
+    const ref = oneSecond(60);
+    expect(oneSecond(30)).toBeCloseTo(ref, 6);
+    expect(oneSecond(90)).toBeCloseTo(ref, 6);
+    expect(oneSecond(144)).toBeCloseTo(ref, 6);
+  });
+
+  it('caps below 1 so a very long frame cannot destabilise the controls', () => {
+    // A multi-second frame (tab was backgrounded) would otherwise push the factor
+    // to ~1; it must stay strictly under 1.
+    expect(frameRateAdjustedDamping(BASE, 5, REF)).toBeLessThanOrEqual(0.9);
+    expect(frameRateAdjustedDamping(BASE, 5, REF)).toBeGreaterThan(0);
+  });
+
+  it('falls back to base for non-positive / non-finite inputs', () => {
+    expect(frameRateAdjustedDamping(BASE, 0, REF)).toBe(BASE);
+    expect(frameRateAdjustedDamping(BASE, -1 / 60, REF)).toBe(BASE);
+    expect(frameRateAdjustedDamping(BASE, NaN, REF)).toBe(BASE);
+    expect(frameRateAdjustedDamping(BASE, 1 / 60, 0)).toBe(BASE);
+    expect(frameRateAdjustedDamping(0, 1 / 60, REF)).toBe(0);
+  });
+});

--- a/tests/voxel-studio-camera.spec.ts
+++ b/tests/voxel-studio-camera.spec.ts
@@ -76,4 +76,23 @@ test.describe('voxel studio camera', () => {
     );
     expect(outside).toBeGreaterThan(5);
   });
+
+  // OrbitControls sets `touch-action: none` on the canvas once (on connect) and
+  // relies on it staying. The studio overrides it while editing, so on teardown
+  // it must RESTORE that value — clearing it to '' would let the browser reclaim
+  // touch gestures, leaving a post-studio orbit drag only partially rotating on
+  // mobile ("the model turns far less"). Mouse orbit is unaffected, so this is a
+  // touch-only regression; we assert the underlying style is preserved.
+  test('restores the canvas touch-action after the studio closes (mobile orbit)', async ({ page }) => {
+    await setup(page);
+    const touchAction = () => page.evaluate(
+      () => (document.querySelector('#viewport') as HTMLCanvasElement).style.touchAction,
+    );
+    // Studio is open here (setup opened the panel); OrbitControls/studio both want 'none'.
+    expect(await touchAction()).toBe('none');
+    // Close the studio and confirm touch-action is restored, not cleared.
+    await page.evaluate(() => (window as unknown as { partwright: { deactivateVoxelPaint(): unknown } }).partwright.deactivateVoxelPaint());
+    await page.waitForTimeout(200);
+    expect(await touchAction()).toBe('none');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes orbiting a voxel model feeling slow / "turning far less" after using Voxel Studio. There are **two** independent causes; this PR addresses both.

### 1. The confirmed root cause (mobile / touch-only) — `touch-action`

The user later narrowed it down: **it only happens on mobile with touch drag.** That pointed straight at `touch-action`.

OrbitControls sets `domElement.style.touchAction = 'none'` **once** (on connect) and relies on it staying — that's what lets it receive the full touch gesture instead of the browser claiming part of the swipe for scroll/pinch. Voxel Studio's teardown reset `touch-action` to `''` instead of restoring it, so **after you've used the studio once, the canvas loses `touch-action: none`**, and on a touch device every subsequent orbit swipe is partially reclaimed by the browser → the model "turns far less." A mouse ignores `touch-action`, which is exactly why it's touch-only and why it was invisible in desktop measurements.

**Fix:** capture the canvas's prior `cursor` / `touch-action` on attach and restore them on detach (instead of blanking to `''`).

Verified in-browser: `touch-action` reads `'none'` before → during → after the studio (it was cleared to `''` afterwards before this change). Regression assertion added to `tests/voxel-studio-camera.spec.ts`.

### 2. Complementary robustness — frame-rate-independent damping

three.js OrbitControls applies damping once per **frame** with no time term, so the orbit "coast" decays per-frame instead of per-second. When the frame rate dips (heavy/smoothed voxel meshes), the same rotation backlog drips out over far more wall-clock time and lags behind the cursor — sluggish, slow-feeling rotation on **any** device. Re-derive the per-frame factor from the real frame delta so the decay stays constant per second: `f = 1 − (1−base)^(Δt·refFps)`, capped just under 1. **No-op at 60 fps**; only compensates when the frame rate drops. Total rotation is unchanged — only its timing is made frame-rate-independent.

## Changes

- **`src/color/voxelPaint.ts`** — save/restore the canvas `cursor` + `touch-action` across the studio's attach/detach (the mobile fix).
- **`src/renderer/orbitDamping.ts`** *(new)* — pure, dependency-free `frameRateAdjustedDamping` helper.
- **`src/renderer/viewport.ts`** — apply it in the animate loop using the existing frame `delta`.
- **`src/config/appConfig.ts`** — `orbitDampingReferenceFps` (default `60`).
- **`src/ui/advancedSettingsModal.tsx`** — expose the knob.
- **`tests/voxel-studio-camera.spec.ts`** — touch-action restoration regression test.
- **`tests/unit/orbitDamping.test.ts`** *(new)* — damping math: constant-per-second across 30/60/90/144 fps, no-op at ref, stability cap, input fallbacks.

## Test plan

- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run test:unit` ✓ (incl. 6 new damping cases)
- `npm run lint:deps` ✓ (acyclic; new module is a leaf)
- `tests/voxel-studio-camera.spec.ts` ✓ (2 tests, incl. new touch-action assertion)
- `tests/voxel-paint.spec.ts` ✓ (9 tests)
- Browser checks: touch-action stays `'none'` through a studio open/close; under 8× CPU throttle full rotation is preserved and the coast settles in ~0.8s.

https://claude.ai/code/session_01Vz6Mzm4DT1McF8j3ncrRq8