### PR TITLE
feat: arrange API parity, hand-written parts, Ctrl-Z, live marquee

### DIFF
--- a/prompts/20260612-000000-arrange-followups-api-parity.md
+++ b/prompts/20260612-000000-arrange-followups-api-parity.md
@@ -1,0 +1,116 @@
+---
+session: "aiK0c"
+timestamp: "2026-06-12T00:00:00Z"
+sequence: 6
+---
+
+## Human
+
+(After PR #603 merged.) We'll want a follow-up PR for the gaps I called out:
+UI ↔ JS-API parity (arrange/undo/align/resize/group on `window.partwright` +
+`help()` + `public/ai.md`); hand-written parts should also be draggable
+(scan code on arrange enter, seed registry); rotation, Z-axis drag,
+group-centroid transforms; Ctrl-Z / Ctrl-Shift-Z keyboard; live highlight
+during marquee; snap-to-grid; missing e2e (drag→undo, Group on marquee,
+session-change clear); lint:deadcode + lint:consistency; work-reviewer.
+
+## Assistant
+
+## Scoped this PR to the high-value / low-risk subset
+
+11 follow-ups span "30 minutes" to "1-2 days." Rolled the foundation pieces
+into one reviewable PR; deferred the big tilt-the-table features (rotation,
+Z-drag, group centroid, snap-to-grid) to their own follow-ups since each is
+substantial enough to deserve its own design + test pass.
+
+This PR delivers: API parity • hand-written parts • keyboard shortcuts •
+live marquee highlight • test gaps closed • lint hygiene.
+
+## Decisions
+
+**API parity surface, mirrored 1:1 with the panel buttons.** Added 20 new
+methods on `window.partwright` covering the full arrange flow: `enterArrange`/
+`exitArrange`/`isArrangeActive`, selection ops (`selectParts`/
+`addToSelection`/`clearSelection`/`getSelection`/`listArrangeParts`),
+history (`undo`/`redo`/`canUndo`/`canRedo`), transforms (`resizeSelection`/
+`alignSelection`), and the operation row (`group`/`subtract`/`intersect`/
+`duplicate`/`mirror`/`deleteSelection`). Each one wraps the same internal
+`apply*` the panel calls — selection Set, registry, and undo stack are shared
+instances, so alternating UI and console calls just works. Added all to the
+`help()` table and the `## Arrange mode` section in `public/ai.md`.
+
+Methods return `{ok:true}` or `{ok:false, reason}` rather than throwing on
+"no selection" / "voxel grids union implicitly" / "selection lost in code"
+— same pattern as the rest of the value-returning surface (CLAUDE.md
+"argument validation" section).
+
+**Hand-written parts: regex inverter for the common shapes per language.**
+Added `src/insert/parseStatement.ts` (pure leaf, no deps) that recovers a
+`PrimitiveSpec` from the construction call of a statement — handles:
+
+- **voxel:** `v.fillBox`, `v.sphere`, `v.cylinder`, `v.sdf(api.sdf.torus(…))`
+- **scad:** optional `translate([…])` + `cube`/`sphere`/`cylinder` (cone via
+  `cylinder(h, r1, r2)`)
+- **JS/BREP:** `Manifold.cube({…}|[…])`, `Manifold.sphere(r|{radius})`,
+  `Manifold.cylinder(h, r)`, `BREP.cube`/`sphere`/`cylinder(r, h)`/`cone`/
+  `torus`, all with optional trailing `.translate([…])`.
+
+For everything else (chained `.rotate`/`.color`, computed args, custom
+expressions) the parser returns null and the part stays unregistered —
+graceful degradation, never a wrong bounding box. arrangeMode's
+`enterArrangeMode` calls `seedRegistryFromCode()` once before activating the
+canvas listener, so the first click finds hand-written parts the same way
+it finds palette-inserted ones.
+
+Extended `scanPartsJs` to also return the full statement text for single-line
+`const` declarations so the parser has something to read. (A multi-line
+declaration whose RHS spans lines without an embedded `;` still works.)
+
+**Keyboard shortcuts route through the central installKeyboardShortcuts.**
+Two cases, mirroring how voxel-studio + paint already split it:
+- Arrange mode **active** → ⌘Z / ⌘⇧Z (Ctrl+Y on non-mac) routes to the
+  palette stack *even when focus is in the editor* (same override as voxel
+  studio), so an arrange drag is one ⌘Z away from being reversed.
+- Arrange mode **not active**, palette stack has history, focus outside the
+  editor → routeUndo/Redo's fall-through hits the palette stack as a "global
+  Tinkercad undo." Inside the code editor the native CodeMirror undo still
+  wins, matching every other text-undo flow.
+
+**Live marquee highlight.** During shift+drag, every part whose bbox centre
+projects inside the rect right now gets a translucent yellow box (opacity
+0.4 vs the solid 0.95 of a real selection box). Built on a separate
+`marqueeCandidateBoxByName` Map so it doesn't disturb the actual selection;
+`updateMarquee` recomputes candidates per pointer move, `commitMarquee` /
+`cancelMarquee` dispose them.
+
+## What this PR does NOT do (own follow-up PRs)
+
+- **Rotation** (per-engine `.rotate([…])` codegen + UI + group-centroid math)
+- **Z-axis drag** (alt-modifier or vertical handle)
+- **Group-centroid transforms** for multi-select resize/rotate
+- **Snap-to-grid** for non-voxel engines
+
+These are each substantial enough to deserve their own design + tests pass.
+Called out in the PR description.
+
+## Tests
+
+- 18 new parseStatement unit tests (in the e2e tier's pure-logic spec)
+  covering voxel / scad / JS / BREP success + null-fallback paths.
+- 4 new palette e2e: console-API alignSelection round-trip, console-API
+  undo/redo round-trip, hand-written parts seed on enter, drag→undo restores
+  position.
+
+Total: 16 palette e2e + 159 codegen-tier tests, all green; typecheck +
+acyclic deps + lint:consistency / lint:deadcode (no new hits in changed
+files).
+
+## Manual verification
+
+- `partwright.enterArrange()` + `partwright.listArrangeParts()` from the
+  console on a hand-written model: returns both `myCube` and `myBall` with
+  correct bboxes.
+- ⌘Z after a marquee → Group: reverses the whole boolean in one step (one
+  Tinkercad-style undo).
+- Shift+drag marquee shows the lasso filling in live as I move the
+  rect — releases into the solid yellow selection boxes without a flicker.

--- a/prompts/20260612-004700-arrange-review-fixes.md
+++ b/prompts/20260612-004700-arrange-review-fixes.md
@@ -1,0 +1,82 @@
+---
+session: "aiK0c"
+timestamp: "2026-06-12T00:47:00Z"
+sequence: 7
+---
+
+## Human
+
+(work-reviewer subagent output on the arrange-followups branch.) Two
+IMPORTANT findings + a whitespace nit. Address the lot before pushing.
+
+1. `scanPartsJs` greedy RHS pattern stops at the first `;` even inside a
+   string literal — `const greeting = "hi;bye";` yields a truncated
+   statement, and the header-only fallback's `name`-keyed dedupe lets the
+   broken entry stick. Fix: make the header fallback REPLACE the broken
+   entry, or drop the greedy path entirely.
+2. UI ↔ JS-API parity miss: the panel's "Auto-combine new shapes"
+   checkbox isn't on `window.partwright.*`. Add `setAutoCombine`/
+   `getAutoCombine` or document the deliberate skip.
+3. `partwright.enterArrange()` opens the panel as a side effect.
+   Document it (or make it opt-in).
+4. Help-table whitespace drift on canUndo/canRedo.
+
+## Assistant
+
+## Decisions
+
+**Rewrote `scanPartsJs` head-only + skip-aware walker.** Instead of patching
+the greedy regex, switched to a head-match (`^const name =`) plus a
+`findStatementEnd` helper that walks forward from there tracking string,
+template, line/block comment, and bracket-balance state. The walker can't
+be confused by a `;` inside `"…"` / `'…'` / `` `…` `` or inside a `(…)` /
+`[…]` / `{…}` because it only treats top-level (depth-0, outside-string-or-
+comment) `;` as the terminator. Drops the prior "header-only fallback"
+entirely — there's now a single, correct path.
+
+Used a `byName` index Map instead of a `seen` Set so a future change that
+wants to replace (not dedupe) earlier matches has a one-line edit; the
+current semantics are still "first wins" / dedupe.
+
+Regression tests: `const greeting = "hi;bye";` produces `statement.endsWith(';')`
+and contains the full string literal; a multi-line `Manifold.cube(...).translate(...)`
+captures the trailing `.translate` too.
+
+**Auto-combine API: `setAutoCombine(on)` mirrors the checkbox both ways.**
+Added a module-level `autoCombineCheckbox` ref so the API path can flip the
+DOM toggle when called (otherwise a user who opens the panel after a
+scripted `setAutoCombine(false)` would see the box still ticked but inserts
+acting un-combined — a real "what is going on" UX trap). `assertBoolean`
+validates the arg the same way the other viewport-control booleans do.
+
+**Documented enterArrange's panel side effect, didn't make it opt-in.**
+The panel needs to be visible for the chip strip / Undo / Size / Align to
+mean anything to the user; making it opt-in would invite "the API moved a
+shape but I have no UI to undo it" surprise paths. Added a `**Side
+effect:**` block in the JSDoc and a paragraph in the `## Arrange mode`
+section of `public/ai.md` so headless callers know what they're getting.
+
+**Whitespace alignment.** Adjusted two `canUndo`/`canRedo` rows in
+`help()` to match the surrounding pattern.
+
+## Schema/back-compat (verified during the rewrite)
+
+The new walker can return shorter statements than the prior pattern for one
+edge case: a `const x = doSomething(); return …` on the same line would now
+stop after `doSomething();` (correct), where the old greedy match would
+ALSO have stopped there (matches). No consumer regression — `\.statement`
+is only read by parseStatement (graceful null on mismatch) and as tooltip
+text.
+
+## Tests
+
+- 2 new scanPartsJs cases (string-literal trap, multi-line).
+- All 18 palette e2e + 161 codegen tests still green; typecheck + acyclic
+  deps + lint:consistency / lint:deadcode (no new hits).
+
+## Manual verification
+
+Console smoke: `partwright.setAutoCombine(false); partwright.getAutoCombine()`
+returns `false`, the panel checkbox unticks live, subsequent shape inserts
+go in *without* a chained `.add(...)` join. `partwright.setAutoCombine(true)`
+flips it back.

--- a/public/ai.md
+++ b/public/ai.md
@@ -272,6 +272,8 @@ partwright.mirrorSelection('x')           // Mirror across axis
 partwright.deleteSelection()              // Remove selected parts from the code
 partwright.undo() / partwright.redo()     // Coarse-grained: one Tinkercad action = one step
 partwright.canUndo() / partwright.canRedo()
+partwright.setAutoCombine(false)          // Insert without auto-union (managed engines)
+partwright.getAutoCombine()               // -> boolean
 await partwright.exportGLB()   // Download GLB (browser file dialog -- prefer exportGLBData() in agent flows)
 partwright.exportSTL()         // Download STL ("                                       exportSTLData() ")
 partwright.exportOBJ()         // Download OBJ ("                                       exportOBJData() ")
@@ -1050,6 +1052,8 @@ partwright.exitArrange();
 ```
 
 A successful action returns `{ ok: true }`; rejected ones return `{ ok: false, reason: <why> }` (e.g. `'no selection'`, `'need 2+ parts'`, `'voxel grids union implicitly'`). The selection set, registry, and undo stack are the **same** instances the panel buttons use — alternating UI clicks and `partwright.*` calls is supported.
+
+**`enterArrange()` opens the Insert panel as a side effect** so the chip strip, Size/Align inputs, and Undo/Redo buttons are visible — matching what a user sees when they enable arrange by hand. Headless flows that just want the canvas pointer hook should still call it; the panel doesn't steal focus from `partwright.*` calls.
 
 **Caveats.** Hand-written parts the regex parser can't decode (chained `.rotate()`, computed args, custom expressions) stay out of the registry and are skipped silently. The current Z-axis drag is locked to a horizontal plane through the pickup point. Voxel grids union implicitly, so `groupSelection` / `subtractSelection` / `intersectSelection` are no-ops in a voxel session.
 

--- a/public/ai.md
+++ b/public/ai.md
@@ -252,6 +252,26 @@ partwright.setTheme('dark'|'light')  // Set color theme
 partwright.getTheme()                // -> 'dark' or 'light'
 partwright.setAutoRun(enabled)       // Enable/disable auto-render on code edit
 partwright.isAutoRunEnabled()        // Whether auto-run is active
+
+// Arrange mode (Tinkercad-style direct manipulation) -- see #arrange-mode
+partwright.enterArrange()                 // Activate the click-to-select / drag-to-move tool -> {ok}
+partwright.exitArrange()                  // Deactivate
+partwright.isArrangeActive()              // -> boolean
+partwright.selectParts(['box','ball'])    // Replace selection -> matched names
+partwright.addToSelection(['cyl'])        // Extend (shift-click equivalent) -> matched names
+partwright.clearSelection()
+partwright.getSelection()                 // -> string[]
+partwright.listArrangeParts()             // -> [{name, box:{min,max}, center}] every part the tool knows about
+partwright.resizeSelection([2,1,1])       // Per-axis scale (or uniform [s,s,s]) -> {ok, reason?}
+partwright.alignSelection('z','center')   // axis 'x'|'y'|'z', mode 'min'|'center'|'max' -> {ok, reason?}
+partwright.groupSelection()               // ∪ Union the selected parts in code (not voxel) -> {ok, reason?}
+partwright.subtractSelection()            // ∖ first - rest
+partwright.intersectSelection()           // ∩
+partwright.duplicateSelection()           // Clone, offset along +X -> {ok}
+partwright.mirrorSelection('x')           // Mirror across axis
+partwright.deleteSelection()              // Remove selected parts from the code
+partwright.undo() / partwright.redo()     // Coarse-grained: one Tinkercad action = one step
+partwright.canUndo() / partwright.canRedo()
 await partwright.exportGLB()   // Download GLB (browser file dialog -- prefer exportGLBData() in agent flows)
 partwright.exportSTL()         // Download STL ("                                       exportSTLData() ")
 partwright.exportOBJ()         // Download OBJ ("                                       exportOBJData() ")
@@ -1007,4 +1027,29 @@ Read `partwright.getSpendingMode()` at session start and honor the user's budget
 Users can mark up the model surface with the **Annotate** tool (✏️ in the viewport overlay): freehand strokes raycast onto the mesh, and text labels pinned to a 3D anchor. Annotations are per-version, persist in session exports, and are distinct from color regions — they do not modify geometry.
 
 **Call `readDoc({name: "annotations"})`** when the user has placed annotations and you want to read them, or when you need to write annotations programmatically — covers the `getAnnotations` / `setAnnotations` shape and the persistence model.
+
+## Arrange mode
+
+<a id="arrange-mode"></a>
+
+Arrange mode is the Tinkercad-style direct-manipulation tool reached from the Insert palette: a persistent viewport mode where clicking a shape selects it, shift-click extends the selection, drag slides parts around, and a shift-drag marquee lassos every part whose centre lands inside it. The same selection drives **Size** (per-axis scale), **Align** (min/center/max along X/Y/Z), and the **Operations** row (Group / Subtract / Intersect / Duplicate / Mirror / Delete). Every action is recorded in a coarse-grained **undo** stack — one Tinkercad-style gesture = one Ctrl-Z step — independent of CodeMirror's per-text-edit history.
+
+The tool also seeds itself from the live code when you enter it: any hand-written declaration the parser recognises (e.g. `const myCube = Manifold.cube([10,10,10]).translate([5,0,0])`, `cube([10,10,10]) // part: foo`, `v.fillBox([0,0,0],[10,10,10],'#abc') // part: ball`) becomes draggable / resizable / alignable — not just parts you inserted from the palette.
+
+Every UI action is exposed on `window.partwright` so you can drive the same flow from code:
+
+```js
+partwright.enterArrange();
+partwright.selectParts(['ball', 'box']);   // Replace selection
+partwright.alignSelection('z', 'min');     // Drop them to the same Z floor
+partwright.resizeSelection([2, 2, 1]);     // 2x2x1 anisotropic scale
+partwright.groupSelection();               // ∪ Union them in code
+partwright.undo();                         // Reverse one step
+partwright.listArrangeParts();             // [{name, box:{min,max}, center}, …]
+partwright.exitArrange();
+```
+
+A successful action returns `{ ok: true }`; rejected ones return `{ ok: false, reason: <why> }` (e.g. `'no selection'`, `'need 2+ parts'`, `'voxel grids union implicitly'`). The selection set, registry, and undo stack are the **same** instances the panel buttons use — alternating UI clicks and `partwright.*` calls is supported.
+
+**Caveats.** Hand-written parts the regex parser can't decode (chained `.rotate()`, computed args, custom expressions) stay out of the registry and are skipped silently. The current Z-axis drag is locked to a horizontal plane through the pickup point. Voxel grids union implicitly, so `groupSelection` / `subtractSelection` / `intersectSelection` are no-ops in a voxel session.
 

--- a/src/insert/arrangeMode.ts
+++ b/src/insert/arrangeMode.ts
@@ -24,6 +24,7 @@ import { primitiveEntry, pickPart, type RegistryEntry } from './spatial';
 import { type PrimitiveSpec, type Vec3, type InsertLanguage } from './codegen';
 import { alignDeltas, formatScaleCall, type AlignAxis, type AlignMode } from './arrangeMath';
 import { recordOperation } from './undoStack';
+import { parseStatement } from './parseStatement';
 
 // Re-export the pure helpers so callers can pick them up from one entry point.
 export { alignDeltas, formatScaleCall };
@@ -103,6 +104,12 @@ let marquee: {
   shiftAtStart: boolean; // true ⇒ additive (preserve existing selection)
 } | null = null;
 
+// Preview wireframes painted on parts the marquee currently covers, so the user
+// sees the lasso filling in live instead of only when they release. Lighter
+// styling (thinner / more transparent) than the real selection box so the user
+// can tell them apart at a glance.
+const marqueeCandidateBoxByName = new Map<string, THREE.LineSegments>();
+
 export function initArrangeMode(d: ArrangeModeDeps): void {
   deps = d;
 }
@@ -118,6 +125,10 @@ export function enterArrangeMode(): void {
     deps.getCb()?.showToast('Open a model first to enter Arrange mode.', { variant: 'warn' });
     return;
   }
+  // Seed the registry from the live code BEFORE we activate listeners so the
+  // first click finds hand-written parts (typed straight into the editor) the
+  // same way it finds palette-inserted ones.
+  seedRegistryFromCode();
   active = true;
   overlayGroup = new THREE.Group();
   overlayGroup.renderOrder = 999;
@@ -135,6 +146,33 @@ export function enterArrangeMode(): void {
     { variant: 'neutral' },
   );
   requestRender();
+}
+
+/** Walk the live code's parts list and seed `specByName` + `registry` for any
+ *  part the palette didn't already know about. This is the bridge that makes
+ *  hand-written declarations (`const myCube = Manifold.cube([...]);`,
+ *  `v.sphere([...], r, '#...'); // part: ball`, etc.) draggable / resizable /
+ *  alignable from arrange mode — without it, only palette-inserted parts were
+ *  arrangeable, which the May 2026 follow-up audit called out as a real gap.
+ *
+ *  Best-effort: parseStatement returns null for any shape it doesn't
+ *  recognise (computed args, custom expressions, chained transforms beyond
+ *  `.translate`); those parts just stay out of the registry and the existing
+ *  "click hits nothing" fallback applies. */
+function seedRegistryFromCode(): void {
+  if (!deps) return;
+  const cb = deps.getCb();
+  if (!cb) return;
+  const lang = cb.getLanguage();
+  const parts = deps.scanParts(cb.getCode(), lang);
+  for (const part of parts) {
+    if (deps.specByName.has(part.name)) continue;
+    if (!part.statement) continue;
+    const spec = parseStatement(part.statement, lang, part.name);
+    if (!spec) continue;
+    deps.specByName.set(part.name, spec);
+    deps.registry.set(part.name, primitiveEntry(spec));
+  }
 }
 
 export function exitArrangeMode(): void {
@@ -482,6 +520,79 @@ function updateMarquee(clientX: number, clientY: number): void {
   marquee.el.style.top = `${y}px`;
   marquee.el.style.width = `${w}px`;
   marquee.el.style.height = `${h}px`;
+  refreshMarqueeCandidates(marquee.el.getBoundingClientRect());
+}
+
+/** Repaint the live candidate wireframes — every part whose bbox centre
+ *  currently projects inside the marquee rect gets a translucent yellow box so
+ *  the user sees the lasso filling in as they drag. Idempotent: drops boxes
+ *  for parts that have fallen outside the rect, adds new ones for entrants. */
+function refreshMarqueeCandidates(rect: DOMRect): void {
+  if (!deps || !overlayGroup) return;
+  const camera = deps.getCamera();
+  const canvas = deps.getCanvas();
+  if (!camera || !canvas) return;
+
+  const inside = new Set<string>();
+  for (const [name, entry] of deps.registry) {
+    // Already in the real selection? Skip — the solid yellow box owns it.
+    if (deps.selection.has(name)) continue;
+    const screen = projectWorldToScreen(entry.center, camera, canvas);
+    if (!screen) continue;
+    if (screen.x >= rect.left && screen.x <= rect.right && screen.y >= rect.top && screen.y <= rect.bottom) {
+      inside.add(name);
+    }
+  }
+
+  // Drop preview boxes that no longer match.
+  for (const [name, box] of [...marqueeCandidateBoxByName]) {
+    if (!inside.has(name) || !deps.registry.has(name)) {
+      overlayGroup.remove(box);
+      disposeLines(box);
+      marqueeCandidateBoxByName.delete(name);
+    }
+  }
+  // Add boxes for fresh entrants.
+  for (const name of inside) {
+    if (marqueeCandidateBoxByName.has(name)) continue;
+    const entry = deps.registry.get(name);
+    if (!entry) continue;
+    const box = makeMarqueeCandidateBox(entry);
+    overlayGroup.add(box);
+    marqueeCandidateBoxByName.set(name, box);
+  }
+  requestRender();
+}
+
+function makeMarqueeCandidateBox(entry: RegistryEntry): THREE.LineSegments {
+  const dx = Math.max(entry.box.max[0] - entry.box.min[0], 0.001);
+  const dy = Math.max(entry.box.max[1] - entry.box.min[1], 0.001);
+  const dz = Math.max(entry.box.max[2] - entry.box.min[2], 0.001);
+  const boxGeo = new THREE.BoxGeometry(dx, dy, dz);
+  const edges = new THREE.EdgesGeometry(boxGeo);
+  boxGeo.dispose();
+  const mat = new THREE.LineBasicMaterial({
+    color: 0xffd34d,
+    transparent: true,
+    opacity: 0.4,
+    depthTest: false,
+  });
+  const lines = new THREE.LineSegments(edges, mat);
+  lines.renderOrder = 999;
+  lines.position.set(entry.center[0], entry.center[1], entry.center[2]);
+  return lines;
+}
+
+function clearMarqueeCandidates(): void {
+  if (!overlayGroup) {
+    marqueeCandidateBoxByName.clear();
+    return;
+  }
+  for (const [, box] of marqueeCandidateBoxByName) {
+    overlayGroup.remove(box);
+    disposeLines(box);
+  }
+  marqueeCandidateBoxByName.clear();
 }
 
 function commitMarquee(): void {
@@ -494,6 +605,10 @@ function commitMarquee(): void {
   const h = rect.height;
   marquee.el.remove();
   marquee = null;
+  // Drop the live candidate previews — refreshArrangeOverlay below paints the
+  // real solid selection boxes for the same parts (no flicker because the
+  // refresh happens in the same tick).
+  clearMarqueeCandidates();
   // A near-zero drag is treated as a click on empty space — just deselect.
   // (Threshold matches DRAG_THRESHOLD_PX so a click-to-deselect path that
   // happened to be shift-held doesn't accidentally hold the selection.)
@@ -526,9 +641,13 @@ function commitMarquee(): void {
 }
 
 function cancelMarquee(): void {
-  if (!marquee) return;
+  if (!marquee) {
+    clearMarqueeCandidates();
+    return;
+  }
   marquee.el.remove();
   marquee = null;
+  clearMarqueeCandidates();
   if (active) refreshArrangeOverlay();
 }
 

--- a/src/insert/codegen.ts
+++ b/src/insert/codegen.ts
@@ -633,29 +633,25 @@ export function emitOperationScad(op: BooleanOpKind, operands: string[], resultN
  *  re-derives from the live code each call so renames/deletes self-correct. */
 export function scanPartsJs(code: string): PartRef[] {
   const out: PartRef[] = [];
-  const seen = new Set<string>();
+  const byName = new Map<string, number>(); // name → index in `out`
   const push = (ref: PartRef) => {
-    if (seen.has(ref.name)) return;
-    seen.add(ref.name);
+    if (byName.has(ref.name)) return;
+    byName.set(ref.name, out.length);
     out.push(ref);
   };
-  // 1) Plain `const name = …;` — capture the full RHS up to the line-ending
-  //    `;` (allowing the statement to span multiple lines as long as the
-  //    semicolon is the first one at column 0..N after the head). The optional
-  //    statement text lets parseStatement (used by arrange mode to seed
-  //    registry entries for hand-written parts) read the construction call.
-  const re = /^[ \t]*(?:const|let)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*([^\n;]*(?:\n[^\n;]*)*);/gm;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(code)) !== null) {
-    const from = m.index;
-    const to = m.index + m[0].length;
-    push({ name: m[1], statement: m[0], range: { from, to } });
-  }
-  // 1b) Header-only fallback for declarations whose RHS the greedy match above
-  //     didn't span (e.g. embedded `;` inside a string literal — rare). Picks
-  //     up just the name so the operand list isn't ever wrong.
+  // 1) Plain `const name = expr;` — extract names + the statement text. The
+  //    optional `statement`/`range` fields let parseStatement (used by arrange
+  //    mode to seed registry entries for hand-written parts) read the
+  //    construction call. We anchor on the bare head so a stray semicolon
+  //    inside a string literal can't truncate the captured statement, and
+  //    then walk forward to the real end-of-statement.
   const head = /^[ \t]*(?:const|let)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=/gm;
-  while ((m = head.exec(code)) !== null) push({ name: m[1] });
+  let m: RegExpExecArray | null;
+  while ((m = head.exec(code)) !== null) {
+    const end = findStatementEnd(code, m.index + m[0].length);
+    if (end < 0) { push({ name: m[1] }); continue; }
+    push({ name: m[1], statement: code.slice(m.index, end), range: { from: m.index, to: end } });
+  }
   // 2) Object-destructure binders — `const { base, lid } = enclosure.box(…)`.
   //    Each bound name is a part. Skip `… = api` (that's the sandbox
   //    destructure: `const { Manifold, CrossSection } = api`), whose names are
@@ -673,6 +669,43 @@ export function scanPartsJs(code: string): PartRef[] {
     }
   }
   return out;
+}
+
+/** Walk forward from `start` until the statement-terminating `;`, skipping
+ *  past string/template/comment content and balanced (), [], {}. Returns the
+ *  exclusive end index (one past the `;`) or -1 if no terminator was found. */
+function findStatementEnd(code: string, start: number): number {
+  let depth = 0;
+  let i = start;
+  const n = code.length;
+  while (i < n) {
+    const c = code[i];
+    if (c === '/' && code[i + 1] === '/') {
+      const nl = code.indexOf('\n', i);
+      i = nl < 0 ? n : nl + 1;
+      continue;
+    }
+    if (c === '/' && code[i + 1] === '*') {
+      const e = code.indexOf('*/', i + 2);
+      i = e < 0 ? n : e + 2;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      i++;
+      while (i < n && code[i] !== quote) {
+        if (code[i] === '\\') i += 2;
+        else i++;
+      }
+      i++;
+      continue;
+    }
+    if (c === '(' || c === '[' || c === '{') { depth++; i++; continue; }
+    if (c === ')' || c === ']' || c === '}') { depth--; i++; continue; }
+    if (c === ';' && depth === 0) return i + 1;
+    i++;
+  }
+  return -1;
 }
 
 /** Voxel: each `v.<method>(…); // part: <name>` line is a part. Returns the

--- a/src/insert/codegen.ts
+++ b/src/insert/codegen.ts
@@ -634,16 +634,28 @@ export function emitOperationScad(op: BooleanOpKind, operands: string[], resultN
 export function scanPartsJs(code: string): PartRef[] {
   const out: PartRef[] = [];
   const seen = new Set<string>();
-  const push = (name: string) => {
-    if (seen.has(name)) return;
-    seen.add(name);
-    out.push({ name });
+  const push = (ref: PartRef) => {
+    if (seen.has(ref.name)) return;
+    seen.add(ref.name);
+    out.push(ref);
   };
-  // 1) Plain `const name =` / `let name =` at the start of a (possibly
-  //    indented) line.
-  const re = /^[ \t]*(?:const|let)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=/gm;
+  // 1) Plain `const name = …;` — capture the full RHS up to the line-ending
+  //    `;` (allowing the statement to span multiple lines as long as the
+  //    semicolon is the first one at column 0..N after the head). The optional
+  //    statement text lets parseStatement (used by arrange mode to seed
+  //    registry entries for hand-written parts) read the construction call.
+  const re = /^[ \t]*(?:const|let)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*([^\n;]*(?:\n[^\n;]*)*);/gm;
   let m: RegExpExecArray | null;
-  while ((m = re.exec(code)) !== null) push(m[1]);
+  while ((m = re.exec(code)) !== null) {
+    const from = m.index;
+    const to = m.index + m[0].length;
+    push({ name: m[1], statement: m[0], range: { from, to } });
+  }
+  // 1b) Header-only fallback for declarations whose RHS the greedy match above
+  //     didn't span (e.g. embedded `;` inside a string literal — rare). Picks
+  //     up just the name so the operand list isn't ever wrong.
+  const head = /^[ \t]*(?:const|let)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=/gm;
+  while ((m = head.exec(code)) !== null) push({ name: m[1] });
   // 2) Object-destructure binders — `const { base, lid } = enclosure.box(…)`.
   //    Each bound name is a part. Skip `… = api` (that's the sandbox
   //    destructure: `const { Manifold, CrossSection } = api`), whose names are
@@ -657,7 +669,7 @@ export function scanPartsJs(code: string): PartRef[] {
       // Handle `a: b` aliasing — the *binding* name is after the colon.
       const part = raw.includes(':') ? raw.split(':')[1] : raw;
       const name = part.trim().replace(/^\.\.\./, '');
-      if (/^[A-Za-z_$][\w$]*$/.test(name)) push(name);
+      if (/^[A-Za-z_$][\w$]*$/.test(name)) push({ name });
     }
   }
   return out;

--- a/src/insert/parseStatement.ts
+++ b/src/insert/parseStatement.ts
@@ -1,0 +1,288 @@
+// Best-effort statement → PrimitiveSpec inverter. Lets arrange mode pick up
+// hand-written parts (typed straight into the editor) instead of only the
+// palette-inserted ones whose specs we kept in memory.
+//
+// Pure, dependency-free, regex-based. Each parser is the rough inverse of the
+// matching `emitPrimitive*` in codegen.ts and handles only the common patterns
+// that emit produces — anything fancier (rotations, chained transforms, JS
+// expressions with computed args) falls through as `null` and the part stays
+// unregistered. Callers treat null as "not arrangeable; skip silently."
+//
+// Scope per language:
+//   - voxel: `v.fillBox`, `v.sphere`, `v.cylinder`, `v.sdf(api.sdf.torus(...))`
+//   - scad:  optional leading `translate([…])` then `cube([…], center=…)` /
+//            `sphere(r=…)` / `cylinder(h=…, r=…, center=…)`
+//   - JS:    optional `const x = Manifold.cube({…} or [...])` / sphere / cylinder /
+//            cone with optional trailing `.translate([…])`
+//
+// Exercised by tests/insert-codegen.spec.ts.
+
+import type { PrimitiveSpec, Vec3, InsertLanguage } from './codegen';
+
+/** Parse a single statement (one line of voxel/scad, or one JS declaration RHS
+ *  expression) back into a PrimitiveSpec. Returns null for any shape we don't
+ *  recognize — callers degrade gracefully (the part stays out of arrange mode's
+ *  registry, but isn't a hard error). */
+export function parseStatement(statement: string, lang: InsertLanguage, name: string): PrimitiveSpec | null {
+  if (!statement) return null;
+  switch (lang) {
+    case 'voxel': return parseVoxelStatement(statement, name);
+    case 'scad': return parseScadStatement(statement, name);
+    case 'manifold-js':
+    case 'replicad': return parseJsStatement(statement, name);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Voxel: statement forms emitted by emitPrimitiveVoxel
+// ---------------------------------------------------------------------------
+
+const NUM = String.raw`-?\d+(?:\.\d+)?`;
+const VEC3 = String.raw`\[\s*(${NUM})\s*,\s*(${NUM})\s*,\s*(${NUM})\s*\]`;
+
+function parseVoxelStatement(stmt: string, name: string): PrimitiveSpec | null {
+  // v.fillBox([x0,y0,z0], [x1,y1,z1], '#color')
+  const box = new RegExp(`\\.\\s*fillBox\\s*\\(\\s*${VEC3}\\s*,\\s*${VEC3}`).exec(stmt);
+  if (box) {
+    const [x0, y0, z0, x1, y1, z1] = box.slice(1).map(Number);
+    // fillBox is inclusive, so size = max - min + 1 voxels.
+    return {
+      kind: 'cube',
+      name,
+      size: [x1 - x0 + 1, y1 - y0 + 1, z1 - z0 + 1],
+      // Position is the un-centered corner; treat as center=false so the
+      // registry bbox reads back identically to what was emitted.
+      position: [x0, y0, z0],
+      center: false,
+    };
+  }
+  // v.sphere([cx,cy,cz], r, '#color')
+  const sph = new RegExp(`\\.\\s*sphere\\s*\\(\\s*${VEC3}\\s*,\\s*(${NUM})`).exec(stmt);
+  if (sph) {
+    const [cx, cy, cz, r] = sph.slice(1).map(Number);
+    return { kind: 'sphere', name, radius: r, position: [cx, cy, cz] };
+  }
+  // v.cylinder([cx,cy,base_z], r, h, '#color', 'z')
+  const cyl = new RegExp(`\\.\\s*cylinder\\s*\\(\\s*${VEC3}\\s*,\\s*(${NUM})\\s*,\\s*(${NUM})`).exec(stmt);
+  if (cyl) {
+    const [cx, cy, base, r, h] = cyl.slice(1).map(Number);
+    return {
+      kind: 'cylinder',
+      name,
+      radius: r,
+      height: h,
+      position: [cx, cy, base],
+      center: false,
+    };
+  }
+  // v.sdf(api.sdf.torus(major, minor)[.translate([x,y,z])], { color: '...' })
+  const torus = /api\.sdf\.torus\s*\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\)/.exec(stmt);
+  if (torus) {
+    const major = Number(torus[1]);
+    const minor = Number(torus[2]);
+    const pos = new RegExp(`\\.translate\\s*\\(\\s*${VEC3}\\s*\\)`).exec(stmt);
+    return {
+      kind: 'torus',
+      name,
+      majorRadius: major,
+      tubeRadius: minor,
+      segments: 64,
+      position: pos ? [Number(pos[1]), Number(pos[2]), Number(pos[3])] : [0, 0, 0],
+    };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// SCAD: statement forms emitted by emitPrimitiveScad
+// ---------------------------------------------------------------------------
+
+function parseScadStatement(stmt: string, name: string): PrimitiveSpec | null {
+  // Strip the trailing `// part: …` comment + trailing `;` so the remainder
+  // is just the construction call (optionally wrapped in translate).
+  let body = stmt.replace(/\/\/.*$/, '').trim();
+  body = body.replace(/;\s*$/, '');
+  let position: Vec3 = [0, 0, 0];
+  const tr = new RegExp(`^translate\\s*\\(\\s*${VEC3}\\s*\\)\\s*`).exec(body);
+  if (tr) {
+    position = [Number(tr[1]), Number(tr[2]), Number(tr[3])];
+    body = body.slice(tr[0].length);
+  }
+  // cube([x,y,z], center=true|false)
+  const cube = new RegExp(`^cube\\s*\\(\\s*${VEC3}(?:\\s*,\\s*center\\s*=\\s*(true|false))?\\s*\\)$`).exec(body);
+  if (cube) {
+    return {
+      kind: 'cube',
+      name,
+      size: [Number(cube[1]), Number(cube[2]), Number(cube[3])],
+      center: cube[4] === 'true',
+      position,
+    };
+  }
+  // sphere(r=…)
+  const sph = new RegExp(`^sphere\\s*\\(\\s*r\\s*=\\s*(${NUM})\\s*\\)$`).exec(body);
+  if (sph) return { kind: 'sphere', name, radius: Number(sph[1]), position };
+  // cylinder(h=…, r=…, center=true|false)
+  const cyl = new RegExp(
+    `^cylinder\\s*\\(\\s*h\\s*=\\s*(${NUM})\\s*,\\s*r\\s*=\\s*(${NUM})(?:\\s*,\\s*center\\s*=\\s*(true|false))?\\s*\\)$`,
+  ).exec(body);
+  if (cyl) {
+    return {
+      kind: 'cylinder',
+      name,
+      height: Number(cyl[1]),
+      radius: Number(cyl[2]),
+      center: cyl[3] === 'true',
+      position,
+    };
+  }
+  // cylinder(h=…, r1=…, r2=…, center=…) — a cone in our spec
+  const cone = new RegExp(
+    `^cylinder\\s*\\(\\s*h\\s*=\\s*(${NUM})\\s*,\\s*r1\\s*=\\s*(${NUM})\\s*,\\s*r2\\s*=\\s*(${NUM})(?:\\s*,\\s*center\\s*=\\s*(true|false))?\\s*\\)$`,
+  ).exec(body);
+  if (cone) {
+    return {
+      kind: 'cone',
+      name,
+      height: Number(cone[1]),
+      radiusBottom: Number(cone[2]),
+      radiusTop: Number(cone[3]),
+      center: cone[4] === 'true',
+      position,
+    };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// JS / BREP: RHS expression following `const <name> = …`
+// ---------------------------------------------------------------------------
+
+function parseJsStatement(stmt: string, name: string): PrimitiveSpec | null {
+  // Statement looks like `const foo = Manifold.cube({...}).translate([...]);` —
+  // or, for BREP, `const foo = BREP.cube([...]).translate([...]);`. We strip
+  // the declaration head and trailing `;` to leave the expression chain.
+  const decl = /^\s*(?:const|let)\s+[A-Za-z_$][A-Za-z0-9_$]*\s*=\s*(.+?);?\s*$/s.exec(stmt);
+  const expr = decl ? decl[1].trim() : stmt.trim();
+  // Pull out any trailing `.translate([x,y,z])` first; the construction call
+  // is whatever's left. (We only support a single translate suffix — anything
+  // more elaborate like .rotate() or compound transforms is out of scope here.)
+  let position: Vec3 = [0, 0, 0];
+  const trMatch = new RegExp(`\\.translate\\s*\\(\\s*${VEC3}\\s*\\)\\s*$`).exec(expr);
+  let head = expr;
+  if (trMatch) {
+    position = [Number(trMatch[1]), Number(trMatch[2]), Number(trMatch[3])];
+    head = expr.slice(0, trMatch.index);
+  }
+  head = head.trim();
+  // Note: we deliberately don't strip *other* trailing `.method()` calls. If
+  // the user chained `.rotate()` / `.color()` / `.simplify()`, the construction
+  // call no longer matches our anchored regexes and the parse returns null —
+  // arrange mode then skips the part instead of moving it under an incorrect
+  // bounding box. Adding broader chain support belongs in a follow-up that can
+  // also extend the per-engine codegen writers to honour those transforms.
+
+  // Manifold.cube([x,y,z], centered?) / Manifold.cube({size: [...], center?})
+  const cubeArr = new RegExp(`^(?:Manifold|BREP)\\.cube\\s*\\(\\s*${VEC3}(?:\\s*,\\s*(true|false))?\\s*\\)$`).exec(head);
+  if (cubeArr) {
+    return {
+      kind: 'cube',
+      name,
+      size: [Number(cubeArr[1]), Number(cubeArr[2]), Number(cubeArr[3])],
+      center: cubeArr[4] === 'true',
+      position,
+    };
+  }
+  const cubeObj = /^(?:Manifold|BREP)\.cube\s*\(\s*\{([^{}]+)\}\s*\)$/.exec(head);
+  if (cubeObj) {
+    const opts = cubeObj[1];
+    const sz = new RegExp(`size\\s*:\\s*${VEC3}`).exec(opts);
+    if (sz) {
+      const cen = /center\s*:\s*(true|false)/.exec(opts);
+      return {
+        kind: 'cube',
+        name,
+        size: [Number(sz[1]), Number(sz[2]), Number(sz[3])],
+        center: cen ? cen[1] === 'true' : false,
+        position,
+      };
+    }
+  }
+  // Manifold.sphere(r) — and BREP.sphere(r)
+  const sphArg = new RegExp(`^(?:Manifold|BREP)\\.sphere\\s*\\(\\s*(${NUM})\\s*\\)$`).exec(head);
+  if (sphArg) return { kind: 'sphere', name, radius: Number(sphArg[1]), position };
+  // Manifold.sphere({radius: r})
+  const sphObj = /^Manifold\.sphere\s*\(\s*\{([^{}]+)\}\s*\)$/.exec(head);
+  if (sphObj) {
+    const r = new RegExp(`radius\\s*:\\s*(${NUM})`).exec(sphObj[1]);
+    if (r) return { kind: 'sphere', name, radius: Number(r[1]), position };
+  }
+  // Manifold.cylinder(h, r) — Manifold-JS positional form
+  const cylJs = new RegExp(`^Manifold\\.cylinder\\s*\\(\\s*(${NUM})\\s*,\\s*(${NUM})\\s*\\)$`).exec(head);
+  if (cylJs) {
+    return {
+      kind: 'cylinder',
+      name,
+      height: Number(cylJs[1]),
+      radius: Number(cylJs[2]),
+      center: false,
+      position,
+    };
+  }
+  // BREP.cylinder(r, h) — note arg order is flipped vs Manifold
+  const cylBrep = new RegExp(`^BREP\\.cylinder\\s*\\(\\s*(${NUM})\\s*,\\s*(${NUM})\\s*\\)$`).exec(head);
+  if (cylBrep) {
+    return {
+      kind: 'cylinder',
+      name,
+      radius: Number(cylBrep[1]),
+      height: Number(cylBrep[2]),
+      center: false,
+      position,
+    };
+  }
+  // Manifold.cylinder({height: h, radius: r, center?})
+  const cylObj = /^Manifold\.cylinder\s*\(\s*\{([^{}]+)\}\s*\)$/.exec(head);
+  if (cylObj) {
+    const opts = cylObj[1];
+    const h = new RegExp(`height\\s*:\\s*(${NUM})`).exec(opts);
+    const r = new RegExp(`radius\\s*:\\s*(${NUM})`).exec(opts);
+    if (h && r) {
+      const cen = /center\s*:\s*(true|false)/.exec(opts);
+      return {
+        kind: 'cylinder',
+        name,
+        height: Number(h[1]),
+        radius: Number(r[1]),
+        center: cen ? cen[1] === 'true' : false,
+        position,
+      };
+    }
+  }
+  // BREP.cone(rBottom, rTop, h)
+  const coneBrep = new RegExp(`^BREP\\.cone\\s*\\(\\s*(${NUM})\\s*,\\s*(${NUM})\\s*,\\s*(${NUM})\\s*\\)$`).exec(head);
+  if (coneBrep) {
+    return {
+      kind: 'cone',
+      name,
+      radiusBottom: Number(coneBrep[1]),
+      radiusTop: Number(coneBrep[2]),
+      height: Number(coneBrep[3]),
+      center: false,
+      position,
+    };
+  }
+  // (Manifold|BREP).torus(major, minor)
+  const torus = new RegExp(`^(?:Manifold|BREP)\\.torus\\s*\\(\\s*(${NUM})\\s*,\\s*(${NUM})\\s*\\)$`).exec(head);
+  if (torus) {
+    return {
+      kind: 'torus',
+      name,
+      majorRadius: Number(torus[1]),
+      tubeRadius: Number(torus[2]),
+      segments: 64,
+      position,
+    };
+  }
+  return null;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -226,6 +226,8 @@ import {
   apiDuplicateSelection,
   apiMirrorSelection,
   apiListParts,
+  apiSetAutoCombine,
+  apiGetAutoCombine,
 } from './ui/insertPalette';
 import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, findColorRegion, resolveSeed, findNearestTriangle, type AdjacencyGraph } from './color/adjacency';
 import { findSlabTriangles, slabRefineRegion, smoothEdgeForResolution } from './color/slabPaint';
@@ -9188,6 +9190,20 @@ async function main() {
       return apiMirrorSelection(axis);
     },
 
+    /** Toggle the "Auto-combine new shapes" checkbox programmatically. When
+     *  on (default), each inserted shape folds into the managed-return
+     *  engine's visible union so it appears immediately; when off, the part
+     *  is added to the code + registered for arrange/pick but not unioned
+     *  until you call `groupSelection`. Only meaningful for manifold-js /
+     *  replicad — voxel + scad union implicitly. */
+    setAutoCombine(on: boolean): void {
+      assertBoolean(on, 'setAutoCombine(on)');
+      apiSetAutoCombine(on);
+    },
+
+    /** Read the current Auto-combine flag. */
+    getAutoCombine(): boolean { return apiGetAutoCombine(); },
+
     // === View rendering API ===
 
     /** Render a single view from any camera angle. Returns a data URL (PNG).
@@ -13524,8 +13540,8 @@ async function main() {
         'listArrangeParts':     { signature: 'listArrangeParts() -- Names + bboxes of every part arrange mode can act on -> [{name, box:{min,max}, center}]', docs: '/ai.md#arrange-mode' },
         'undo':                 { signature: 'undo() -- Reverse the last palette operation (insert/move/resize/align/boolean/etc) -> label or null', docs: '/ai.md#arrange-mode' },
         'redo':                 { signature: 'redo() -- Reapply the last undone palette operation -> label or null', docs: '/ai.md#arrange-mode' },
-        'canUndo':               { signature: 'canUndo() -- Whether undo() would do anything', docs: '/ai.md#arrange-mode' },
-        'canRedo':               { signature: 'canRedo() -- Whether redo() would do anything', docs: '/ai.md#arrange-mode' },
+        'canUndo':              { signature: 'canUndo() -- Whether undo() would do anything', docs: '/ai.md#arrange-mode' },
+        'canRedo':              { signature: 'canRedo() -- Whether redo() would do anything', docs: '/ai.md#arrange-mode' },
         'resizeSelection':      { signature: 'resizeSelection([sx,sy,sz]) -- Scale selected parts per-axis (or uniform [s,s,s]) -> {ok}', docs: '/ai.md#arrange-mode' },
         'alignSelection':       { signature: 'alignSelection(axis, mode) -- axis: "x"|"y"|"z", mode: "min"|"center"|"max" -> {ok}', docs: '/ai.md#arrange-mode' },
         'groupSelection':       { signature: 'groupSelection() -- Union selected parts in code (∪) -> {ok}', docs: '/ai.md#arrange-mode' },
@@ -13534,6 +13550,8 @@ async function main() {
         'deleteSelection':      { signature: 'deleteSelection() -- Remove selected parts from the code -> {ok}', docs: '/ai.md#arrange-mode' },
         'duplicateSelection':   { signature: 'duplicateSelection() -- Clone selected parts, offset along +X -> {ok}', docs: '/ai.md#arrange-mode' },
         'mirrorSelection':      { signature: 'mirrorSelection("x"|"y"|"z") -- Mirror selected parts in place across axis -> {ok}', docs: '/ai.md#arrange-mode' },
+        'setAutoCombine':       { signature: 'setAutoCombine(on) -- Toggle "Auto-combine new shapes" (managed-return engines only)', docs: '/ai.md#arrange-mode' },
+        'getAutoCombine':       { signature: 'getAutoCombine() -- Whether Auto-combine is currently on', docs: '/ai.md#arrange-mode' },
         // View
         'setView':         { signature: 'setView(tab) -- Switch tab: "interactive", "gallery", "images", "diff", "notes"', docs: '/ai.md#how-to-use-this-tool' },
         'getViewState':    { signature: 'getViewState() -- Current tab and camera state', docs: '/ai.md#how-to-use-this-tool' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -203,7 +203,30 @@ import { setReadOnlyReason } from './editor/editorAccess';
 import { asLanguage } from './storage/languageFallback';
 import { encodeShare, decodeShare, validateSharePayloadShape, ShareUnsupportedError } from './share/shareLink';
 import { openShareModal, renderSharedBanner, renderSharedOverlay } from './share/shareUI';
-import { initInsertPalette, setInsertPaletteAvailable } from './ui/insertPalette';
+import {
+  initInsertPalette,
+  setInsertPaletteAvailable,
+  apiEnterArrange,
+  apiExitArrange,
+  apiIsArrangeActive,
+  apiSetSelection,
+  apiAddToSelection,
+  apiClearSelection,
+  apiGetSelection,
+  apiUndo,
+  apiRedo,
+  apiCanUndo,
+  apiCanRedo,
+  apiResizeSelection,
+  apiAlignSelection,
+  apiGroupSelection,
+  apiSubtractSelection,
+  apiIntersectSelection,
+  apiDeleteSelection,
+  apiDuplicateSelection,
+  apiMirrorSelection,
+  apiListParts,
+} from './ui/insertPalette';
 import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, findColorRegion, resolveSeed, findNearestTriangle, type AdjacencyGraph } from './color/adjacency';
 import { findSlabTriangles, slabRefineRegion, smoothEdgeForResolution } from './color/slabPaint';
 import { findBoxTriangles, findShapeTriangles, shapeRefineRegion } from './color/boxPaint';
@@ -9060,6 +9083,111 @@ async function main() {
       return isAutoRun();
     },
 
+    // === Insert & arrange palette ===
+    //
+    // Drives the same Tinkercad-style arrange tool you reach from the toolbar.
+    // The selection Set, undo stack, and per-engine code rewriters are shared
+    // with the panel — calling `partwright.enterArrange()` then
+    // `partwright.alignSelection('z','center')` is identical to clicking the
+    // toggle, ⇧-clicking parts, and pressing the Z⊣ Align button.
+
+    /** Turn arrange mode on (the persistent click-to-select / drag-to-move
+     *  viewport tool). Opens the Insert palette if needed so chip strip and
+     *  undo controls are visible. Returns `{ ok: true }` on success. */
+    enterArrange(): { ok: boolean; reason?: string } {
+      return apiEnterArrange();
+    },
+
+    /** Turn arrange mode off and exit the canvas pointer hook. */
+    exitArrange(): void { apiExitArrange(); },
+
+    /** Whether arrange mode is currently capturing pointer events. */
+    isArrangeActive(): boolean { return apiIsArrangeActive(); },
+
+    /** Replace the arrange-mode selection with the given part names. Names
+     *  unknown to the current code are silently dropped; the returned array
+     *  lists names that actually stuck. */
+    selectParts(names: string[]): string[] {
+      assertArray(names, 'selectParts(names)');
+      for (let i = 0; i < names.length; i++) assertString(names[i], `selectParts(names[${i}])`);
+      return apiSetSelection(names);
+    },
+
+    /** Extend the selection — equivalent to ⇧-click on each part. */
+    addToSelection(names: string[]): string[] {
+      assertArray(names, 'addToSelection(names)');
+      for (let i = 0; i < names.length; i++) assertString(names[i], `addToSelection(names[${i}])`);
+      return apiAddToSelection(names);
+    },
+
+    /** Clear the arrange-mode selection. */
+    clearSelection(): void { apiClearSelection(); },
+
+    /** Names the arrange tool is currently treating as the active group. */
+    getSelection(): string[] { return apiGetSelection(); },
+
+    /** List the parts arrange mode can currently work with. Returns
+     *  `[{ name, box: { min, max }, center }]`. Includes both palette-inserted
+     *  parts and hand-written ones the parser was able to resolve. */
+    listArrangeParts(): Array<{ name: string; box: { min: [number, number, number]; max: [number, number, number] }; center: [number, number, number] }> {
+      return apiListParts();
+    },
+
+    /** Step back one palette operation (insert / move / resize / align /
+     *  duplicate / delete / mirror / boolean). Returns the label of the
+     *  reversed op, or null when nothing to undo. */
+    undo(): string | null { return apiUndo(); },
+
+    /** Reapply the most recently undone palette operation. */
+    redo(): string | null { return apiRedo(); },
+
+    /** Whether `undo()` would do anything right now. */
+    canUndo(): boolean { return apiCanUndo(); },
+
+    /** Whether `redo()` would do anything right now. */
+    canRedo(): boolean { return apiCanRedo(); },
+
+    /** Scale every part in the selection. `scale` may be uniform `[s,s,s]`
+     *  or anisotropic `[sx, sy, sz]`. Same path as the Size X/Y/Z inputs.
+     *  Errors are returned as `{ ok: false, reason }`. */
+    resizeSelection(scale: [number, number, number]): { ok: boolean; reason?: string } {
+      assertNumberTuple(scale, 3, 'resizeSelection(scale)');
+      return apiResizeSelection(scale as [number, number, number]);
+    },
+
+    /** Align 2+ selected parts on `axis` ('x' | 'y' | 'z') to `mode`
+     *  ('min' | 'center' | 'max'). The reference is the union of the
+     *  selection's bboxes (Tinkercad-style). */
+    alignSelection(axis: 'x' | 'y' | 'z', mode: 'min' | 'center' | 'max'): { ok: boolean; reason?: string } {
+      assertEnum(axis, ['x', 'y', 'z'] as const, 'alignSelection(axis)');
+      assertEnum(mode, ['min', 'center', 'max'] as const, 'alignSelection(mode)');
+      return apiAlignSelection(axis, mode);
+    },
+
+    /** Union the selected parts in code — same as the ∪ Group button. Voxel
+     *  grids union implicitly so the call is rejected there. */
+    groupSelection(): { ok: boolean; reason?: string } { return apiGroupSelection(); },
+
+    /** Subtract every later operand from the first selected part. */
+    subtractSelection(): { ok: boolean; reason?: string } { return apiSubtractSelection(); },
+
+    /** Intersect every selected part. */
+    intersectSelection(): { ok: boolean; reason?: string } { return apiIntersectSelection(); },
+
+    /** Remove every selected part from the code. */
+    deleteSelection(): { ok: boolean; reason?: string } { return apiDeleteSelection(); },
+
+    /** Clone every selected part, offset along +X. New parts replace the
+     *  selection so a follow-up call (resize / align / move) operates on the
+     *  copies. */
+    duplicateSelection(): { ok: boolean; reason?: string } { return apiDuplicateSelection(); },
+
+    /** Mirror every selected part in place across the given axis. */
+    mirrorSelection(axis: 'x' | 'y' | 'z'): { ok: boolean; reason?: string } {
+      assertEnum(axis, ['x', 'y', 'z'] as const, 'mirrorSelection(axis)');
+      return apiMirrorSelection(axis);
+    },
+
     // === View rendering API ===
 
     /** Render a single view from any camera angle. Returns a data URL (PNG).
@@ -13385,6 +13513,27 @@ async function main() {
         'getTheme':             { signature: 'getTheme() -- Current color theme', docs: '/ai.md#viewport-controls' },
         'setAutoRun':           { signature: 'setAutoRun(enabled) -- Enable/disable auto-render on edit', docs: '/ai.md#viewport-controls' },
         'isAutoRunEnabled':     { signature: 'isAutoRunEnabled() -- Whether auto-run is active', docs: '/ai.md#viewport-controls' },
+        // Insert & arrange palette (Tinkercad-style direct manipulation)
+        'enterArrange':         { signature: 'enterArrange() -- Activate arrange-mode pointer hook (drag to move parts in 3D) -> {ok}', docs: '/ai.md#arrange-mode' },
+        'exitArrange':          { signature: 'exitArrange() -- Deactivate arrange mode', docs: '/ai.md#arrange-mode' },
+        'isArrangeActive':      { signature: 'isArrangeActive() -- Whether arrange mode is currently capturing pointer events', docs: '/ai.md#arrange-mode' },
+        'selectParts':          { signature: 'selectParts(names) -- Replace the arrange-mode selection -> matched names', docs: '/ai.md#arrange-mode' },
+        'addToSelection':       { signature: 'addToSelection(names) -- Extend the arrange-mode selection -> matched names', docs: '/ai.md#arrange-mode' },
+        'clearSelection':       { signature: 'clearSelection() -- Drop everything from the arrange-mode selection', docs: '/ai.md#arrange-mode' },
+        'getSelection':         { signature: 'getSelection() -- Current arrange-mode selection -> string[]', docs: '/ai.md#arrange-mode' },
+        'listArrangeParts':     { signature: 'listArrangeParts() -- Names + bboxes of every part arrange mode can act on -> [{name, box:{min,max}, center}]', docs: '/ai.md#arrange-mode' },
+        'undo':                 { signature: 'undo() -- Reverse the last palette operation (insert/move/resize/align/boolean/etc) -> label or null', docs: '/ai.md#arrange-mode' },
+        'redo':                 { signature: 'redo() -- Reapply the last undone palette operation -> label or null', docs: '/ai.md#arrange-mode' },
+        'canUndo':               { signature: 'canUndo() -- Whether undo() would do anything', docs: '/ai.md#arrange-mode' },
+        'canRedo':               { signature: 'canRedo() -- Whether redo() would do anything', docs: '/ai.md#arrange-mode' },
+        'resizeSelection':      { signature: 'resizeSelection([sx,sy,sz]) -- Scale selected parts per-axis (or uniform [s,s,s]) -> {ok}', docs: '/ai.md#arrange-mode' },
+        'alignSelection':       { signature: 'alignSelection(axis, mode) -- axis: "x"|"y"|"z", mode: "min"|"center"|"max" -> {ok}', docs: '/ai.md#arrange-mode' },
+        'groupSelection':       { signature: 'groupSelection() -- Union selected parts in code (∪) -> {ok}', docs: '/ai.md#arrange-mode' },
+        'subtractSelection':    { signature: 'subtractSelection() -- Subtract later operands from the first (∖) -> {ok}', docs: '/ai.md#arrange-mode' },
+        'intersectSelection':   { signature: 'intersectSelection() -- Intersect every selected part (∩) -> {ok}', docs: '/ai.md#arrange-mode' },
+        'deleteSelection':      { signature: 'deleteSelection() -- Remove selected parts from the code -> {ok}', docs: '/ai.md#arrange-mode' },
+        'duplicateSelection':   { signature: 'duplicateSelection() -- Clone selected parts, offset along +X -> {ok}', docs: '/ai.md#arrange-mode' },
+        'mirrorSelection':      { signature: 'mirrorSelection("x"|"y"|"z") -- Mirror selected parts in place across axis -> {ok}', docs: '/ai.md#arrange-mode' },
         // View
         'setView':         { signature: 'setView(tab) -- Switch tab: "interactive", "gallery", "images", "diff", "notes"', docs: '/ai.md#how-to-use-this-tool' },
         'getViewState':    { signature: 'getViewState() -- Current tab and camera state', docs: '/ai.md#how-to-use-this-tool' },

--- a/src/ui/insertPalette.ts
+++ b/src/ui/insertPalette.ts
@@ -141,6 +141,8 @@ let quickActionsEl: HTMLElement | null = null;
 // explicitly Union it. Only meaningful for the single-return engines
 // (manifold-js / replicad) — scad & voxel union implicitly.
 let autoCombine = true;
+// Cached checkbox element so the public API can flip the toggle from a script.
+let autoCombineCheckbox: HTMLInputElement | null = null;
 
 // Refs to the sections that show/hide per active engine, repainted by
 // refreshForLanguage() on open + on language change.
@@ -422,9 +424,14 @@ export function setInsertPaletteAvailable(available: boolean): void {
 // from CLAUDE.md: anything you can click here should also be callable in code.
 // ---------------------------------------------------------------------------
 
-/** Programmatic equivalent of clicking the ✥ Arrange toggle ON. Opens the
- *  palette panel if needed so chip-strip / Undo / Size / Align UI is visible
- *  for whatever follow-up calls hit. Idempotent. */
+/** Programmatic equivalent of clicking the ✥ Arrange toggle ON.
+ *
+ *  **Side effect:** opens the Insert palette panel if it wasn't already open
+ *  so the chip strip / Undo / Size / Align controls are visible to whatever
+ *  drives the API next — matching what a user sees when they enable arrange
+ *  by hand. Headless / scripted flows that just want the canvas pointer hook
+ *  without the panel mounted should still call this (the panel never steals
+ *  focus from `window.partwright.*`); it does occupy viewport real estate. */
 export function apiEnterArrange(): { ok: boolean; reason?: string } {
   if (!cb) return { ok: false, reason: 'insert palette not initialized' };
   if (!isInsertPaletteOpen()) openInsertPalette();
@@ -434,6 +441,18 @@ export function apiEnterArrange(): { ok: boolean; reason?: string } {
   }
   return { ok: isArrangeActive() };
 }
+
+/** Toggle the "Auto-combine new shapes" checkbox programmatically. When off,
+ *  inserted shapes are added to the code but not folded into the visible
+ *  union (managed-return engines only). Keeps the panel's checkbox state in
+ *  sync so the user sees the new value if they then open the panel. */
+export function apiSetAutoCombine(on: boolean): void {
+  autoCombine = on;
+  if (autoCombineCheckbox) autoCombineCheckbox.checked = on;
+  updateCombineHint();
+}
+
+export function apiGetAutoCombine(): boolean { return autoCombine; }
 
 /** Programmatic equivalent of clicking the toggle OFF. */
 export function apiExitArrange(): void {
@@ -713,6 +732,7 @@ function buildPanel(): HTMLElement {
     autoCombine = autoCb.checked;
     updateCombineHint();
   });
+  autoCombineCheckbox = autoCb;
   const autoCbLabel = document.createElement('span');
   autoCbLabel.textContent = 'Auto-combine new shapes';
   autoCombineRowEl.append(autoCb, autoCbLabel);

--- a/src/ui/insertPalette.ts
+++ b/src/ui/insertPalette.ts
@@ -417,6 +417,172 @@ export function setInsertPaletteAvailable(available: boolean): void {
 }
 
 // ---------------------------------------------------------------------------
+// Public API surface — drives the palette's tool behaviours from
+// `window.partwright` (and the in-app AI). Keeps the UI <-> JS-API parity rule
+// from CLAUDE.md: anything you can click here should also be callable in code.
+// ---------------------------------------------------------------------------
+
+/** Programmatic equivalent of clicking the ✥ Arrange toggle ON. Opens the
+ *  palette panel if needed so chip-strip / Undo / Size / Align UI is visible
+ *  for whatever follow-up calls hit. Idempotent. */
+export function apiEnterArrange(): { ok: boolean; reason?: string } {
+  if (!cb) return { ok: false, reason: 'insert palette not initialized' };
+  if (!isInsertPaletteOpen()) openInsertPalette();
+  if (!isArrangeActive()) {
+    enterArrangeMode();
+    updateArrangeToggleState();
+  }
+  return { ok: isArrangeActive() };
+}
+
+/** Programmatic equivalent of clicking the toggle OFF. */
+export function apiExitArrange(): void {
+  if (isArrangeActive()) {
+    exitArrangeMode();
+    updateArrangeToggleState();
+  }
+}
+
+export function apiIsArrangeActive(): boolean { return isArrangeActive(); }
+
+/** Replace the arrange-mode selection with `names`. Names are matched against
+ *  the live code's scanned parts (so a typo just produces an empty selection).
+ *  Returns the names that actually matched. */
+export function apiSetSelection(names: readonly string[]): string[] {
+  if (!cb) return [];
+  const valid = new Set(scanParts(cb.getCode(), cb.getLanguage()).map(p => p.name));
+  selection.clear();
+  const matched: string[] = [];
+  for (const name of names) {
+    if (valid.has(name)) { selection.add(name); matched.push(name); }
+  }
+  rerenderSelectionUI();
+  return matched;
+}
+
+/** Add `names` to the current selection without clearing existing entries.
+ *  Mirrors shift-click. Returns names that matched live parts. */
+export function apiAddToSelection(names: readonly string[]): string[] {
+  if (!cb) return [];
+  const valid = new Set(scanParts(cb.getCode(), cb.getLanguage()).map(p => p.name));
+  const matched: string[] = [];
+  for (const name of names) {
+    if (valid.has(name)) { selection.add(name); matched.push(name); }
+  }
+  rerenderSelectionUI();
+  return matched;
+}
+
+/** Drop everything from the selection — equivalent to clicking empty space in
+ *  arrange mode without Shift held. */
+export function apiClearSelection(): void {
+  if (selection.size === 0) return;
+  selection.clear();
+  rerenderSelectionUI();
+}
+
+/** Snapshot the current selection — the names the UI is treating as the
+ *  active group. */
+export function apiGetSelection(): string[] { return [...selection]; }
+
+/** Run the undo stack's `undo()` and surface its label as a toast (matches
+ *  the panel button). Returns the undone op's label, or null. */
+export function apiUndo(): string | null {
+  const label = undoOp();
+  if (label && cb) cb.showToast(`Undid: ${label}`, { variant: 'neutral' });
+  return label;
+}
+
+export function apiRedo(): string | null {
+  const label = redoOp();
+  if (label && cb) cb.showToast(`Redid: ${label}`, { variant: 'neutral' });
+  return label;
+}
+
+export function apiCanUndo(): boolean { return canUndo(); }
+export function apiCanRedo(): boolean { return canRedo(); }
+
+/** Resize the current selection — same call applyResize uses, exposed for
+ *  scripted edits. `scale` may be uniform-or-anisotropic. */
+export function apiResizeSelection(scale: Vec3): { ok: boolean; reason?: string } {
+  if (!cb) return { ok: false, reason: 'insert palette not initialized' };
+  if (selection.size === 0) return { ok: false, reason: 'no selection' };
+  applyResize(scale);
+  return { ok: true };
+}
+
+/** Align the current selection on `axis` to `mode` (min / center / max). */
+export function apiAlignSelection(axis: AlignAxis, mode: AlignMode): { ok: boolean; reason?: string } {
+  if (!cb) return { ok: false, reason: 'insert palette not initialized' };
+  if (selection.size < 2) return { ok: false, reason: 'need 2+ parts' };
+  applyAlign(axis, mode);
+  return { ok: true };
+}
+
+/** Group the current selection — same union the palette's ∪ button drives.
+ *  Engine-aware: voxel grids union implicitly, so this is a no-op there. */
+export function apiGroupSelection(): { ok: boolean; reason?: string } {
+  return apiBooleanSelection('union');
+}
+
+export function apiSubtractSelection(): { ok: boolean; reason?: string } {
+  return apiBooleanSelection('subtract');
+}
+
+export function apiIntersectSelection(): { ok: boolean; reason?: string } {
+  return apiBooleanSelection('intersect');
+}
+
+function apiBooleanSelection(op: BooleanOpKind): { ok: boolean; reason?: string } {
+  if (!cb) return { ok: false, reason: 'insert palette not initialized' };
+  if (selection.size < 2) return { ok: false, reason: 'need 2+ parts' };
+  const lang = cb.getLanguage();
+  if (lang === 'voxel') return { ok: false, reason: 'voxel grids union implicitly' };
+  const liveParts = scanParts(cb.getCode(), lang);
+  const partByName = new Map(liveParts.map(p => [p.name, p]));
+  const operands: Operand[] = [];
+  for (const name of selection) {
+    const part = partByName.get(name);
+    if (!part) continue;
+    operands.push({ name: part.name, statement: part.statement, range: part.range });
+  }
+  if (operands.length < 2) return { ok: false, reason: 'selection lost in code' };
+  applyOperation(op, operands, lang);
+  selection.clear();
+  rerenderSelectionUI();
+  return { ok: true };
+}
+
+export function apiDeleteSelection(): { ok: boolean; reason?: string } {
+  if (!cb) return { ok: false, reason: 'insert palette not initialized' };
+  if (selection.size === 0) return { ok: false, reason: 'no selection' };
+  applyQuickDelete();
+  return { ok: true };
+}
+
+export function apiDuplicateSelection(): { ok: boolean; reason?: string } {
+  if (!cb) return { ok: false, reason: 'insert palette not initialized' };
+  if (selection.size === 0) return { ok: false, reason: 'no selection' };
+  applyQuickDuplicate();
+  return { ok: true };
+}
+
+export function apiMirrorSelection(axis: MirrorAxis): { ok: boolean; reason?: string } {
+  if (!cb) return { ok: false, reason: 'insert palette not initialized' };
+  if (selection.size === 0) return { ok: false, reason: 'no selection' };
+  applyQuickMirror(axis);
+  return { ok: true };
+}
+
+/** List the parts arrange mode currently knows about, with their bboxes.
+ *  Includes both palette-inserted parts and hand-written parts the parser
+ *  could resolve (arrange enters once to seed). Returns an array so external
+ *  callers don't get a live reference to the internal Map. */
+export function apiListParts(): Array<{ name: string; box: RegistryEntry['box']; center: RegistryEntry['center'] }> {
+  return [...registry.entries()].map(([name, entry]) => ({ name, box: entry.box, center: entry.center }));
+}
+
+// ---------------------------------------------------------------------------
 // Panel
 // ---------------------------------------------------------------------------
 

--- a/src/ui/keyboardShortcuts.ts
+++ b/src/ui/keyboardShortcuts.ts
@@ -28,6 +28,7 @@ import { isActive as isVoxelStudioActive, undo as voxelStudioUndo, redo as voxel
 import { removeLastStroke, redoLastStroke } from '../annotations/annotations';
 import { isActive as isSelectActive } from '../annotations/selectMode';
 import { isAnnotateOpen } from '../annotations/annotateUI';
+import { apiUndo, apiRedo, apiCanUndo, apiCanRedo, apiIsArrangeActive } from './insertPalette';
 
 export interface ShortcutHandlers {
   /** Persist the current code/geometry/paint/annotations as a new version. */
@@ -65,6 +66,15 @@ function routeUndo(): boolean {
   if (annotateContextActive()) {
     return removeLastStroke() !== null;
   }
+  // Insert palette's coarse-grained palette stack catches the "no other tool
+  // active, but the user just inserted / moved / resized a part" case. Driven
+  // by the same arrangeMode + applyResize/applyAlign paths the Undo button
+  // does; the active arrange-mode case is handled by the dedicated branch in
+  // installKeyboardShortcuts so it can override the editable-target guard
+  // (matches the voxel-studio precedent).
+  if (apiCanUndo()) {
+    return apiUndo() !== null;
+  }
   return false;
 }
 
@@ -74,6 +84,9 @@ function routeRedo(): boolean {
   }
   if (annotateContextActive()) {
     return redoLastStroke() !== null;
+  }
+  if (apiCanRedo()) {
+    return apiRedo() !== null;
   }
   return false;
 }
@@ -117,6 +130,20 @@ export function installKeyboardShortcuts(handlers: ShortcutHandlers): void {
     if (isVoxelStudioActive() && (key === 'z' || (key === 'y' && !IS_MAC))) {
       const redo = e.shiftKey || key === 'y';
       if (redo ? voxelStudioRedo() : voxelStudioUndo()) e.preventDefault();
+      return;
+    }
+
+    // Arrange mode owns undo/redo while it's actively capturing the canvas —
+    // the user expects ⌘Z to reverse the last gesture (insert / move / resize /
+    // align / boolean) even if focus happens to be in the editor. Routes
+    // straight to the palette's coarse stack, bypassing the editable-target
+    // guard. (When arrange isn't active but the panel still has history,
+    // routeUndo / routeRedo below pick it up — but only outside text fields,
+    // so the editor's per-keystroke undo still works.)
+    if (apiIsArrangeActive() && (key === 'z' || (key === 'y' && !IS_MAC))) {
+      const redo = e.shiftKey || key === 'y';
+      const label = redo ? apiRedo() : apiUndo();
+      if (label !== null) e.preventDefault();
       return;
     }
 

--- a/tests/insert-codegen.spec.ts
+++ b/tests/insert-codegen.spec.ts
@@ -1344,5 +1344,22 @@ test.describe('scanPartsJs now also returns statement text for single-line const
     const ball = refs.find(r => r.name === 'ball');
     expect(ball?.statement).toContain('Manifold.sphere');
   });
+
+  test('semicolons inside string literals do not truncate the captured statement', () => {
+    // A naive `/[^;]*;/` regex would stop after `"hi;"`, leaving a
+    // malformed RHS. The skip-aware walker keeps going past the string.
+    const code = 'const greeting = "hi;bye";\nconst box = Manifold.cube([1,2,3]);';
+    const refs = scanPartsJs(code);
+    const greeting = refs.find(r => r.name === 'greeting');
+    expect(greeting?.statement).toContain('"hi;bye"');
+    expect(greeting?.statement?.trim().endsWith(';')).toBe(true);
+  });
+
+  test('multi-line statements are captured in full', () => {
+    const code = 'const box = Manifold\n  .cube([1,2,3], true)\n  .translate([5,0,0]);';
+    const refs = scanPartsJs(code);
+    const box = refs.find(r => r.name === 'box');
+    expect(box?.statement).toContain('.translate');
+  });
 });
 

--- a/tests/insert-codegen.spec.ts
+++ b/tests/insert-codegen.spec.ts
@@ -53,6 +53,7 @@ import {
 import { primitiveEntry, unionBoxes, pickPart, translateEntry, type RegistryEntry } from '../src/insert/spatial';
 import { STARTERS } from '../src/editor/starters';
 import { alignDeltas } from '../src/insert/arrangeMath';
+import { parseStatement } from '../src/insert/parseStatement';
 import {
   initUndoStack,
   recordOperation,
@@ -1188,6 +1189,160 @@ test.describe('Arrange — alignDeltas', () => {
     ]);
     const deltas = alignDeltas(['a', 'ghost'], reg, 'x', 'min');
     expect(deltas.size).toBe(0); // only one valid entry → nothing to align against
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseStatement — recover PrimitiveSpec from hand-written code so arrange
+// mode can drag/resize/align parts the palette never inserted itself.
+// ---------------------------------------------------------------------------
+
+test.describe('parseStatement — voxel', () => {
+  test('fillBox → cube spec with size and corner position', () => {
+    const stmt = `v.fillBox([0, 0, 0], [4, 4, 4], '#abc')`;
+    const spec = parseStatement(stmt, 'voxel', 'box');
+    expect(spec).not.toBeNull();
+    expect(spec!.kind).toBe('cube');
+    if (spec!.kind !== 'cube') return;
+    expect(spec!.size).toEqual([5, 5, 5]); // inclusive fillBox: max-min+1
+    expect(spec!.position).toEqual([0, 0, 0]);
+    expect(spec!.center).toBe(false);
+  });
+
+  test('sphere → sphere spec with center position', () => {
+    const stmt = `v.sphere([10, 5, 0], 3, '#fff')`;
+    const spec = parseStatement(stmt, 'voxel', 'ball');
+    expect(spec).not.toBeNull();
+    if (spec!.kind !== 'sphere') throw new Error('expected sphere');
+    expect(spec!.radius).toBe(3);
+    expect(spec!.position).toEqual([10, 5, 0]);
+  });
+
+  test('cylinder → cylinder spec with base z', () => {
+    const stmt = `v.cylinder([0, 0, 0], 5, 10, '#fff', 'z')`;
+    const spec = parseStatement(stmt, 'voxel', 'cyl');
+    expect(spec).not.toBeNull();
+    if (spec!.kind !== 'cylinder') throw new Error('expected cylinder');
+    expect(spec!.radius).toBe(5);
+    expect(spec!.height).toBe(10);
+  });
+
+  test('sdf torus → torus spec', () => {
+    const stmt = `v.sdf(api.sdf.torus(8, 2).translate([5, 0, 0]), { color: '#fff' })`;
+    const spec = parseStatement(stmt, 'voxel', 'torus');
+    expect(spec).not.toBeNull();
+    if (spec!.kind !== 'torus') throw new Error('expected torus');
+    expect(spec!.majorRadius).toBe(8);
+    expect(spec!.tubeRadius).toBe(2);
+    expect(spec!.position).toEqual([5, 0, 0]);
+  });
+
+  test('returns null for an unparseable shape', () => {
+    expect(parseStatement(`v.someUnknownThing([1,2,3])`, 'voxel', 'x')).toBeNull();
+  });
+});
+
+test.describe('parseStatement — SCAD', () => {
+  test('cube with translate wrap', () => {
+    const stmt = `translate([5, 0, 0]) cube([10, 10, 10], center=true); // part: box`;
+    const spec = parseStatement(stmt, 'scad', 'box');
+    expect(spec).not.toBeNull();
+    if (spec!.kind !== 'cube') throw new Error('expected cube');
+    expect(spec!.size).toEqual([10, 10, 10]);
+    expect(spec!.center).toBe(true);
+    expect(spec!.position).toEqual([5, 0, 0]);
+  });
+
+  test('bare cube (no translate, no center) → uncentered at origin', () => {
+    const stmt = `cube([4, 6, 8])`;
+    const spec = parseStatement(stmt, 'scad', 'b');
+    if (!spec || spec.kind !== 'cube') throw new Error('expected cube');
+    expect(spec.size).toEqual([4, 6, 8]);
+    expect(spec.center).toBe(false);
+    expect(spec.position).toEqual([0, 0, 0]);
+  });
+
+  test('cylinder with named args', () => {
+    const stmt = `translate([0, 0, 5]) cylinder(h=20, r=4, center=false);`;
+    const spec = parseStatement(stmt, 'scad', 'c');
+    if (!spec || spec.kind !== 'cylinder') throw new Error('expected cylinder');
+    expect(spec.radius).toBe(4);
+    expect(spec.height).toBe(20);
+    expect(spec.position).toEqual([0, 0, 5]);
+  });
+
+  test('cone (cylinder with r1/r2) → cone spec', () => {
+    const stmt = `cylinder(h=10, r1=5, r2=2);`;
+    const spec = parseStatement(stmt, 'scad', 'c');
+    if (!spec || spec.kind !== 'cone') throw new Error('expected cone');
+    expect(spec.radiusBottom).toBe(5);
+    expect(spec.radiusTop).toBe(2);
+    expect(spec.height).toBe(10);
+  });
+
+  test('returns null for unrecognized SCAD shapes', () => {
+    expect(parseStatement(`linear_extrude(10) circle(r=5);`, 'scad', 'x')).toBeNull();
+  });
+});
+
+test.describe('parseStatement — manifold-js / BREP', () => {
+  test('Manifold.cube with array args', () => {
+    const stmt = `const box = Manifold.cube([10, 20, 30], true).translate([5, 0, 0]);`;
+    const spec = parseStatement(stmt, 'manifold-js', 'box');
+    if (!spec || spec.kind !== 'cube') throw new Error('expected cube');
+    expect(spec.size).toEqual([10, 20, 30]);
+    expect(spec.center).toBe(true);
+    expect(spec.position).toEqual([5, 0, 0]);
+  });
+
+  test('Manifold.cube with object args', () => {
+    const stmt = `const c = Manifold.cube({ size: [4, 6, 8], center: false });`;
+    const spec = parseStatement(stmt, 'manifold-js', 'c');
+    if (!spec || spec.kind !== 'cube') throw new Error('expected cube');
+    expect(spec.size).toEqual([4, 6, 8]);
+    expect(spec.center).toBe(false);
+  });
+
+  test('Manifold.sphere (positional)', () => {
+    const spec = parseStatement(`const ball = Manifold.sphere(5);`, 'manifold-js', 'ball');
+    if (!spec || spec.kind !== 'sphere') throw new Error('expected sphere');
+    expect(spec.radius).toBe(5);
+  });
+
+  test('Manifold.cylinder (h, r)', () => {
+    const spec = parseStatement(`const cyl = Manifold.cylinder(10, 3);`, 'manifold-js', 'cyl');
+    if (!spec || spec.kind !== 'cylinder') throw new Error('expected cylinder');
+    expect(spec.height).toBe(10);
+    expect(spec.radius).toBe(3);
+  });
+
+  test('BREP.cylinder (r, h) — arg order flipped vs Manifold', () => {
+    const spec = parseStatement(`const cyl = BREP.cylinder(3, 10);`, 'replicad', 'cyl');
+    if (!spec || spec.kind !== 'cylinder') throw new Error('expected cylinder');
+    expect(spec.radius).toBe(3);
+    expect(spec.height).toBe(10);
+  });
+
+  test('returns null for chained transforms we do not understand', () => {
+    expect(parseStatement(
+      `const x = Manifold.cube([10,10,10]).rotate([0,0,30]).translate([5,0,0]);`,
+      'manifold-js', 'x',
+    )).toBeNull();
+  });
+
+  test('returns null for arbitrary expressions', () => {
+    expect(parseStatement(`const x = api.text("hi");`, 'manifold-js', 'x')).toBeNull();
+  });
+});
+
+test.describe('scanPartsJs now also returns statement text for single-line const decls', () => {
+  test('captures statement for parsing', () => {
+    const code = 'const box = Manifold.cube([1,2,3], true);\nconst ball = Manifold.sphere(4);';
+    const refs = scanPartsJs(code);
+    const box = refs.find(r => r.name === 'box');
+    expect(box?.statement).toContain('Manifold.cube');
+    const ball = refs.find(r => r.name === 'ball');
+    expect(ball?.statement).toContain('Manifold.sphere');
   });
 });
 

--- a/tests/insert-palette.spec.ts
+++ b/tests/insert-palette.spec.ts
@@ -580,4 +580,57 @@ test.describe('Insert palette', () => {
     expect(undone).toContain('Move');
     await expect.poll(() => getCode(page)).toBe(codeBeforeDrag);
   });
+
+  test('partwright API: groupSelection on two parts produces a union in code', async ({ page }) => {
+    await gotoEditor(page);
+    await page.evaluate(() => {
+      const code = [
+        'const { Manifold } = api;',
+        'const a = Manifold.cube([6, 6, 6], true);',
+        'const b = Manifold.sphere(3).translate([4, 0, 0]);',
+        'return a.add(b);',
+      ].join('\n');
+      (window as unknown as { partwright: { setCode(c: string): void; run(): void } }).partwright.setCode(code);
+      (window as unknown as { partwright: { run(): void } }).partwright.run();
+    });
+
+    const result = await page.evaluate(() => {
+      const w = window as unknown as { partwright: { enterArrange(): unknown; selectParts(n: string[]): string[]; groupSelection(): { ok: boolean } } };
+      w.partwright.enterArrange();
+      w.partwright.selectParts(['a', 'b']);
+      return w.partwright.groupSelection();
+    });
+    expect(result.ok).toBe(true);
+    // Union codegen: `const merged = a.add(b);`. The exact result name varies
+    // (uniqueName picks merged / merged2 / …), but a new declaration with .add
+    // is the signature.
+    await expect.poll(() => getCode(page)).toMatch(/const merged\d* = a\.add\(b\);/);
+
+    // Undo reverses the group (the operation goes; `a` and `b` reappear standalone).
+    await page.evaluate(() => (window as unknown as { partwright: { undo(): string | null } }).partwright.undo());
+    await expect.poll(() => getCode(page)).not.toMatch(/const merged\d* = a\.add\(b\);/);
+
+    await page.evaluate(() => (window as unknown as { partwright: { exitArrange(): void } }).partwright.exitArrange());
+  });
+
+  test('session-changed event clears the palette undo history', async ({ page }) => {
+    await gotoEditor(page);
+    await page.evaluate(() => (window as unknown as { partwright: { setCode(c: string): void; run(): void } })
+      .partwright.setCode('const { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);'));
+    await page.evaluate(() => (window as unknown as { partwright: { run(): void } }).partwright.run());
+
+    // Insert a part to seed the undo stack.
+    await page.locator('#btn-insert').dispatchEvent('click');
+    await page.locator(palette).getByRole('button', { name: 'Cube' }).click();
+    await page.getByRole('button', { name: 'Insert', exact: true }).click();
+    await expect.poll(() => getCode(page)).toContain('const box');
+    expect(await page.evaluate(() => (window as unknown as { partwright: { canUndo(): boolean } }).partwright.canUndo())).toBe(true);
+
+    // Fire the session-changed event the way the session manager would.
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent('session-changed')));
+
+    // History is dropped — canUndo returns false even though the editor still
+    // shows code that previously had an Insert step on the stack.
+    expect(await page.evaluate(() => (window as unknown as { partwright: { canUndo(): boolean } }).partwright.canUndo())).toBe(false);
+  });
 });

--- a/tests/insert-palette.spec.ts
+++ b/tests/insert-palette.spec.ts
@@ -437,4 +437,147 @@ test.describe('Insert palette', () => {
     await page.locator('#insert-arrange-toggle').click();
     await expect(page.locator('#insert-arrange-toggle')).not.toContainText('ON');
   });
+
+  test('partwright API: enterArrange + alignSelection drives the same flow as the panel', async ({ page }) => {
+    await gotoEditor(page);
+    // Two cubes at different Z so an align('z', 'min') has a visible effect.
+    await page.evaluate(() => {
+      const code = [
+        'const { Manifold } = api;',
+        'const box = Manifold.cube([10, 10, 10], true);',
+        'const ball = Manifold.sphere(4).translate([20, 0, 8]);',
+        'return box.add(ball);',
+      ].join('\n');
+      (window as unknown as { partwright: { setCode(c: string): void; run(): void } }).partwright.setCode(code);
+      (window as unknown as { partwright: { run(): void } }).partwright.run();
+    });
+
+    // No UI click: arrange enters via the console API; seeding happens
+    // automatically. listArrangeParts surfaces both hand-written parts.
+    const { active, parts } = await page.evaluate(() => {
+      const w = window as unknown as { partwright: { enterArrange(): { ok: boolean }; isArrangeActive(): boolean; listArrangeParts(): Array<{ name: string }> } };
+      w.partwright.enterArrange();
+      return { active: w.partwright.isArrangeActive(), parts: w.partwright.listArrangeParts().map(p => p.name) };
+    });
+    expect(active).toBe(true);
+    expect(parts).toContain('box');
+    expect(parts).toContain('ball');
+
+    // Select both → align Z 'min'. ball was at z=8; should move down to z=0.
+    const result = await page.evaluate(() => {
+      const w = window as unknown as { partwright: { selectParts(n: string[]): string[]; alignSelection(a: 'x' | 'y' | 'z', m: 'min' | 'center' | 'max'): { ok: boolean } } };
+      w.partwright.selectParts(['box', 'ball']);
+      return w.partwright.alignSelection('z', 'min');
+    });
+    expect(result.ok).toBe(true);
+
+    // The ball's translate should have been re-emitted with a lower Z. We don't
+    // pin the exact value (depends on the precise bbox math), but its Z
+    // coordinate must drop below the original 8.
+    await expect.poll(() => getCode(page)).toMatch(/ball = Manifold\.sphere\(4\)\.translate\(\[[^\]]*, [^,]*, (-?\d+(?:\.\d+)?)\]\)/);
+    const code = await getCode(page);
+    const m = /ball = Manifold\.sphere\(4\)\.translate\(\[[^,]*,\s*[^,]*,\s*(-?\d+(?:\.\d+)?)\]\)/.exec(code);
+    expect(m).not.toBeNull();
+    expect(parseFloat(m![1])).toBeLessThan(8);
+
+    // Tidy up.
+    await page.evaluate(() => (window as unknown as { partwright: { exitArrange(): void } }).partwright.exitArrange());
+  });
+
+  test('partwright API: undo / redo round-trip mirrors the buttons', async ({ page }) => {
+    await gotoEditor(page);
+    await page.evaluate(() => (window as unknown as { partwright: { setCode(c: string): void; run(): void } })
+      .partwright.setCode('const { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);'));
+    await page.evaluate(() => (window as unknown as { partwright: { run(): void } }).partwright.run());
+
+    await page.locator('#btn-insert').dispatchEvent('click');
+    await page.locator(palette).getByRole('button', { name: 'Cube' }).click();
+    await page.getByRole('button', { name: 'Insert', exact: true }).click();
+    await expect.poll(() => getCode(page)).toContain('const box');
+
+    // API-level undo reverses the insert; canUndo / canRedo agree.
+    const before = await page.evaluate(() => (window as unknown as { partwright: { canUndo(): boolean; canRedo(): boolean } }).partwright.canUndo());
+    expect(before).toBe(true);
+    const label = await page.evaluate(() => (window as unknown as { partwright: { undo(): string | null } }).partwright.undo());
+    expect(label).toContain('Insert');
+    await expect.poll(() => getCode(page)).not.toContain('const box');
+
+    const canRedo = await page.evaluate(() => (window as unknown as { partwright: { canRedo(): boolean } }).partwright.canRedo());
+    expect(canRedo).toBe(true);
+    const redoLabel = await page.evaluate(() => (window as unknown as { partwright: { redo(): string | null } }).partwright.redo());
+    expect(redoLabel).toContain('Insert');
+    await expect.poll(() => getCode(page)).toContain('const box');
+  });
+
+  test('hand-written parts seed the arrange registry on enter', async ({ page }) => {
+    await gotoEditor(page);
+    // Code typed straight into the editor — no palette involvement. The parser
+    // recognises Manifold.cube / .sphere with optional .translate.
+    await page.evaluate(() => {
+      const code = [
+        'const { Manifold } = api;',
+        'const myCube = Manifold.cube([8, 8, 8], true).translate([10, 0, 0]);',
+        'const myBall = Manifold.sphere(3);',
+        'return myCube.add(myBall);',
+      ].join('\n');
+      (window as unknown as { partwright: { setCode(c: string): void; run(): void } }).partwright.setCode(code);
+      (window as unknown as { partwright: { run(): void } }).partwright.run();
+    });
+
+    const parts = await page.evaluate(() => {
+      const w = window as unknown as { partwright: { enterArrange(): unknown; listArrangeParts(): Array<{ name: string; box: { min: number[]; max: number[] } }> } };
+      w.partwright.enterArrange();
+      return w.partwright.listArrangeParts();
+    });
+    const names = parts.map(p => p.name);
+    expect(names).toContain('myCube');
+    expect(names).toContain('myBall');
+    // The cube was translated to (10,0,0), centered with size 8 — so its bbox
+    // X spans roughly 6..14. The parser should report the correct world bbox.
+    const cube = parts.find(p => p.name === 'myCube')!;
+    expect(cube.box.min[0]).toBeCloseTo(6, 1);
+    expect(cube.box.max[0]).toBeCloseTo(14, 1);
+
+    await page.evaluate(() => (window as unknown as { partwright: { exitArrange(): void } }).partwright.exitArrange());
+  });
+
+  test('Arrange mode: drag → undo restores the original position', async ({ page }) => {
+    await gotoEditor(page);
+    await page.evaluate(() => (window as unknown as { partwright: { setCode(c: string): void; run(): void } })
+      .partwright.setCode('const { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);'));
+    await page.evaluate(() => (window as unknown as { partwright: { run(): void } }).partwright.run());
+
+    await page.locator('#btn-insert').dispatchEvent('click');
+    await page.locator(palette).getByRole('button', { name: 'Cube' }).click();
+    await page.getByRole('button', { name: 'Insert', exact: true }).click();
+    await expect.poll(() => getCode(page)).toContain('const box');
+    const codeBeforeDrag = await getCode(page);
+
+    // Move palette out of the canvas's way + enter arrange mode.
+    await page.evaluate(() => {
+      const p = document.querySelector('#insert-palette-panel') as HTMLElement | null;
+      if (p) { p.style.left = '8px'; p.style.top = '8px'; p.style.right = 'auto'; }
+    });
+    await page.locator('#insert-arrange-toggle').click();
+
+    // Drag the cube right by a sensible amount in screen px so the translate
+    // commit visibly shifts +X (the world delta depends on camera, but the
+    // direction is right).
+    const cBox = await page.locator('canvas').first().boundingBox();
+    if (!cBox) throw new Error('canvas missing');
+    const cx = cBox.x + cBox.width / 2;
+    const cy = cBox.y + cBox.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 100, cy, { steps: 10 });
+    await page.mouse.up();
+
+    // After commit, the code includes a translate(...) chain on box.
+    await expect.poll(() => getCode(page)).toMatch(/\.translate\(\[/);
+
+    // Undo via the API; the code reverts to its pre-drag form.
+    const undone = await page.evaluate(() => (window as unknown as { partwright: { undo(): string | null } }).partwright.undo());
+    expect(undone).toContain('Move');
+    await expect.poll(() => getCode(page)).toBe(codeBeforeDrag);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the follow-up gaps from PR #603's review pass — the Tinkercad-style Arrange tool now has matching `window.partwright.*` coverage, hand-written parts are draggable / resizable / alignable, Ctrl-Z works, and the marquee paints live candidate previews.

**What ships**

- **UI ↔ JS-API parity** (CLAUDE.md norm): 22 new `window.partwright.*` methods covering the full arrange flow — `enterArrange`/`exitArrange`/`isArrangeActive`, selection (`selectParts`/`addToSelection`/`clearSelection`/`getSelection`/`listArrangeParts`), history (`undo`/`redo`/`canUndo`/`canRedo`), transforms (`resizeSelection`/`alignSelection`), operations (`groupSelection`/`subtractSelection`/`intersectSelection`/`duplicateSelection`/`mirrorSelection`/`deleteSelection`), and the panel's `setAutoCombine`/`getAutoCombine` toggle. All registered in `help()` and documented in a new `## Arrange mode` section in `public/ai.md`. Methods return `{ok:true}` or `{ok:false, reason}` rather than throwing.
- **Hand-written parts** now seed the arrange registry on enter via a new best-effort regex parser at `src/insert/parseStatement.ts`. Handles voxel `fillBox`/`sphere`/`cylinder`/`sdf-torus`; SCAD `cube`/`sphere`/`cylinder`/`cone` with optional leading `translate`; Manifold-JS + BREP `cube`/`sphere`/`cylinder`/`cone`/`torus` with optional trailing `.translate`. Anything fancier (chained `.rotate`, computed args, custom expressions) returns null — graceful degradation; the part stays out of the registry, never gets a wrong bbox.
- **Keyboard shortcuts** (`⌘Z` / `⌘⇧Z` / `Ctrl+Y`) routed through the central `installKeyboardShortcuts`. Arrange-active overrides the editable-target guard (mirrors voxel-studio's pattern); arrange-history fallback fires only outside text fields so CodeMirror's per-keystroke undo still wins there.
- **Live marquee highlight**: shift+drag paints translucent yellow boxes on every candidate part as the rect moves, then transitions to the solid selection boxes on release.
- **Test gaps closed**: 20 new `parseStatement` + `scanPartsJs` unit tests in the e2e tier; 6 new palette e2e (API-driven align, API-driven undo/redo, hand-written part seeding, drag→undo restoration, groupSelection via API, session-changed history clear).

**Deferred to their own follow-up PRs**

Each is substantial enough to deserve a dedicated design + tests pass:

- **Rotation** (per-engine `.rotate([…])` codegen + UI + group-centroid math)
- **Z-axis drag** (alt-modifier or vertical handle)
- **Group-centroid transforms** for multi-select resize/rotate
- **Snap-to-grid** for non-voxel engines

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 1252 pass
- [x] `npx playwright test insert-codegen` — 161 pass (20 new)
- [x] `npx playwright test insert-palette` — 18 pass (6 new)
- [x] `npm run lint:deps` — acyclic
- [x] `npm run lint:consistency` — no new hits
- [x] `npm run lint:deadcode` — no new hits
- [x] `work-reviewer` agent pass — 2 important findings fixed (scanPartsJs string-literal trap, autoCombine API parity)
- [x] Manual: hand-written model with two `const myX = Manifold.…` declarations is fully arrangeable from the console (`partwright.enterArrange()` → `selectParts(['myCube','myBall'])` → `alignSelection('z','min')`) — screenshot posted in the chat
- [x] Manual: shift+drag marquee paints live candidate previews on both parts as the rect grows; releases into solid selection boxes without a flicker

https://claude.ai/code/session_01HXdX6NdV5tR7p61DMGFyJn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXdX6NdV5tR7p61DMGFyJn)_