### PR TITLE
docs: retro for models catalog refresh (2026-06-11)

### DIFF
--- a/retros/inbox/20260611-141558-refresh-models-catalog.md
+++ b/retros/inbox/20260611-141558-refresh-models-catalog.md
@@ -1,0 +1,24 @@
+---
+date: "2026-06-11T14:15:58Z"
+task: "chore: refresh models catalog snapshot"
+pr: 504
+areas: [tooling, agents, providers]
+cost: low
+---
+
+## Liked / Worked
+- The `refresh-models-catalog.md` skill doc was complete and self-contained — no ambiguity about branch name, commit message, or PR strategy.
+- `npm run refresh-models` soft-fails on network error (exit 0, no diff), so the `git diff --quiet` guard cleanly stops early when upstream is down.
+- Reusing the existing open PR by pushing to the branch via `create_or_update_file` worked perfectly — no duplicate PR created.
+
+## Lacked
+- The Telegram channel `@PartwrightStudio` wasn't directly addressable by username — needed `getUpdates` to discover the numeric chat ID (`-1003948930577`). The skill didn't document this. (~2 extra turns)
+- The stop hook complained about uncommitted local changes even though the skill explicitly says not to commit locally. Had to explicitly `git restore` the regenerated file to clean the working tree.
+
+## Learned
+- The `chore/refresh-models-catalog` branch is long-lived; `create_or_update_file` requires the file's blob SHA from the *branch* (not `main`), fetched via `get_file_contents` with `ref: refs/heads/<branch>`.
+- The Telegram bot ID for this project is `@partwright_bot`, channel numeric ID `-1003948930577`. The `@PartwrightStudio` username alias fails the API but the numeric ID works.
+
+## Longed for
+- The Telegram chat ID (numeric) should be documented alongside the bot token in CLAUDE.md or the skill doc so agents don't burn turns on `getUpdates` discovery every run.
+- A `git restore` step at the end of `refresh-models-catalog.md` would prevent the stop hook false-positive about uncommitted local changes.


### PR DESCRIPTION
## Summary
- Adds a retro entry for the 2026-06-11 models catalog refresh task
- Key findings: Telegram numeric chat ID discovery friction, stop-hook false-positive from non-committed local regenerated file, and suggestions to document both in the skill

## Test plan
- [ ] No code changes — retro entry only

https://claude.ai/code/session_01PhHnh5GiPtC9f7mRbgokwu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhHnh5GiPtC9f7mRbgokwu)_