### PR TITLE
fix: escape user-typed filament slot name before innerHTML (XSS)

### DIFF
--- a/prompts/release-fix-palette-xss.md
+++ b/prompts/release-fix-palette-xss.md
@@ -1,0 +1,26 @@
+---
+date: 2026-06-12
+branch: claude/elegant-turing-sjwiei-palette-xss
+files_changed:
+  - src/color/paletteManager.ts
+---
+
+## Human
+
+Pre-production-release security review of `main`. Fix any XSS / injection sinks
+introduced in the recent merge window.
+
+## Assistant
+
+The filament-palette manager interpolated a user-typed filament slot name
+(`slot.name`) directly into `innerHTML` without escaping
+(`paletteManager.ts:342`). A slot named e.g. `<img src=x onerror=…>` would
+execute when the palette swatch list renders. This landed with the filament
+palette feature (PR #343 area) in this release window.
+
+Fix: wrap `slot.name` in the existing `escapeHtml()` helper
+(`src/ui/htmlUtils.ts`), matching the other escaped user-text innerHTML sites
+(import file names, session names). The sibling "off-palette" branch is a
+constant string + safe hex, so it needed no change.
+
+Verified: typecheck + the palette-import-constrain e2e specs pass.

--- a/src/color/paletteManager.ts
+++ b/src/color/paletteManager.ts
@@ -8,6 +8,7 @@
 import { createToolPanelShell } from '../ui/toolPanel';
 import { BUTTON_PRIMARY } from '../ui/styleConstants';
 import { showToast } from '../ui/toast';
+import { escapeHtml } from '../ui/htmlUtils';
 import { promptDialog, confirmDialog } from '../ui/dialogs';
 import {
   listPalettes,
@@ -339,7 +340,7 @@ export function openPaletteManager(): void {
     label.className = 'text-[11px] flex-1 min-w-0 truncate';
     const slot = slotForColor(rgb);
     if (slot) {
-      label.innerHTML = `<span class="font-mono text-zinc-400">${rgbToHex(rgb)}</span> <span class="text-emerald-400">✓ ${slot.name}</span>`;
+      label.innerHTML = `<span class="font-mono text-zinc-400">${rgbToHex(rgb)}</span> <span class="text-emerald-400">✓ ${escapeHtml(slot.name)}</span>`;
     } else {
       label.innerHTML = `<span class="font-mono text-zinc-300">${rgbToHex(rgb)}</span> <span class="text-amber-400">off-palette</span>`;
     }


### PR DESCRIPTION
Part of a pre-production-release review of `main` (543 commits since `production`). The security review found one genuine injection sink in the merge window.

## Summary

`paletteManager` interpolated a **user-typed filament slot name** (`slot.name`) directly into `innerHTML` without escaping (`paletteManager.ts:342`). A slot named e.g. ``'&lt;img src=x onerror=alert(1)&gt;'`` would execute when the palette swatch list renders. This landed with the filament-palette feature in this release window; `slot.name` comes from a free-text `<input>` and is persisted in localStorage.

Fix: wrap `slot.name` in the existing `escapeHtml()` helper (`src/ui/htmlUtils.ts`), matching the other escaped user-text innerHTML sites (import file names, session names). The sibling "off-palette" branch is a constant string + safe hex and needed no change.

The rest of the AI/chat transcript and modal `innerHTML` sites were reviewed and are clean (all `textContent`, or interpolate only numbers/constants).

## Test plan

- `npm run typecheck` — clean
- `npx playwright test palette-import-constrain` — 2 pass (no regression in palette rendering)

https://claude.ai/code/session_011cMXaPDR8PpCetgRpKXNwL

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMXaPDR8PpCetgRpKXNwL)_