### PR TITLE
fix: recover from stale-deploy chunk-load failures instead of spinning forever

### DIFF
--- a/prompts/20260612-043000-chunk-load-stale-deploy-recovery.md
+++ b/prompts/20260612-043000-chunk-load-stale-deploy-recovery.md
@@ -1,0 +1,55 @@
+---
+date: 2026-06-12
+title: Recover from stale-deploy chunk-load failures instead of spinning forever
+human: kriskemper@gmail.com
+prefix: fix
+---
+
+## Human
+
+Loaded the app (the main branch deploy, main.partwright.pages.dev/editor) and saw a
+loading bar forever. A new window loaded fine. The stuck tab's console showed:
+
+- "Failed to load module script: Expected a JavaScript-or-Wasm module script but the
+  server responded with a MIME type of 'text/html'."
+- "Failed to fetch dynamically imported module: .../assets/main-DZLxNqfy.js"
+
+## Assistant
+
+### Diagnosis
+
+Classic stale-deploy chunk mismatch. `src/entry.ts` is the only statically-loaded
+module; it does `import('./main')` with no `.catch`. When a new build deploys while a
+tab is open (or the tab grabbed a half-swapped asset set during the deploy window), the
+page references a `main-*.js` hash the server no longer has. The hashed chunk 404s,
+Cloudflare's SPA fallback (`/* /index.html 200`) serves `index.html` in its place, and
+the browser rejects that as the wrong MIME type. The rejected import promise was
+unhandled, and the loading splash — only removed once `main.ts` runs — spun forever.
+A fresh window worked because it fetched an internally-consistent index.html + chunks.
+
+### Fix
+
+One-time auto hard-reload as recovery: a fresh navigation pulls the new index.html and
+the chunk hashes that actually exist. Guarded by a `sessionStorage` flag so a genuinely
+persistent failure (offline, chunk truly gone, or a real runtime error during module
+eval) surfaces an actionable "Reload" prompt in the splash instead of an infinite
+reload loop or an infinite spinner.
+
+- New pure module `src/chunkReload.ts` holds the decision logic — `isChunkLoadError`
+  (matches Chrome/Firefox/Safari dynamic-import + MIME wordings) and
+  `chunkRecoveryAction` (reload once on the first chunk error, else notify). Kept pure
+  so it lives in the fast unit tier (`tests/unit/chunkReload.test.ts`).
+- `src/entry.ts` wires it to the real `sessionStorage`/`location`/DOM: `.catch` on the
+  bundle import plus a `vite:preloadError` window listener (the dependency-preload half
+  of the same failure). Only chunk-load errors auto-reload; the guard is cleared on a
+  successful boot so a later deploy in a long-lived tab still earns its own one retry.
+  The Reload prompt only replaces the splash on app routes — the landing route's static
+  HTML stays usable, so we don't cover it.
+
+### Verification
+
+- Unit: 9 new tests for the detection + decision logic; full tier green (1273).
+- Browser: a scratch Playwright spec intercepted `/src/main.ts` and returned
+  `text/html` (mimicking the SPA fallback). Confirmed it auto-reloaded once then showed
+  the Reload prompt — no infinite spinner. Also confirmed a normal `/editor` load is
+  unaffected. `npm run build` green.

