### PR TITLE
fix: accept scope opts in applySurfaceTexture + thread knurl profile

### DIFF
--- a/prompts/release-fix-surface-texture-api.md
+++ b/prompts/release-fix-surface-texture-api.md
@@ -1,0 +1,47 @@
+---
+date: 2026-06-12
+branch: claude/elegant-turing-sjwiei-surface-api
+files_changed:
+  - src/main.ts
+  - src/ai/tools.ts
+---
+
+## Human
+
+Pre-production-release review of `main` (543 commits since `production`). Find
+and fix critical defects from the recent merge window before cutting the
+release. Multiple review subagents scanned the diff across categories.
+
+## Assistant
+
+This PR fixes two real surface-texture API bugs surfaced by the review:
+
+1. **CRITICAL — `applySurfaceTexture` rejected the scope opts it advertises.**
+   The documented "best path" wrapper (and the AI chat tool) is supposed to
+   accept `label:'name'` / `region:{point,radius}` to scope a texture, but its
+   `assertNoUnknownKeys` allow-list only included the per-modifier fields plus
+   `preserveColor` — so `{label:'grip'}` returned `{error:"unknown key 'label'"}`
+   before ever reaching `applySurfaceTextureAsCode` (which *does* resolve scopes
+   via `parseSurfaceOpts`). The `opts` type also structurally forbade the
+   `region` object. Fix: widen `opts` to `Record<string, unknown>`, add
+   `SURFACE_SCOPE_KEYS` to the allow-list, split the scope out, pass it to the
+   code path, and return a clear error (instead of silently texturing the whole
+   model) when a scope is given on a bake-only session. This also gives the
+   previously-dead `SURFACE_SCOPE_KEYS` export a real importer.
+
+2. **HIGH — knurl `profile` (round vs pyramid) was silently dropped on the bake
+   path.** `buildSurfaceModifier` hand-lists each modifier's fields and never
+   read `opts.profile`, so the Surface panel's "Pyramid" choice always baked
+   round bumps and there was no API/help way to bake a pyramid knurl. The
+   in-code `api.surface.knurl({profile})` path already worked (it spreads
+   defaults+opts), so the two paths had drifted. Fix: thread `profile` into the
+   bake builder, add it to `applyKnurlTexture`'s opts type and the `help()`
+   signature.
+
+Also fixed the doc/cast drift these touched: `previewSurfaceModifier`'s JSDoc +
+`help()` id list (missing `knurl`/`engrave`), and the `applySurfaceTexture`
+dispatch cast in `tools.ts` (missing `knurl`).
+
+Verified: typecheck + 1264 unit tests pass; a browser probe confirmed both
+scoped (`label`/`region`) calls and a `profile:'pyramid'` knurl now return
+`ok:true` with the scope/profile preserved in the generated code.

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1927,7 +1927,7 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.setReliefPreviewMode(input.mode);
     case 'applySurfaceTexture':
       return api.applySurfaceTexture(
-        input.id as 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'voronoi' | 'smooth',
+        input.id as 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'knurl' | 'voronoi' | 'smooth',
         input.opts as Record<string, number | boolean | string> | undefined,
         input.mode as 'auto' | 'code' | 'bake' | undefined,
       );

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,7 @@ import { buildTextStampMask, buildImageStampMask } from './surface/engraveStampH
 import { buildTransformCode, computePlacementDelta, isNoopDelta, isNoopRotation, isNoopScale, placementLabel, rotationLabel, mirrorLabel, scaleLabel, rotateAboutCenterSteps, mirrorAboutCenterSteps, bestFlatDownRotation, applySteps, meshBox, type PlacementBox, type PlacementOps, type TransformStep, type Vec3 } from './surface/placement';
 import { nearestTriangleMap, remapTriangleSets, selectTrianglesNearSeeds } from './surface/colorTransfer';
 import { surfaceCacheStatus, computeChain, surfaceChainKey, seedSurfaceCache, meshContentKey, cancelSurfaceCompute, surfaceComputeInFlight, SurfaceComputeCancelled, type SurfaceOp } from './surface/surfaceOps';
