### PR TITLE
fix: share the colour palette and fix curved stamp colouring in engrave/emboss

### DIFF
--- a/prompts/20260611-184000-engrave-color-palette-and-stamp-coloring.md
+++ b/prompts/20260611-184000-engrave-color-palette-and-stamp-coloring.md
@@ -1,0 +1,76 @@
+---
+session: "engrave-color-palette-and-stamp-coloring"
+timestamp: "2026-06-11T18:40:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+In the emboss/engrave surface submenu, the "Color the letters" picker only
+offered the browser's native colour input — not the shared colour palette every
+other paint tool uses. Add that palette (in a popup-style swatch grid; a custom
+picker for off-palette colours is fine). Separately, the auto-colouring of
+stamped text was wrong on a curved surface: engraving a word wrapped around a
+sphere didn't catch every triangle of the channel, and embossing bled the colour
+out onto sphere-surface triangles that weren't part of the letters. Investigate
+and improve.
+
+## Assistant
+
+### Root cause of the colouring bugs
+
+`stampTriColors` (`src/surface/modifiers.ts`) classified each baked triangle by
+re-running the stamp's own projection math (`stampEvaluator`) at the triangle
+centroid and thresholding the projection-relative `depthInto`. On a curved face
+the planar/cylindrical "face" the stamp projects onto drifts away from the real
+surface, so that depth band fails two ways:
+
+- **Engrave** used `depthInto > eps && m > 0.15 && depthInto < depth + 2·eps`.
+  At the laterally-divergent edge letters the channel's `depthInto` drifts past
+  the `depth + 2·eps` ceiling (and even below `eps`), so those triangles were
+  dropped — the "didn't catch every triangle" report.
+- **Emboss** bounded laterally by the *stamp rectangle* (`inRect`) instead of ink
+  coverage, so every unraised skin triangle inside the rectangle that read as
+  "above the face" got coloured — the bleed.
+
+### Fix — classify by displacement off the original surface, not a depth band
+
+The robust discriminator is "did this triangle move off the original surface".
+The untouched skin (including the sphere's far side) stays put; the relief/channel
+is displaced. So emboss and engrave now share one rule: **under ink (`m > 0.15`)
+AND displaced past a small noise threshold**. No `depthInto` band, so curvature
+can't drift it.
+
+- Added `nearestSurfaceDistance` to `src/surface/colorTransfer.ts`: a true
+  **point-to-triangle** distance (Ericson closest-point), reusing the existing
+  centroid spatial-hash only to pick the candidate triangle. Point-to-triangle
+  has **no tessellation-density floor** (a point lying on the surface reads ~0),
+  so the threshold can sit just above the surface-nets noise (`1.5·eps`) and the
+  walls colour right up to the rim. The reference is densified (`denseColorSource`
+  or a `diag/80` subdivide) only so the centroid pick lands on the correct face
+  on coarse inputs.
+- Refactored `nearestTriangleMap` and the new function onto a shared
+  `nearestCentroidCore` (returns index + squared distance) so there's one hashing
+  implementation.
+- **Through-cut** keeps its depth-band test: material is removed, so there's no
+  "displaced" hole wall and no far side under the cut to confuse it.
+
+Verified in-browser (HELLO wrapped around a sphere, ±curve): engrave now fully
+uniform across every letter incl. the divergent edge letters; emboss confined to
+the raised letters with zero skin bleed.
+
+### Fix — shared palette in the picker
+
+Added a `colorField` helper in `src/ui/surfaceModal.ts` that renders the shared
+filament palette (`listFilaments()`) as a swatch grid plus a native picker for
+off-palette colours, mirroring the paint tools' `createPaletteSection`. Replaced
+the lone `<input type="color">` in the engrave tab with it. It snapshots the
+palette at open (the panel is short-lived, so it doesn't subscribe to live edits
+the way the persistent paint drawer does) and still feeds `engraveModel`'s
+existing `color` hex param — no API/parity surface changed.
+
+### Tests
+
+Swapped the unit coverage to `nearestSurfaceDistance` (identity ~0, no
+tessellation floor on a re-meshed surface, translated-off distance, empty-ref
+Infinity). Full preflight green (typecheck + 1183 unit + acyclic graph).

--- a/src/surface/colorTransfer.ts
+++ b/src/surface/colorTransfer.ts
@@ -25,14 +25,16 @@ function centroids(mesh: MeshData): Float32Array {
   return out;
 }
 
-/** For each triangle of `newMesh`, the index of the nearest (by centroid)
- *  triangle of `oldMesh`. Returns an `Int32Array` of length `newMesh.numTri`
- *  (entries are `-1` only when `oldMesh` has no triangles). Uses a uniform
- *  spatial hash over old centroids with ring-expanding search, so it stays
- *  near-linear instead of the naive O(new·old). */
-export function nearestTriangleMap(oldMesh: MeshData, newMesh: MeshData): Int32Array {
-  const result = new Int32Array(newMesh.numTri).fill(-1);
-  if (oldMesh.numTri === 0 || newMesh.numTri === 0) return result;
+/** Core nearest-centroid query: for each triangle of `newMesh`, the index of the
+ *  nearest (by centroid) triangle of `oldMesh` *and* the squared distance to it.
+ *  Index entries are `-1` (and dist2 `Infinity`) only when `oldMesh` has no
+ *  triangles. Uses a uniform spatial hash over old centroids with ring-expanding
+ *  search, so it stays near-linear instead of the naive O(new·old). Shared by
+ *  {@link nearestTriangleMap} (index only) and {@link nearestCentroidDistance}. */
+function nearestCentroidCore(oldMesh: MeshData, newMesh: MeshData): { index: Int32Array; dist2: Float32Array } {
+  const index = new Int32Array(newMesh.numTri).fill(-1);
+  const dist2 = new Float32Array(newMesh.numTri).fill(Infinity);
+  if (oldMesh.numTri === 0 || newMesh.numTri === 0) return { index, dist2 };
 
   const oc = centroids(oldMesh);
   // Bounds of the old centroids.
@@ -90,7 +92,96 @@ export function nearestTriangleMap(oldMesh: MeshData, newMesh: MeshData): Int32A
         }
       }
     }