--- a/src/chunkReload.ts
+++ b/src/chunkReload.ts
@@ -1,0 +1,59 @@
+// Recovery logic for stale-deploy dynamic-import failures.
+//
+// The app is a single static bundle whose chunks carry content-hashed names
+// (e.g. `main-DZLxNqfy.js`). When a new build deploys while a tab is open — or
+// the tab loaded a half-swapped asset set during the deploy window — the page
+// holds references to chunk hashes the server no longer has. Importing one then
+// 404s, and Cloudflare's SPA fallback (`/* /index.html 200`) serves index.html
+// in its place, which the browser rejects as the wrong MIME type:
+//   "Failed to load module script: Expected a JavaScript-or-Wasm module script
+//    but the server responded with a MIME type of 'text/html'."
+//   "Failed to fetch dynamically imported module: …/assets/main-XXXX.js"
+//
+// `src/entry.ts` is the only statically-loaded module, so it's the single place
+// the app-bundle import can fail. Left unhandled, the rejection is silent and
+// the loading splash (removed only once main.ts runs) spins forever. The remedy
+// is a one-time hard reload: a fresh navigation fetches the new index.html and
+// its matching chunk hashes. This module holds the pure decision logic so it's
+// unit-testable; entry.ts wires it to the real `sessionStorage`/`location`/DOM.
+
+// sessionStorage flag marking that we've already auto-reloaded this session, so
+// a genuinely persistent failure (offline, a chunk truly gone) doesn't loop.
+// A structural key, not a tunable knob — intentionally inline.
+export const CHUNK_RELOAD_GUARD_KEY = 'pw:chunkReloadAttempted';
+
+/**
+ * True when an error looks like a failed dynamic-import / module-script load —
+ * the signature of a stale-deploy chunk mismatch — rather than a runtime bug
+ * thrown while the module evaluated. Matches the wording browsers use across
+ * Chrome, Firefox, and Safari.
+ */
+export function isChunkLoadError(err: unknown): boolean {
+  const msg =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'string'
+        ? err
+        : String((err as { message?: unknown } | null | undefined)?.message ?? err ?? '');
+  return (
+    /dynamically imported module/i.test(msg) || // Chrome: "Failed to fetch dynamically imported module"
+    /error loading dynamically imported module/i.test(msg) || // Firefox
+    /importing a module script failed/i.test(msg) || // Safari
+    /module script/i.test(msg) || // generic "Failed to load module script…"
+    /mime type/i.test(msg) // the text/html SPA-fallback MIME rejection
+  );
+}
+
+/**
+ * Decide how to recover from an app-bundle load failure, given whether a
+ * reload was already attempted this session. The first chunk-load failure
+ * earns a single hard reload; anything after that (or a non-chunk error) gets
+ * an actionable message instead of a reload loop.
+ */
+export function chunkRecoveryAction(
+  err: unknown,
+  reloadAlreadyAttempted: boolean,
+): 'reload' | 'notify' {
+  if (isChunkLoadError(err) && !reloadAlreadyAttempted) return 'reload';
+  return 'notify';
+}

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -8,6 +8,8 @@
 // The landing predicate must match shouldShowLanding() in src/main.ts and the
 // pre-paint check in public/route-init.js: pathname "/" with no editor view
 // state in the query or a share hash.
+import { CHUNK_RELOAD_GUARD_KEY, chunkRecoveryAction } from './chunkReload';
+
 function isLandingRoute(): boolean {
   const p = window.location.pathname;
   const q = window.location.search;
@@ -26,8 +28,112 @@ function isLandingRoute(): boolean {
   );
 }
 
-if (isLandingRoute()) {
-  void import('./landing/landingEntry');
-} else {
-  void import('./main');
+function guardAttempted(): boolean {
+  try {
+    return sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY) === '1';
+  } catch {
+    return false;
+  }
 }