-import { SURFACE_OP_IDS, SURFACE_OP_FIELDS, parseSurfaceOpts, isSurfaceOpId, type SurfaceOpId, type PersistedSurfaceTexture, type ResolvedScope } from './surface/surfaceOpSpec';
+import { SURFACE_OP_IDS, SURFACE_OP_FIELDS, SURFACE_SCOPE_KEYS, parseSurfaceOpts, isSurfaceOpId, type SurfaceOpId, type PersistedSurfaceTexture, type ResolvedScope } from './surface/surfaceOpSpec';
 import { upsertSurfaceCall } from './surface/surfaceCodegen';
 import { initSurfaceUI } from './ui/surfaceModal';
 import { initResizeUI } from './ui/resizeModal';
@@ -7744,6 +7744,7 @@ async function main() {
         cellWidth: (opts?.cellWidth as number) ?? base.cellWidth,
         cellHeight: (opts?.cellHeight as number) ?? base.cellHeight,
         style: (opts?.style as 'diamond' | 'straight' | 'ribs') ?? base.style,
+        profile: (opts?.profile as 'round' | 'pyramid') ?? base.profile,
         sharpness: (opts?.sharpness as number) ?? base.sharpness,
         grainAngleDeg: (opts?.grainAngleDeg as number) ?? base.grainAngleDeg,
         seed: (opts?.seed as number) ?? base.seed,
@@ -7928,7 +7929,7 @@ async function main() {
     },
     /** Non-destructive viewport preview of a surface modifier (no version saved).
      *  Call clearSurfacePreview() / re-run to restore.
-     *  id: 'fuzzy'|'knit'|'cable'|'waffle'|'fur'|'woven'|'voronoi'|'voronoiLamp'|'engrave'|'smooth'|'voxelize'. */
+     *  id: 'fuzzy'|'knit'|'cable'|'waffle'|'fur'|'woven'|'knurl'|'voronoi'|'voronoiLamp'|'engrave'|'smooth'|'voxelize'. */
     async previewSurfaceModifier(id: 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'knurl' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize', opts?: Record<string, unknown>, preserveColor = true): Promise<{ ok: true } | { error: string }> {
       try {
         const scopedOpts = resolvePreviewScope(id, opts);
@@ -8021,7 +8022,7 @@ async function main() {
      *  Returns the underlying result plus `path: 'code' | 'bake'`. */
     async applySurfaceTexture(
       id: SurfaceOpId,
-      opts?: Record<string, number | boolean | string>,
+      opts?: Record<string, unknown>,
       mode: 'auto' | 'code' | 'bake' = 'auto',
     ) {
       const check = guard(() => {
@@ -8029,18 +8030,29 @@ async function main() {
         assertEnum(mode, ['auto', 'code', 'bake'], 'applySurfaceTexture(_, _, mode)');
         if (opts !== undefined) {
           const o = assertObject(opts, 'applySurfaceTexture(_, opts)')!;
-          assertNoUnknownKeys(o, [...(SURFACE_OP_FIELDS[id as SurfaceOpId] ?? []), 'preserveColor'], 'applySurfaceTexture(_, opts)');
+          assertNoUnknownKeys(o, [...(SURFACE_OP_FIELDS[id as SurfaceOpId] ?? []), 'preserveColor', ...SURFACE_SCOPE_KEYS], 'applySurfaceTexture(_, opts)');
         }
         return true;
       });
       if (typeof check === 'object' && check !== null && 'error' in check) return check;
-      const { preserveColor, ...opOpts } = (opts ?? {}) as Record<string, number | boolean | string> & { preserveColor?: boolean };
+      const { preserveColor, label, region, ...opOpts } = (opts ?? {}) as Record<string, unknown> & { preserveColor?: boolean };
+      const scoped = label !== undefined || region !== undefined;
+      const scopeOpts = {
+        ...(label !== undefined ? { label } : {}),
+        ...(region !== undefined ? { region } : {}),
+      };
       const asCode = mode === 'code' || (mode === 'auto' && getActiveLanguage() === 'manifold-js');
       if (asCode) {
-        const r = await partwrightAPI.applySurfaceTextureAsCode(id, opOpts);
+        // The code path resolves label/region scopes via parseSurfaceOpts.
+        const r = await partwrightAPI.applySurfaceTextureAsCode(id, { ...opOpts, ...scopeOpts });
         return { path: 'code' as const, ...r };
       }
-      const bakeOpts = { ...opOpts, ...(preserveColor !== undefined ? { preserveColor } : {}) };
+      // Bake methods are whole-model only — they can't honor a label/region
+      // scope, so reject rather than silently texture the entire mesh.
+      if (scoped) {
+        return { error: `applySurfaceTexture: scoping (label/region) is only supported on the code path (a manifold-js session). The current session bakes whole-model; switch to manifold-js or drop the scope.` };
+      }
+      const bakeOpts = { ...opOpts, ...(preserveColor !== undefined ? { preserveColor } : {}) } as Record<string, number | boolean | string> & { preserveColor?: boolean };
       const r = id === 'fuzzy' ? await partwrightAPI.applyFuzzySkin(bakeOpts)
         : id === 'knit' ? await partwrightAPI.applyKnitTexture(bakeOpts)
         : id === 'cable' ? await partwrightAPI.applyCableKnit(bakeOpts)
@@ -8239,6 +8251,7 @@ async function main() {
       cellWidth?: number;
       cellHeight?: number;
       style?: 'diamond' | 'straight' | 'ribs';
+      profile?: 'round' | 'pyramid';
       sharpness?: number;
       grainAngleDeg?: number;
       seed?: number;
@@ -13706,7 +13719,7 @@ async function main() {
         // api.surface.* alternative keeps the texture parametric instead)
         'modelHasColor':   { signature: 'modelHasColor() -- Whether the model carries any color (user paint or code-declared)', docs: '/ai/colors.md' },
         'ensureSurfaceTexturesApplied': { signature: 'await ensureSurfaceTexturesApplied() -- Apply any pending (cancelled/failed) api.surface.* chain so the live mesh is textured -> {ok}', docs: '/ai/textures.md' },
-        'previewSurfaceModifier': { signature: "previewSurfaceModifier(id, opts?, preserveColor?) -- Non-destructive viewport preview of a modifier; id: 'fuzzy'|'knit'|'cable'|'waffle'|'fur'|'woven'|'voronoi'|'voronoiLamp'|'smooth'|'voxelize' -> {ok} or {error}", docs: '/ai/textures.md' },
+        'previewSurfaceModifier': { signature: "previewSurfaceModifier(id, opts?, preserveColor?) -- Non-destructive viewport preview of a modifier; id: 'fuzzy'|'knit'|'cable'|'waffle'|'fur'|'woven'|'knurl'|'voronoi'|'voronoiLamp'|'engrave'|'smooth'|'voxelize' -> {ok} or {error}", docs: '/ai/textures.md' },
         'clearSurfacePreview': { signature: 'clearSurfacePreview() -- Discard a live surface preview and restore the current mesh', docs: '/ai/textures.md' },
         'applySurfaceTexture': { signature: "await applySurfaceTexture(id, opts?, mode?) -- Texture by the best path: mode 'auto' (default) writes api.surface.<id> as code on manifold-js, bakes elsewhere; 'code'/'bake' force a path. opts may scope the code path with label:'name' or region:{point,radius}. Returns the result plus path: 'code'|'bake'", docs: '/ai/textures.md' },
         'applySurfaceTextureAsCode': { signature: "await applySurfaceTextureAsCode(id, opts?) -- Write api.surface.<id>({…}) into the code (insert before the final return, or update the existing call) instead of baking; re-runs and saves a version. manifold-js only. opts may add a scope: label:'name' (an api.label region) or region:{point:[x,y,z],radius}. id: 'fuzzy'|'knit'|'cable'|'waffle'|'fur'|'woven'|'knurl'|'voronoi'|'smooth'", docs: '/ai/textures.md' },
@@ -13716,7 +13729,7 @@ async function main() {
         'applyWaffleStitch': { signature: 'await applyWaffleStitch({amplitude?, cellWidth?, cellHeight?, sharpness?, rowOffset?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE waffle grid; saves a new version. In-code alternative: api.surface.waffle', docs: '/ai/textures.md' },
         'applyFurVelvet':  { signature: 'await applyFurVelvet({amplitude?, fiberSpacing?, fiberLength?, octaves?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE fur/velvet fibers; saves a new version. In-code alternative: api.surface.fur', docs: '/ai/textures.md' },
         'applyWovenFabric':{ signature: 'await applyWovenFabric({amplitude?, threadSpacing?, threadWidth?, underDepth?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE woven threads; saves a new version. In-code alternative: api.surface.woven', docs: '/ai/textures.md' },
-        'applyKnurlTexture':{ signature: 'await applyKnurlTexture({amplitude?, cellWidth?, cellHeight?, style?, sharpness?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE knurl grip (style: diamond|straight|ribs); saves a new version. In-code alternative: api.surface.knurl', docs: '/ai/textures.md' },
+        'applyKnurlTexture':{ signature: 'await applyKnurlTexture({amplitude?, cellWidth?, cellHeight?, style?, profile?, sharpness?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE knurl grip (style: diamond|straight|ribs; profile: round|pyramid); saves a new version. In-code alternative: api.surface.knurl', docs: '/ai/textures.md' },
         'applyVoronoiShell': { signature: 'await applyVoronoiShell({amplitude?, cellSize?, wallWidth?, raised?, jitter?, grainAngleDeg?, seed?, quality?, preserveColor?}) -- BAKE Voronoi cell relief; saves a new version. In-code alternative: api.surface.voronoi', docs: '/ai/textures.md' },
         'applyVoronoiLamp':{ signature: 'await applyVoronoiLamp({cellSize?, wallThickness?, strutWidth?, resolution?, jitter?, grainAngleDeg?, seed?, preserveColor?}) -- Convert the model into a perforated Voronoi lamp shell (bake only — no api.surface twin)', docs: '/ai/textures.md' },
         'engraveModel':    { signature: "await engraveModel({text | imageUrl, raised?, through?, depth?, size?, color?, axis?, side?, posU?, posV?, rotationDeg?, curveAxis?, curveAngleDeg?, font?, resolution?, watertight?, preserveColor?}) -- Carve text/image as recessed channels (engrave), holes (through), or a raised relief (raised = emboss); color paints the letters ('#rrggbb' or [r,g,b] 0–1). Saves a new version.", docs: '/ai/textures.md#engravemodel' },


### PR DESCRIPTION
Part of a pre-production-release review of `main` (543 commits since `production`). This PR fixes two real surface-texture API bugs found by the review.

## Summary

**1. CRITICAL — `applySurfaceTexture` rejected the scope opts it advertises.**
The auto-routing "best path" wrapper (and the `applySurfaceTexture` AI chat tool) is documented to accept `label:'name'` / `region:{point,radius}` to scope a texture, but its `assertNoUnknownKeys` allow-list only included the per-modifier fields plus `preserveColor`. So `applySurfaceTexture('knurl', { label: 'grip' })` returned `{ error: "unknown key 'label'" }` before ever reaching `applySurfaceTextureAsCode` (which *does* resolve scopes via `parseSurfaceOpts`). The `opts` type also structurally forbade the `region` object. This broke AI-driven scoped texturing — a flagship recent feature.

- Widen `opts` to `Record<string, unknown>`, add `SURFACE_SCOPE_KEYS` to the allow-list, split the scope out and pass it to the code path.
- On a bake-only session (where whole-model bake methods can't honor a scope), return a clear error instead of silently texturing the entire mesh.
- This gives the previously-dead `SURFACE_SCOPE_KEYS` export a real importer.

**2. HIGH — knurl `profile` (round vs pyramid) was silently dropped on the bake path.**
`buildSurfaceModifier` hand-lists each modifier's fields and never read `opts.profile`, so the Surface panel's "Pyramid (machinist diamonds)" choice always baked round bumps, and there was no API/help path to bake a pyramid knurl. The in-code `api.surface.knurl({ profile })` path already worked (it spreads defaults+opts), so the two paths had drifted.

- Thread `profile` into the bake builder, `applyKnurlTexture`'s opts type, and the `help()` signature.

**Touched doc/cast drift fixed alongside:** `previewSurfaceModifier` JSDoc + `help()` id list (were missing `knurl`/`engrave`), and the `applySurfaceTexture` dispatch cast in `tools.ts` (was missing `knurl`).

## Test plan

- `npm run typecheck` — clean
- `npm run test:unit` — 1264 pass
- Browser probe: `applySurfaceTexture('knurl', { label: 'grip', profile: 'pyramid' })` and `applySurfaceTexture('fuzzy', { region: { point, radius } })` both return `ok:true` with the scope/profile preserved in the generated code (previously the first was rejected as `unknown key 'label'`).

https://claude.ai/code/session_011cMXaPDR8PpCetgRpKXNwL

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMXaPDR8PpCetgRpKXNwL)_