### PR TITLE
feat: add knurl as a Surface-menu texture

### DIFF
--- a/prompts/20260611-191130-knurl-surface-texture.md
+++ b/prompts/20260611-191130-knurl-surface-texture.md
@@ -1,0 +1,49 @@
+---
+session: "e9c4a1"
+timestamp: "2026-06-11T19:11:30Z"
+model: claude-opus-4-8
+tools: [explore, playwright]
+sequence: 3
+---
+
+## Human
+
+Asked whether knurl can be applied from the UI like the Surface menu. After
+confirming it would mean adding knurl as a surface-modifier texture (not the
+existing `api.knurl` shape generator), chose the full-texture scope.
+
+## Assistant
+
+## Key decisions
+
+**Knurl as a normal-displacement texture, not a generator.** The existing
+`api.knurl.*` builds whole knurled cylinders; the Surface panel displaces an
+existing mesh's surface over a triplanar projection. These are complementary
+(like `api.gears` vs. a hypothetical gear texture). The new `knurlTexture` is a
+sibling of `waffleStitch` — it reuses the exact same subdivide → triplanar →
+displace-along-normal pipeline, so it inherits the panel's region/patch support,
+in-code `api.surface.knurl`, persistence, and AI-tool wiring for free.
+
+**Displacement field**: three styles selected by a `style` option —
+`diamond` = product of two opposite-handed cosine ridge families (a 45° bump
+grid), `straight` = one cosine ridge family across the column axis, `ribs` =
+across the row axis. `amplitude · raise^sharpness`, accumulated triplanar.
+
+**Followed the full waffle/woven checklist** (mapped by the explore agent — ~17
+touch-points) so the feature has complete parity: `knurlTexture.ts` (math) +
+`applyKnurl`/`applyKnurlPatch`/`defaultKnurlOptions` in `modifiers.ts`, the
+`SurfaceModifierId`/`SurfaceOpId` unions, `SURFACE_OP_FIELDS` allow-list (incl.
+the `style` string key), the `surfaceOps.ts` dispatch, the `api.surface.knurl`
+sandbox entry in `manifoldJs.ts`, the `main.ts` `buildSurfaceModifier` block +
+`textureWarnings` branch + `applyKnurlTexture` console method + `help()` row, and
+the `surfaceModal.ts` tab + `dropdown`/sliders + apply dispatch + command-palette
+entry. Plus `textures.md` docs and a unit-test case in the shared fabric table.
+
+**Verification**: `model:preview` (SSR engine) intentionally does NOT run the
+main-thread surface ops, so it can't verify the texture — confirmed it returned
+the bare cylinder (252 tris). Verified instead via (1) unit tests on the pure
+math (three styles distinct; displacement bounded to [0, amplitude] outward),
+and (2) a Playwright spec driving the real editor: `applyKnurlTexture` baked the
+cylinder to 389k tris (manifold) with a clear diamond cross-hatch, and the
+command palette → Surface panel opened on the Knurl tab with the Pattern
+dropdown + sliders rendering correctly.

--- a/public/ai/textures.md
+++ b/public/ai/textures.md
@@ -11,6 +11,7 @@ vertices along their normals. Seven textures are available:
 | `applyWaffleStitch` | Recessed grid cells with raised borders | Waffle-knit, waffle irons, honeycomb patterns |
 | `applyFurVelvet` | Directional anisotropic pile (velvet, fur, chenille) | Animal fur, velvet fabric, soft plush surfaces |
 | `applyWovenFabric` | Plain-weave over/under interlacing | Baskets, woven cloth, twill, burlap |
+| `applyKnurlTexture` | Functional grip relief — diamond / straight / ribs | Knobs, thumbscrews, tool handles, grips |
 | `applyVoronoiShell` | Organic cell-wall ridge network (Voronoi cells) | Lampshades, planters, vases, cracked-mud / dragonfly-wing shells |
 
 Two further mesh operations live in the same panel and share the same