+
+function setGuard(): void {
+  try {
+    sessionStorage.setItem(CHUNK_RELOAD_GUARD_KEY, '1');
+  } catch {
+    /* sessionStorage can be unavailable (private mode, disabled) — no-op */
+  }
+}
+
+function clearGuard(): void {
+  try {
+    sessionStorage.removeItem(CHUNK_RELOAD_GUARD_KEY);
+  } catch {
+    /* no-op */
+  }
+}
+
+// Replace the forever-spinning splash with an actionable Reload prompt. Only
+// used on app routes (the splash is the active view there); on the landing
+// route the static inline HTML stays fully usable, so we don't cover it.
+function showReloadPrompt(staleDeploy: boolean): void {
+  const splash = document.getElementById('loading-splash');
+  if (!splash) return;
+  splash.innerHTML = '';
+  splash.style.display = 'flex';
+
+  const card = document.createElement('div');
+  card.style.cssText =
+    'display:flex;flex-direction:column;align-items:center;gap:16px;max-width:360px;text-align:center;padding:24px;font-family:system-ui,-apple-system,sans-serif';
+
+  const title = document.createElement('div');
+  title.style.cssText = 'font-size:24px;font-weight:700;color:#fafafa;letter-spacing:-0.5px';
+  title.textContent = 'Partwright';
+
+  const msg = document.createElement('div');
+  msg.style.cssText = 'font-size:14px;line-height:1.6;color:#a1a1aa';
+  msg.textContent = staleDeploy
+    ? 'A new version was deployed while this tab was open, so it couldn’t finish loading. Reload to get the latest build.'
+    : 'Something went wrong while loading the app. Reloading usually fixes it.';
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = 'Reload';
+  btn.style.cssText =
+    'padding:10px 24px;border-radius:10px;font-size:14px;font-weight:600;color:#1c1917;background:linear-gradient(135deg,#fcd34d,#f59e0b);border:0;cursor:pointer';
+  btn.addEventListener('click', () => {
+    // Manual reload clears the guard so the fresh load gets its own retry budget.
+    clearGuard();
+    window.location.reload();
+  });
+
+  card.append(title, msg, btn);
+  splash.appendChild(card);
+}
+
+let recovering = false;
+function handleLoadFailure(err: unknown, landing: boolean): void {
+  if (recovering) return;
+  recovering = true;
+  console.error('[partwright] Failed to load the app bundle:', err);
+
+  const action = chunkRecoveryAction(err, guardAttempted());
+  if (action === 'reload') {
+    setGuard();
+    // Hard reload — a fresh navigation pulls the new index.html and the chunk
+    // hashes that actually exist on the server.
+    window.location.reload();
+    return;
+  }
+
+  // Second failure this session (or a non-chunk error): don't loop. On app
+  // routes, swap the spinner for a Reload prompt; on the landing route the
+  // static page is still usable, so just leave it.
+  if (!landing) showReloadPrompt(isStaleDeploy(err));
+}
+
+// chunkRecoveryAction already encodes the chunk-vs-other distinction for the
+// action; for messaging we recompute the "stale deploy" flavour cheaply.
+function isStaleDeploy(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  return /module|mime type/i.test(msg);
+}
+
+// Vite dispatches this on the window when its preload helper fails to fetch a
+// dynamic import's dependencies (the other half of the stale-deploy story).
+// Preventing default suppresses Vite's own uncaught-error log and routes the
+// failure through the same one-time-reload recovery; the import's `.catch`
+// below is the backstop for the entry chunk's own load failure.
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault();
+  handleLoadFailure((event as Event & { payload?: unknown }).payload, isLandingRoute());
+});
+
+const landing = isLandingRoute();
+const appLoad = landing ? import('./landing/landingEntry') : import('./main');
+appLoad
+  .then(() => {
+    // Successful boot: release the retry budget so a future deploy in this
+    // long-lived tab still earns its own one-time auto-reload.
+    clearGuard();
+  })
+  .catch((err: unknown) => handleLoadFailure(err, landing));

