### PR TITLE
fix: implement figure spine + head tilt, floor eye protrusion, harden bald/brows

### DIFF
--- a/prompts/20260611-183000-figure-api-bug-cluster-fixes.md
+++ b/prompts/20260611-183000-figure-api-bug-cluster-fixes.md
@@ -1,0 +1,69 @@
+---
+session: "01B8i3Nc4JgG6iV6eAsrYFq6"
+timestamp: "2026-06-11T18:30:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+Ran a four-subagent audit of the `api.sdf.figure` API for bugs/defects (looking
+at the catalog figures for visible evidence), reconciled the findings against
+the latest `main` (PR #588 had since fixed the arm-hinge instability), then asked
+to open a PR fixing the "first cluster": the parsed-but-dead DOFs (spine,
+head.tilt), the eyes-default/protrusion-floor paint-label issue, and the cheap
+`bald`/`brows`/`weldBody` wins.
+
+## Assistant
+
+## Key decisions
+
+**`spine.{lean,side,turn}` — implemented as a waist pivot, not rejected.** The
+fields were validated and stored but no FK read them (9 of 10 catalog figures
+set `spine` and silently got nothing — the same "parsed but never read" class
+PR #588 had just fixed for leg-twist). Modelled the spine as a single rigid
+rotation of the above-navel mass (chest, neck, head, both arms, face anchors)
+about the navel line, legs/pelvis planted. Chose a rigid transform applied at
+the rig's return so every limb's internal shape is preserved (transform each
+point about the pivot, each direction by the rotation only — arms stay
+attached, bone lengths unchanged). Guarded by `spineActive` so zero-spine is
+byte-identical: all 63 pre-existing figure tests (incl. the double-biceps /
+ballet / lunge recipes) passed unmodified.
+
+**`head.tilt` — apply as a roll about the forward axis.** It was `rotY(hf,
+tilt)` on the forward vector, then discarded by the cross-product frame rebuild
+— a literal no-op. Now rolls the `headLeft`/`headUp` axes about `hf` by `-tilt`
+(crown toward the figure's LEFT shoulder for +tilt). Also reordered
+`orientToHeadPose` so its tilt term is the innermost rotation — provably
+equivalent to rolling about the *posed* forward axis last, so the carved
+mouth/eye parts roll consistently with the corrected frame (the old outer
+`rotY` disagreed once tilt did anything).
+
+**Eyes — protrusion floor + assemble default OFF.** Two of the three reported
+eye failures: (a) `assemble` built eyes by default and the canonical
+weld→`.label('skin')` flow flattened their paint labels to 0 triangles — flipped
+the default to OFF (opt back in with `eyes: true`), matching every catalog/doc
+usage; (c) the `rad*0.28` eyeball push was ~1 march cell and collapsed on
+posed/enlarged heads — floored it at `r.head*0.09` (~2 cells), the same
+cell-count discipline the mouth cavity already uses. Verified headlessly: a
+posed stocky head now resolves eyes/iris/pupil at 1893/1102/379 tris (was
+collapsing toward 0). The third sub-issue (pupil sub-cell when the build omits
+`detail: F.faceDetail(rig)`) is inherent to skipping the detail region — the
+docs already mandate it — so I only modestly thickened the lenses rather than
+bloat the pupil; the documented `faceDetail` path resolves robustly.
+
+**Cheap correctness wins.** `bald` hair returned `sphere(1e-3)` parked at
+z≈−1e6, poisoning `bounds()`/`placeAt`; now a sub-cell sphere at the head centre
+(meshes to nothing, swallowed in a union, sane bbox). `brows` accepted an
+options object it entirely ignored (violating the "unknown keys rejected"
+convention) — gave it validated `thickness`/`lift` knobs. Dropped the unused
+`sdf` param from `weldBody`.
+
+**Scope held back for a follow-up PR:** base auto-radius blowup on raised-limb
+poses, the deltoid lump / persistent genus, the lip-ring near-tangent handles,
+and the robe-skirt-cone feet poke-through — all more tuning-heavy and better
+done with a visual-iteration loop.
+
+**Verification:** 76 figure unit tests (13 new regressions mirroring the
+pose-recipe harness), full build + 1192 unit tests green, and headless
+`model:preview` renders confirming the body leans at the waist and the head
+rolls toward a shoulder.

--- a/public/ai/figure.md
+++ b/public/ai/figure.md
@@ -123,8 +123,17 @@ pose: { arms: { abduct: 90 }, armL: { abduct: 0 } }           // right arm out, 
 | `leg*.knee` | bend the shank toward the back +Y (0–150) |
 | `leg*.twist` | **hip turnout** — yaw the foot OUT (toe toward +X on the left, −X on the right) and roll a bent-knee plié outward. 0 = toes forward; `legs: { twist: 30 }` is a relaxed turnout, ~`45–60` a ballet first/fifth. |
 | `head.turn` | yaw (look figure-left +/right −) |
-| `head.tilt` | tip toward a shoulder |
+| `head.tilt` | roll the head toward a shoulder (+ = toward the figure's LEFT shoulder) |
 | `head.nod` | look down (+) / up (−) |
+| `spine.lean` | bend the upper body forward −Y (+) / back +Y (−) at the waist |
+| `spine.side` | lean the upper body toward the figure's LEFT (+) / right (−) shoulder |
+| `spine.turn` | twist the shoulders/upper body toward figure-left (+) / right (−) |
+
+> **`spine.{lean,side,turn}` bend the whole upper body at the waist** — chest,
+> neck, head, and both arms rotate together about the navel while the legs stay
+> planted. Use it for a bow, a slouch, a weight shift, or a contrapposto twist
+> (combine with `head.*` to counter-rotate the gaze). `head.tilt` rolls only the
+> head; `spine.side` leans the whole torso.
 
 > **Arms-overhead / fists-up poses need `twist`.** Elbow flexion alone curls the
 > forearm *forward* (toward −Y); for a side-raised arm that plane is horizontal,
@@ -202,13 +211,20 @@ second component.
 
 ```js
 F.face.assemble(head, rig, {
-  eyes:  true | { radius } | false,
+  eyes:  true | { radius } | false,   // OFF by default — see note below
   nose:  true | { tipRadius, length } | false,
   mouth: true | { style, width, smirk, open } | false,
   ears:  true | { size } | false,
-  brows: { } | false,        // off by default; pass {} to add
+  brows: { thickness, lift } | false, // off by default; pass {} or a tuning object to add
 })
 ```
+
+> **Eyes default to OFF in `assemble`.** The recommended flow welds the face into
+> the body and `.label('skin')`s it — which would flatten any in-face eyes into
+> the skin region (their `eyes`/`iris`/`pupil` labels would resolve to **0
+> paintable triangles**). So build eyes at the **top level** instead —
+> `sdf.union(skin, F.face.eyes(rig), …)` — and only pass `eyes: true` to
+> `assemble` when you are *not* re-labelling the result.
 
 `assemble` welds features onto the head with **small** `k` so the nose bridge
 and ear margins stay crisp (vs the soft body weld), and **carves** the carved

--- a/src/geometry/sdfFigure.ts
+++ b/src/geometry/sdfFigure.ts
@@ -70,6 +70,7 @@ export interface SdfApi {
 // --- Small vector math ----------------------------------------------------
 
 function add3(a: Vec3, b: Vec3): Vec3 { return [a[0] + b[0], a[1] + b[1], a[2] + b[2]]; }
+function sub3(a: Vec3, b: Vec3): Vec3 { return [a[0] - b[0], a[1] - b[1], a[2] - b[2]]; }
 function scale3(a: Vec3, s: number): Vec3 { return [a[0] * s, a[1] * s, a[2] * s]; }
 function len3(a: Vec3): number { return Math.hypot(a[0], a[1], a[2]); }
 function norm3(a: Vec3): Vec3 { const l = len3(a) || 1; return [a[0] / l, a[1] / l, a[2] / l]; }
@@ -343,11 +344,20 @@ function buildRig(rawOpts: unknown): Rig {
   let hf: Vec3 = [0, -1, 0];
   hf = rotZ(hf, pose.head.turn);    // yaw
   hf = rotX(hf, pose.head.nod);     // nod
-  hf = rotY(hf, pose.head.tilt);    // tilt
   hf = norm3(hf);
   const up: Vec3 = [0, 0, 1];
-  const headLeft = norm3(cross3(up, hf));   // +X when facing −Y (figure's left)
-  const headUp = norm3(cross3(hf, headLeft)); // +Z when upright
+  let headLeft = norm3(cross3(up, hf));   // +X when facing −Y (figure's left)
+  let headUp = norm3(cross3(hf, headLeft)); // +Z when upright
+  // `tilt` rolls the head toward a shoulder — a rotation of the up/left axes
+  // ABOUT the forward axis. It must be applied here, not to `hf`: rolling `hf`
+  // about itself is a no-op, and the cross-product frame above discards any
+  // roll component, so the old `rotY(hf, tilt)` did literally nothing. Positive
+  // tilt drops the crown toward the figure's LEFT shoulder (+X), matching the
+  // `turn`-left-positive convention.
+  if (pose.head.tilt) {
+    headLeft = norm3(rotAxis(headLeft, hf, -pose.head.tilt));
+    headUp = norm3(rotAxis(headUp, hf, -pose.head.tilt));
+  }
 
   const fAnchor = (f: number, u: number, s: number): Vec3 =>
     add3(headCenter, add3(add3(scale3(hf, f), scale3(headUp, u)), scale3(headLeft, s)));
@@ -364,28 +374,53 @@ function buildRig(rawOpts: unknown): Rig {
     chinTip: fAnchor(r.headZ * 0.55, -headH * 0.46, 0),
   };
 
+  // --- Spine: rigid-rotate the above-waist mass about the navel ----------
+  // `spine.{lean,turn,side}` were parsed and validated but never applied.
+  // Model the spine as a single waist pivot: rotate every above-navel joint and
+  // direction (chest, neck, head, BOTH arms, and the face anchors) about the
+  // navel line. lean = forward(+)/back(−) bend (about the lateral X axis);
+  // side = lean toward the figure's LEFT(+)/right(−) shoulder (about the
+  // forward Y axis); turn = twist the shoulders toward figure-left(+) (about
+  // the vertical Z axis) — matching the head.turn/side sign conventions. The
+  // pelvis, hips, legs and feet stay planted: the figure bends at the waist.
+  // A rigid rotation about the pivot preserves every limb's internal shape, so
+  // transforming each point/direction individually keeps the arms attached.
+  // Zero spine ⇒ identity, so every existing pose (incl. the documented
+  // double-biceps / ballet / lunge recipes) is byte-for-byte unchanged.
+  const sp = pose.spine;
+  const spineActive = sp.lean !== 0 || sp.turn !== 0 || sp.side !== 0;
+  const spinePivot: Vec3 = [0, 0, navelZ];
+  const spineRot = (v: Vec3): Vec3 => rotY(rotX(rotZ(v, sp.turn), sp.lean), sp.side);
+  const sPt = (p: Vec3): Vec3 => spineActive ? add3(spinePivot, spineRot(sub3(p, spinePivot))) : p;
+  const sDir = (v: Vec3): Vec3 => spineActive ? spineRot(v) : v;
+  const sFace: FaceAnchors = spineActive ? {
+    eyeL: sPt(face.eyeL), eyeR: sPt(face.eyeR), browL: sPt(face.browL), browR: sPt(face.browR),
+    nose: sPt(face.nose), mouth: sPt(face.mouth), earL: sPt(face.earL), earR: sPt(face.earR),
+    chinTip: sPt(face.chinTip),
+  } : face;
+
   return {
     joints: {
-      pelvis: [0, 0, pelvisZ], navel: [0, -r.chestY * 0.4, navelZ], chest: [0, -r.chestY * 0.2, chestZ],
-      neckBase: [0, 0, shoulderZ + neckLen * 0.2], headCenter, crown: [headCenter[0], headCenter[1], H], chin: [0, 0, chinZ],
-      shoulderL: aL.S, elbowL: aL.E, wristL: aL.W, handL: aL.handC,
-      shoulderR: aR.S, elbowR: aR.E, wristR: aR.W, handR: aR.handC,
+      pelvis: [0, 0, pelvisZ], navel: [0, -r.chestY * 0.4, navelZ], chest: sPt([0, -r.chestY * 0.2, chestZ]),
+      neckBase: sPt([0, 0, shoulderZ + neckLen * 0.2]), headCenter: sPt(headCenter), crown: sPt([headCenter[0], headCenter[1], H]), chin: sPt([0, 0, chinZ]),
+      shoulderL: sPt(aL.S), elbowL: sPt(aL.E), wristL: sPt(aL.W), handL: sPt(aL.handC),
+      shoulderR: sPt(aR.S), elbowR: sPt(aR.E), wristR: sPt(aR.W), handR: sPt(aR.handC),
       hipL: lL.Hj, kneeL: lL.K, ankleL: lL.A, hipR: lR.Hj, kneeR: lR.K, ankleR: lR.A,
     },
     r,
     dir: {
-      upperArmL: aL.dir, foreArmL: aL.foreDir, upperArmR: aR.dir, foreArmR: aR.foreDir,
+      upperArmL: sDir(aL.dir), foreArmL: sDir(aL.foreDir), upperArmR: sDir(aR.dir), foreArmR: sDir(aR.foreDir),
       // The elbow-hinge axis (post-twist) — ⟂ to the forearm-curl plane. The
       // hand frame derives from it: fingers splay along the hinge, the palm
       // faces hinge × foreArm (the curl direction).
-      elbowHingeL: aL.hinge, elbowHingeR: aR.hinge,
+      elbowHingeL: sDir(aL.hinge), elbowHingeR: sDir(aR.hinge),
       thighL: lL.dir, shankL: lL.shankDir, thighR: lR.dir, shankR: lR.shankDir,
       // Foot heading per side (front −Y yawed by hip turnout) — buildFeet
       // orients toe/heel along it, so leg twist turns the feet out.
       footL: lL.footFwd, footR: lR.footFwd,
-      headForward: hf, headUp, headLeft,
+      headForward: sDir(hf), headUp: sDir(headUp), headLeft: sDir(headLeft),
     },
-    face,
+    face: sFace,
     opts: { height: H, headsTall: N, build, pose },
   };
 }
@@ -638,13 +673,17 @@ function buildEyes(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
   const style = o.style === undefined ? 'iris'
     : assertEnum(o.style, ['solid', 'iris'] as const, 'eyes.style');
   const f = rig.dir.headForward;
-  // Push the eyeballs out by a fraction of their radius: enough that a dome
-  // reliably protrudes past the cheek welds (an eye centred ON the anchor
-  // can be fully swallowed, leaving a paintable label with zero triangles),
-  // but shallow enough that the eye reads as sitting IN the face rather
-  // than stuck onto it.
-  const cL = add3(rig.face.eyeL, scale3(f, rad * 0.28));
-  const cR = add3(rig.face.eyeR, scale3(f, rad * 0.28));
+  // Push the eyeballs out so a dome reliably protrudes past the cheek welds —
+  // an eye centred ON the anchor can be fully swallowed, leaving a paintable
+  // label with zero triangles. `rad * 0.28` alone is ~1 face-detail march cell
+  // (faceDetail's head edge ≈ r.head * 0.045) and shrinks toward zero as the
+  // head is posed/enlarged, so the eye/iris/pupil labels collapse to 0 tris on
+  // many figures. Floor the push at ~2 cells (r.head * 0.09) — the same
+  // cell-count discipline the mouth cavity (`cavH`) already uses — while
+  // staying shallow enough that the eye reads as sitting IN the face.
+  const push = Math.max(rad * 0.28, rig.r.head * 0.09);
+  const cL = add3(rig.face.eyeL, scale3(f, push));
+  const cR = add3(rig.face.eyeR, scale3(f, push));
   const pair = (r: number, forwardOff: number): Node => {
     const off = scale3(f, forwardOff);
     return sdf.sphere(r).translate(add3(cL, off)).union(sdf.sphere(r).translate(add3(cR, off)));
@@ -666,9 +705,14 @@ function buildEyes(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
       orientToHeadPose(sdf.ellipsoid(rxz, ry, rxz), rig).translate(add3(c, d));
     return one(cL).union(one(cR));
   };
+  // Lens depth (the `ry` term) is set ≥ ~1.5 cells thick so each lens resolves
+  // even when the build forgets the recommended `detail: F.faceDetail(rig)` and
+  // marches the whole figure on the coarse global grid — a thinner cap aliased
+  // the pupil away to 0 triangles there. It only deepens the lens INTO the
+  // eyeball; the front face (and thus the painted-on-circle read) is unchanged.
   const sclera = pair(rad, 0).label('eyes');
-  const iris = lensPair(rad * 0.52, rad * 0.2, rad * 1.08).label('iris');
-  const pupil = lensPair(rad * 0.3, rad * 0.14, rad * 1.15).label('pupil');
+  const iris = lensPair(rad * 0.52, rad * 0.24, rad * 1.08).label('iris');
+  const pupil = lensPair(rad * 0.3, rad * 0.18, rad * 1.15).label('pupil');
   return sclera.union(iris).union(pupil);
 }
 
@@ -691,11 +735,16 @@ interface MouthPart { node: Node; mode: 'add' | 'carve' }
 
 const MOUTH_FIELDS = ['width', 'smirk', 'open', 'style', 'teeth', 'lips'];
 
-/** Replay the rig's head rotation order (turn → nod → tilt) on an
- *  origin-built node, so axis-aligned mouth parts follow the head pose. */
+/** Orient an origin-built node into the posed head frame, so axis-aligned
+ *  mouth/eye parts follow the head pose. `tilt` is a ROLL about the (canonical)
+ *  forward axis, so it is applied FIRST (innermost) — carrying it through the
+ *  yaw/nod rotation is equivalent to rolling about the posed forward axis last,
+ *  which is exactly how the head frame applies tilt. (The old form applied tilt
+ *  as an outer `rotY`, which disagreed with the frame once tilt actually did
+ *  anything.) */
 function orientToHeadPose(node: Node, rig: Rig): Node {
   const p = rig.opts.pose.head;
-  return node.rotate([0, 0, p.turn]).rotate([p.nod, 0, 0]).rotate([0, p.tilt, 0]);
+  return node.rotate([0, p.tilt, 0]).rotate([0, 0, p.turn]).rotate([p.nod, 0, 0]);
 }
 
 /** Shared geometry of the open-mouth cavity, used by both the carve and the
@@ -886,16 +935,20 @@ function buildEars(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
   return earL.union(earR);
 }
 
-function buildBrows(sdf: SdfApi, rig: Rig): Node {
+function buildBrows(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
   // Arched ridges that HUG the skull. A straight capsule chord between two
   // points on a curved surface leaves its middle proud (the "shelf brow"
   // look), so each brow is an arc whose points (a) curve up toward the
   // middle and (b) pull BACK following the skull's lateral curvature, and
   // the whole ridge is sunk by part of its radius.
+  const o = obj(opts, 'brows(opts)');
+  assertNoUnknownKeys(o, ['thickness', 'lift'], 'brows(opts)');
+  const thickness = num(o.thickness, 1, 'brows.thickness', 0.1, 5); // ridge weight
+  const lift = num(o.lift, 1, 'brows.lift', 0, 5);                   // mid-brow arch
   const f = rig.dir.headForward, u = rig.dir.headUp, right = rig.dir.headLeft;
-  const w = rig.r.head * 0.24;          // half-span of one brow
-  const browRad = rig.r.head * 0.045;   // slimmer than the old 0.06 bar
-  const arch = rig.r.head * 0.06;       // mid-brow lift
+  const w = rig.r.head * 0.24;                  // half-span of one brow
+  const browRad = rig.r.head * 0.045 * thickness;
+  const arch = rig.r.head * 0.06 * lift;        // mid-brow lift
   const sink = browRad * 0.5;
   const SEGS = 4;
   const browArc = (anchor: Vec3): Node => {
@@ -923,16 +976,19 @@ function buildBrows(sdf: SdfApi, rig: Rig): Node {
  *  the soft body weld. Carved mouth styles ('smile'/'open') are subtracted
  *  instead. Pass `false` for any feature to skip it.
  *
- *  Eyes are hard-unioned (paintable seam) — for separately-paintable eyes,
- *  pass `eyes: false` here and union `F.face.eyes(rig).label('eyes')` at the
- *  top level instead (see /ai/figure.md). */
+ *  Eyes default to OFF here. The recommended flow welds the assembled face into
+ *  the body and labels the whole thing `.label('skin')` — which would FLATTEN
+ *  in-face eyes into the skin region (their `eyes`/`iris`/`pupil` labels resolve
+ *  to 0 paintable triangles). So build eyes at the top level instead:
+ *  `sdf.union(skin, F.face.eyes(rig), …)`. Pass `eyes: true` (or an options
+ *  object) only when you are NOT re-labelling the result. (See /ai/figure.md.) */
 function assembleFace(sdf: SdfApi, head: Node, rig: Rig, opts?: unknown): Node {
   const o = obj(opts, 'face.assemble(opts)');
   assertNoUnknownKeys(o, ['eyes', 'nose', 'mouth', 'ears', 'brows'], 'face.assemble(opts)');
   const crease = rig.r.head * 0.12;
   let result = head;
   if (o.nose !== false) result = result.smoothUnion(buildNose(sdf, rig, o.nose === true ? undefined : o.nose), crease);
-  if (o.brows !== false && o.brows !== undefined) result = result.smoothUnion(buildBrows(sdf, rig), crease);
+  if (o.brows !== false && o.brows !== undefined) result = result.smoothUnion(buildBrows(sdf, rig, o.brows === true ? undefined : o.brows), crease);
   if (o.ears !== false) result = result.smoothUnion(buildEars(sdf, rig, o.ears === true ? undefined : o.ears), crease * 1.5);
   if (o.mouth !== false) {
     const mouth = buildMouthPart(sdf, rig, o.mouth === true ? undefined : o.mouth);
@@ -940,7 +996,12 @@ function assembleFace(sdf: SdfApi, head: Node, rig: Rig, opts?: unknown): Node {
       ? result.smoothUnion(mouth.node, crease * 0.7)
       : result.smoothSubtract(mouth.node, crease * 0.5);
   }
-  if (o.eyes !== false) result = result.union(buildEyes(sdf, rig, o.eyes === true ? undefined : o.eyes));
+  // Eyes default OFF (see docstring): only build them when explicitly opted in,
+  // so the canonical weld-then-`.label('skin')` flow can't silently flatten the
+  // eye paint labels. `eyes: true` or `eyes: { … }` opts in.
+  if (o.eyes !== undefined && o.eyes !== false) {
+    result = result.union(buildEyes(sdf, rig, o.eyes === true ? undefined : o.eyes));
+  }
   return result;
 }
 
@@ -973,7 +1034,12 @@ function buildHair(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
   assertNoUnknownKeys(o, ['style', 'thickness', 'hairline'], 'hair(opts)');
   const style = o.style === undefined ? 'short'
     : assertEnum(o.style, ['short', 'long', 'bun', 'bald', 'bangs', 'ponytail'] as const, 'hair.style');
-  if (style === 'bald') return sdf.sphere(1e-3).translate([0, 0, -1e6]); // empty-ish
+  // bald = no hair. Return a sub-cell sphere AT the head centre (not parked at
+  // z ≈ −1e6): it meshes to nothing on any real grid and is swallowed inside
+  // the skull in a figure union, but its `bounds()` stays at the head — so
+  // `F.placeAt(baldHair, …)` and any bbox-driven composition still work,
+  // instead of snapping to a point a million units below the model.
+  if (style === 'bald') return sdf.sphere(1e-3).translate(rig.joints.headCenter as Vec3);
   // Hairline height = where the face window's top edge sits. 'low' brings the
   // hair down to the brows (the bangs default), 'high' shows more forehead.
   const hairline = o.hairline === undefined ? (style === 'bangs' ? 'low' : 'mid')
@@ -1171,14 +1237,13 @@ function buildTop(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
 
 /** Smooth-weld the major body masses with one rig-derived soft k. Face
  *  features keep their crisp creases (they were welded in assembleFace). */
-function weldBody(sdf: SdfApi, rig: Rig, parts: unknown, opts?: unknown): Node {
+function weldBody(rig: Rig, parts: unknown, opts?: unknown): Node {
   if (!Array.isArray(parts) || parts.length === 0) {
     throw new ValidationError('figure.weld(rig, parts): `parts` must be a non-empty array of SDF nodes.');
   }
   const o = obj(opts, 'weld(opts)');
   assertNoUnknownKeys(o, ['k'], 'weld(opts)');
   const k = num(o.k, Math.min(rig.r.foreArm, rig.r.neck) * 0.85, 'weld.k', 1e-4);
-  void sdf;
   let acc = parts[0] as Node;
   for (let i = 1; i < parts.length; i++) acc = acc.smoothUnion(parts[i] as Node, k);
   return acc;
@@ -1262,7 +1327,7 @@ export function createFigureNamespace(sdf: SdfApi): FigureNamespace {
     head: (rig) => buildHead(sdf, assertRig(rig, 'head(rig)')),
     base: (rig, opts) => buildBase(sdf, assertRig(rig, 'base(rig)'), opts),
     hair: (rig, opts) => buildHair(sdf, assertRig(rig, 'hair(rig)'), opts),
-    weld: (rig, parts, opts) => weldBody(sdf, assertRig(rig, 'weld(rig)'), parts, opts),
+    weld: (rig, parts, opts) => weldBody(assertRig(rig, 'weld(rig)'), parts, opts),
     placeAt: (node, joint, opts) => placeAt(node as Node, joint, opts),
     faceDetail: (rig, opts) => faceDetail(assertRig(rig, 'faceDetail(rig)'), opts),
     handDetail: (rig, opts) => handDetail(assertRig(rig, 'handDetail(rig)'), opts),
@@ -1272,7 +1337,7 @@ export function createFigureNamespace(sdf: SdfApi): FigureNamespace {
       mouth: (rig, opts) => buildMouth(sdf, assertRig(rig, 'face.mouth(rig)'), opts),
       mouthAccents: (rig, opts) => buildMouthAccents(sdf, assertRig(rig, 'face.mouthAccents(rig)'), opts),
       ears: (rig, opts) => buildEars(sdf, assertRig(rig, 'face.ears(rig)'), opts),
-      brows: (rig) => buildBrows(sdf, assertRig(rig, 'face.brows(rig)')),
+      brows: (rig, opts) => buildBrows(sdf, assertRig(rig, 'face.brows(rig)'), opts),
       assemble: (head, rig, opts) => assembleFace(sdf, head as Node, assertRig(rig, 'face.assemble(rig)'), opts),
     },
     clothing: {

--- a/tests/unit/sdfFigure.test.ts
+++ b/tests/unit/sdfFigure.test.ts
@@ -5,7 +5,7 @@
 // exercised headlessly via model:preview / the e2e tier.
 
 import { describe, it, expect } from 'vitest';
-import { __figureTestables__ } from '../../src/geometry/sdfFigure';
+import { __figureTestables__, createFigureNamespace } from '../../src/geometry/sdfFigure';
 import { __testables__ as sdfT, partitionByLabel, type SdfNode } from '../../src/geometry/sdf';
 import type { SdfApi } from '../../src/geometry/sdfFigure';
 
@@ -596,6 +596,134 @@ describe('figure faceDetail — detail-region helper', () => {
     expect(head.edgeLength).toBe(0.1);
     expect(mouth.edgeLength).toBe(0.05);
     expect(() => faceDetail(rig, { density: 2 })).toThrow();
+  });
+});
+
+describe('figure rig — head tilt (was a silent no-op)', () => {
+  // Regression: tilt was applied as `rotY(hf, tilt)` to the forward vector and
+  // then discarded by the cross-product frame rebuild, so it did nothing. It is
+  // now a roll of the up/left axes about the forward axis.
+  it('rolls the head toward a shoulder — headUp leans laterally', () => {
+    const neutral = buildRig({});
+    const tilted = buildRig({ pose: { head: { tilt: 20 } } });
+    // Positive tilt drops the crown toward the figure's LEFT shoulder (+X).
+    expect(neutral.dir.headUp[0]).toBeCloseTo(0, 6);
+    expect(tilted.dir.headUp[0]).toBeGreaterThan(0.2);
+    // It is a pure roll: the forward direction is unchanged.
+    expect(dist(tilted.dir.headForward, neutral.dir.headForward)).toBeLessThan(1e-9);
+  });
+
+  it('moves the face anchors (eyes follow the roll)', () => {
+    const neutral = buildRig({});
+    const tilted = buildRig({ pose: { head: { tilt: 20 } } });
+    expect(dist(tilted.face.eyeL, neutral.face.eyeL)).toBeGreaterThan(0.1);
+  });
+
+  it('tilt: 0 is byte-identical to no head pose', () => {
+    const a = buildRig({});
+    const b = buildRig({ pose: { head: { tilt: 0 } } });
+    expect(b.dir.headUp).toEqual(a.dir.headUp);
+    expect(b.face.eyeL).toEqual(a.face.eyeL);
+  });
+});
+
+describe('figure rig — spine (was parsed but never applied)', () => {
+  // Regression: spine.{lean,turn,side} were validated and stored but no FK ever
+  // read them. They now rigidly rotate the above-waist mass about the navel.
+  const neutral = buildRig({});
+
+  it('lean bends the upper body forward (−Y) at the waist', () => {
+    const leaned = buildRig({ pose: { spine: { lean: 25 } } });
+    expect(leaned.joints.chest[1]).toBeLessThan(neutral.joints.chest[1] - 0.5);
+    expect(leaned.joints.headCenter[1]).toBeLessThan(neutral.joints.headCenter[1] - 1);
+    // legs stay planted — the figure bends at the waist, not the ankles.
+    expect(leaned.joints.ankleL).toEqual(neutral.joints.ankleL);
+    expect(leaned.joints.pelvis).toEqual(neutral.joints.pelvis);
+  });
+
+  it('side leans toward the figure-left shoulder (+X); turn twists the shoulders', () => {
+    const sided = buildRig({ pose: { spine: { side: 25 } } });
+    expect(sided.joints.headCenter[0]).toBeGreaterThan(neutral.joints.headCenter[0] + 0.5);
+    const turned = buildRig({ pose: { spine: { turn: 30 } } });
+    // the shoulder line rotates about Z — shoulders are no longer purely ±X.
+    expect(Math.abs(turned.joints.shoulderL[1])).toBeGreaterThan(0.5);
+  });
+
+  it('is a rigid rotation: arms ride the spine but keep their bone lengths', () => {
+    const leaned = buildRig({ pose: { spine: { lean: 25 }, armL: { abduct: 40, elbow: 60 } } });
+    const upright = buildRig({ pose: { armL: { abduct: 40, elbow: 60 } } });
+    // the whole arm moved with the torso…
+    expect(dist(leaned.joints.handL, upright.joints.handL)).toBeGreaterThan(0.5);
+    // …but the upper-arm bone length is preserved (rigid, still attached).
+    const boneLen = (rig: typeof leaned) => dist(rig.joints.shoulderL, rig.joints.elbowL);
+    expect(boneLen(leaned)).toBeCloseTo(boneLen(upright), 5);
+  });
+
+  it('zero spine is byte-identical to no spine (every existing pose unchanged)', () => {
+    const z = buildRig({ pose: { spine: { lean: 0, turn: 0, side: 0 } } });
+    for (const j of ['chest', 'headCenter', 'shoulderL', 'handR', 'crown'] as const) {
+      expect(z.joints[j]).toEqual(neutral.joints[j]);
+    }
+    expect(z.dir.headForward).toEqual(neutral.dir.headForward);
+  });
+});
+
+describe('figure eyes — protrusion floor', () => {
+  it('floors the eyeball push at ~2 face-detail cells so labels never bury', () => {
+    // Regression: a `rad * 0.28` push was ~1 march cell and shrank to 0 on many
+    // figures, collapsing the eye/iris/pupil labels. Now floored at r.head*0.09.
+    const rig = buildRig({ height: 60, headsTall: 6 });
+    const rad = rig.r.head * 0.16;            // the default eyes radius
+    const solid = buildEyes(api, rig, { style: 'solid' }) as SdfNode;
+    // forward (−Y) reach of the eyeball front past the eye anchor plane.
+    const reach = -solid.bounds().min[1];
+    expect(reach).toBeGreaterThan(-rig.face.eyeL[1] + rig.r.head * 0.09 + rad - 1e-6);
+  });
+});
+
+describe('figure face.assemble — eyes default OFF', () => {
+  const F = createFigureNamespace(api);
+  const rig = buildRig({ height: 60, headsTall: 5 });
+  const labelsOf = (node: unknown): string[] =>
+    partitionByLabel(node as SdfNode).map(p => p.labelName).filter((n): n is string => !!n).sort();
+
+  it('omits eyes by default (so a later .label("skin") cannot flatten them)', () => {
+    const face = F.face.assemble(F.head(rig), rig);
+    expect(labelsOf(face)).not.toContain('iris');
+    expect(labelsOf(face)).not.toContain('pupil');
+  });
+
+  it('eyes: true opts the in-face eyes back in', () => {
+    const face = F.face.assemble(F.head(rig), rig, { eyes: true });
+    expect(labelsOf(face)).toEqual(expect.arrayContaining(['eyes', 'iris', 'pupil']));
+  });
+});
+
+describe('figure brows — validated options (were silently ignored)', () => {
+  const F = createFigureNamespace(api);
+  const rig = buildRig({});
+  it('accepts thickness / lift and rejects unknown keys', () => {
+    expect(() => F.face.brows(rig, { thickness: 2, lift: 1.5 })).not.toThrow();
+    expect(() => F.face.brows(rig, { bogus: 1 })).toThrow();
+  });
+  it('thickness actually changes the ridge (no longer a no-op payload)', () => {
+    const thin = (F.face.brows(rig, { thickness: 1 }) as SdfNode).bounds();
+    const thick = (F.face.brows(rig, { thickness: 3 }) as SdfNode).bounds();
+    // a heavier ridge has a larger bbox than a slim one.
+    const span = (b: { min: number[]; max: number[] }) => b.max[2] - b.min[2];
+    expect(span(thick)).toBeGreaterThan(span(thin));
+  });
+});
+
+describe('figure hair — bald does not poison bounds()', () => {
+  it('bald returns an empty node bounded at the head, not at z ≈ −1e6', () => {
+    // Regression: bald returned sphere(1e-3) parked at z=−1e6, which broke
+    // bounds()/placeAt (snapped a million units down).
+    const rig = buildRig({ height: 60 });
+    const b = (buildHair(api, rig, { style: 'bald' }) as SdfNode).bounds();
+    const cz = (b.min[2] + b.max[2]) / 2;
+    expect(cz).toBeCloseTo(rig.joints.headCenter[2], 2);
+    expect(cz).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

First fix cluster from a four-subagent audit of the `api.sdf.figure` API. The audit ran against PR #585's code; the arm-hinge instability it found was already fixed by PR #588, so this PR targets the **untouched** defects — chiefly two documented DOFs that were silently dead, plus a paint-label footgun and a few cheap correctness wins.

### Fixes

- **`spine.{lean,side,turn}` were parsed/validated but never applied.** 9 of 10 catalog figures set a `spine` pose and got nothing (the same "parsed but never read" class that PR #588 fixed for leg-twist). Implemented as a rigid waist-pivot rotation of the above-navel mass (chest, neck, head, both arms, face anchors); legs and pelvis stay planted. A `spineActive` guard makes **zero-spine byte-identical** to before, so every existing pose — including the double-biceps / ballet / lunge recipes — is unchanged.
- **`head.tilt` was a no-op** (`rotY` on the forward vector, then discarded by the cross-product frame rebuild). Now applied as a roll of the head up/left axes about the forward axis (crown toward the figure's LEFT shoulder for +tilt). `orientToHeadPose` reordered so its tilt term is innermost — provably equivalent to rolling about the posed forward axis, so carved mouth/eye parts roll consistently with the corrected frame.
- **`face.assemble` built eyes by default**, which the canonical weld→`.label('skin')` flow flattened to **0 paintable triangles**. Eyes now default **OFF** (opt in with `eyes: true`); build them at the top level per the docs.
- **The eyeball protrusion (`rad*0.28`, ~1 march cell) collapsed eye paint labels on posed/enlarged heads.** Floored at `r.head*0.09` (~2 cells), the same cell-count discipline the mouth cavity already uses, plus modest lens thickening for coarse-grid robustness.
- **`bald` hair returned `sphere(1e-3)` parked at z≈−1e6**, poisoning `bounds()`/`placeAt`. Now an empty-but-head-bounded node.
- **`brows` accepted an options object it entirely ignored** (violating the "unknown keys rejected" convention). Added validated `thickness` / `lift` knobs.
- Dropped the unused `sdf` param from `weldBody`.

### Deferred to a follow-up PR
Base auto-radius blowup on raised-limb poses, the deltoid lump / persistent genus, the lip-ring near-tangent handles, and the robe-skirt-cone feet poke-through — all more tuning-heavy and better done with a visual-iteration loop.

## Test plan

- **76 figure unit tests** (13 new regressions mirroring the pose-recipe harness: head tilt, spine lean/side/turn + rigidity + zero-spine identity, eye protrusion floor, eyes-default-off, brows validation, bald bounds). All green.
- **`npm run build` + 1192 unit tests** green.
- **Headless `model:preview` verification:**
  - A `spine.lean 28` + `head.tilt 22` figure renders with the upper body leaning forward at the waist (legs planted) and the head rolled toward a shoulder — manifold, one component.
  - Paint-label probes confirm eyes/iris/pupil resolve to non-zero triangles on a posed stocky head (1893 / 1102 / 379 tris) and a small figure — previously collapsing toward 0.

https://claude.ai/code/session_01B8i3Nc4JgG6iV6eAsrYFq6

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8i3Nc4JgG6iV6eAsrYFq6)_