-    result[t] = best;
+    index[t] = best;
+    if (best >= 0) dist2[t] = bestD;
   }
-  return result;
+  return { index, dist2 };
+}
+
+/** For each triangle of `newMesh`, the index of the nearest (by centroid)
+ *  triangle of `oldMesh`. Returns an `Int32Array` of length `newMesh.numTri`
+ *  (entries are `-1` only when `oldMesh` has no triangles). */
+export function nearestTriangleMap(oldMesh: MeshData, newMesh: MeshData): Int32Array {
+  return nearestCentroidCore(oldMesh, newMesh).index;
+}
+
+/** Squared distance from point `p` to triangle `(a,b,c)` — the standard
+ *  closest-point-on-triangle (Ericson, Real-Time Collision Detection). Pure. */
+function pointTriDist2(
+  px: number, py: number, pz: number,
+  ax: number, ay: number, az: number,
+  bx: number, by: number, bz: number,
+  cx: number, cy: number, cz: number,
+): number {
+  const abx = bx - ax, aby = by - ay, abz = bz - az;
+  const acx = cx - ax, acy = cy - ay, acz = cz - az;
+  const apx = px - ax, apy = py - ay, apz = pz - az;
+  const d1 = abx * apx + aby * apy + abz * apz;
+  const d2 = acx * apx + acy * apy + acz * apz;
+  if (d1 <= 0 && d2 <= 0) return apx * apx + apy * apy + apz * apz; // vertex A
+  const bpx = px - bx, bpy = py - by, bpz = pz - bz;
+  const d3 = abx * bpx + aby * bpy + abz * bpz;
+  const d4 = acx * bpx + acy * bpy + acz * bpz;
+  if (d3 >= 0 && d4 <= d3) return bpx * bpx + bpy * bpy + bpz * bpz; // vertex B
+  const vc = d1 * d4 - d3 * d2;
+  if (vc <= 0 && d1 >= 0 && d3 <= 0) { // edge AB
+    const w = d1 / (d1 - d3);
+    const qx = ax + w * abx, qy = ay + w * aby, qz = az + w * abz;
+    return (px - qx) ** 2 + (py - qy) ** 2 + (pz - qz) ** 2;
+  }
+  const cpx = px - cx, cpy = py - cy, cpz = pz - cz;
+  const d5 = abx * cpx + aby * cpy + abz * cpz;
+  const d6 = acx * cpx + acy * cpy + acz * cpz;
+  if (d6 >= 0 && d5 <= d6) return cpx * cpx + cpy * cpy + cpz * cpz; // vertex C
+  const vb = d5 * d2 - d1 * d6;
+  if (vb <= 0 && d2 >= 0 && d6 <= 0) { // edge AC
+    const w = d2 / (d2 - d6);
+    const qx = ax + w * acx, qy = ay + w * acy, qz = az + w * acz;
+    return (px - qx) ** 2 + (py - qy) ** 2 + (pz - qz) ** 2;
+  }
+  const va = d3 * d6 - d5 * d4;
+  if (va <= 0 && d4 - d3 >= 0 && d5 - d6 >= 0) { // edge BC
+    const w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+    const qx = bx + w * (cx - bx), qy = by + w * (cy - by), qz = bz + w * (cz - bz);
+    return (px - qx) ** 2 + (py - qy) ** 2 + (pz - qz) ** 2;
+  }
+  // Interior — project onto the triangle plane via barycentric coords.
+  const denom = 1 / (va + vb + vc);
+  const v = vb * denom, w = vc * denom;
+  const qx = ax + abx * v + acx * w, qy = ay + aby * v + acy * w, qz = az + abz * v + acz * w;
+  return (px - qx) ** 2 + (py - qy) ** 2 + (pz - qz) ** 2;
+}
+
+/** For each triangle of `queryMesh`, the true distance from its centroid to the
+ *  nearest *surface* of `refMesh` (point-to-triangle, not centroid-to-centroid,
+ *  so it has no tessellation-density floor — a point lying on the reference
+ *  surface reads ~0 regardless of how coarse the reference is). Entries are
+ *  `Infinity` only when `refMesh` has no triangles. The engrave/emboss colorizer
+ *  uses it to tell stamp geometry (raised relief / carved channel, displaced off
+ *  the surface) from the untouched skin — robust on curved faces, where a
+ *  projection-relative depth band drifts. The nearest *triangle* is taken by
+ *  centroid (cheap spatial hash); for the meshes here (a dense base vs its
+ *  re-meshed carve) that triangle is the geometrically nearest too. */
+export function nearestSurfaceDistance(refMesh: MeshData, queryMesh: MeshData): Float32Array {
+  const out = new Float32Array(queryMesh.numTri).fill(Infinity);
+  if (refMesh.numTri === 0 || queryMesh.numTri === 0) return out;
+  const { index } = nearestCentroidCore(refMesh, queryMesh);
+  const { vertProperties: rvp, triVerts: rtv, numProp: rnp } = refMesh;
+  const { vertProperties: qvp, triVerts: qtv, numProp: qnp } = queryMesh;
+  for (let t = 0; t < queryMesh.numTri; t++) {
+    const ti = index[t];
+    if (ti < 0) continue;
+    const qa = qtv[t * 3] * qnp, qb = qtv[t * 3 + 1] * qnp, qc = qtv[t * 3 + 2] * qnp;
+    const px = (qvp[qa] + qvp[qb] + qvp[qc]) / 3;
+    const py = (qvp[qa + 1] + qvp[qb + 1] + qvp[qc + 1]) / 3;
+    const pz = (qvp[qa + 2] + qvp[qb + 2] + qvp[qc + 2]) / 3;
+    const a = rtv[ti * 3] * rnp, b = rtv[ti * 3 + 1] * rnp, c = rtv[ti * 3 + 2] * rnp;
+    out[t] = Math.sqrt(pointTriDist2(
+      px, py, pz,
+      rvp[a], rvp[a + 1], rvp[a + 2],
+      rvp[b], rvp[b + 1], rvp[b + 2],
+      rvp[c], rvp[c + 1], rvp[c + 2],
+    ));
+  }
+  return out;
 }

