### PR TITLE
fix: align voxel mesher smooth default with grid/UI default

### DIFF
--- a/prompts/release-fix-voxel-smooth-default.md
+++ b/prompts/release-fix-voxel-smooth-default.md
@@ -1,0 +1,29 @@
+---
+date: 2026-06-12
+branch: claude/elegant-turing-sjwiei-voxel-smooth
+files_changed:
+  - src/geometry/voxel/grid.ts
+  - src/geometry/voxel/mesher.ts
+---
+
+## Human
+
+Pre-production-release review of `main`. Fix critical defects from the recent
+merge window before cutting the release.
+
+## Assistant
+
+The voxel mesher and the rest of the app disagreed on the default smoothing
+algorithm. `grid.ts`'s `DEFAULT_SMOOTH_ALGORITHM` (what a bare `.smooth()`
+stamps) and the Voxel Studio UI both default to `surfaceNets`, but the mesher's
+`smoothAlgorithm()` fallback for a `Surfacing` with `algorithm: undefined`
+returned `taubin`. Such an object can't come from `VoxelGrid.smooth()` (which
+always stamps the field), but it can from `clone()` of an older surfacing or
+direct construction — and then the mesh renders `taubin` while the UI claims
+`surfaceNets`, and the "Update code" round-trip (which suppresses the
+`surfaceNets` default in codegen) silently re-renders it as `surfaceNets`.
+
+Fix: export `DEFAULT_SMOOTH_ALGORITHM` from `grid.ts` and have the mesher fall
+back to it, so there's a single source of truth and mesher/UI/codegen agree.
+
+Verified: typecheck + the voxel unit tier (175 tests) pass.

--- a/src/geometry/voxel/grid.ts
+++ b/src/geometry/voxel/grid.ts
@@ -42,7 +42,7 @@ const MAX_GRID_CELLS = 0x7fffffff; // 2^31 - 1
 /** Which smoothing algorithm a bare `.smooth()` (no `algorithm` arg) selects.
  *  `taubin` is the original mesh-relaxation smoother; `surfaceNets` is the
  *  newer native-resolution smoother. Flip this to change the product default. */
-const DEFAULT_SMOOTH_ALGORITHM: 'taubin' | 'surfaceNets' = 'surfaceNets';
+export const DEFAULT_SMOOTH_ALGORITHM: 'taubin' | 'surfaceNets' = 'surfaceNets';
 
 function assertCoord(v: number, name: string): number {
   const n = assertNumber(v, name, { integer: true, min: COORD_MIN, max: COORD_MAX })!;

--- a/src/geometry/voxel/mesher.ts
+++ b/src/geometry/voxel/mesher.ts
@@ -16,7 +16,7 @@
 // Pure logic (no DOM/WASM): unit-tested in the vitest tier.
 
 import type { MeshData } from '../types';
-import { VoxelGrid, colorComponents, type Surfacing } from './grid';
+import { VoxelGrid, colorComponents, DEFAULT_SMOOTH_ALGORITHM, type Surfacing } from './grid';
 import { taubinSmooth, scaleMeshPositions, type SmoothPins } from './smooth';
 import { surfaceNetsMesh } from './surfaceNets';
 
@@ -245,11 +245,13 @@ function emitGreedyQuad(
   triColors.push(r, g, b, r, g, b);
 }
 
-/** Which smoothing algorithm a `smooth()` grid uses. Falls back to the legacy
- *  `taubin` for Surfacing objects that predate the `algorithm` field; `smooth()`
- *  itself stamps the current default (see grid.ts) onto every new call. */
+/** Which smoothing algorithm a `smooth()` grid uses. Falls back to the shared
+ *  product default for Surfacing objects that predate the `algorithm` field (or
+ *  arrive via clone/direct construction); `smooth()` itself stamps that same
+ *  default onto every new call. Mesher and UI must agree on this fallback, so
+ *  both read DEFAULT_SMOOTH_ALGORITHM rather than hardcoding a value. */
 function smoothAlgorithm(surf: Surfacing): 'taubin' | 'surfaceNets' {
-  return surf.algorithm ?? 'taubin';
+  return surf.algorithm ?? DEFAULT_SMOOTH_ALGORITHM;
 }
 
 /** Mesh a grid according to its surfacing setting. `blocks` (default) returns


### PR DESCRIPTION
Part of a pre-production-release review of `main` (543 commits since `production`).

## Summary

The voxel mesher disagreed with the rest of the app on the default smoothing algorithm:

- `grid.ts`'s `DEFAULT_SMOOTH_ALGORITHM` (what a bare `.smooth()` stamps) = `surfaceNets`
- Voxel Studio UI default = `surfaceNets`
- but `mesher.ts`'s `smoothAlgorithm()` fell back to **`taubin`** for a `Surfacing` with `algorithm: undefined`

Such an object can't arise from `VoxelGrid.smooth()` (which always stamps the field), but it *can* from `clone()` of an older surfacing or direct construction. In that case the mesh renders `taubin` while the UI claims `surfaceNets`, and the "Update code" round-trip (whose codegen suppresses the `surfaceNets` default) silently re-renders it as `surfaceNets`.

Fix: export `DEFAULT_SMOOTH_ALGORITHM` from `grid.ts` and read it in the mesher fallback, so mesher / UI / codegen share one source of truth.

## Test plan

- `npm run typecheck` — clean
- `npx vitest run voxel` — 175 pass

https://claude.ai/code/session_011cMXaPDR8PpCetgRpKXNwL

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMXaPDR8PpCetgRpKXNwL)_