@@ -45,7 +46,7 @@ return body;
 ```
 
 - Available ops: `api.surface.fuzzy`, `.knit`, `.cable`, `.waffle`, `.fur`,
-  `.woven`, `.voronoi`, `.smooth`. Each takes the **same options** as its
+  `.woven`, `.knurl`, `.voronoi`, `.smooth`. Each takes the **same options** as its
   `apply*` tool (size-relative defaults fill in anything you omit). There's also
   a generic `api.surface.apply('knit', { … })` form.
 - **`applySurfaceTextureAsCode(id, opts?)`** writes the call into the code for
@@ -273,6 +274,39 @@ slightly depressed.
 - Open weave / burlap: `threadWidth=0.35`, `threadSpacing=d*0.05`, `underDepth=0.5`
 - Tight fabric: `threadWidth=0.65`, `threadSpacing=d*0.03`, `underDepth=0.2`
 - Basket weave: `threadWidth=0.55`, `threadSpacing=d*0.06`, `underDepth=0.4`
+
+---
+
+## applyKnurlTexture
+
+```
+applyKnurlTexture({ amplitude?, cellWidth?, cellHeight?, style?, sharpness?,
+                    grainAngleDeg?, seed?, quality?, preserveColor? })
+```
+
+Functional grip relief, displaced along surface normals. This textures **any
+existing mesh** — distinct from the `api.knurl.*` shape generator (which builds
+a whole knurled cylinder). Use it to add grip to a knob, bottle, pen barrel, or
+handle you already modeled. Region-selectable (texture only painted triangles).
+
+| Parameter | Default | Notes |
+|-----------|---------|-------|
+| `style` | `'diamond'` | `'diamond'` (cross-hatch), `'straight'` (axial splines), `'ribs'` (horizontal rings). |
+| `amplitude` | ~2% of diagonal | Peak ridge height. |
+| `cellWidth` | ~5% of diagonal | Ridge spacing along the column axis. |
+| `cellHeight` | = cellWidth | Ridge spacing along the row (Z) axis. For square diamonds keep equal to cellWidth. |
+| `sharpness` | 2 | Ridge crispness. 1 = soft rounded, 2–4 = crisp, 6+ = sharp peaks. |
+| `grainAngleDeg` | 0 | Rotate the grid in the XY plane. |
+| `seed` | 1 | Deterministic seed (reserved). |
+| `quality` | 3 | Mesh detail 1 (draft) to 5 (ultra). Higher = smoother, slower. |
+| `preserveColor` | true | Carry paint through subdivision. |
+
+**Look guidance:**
+- Thumbscrew grip: `style='diamond'`, `cellWidth=d*0.04`, `sharpness=2`
+- Knob splines: `style='straight'`, `cellWidth=d*0.05`
+- Finger ridges: `style='ribs'`, `cellHeight=d*0.06`
+
+In-code form: `api.surface.knurl({ style:'diamond', cellWidth: 2, amplitude: 0.6 })`.
 
 ---
 

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -486,6 +486,7 @@ export const manifoldJsEngine: Engine = {
       waffle: makeSurfaceFn('waffle'),
       fur: makeSurfaceFn('fur'),
       woven: makeSurfaceFn('woven'),
+      knurl: makeSurfaceFn('knurl'),
       voronoi: makeSurfaceFn('voronoi'),
       smooth: makeSurfaceFn('smooth'),
       /** Generic form: `api.surface.apply('knit', { … })` — handy for data-driven code. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,7 +121,7 @@ import { appendVoxelEditsToCode, editOpCount, formatSurfacingCall } from './geom
 import * as voxelPaint from './color/voxelPaint';
 import { setActiveImports, getActiveImports, type ImportedMesh } from './import/importedMesh';
 import { getCompanionFiles, setCompanionFiles, addCompanionFile as addCompanionFileToRegistry, removeCompanionFile as removeCompanionFileFromRegistry, updateCompanionFile, detectMissingIncludes, normalizeCompanionPath, companionFilesEqual } from './import/companionFiles';
-import { applyFuzzy, applyFuzzyPatch, applyKnit, applyKnitAsync, applyKnitPatch, applyKnitPatchAsync, applyCable, applyCablePatch, applyWaffle, applyWafflePatch, applyFur, applyFurPatch, applyWoven, applyWovenPatch, applyVoronoi, applyVoronoiPatch, applyVoronoiLamp, applyEngrave, applySmooth, applySmoothPatch, applyVoxelize, applyScale, defaultFuzzyOptions, defaultKnitOptions, defaultCableOptions, defaultWaffleOptions, defaultFurOptions, defaultWovenOptions, defaultVoronoiOptions, defaultVoronoiLampOptions, defaultEngraveOptions, defaultSmoothOptions, modelDiagonal, applyTransform, SdfAbortError, type ModifierResult, type EngraveProjection, type StampMask, type SdfRunControl } from './surface/modifiers';
+import { applyFuzzy, applyFuzzyPatch, applyKnit, applyKnitAsync, applyKnitPatch, applyKnitPatchAsync, applyCable, applyCablePatch, applyWaffle, applyWafflePatch, applyFur, applyFurPatch, applyWoven, applyWovenPatch, applyKnurl, applyKnurlPatch, applyVoronoi, applyVoronoiPatch, applyVoronoiLamp, applyEngrave, applySmooth, applySmoothPatch, applyVoxelize, applyScale, defaultFuzzyOptions, defaultKnitOptions, defaultCableOptions, defaultWaffleOptions, defaultFurOptions, defaultWovenOptions, defaultKnurlOptions, defaultVoronoiOptions, defaultVoronoiLampOptions, defaultEngraveOptions, defaultSmoothOptions, modelDiagonal, applyTransform, SdfAbortError, type ModifierResult, type EngraveProjection, type StampMask, type SdfRunControl } from './surface/modifiers';
 import { buildTextStampMask, buildImageStampMask } from './surface/engraveStampHost';
 import { buildTransformCode, computePlacementDelta, isNoopDelta, isNoopRotation, placementLabel, rotationLabel, mirrorLabel, rotateAboutCenterSteps, mirrorAboutCenterSteps, bestFlatDownRotation, applySteps, meshBox, type PlacementBox, type PlacementOps, type TransformStep, type Vec3 } from './surface/placement';
 import { nearestTriangleMap } from './surface/colorTransfer';
@@ -7070,7 +7070,7 @@ async function main() {
    *  feature size relative to the model's bounding-box diagonal so the AI gets
    *  actionable feedback before spending time on a degenerate run. */
   function textureWarnings(
-    id: 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'voronoi',
+    id: 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'knurl' | 'voronoi',
     opts: Record<string, unknown>,
     mesh: MeshData,
   ): string[] {
@@ -7172,6 +7172,20 @@ async function main() {
         warnings.push(
           `threadSpacing (${ts.toFixed(4)}) is very small — weave will be invisible; ` +
           `try threadSpacing ≈ ${(diag * 0.04).toFixed(3)}`,
+        );
+      }
+    } else if (id === 'knurl') {
+      const cw = (opts.cellWidth as number | undefined) ?? 0;
+      if (cw > diag * 0.4) {
+        warnings.push(
+          `cellWidth (${cw.toFixed(3)}) is large relative to the model diagonal (${diag.toFixed(2)}) — ` +
+          `fewer than 3 ridges visible; try cellWidth ≈ ${(diag * 0.05).toFixed(3)}`,
+        );
+      }
+      if (cw > 0 && cw < diag / 400) {
+        warnings.push(
+          `cellWidth (${cw.toFixed(4)}) is very small — the knurl will be invisible; ` +
+          `try cellWidth ≈ ${(diag * 0.05).toFixed(3)}`,
         );
       }
     } else if (id === 'voronoi') {
@@ -7572,7 +7586,7 @@ async function main() {
   // `quality` (mesh-detail) is threaded into each opts object so the surface
   // panel's detail slider takes effect in both preview and apply.
   async function buildSurfaceModifier(
-    id: 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize',
+    id: 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'knurl' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize',
     opts: Record<string, unknown> | undefined,
     preserveColor: boolean,
     ctl?: SdfRunControl,
@@ -7673,6 +7687,22 @@ async function main() {
       };
       if (sel && sel.size > 0) return applyWovenPatch(mesh, wovenOpts, sel);
       return applyWoven(mesh, wovenOpts);
+    }
+    if (id === 'knurl') {
+      const mesh = meshForModifier(preserveColor);
+      const base = defaultKnurlOptions(mesh);
+      const knurlOpts = {
+        amplitude: (opts?.amplitude as number) ?? base.amplitude,
+        cellWidth: (opts?.cellWidth as number) ?? base.cellWidth,
+        cellHeight: (opts?.cellHeight as number) ?? base.cellHeight,
+        style: (opts?.style as 'diamond' | 'straight' | 'ribs') ?? base.style,
+        sharpness: (opts?.sharpness as number) ?? base.sharpness,
+        grainAngleDeg: (opts?.grainAngleDeg as number) ?? base.grainAngleDeg,
+        seed: (opts?.seed as number) ?? base.seed,
+        quality: (opts?.quality as number) ?? base.quality,
+      };
+      if (sel && sel.size > 0) return applyKnurlPatch(mesh, knurlOpts, sel);
+      return applyKnurl(mesh, knurlOpts);
     }
     if (id === 'voronoi') {
       const mesh = meshForModifier(preserveColor);
@@ -7808,7 +7838,7 @@ async function main() {
     /** Non-destructive viewport preview of a surface modifier (no version saved).
      *  Call clearSurfacePreview() / re-run to restore.
      *  id: 'fuzzy'|'knit'|'cable'|'waffle'|'fur'|'woven'|'voronoi'|'voronoiLamp'|'engrave'|'smooth'|'voxelize'. */
-    async previewSurfaceModifier(id: 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize', opts?: Record<string, unknown>, preserveColor = true): Promise<{ ok: true } | { error: string }> {
+    async previewSurfaceModifier(id: 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'knurl' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize', opts?: Record<string, unknown>, preserveColor = true): Promise<{ ok: true } | { error: string }> {
       try {
         previewSurfaceModifier(await buildSurfaceModifierProgress(id, opts, preserveColor), preserveColor);
         return { ok: true };
@@ -8052,6 +8082,36 @@ async function main() {
         const mesh = requireCurrentMeshForModifier();
         const warns = textureWarnings('woven', opts ?? {}, mesh);
         const result = await commitSurfaceModifier(await buildSurfaceModifierProgress('woven', opts, preserve), preserve);
+        if (warns.length > 0 && result && typeof result === 'object' && 'ok' in result) {
+          const existing = (result as Record<string, unknown>).warnings as string[] | undefined;
+          return { ...result, warnings: [...warns, ...(existing ?? [])] };
+        }
+        return result;
+      } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
+    },
+
+    /** Apply a knurl grip texture to the current model; saves a new version.
+     *  Functional grip relief — diamond cross-hatch, straight axial splines, or
+     *  horizontal finger ribs — displaced along surface normals. Distinct from
+     *  the `api.knurl.*` shape generator: this textures any existing mesh.
+     *  `preserveColor` (default true) carries paint across subdivision.
+     *  Returns `{ ok, label, geometry, colorsCarried, warnings? }`. */
+    async applyKnurlTexture(opts?: {
+      amplitude?: number;
+      cellWidth?: number;
+      cellHeight?: number;
+      style?: 'diamond' | 'straight' | 'ribs';
+      sharpness?: number;
+      grainAngleDeg?: number;
+      seed?: number;
+      quality?: number;
+      preserveColor?: boolean;
+    }) {
+      try {
+        const preserve = opts?.preserveColor ?? true;
+        const mesh = requireCurrentMeshForModifier();
+        const warns = textureWarnings('knurl', opts ?? {}, mesh);
+        const result = await commitSurfaceModifier(await buildSurfaceModifierProgress('knurl', opts, preserve), preserve);
         if (warns.length > 0 && result && typeof result === 'object' && 'ok' in result) {
           const existing = (result as Record<string, unknown>).warnings as string[] | undefined;
           return { ...result, warnings: [...warns, ...(existing ?? [])] };
@@ -13334,6 +13394,7 @@ async function main() {
         'applyWaffleStitch': { signature: 'await applyWaffleStitch({amplitude?, cellWidth?, cellHeight?, sharpness?, rowOffset?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE waffle grid; saves a new version. In-code alternative: api.surface.waffle', docs: '/ai/textures.md' },
         'applyFurVelvet':  { signature: 'await applyFurVelvet({amplitude?, fiberSpacing?, fiberLength?, octaves?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE fur/velvet fibers; saves a new version. In-code alternative: api.surface.fur', docs: '/ai/textures.md' },
         'applyWovenFabric':{ signature: 'await applyWovenFabric({amplitude?, threadSpacing?, threadWidth?, underDepth?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE woven threads; saves a new version. In-code alternative: api.surface.woven', docs: '/ai/textures.md' },
+        'applyKnurlTexture':{ signature: 'await applyKnurlTexture({amplitude?, cellWidth?, cellHeight?, style?, sharpness?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE knurl grip (style: diamond|straight|ribs); saves a new version. In-code alternative: api.surface.knurl', docs: '/ai/textures.md' },
         'applyVoronoiShell': { signature: 'await applyVoronoiShell({amplitude?, cellSize?, wallWidth?, raised?, jitter?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE Voronoi cell relief; saves a new version. In-code alternative: api.surface.voronoi', docs: '/ai/textures.md' },
         'applyVoronoiLamp':{ signature: 'await applyVoronoiLamp({cellSize?, wallThickness?, strutWidth?, resolution?, jitter?, grainAngleDeg?, seed?, preserveColor?}) -- Convert the model into a perforated Voronoi lamp shell (bake only — no api.surface twin)', docs: '/ai/textures.md' },
         'engraveModel':    { signature: "await engraveModel({text | imageUrl, raised?, through?, depth?, size?, color?, axis?, side?, posU?, posV?, rotationDeg?, curveAxis?, curveAngleDeg?, font?, resolution?, watertight?, preserveColor?}) -- Carve text/image as recessed channels (engrave), holes (through), or a raised relief (raised = emboss); color paints the letters ('#rrggbb' or [r,g,b] 0–1). Saves a new version.", docs: '/ai/textures.md#engravemodel' },

--- a/src/surface/knurlTexture.ts
+++ b/src/surface/knurlTexture.ts
@@ -1,0 +1,120 @@
+// Knurl surface texture.
+//
+// Produces functional grip relief — the diamond cross-hatch of a thumbscrew,
+// the straight axial splines of a knob, or horizontal finger ribs — displaced
+// along surface normals over a triplanar projection (the same projection the
+// waffle / woven textures use). Unlike the `api.knurl.*` shape generator (which
+// builds a whole knurled cylinder), this textures ANY existing mesh's surface.
+//
+// Algorithm (mirrors waffleStitch):
+//   1. Map world position onto grip-grid axes (grainAngleDeg rotates in XY; the
+//      second axis is Z so the pattern runs "up" the model by default).
+//   2. Compute a raise field in [0,1] per style:
+//        diamond  — product of two opposite-handed cosine ridge families →
+//                   a 45°-rotated diamond bump grid
+//        straight — a single cosine ridge family across the column axis →
+//                   vertical splines
+//        ribs     — a single cosine ridge family across the row axis →
+//                   horizontal rings
+//   3. Displacement = amplitude × raise^sharpness, accumulated triplanar.
+//
+// Pure logic (no DOM/WASM) → unit-tested in the vitest tier.
+
+import type { MeshData } from '../geometry/types';
+import {
+  subdivideToMaxEdge,
+  extractPositions,
+  computeVertexNormals,
+  bboxOf,
+  triplanarCoords,
+} from './meshSubdivide';
+
+export type KnurlStyle = 'diamond' | 'straight' | 'ribs';
+
+export interface KnurlTextureOptions {
+  /** Peak ridge height in world units. */
+  amplitude: number;
+  /** Spacing of one ridge cell along the column axis, world units. */
+  cellWidth: number;
+  /** Spacing along the row (Z) axis. Default cellWidth (square diamonds). */
+  cellHeight?: number;
+  /** Knurl pattern. Default 'diamond'. */
+  style?: KnurlStyle;
+  /** Ridge crispness. 1 = soft rounded, 2–4 = crisp, 6+ = sharp peaks. Default 2. */
+  sharpness?: number;
+  /** Rotate the grid in the XY plane (degrees). Default 0. */
+  grainAngleDeg?: number;
+  /** Deterministic seed (reserved for future variation). Default 1. */
+  seed?: number;
+  /** Densify mesh before displacing. Default true. */
+  subdivide?: boolean;
+  /** Subdivision quality 1 (draft) – 5 (ultra). Default 3. */
+  quality?: number;
+}
+
+const TAU = Math.PI * 2;
+
+export function knurlTexture(mesh: MeshData, opts: KnurlTextureOptions): MeshData {
+  const amplitude = Math.max(0, opts.amplitude);
+  const cellW = Math.max(1e-4, opts.cellWidth);
+  const cellH = Math.max(1e-4, opts.cellHeight ?? cellW);
+  const style: KnurlStyle = opts.style ?? 'diamond';
+  const sharpness = Math.max(1, opts.sharpness ?? 2);
+  const angleRad = ((opts.grainAngleDeg ?? 0) * Math.PI) / 180;
+  const cosA = Math.cos(angleRad), sinA = Math.sin(angleRad);
+
+  let base: MeshData = mesh;
+  if (opts.subdivide !== false && amplitude > 0) {
+    const quality = Math.max(1, Math.min(5, Math.round(opts.quality ?? 3)));
+    const qScale = 2 ** ((quality - 3) / 2);
+    const diag = Math.hypot(...bboxOf(extractPositions(mesh)).size);
+    const targetEdge = Math.max(Math.min(cellW, cellH) / (4 * qScale), diag / (400 * qScale));
+    base = subdivideToMaxEdge(mesh, { maxEdge: targetEdge, maxRounds: 6 });
+  }
+
+  const positions = base.numProp === 3
+    ? Float32Array.from(base.vertProperties)
+    : extractPositions(base);
+  const normals = computeVertexNormals(positions, base.triVerts);
+
+  for (let v = 0; v < base.numVert; v++) {
+    const px = positions[v * 3], py = positions[v * 3 + 1], pz = positions[v * 3 + 2];
+    const nx = normals[v * 3], ny = normals[v * 3 + 1], nz = normals[v * 3 + 2];
+
+    const { pairs, weights } = triplanarCoords(px, py, pz, nx, ny, nz);
+    let d = 0;
+    for (let i = 0; i < 3; i++) {
+      const [s, t] = pairs[i];
+      const gx = cosA * s + sinA * t;
+      const gz = -sinA * s + cosA * t;
+      const col = gx / cellW;
+      const row = gz / cellH;
+
+      let raise: number;
+      if (style === 'straight') {
+        raise = 0.5 + 0.5 * Math.cos(TAU * col);
+      } else if (style === 'ribs') {
+        raise = 0.5 + 0.5 * Math.cos(TAU * row);
+      } else {
+        // diamond: two opposite-handed ridge families → a 45° bump grid.
+        const a = 0.5 + 0.5 * Math.cos(TAU * (col + row));
+        const b = 0.5 + 0.5 * Math.cos(TAU * (col - row));
+        raise = a * b;
+      }
+      d += weights[i] * amplitude * raise ** sharpness;
+    }
+
+    positions[v * 3]     = px + nx * d;
+    positions[v * 3 + 1] = py + ny * d;
+    positions[v * 3 + 2] = pz + nz * d;
+  }
+
+  return {
+    vertProperties: positions,
+    triVerts: base.triVerts,
+    numVert: base.numVert,
+    numTri: base.numTri,
+    numProp: 3,
+    triColors: base.triColors,
+  };
+}

--- a/src/surface/modifiers.ts
+++ b/src/surface/modifiers.ts
@@ -19,6 +19,7 @@ import { cableKnit, type CableKnitOptions } from './cableKnit';
 import { waffleStitch, type WaffleStitchOptions } from './waffleStitch';
 import { furVelvet, type FurVelvetOptions } from './furVelvet';
 import { wovenFabric, type WovenFabricOptions } from './wovenFabric';
+import { knurlTexture, type KnurlTextureOptions } from './knurlTexture';
 import { voronoiShell, type VoronoiShellOptions } from './voronoiShell';
 import { voronoiLattice, type VoronoiLampOptions } from './voronoiLattice';
 import { smoothSurface, type SmoothOptions } from './smoothSurface';
@@ -35,7 +36,7 @@ import { stampEvaluator, maskAspect, type EngraveProjection } from './engraveSta
 import { nearestTriangleMap } from './colorTransfer';
 import { type SdfRunControl } from './sdfModifier';
 
-export type SurfaceModifierId = 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize';
+export type SurfaceModifierId = 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'knurl' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize';
 
 export interface ModifierManifoldResult {
   kind: 'manifold';
@@ -144,6 +145,7 @@ export { type CableKnitOptions };
 export { type WaffleStitchOptions };
 export { type FurVelvetOptions };
 export { type WovenFabricOptions };
+export { type KnurlTextureOptions };
 export { type VoronoiShellOptions };
 export { type VoronoiLampOptions };
 export { type EngraveProjection, type StampMask } from './engraveStamp';
@@ -361,6 +363,13 @@ export function applyWafflePatch(mesh: MeshData, opts: WaffleStitchOptions, sele
   return { kind: 'manifold', label: 'waffle stitch (patch)', mesh: patched, code: manifoldWrapper([`Waffle stitch patch applied on ${today()}.`, `The textured mesh is baked onto api.imports[0].`]) };
 }
 
+export function applyKnurlPatch(mesh: MeshData, opts: KnurlTextureOptions, selectedTris: Set<number>): ModifierManifoldResult {
+  const diag = modelDiagonal(mesh) || 10;
+  const pre = patchSubdivTarget(diag, Math.max(1e-4, opts.cellWidth), opts.quality ?? 3);
+  const patched = runOnPatch(mesh, selectedTris, (sub) => knurlTexture(sub, { ...opts, subdivide: false }), pre);
+  return { kind: 'manifold', label: 'knurl (patch)', mesh: patched, code: manifoldWrapper([`Knurl patch applied on ${today()}.`, `The textured mesh is baked onto api.imports[0].`]) };
+}
+
 export function applyFurPatch(mesh: MeshData, opts: FurVelvetOptions, selectedTris: Set<number>): ModifierManifoldResult {
   const diag = modelDiagonal(mesh) || 10;
   const pre = patchSubdivTarget(diag, Math.max(1e-4, opts.fiberSpacing), opts.quality ?? 3);
@@ -416,6 +425,21 @@ export function defaultWaffleOptions(mesh: MeshData): Required<WaffleStitchOptio
     cellHeight: d * 0.06,
     sharpness: 3,
     rowOffset: 0,
+    grainAngleDeg: 0,
+    seed: 1,
+    quality: 3,
+    subdivide: true,
+  };
+}
+
+export function defaultKnurlOptions(mesh: MeshData): Required<KnurlTextureOptions> {
+  const d = modelDiagonal(mesh) || 10;
+  return {
+    amplitude: d * 0.02,
+    cellWidth: d * 0.05,
+    cellHeight: d * 0.05,
+    style: 'diamond',
+    sharpness: 2,
     grainAngleDeg: 0,
     seed: 1,
     quality: 3,
@@ -513,6 +537,19 @@ export function applyWaffle(mesh: MeshData, opts: WaffleStitchOptions): Modifier
     mesh: baked,
     code: manifoldWrapper([
       `Waffle stitch applied on ${today()} — cell ${opts.cellWidth.toFixed(2)} × ${(opts.cellHeight ?? opts.cellWidth).toFixed(2)}, sharpness ${opts.sharpness ?? 3}.`,
+      `The textured mesh is baked onto api.imports[0]. Re-apply from the Surface panel to retune.`,
+    ]),
+  };
+}
+
+export function applyKnurl(mesh: MeshData, opts: KnurlTextureOptions): ModifierManifoldResult {
+  const baked = knurlTexture(mesh, opts);
+  return {
+    kind: 'manifold',
+    label: 'knurl',
+    mesh: baked,
+    code: manifoldWrapper([
+      `Knurl applied on ${today()} — ${opts.style ?? 'diamond'}, cell ${opts.cellWidth.toFixed(2)}, amplitude ${opts.amplitude.toFixed(2)}.`,
       `The textured mesh is baked onto api.imports[0]. Re-apply from the Surface panel to retune.`,
     ]),
   };

--- a/src/surface/surfaceOpSpec.ts
+++ b/src/surface/surfaceOpSpec.ts
@@ -20,6 +20,7 @@ export type SurfaceOpId =
   | 'waffle'
   | 'fur'
   | 'woven'
+  | 'knurl'
   | 'voronoi'
   | 'smooth';
 
@@ -43,6 +44,7 @@ export const SURFACE_OP_FIELDS: Record<SurfaceOpId, readonly string[]> = {
   waffle: ['amplitude', 'cellWidth', 'cellHeight', 'sharpness', 'rowOffset', 'grainAngleDeg', 'seed', 'quality', 'subdivide'],
   fur: ['amplitude', 'fiberSpacing', 'fiberLength', 'octaves', 'grainAngleDeg', 'seed', 'quality', 'subdivide'],
   woven: ['amplitude', 'threadSpacing', 'threadWidth', 'underDepth', 'grainAngleDeg', 'seed', 'quality', 'subdivide'],
+  knurl: ['amplitude', 'cellWidth', 'cellHeight', 'style', 'sharpness', 'grainAngleDeg', 'seed', 'quality', 'subdivide'],
   voronoi: ['amplitude', 'cellSize', 'wallWidth', 'raised', 'jitter', 'grainAngleDeg', 'seed', 'quality', 'subdivide'],
   smooth: ['iterations', 'subdivide'],
 };

--- a/src/surface/surfaceOps.ts
+++ b/src/surface/surfaceOps.ts
@@ -16,9 +16,9 @@ import type { MeshData } from '../geometry/types';
 import { simpleHash } from '../geometry/statsComputation';
 import type { SurfaceOp, SurfaceOpId } from './surfaceOpSpec';
 import {
-  applyFuzzy, applyKnitAsync, applyCable, applyWaffle, applyFur, applyWoven, applyVoronoi, applySmooth,
+  applyFuzzy, applyKnitAsync, applyCable, applyWaffle, applyFur, applyWoven, applyKnurl, applyVoronoi, applySmooth,
   defaultFuzzyOptions, defaultKnitOptions, defaultCableOptions, defaultWaffleOptions,
-  defaultFurOptions, defaultWovenOptions, defaultVoronoiOptions, defaultSmoothOptions,
+  defaultFurOptions, defaultWovenOptions, defaultKnurlOptions, defaultVoronoiOptions, defaultSmoothOptions,
 } from './modifiers';
 
 /** Memo cache: prefix key → textured mesh after that prefix of the chain.
@@ -58,6 +58,7 @@ async function applyOne(mesh: MeshData, op: SurfaceOp): Promise<MeshData> {
     case 'waffle':  return applyWaffle(mesh, { ...defaultWaffleOptions(mesh), ...p }).mesh;
     case 'fur':     return applyFur(mesh, { ...defaultFurOptions(mesh), ...p }).mesh;
     case 'woven':   return applyWoven(mesh, { ...defaultWovenOptions(mesh), ...p }).mesh;
+    case 'knurl':   return applyKnurl(mesh, { ...defaultKnurlOptions(mesh), ...p }).mesh;
     case 'voronoi': return applyVoronoi(mesh, { ...defaultVoronoiOptions(mesh), ...p }).mesh;
     case 'smooth':  return applySmooth(mesh, { ...defaultSmoothOptions(), ...p }).mesh;
     default: {

--- a/src/ui/surfaceModal.ts
+++ b/src/ui/surfaceModal.ts
@@ -25,7 +25,7 @@ import type { StampMask, EngraveProjection } from '../surface/modifiers';
 import { engravePlanarFootprint, engraveFreeFootprint } from '../surface/engraveStamp';
 
 type ApplyResult = { error?: string; label?: string } | Record<string, unknown>;
-type ModId = 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize';
+type ModId = 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'knurl' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize';
 
 /** The subset of the console API the surface UI needs. */
 export interface SurfaceApi {
@@ -35,6 +35,7 @@ export interface SurfaceApi {
   applyWaffleStitch(opts?: { amplitude?: number; cellWidth?: number; cellHeight?: number; sharpness?: number; rowOffset?: number; grainAngleDeg?: number; seed?: number; quality?: number; preserveColor?: boolean }): Promise<ApplyResult>;
   applyFurVelvet(opts?: { amplitude?: number; fiberSpacing?: number; fiberLength?: number; octaves?: number; grainAngleDeg?: number; seed?: number; quality?: number; preserveColor?: boolean }): Promise<ApplyResult>;
   applyWovenFabric(opts?: { amplitude?: number; threadSpacing?: number; threadWidth?: number; underDepth?: number; grainAngleDeg?: number; seed?: number; quality?: number; preserveColor?: boolean }): Promise<ApplyResult>;
+  applyKnurlTexture(opts?: { amplitude?: number; cellWidth?: number; cellHeight?: number; style?: 'diamond' | 'straight' | 'ribs'; sharpness?: number; grainAngleDeg?: number; seed?: number; quality?: number; selectedTriangles?: Set<number>; preserveColor?: boolean }): Promise<ApplyResult>;
   applyVoronoiShell(opts?: { amplitude?: number; cellSize?: number; wallWidth?: number; raised?: boolean; jitter?: number; grainAngleDeg?: number; seed?: number; quality?: number; preserveColor?: boolean }): Promise<ApplyResult>;
   applyVoronoiLamp(opts?: { cellSize?: number; wallThickness?: number; strutWidth?: number; resolution?: number; jitter?: number; grainAngleDeg?: number; seed?: number; smooth?: boolean; preserveColor?: boolean }): Promise<ApplyResult>;
   buildEngraveStamp(spec?: { text?: string; font?: 'regular' | 'bold' | 'italic' | 'bold-italic'; imageUrl?: string; invert?: boolean }): Promise<{ mask: StampMask; width: number; height: number } | { error: string }>;
@@ -271,6 +272,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
     { id: 'waffle', label: 'Waffle' },
     { id: 'fur', label: 'Fur' },
     { id: 'woven', label: 'Woven' },
+    { id: 'knurl', label: 'Knurl' },
     { id: 'voronoi', label: 'Voronoi (relief)' },
     { id: 'voronoiLamp', label: 'Voronoi lamp' },
     { id: 'engrave', label: 'Engrave' },
@@ -372,7 +374,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
 
   // Modifiers expressible as in-code `api.surface.*` calls. voxelize/voronoiLamp
   // change engines and engrave is a boolean cut, so they stay bake-only.
-  const IN_CODE_IDS = new Set<Tab>(['fuzzy', 'knit', 'cable', 'waffle', 'fur', 'woven', 'voronoi', 'smooth']);
+  const IN_CODE_IDS = new Set<Tab>(['fuzzy', 'knit', 'cable', 'waffle', 'fur', 'woven', 'knurl', 'voronoi', 'smooth']);
   // Tabs that hide the region picker entirely (always whole-model).
   const REGIONLESS_TABS = new Set<Tab>(['voxelize', 'voronoiLamp', 'engrave']);
 
@@ -676,6 +678,29 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
         threadWidth: tw.get(),
         amplitude: amp.get(),
         underDepth: ud.get(),
+        grainAngleDeg: grain.get(),
+        quality: detail.get(),
+        selectedTriangles: activeSelection(),
+      });
+    } else if (active === 'knurl') {
+      const style = dropdown<'diamond' | 'straight' | 'ribs'>('Pattern', [
+        ['diamond', 'Diamond (cross-hatch)'],
+        ['straight', 'Straight (axial splines)'],
+        ['ribs', 'Ribs (horizontal rings)'],
+      ], 'diamond', schedulePreview);
+      const cw = slider('Cell width (ridge spacing)', span * 0.008, span * 0.25, span * 0.05, span * 0.004, n => n.toFixed(3), schedulePreview);
+      const ch = slider('Cell height', span * 0.008, span * 0.25, span * 0.05, span * 0.004, n => n.toFixed(3), schedulePreview);
+      const amp = slider('Amplitude (ridge height)', 0, span * 0.06, span * 0.02, span * 0.001, n => n.toFixed(3), schedulePreview);
+      const sharp = slider('Sharpness', 1, 8, 2, 0.5, n => n.toFixed(1), schedulePreview);
+      const grain = slider('Grain angle (°)', 0, 180, 0, 5, n => String(n) + '°', schedulePreview);
+      body.append(style.wrap, cw.wrap, ch.wrap, amp.wrap, sharp.wrap, grain.wrap, detail.wrap);
+      body.append(el('p', 'text-[11px] text-zinc-500', 'Functional grip relief. Diamond = thumbscrew cross-hatch; straight = axial splines; ribs = horizontal finger rings. Sharpness 1=soft rounded, 2=crisp, 6+=sharp peaks.'));
+      currentOpts = () => ({
+        style: style.get(),
+        cellWidth: cw.get(),
+        cellHeight: ch.get(),
+        amplitude: amp.get(),
+        sharpness: sharp.get(),
         grainAngleDeg: grain.get(),
         quality: detail.get(),
         selectedTriangles: activeSelection(),
@@ -1138,6 +1163,7 @@ export function openSurfaceModal(api: SurfaceApi, initialTab: Tab = 'fuzzy'): vo
         : active === 'waffle' ? await api.applyWaffleStitch(opts)
         : active === 'fur' ? await api.applyFurVelvet(opts)
         : active === 'woven' ? await api.applyWovenFabric(opts)
+        : active === 'knurl' ? await api.applyKnurlTexture(opts)
         : active === 'voronoi' ? await api.applyVoronoiShell(opts)
         : active === 'voronoiLamp' ? await api.applyVoronoiLamp(opts)
         : active === 'engrave' ? await api.engraveModel(opts)
@@ -1179,6 +1205,7 @@ export function initSurfaceUI(api: SurfaceApi): void {
     { id: 'surface-waffle', title: 'Surface: Waffle stitch', hint: 'Modifier', keywords: 'waffle stitch grid honeycomb cell recessed border', run: () => openSurfaceModal(api, 'waffle') },
     { id: 'surface-fur', title: 'Surface: Fur / velvet', hint: 'Modifier', keywords: 'fur velvet pile fabric soft directional fiber', run: () => openSurfaceModal(api, 'fur') },
     { id: 'surface-woven', title: 'Surface: Woven fabric', hint: 'Modifier', keywords: 'woven weave fabric basket cloth interlace thread', run: () => openSurfaceModal(api, 'woven') },
+    { id: 'surface-knurl', title: 'Surface: Knurl grip', hint: 'Modifier', keywords: 'knurl knurling grip diamond cross-hatch straight splines ribs knob thumbscrew handle texture', run: () => openSurfaceModal(api, 'knurl') },
     { id: 'surface-voronoi', title: 'Surface: Voronoi texture', hint: 'Modifier', keywords: 'voronoi cell relief organic cracked web ridges struts texture', run: () => openSurfaceModal(api, 'voronoi') },
     { id: 'surface-voronoi-lamp', title: 'Surface: Voronoi lamp (perforated shell)', hint: 'Modifier', keywords: 'voronoi lamp shell lattice perforated cutout holes see-through planter lampshade voxel', run: () => openSurfaceModal(api, 'voronoiLamp') },
     { id: 'surface-engrave', title: 'Surface: Engrave / emboss / cut-through text or image', hint: 'Modifier', keywords: 'engrave emboss carve raised relief cut through text image stencil label logo name plate recess channel color', run: () => openSurfaceModal(api, 'engrave') },

--- a/tests/unit/surface.test.ts
+++ b/tests/unit/surface.test.ts
@@ -14,6 +14,7 @@ import { cableKnit } from '../../src/surface/cableKnit';
 import { waffleStitch } from '../../src/surface/waffleStitch';
 import { furVelvet } from '../../src/surface/furVelvet';
 import { wovenFabric } from '../../src/surface/wovenFabric';
+import { knurlTexture } from '../../src/surface/knurlTexture';
 import { voronoiShell } from '../../src/surface/voronoiShell';
 import { voronoiLattice } from '../../src/surface/voronoiLattice';
 import { surfaceNetsField } from '../../src/surface/surfaceNetsField';
@@ -186,6 +187,7 @@ describe('fabric textures (cable / waffle / fur / woven / voronoi)', () => {
     { name: 'furVelvet', fn: furVelvet as (m: MeshData, o: Record<string, number>) => MeshData, opts: { amplitude: 0.5, fiberSpacing: 2, seed: 3 } },
     { name: 'wovenFabric', fn: wovenFabric as (m: MeshData, o: Record<string, number>) => MeshData, opts: { amplitude: 0.5, threadSpacing: 2, seed: 3 } },
     { name: 'voronoiShell', fn: voronoiShell as (m: MeshData, o: Record<string, number>) => MeshData, opts: { amplitude: 0.5, cellSize: 3, seed: 3 } },
+    { name: 'knurlTexture', fn: knurlTexture as (m: MeshData, o: Record<string, number>) => MeshData, opts: { amplitude: 0.5, cellWidth: 2, seed: 3 } },
   ] as const;
 
   for (const { name, fn, opts } of cases) {
@@ -210,6 +212,28 @@ describe('fabric textures (cable / waffle / fur / woven / voronoi)', () => {
       expect([...out.triColors!].every(v => v === 42)).toBe(true);
     });
   }
+});
+
+describe('knurlTexture', () => {
+  it('the three styles produce distinct displacements', () => {
+    const diamond = knurlTexture(cube(10), { amplitude: 0.5, cellWidth: 2, style: 'diamond' });
+    const straight = knurlTexture(cube(10), { amplitude: 0.5, cellWidth: 2, style: 'straight' });
+    const ribs = knurlTexture(cube(10), { amplitude: 0.5, cellWidth: 2, style: 'ribs' });
+    expect([...diamond.vertProperties]).not.toEqual([...straight.vertProperties]);
+    expect([...straight.vertProperties]).not.toEqual([...ribs.vertProperties]);
+  });
+
+  it('displacement is outward-bounded by amplitude (ridges only raise)', () => {
+    // A knurl raises the surface by [0, amplitude] along the normal; on an
+    // axis-aligned cube face the max coordinate can grow by at most amplitude.
+    const amp = 0.5;
+    const out = knurlTexture(cube(10), { amplitude: amp, cellWidth: 2, style: 'diamond' });
+    let maxX = -Infinity;
+    for (let v = 0; v < out.numVert; v++) maxX = Math.max(maxX, out.vertProperties[v * 3]);
+    // Cube spans [0,10]; the +X face can rise to at most 10 + amplitude (+ε).
+    expect(maxX).toBeLessThanOrEqual(10 + amp + 1e-3);
+    expect(maxX).toBeGreaterThan(10); // something raised
+  });
 });
 
 describe('voronoiShell', () => {


### PR DESCRIPTION
## Summary

Adds **knurl** to the Surface panel's texture family so a functional grip can be applied to **any** mesh — a knob you sculpted, a bottle, a pen barrel — not just to a generated cylinder.

This is the UI-driven counterpart to the `api.knurl.*` shape generator (shipped in #577). They're complementary: the generator *builds* a knurled cylinder; this texture *displaces an existing surface*, exactly like the waffle/woven textures already in the panel.

### What it does
- Three patterns via a **style** dropdown: `diamond` (cross-hatch), `straight` (axial splines), `ribs` (horizontal finger rings).
- Full Surface-panel integration: tab + style dropdown + cell-width/height/amplitude/sharpness/grain sliders, live preview, **region/patch** selection (texture only painted triangles), and **"Apply as code"** → `api.surface.knurl({…})`.
- Console + AI parity: `partwright.applyKnurlTexture({...})`, the `api.surface.knurl` in-code op, `help()` entry, command-palette entry.

### Implementation
Mirrors the waffle/woven sibling pattern end to end:
- `src/surface/knurlTexture.ts` — triplanar normal-displacement math (subdivide → displace), reused by the bake and in-code paths.
- `applyKnurl` / `applyKnurlPatch` / `defaultKnurlOptions` in `modifiers.ts`; the `SurfaceModifierId`/`SurfaceOpId` unions; `SURFACE_OP_FIELDS` (incl. the `style` key); `surfaceOps.ts` dispatch; `api.surface.knurl` in `manifoldJs.ts`; `main.ts` `buildSurfaceModifier` block + `textureWarnings` + `applyKnurlTexture` + `help()`; `surfaceModal.ts` tab/controls/dispatch + command-palette entry; `public/ai/textures.md`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test:unit` — 1198 passed, incl. new knurl cases (three styles distinct; displacement bounded to [0, amplitude])
- [x] `npm run lint:deps` (acyclic), `lint:consistency` (no new hits)
- [x] Manual browser check: `applyKnurlTexture` baked a cylinder to 389k tris (manifold) with a clear diamond cross-hatch; command palette → Surface panel opens on the **Knurl** tab with the Pattern dropdown + sliders rendering. (Screenshots in session.)
- [ ] PR-checks e2e shards green

Note: `model:preview` intentionally can't verify this — the SSR engine doesn't run the main-thread surface ops — so verification is unit tests + the browser spec.

https://claude.ai/code/session_01Sp9BBtoRetThUCQjQw4kPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sp9BBtoRetThUCQjQw4kPF)_