### PR TITLE
feat: arrange rotation, Z-drag, group-centroid pivot, snap-to-grid

### DIFF
--- a/prompts/20260612-013000-arrange-rotate-zdrag-centroid-snap.md
+++ b/prompts/20260612-013000-arrange-rotate-zdrag-centroid-snap.md
@@ -1,0 +1,93 @@
+---
+session: "aiK0c"
+timestamp: "2026-06-12T01:30:00Z"
+sequence: 8
+---
+
+## Human
+
+(After PR #607 merged.) Do all the deferred arrange follow-ups in a new
+PR: rotation, Z-axis drag, group-centroid transforms, snap-to-grid.
+
+## Assistant
+
+## Decisions
+
+**Rotation: per-engine `.rotate([rx,ry,rz])` codegen modelled on `.scale`.**
+For JS/BREP, `setPartRotateJs` inserts the call BEFORE any trailing
+`.translate(…)` so the pivot is the part's origin (so it rotates in place at
+its world position). For SCAD, `setPartRotateScad` wraps with
+`rotate([…])` AFTER any leading `translate([…])` — SCAD's right-to-left
+application order gives the same in-place-at-position result. Both
+compound additively with an existing leading rotate (Tinkercad-style
+"add 30°" semantics) rather than stacking calls. Voxel rotation is
+rejected with a warn toast — lattice quantization makes arbitrary angles
+unfaithful, and snap-to-90° voxel rotation can come later.
+
+**Z-axis drag: alt-held during drag builds a vertical plane facing the
+camera through the pickup point.** The plane normal is the camera-to-pivot
+direction flattened onto XY. We still only consume the Z component of the
+hit, but the camera-aware orientation keeps the part under the cursor as
+the user orbits. Tinkercad-feel "lift up" gesture.
+
+**Group-centroid transforms (resize + rotate).** When 2+ are selected,
+`applyResize` and `applyRotate` snapshot the pre-transform centres and
+compute the group centroid (union-of-bboxes midpoint) BEFORE editing
+any code. After the per-part code edit (which scales/rotates each part
+around its own centre, leaving its centre fixed), a follow-up
+`writePartTranslateDelta` per part spreads/swings the parts around the
+shared pivot. Two pure-leaf helpers in arrangeMath.ts:
+`groupCentroidScaleDelta` (anisotropic, all axes) and
+`groupCentroidRotateZDelta` (Z plane only — arbitrary 3D rotation around
+an arbitrary 3D pivot is rarely what a CAD user wants). Both wrapped in
+the same recordOperation so a group resize/rotate is one Ctrl-Z step.
+
+**Snap-to-grid: round every per-engine translate delta.** When the panel
+toggle is on, `writePartTranslateDelta` rounds the JS/SCAD effective
+delta to whole units; voxel already snaps. Affects drag commits, the
+Align spread, and the new Group-centroid rotate/scale spread —
+everything that flows through the shared writeback path. Module-level
+`snapToGrid` + `snapToGridCheckbox` (for API/UI sync) mirror the
+`autoCombine` pattern.
+
+**Parser now accepts a single trailing `.rotate([…]).translate([…])`
+chain.** Hand-written code like `Manifold.cube([10,10,10]).rotate([0,0,30]).translate([5,0,0])`
+parses to a cube spec (size + position; bbox is the un-rotated AABB, which
+over-estimates the footprint but is safe). The controller's
+`setPartRotateJs` compounds onto the existing `.rotate` rather than
+stacking, so iterated rotates round-trip correctly. Updated the old
+"chained transforms → null" test to reflect the new contract;
+multi-method chains beyond rotate-translate still return null.
+
+**API parity, mirrored 1:1 with the new panel rows.** Added
+`partwright.rotateSelection([rx,ry,rz])`, `setSnapToGrid(on)` /
+`getSnapToGrid()`. Same `{ok, reason?}` return shape as the other
+selection ops. Documented in `public/ai.md` under the `## Arrange mode`
+section's new "Drag along Z" / "Group centroid" / "Snap-to-grid"
+paragraphs.
+
+## Tests
+
+- 14 new codegen + math units (setPartRotateJs, setPartRotateScad,
+  groupCentroid, groupCentroidScaleDelta, groupCentroidRotateZDelta).
+- 3 new palette e2e: API rotateSelection writes `.rotate` before
+  `.translate`; group-centroid scale spreads two parts apart from origin;
+  setSnapToGrid rounds drag commits to integers.
+- All 180 codegen + 21 palette e2e + 1252 unit tests green; typecheck +
+  acyclic deps + lint:consistency / lint:deadcode clean.
+
+## Manual verification
+
+Console smoke: two cubes at ±10 on X, both selected →
+`partwright.rotateSelection([0,0,45])` rotates each by 45° AND swings
+both around the group centroid (visible in screenshots).
+The code shows `.rotate([0, 0, 45]).translate([-…, 0, 0])` on each part,
+and Undo is enabled (one undo step for the whole group rotate).
+
+## What this PR does NOT do (own follow-ups, called out in PR description)
+
+- **Rotation handles in the viewport** — Tinkercad has 3 ring gizmos; we
+  ship numeric inputs only. The drag-handle UX is a deeper viewport
+  refactor (and most CAD agents drive via the API anyway).
+- **Voxel snap-to-90° rotation** — explicitly rejected with a toast.
+- **Rotate from arrange-drag** — drag is still translate-only.

