### PR TITLE
fix: insert/arrange palette correctness (resize result, dedup, undo buttons)

### DIFF
--- a/prompts/release-fix-insert-arrange.md
+++ b/prompts/release-fix-insert-arrange.md
@@ -1,0 +1,42 @@
+---
+date: 2026-06-12
+branch: claude/elegant-turing-sjwiei-insert-arrange
+files_changed:
+  - src/renderer/meshGeometry.ts
+  - src/renderer/phantomGeometry.ts
+  - src/ui/insertPalette.ts
+---
+
+## Human
+
+Pre-production-release review of `main`. Fix correctness defects from the recent
+merge window (the insert/arrange palette is the newest, roughest area).
+
+## Assistant
+
+Three correctness fixes in the insert/arrange palette:
+
+1. **`apiResizeSelection` returned `{ ok: true }` on rejected input.** Its
+   internal `applyResize()` toasts and silently no-ops on a non-positive scale
+   factor, so a scripted/AI caller branching on the result saw a false success
+   (violating the "return `{error}` on bad input" API rule). Validate
+   positivity in the wrapper and return `{ ok: false, reason }`. (The UI dialog
+   already clamps, so users were unaffected.)
+
+2. **`meshDataToGeometry` was duplicated and had diverged** between
+   `renderer/phantomGeometry.ts` (computed vertex normals) and
+   `ui/insertPalette.ts` (did not). Harmless today — the palette's copy only
+   feeds raycaster pick meshes — but a drift trap. Extracted a single
+   `renderer/meshGeometry.ts` leaf (with normals) and pointed both at it.
+
+3. **The Undo/Redo panel buttons duplicated `apiUndo`/`apiRedo`'s toast logic**
+   instead of calling them, so the keyboard / console path and the buttons
+   could drift. Routed the buttons through `apiUndo()` / `apiRedo()`.
+
+Skipped a flagged "divide-by-zero" in `syncBoxToEntry` — the divisor is always
+≥0.001 or undefined (→NaN→`|| 1`), so it can't actually occur; adding a guard
+would be noise.
+
+Verified: typecheck, no new circular deps, 1264 unit tests, and the full
+insert-palette + insert-codegen e2e suites (205 tests) all pass — including the
+undo/redo button and round-trip cases.

--- a/src/renderer/meshGeometry.ts
+++ b/src/renderer/meshGeometry.ts
@@ -1,0 +1,25 @@
+// Shared MeshData → THREE.BufferGeometry conversion.
+//
+// A low-level renderer leaf so both the phantom-overlay path
+// (`phantomGeometry.ts`) and the insert-palette pick meshes (`ui/insertPalette.ts`)
+// build geometry the same way — they had diverged (one computed vertex normals,
+// the other didn't). Lives in the renderer layer so UI may import it without an
+// upward dependency.
+import * as THREE from 'three';
+import type { MeshData } from '../geometry/types';
+
+/** Build a positions+index BufferGeometry from MeshData, with computed vertex
+ *  normals (needed for shaded display; harmless for raycast-only pick meshes). */
+export function meshDataToGeometry(mesh: MeshData): THREE.BufferGeometry {
+  const geometry = new THREE.BufferGeometry();
+  const positions = new Float32Array(mesh.numVert * 3);
+  for (let i = 0; i < mesh.numVert; i++) {
+    positions[i * 3] = mesh.vertProperties[i * mesh.numProp];
+    positions[i * 3 + 1] = mesh.vertProperties[i * mesh.numProp + 1];
+    positions[i * 3 + 2] = mesh.vertProperties[i * mesh.numProp + 2];
+  }
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geometry.setIndex(new THREE.BufferAttribute(mesh.triVerts, 1));
+  geometry.computeVertexNormals();
+  return geometry;
+}

--- a/src/renderer/phantomGeometry.ts
+++ b/src/renderer/phantomGeometry.ts
@@ -3,6 +3,7 @@
 import * as THREE from 'three';
 import type { MeshData } from '../geometry/types';
 import { requestRender } from './viewport';
+import { meshDataToGeometry } from './meshGeometry';
 
 let phantomGroup: THREE.Group | null = null;
 