--- a/tests/unit/chunkReload.test.ts
+++ b/tests/unit/chunkReload.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { isChunkLoadError, chunkRecoveryAction, CHUNK_RELOAD_GUARD_KEY } from '../../src/chunkReload';
+
+describe('isChunkLoadError', () => {
+  it('matches the Chrome dynamic-import failure', () => {
+    expect(
+      isChunkLoadError(
+        new Error(
+          'Failed to fetch dynamically imported module: https://main.partwright.pages.dev/assets/main-DZLxNqfy.js',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('matches the MIME-type module-script rejection (SPA fallback served HTML)', () => {
+    expect(
+      isChunkLoadError(
+        new Error(
+          "Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of \"text/html\".",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('matches the Firefox and Safari wordings', () => {
+    expect(isChunkLoadError(new Error('error loading dynamically imported module'))).toBe(true);
+    expect(isChunkLoadError(new Error('Importing a module script failed.'))).toBe(true);
+  });
+
+  it('accepts plain strings and error-like objects', () => {
+    expect(isChunkLoadError('Failed to fetch dynamically imported module')).toBe(true);
+    expect(isChunkLoadError({ message: 'wrong MIME type' })).toBe(true);
+  });
+
+  it('does not match unrelated runtime errors', () => {
+    expect(isChunkLoadError(new Error('Cannot read properties of undefined'))).toBe(false);
+    expect(isChunkLoadError(new TypeError('x is not a function'))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+});
+
+describe('chunkRecoveryAction', () => {
+  const chunkErr = new Error('Failed to fetch dynamically imported module: /assets/main-X.js');
+  const runtimeErr = new Error('Cannot read properties of undefined');
+
+  it('reloads once on the first chunk-load failure', () => {
+    expect(chunkRecoveryAction(chunkErr, false)).toBe('reload');
+  });
+
+  it('stops reloading after a reload was already attempted this session', () => {
+    expect(chunkRecoveryAction(chunkErr, true)).toBe('notify');
+  });
+
+  it('never auto-reloads on a non-chunk runtime error', () => {
+    expect(chunkRecoveryAction(runtimeErr, false)).toBe('notify');
+    expect(chunkRecoveryAction(runtimeErr, true)).toBe('notify');
+  });
+});
+
+describe('CHUNK_RELOAD_GUARD_KEY', () => {
+  it('is a stable sessionStorage key', () => {
+    expect(CHUNK_RELOAD_GUARD_KEY).toBe('pw:chunkReloadAttempted');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a **forever-spinning loading bar** on already-open tabs after a new deploy. Reported on `main.partwright.pages.dev/editor`: the splash spun indefinitely while the console showed:

- `Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html".`
- `Failed to fetch dynamically imported module: …/assets/main-DZLxNqfy.js`

### Root cause

`src/entry.ts` is the only statically-loaded module; it does `import('./main')` with **no `.catch`**. When a new build deploys while a tab is open (or the tab grabbed a half-swapped asset set during the deploy window), the page references a `main-*.js` content-hash the server no longer has. The hashed chunk 404s, Cloudflare's SPA fallback (`/* /index.html 200`) serves `index.html` in its place, and the browser rejects that as the wrong MIME type. The rejected promise was unhandled, and the loading splash — only removed once `main.ts` runs — spun forever. Opening a new window worked because it fetched an internally-consistent `index.html` + chunk set.

### Fix

A one-time hard reload as recovery: a fresh navigation pulls the new `index.html` and the chunk hashes that actually exist on the server. Guarded by a `sessionStorage` flag so a genuinely persistent failure (offline, chunk truly gone, or a real runtime error during module eval) surfaces an actionable **Reload** prompt in the splash instead of an infinite reload loop or an infinite spinner.

- **New pure module `src/chunkReload.ts`** — `isChunkLoadError` (matches the Chrome / Firefox / Safari dynamic-import + MIME wordings) and `chunkRecoveryAction` (reload once on the first chunk error, else notify). Kept dependency-free so it lives in the fast unit tier.
- **`src/entry.ts`** wires it to the real `sessionStorage` / `location` / DOM: `.catch` on the bundle import plus a `vite:preloadError` window listener (the dependency-preload half of the same failure). Only chunk-load errors auto-reload; the guard clears on a successful boot so a later deploy in a long-lived tab still earns its own one retry. The Reload prompt only replaces the splash on app routes — the landing route's static HTML stays usable.

## Test plan

- [x] `npm run typecheck` / `npm run build` — green
- [x] `npm run test:unit` — green (1273 tests; +9 new for `chunkReload`)
- [x] **Browser:** scratch Playwright spec intercepted `/src/main.ts` and returned `text/html` (mimicking the SPA fallback). Confirmed it auto-reloaded once, then showed the Reload prompt — no infinite spinner.
- [x] **Browser:** normal `/editor` load unaffected (editor renders fully).
- [ ] PR-checks shards green