--- a/prompts/20260612-014000-arrange-pr609-review-fixes.md
+++ b/prompts/20260612-014000-arrange-pr609-review-fixes.md
@@ -1,0 +1,82 @@
+---
+session: "aiK0c"
+timestamp: "2026-06-12T01:40:00Z"
+sequence: 9
+---
+
+## Human
+
+(work-reviewer subagent output on PR #609's branch.) Two IMPORTANT
+findings + tightens. Address before pushing.
+
+1. setPartRotateScad has an `if (scaleMatch)` / `else` branch that
+   produces identical strings — dead branch with misleading comment.
+2. Alt-modifier for Z-drag is re-read per pointermove instead of locked
+   at drag start. Releasing alt mid-drag switches the plane and jumps
+   the ghost. UX surprise.
+3. Snap label says "Snap drag" but writePartTranslateDelta snaps every
+   per-engine translate (align, rotate spread, drag). Mislabelled.
+4. Snap-to-grid amplifies group-centroid drift — round-independently
+   spreads can shift the layout up to N units. Doc note.
+5. Rotate tooltip claims "around the part / group centroid" but only Z
+   pivots around the group; X/Y are per-part.
+6. parseStatement only accepts `.rotate(...).translate(...)`, not the
+   reverse. Pin with a test.
+7. SCAD rotate test coverage gaps: no bare-cube, no scale-only-without-
+   translate, no full translate+scale chain.
+
+## Assistant
+
+## Decisions
+
+**#2 (UX) — Lock `dragVertical` at threshold cross, not per pointermove.**
+Read `e.altKey` once inside the threshold-crossed branch of
+`onPointerMove`, store on `dragVertical`, and use that for the rest of
+the gesture. Releasing alt mid-drag no longer jumps the ghost between
+horizontal-XY and vertical-Z planes. Cleared on `cancelDrag` so a stale
+flag can't bleed across drags. Matches every other modifier-locked
+gesture in the app (paint slab-fan, marquee shift-at-start).
+
+**#1 — Collapsed the dead branch in `setPartRotateScad`.** The
+`if (scaleMatch)` and `else` produced literally the same string; the
+guard was a documentation hook the comment then mis-described. Single
+path now (`afterTrans` already carries any leading scale, so prepending
+`rotate` before it gives the right `translate(t) rotate(r) scale(s)
+cube()` chain). Added an exhaustive comment explaining the
+right-to-left SCAD application order so the next reader doesn't
+re-introduce the branch chasing a phantom scale path.
+
+**#3 — Snap label retitled to "Snap moves to whole units" + tooltip.**
+The function name `writePartTranslateDelta` and its callers (drag
+commit, align spread, group-centroid scale/rotate spread) all share
+the same snap path. The label now covers the broader scope explicitly;
+a `title` adds the per-flow list so a user toggling it for drag
+cleanup understands the knock-on effects on align/group-spread.
+
+**#5 — Rotate tooltip clarifies Z-only pivot for groups.** New text:
+"For 2+ parts, the Z rotation also swings the group around its
+centroid; X/Y rotations stay per-part." Mirrors what ai.md already says.
+
+**#4 — Added a one-line drift caveat to ai.md's Snap-to-grid
+paragraph.** Not a code fix — the per-part rounding is the documented
+behaviour — but surfacing the limit lets a user dial it intentionally.
+
+**#6 + #7 — Test additions:**
+- `parseStatement` returns null for `.translate(...).rotate(...)` —
+  pins the one-way chain-order contract so a future refactor can't
+  accidentally accept it and break setPartRotateJs's "compound onto
+  existing" expectation.
+- `setPartRotateScad` covers (a) bare cube (no leading transforms),
+  (b) scale-only without translate (exercises the collapsed-branch
+  path), and (c) full `translate + scale + cube` (confirms the
+  documented chain order `translate(t) rotate(r) scale(s) cube()`).
+
+## Tests
+
+184 codegen, 21 palette e2e, all green. Typecheck clean.
+
+## Manual verification
+
+Driver: same alt-drag scenario from the original review case —
+alt+drag the ghost from its centre, release alt mid-gesture, see
+that the ghost stays on the vertical plane. ✓

--- a/public/ai.md
+++ b/public/ai.md
@@ -269,11 +269,14 @@ partwright.subtractSelection()            // ∖ first - rest
 partwright.intersectSelection()           // ∩
 partwright.duplicateSelection()           // Clone, offset along +X -> {ok}
 partwright.mirrorSelection('x')           // Mirror across axis
+partwright.rotateSelection([0,0,90])      // Rotate in place (degrees, per-axis); 2+ pivots around group centroid (Z)
 partwright.deleteSelection()              // Remove selected parts from the code
 partwright.undo() / partwright.redo()     // Coarse-grained: one Tinkercad action = one step
 partwright.canUndo() / partwright.canRedo()
 partwright.setAutoCombine(false)          // Insert without auto-union (managed engines)
 partwright.getAutoCombine()               // -> boolean
+partwright.setSnapToGrid(true)            // Round drag/translate deltas to whole units (non-voxel)
+partwright.getSnapToGrid()                // -> boolean
 await partwright.exportGLB()   // Download GLB (browser file dialog -- prefer exportGLBData() in agent flows)
 partwright.exportSTL()         // Download STL ("                                       exportSTLData() ")
 partwright.exportOBJ()         // Download OBJ ("                                       exportOBJData() ")
@@ -1055,5 +1058,11 @@ A successful action returns `{ ok: true }`; rejected ones return `{ ok: false, r
 
 **`enterArrange()` opens the Insert panel as a side effect** so the chip strip, Size/Align inputs, and Undo/Redo buttons are visible — matching what a user sees when they enable arrange by hand. Headless flows that just want the canvas pointer hook should still call it; the panel doesn't steal focus from `partwright.*` calls.
 
-**Caveats.** Hand-written parts the regex parser can't decode (chained `.rotate()`, computed args, custom expressions) stay out of the registry and are skipped silently. The current Z-axis drag is locked to a horizontal plane through the pickup point. Voxel grids union implicitly, so `groupSelection` / `subtractSelection` / `intersectSelection` are no-ops in a voxel session.
+**Drag along Z.** Hold **Alt** during drag to slide the part along the world Z axis instead of across the horizontal plane (Tinkercad's lift-up gesture). The drag plane is built from the camera's look direction so the part stays under the cursor as the camera turns.
+
+**Group centroid.** When 2+ parts are selected, `resizeSelection` scales around — and `rotateSelection` (Z axis) pivots around — the **union centroid** rather than each part's own centre. This matches Tinkercad's behaviour: a group resize spreads the parts apart and a Z-rotation swings them around the common pivot.
+
+**Snap-to-grid.** `setSnapToGrid(true)` rounds every per-engine translate delta (drag commit, align spread, rotate spread) to whole units. Voxel grids already snap; this gives the JS/SCAD/BREP engines an opt-in tidy-lattice mode.
+
+**Caveats.** Hand-written parts the regex parser can't decode (chained `.scale()`/`.color()`/computed args/custom expressions) stay out of the registry and are skipped silently — a single trailing `.translate(...)` and a single trailing `.rotate(...)` are recognised. Voxel rotation is rejected (lattice quantization makes arbitrary angles unfaithful). Voxel grids union implicitly, so `groupSelection` / `subtractSelection` / `intersectSelection` are no-ops in a voxel session.
 

--- a/public/ai.md
+++ b/public/ai.md
@@ -1062,7 +1062,7 @@ A successful action returns `{ ok: true }`; rejected ones return `{ ok: false, r
 
 **Group centroid.** When 2+ parts are selected, `resizeSelection` scales around — and `rotateSelection` (Z axis) pivots around — the **union centroid** rather than each part's own centre. This matches Tinkercad's behaviour: a group resize spreads the parts apart and a Z-rotation swings them around the common pivot.
 
-**Snap-to-grid.** `setSnapToGrid(true)` rounds every per-engine translate delta (drag commit, align spread, rotate spread) to whole units. Voxel grids already snap; this gives the JS/SCAD/BREP engines an opt-in tidy-lattice mode.
+**Snap-to-grid.** `setSnapToGrid(true)` rounds every per-engine translate delta (drag commit, align spread, rotate spread) to whole units. Voxel grids already snap; this gives the JS/SCAD/BREP engines an opt-in tidy-lattice mode. Note: with snap on, each part in a group transform rounds independently, so a fractional group-spread (e.g. a 2.5× scale) can drift the layout by up to one unit per part.
 
 **Caveats.** Hand-written parts the regex parser can't decode (chained `.scale()`/`.color()`/computed args/custom expressions) stay out of the registry and are skipped silently — a single trailing `.translate(...)` and a single trailing `.rotate(...)` are recognised. Voxel rotation is rejected (lattice quantization makes arbitrary angles unfaithful). Voxel grids union implicitly, so `groupSelection` / `subtractSelection` / `intersectSelection` are no-ops in a voxel session.
 

--- a/src/insert/arrangeMath.ts
+++ b/src/insert/arrangeMath.ts
@@ -54,3 +54,71 @@ export function formatScaleCall(scale: Vec3): string {
   const s = scale.map(v => Math.max(0.001, v)) as Vec3;
   return `.scale([${fmt(s[0])}, ${fmt(s[1])}, ${fmt(s[2])}])`;
 }
+
+/** Centre of the union of every selected part's bbox — the pivot for a
+ *  group-centroid scale or rotate, matching Tinkercad's "scale 2+ parts as
+ *  one". Returns null when nothing in `names` resolves to a registry entry. */
+export function groupCentroid(
+  names: Iterable<string>,
+  registry: Map<string, RegistryEntry>,
+): Vec3 | null {
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  let any = false;
+  for (const name of names) {
+    const e = registry.get(name);
+    if (!e) continue;
+    any = true;
+    if (e.box.min[0] < minX) minX = e.box.min[0];
+    if (e.box.min[1] < minY) minY = e.box.min[1];
+    if (e.box.min[2] < minZ) minZ = e.box.min[2];
+    if (e.box.max[0] > maxX) maxX = e.box.max[0];
+    if (e.box.max[1] > maxY) maxY = e.box.max[1];
+    if (e.box.max[2] > maxZ) maxZ = e.box.max[2];
+  }
+  if (!any) return null;
+  return [(minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2];
+}
+
+/** For a group-centroid scale, the per-part translate delta needed so the
+ *  part's centre lies the right distance from the pivot AFTER each part is
+ *  scaled around its own centre by the same factor. Caller still applies the
+ *  scale to each part individually — this helper only produces the
+ *  "spread / pull-in" component that turns N scale-in-place ops into a
+ *  scale-around-the-group-centre.
+ *
+ *  Math: newCentre[i] = pivot[i] + (centre[i] − pivot[i]) × scale[i]
+ *       delta[i]      = newCentre[i] − centre[i]
+ *                     = (centre[i] − pivot[i]) × (scale[i] − 1) */
+export function groupCentroidScaleDelta(center: Vec3, pivot: Vec3, scale: Vec3): Vec3 {
+  return [
+    (center[0] - pivot[0]) * (scale[0] - 1),
+    (center[1] - pivot[1]) * (scale[1] - 1),
+    (center[2] - pivot[2]) * (scale[2] - 1),
+  ];
+}
+
+/** For a group-centroid Z-axis rotation (degrees), the per-part translate
+ *  delta needed so each part's centre lies on the rotated radius around
+ *  pivot. Caller still applies the rotation to each part individually —
+ *  this helper produces the swing-around-the-group-centre component. We
+ *  expose Z separately because (a) it's the only single-axis rotation
+ *  with a clean planar pivot — XY rotation around an arbitrary 3D pivot
+ *  is well-defined too but rarely what a CAD user wants in a flat-on-the-
+ *  build-plate workflow, and (b) only Z makes physical sense for voxel
+ *  snap-to-90° rotations.
+ *
+ *  Math for Z rotation by θ around `pivot`:
+ *    [x'] = pivot + R(θ) · (center − pivot)
+ *    delta = [x' − x]
+ *  where R(θ) is the 2D rotation matrix in the XY plane (Z component stays). */
+export function groupCentroidRotateZDelta(center: Vec3, pivot: Vec3, deg: number): Vec3 {
+  if (deg === 0) return [0, 0, 0];
+  const rad = deg * Math.PI / 180;
+  const c = Math.cos(rad), s = Math.sin(rad);
+  const dx = center[0] - pivot[0];
+  const dy = center[1] - pivot[1];
+  const nx = pivot[0] + c * dx - s * dy;
+  const ny = pivot[1] + s * dx + c * dy;
+  return [nx - center[0], ny - center[1], 0];
+}

--- a/src/insert/arrangeMode.ts
+++ b/src/insert/arrangeMode.ts
@@ -22,12 +22,20 @@ import * as THREE from 'three';
 import { getScene, setGizmoLock, requestRender } from '../renderer/viewport';
 import { primitiveEntry, pickPart, type RegistryEntry } from './spatial';
 import { type PrimitiveSpec, type Vec3, type InsertLanguage } from './codegen';
-import { alignDeltas, formatScaleCall, type AlignAxis, type AlignMode } from './arrangeMath';
+import {
+  alignDeltas,
+  formatScaleCall,
+  groupCentroid,
+  groupCentroidScaleDelta,
+  groupCentroidRotateZDelta,
+  type AlignAxis,
+  type AlignMode,
+} from './arrangeMath';
 import { recordOperation } from './undoStack';
 import { parseStatement } from './parseStatement';
 
 // Re-export the pure helpers so callers can pick them up from one entry point.
-export { alignDeltas, formatScaleCall };
+export { alignDeltas, formatScaleCall, groupCentroid, groupCentroidScaleDelta, groupCentroidRotateZDelta };
 export type { AlignAxis, AlignMode };
 
 export interface ScannedPart {
@@ -333,15 +341,46 @@ function onPointerMove(e: PointerEvent): void {
   }
 
   if (dragging) {
-    const plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), -pointerStart.world.z);
+    // Drag plane selection:
+    //   - default: horizontal plane through the pickup point — slides the part
+    //     across the build plate.
+    //   - alt held: vertical plane facing the camera through the pickup point
+    //     — lifts the part along the world Z axis. Cleaner than a "use Y mouse
+    //     motion as Z" approximation because the projection picks up the
+    //     camera distance correctly, so a click on a high feature scales the
+    //     drag the same way the horizontal drag does.
+    const plane = e.altKey
+      ? makeVerticalPlane(camera, pointerStart.world)
+      : new THREE.Plane(new THREE.Vector3(0, 0, 1), -pointerStart.world.z);
     const hit = projectToPlane(e.clientX, e.clientY, camera, canvas, plane);
     if (!hit) return;
-    const delta: Vec3 = [hit.x - pointerStart.world.x, hit.y - pointerStart.world.y, 0];
+    const delta: Vec3 = e.altKey
+      ? [0, 0, hit.z - pointerStart.world.z]
+      : [hit.x - pointerStart.world.x, hit.y - pointerStart.world.y, 0];
     applyGhostDelta(delta);
     requestRender();
     e.stopPropagation();
     e.preventDefault();
   }
+}
+
+/** Build a vertical plane through `pivot` whose normal is the horizontal
+ *  component of the camera's look direction. Lets alt-drag map the user's
+ *  in-plane pointer motion to a clean world-Z delta (we still only consume
+ *  the Z component, but the plane orientation keeps the in-plane projection
+ *  meaningful — the part stays under the cursor as the camera turns). */
+function makeVerticalPlane(camera: THREE.Camera, pivot: THREE.Vector3): THREE.Plane {
+  // Look-direction from camera to pivot, flattened onto the XY plane.
+  const look = pivot.clone().sub(camera.getWorldPosition(new THREE.Vector3()));
+  look.z = 0;
+  if (look.lengthSq() < 1e-6) look.set(1, 0, 0); // top-down camera: fall back to +X
+  look.normalize();
+  // Plane normal = -look so the user faces the plane (the plane equation
+  // n·x = -d is consistent with Three's setFromNormalAndCoplanarPoint).
+  const normal = look.clone().multiplyScalar(-1);
+  const plane = new THREE.Plane();
+  plane.setFromNormalAndCoplanarPoint(normal, pivot);
+  return plane;
 }
 
 function onPointerUp(e: PointerEvent): void {

--- a/src/insert/arrangeMode.ts
+++ b/src/insert/arrangeMode.ts
@@ -99,6 +99,12 @@ let dragNames: string[] = [];
 let dragBaseline = new Map<string, Vec3>(); // pre-drag centres for each ghost
 const DRAG_THRESHOLD_PX = 4;
 let dragging = false;
+// Drag-plane choice is locked at `beginDrag` — alt-held at drag-start picks the
+// vertical (Z) plane; releasing alt mid-drag does NOT switch back to horizontal
+// (and pressing alt mid-drag does NOT switch in). Otherwise the ghost would
+// jump as the alt key changes state — confusing UX caught in the post-merge
+// review of this milestone.
+let dragVertical = false;
 
 // Marquee (shift+drag on empty space) — a DOM overlay rectangle that selects
 // every part whose bbox centre projects inside it on release. State is held
@@ -337,24 +343,29 @@ function onPointerMove(e: PointerEvent): void {
       deps.onSelectionChanged();
       refreshArrangeOverlay();
     }
+    // Lock the drag-plane choice at this point — alt held when the user
+    // crossed the drag threshold picks the vertical (Z) plane for the whole
+    // gesture. Toggling alt mid-drag would otherwise jump the ghost between
+    // horizontal-XY and vertical-Z projections, which the post-PR-#609 review
+    // flagged as a UX surprise.
+    dragVertical = e.altKey;
     beginDrag();
   }
 
   if (dragging) {
-    // Drag plane selection:
+    // Drag plane selection (locked at `dragVertical`):
     //   - default: horizontal plane through the pickup point — slides the part
     //     across the build plate.
-    //   - alt held: vertical plane facing the camera through the pickup point
-    //     — lifts the part along the world Z axis. Cleaner than a "use Y mouse
-    //     motion as Z" approximation because the projection picks up the
-    //     camera distance correctly, so a click on a high feature scales the
-    //     drag the same way the horizontal drag does.
-    const plane = e.altKey
+    //   - alt at drag-start: vertical plane facing the camera through the
+    //     pickup point — lifts the part along the world Z axis. Cleaner than
+    //     a "use Y mouse motion as Z" approximation because the projection
+    //     picks up the camera distance correctly.
+    const plane = dragVertical
       ? makeVerticalPlane(camera, pointerStart.world)
       : new THREE.Plane(new THREE.Vector3(0, 0, 1), -pointerStart.world.z);
     const hit = projectToPlane(e.clientX, e.clientY, camera, canvas, plane);
     if (!hit) return;
-    const delta: Vec3 = e.altKey
+    const delta: Vec3 = dragVertical
       ? [0, 0, hit.z - pointerStart.world.z]
       : [hit.x - pointerStart.world.x, hit.y - pointerStart.world.y, 0];
     applyGhostDelta(delta);
@@ -510,6 +521,7 @@ function commitDrag(): void {
 function cancelDrag(): void {
   cleanupGhosts();
   dragging = false;
+  dragVertical = false;
   pendingPart = null;
   pointerStart = null;
   if (active) refreshArrangeOverlay();

--- a/src/insert/controller.ts
+++ b/src/insert/controller.ts
@@ -542,11 +542,13 @@ export function setPartRotateScad(
   const afterTrans = transMatch ? stmt.slice(transMatch[0].length) : stmt;
   const head = transMatch ? transMatch[0] : '';
 
-  // A leading scale, if present, must run after rotate (rotate-then-scale
-  // matches the JS chain order and avoids a sheared shape). Place the new
-  // `rotate(...)` between translate and scale so the chain reads:
-  //   translate(t) rotate(r) scale(s) <construction>
-  const leadingScaleRe = new RegExp(`^scale\\(${TRIPLE}\\)\\s*`);
+  // Place the new `rotate(...)` between any leading translate and whatever
+  // else (scale / construction call) is in the chain. SCAD applies modifiers
+  // right-to-left, so `translate(t) rotate(r) scale(s) cube(...)` reads as
+  // scale-at-origin → rotate-around-origin → translate-to-position, matching
+  // the JS chain `cube(...).scale(s).rotate(r).translate(t)`. We don't need
+  // a separate "leading scale" branch — `afterTrans` already carries the
+  // scale (if present) and prepending rotate before it gives the right order.
   const leadingRotateRe = new RegExp(`^rotate\\(${TRIPLE}\\)\\s*`);
   const rotateMatch = leadingRotateRe.exec(afterTrans);
   let updated: string;
@@ -554,15 +556,8 @@ export function setPartRotateScad(
     const compound = addRotateTriple(rotateMatch[0].replace(/\s*$/, ''), deg);
     updated = `${head}${compound} ${afterTrans.slice(rotateMatch[0].length)}`;
   } else {
-    const scaleMatch = leadingScaleRe.exec(afterTrans);
     const rotateCall = `rotate([${fmt(deg[0])}, ${fmt(deg[1])}, ${fmt(deg[2])}])`;
-    if (scaleMatch) {
-      // Insert rotate BEFORE the leading scale so SCAD's right-to-left
-      // application order runs scale first (around origin), then rotate.
-      updated = `${head}${rotateCall} ${afterTrans}`;
-    } else {
-      updated = `${head}${rotateCall} ${afterTrans}`;
-    }
+    updated = `${head}${rotateCall} ${afterTrans}`;
   }
   return code.slice(0, statement.from) + updated + code.slice(statement.to);
 }

--- a/src/insert/controller.ts
+++ b/src/insert/controller.ts
@@ -471,6 +471,103 @@ export function setPartScaleScad(
 }
 
 // ---------------------------------------------------------------------------
+// Rotate: insert a per-axis `.rotate([rx,ry,rz])` into the chain. Like scale,
+// rotation happens at the origin and translate moves the part, so the rotate
+// must come *before* any trailing `.translate(...)` (otherwise the rotation
+// would swing the part around the world origin). Tinkercad-style "rotate in
+// place around the part's centre" for any origin-centred primitive.
+//
+// Angles are degrees. Identity (all zero) returns the code unchanged so
+// chasing-no-op resize/rotate buttons doesn't pile up `.rotate([0,0,0])`.
+// ---------------------------------------------------------------------------
+
+function addRotateTriple(call: string, delta: Vec3): string {
+  // `.rotate([a,b,c])` → `.rotate([a+rx,b+ry,c+rz])`. Lets a second rotation
+  // compound onto the first (additive in degrees) instead of stacking calls.
+  // Rotations don't commute in 3D, but the chained-degree convention is what
+  // every Tinkercad-style tool uses; the model recomputes on apply so the
+  // user sees the effect immediately and can iterate.
+  const re = new RegExp(TRIPLE);
+  return call.replace(re, (_full, a: string, b: string, c: string) =>
+    `[${fmt(parseFloat(a) + delta[0])}, ${fmt(parseFloat(b) + delta[1])}, ${fmt(parseFloat(c) + delta[2])}]`,
+  );
+}
+
+/** Apply a per-axis rotation (degrees) to a JS-engine part. Inserted *before*
+ *  any trailing `.translate([…])` so the rotation pivots around the part's own
+ *  origin and the position is preserved. Compounds with an existing `.rotate`
+ *  rather than stacking a second call. Returns the code unchanged when no
+ *  matching `const <name> = …;` is found, or when the rotation is the identity. */
+export function setPartRotateJs(code: string, name: string, deg: Vec3): string {
+  if (deg[0] === 0 && deg[1] === 0 && deg[2] === 0) return code;
+  const declRe = new RegExp(`(const\\s+${escapeRegExp(name)}\\s*=\\s*)([\\s\\S]*?)(;)`);
+  const m = declRe.exec(code);
+  if (!m) return code;
+  let rhs = m[2];
+  const rotRe = new RegExp(`\\.rotate\\(${TRIPLE}\\)`, 'g');
+  const existing = [...rhs.matchAll(rotRe)];
+  if (existing.length > 0) {
+    const last = existing[existing.length - 1];
+    const updated = addRotateTriple(last[0], deg);
+    rhs = rhs.slice(0, last.index!) + updated + rhs.slice(last.index! + last[0].length);
+  } else {
+    const rotCall = `.rotate([${fmt(deg[0])}, ${fmt(deg[1])}, ${fmt(deg[2])}])`;
+    const transRe = new RegExp(`\\.translate\\(${TRIPLE}\\)`, 'g');
+    const trans = [...rhs.matchAll(transRe)];
+    if (trans.length > 0) {
+      // Place rotate before the first translate so the part keeps its position.
+      const first = trans[0];
+      rhs = rhs.slice(0, first.index!) + rotCall + rhs.slice(first.index!);
+    } else {
+      rhs = `${rhs}${rotCall}`;
+    }
+  }
+  return code.slice(0, m.index) + m[1] + rhs + m[3] + code.slice(m.index + m[0].length);
+}
+
+/** Apply a per-axis rotation (degrees) to an OpenSCAD part: wrap its
+ *  construction in `rotate([rx,ry,rz])`, placed *after* any leading
+ *  `translate([…])` (so the chain reads as rotate-then-translate, putting
+ *  the rotation at the part's centre). Compounds additively with an existing
+ *  leading rotate. */
+export function setPartRotateScad(
+  code: string,
+  statement: { from: number; to: number },
+  deg: Vec3,
+): string {
+  if (deg[0] === 0 && deg[1] === 0 && deg[2] === 0) return code;
+  const stmt = code.slice(statement.from, statement.to);
+  const leadingTransRe = new RegExp(`^translate\\(${TRIPLE}\\)\\s*`);
+  const transMatch = leadingTransRe.exec(stmt);
+  const afterTrans = transMatch ? stmt.slice(transMatch[0].length) : stmt;
+  const head = transMatch ? transMatch[0] : '';
+
+  // A leading scale, if present, must run after rotate (rotate-then-scale
+  // matches the JS chain order and avoids a sheared shape). Place the new
+  // `rotate(...)` between translate and scale so the chain reads:
+  //   translate(t) rotate(r) scale(s) <construction>
+  const leadingScaleRe = new RegExp(`^scale\\(${TRIPLE}\\)\\s*`);
+  const leadingRotateRe = new RegExp(`^rotate\\(${TRIPLE}\\)\\s*`);
+  const rotateMatch = leadingRotateRe.exec(afterTrans);
+  let updated: string;
+  if (rotateMatch) {
+    const compound = addRotateTriple(rotateMatch[0].replace(/\s*$/, ''), deg);
+    updated = `${head}${compound} ${afterTrans.slice(rotateMatch[0].length)}`;
+  } else {
+    const scaleMatch = leadingScaleRe.exec(afterTrans);
+    const rotateCall = `rotate([${fmt(deg[0])}, ${fmt(deg[1])}, ${fmt(deg[2])}])`;
+    if (scaleMatch) {
+      // Insert rotate BEFORE the leading scale so SCAD's right-to-left
+      // application order runs scale first (around origin), then rotate.
+      updated = `${head}${rotateCall} ${afterTrans}`;
+    } else {
+      updated = `${head}${rotateCall} ${afterTrans}`;
+    }
+  }
+  return code.slice(0, statement.from) + updated + code.slice(statement.to);
+}
+
+// ---------------------------------------------------------------------------
 // Mirror / Duplicate / Delete (selection-driven quick actions)
 // ---------------------------------------------------------------------------
 

--- a/src/insert/parseStatement.ts
+++ b/src/insert/parseStatement.ts
@@ -164,23 +164,29 @@ function parseJsStatement(stmt: string, name: string): PrimitiveSpec | null {
   // the declaration head and trailing `;` to leave the expression chain.
   const decl = /^\s*(?:const|let)\s+[A-Za-z_$][A-Za-z0-9_$]*\s*=\s*(.+?);?\s*$/s.exec(stmt);
   const expr = decl ? decl[1].trim() : stmt.trim();
-  // Pull out any trailing `.translate([x,y,z])` first; the construction call
-  // is whatever's left. (We only support a single translate suffix — anything
-  // more elaborate like .rotate() or compound transforms is out of scope here.)
+  // Strip optional trailing `.translate([x,y,z])` (position) and a single
+  // trailing `.rotate([rx,ry,rz])` before it. We accept the chain order
+  // `.rotate(...).translate(...)` because that's what `setPartRotateJs` emits
+  // (rotate around origin, then translate to position). Anything beyond a
+  // single rotate-translate suffix is out of scope and the parse returns null.
   let position: Vec3 = [0, 0, 0];
-  const trMatch = new RegExp(`\\.translate\\s*\\(\\s*${VEC3}\\s*\\)\\s*$`).exec(expr);
-  let head = expr;
+  let working = expr;
+  const trMatch = new RegExp(`\\.translate\\s*\\(\\s*${VEC3}\\s*\\)\\s*$`).exec(working);
   if (trMatch) {
     position = [Number(trMatch[1]), Number(trMatch[2]), Number(trMatch[3])];
-    head = expr.slice(0, trMatch.index);
+    working = working.slice(0, trMatch.index);
   }
-  head = head.trim();
-  // Note: we deliberately don't strip *other* trailing `.method()` calls. If
-  // the user chained `.rotate()` / `.color()` / `.simplify()`, the construction
-  // call no longer matches our anchored regexes and the parse returns null —
-  // arrange mode then skips the part instead of moving it under an incorrect
-  // bounding box. Adding broader chain support belongs in a follow-up that can
-  // also extend the per-engine codegen writers to honour those transforms.
+  const rotMatch = new RegExp(`\\.rotate\\s*\\(\\s*${VEC3}\\s*\\)\\s*$`).exec(working);
+  if (rotMatch) {
+    // We accept rotation in the chain but don't model it in the spec (no
+    // rotation field). Arrange-mode treats this part as draggable / resizable
+    // / re-rotateable; bbox is the un-rotated AABB, which over-estimates the
+    // footprint but never falsely under-estimates — and the controller's
+    // setPartRotateJs compounds onto the existing `.rotate` rather than
+    // stacking a new one, so iterated rotates round-trip correctly.
+    working = working.slice(0, rotMatch.index);
+  }
+  let head = working.trim();
 
   // Manifold.cube([x,y,z], centered?) / Manifold.cube({size: [...], center?})
   const cubeArr = new RegExp(`^(?:Manifold|BREP)\\.cube\\s*\\(\\s*${VEC3}(?:\\s*,\\s*(true|false))?\\s*\\)$`).exec(head);

--- a/src/main.ts
+++ b/src/main.ts
@@ -228,6 +228,9 @@ import {
   apiListParts,
   apiSetAutoCombine,
   apiGetAutoCombine,
+  apiSetSnapToGrid,
+  apiGetSnapToGrid,
+  apiRotateSelection,
 } from './ui/insertPalette';
 import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, findColorRegion, resolveSeed, findNearestTriangle, type AdjacencyGraph } from './color/adjacency';
 import { findSlabTriangles, slabRefineRegion, smoothEdgeForResolution } from './color/slabPaint';
@@ -9204,6 +9207,26 @@ async function main() {
     /** Read the current Auto-combine flag. */
     getAutoCombine(): boolean { return apiGetAutoCombine(); },
 
+    /** Toggle "Snap drag to whole units" — when on, arrange-mode drag
+     *  commits and the per-engine writeback paths round to whole units.
+     *  Voxel grids already snap; this gives the JS/SCAD/BREP engines an
+     *  opt-in "tidy lattice" mode. */
+    setSnapToGrid(on: boolean): void {
+      assertBoolean(on, 'setSnapToGrid(on)');
+      apiSetSnapToGrid(on);
+    },
+
+    /** Read the current snap-to-grid flag. */
+    getSnapToGrid(): boolean { return apiGetSnapToGrid(); },
+
+    /** Rotate the current selection in place (degrees, per-axis). For 2+
+     *  selected parts, the rotation pivots around the group centroid in the
+     *  XY plane. Voxel sessions are rejected (lattice quantization). */
+    rotateSelection(deg: [number, number, number]): { ok: boolean; reason?: string } {
+      assertNumberTuple(deg, 3, 'rotateSelection(deg)');
+      return apiRotateSelection(deg as [number, number, number]);
+    },
+
     // === View rendering API ===
 
     /** Render a single view from any camera angle. Returns a data URL (PNG).
@@ -13552,6 +13575,9 @@ async function main() {
         'mirrorSelection':      { signature: 'mirrorSelection("x"|"y"|"z") -- Mirror selected parts in place across axis -> {ok}', docs: '/ai.md#arrange-mode' },
         'setAutoCombine':       { signature: 'setAutoCombine(on) -- Toggle "Auto-combine new shapes" (managed-return engines only)', docs: '/ai.md#arrange-mode' },
         'getAutoCombine':       { signature: 'getAutoCombine() -- Whether Auto-combine is currently on', docs: '/ai.md#arrange-mode' },
+        'setSnapToGrid':        { signature: 'setSnapToGrid(on) -- Round arrange-drag deltas to whole units (non-voxel engines)', docs: '/ai.md#arrange-mode' },
+        'getSnapToGrid':        { signature: 'getSnapToGrid() -- Whether snap-to-grid is currently on', docs: '/ai.md#arrange-mode' },
+        'rotateSelection':      { signature: 'rotateSelection([rx,ry,rz]) -- Rotate selected parts in place (degrees); 2+ parts pivot around the group centroid (Z plane) -> {ok}', docs: '/ai.md#arrange-mode' },
         // View
         'setView':         { signature: 'setView(tab) -- Switch tab: "interactive", "gallery", "images", "diff", "notes"', docs: '/ai.md#how-to-use-this-tool' },
         'getViewState':    { signature: 'getViewState() -- Current tab and camera state', docs: '/ai.md#how-to-use-this-tool' },

--- a/src/ui/insertPalette.ts
+++ b/src/ui/insertPalette.ts
@@ -60,6 +60,8 @@ import {
   setPartTranslateDeltaScad,
   setPartScaleJs,
   setPartScaleScad,
+  setPartRotateJs,
+  setPartRotateScad,
   mirrorPartJs,
   mirrorPartScad,
   duplicatePartJs,
@@ -75,6 +77,9 @@ import {
   isArrangeActive,
   refreshArrangeOverlay,
   alignDeltas,
+  groupCentroid,
+  groupCentroidScaleDelta,
+  groupCentroidRotateZDelta,
   type AlignAxis,
   type AlignMode,
 } from '../insert/arrangeMode';
@@ -162,9 +167,17 @@ let combineHintEl: HTMLElement | null = null;
 let arrangeToggleBtn: HTMLButtonElement | null = null;
 let sizeSectionEl: HTMLElement | null = null;
 let alignSectionEl: HTMLElement | null = null;
+let rotateSectionEl: HTMLElement | null = null;
 let sizeInputs: [HTMLInputElement, HTMLInputElement, HTMLInputElement] | null = null;
+let rotateInputs: [HTMLInputElement, HTMLInputElement, HTMLInputElement] | null = null;
 let undoBtn: HTMLButtonElement | null = null;
 let redoBtn: HTMLButtonElement | null = null;
+// Snap-to-grid: when on, arrange-mode drag commits and (optionally) other
+// per-axis writebacks round to whole-unit deltas. Voxel grids already snap;
+// this affects the other engines so a CAD-feel "tidy lattice" workflow is
+// available there too. Persists across panel open/close like Auto-combine.
+let snapToGrid = false;
+let snapToGridCheckbox: HTMLInputElement | null = null;
 
 const RESULT_BASE: Record<BooleanOpKind, string> = {
   union: 'merged',
@@ -454,6 +467,16 @@ export function apiSetAutoCombine(on: boolean): void {
 
 export function apiGetAutoCombine(): boolean { return autoCombine; }
 
+/** Toggle the snap-to-whole-units checkbox programmatically. Voxel grids
+ *  already snap; the toggle gives the JS/SCAD/BREP engines an opt-in
+ *  "tidy lattice" mode for drag commits + Align/Rotate group-spread writes. */
+export function apiSetSnapToGrid(on: boolean): void {
+  snapToGrid = on;
+  if (snapToGridCheckbox) snapToGridCheckbox.checked = on;
+}
+
+export function apiGetSnapToGrid(): boolean { return snapToGrid; }
+
 /** Programmatic equivalent of clicking the toggle OFF. */
 export function apiExitArrange(): void {
   if (isArrangeActive()) {
@@ -576,6 +599,17 @@ export function apiDeleteSelection(): { ok: boolean; reason?: string } {
   if (!cb) return { ok: false, reason: 'insert palette not initialized' };
   if (selection.size === 0) return { ok: false, reason: 'no selection' };
   applyQuickDelete();
+  return { ok: true };
+}
+
+/** Rotate the current selection in place. Degrees, per-axis. Same path as
+ *  the Rotate row's Apply button. Voxel sessions reject (lattice
+ *  quantization). */
+export function apiRotateSelection(deg: Vec3): { ok: boolean; reason?: string } {
+  if (!cb) return { ok: false, reason: 'insert palette not initialized' };
+  if (selection.size === 0) return { ok: false, reason: 'no selection' };
+  if (cb.getLanguage() === 'voxel') return { ok: false, reason: 'voxel rotation not supported' };
+  applyRotate(deg);
   return { ok: true };
 }
 
@@ -813,7 +847,71 @@ function buildPanel(): HTMLElement {
   });
   sizeBtnRow.append(applySizeBtn, resetSizeBtn);
   sizeSectionEl.appendChild(sizeBtnRow);
+
+  // Snap-to-grid checkbox — only meaningful for non-voxel engines (voxel
+  // grids already snap). When on, arrange-mode drag deltas round to integer
+  // units before commit so parts slot onto a tidy lattice.
+  const snapRow = document.createElement('label');
+  snapRow.className = 'flex items-center gap-2 text-[11px] text-zinc-400 cursor-pointer select-none';
+  const snapCb = document.createElement('input');
+  snapCb.type = 'checkbox';
+  snapCb.id = 'insert-snap-to-grid';
+  snapCb.className = 'accent-blue-500 w-3.5 h-3.5';
+  snapCb.checked = snapToGrid;
+  snapCb.addEventListener('change', () => { snapToGrid = snapCb.checked; });
+  snapToGridCheckbox = snapCb;
+  const snapLabel = document.createElement('span');
+  snapLabel.textContent = 'Snap drag to whole units';
+  snapRow.append(snapCb, snapLabel);
+  sizeSectionEl.appendChild(snapRow);
+
   p.appendChild(sizeSectionEl);
+
+  // --- Rotate (per-axis degrees; 1+ selected) ---
+  rotateSectionEl = document.createElement('div');
+  rotateSectionEl.appendChild(sectionLabel('Rotate (°)'));
+  const rotRow = document.createElement('div');
+  rotRow.className = 'flex items-center gap-1.5 mb-1';
+  const rotLabels: Array<['X' | 'Y' | 'Z', string]> = [['X', 'X rotation in degrees'], ['Y', 'Y rotation in degrees'], ['Z', 'Z rotation in degrees']];
+  const rotInputsArr: HTMLInputElement[] = [];
+  for (const [axis, hint] of rotLabels) {
+    const wrap = document.createElement('div');
+    wrap.className = 'flex items-center gap-1 flex-1';
+    const lab = document.createElement('span');
+    lab.className = 'text-[10px] text-zinc-400 w-3';
+    lab.textContent = axis;
+    const inp = document.createElement('input');
+    inp.type = 'number';
+    inp.step = '15';
+    inp.value = '0';
+    inp.title = hint;
+    inp.className = 'flex-1 min-w-0 bg-zinc-900 border border-zinc-600 rounded px-1.5 py-1 text-[11px] text-zinc-100 text-right';
+    inp.dataset.axis = axis;
+    wrap.append(lab, inp);
+    rotRow.appendChild(wrap);
+    rotInputsArr.push(inp);
+  }
+  rotateInputs = [rotInputsArr[0], rotInputsArr[1], rotInputsArr[2]];
+  rotateSectionEl.appendChild(rotRow);
+  const rotBtnRow = document.createElement('div');
+  rotBtnRow.className = 'flex gap-1.5 mb-1';
+  const applyRotBtn = paletteButton('✓ Apply rotate', 'Rotate the selected parts by these degrees (in place around the part / group centroid)', () => {
+    const rx = parseFloat(rotateInputs![0].value) || 0;
+    const ry = parseFloat(rotateInputs![1].value) || 0;
+    const rz = parseFloat(rotateInputs![2].value) || 0;
+    applyRotate([rx, ry, rz]);
+    rotateInputs![0].value = '0';
+    rotateInputs![1].value = '0';
+    rotateInputs![2].value = '0';
+  });
+  const resetRotBtn = paletteButton('⟲ 0°', 'Reset the rotation inputs to 0', () => {
+    rotateInputs![0].value = '0';
+    rotateInputs![1].value = '0';
+    rotateInputs![2].value = '0';
+  });
+  rotBtnRow.append(applyRotBtn, resetRotBtn);
+  rotateSectionEl.appendChild(rotBtnRow);
+  p.appendChild(rotateSectionEl);
 
   // --- Align (2+ selected) ---
   alignSectionEl = document.createElement('div');
@@ -896,6 +994,10 @@ function writePartTranslateDelta(name: string, delta: Vec3): boolean {
   if (Math.abs(delta[0]) < 1e-5 && Math.abs(delta[1]) < 1e-5 && Math.abs(delta[2]) < 1e-5) return false;
   const lang = cb.getLanguage();
   let eff: Vec3 = delta;
+  // Snap-to-grid: round every-engine delta to whole units when the panel
+  // toggle is on. Voxel already rounds (its grid IS integer) — the redundant
+  // round is cheap and keeps the path uniform.
+  if (snapToGrid) eff = [Math.round(delta[0]), Math.round(delta[1]), Math.round(delta[2])];
   let newCode: string;
   if (lang === 'scad') {
     const part = scanParts(cb.getCode(), 'scad').find(p => p.name === name);
@@ -903,7 +1005,8 @@ function writePartTranslateDelta(name: string, delta: Vec3): boolean {
       cb.showToast('Could not locate that part in the SCAD code.', { variant: 'warn' });
       return false;
     }
-    newCode = setPartTranslateDeltaScad(cb.getCode(), part.range, delta);
+    if (snapToGrid && eff[0] === 0 && eff[1] === 0 && eff[2] === 0) return false;
+    newCode = setPartTranslateDeltaScad(cb.getCode(), part.range, eff);
   } else if (lang === 'voxel') {
     eff = [Math.round(delta[0]), Math.round(delta[1]), Math.round(delta[2])];
     if (eff[0] === 0 && eff[1] === 0 && eff[2] === 0) return false;
@@ -919,7 +1022,8 @@ function writePartTranslateDelta(name: string, delta: Vec3): boolean {
     const stmt = emitPrimitiveVoxel(moved, voxelGridVar(cb.getCode()), colour ? colour[1] : VOXEL_DEFAULT_COLOR);
     newCode = replaceVoxelStatement(cb.getCode(), part.range, stmt);
   } else {
-    newCode = setPartTranslateDeltaJs(cb.getCode(), name, delta);
+    if (snapToGrid && eff[0] === 0 && eff[1] === 0 && eff[2] === 0) return false;
+    newCode = setPartTranslateDeltaJs(cb.getCode(), name, eff);
   }
   cb.setCode(newCode);
   const spec = specByName.get(name);
@@ -961,6 +1065,17 @@ function applyResize(scale: Vec3): void {
   const lang = cb.getLanguage();
   const names = [...selection];
   if (names.length === 0) return;
+  // For 2+ parts, Tinkercad scales around the GROUP centroid (the union of
+  // selected bboxes), not each part's own. We compute the pre-scale centres
+  // and centroid here, apply the per-part scale (size grows around own
+  // centre), then translate each part by the centroid-relative delta so the
+  // whole group spreads/pulls-in around the pivot.
+  const pivot = names.length >= 2 ? groupCentroid(names, registry) : null;
+  const preCenters = new Map<string, Vec3>();
+  if (pivot) for (const n of names) {
+    const e = registry.get(n);
+    if (e) preCenters.set(n, [...e.center] as Vec3);
+  }
   const skipped: string[] = [];
   let appliedAny = false;
   const label = `Resize ${fmtScale(scale)} · ${names.length === 1 ? names[0] : `${names.length} parts`}`;
@@ -994,6 +1109,18 @@ function applyResize(scale: Vec3): void {
         appliedAny = true;
       }
     }
+    // Group-centroid spread pass. Done AFTER the per-part scale loop (and
+    // inside the same recordOperation) so it's one undo step. The translate
+    // delta is computed from the PRE-scale centres, which stay constant
+    // through scale-around-own-centre, so the order is order-safe.
+    if (pivot && appliedAny) {
+      for (const name of names) {
+        const c0 = preCenters.get(name);
+        if (!c0) continue;
+        const delta = groupCentroidScaleDelta(c0, pivot, scale);
+        writePartTranslateDelta(name, delta);
+      }
+    }
     if (skipped.length > 0) {
       c.showToast(
         skipped.length === names.length
@@ -1007,6 +1134,85 @@ function applyResize(scale: Vec3): void {
       refreshArrangeOverlay();
     }
   });
+}
+
+/** Rotate the selected parts in place. JS/BREP insert `.rotate([rx,ry,rz])`
+ *  before the trailing translate so the pivot is the part's own origin; SCAD
+ *  wraps with `rotate(...)` after any leading translate. Voxel rotation is
+ *  unsupported in this pass (lattice quantization makes arbitrary angles
+ *  unfaithful) — surfaces as a warn toast.
+ *
+ *  For 2+ selected parts, each part also gets a translate delta so the group
+ *  rotates around the union centroid in the XY plane (Z rotation only —
+ *  arbitrary 3D pivots rarely match user intent in a flat-on-build-plate
+ *  workflow). Pre-rotation centres are snapshotted before any code edit so
+ *  the spread is computed against the original layout. */
+function applyRotate(deg: Vec3): void {
+  if (!cb) return;
+  if (deg[0] === 0 && deg[1] === 0 && deg[2] === 0) return;
+  const lang = cb.getLanguage();
+  const names = [...selection];
+  if (names.length === 0) return;
+  if (lang === 'voxel') {
+    cb.showToast('Voxel rotation isn’t supported yet — try manifold-js / SCAD / BREP.', { variant: 'warn' });
+    return;
+  }
+  const pivot = names.length >= 2 ? groupCentroid(names, registry) : null;
+  const preCenters = new Map<string, Vec3>();
+  if (pivot) for (const n of names) {
+    const e = registry.get(n);
+    if (e) preCenters.set(n, [...e.center] as Vec3);
+  }
+  const skipped: string[] = [];
+  let appliedAny = false;
+  const label = `Rotate ${fmtDeg(deg)} · ${names.length === 1 ? names[0] : `${names.length} parts`}`;
+  const c = cb;
+  recordOperation(label, () => {
+    for (const name of names) {
+      if (lang === 'scad') {
+        const part = scanParts(c.getCode(), 'scad').find(p => p.name === name);
+        if (!part?.range) { skipped.push(name); continue; }
+        c.setCode(setPartRotateScad(c.getCode(), part.range, deg));
+        appliedAny = true;
+      } else {
+        const code = c.getCode();
+        const updated = setPartRotateJs(code, name, deg);
+        if (updated === code) { skipped.push(name); continue; }
+        c.setCode(updated);
+        appliedAny = true;
+      }
+    }
+    // Group-centroid swing pass (Z axis only). Same one-undo-step shape as
+    // the resize pivot pass above.
+    if (pivot && appliedAny && deg[2] !== 0) {
+      for (const name of names) {
+        const c0 = preCenters.get(name);
+        if (!c0) continue;
+        const delta = groupCentroidRotateZDelta(c0, pivot, deg[2]);
+        writePartTranslateDelta(name, delta);
+      }
+    }
+    if (skipped.length > 0) {
+      c.showToast(
+        skipped.length === names.length
+          ? 'Rotate could not locate the selected parts in the code.'
+          : `Rotated ${names.length - skipped.length}; skipped ${skipped.length} (no matching declaration).`,
+        { variant: skipped.length === names.length ? 'warn' : 'neutral' },
+      );
+    }
+    if (appliedAny) {
+      c.run();
+      refreshArrangeOverlay();
+    }
+  });
+}
+
+function fmtDeg(d: Vec3): string {
+  // Compact "90°" / "0/0/90°" for the undo label.
+  if (d[0] === 0 && d[1] === 0) return `${d[2]}°`;
+  if (d[1] === 0 && d[2] === 0) return `${d[0]}°`;
+  if (d[0] === 0 && d[2] === 0) return `${d[1]}°`;
+  return `${d[0]}/${d[1]}/${d[2]}°`;
 }
 
 function fmtScale(s: Vec3): string {
@@ -1144,6 +1350,7 @@ function rerenderSelectionUI(): void {
   // Size: 1+ selected; Align: 2+ selected. Hidden otherwise so the panel stays
   // dense for the common "nothing selected yet" state.
   sizeSectionEl?.classList.toggle('hidden', selection.size === 0);
+  rotateSectionEl?.classList.toggle('hidden', selection.size === 0);
   alignSectionEl?.classList.toggle('hidden', selection.size < 2);
   refreshArrangeOverlay();
 }

--- a/src/ui/insertPalette.ts
+++ b/src/ui/insertPalette.ts
@@ -861,7 +861,12 @@ function buildPanel(): HTMLElement {
   snapCb.addEventListener('change', () => { snapToGrid = snapCb.checked; });
   snapToGridCheckbox = snapCb;
   const snapLabel = document.createElement('span');
-  snapLabel.textContent = 'Snap drag to whole units';
+  // Covers all per-engine translate writebacks — drag commit, align spread,
+  // and the group-centroid scale/rotate spread — not just drag. Label the
+  // broader scope so a user toggling it for drag-cleanup isn't surprised
+  // when their next Align rounds too.
+  snapLabel.textContent = 'Snap moves to whole units';
+  snapLabel.title = 'Round every translate writeback (drag, align, group resize/rotate spread) to integers';
   snapRow.append(snapCb, snapLabel);
   sizeSectionEl.appendChild(snapRow);
 
@@ -895,7 +900,7 @@ function buildPanel(): HTMLElement {
   rotateSectionEl.appendChild(rotRow);
   const rotBtnRow = document.createElement('div');
   rotBtnRow.className = 'flex gap-1.5 mb-1';
-  const applyRotBtn = paletteButton('✓ Apply rotate', 'Rotate the selected parts by these degrees (in place around the part / group centroid)', () => {
+  const applyRotBtn = paletteButton('✓ Apply rotate', 'Rotate the selected parts by these degrees in place. For 2+ parts, the Z rotation also swings the group around its centroid; X/Y rotations stay per-part.', () => {
     const rx = parseFloat(rotateInputs![0].value) || 0;
     const ry = parseFloat(rotateInputs![1].value) || 0;
     const rz = parseFloat(rotateInputs![2].value) || 0;

--- a/tests/insert-codegen.spec.ts
+++ b/tests/insert-codegen.spec.ts
@@ -1350,6 +1350,16 @@ test.describe('parseStatement — manifold-js / BREP', () => {
   test('returns null for arbitrary expressions', () => {
     expect(parseStatement(`const x = api.text("hi");`, 'manifold-js', 'x')).toBeNull();
   });
+
+  test('returns null when translate precedes rotate (only rotate-then-translate is accepted)', () => {
+    // setPartRotateJs always inserts rotate BEFORE translate, so palette-touched
+    // parts always parse. Hand-written code in the reverse order is
+    // unrecognised — the chain-order contract is one-way.
+    expect(parseStatement(
+      `const x = Manifold.cube([10,10,10]).translate([5,0,0]).rotate([0,0,30]);`,
+      'manifold-js', 'x',
+    )).toBeNull();
+  });
 });
 
 test.describe('scanPartsJs now also returns statement text for single-line const decls', () => {
@@ -1432,6 +1442,26 @@ test.describe('setPartRotateScad', () => {
   test('identity rotation returns the code unchanged', () => {
     const code = 'cube([1,1,1]); // part: a';
     expect(setPartRotateScad(code, { from: 0, to: code.length }, [0, 0, 0])).toBe(code);
+  });
+
+  test('bare cube (no leading transforms) prepends rotate at the head', () => {
+    const code = 'cube([10, 10, 10]); // part: box';
+    const updated = setPartRotateScad(code, { from: 0, to: code.length }, [0, 0, 90]);
+    expect(updated).toContain('rotate([0, 0, 90]) cube([10, 10, 10]);');
+  });
+
+  test('inserts rotate between leading scale and construction (no leading translate)', () => {
+    // scale-then-rotate-then-cube right-to-left == rotate(scale(cube)) — the
+    // rotate sits between the existing scale and the bare construction call.
+    const code = 'scale([2, 1, 1]) cube([10, 10, 10]); // part: box';
+    const updated = setPartRotateScad(code, { from: 0, to: code.length }, [0, 0, 45]);
+    expect(updated).toContain('rotate([0, 0, 45]) scale([2, 1, 1]) cube([10, 10, 10]);');
+  });
+
+  test('chain order with translate + scale + cube reads translate→rotate→scale→cube', () => {
+    const code = 'translate([5, 0, 0]) scale([2, 1, 1]) cube([10, 10, 10]); // part: box';
+    const updated = setPartRotateScad(code, { from: 0, to: code.length }, [0, 0, 45]);
+    expect(updated).toContain('translate([5, 0, 0]) rotate([0, 0, 45]) scale([2, 1, 1]) cube([10, 10, 10]);');
   });
 });
 

--- a/tests/insert-codegen.spec.ts
+++ b/tests/insert-codegen.spec.ts
@@ -41,6 +41,8 @@ import {
   setPartTranslateDeltaJs,
   setPartTranslateDeltaScad,
   setPartScaleJs,
+  setPartRotateJs,
+  setPartRotateScad,
   setPartScaleScad,
   mirrorPartJs,
   mirrorPartScad,
@@ -1323,9 +1325,24 @@ test.describe('parseStatement — manifold-js / BREP', () => {
     expect(spec.height).toBe(10);
   });
 
-  test('returns null for chained transforms we do not understand', () => {
-    expect(parseStatement(
+  test('accepts a single trailing .rotate(...).translate(...) chain', () => {
+    // We model the spec's bbox as the un-rotated AABB (over-estimates the
+    // post-rotation footprint, but never under-estimates — and arrange's
+    // controller compounds rotations rather than stacking). Position comes
+    // from the trailing translate; size from the construction call.
+    const spec = parseStatement(
       `const x = Manifold.cube([10,10,10]).rotate([0,0,30]).translate([5,0,0]);`,
+      'manifold-js', 'x',
+    );
+    if (!spec || spec.kind !== 'cube') throw new Error('expected cube');
+    expect(spec.size).toEqual([10, 10, 10]);
+    expect(spec.position).toEqual([5, 0, 0]);
+  });
+
+  test('still returns null for transforms beyond a single rotate-then-translate', () => {
+    // Two translate suffixes / arbitrary other chain methods stay null.
+    expect(parseStatement(
+      `const x = Manifold.cube([10,10,10]).color([1,0,0]).translate([5,0,0]);`,
       'manifold-js', 'x',
     )).toBeNull();
   });
@@ -1360,6 +1377,129 @@ test.describe('scanPartsJs now also returns statement text for single-line const
     const refs = scanPartsJs(code);
     const box = refs.find(r => r.name === 'box');
     expect(box?.statement).toContain('.translate');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rotate codegen — JS / SCAD per-engine `.rotate([rx,ry,rz])` insertion
+// ---------------------------------------------------------------------------
+
+test.describe('setPartRotateJs', () => {
+  test('inserts .rotate before a trailing .translate so the pivot is the part origin', () => {
+    const code = 'const box = Manifold.cube([10,10,10], true).translate([5,0,0]);';
+    const updated = setPartRotateJs(code, 'box', [0, 0, 90]);
+    expect(updated).toBe('const box = Manifold.cube([10,10,10], true).rotate([0, 0, 90]).translate([5,0,0]);');
+  });
+
+  test('appends .rotate when no translate exists', () => {
+    const code = 'const box = Manifold.cube([10,10,10], true);';
+    const updated = setPartRotateJs(code, 'box', [45, 0, 0]);
+    expect(updated).toBe('const box = Manifold.cube([10,10,10], true).rotate([45, 0, 0]);');
+  });
+
+  test('compounds additively with an existing .rotate triple', () => {
+    const code = 'const box = Manifold.cube([10,10,10], true).rotate([0, 0, 45]).translate([5,0,0]);';
+    const updated = setPartRotateJs(code, 'box', [0, 0, 45]);
+    expect(updated).toContain('.rotate([0, 0, 90])');
+    // The translate is preserved.
+    expect(updated).toContain('.translate([5,0,0])');
+  });
+
+  test('identity rotation returns the code unchanged', () => {
+    const code = 'const box = Manifold.cube([10,10,10], true);';
+    expect(setPartRotateJs(code, 'box', [0, 0, 0])).toBe(code);
+  });
+
+  test('returns code unchanged when the named part is missing', () => {
+    const code = 'const box = Manifold.cube([10,10,10], true);';
+    expect(setPartRotateJs(code, 'missing', [0, 0, 90])).toBe(code);
+  });
+});
+
+test.describe('setPartRotateScad', () => {
+  test('wraps construction with rotate AFTER the leading translate', () => {
+    const code = 'translate([5, 0, 0]) cube([10, 10, 10], center=true); // part: box';
+    const updated = setPartRotateScad(code, { from: 0, to: code.length }, [0, 0, 90]);
+    expect(updated).toContain('translate([5, 0, 0]) rotate([0, 0, 90]) cube([10, 10, 10], center=true);');
+  });
+
+  test('compounds additively with an existing leading rotate', () => {
+    const code = 'translate([0,0,0]) rotate([0, 0, 30]) cube([10,10,10]); // part: box';
+    const updated = setPartRotateScad(code, { from: 0, to: code.length }, [0, 0, 30]);
+    expect(updated).toContain('rotate([0, 0, 60])');
+  });
+
+  test('identity rotation returns the code unchanged', () => {
+    const code = 'cube([1,1,1]); // part: a';
+    expect(setPartRotateScad(code, { from: 0, to: code.length }, [0, 0, 0])).toBe(code);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group-centroid math (resize + Z-rotation pivots for 2+ selection)
+// ---------------------------------------------------------------------------
+
+import { groupCentroid, groupCentroidScaleDelta, groupCentroidRotateZDelta } from '../src/insert/arrangeMath';
+
+test.describe('groupCentroid', () => {
+  function entryRE(min: Vec3, max: Vec3): RegistryEntry {
+    return { box: { min, max }, center: [(min[0] + max[0]) / 2, (min[1] + max[1]) / 2, (min[2] + max[2]) / 2] };
+  }
+
+  test('returns midpoint of the union bbox', () => {
+    const reg = new Map<string, RegistryEntry>([
+      ['a', entryRE([-5, -5, 0], [5, 5, 10])],
+      ['b', entryRE([15, -5, 0], [25, 5, 10])],
+    ]);
+    expect(groupCentroid(['a', 'b'], reg)).toEqual([10, 0, 5]);
+  });
+
+  test('null when nothing resolves', () => {
+    expect(groupCentroid(['ghost'], new Map())).toBeNull();
+  });
+});
+
+test.describe('groupCentroidScaleDelta', () => {
+  test('zero delta when scale is identity', () => {
+    expect(groupCentroidScaleDelta([5, 0, 0], [0, 0, 0], [1, 1, 1])).toEqual([0, 0, 0]);
+  });
+
+  test('2x scale doubles the distance from the pivot', () => {
+    // Centre at [5,0,0], pivot at origin → new centre [10,0,0]; delta = [5,0,0].
+    expect(groupCentroidScaleDelta([5, 0, 0], [0, 0, 0], [2, 1, 1])).toEqual([5, 0, 0]);
+  });
+
+  test('per-axis anisotropic factors apply independently', () => {
+    expect(groupCentroidScaleDelta([4, 6, 0], [0, 0, 0], [2, 0.5, 1])).toEqual([4, -3, 0]);
+  });
+
+  test('zero delta when the centre coincides with the pivot', () => {
+    expect(groupCentroidScaleDelta([0, 0, 0], [0, 0, 0], [3, 3, 3])).toEqual([0, 0, 0]);
+  });
+});
+
+test.describe('groupCentroidRotateZDelta', () => {
+  test('zero rotation gives zero delta', () => {
+    expect(groupCentroidRotateZDelta([5, 0, 0], [0, 0, 0], 0)).toEqual([0, 0, 0]);
+  });
+
+  test('90° around origin swings a point on +X to +Y', () => {
+    const d = groupCentroidRotateZDelta([5, 0, 0], [0, 0, 0], 90);
+    // Expected new position: [0, 5, 0]; delta from [5,0,0] is [-5, 5, 0].
+    expect(d[0]).toBeCloseTo(-5, 6);
+    expect(d[1]).toBeCloseTo(5, 6);
+    expect(d[2]).toBe(0);
+  });
+
+  test('preserves Z untouched', () => {
+    const d = groupCentroidRotateZDelta([5, 0, 7], [0, 0, 0], 45);
+    expect(d[2]).toBe(0);
+  });
+
+  test('point at pivot stays put under any rotation', () => {
+    const d = groupCentroidRotateZDelta([3, 4, 0], [3, 4, 0], 137);
+    expect(d[0]).toBeCloseTo(0, 6);
+    expect(d[1]).toBeCloseTo(0, 6);
   });
 });
 

--- a/tests/insert-palette.spec.ts
+++ b/tests/insert-palette.spec.ts
@@ -633,4 +633,104 @@ test.describe('Insert palette', () => {
     // shows code that previously had an Insert step on the stack.
     expect(await page.evaluate(() => (window as unknown as { partwright: { canUndo(): boolean } }).partwright.canUndo())).toBe(false);
   });
+
+  test('partwright API: rotateSelection writes .rotate before .translate', async ({ page }) => {
+    await gotoEditor(page);
+    await page.evaluate(() => {
+      const code = [
+        'const { Manifold } = api;',
+        'const box = Manifold.cube([10, 10, 10], true).translate([5, 0, 0]);',
+        'return box;',
+      ].join('\n');
+      (window as unknown as { partwright: { setCode(c: string): void; run(): void } }).partwright.setCode(code);
+      (window as unknown as { partwright: { run(): void } }).partwright.run();
+    });
+
+    const result = await page.evaluate(() => {
+      const w = window as unknown as { partwright: { enterArrange(): unknown; selectParts(n: string[]): string[]; rotateSelection(d: number[]): { ok: boolean } } };
+      w.partwright.enterArrange();
+      w.partwright.selectParts(['box']);
+      return w.partwright.rotateSelection([0, 0, 90]);
+    });
+    expect(result.ok).toBe(true);
+    // Rotate goes before translate so the pivot is the part's own origin.
+    await expect.poll(() => getCode(page)).toMatch(/Manifold\.cube\(\[10, 10, 10\], true\)\.rotate\(\[0, 0, 90\]\)\.translate\(\[5, 0, 0\]\);/);
+
+    await page.evaluate(() => (window as unknown as { partwright: { exitArrange(): void } }).partwright.exitArrange());
+  });
+
+  test('partwright API: group-centroid scale spreads two parts apart', async ({ page }) => {
+    await gotoEditor(page);
+    // Two cubes 10 apart, centred at ±5 on X. After 2× X scale around their
+    // group centroid (origin), each centre should move to ±10 on X — i.e.
+    // each part gets an extra translate of ±5.
+    await page.evaluate(() => {
+      const code = [
+        'const { Manifold } = api;',
+        'const a = Manifold.cube([4, 4, 4], true).translate([-5, 0, 0]);',
+        'const b = Manifold.cube([4, 4, 4], true).translate([5, 0, 0]);',
+        'return a.add(b);',
+      ].join('\n');
+      (window as unknown as { partwright: { setCode(c: string): void; run(): void } }).partwright.setCode(code);
+      (window as unknown as { partwright: { run(): void } }).partwright.run();
+    });
+
+    const result = await page.evaluate(() => {
+      const w = window as unknown as { partwright: { enterArrange(): unknown; selectParts(n: string[]): string[]; resizeSelection(s: number[]): { ok: boolean } } };
+      w.partwright.enterArrange();
+      w.partwright.selectParts(['a', 'b']);
+      return w.partwright.resizeSelection([2, 1, 1]);
+    });
+    expect(result.ok).toBe(true);
+
+    // Each cube doubles in X AND its centre's distance from the origin doubles.
+    // `b` was at +5; after 2× group-centroid scale, centre is at +10 — so the
+    // translate's X should now be 10.
+    const code = await getCode(page);
+    const bMatch = /const b =.*?\.translate\(\[(-?\d+(?:\.\d+)?), [^,]+, [^,]+\]\)/.exec(code);
+    expect(bMatch).not.toBeNull();
+    expect(parseFloat(bMatch![1])).toBeCloseTo(10, 1);
+    const aMatch = /const a =.*?\.translate\(\[(-?\d+(?:\.\d+)?), [^,]+, [^,]+\]\)/.exec(code);
+    expect(parseFloat(aMatch![1])).toBeCloseTo(-10, 1);
+
+    await page.evaluate(() => (window as unknown as { partwright: { exitArrange(): void } }).partwright.exitArrange());
+  });
+
+  test('partwright API: setSnapToGrid rounds non-voxel drag commits', async ({ page }) => {
+    await gotoEditor(page);
+    await page.evaluate(() => (window as unknown as { partwright: { setCode(c: string): void; run(): void } })
+      .partwright.setCode('const { Manifold } = api;\nreturn Manifold.cube([10, 10, 10], true);'));
+    await page.evaluate(() => (window as unknown as { partwright: { run(): void } }).partwright.run());
+
+    await page.locator('#btn-insert').dispatchEvent('click');
+    await page.locator(palette).getByRole('button', { name: 'Cube' }).click();
+    await page.getByRole('button', { name: 'Insert', exact: true }).click();
+    await expect.poll(() => getCode(page)).toContain('const box');
+
+    // Snap on, then move palette out of the way and drag the box.
+    await page.evaluate(() => (window as unknown as { partwright: { setSnapToGrid(on: boolean): void } }).partwright.setSnapToGrid(true));
+    await page.evaluate(() => {
+      const p = document.querySelector('#insert-palette-panel') as HTMLElement | null;
+      if (p) { p.style.left = '8px'; p.style.top = '8px'; p.style.right = 'auto'; }
+    });
+    await page.locator('#insert-arrange-toggle').click();
+
+    const cBox = await page.locator('canvas').first().boundingBox();
+    if (!cBox) throw new Error('canvas missing');
+    const cx = cBox.x + cBox.width / 2;
+    const cy = cBox.y + cBox.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 100, cy, { steps: 10 });
+    await page.mouse.up();
+
+    // The translate triple should be integers when snap is on.
+    await expect.poll(() => getCode(page)).toMatch(/\.translate\(\[/);
+    const code = await getCode(page);
+    const triple = /\.translate\(\[(-?\d+(?:\.\d+)?), (-?\d+(?:\.\d+)?), (-?\d+(?:\.\d+)?)\]\)/.exec(code);
+    expect(triple).not.toBeNull();
+    for (let i = 1; i <= 3; i++) {
+      expect(Number.isInteger(parseFloat(triple![i]))).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Closes the four deferred arrange follow-ups from PR #607.

**Rotation**

- `setPartRotateJs` inserts `.rotate([rx,ry,rz])` *before* the trailing `.translate(…)` so the pivot is the part's own origin (no swinging-around-world-origin surprise).
- `setPartRotateScad` wraps with `rotate([…])` *after* any leading `translate([…])` — SCAD's right-to-left application order produces the same in-place pivot.
- Both compound additively with an existing rotate (`30°` + `30°` → `60°`, not stacked calls).
- Voxel rotation rejected with a warn toast — lattice quantization makes arbitrary angles unfaithful; snap-to-90° voxel rotation is its own follow-up.
- New Rotate row in the panel: X/Y/Z degree inputs + Apply/Reset. `partwright.rotateSelection([rx,ry,rz])` mirrors the button.

**Z-axis drag (alt modifier)**

- Hold Alt during arrange-drag → the drag plane becomes vertical, facing the camera through the pickup point (normal = camera-to-pivot direction flattened onto XY). Only the world-Z component of the hit is consumed, so motion is pure-vertical. Cleaner than a "Y mouse → Z world" approximation because the camera-aware plane keeps the part under the cursor as the user orbits.
- Top-down camera falls back to `+X` normal (Z-drag on a top-down view doesn't make sense anyway).

**Group-centroid pivot for 2+ selection**

- Two pure-leaf helpers in `arrangeMath.ts`: `groupCentroidScaleDelta` (per-axis, all 3) and `groupCentroidRotateZDelta` (Z plane only — arbitrary 3D pivots rarely match user intent for CAD-on-build-plate).
- `applyResize` and `applyRotate` snapshot the pre-transform centres + the union centroid BEFORE any code edit; after each part scales/rotates around its own centre (which leaves the centre fixed), a follow-up `writePartTranslateDelta` per part spreads/swings the group around the shared pivot. One `recordOperation` wraps the lot so it's one undo step.
- Single-part transforms still pivot at the part centre (no spread — `pivot = null`).

**Snap-to-grid**

- New checkbox in the Size section (and `partwright.setSnapToGrid` on the API). When on, `writePartTranslateDelta` rounds the JS/SCAD effective delta to whole units — affects drag commits, align spread, and the new centroid spread. Voxel already snaps.

**Other**

- `parseStatement` now accepts a single trailing `.rotate([…]).translate([…])` chain on hand-written JS so a rotated part is still arrangeable (bbox is the un-rotated AABB — over-estimates the footprint but never under-estimates).
- Updated the old "chained transforms → null" test to reflect the new contract; multi-method chains beyond rotate-translate still return null.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 1252 pass
- [x] `npx playwright test insert-codegen` — 180 pass (14 new: setPartRotateJs ×5, setPartRotateScad ×3, groupCentroid math ×6)
- [x] `npx playwright test insert-palette` — 21 pass (3 new: rotateSelection writes `.rotate` before `.translate`; group-centroid scale spreads two parts apart from origin; setSnapToGrid rounds drag commits to integers)
- [x] `npm run lint:deps` — acyclic
- [x] `npm run lint:consistency` — no new hits
- [x] `npm run lint:deadcode` — no new hits
- [ ] `work-reviewer` agent pass (running in background)
- [x] Manual: two cubes at ±10 X, both selected → `partwright.rotateSelection([0,0,45])` rotates each by 45° AND swings both around the group centroid (screenshots posted in chat); code shows `.rotate([0, 0, 45]).translate([…])` on each part; Undo enabled

https://claude.ai/code/session_01HXdX6NdV5tR7p61DMGFyJn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXdX6NdV5tR7p61DMGFyJn)_