--- a/src/surface/modifiers.ts
+++ b/src/surface/modifiers.ts
@@ -31,8 +31,8 @@ import { applySteps, type TransformStep } from './placement';
 import { meshGrid } from '../geometry/voxel/mesher';
 import { voronoiLampSdfMesh } from './voronoiLampSdf';
 import { engraveMesh, engraveFieldResolution, type EngraveSdfOptions } from './engraveSdf';
-import { stampEvaluator, maskAspect, type EngraveProjection } from './engraveStamp';
-import { nearestTriangleMap } from './colorTransfer';
+import { stampEvaluator, type EngraveProjection } from './engraveStamp';
+import { nearestTriangleMap, nearestSurfaceDistance } from './colorTransfer';
 import { type SdfRunControl } from './sdfModifier';
 
 export type SurfaceModifierId = 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize';
@@ -735,10 +735,34 @@ function stampTriColors(
   // Surface-nets places vertices within ~half a voxel of the true surface;
   // classify with that tolerance off the face so seam triangles don't flicker.
   const eps = (Math.max(...bbox.size) || 10) / engraveFieldResolution(opts.resolution) * 0.5;
-  // The same tolerance in normalized stamp coordinates, for the rect bound.
-  const stampW = Math.max(1e-6, opts.size);
-  const stampH = stampW / Math.max(1e-6, maskAspect(opts.mask));
-  const epsU = eps / stampW, epsV = eps / stampH;
+  // Ink coverage threshold: bounds the letters laterally for *every* mode (the
+  // m≈0.5 isocontour is the relief/channel wall, so this keeps the walls while
+  // trimming the antialiased fringe outside the letters).
+  const inkMin = 0.15;
+  // How far a baked triangle's centroid must sit off the original surface to count
+  // as stamp geometry rather than the untouched skin. Distance from the surface
+  // (not a projection-relative depth band) is what makes emboss/engrave coloring
+  // robust on curved faces: on a sphere the planar/cylindrical "face" the stamp
+  // projects onto drifts away from the real surface, so a depth-band test both
+  // misses far channel walls (engrave) and catches unraised skin inside the stamp
+  // rectangle (emboss bleed). Displacement keys off the geometry change instead.
+  // `nearestSurfaceDistance` is a true point-to-triangle distance (no
+  // tessellation floor), so the threshold can sit just above the surface-nets
+  // noise — the channel/relief walls then color right up to the rim.
+  const dispMin = eps * 1.5;
+  // Dense geometric reference for the displacement test. The distance is
+  // point-to-triangle (so there's no tessellation floor — points on the surface
+  // read ~0), but the *nearest* triangle is picked by centroid, which only lands
+  // on the right face when faces are small; densify a coarse input (e.g. a plain
+  // cube) so that selection is reliable. Reuse the paint-dense source if built.
+  const geomRef = denseSrc
+    ?? (input.numTri > 0
+      ? subdivideToMaxEdge(input, { maxEdge: (modelDiagonal(input) || 10) / 80, maxRounds: 5 })
+      : input);
+  // Through-cut hole walls aren't "displaced" from the surface (material is
+  // removed, leaving no far side under the cut), so they stay on the depth-band
+  // test; emboss/engrave use the displacement test.
+  const dist = !opts.through && geomRef.numTri > 0 ? nearestSurfaceDistance(geomRef, baked) : null;
   const [r, g, b] = opts.color!.map(c => Math.round(Math.min(1, Math.max(0, c)) * 255));
   const { vertProperties: vp, triVerts: tv, numProp, numTri } = baked;
   for (let t = 0; t < numTri; t++) {
@@ -746,15 +770,20 @@ function stampTriColors(
     const cx = (vp[a] + vp[bI] + vp[c]) / 3;
     const cy = (vp[a + 1] + vp[bI + 1] + vp[c + 1]) / 3;
     const cz = (vp[a + 2] + vp[bI + 2] + vp[c + 2]) / 3;
-    const { m, depthInto, u, v } = evalStamp(cx, cy, cz);
-    // Emboss: anything above the face inside the stamp rectangle is relief —
-    // the rect (not ink coverage) bounds it laterally, so relief side-walls at
-    // an ink edge still color. Engrave/through: below the face, under ink,
-    // within the carve depth.
-    const inRect = u >= -epsU && u <= 1 + epsU && v >= -epsV && v <= 1 + epsV;
-    const stamped = opts.raised
-      ? depthInto < -eps && inRect
-      : depthInto > eps && m > 0.15 && (opts.through || depthInto < opts.depth + 2 * eps);
+    const { m, depthInto } = evalStamp(cx, cy, cz);
+    // Color the stamp itself, bounded laterally by ink (m). Emboss and engrave
+    // share one rule — a baked triangle is stamp geometry iff it's under ink AND
+    // displaced off the original surface (the raised relief, or the carved channel
+    // walls + floor). Distance-from-surface — not a projection-relative depth band
+    // — is what makes this robust on curved faces: the planar/cylindrical "face"
+    // the stamp projects onto drifts away from a sphere, so a depth test misses far
+    // channel walls (engrave under-color) and catches unraised skin inside the
+    // stamp rectangle (emboss bleed); the geometry change has neither failure.
+    // Through-cuts remove material (no far side under the cut, nothing
+    // "displaced"), so the hole walls stay on the depth-band test.
+    const stamped = opts.through
+      ? depthInto > eps && m > inkMin
+      : m > inkMin && (dist ? dist[t] > dispMin : false);
     if (!stamped) continue;
     triColors[t * 3] = r; triColors[t * 3 + 1] = g; triColors[t * 3 + 2] = b;
     painted[t] = 1;

--- a/src/ui/surfaceModal.ts
+++ b/src/ui/surfaceModal.ts
@@ -23,6 +23,7 @@ import { getCurrentMesh, previewTriangles } from '../color/paintMode';
 import { buildTriColors } from '../color/regions';
 import type { StampMask, EngraveProjection } from '../surface/modifiers';
 import { engravePlanarFootprint, engraveFreeFootprint } from '../surface/engraveStamp';
+import { listFilaments } from '../color/palette';
 
 type ApplyResult = { error?: string; label?: string } | Record<string, unknown>;
 type ModId = 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize';
@@ -229,6 +230,63 @@ function dropdown<T extends string>(
   sel.addEventListener('change', onChange);
   wrap.append(sel);
   return { wrap, get: () => sel.value as T };
+}
+
+/** Normalize any hex form to the `#rrggbb` a native colour input requires. */
+function toColorInputHex(hex: string): string {
+  let h = hex.trim().replace(/^#/, '');
+  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  return /^[0-9a-fA-F]{6}$/.test(h) ? `#${h.toLowerCase()}` : '#d4af37';
+}
+
+/** A colour control that mirrors the paint tools: the shared filament palette as
+ *  a swatch grid (click to pick a slot) plus a native picker for an off-palette
+ *  colour. Returns the current hex via `get()`. `onChange` fires on every pick.
+ *  Snapshots the palette at creation — the panel is short-lived, so it doesn't
+ *  subscribe to live palette edits the way the persistent paint drawer does. */
+function colorField(initial: string, onChange: () => void) {
+  const wrap = el('div', 'mb-3');
+  let value = toColorInputHex(initial);
+
+  const grid = el('div', 'grid grid-cols-6 gap-1.5 mb-2');
+  const swatches: { btn: HTMLButtonElement; hex: string }[] = [];
+  const syncRings = () => {
+    for (const s of swatches) {
+      const on = toColorInputHex(s.hex) === value;
+      s.btn.classList.toggle('border-white/80', on);
+      s.btn.classList.toggle('ring-1', on);
+      s.btn.classList.toggle('ring-white/30', on);
+      s.btn.classList.toggle('border-transparent', !on);
+    }
+  };
+
+  for (const f of listFilaments()) {
+    const btn = el('button', 'w-6 h-6 rounded border-2 border-transparent hover:border-white/50 transition-colors');
+    btn.type = 'button';
+    btn.style.backgroundColor = f.hex;
+    btn.title = `${f.name} (${f.hex})`;
+    btn.addEventListener('click', () => {
+      value = toColorInputHex(f.hex);
+      picker.value = value;
+      syncRings();
+      onChange();
+    });
+    swatches.push({ btn, hex: f.hex });
+    grid.append(btn);
+  }
+
+  // Off-palette custom colour. 'change' (not 'input') — re-running the SDF carve
+  // on every drag tick of the native picker would queue a carve per hover.
+  const customRow = el('label', 'flex items-center gap-1.5 cursor-pointer');
+  const picker = el('input', 'w-6 h-6 rounded cursor-pointer border-0 p-0 bg-transparent');
+  picker.type = 'color';
+  picker.value = value;
+  picker.addEventListener('change', () => { value = picker.value; syncRings(); onChange(); });
+  customRow.append(picker, el('span', 'text-[10px] text-zinc-500', 'Custom colour'));
+
+  wrap.append(grid, customRow);
+  syncRings();
+  return { wrap, get: () => value };
 }
 
 /** Find the viewport container used by the other overlay panels. */
@@ -821,15 +879,12 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
         schedulePreview, { round: n => Math.round(n * 1000) / 1000 });
       const depthWrap = depth.wrap;
       // Optional letter color — colors the raised relief (emboss) or the
-      // channel walls (engrave/through) for multicolor prints.
-      const colorChk = checkbox('Color the letters', false, () => { colorPick.style.display = colorChk.get() ? '' : 'none'; schedulePreview(); });
-      const colorPick = el('input', 'w-full h-7 mb-3 bg-zinc-800 border border-zinc-700 rounded cursor-pointer');
-      colorPick.type = 'color';
-      colorPick.value = '#d4af37';
-      colorPick.style.display = 'none';
-      // 'change' (not 'input') — re-running the SDF sweep on every drag tick of
-      // the native picker would queue a carve per swatch hover.
-      colorPick.addEventListener('change', schedulePreview);
+      // channel walls (engrave/through) for multicolor prints. The picker is the
+      // shared filament palette (same swatches as the paint tools) + a custom
+      // off-palette colour, so engrave colours stay consistent with painting.
+      const colorChk = checkbox('Color the letters', false, () => { colorCtl.wrap.style.display = colorChk.get() ? '' : 'none'; schedulePreview(); });
+      const colorCtl = colorField('#d4af37', schedulePreview);
+      colorCtl.wrap.style.display = 'none';
       const syncEngraveModeUI = () => { depthWrap.style.display = modeSel.get() === 'through' ? 'none' : ''; };
       const res = sliderWithEntry('Resolution', 48, 220, 180, 1, 256, schedulePreview);
       const wtight = checkbox('One connected piece (printable)', true, schedulePreview);
@@ -838,7 +893,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
       engraveSizeGet = () => sizeS.get();
       engraveIsPlanar = () => true; // placement is always face-based now → outline always applies
 
-      body.append(textWrap, font.wrap, imgWrap, invert.wrap, placeWrap, angle.wrap, curveAxis.wrap, curveAngle.wrap, modeSel.wrap, sizeS.wrap, depthWrap, colorChk.wrap, colorPick, res.wrap, wtight.wrap);
+      body.append(textWrap, font.wrap, imgWrap, invert.wrap, placeWrap, angle.wrap, curveAxis.wrap, curveAngle.wrap, modeSel.wrap, sizeS.wrap, depthWrap, colorChk.wrap, colorCtl.wrap, res.wrap, wtight.wrap);
       body.append(el('p', 'text-[11px] text-zinc-500', 'Stamps text or an image onto the model — engraved channels, a raised emboss, or holes cut clean through (stencil). Type text and press Apply, then "place on model": move over the model (a blue outline follows the cursor) and click to drop it on that face. Fine-tune with the position sliders / rotation, and use Curve to wrap the text around a cylinder or dome. "Color the letters" paints the stamp for multicolor prints. Raise resolution if thin strokes look mushy.'));
       syncCurveUI();
       syncEngraveModeUI();
@@ -859,7 +914,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
         raised: modeSel.get() === 'emboss',
         depth: depth.get(),
         size: sizeS.get(),
-        color: colorChk.get() ? colorPick.value : undefined,
+        color: colorChk.get() ? colorCtl.get() : undefined,
         resolution: res.get(),
         watertight: wtight.get(),
       });

--- a/tests/unit/surface.test.ts
+++ b/tests/unit/surface.test.ts
@@ -23,7 +23,7 @@ import { smoothSurface } from '../../src/surface/smoothSurface';
 import { voxelizeMesh } from '../../src/surface/voxelizeMesh';
 import { encodeGrid } from '../../src/geometry/voxel/grid';
 import { applyFuzzy, applyKnit, applyKnitPatch, applySmooth, applyVoxelize, applyVoronoiLamp } from '../../src/surface/modifiers';
-import { nearestTriangleMap } from '../../src/surface/colorTransfer';
+import { nearestTriangleMap, nearestSurfaceDistance } from '../../src/surface/colorTransfer';
 
 /** Axis-aligned cube from [0,s]^3 as a 8-vertex / 12-triangle MeshData. */
 function cube(s = 10): MeshData {
@@ -458,6 +458,45 @@ describe('modifiers (codegen)', () => {
       const moved: MeshData = { ...c, vertProperties: Float32Array.from(c.vertProperties, (v, i) => v + (i % 3 === 0 ? 0.05 : -0.03)) };
       const map = nearestTriangleMap(c, moved);
       for (let t = 0; t < c.numTri; t++) expect(map[t]).toBe(t);
+    });
+  });
+
+  describe('nearestSurfaceDistance (engrave/emboss displacement)', () => {
+    it('reports ~0 for an identical mesh', () => {
+      const c = cube(10);
+      const d = nearestSurfaceDistance(c, c);
+      expect(d.length).toBe(c.numTri);
+      for (let t = 0; t < c.numTri; t++) expect(d[t]).toBeCloseTo(0, 5);
+    });
+
+    it('has no tessellation floor — points on a re-meshed surface read ~0', () => {
+      // Point-to-triangle (not centroid-to-centroid) distance: a re-tessellated
+      // copy of the same surface reads ~0 everywhere, even though its triangle
+      // centroids don't coincide with the reference's. (A centroid-to-centroid
+      // proxy would report up to ~half the reference edge length instead.) The
+      // reference is moderately dense so the nearest triangle is picked correctly.
+      const ref = subdivideToMaxEdge(cube(20), { maxEdge: 2 });
+      const requeried = subdivideToMaxEdge(cube(20), { maxEdge: 3 });
+      const d = nearestSurfaceDistance(ref, requeried);
+      for (let t = 0; t < requeried.numTri; t++) expect(d[t]).toBeLessThan(1e-3);
+    });
+
+    it('reports the offset distance for a translated-off copy', () => {
+      // Translate every vertex straight up by 3: the moved top/bottom/side faces
+      // now sit 3 off the original surface, so the max distance is ~3.
+      const c = cube(20);
+      const moved: MeshData = { ...c, vertProperties: Float32Array.from(c.vertProperties, (v, i) => (i % 3 === 2 ? v + 3 : v)) };
+      const d = nearestSurfaceDistance(c, moved);
+      let maxD = 0;
+      for (let t = 0; t < d.length; t++) maxD = Math.max(maxD, d[t]);
+      expect(maxD).toBeGreaterThan(2.5);
+      expect(maxD).toBeLessThanOrEqual(3 + 1e-3);
+    });
+
+    it('reports Infinity entries when the reference mesh is empty', () => {
+      const empty: MeshData = { vertProperties: new Float32Array(), triVerts: new Uint32Array(), numVert: 0, numTri: 0, numProp: 3 };
+      const d = nearestSurfaceDistance(empty, cube(10));
+      expect([...d].every(v => v === Infinity)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Two fixes to the emboss/engrave surface submenu's letter colouring.

### 1. Shared colour palette in the picker
The "Color the letters" control only offered the browser's native colour input. It now renders the **shared filament palette** as a swatch grid (the same colours the paint tools use) plus a **custom off-palette picker** — so engrave/emboss colours stay consistent with painting. A new `colorField` helper in `src/ui/surfaceModal.ts` mirrors the paint UI's swatch section; it feeds `engraveModel`'s existing `color` hex param, so no API surface changed.

| Before | After |
|---|---|
| lone native `<input type="color">` | palette swatches (White/Black/Red/Yellow/Blue/Gray) + Custom colour |

### 2. Curved-surface stamp colouring
Auto-colouring classified each baked triangle with the stamp's **projection-relative depth band**. On a curved face the planar/cylindrical "face" the stamp projects onto drifts from the real surface, so the band failed two ways:

- **Engrave** dropped channel triangles at the laterally-divergent edge letters (their `depthInto` drifts past the depth ceiling) — *"didn't catch every triangle."*
- **Emboss** bounded laterally by the stamp *rectangle* instead of ink coverage, so unraised skin inside the rectangle got coloured — *the bleed.*

Both modes now classify by **true distance off the original surface** (the relief/channel is displaced; the untouched skin and far side are not), gated by ink coverage `m`:

- New `nearestSurfaceDistance` in `src/surface/colorTransfer.ts`: a **point-to-triangle** distance (Ericson closest-point) reusing the existing centroid spatial hash to pick the candidate triangle. Point-to-triangle has no tessellation-density floor, so the threshold sits just above surface-nets noise (`1.5·eps`) and walls colour right to the rim.
- `nearestTriangleMap` + the new function now share one `nearestCentroidCore`.
- **Through-cuts** keep the depth-band test (material removed ⇒ no displaced wall, no far side under the cut).

## Verification

Drove `engraveModel` on a `HELLO` stamp wrapped around a sphere (curved around the vertical axis), engrave + emboss, via a throwaway Playwright spec + `renderView`:

- **Engrave** — every letter (incl. the divergent `H`/`O`) fully and uniformly coloured; no white gaps.
- **Emboss** — colour confined to the raised letters; **zero** bleed onto the surrounding sphere.
- Palette swatch UI screenshot confirmed in the panel.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:unit` (1183 pass; new `nearestSurfaceDistance` coverage — identity ~0, no tessellation floor, translated-off distance, empty-ref Infinity)
- [x] `npm run lint:deps` (acyclic)
- [x] Manual browser verification (engrave/emboss renders + palette screenshot)
- [ ] PR-checks e2e shards (run on this draft)

https://claude.ai/code/session_015NYavh6FtVAKPewemA3uN5

---
_Generated by [Claude Code](https://claude.ai/code/session_015NYavh6FtVAKPewemA3uN5)_