@@ -10,22 +11,6 @@ export interface PhantomOptions {
   color?: number;
   opacity?: number;
   wireframe?: boolean;
-}
-
-function meshDataToGeometry(mesh: MeshData): THREE.BufferGeometry {
-  const geometry = new THREE.BufferGeometry();
-  const positions = new Float32Array(mesh.numVert * 3);
-
-  for (let i = 0; i < mesh.numVert; i++) {
-    positions[i * 3] = mesh.vertProperties[i * mesh.numProp];
-    positions[i * 3 + 1] = mesh.vertProperties[i * mesh.numProp + 1];
-    positions[i * 3 + 2] = mesh.vertProperties[i * mesh.numProp + 2];
-  }
-
-  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-  geometry.setIndex(new THREE.BufferAttribute(mesh.triVerts, 1));
-  geometry.computeVertexNormals();
-  return geometry;
 }
 
 export function initPhantomGroup(scene: THREE.Scene): THREE.Group {

--- a/src/ui/insertPalette.ts
+++ b/src/ui/insertPalette.ts
@@ -24,6 +24,7 @@ import { attachViewportPanelDrag, setInitialPanelPosition } from './viewportPane
 import { openViewportPanel, closeViewportPanel, type ViewportPanel } from './viewportPanelRegistry';
 import { viewportToolsMount } from './popoverMenu';
 import { getScene, getMeshGroup } from '../renderer/viewport';
+import { meshDataToGeometry } from '../renderer/meshGeometry';
 import {
   emitPrimitive,
   emitPrimitiveVoxel,
@@ -549,6 +550,11 @@ export function apiCanRedo(): boolean { return canRedo(); }
 export function apiResizeSelection(scale: Vec3): { ok: boolean; reason?: string } {
   if (!cb) return { ok: false, reason: 'insert palette not initialized' };
   if (selection.size === 0) return { ok: false, reason: 'no selection' };
+  // applyResize() toasts and silently no-ops on a non-positive factor; a
+  // scripted/AI caller needs the failure surfaced, not a false { ok: true }.
+  if (scale[0] <= 0 || scale[1] <= 0 || scale[2] <= 0) {
+    return { ok: false, reason: 'scale factors must be positive' };
+  }
   applyResize(scale);
   return { ok: true };
 }
@@ -689,19 +695,13 @@ function buildPanel(): HTMLElement {
   undoBtn.className = 'flex-1 px-2 py-1.5 rounded text-xs font-medium text-zinc-100 bg-zinc-700/60 hover:bg-zinc-600 border border-zinc-600/60 transition-colors disabled:opacity-40 disabled:cursor-not-allowed';
   undoBtn.textContent = '↶ Undo';
   undoBtn.title = 'Undo the last palette operation';
-  undoBtn.addEventListener('click', () => {
-    const label = undoOp();
-    if (label && cb) cb.showToast(`Undid: ${label}`, { variant: 'neutral' });
-  });
+  undoBtn.addEventListener('click', () => { apiUndo(); });
   redoBtn = document.createElement('button');
   redoBtn.id = 'insert-redo';
   redoBtn.className = undoBtn.className;
   redoBtn.textContent = '↷ Redo';
   redoBtn.title = 'Redo the last undone palette operation';
-  redoBtn.addEventListener('click', () => {
-    const label = redoOp();
-    if (label && cb) cb.showToast(`Redid: ${label}`, { variant: 'neutral' });
-  });
+  redoBtn.addEventListener('click', () => { apiRedo(); });
   historyRow.append(undoBtn, redoBtn);
   p.appendChild(historyRow);
 
@@ -2352,15 +2352,3 @@ function applyQuickDelete(): void {
   });
 }
 
-function meshDataToGeometry(mesh: MeshData): THREE.BufferGeometry {
-  const geometry = new THREE.BufferGeometry();
-  const positions = new Float32Array(mesh.numVert * 3);
-  for (let i = 0; i < mesh.numVert; i++) {
-    positions[i * 3] = mesh.vertProperties[i * mesh.numProp];
-    positions[i * 3 + 1] = mesh.vertProperties[i * mesh.numProp + 1];
-    positions[i * 3 + 2] = mesh.vertProperties[i * mesh.numProp + 2];
-  }
-  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-  geometry.setIndex(new THREE.BufferAttribute(mesh.triVerts, 1));
-  return geometry;
-}


### PR DESCRIPTION
Part of a pre-production-release review of `main` (543 commits since `production`). The insert/arrange palette is the newest, roughest area — three correctness fixes:

## Summary

1. **`apiResizeSelection` returned `{ ok: true }` on rejected input.** Its internal `applyResize()` toasts and silently no-ops on a non-positive scale factor, so a scripted/AI caller branching on the result saw a false success (violates the "return `{error}` on bad input" API rule). Now validates positivity in the wrapper and returns `{ ok: false, reason }`. The UI dialog already clamps, so interactive users were unaffected.

2. **`meshDataToGeometry` was duplicated and had diverged** between `renderer/phantomGeometry.ts` (computed vertex normals) and `ui/insertPalette.ts` (did not). Harmless today — the palette's copy only feeds raycaster pick meshes — but a drift trap. Extracted a single `renderer/meshGeometry.ts` leaf (with normals) and pointed both at it.

3. **The Undo/Redo panel buttons duplicated `apiUndo`/`apiRedo`'s toast logic** instead of calling them, so the keyboard/console path and the buttons could drift. Routed the buttons through `apiUndo()` / `apiRedo()`.

A flagged "divide-by-zero" in `syncBoxToEntry` was **not** changed — the divisor is always ≥0.001 or `undefined` (→`NaN`→`|| 1`), so it can't actually occur.

## Test plan

- `npm run typecheck` — clean
- `npm run lint:deps` — no new circular deps (added `meshGeometry.ts` leaf)
- `npm run test:unit` — 1264 pass
- `npx playwright test insert-palette insert-codegen` — 205 pass, including the undo/redo button and API round-trip cases

https://claude.ai/code/session_011cMXaPDR8PpCetgRpKXNwL

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMXaPDR8PpCetgRpKXNwL)_