### PR TITLE
feat: setVoxelRounding API parity + dead-export/duplication cleanup

### DIFF
--- a/prompts/feat-set-voxel-rounding-api.md
+++ b/prompts/feat-set-voxel-rounding-api.md
@@ -1,0 +1,44 @@
+---
+date: 2026-06-12
+branch: claude/elegant-turing-sjwiei
+files_changed:
+  - src/main.ts
+  - public/ai/voxel.md
+  - tests/voxel-studio.spec.ts
+---
+
+## Human
+
+Follow-up to the pre-release review: close the `setVoxelRounding` UI↔JS-API
+parity gap (the Voxel Studio Rounding panel had no `window.partwright` twin).
+
+## Assistant
+
+The Rounding panel (`voxelPaintUI.ts` → `voxelPaint.setRounding`) was only
+reachable by clicking — a parity gap of exactly the kind the mid-2026 audit
+flagged. Added the console/MCP twin so an agent can drive what the panel does.
+
+- **`setVoxelRounding(opts | null)`** on `partwrightAPI`, mirroring the sibling
+  `setVoxelBrush`/`setVoxelLevelAxis` pattern: active-guard first, then inline
+  per-field validation returning `{ error }` (never throwing, per the
+  value-returning-method rule), then `voxelPaint.setRounding` +
+  `syncVoxelPaintUI()` so the panel reflects the change, returning the resolved
+  `{ surfacing }`. `null` → hard blocks.
+- **Validation mirrors the engine's real bounds** so nothing reaches
+  `VoxelGrid.smooth()` that it would *throw* on: `algorithm` ∈
+  {taubin,surfaceNets}, `strength` 0..1, `iterations` 1..8, `flatBottom` bool,
+  `baseLayers` int 0..1024. `baseLayers: 0` is treated as "no flat base" and
+  stripped (the engine's `smooth` requires `baseLayers ≥ 1`, so passing 0 would
+  throw — the UI does the same `>0 ? n : undefined` dance).
+- **`getVoxelRounding()`** for read-back parity.
+- Registered both in the `help()` table (the discoverability surface) and
+  documented them in `public/ai/voxel.md` (code block + bullet).
+
+Verified in a real browser: error paths return `{error}`, surfaceNets/taubin
+apply and read back, `null` reverts to blocky, and the panel's Rounding controls
+reflect the programmatic state (screenshot posted). Added two permanent
+golden-path e2e tests in `voxel-studio.spec.ts` (happy path + read-back, and the
+studio-inactive error path). Did NOT add an `src/ai/tools.ts` chat tool — the
+Voxel Studio is interactive direct-manipulation, and the chat AI's documented
+path for rounding is writing `.smooth({...})` in code; the console API is the
+right level here.

--- a/prompts/refactor-dead-exports-and-dedup.md
+++ b/prompts/refactor-dead-exports-and-dedup.md
@@ -1,0 +1,62 @@
+---
+date: 2026-06-12
+branch: claude/elegant-turing-sjwiei
+files_changed:
+  - src/ai/custom.ts
+  - src/geometry/printerSettings.ts
+  - src/geometry/voxel/grid.ts
+  - src/geometry/voxel/edits.ts
+  - src/ui/insertPalette.ts
+---
+
+## Human
+
+Follow-up to the pre-release review: dead-export and duplication cleanup.
+
+## Assistant
+
+Each candidate was verified by grepping `src/` AND `tests/` (knip can't see the
+e2e suite's dynamic `import('/src/...')`), so nothing live was removed.
+
+**Dead exports removed:**
+
+1. **`resetClient` in `src/ai/custom.ts`** — a no-op (`// Stateless`) with zero
+   importers. The anthropic/openai/gemini `resetClient`s are live (settings &
+   key modals + provider e2e specs) and were left untouched. Deleted only the
+   custom one.
+2. **`onPrinterSettingsChange` in `src/geometry/printerSettings.ts`** — a
+   pub/sub never subscribed to. Removed the function plus the now-write-never
+   `listeners` Set and the `savePrinterSettings` notify loop, and dropped the
+   stale "listeners" mention from the file header.
+
+**Kept (knip false-positive triage):**
+
+- **`addTarget` in `voxel/edits.ts`** is NOT dead — `tests/unit/voxelEdits.test.ts`
+  imports and exercises it. (It was on my earlier suspect list; grep cleared it.)
+- **`SurfaceModifierId`** is an advisory unused *type*, but it's the canonical
+  documented enumeration of the modifier set (named in CLAUDE.md and a sibling
+  JSDoc). Per the "exports/types need per-symbol triage" rule, kept as living
+  documentation rather than deleted for marginal gain.
+
+**Duplication consolidated (only the genuinely-identical cases):**
+
+3. **Voxel 6-face neighbour offsets** were duplicated: an exported
+   `FACE_NEIGHBORS` in `edits.ts` and a char-for-char identical local `NEIGHBORS`
+   inside `grid.ts`'s `faceComponentCount()`. Promoted the constant to a single
+   exported `FACE_NEIGHBORS` in `grid.ts` (the lower module — `edits` already
+   imports `grid`, so no new import edge / no cycle) and re-exported it from
+   `edits.ts` for back-compat.
+4. **The insert-palette click-to-pick raycaster** was wired inline twice
+   (operand pick + multi-select), identical but for the per-hit callback.
+   Extracted a local `attachPartPicker(canvas, camera, mesh, onPick)` helper that
+   also owns the geometry/material disposal, and routed both sessions through it.
+
+**Investigated but deliberately NOT merged** (divergent — merging would be a
+bug): the broader Raycaster usages (annotation overlay vs programmatic probe vs
+plane-intersect vs interactive-mesh are four distinct patterns), and the two
+`NUM` numeric-parse regexes (`controller.ts` accepts `.5`/scientific notation;
+`parseStatement.ts` is a strict parser for a controlled emission format).
+
+Verified: typecheck, no circular deps (`lint:deps`), knip clean of the removed
+symbols, 1264 unit tests, and the full insert-palette + insert-codegen e2e
+suites (205 tests) — which exercise the refactored raycaster pick path.

--- a/public/ai/voxel.md
+++ b/public/ai/voxel.md
@@ -443,6 +443,12 @@ partwright.voxelStudioEndStroke();               // -> { ok, voxelCount }
 partwright.voxelStudioUndo();                                    // -> { undone, voxelCount }
 partwright.voxelStudioRedo();                                    // -> { redone, voxelCount }
 
+// Corner rounding (the Rounding panel, programmatically):
+partwright.setVoxelRounding({ algorithm: 'surfaceNets' });        // -> { surfacing }
+partwright.setVoxelRounding({ algorithm: 'taubin', strength: 0.5, baseLayers: 3 });
+partwright.getVoxelRounding();                                    // -> { surfacing } (null when blocky)
+partwright.setVoxelRounding(null);                                // back to hard blocks
+
 // Commit — two options:
 await partwright.updateVoxelCode({ label: 'castle' });   // keep code, append edits
 await partwright.bakeVoxelsToCode({ label: 'castle' });  // replace with voxels.decode(...)
@@ -468,6 +474,12 @@ await partwright.bakeVoxelsToCode({ label: 'castle' });  // replace with voxels.
   layers, a `boxRemove` carves that many deeper); `0` = flush to the face.
   Returns the resolved settings.
 - `setVoxelLevelAxis(axis)` — `0`/`1`/`2` (x/y/z) for the `level` tool.
+- `setVoxelRounding(opts | null)` — the Rounding panel's surfacing, set in code.
+  `null` = hard blocks; an object smooths: `algorithm` (`'taubin' | 'surfaceNets'`),
+  `strength` (0..1, taubin only), `iterations` (1..8), `flatBottom` (bool, keep a
+  flat print bed), `baseLayers` (int — keep the bottom N voxel layers blocky;
+  `0` = none). Returns `{ surfacing }` or `{ error }`. `getVoxelRounding()` reads
+  the current surfacing back (`{ surfacing }`, `null` when blocky).
 - `voxelStudioBeginStroke()` / `voxelStudioEndStroke()` — bracket a run of
   `voxelStudioApply` calls so they collapse into one undo step (the
   programmatic equivalent of a click-drag).

--- a/src/ai/custom.ts
+++ b/src/ai/custom.ts
@@ -55,10 +55,6 @@ function authHeaders(apiKey: string): HeadersInit {
   return headers;
 }
 
-export function resetClient(): void {
-  // Stateless — each request opens its own fetch.
-}
-
 export async function streamTurn(
   spec: CustomRequestSpec,
   callbacks: StreamCallbacks = {},

--- a/src/geometry/printerSettings.ts
+++ b/src/geometry/printerSettings.ts
@@ -2,7 +2,7 @@
 // 3D printer the user is targeting so the print-aware tools (printability
 // checks, scale-to-fit, split-for-printing) all read one shared source of
 // truth. Persisted to localStorage as one JSON blob, mirroring the
-// qualitySettings.ts pattern (cache + listeners + merge-with-defaults).
+// qualitySettings.ts pattern (cache + merge-with-defaults).
 //
 // Units follow the app convention: "arbitrary, but treat as millimetres for
 // printing." The defaults match a common 256 mm bed (e.g. Bambu X1/P1).
@@ -46,7 +46,6 @@ const MIN_NOZZLE = 0.05;
 const MAX_NOZZLE = 2;
 
 let cached: PrinterSettings | null = null;
-const listeners = new Set<(s: PrinterSettings) => void>();
 
 function clampBedAxis(n: unknown, fallback: number): number {
   if (typeof n !== 'number' || !Number.isFinite(n)) return fallback;
@@ -101,13 +100,7 @@ export function savePrinterSettings(next: Partial<PrinterSettings>): PrinterSett
     // localStorage may be full or disabled (private browsing). Settings
     // remain applied for this session; we don't surface the failure.
   }
-  for (const fn of listeners) fn(merged);
   return merged;
-}
-
-export function onPrinterSettingsChange(fn: (s: PrinterSettings) => void): () => void {
-  listeners.add(fn);
-  return () => { listeners.delete(fn); };
 }
 
 /** Convenience: the build volume as a plain tuple. */

--- a/src/geometry/voxel/edits.ts
+++ b/src/geometry/voxel/edits.ts
@@ -7,13 +7,12 @@
 // vitest tier without pulling in the viewport/raycast glue that lives in
 // src/color/voxelPaint.ts.
 
-import type { Vec3 } from './grid';
-import { VoxelGrid, normalizeColor, type ColorInput, COORD_MIN, COORD_MAX } from './grid';
+import { VoxelGrid, normalizeColor, FACE_NEIGHBORS, type Vec3, type ColorInput, COORD_MIN, COORD_MAX } from './grid';
 
-/** The 6 face-neighbor offsets (shared by flood fill and the "add" tool). */
-export const FACE_NEIGHBORS: Vec3[] = [
-  [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1],
-];
+// `FACE_NEIGHBORS` (the 6 face-neighbour offsets, shared by the flood-fill and
+// "add" tools below) now lives in `grid.ts` as the single source of truth — see
+// its definition there. Re-exported here for back-compat with existing importers.
+export { FACE_NEIGHBORS };
 
 function inRange(x: number, y: number, z: number): boolean {
   return x >= COORD_MIN && x <= COORD_MAX

--- a/src/geometry/voxel/grid.ts
+++ b/src/geometry/voxel/grid.ts
@@ -16,6 +16,13 @@ export type Vec3 = [number, number, number];
  *  packed `0xRRGGBB` number. Normalized to a 24-bit integer internally. */
 export type ColorInput = Vec3 | string | number;
 
+/** The 6 face-neighbour offsets (±X, ±Y, ±Z). The single source of truth for
+ *  face-connectivity across the voxel modules: `faceComponentCount` below and
+ *  the flood-fill / "add" tools in `edits.ts` both consume it. */
+export const FACE_NEIGHBORS: Vec3[] = [
+  [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1],
+];
+
 // Coordinates are packed into a single JS integer key for fast Map lookups.
 // 11 bits per axis (offset by HALF) gives a usable range of [-1024, 1023] per
 // axis; the largest key (~8.59e9) stays well under Number.MAX_SAFE_INTEGER.
@@ -208,7 +215,6 @@ export class VoxelGrid {
   faceComponentCount(): number {
     if (this.cells.size === 0) return 0;
     const visited = new Set<number>();
-    const NEIGHBORS: Vec3[] = [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]];
     let components = 0;
     for (const startKey of this.cells.keys()) {
       if (visited.has(startKey)) continue;
@@ -221,7 +227,7 @@ export class VoxelGrid {
         const z = (key % DIM) - HALF;
         const y = (Math.floor(key / DIM) % DIM) - HALF;
         const x = Math.floor(key / (DIM * DIM)) - HALF;
-        for (const [dx, dy, dz] of NEIGHBORS) {
+        for (const [dx, dy, dz] of FACE_NEIGHBORS) {
           const nx = x + dx, ny = y + dy, nz = z + dz;
           if (!inRange(nx, ny, nz)) continue;
           const nKey = packKey(nx, ny, nz);

--- a/src/main.ts
+++ b/src/main.ts
@@ -13235,6 +13235,54 @@ async function main() {
       return { axis };
     },
 
+    /** Set the active grid's surfacing (corner rounding) — the programmatic twin
+     *  of the Voxel Studio Rounding panel. Pass `null` for hard blocks, or
+     *  `{ algorithm?: 'taubin'|'surfaceNets', strength?: 0..1, iterations?: 1..8,
+     *  flatBottom?: bool, baseLayers?: int (0 = no flat base) }` to smooth.
+     *  Requires `activateVoxelPaint()` first. Returns `{ surfacing }` (the
+     *  resolved surfacing, or `null` when blocky) or `{ error }`. */
+    setVoxelRounding(opts: import('./color/voxelPaint').RoundingOpts | null) {
+      if (!voxelPaint.isActive()) return { error: 'Voxel Studio is not active — call activateVoxelPaint() first.' };
+      if (opts === null) {
+        voxelPaint.setRounding(null);
+        syncVoxelPaintUI();
+        return { surfacing: voxelPaint.getSurfacing() };
+      }
+      if (typeof opts !== 'object' || Array.isArray(opts)) return { error: 'setVoxelRounding.opts must be an object or null' };
+      const clean: import('./color/voxelPaint').RoundingOpts = {};
+      if (opts.algorithm !== undefined) {
+        if (opts.algorithm !== 'taubin' && opts.algorithm !== 'surfaceNets') return { error: "setVoxelRounding.algorithm must be 'taubin' or 'surfaceNets'" };
+        clean.algorithm = opts.algorithm;
+      }
+      if (opts.strength !== undefined) {
+        if (typeof opts.strength !== 'number' || opts.strength < 0 || opts.strength > 1) return { error: 'setVoxelRounding.strength must be a number 0..1' };
+        clean.strength = opts.strength;
+      }
+      if (opts.iterations !== undefined) {
+        if (typeof opts.iterations !== 'number' || !Number.isInteger(opts.iterations) || opts.iterations < 1 || opts.iterations > 8) return { error: 'setVoxelRounding.iterations must be an integer 1..8' };
+        clean.iterations = opts.iterations;
+      }
+      if (opts.flatBottom !== undefined) {
+        if (typeof opts.flatBottom !== 'boolean') return { error: 'setVoxelRounding.flatBottom must be a boolean' };
+        clean.flatBottom = opts.flatBottom;
+      }
+      if (opts.baseLayers !== undefined) {
+        if (typeof opts.baseLayers !== 'number' || !Number.isInteger(opts.baseLayers) || opts.baseLayers < 0 || opts.baseLayers > 1024) return { error: 'setVoxelRounding.baseLayers must be an integer 0..1024' };
+        if (opts.baseLayers > 0) clean.baseLayers = opts.baseLayers; // 0 = no flat base
+      }
+      voxelPaint.setRounding(clean);
+      syncVoxelPaintUI();
+      return { surfacing: voxelPaint.getSurfacing() };
+    },
+
+    /** Read the active grid's current surfacing (corner rounding) settings.
+     *  Returns `{ surfacing }` (the Surfacing object, or `null` when blocky) or
+     *  `{ error }` when Voxel Studio is not active. */
+    getVoxelRounding() {
+      if (!voxelPaint.isActive()) return { error: 'Voxel Studio is not active — call activateVoxelPaint() first.' };
+      return { surfacing: voxelPaint.getSurfacing() };
+    },
+
     /** Begin a brush stroke: subsequent `voxelStudioApply` calls collapse into a
      *  single undo step until `voxelStudioEndStroke()`. This is the programmatic
      *  equivalent of a click-drag. Returns `{ ok }` or `{ error }`. */
@@ -13736,6 +13784,8 @@ async function main() {
         'buildEngraveStamp': { signature: 'await buildEngraveStamp({text?, font?, imageUrl?, invert?}) -- Rasterize an ink mask for engraveModel/the Surface panel -> {mask, width, height}', docs: '/ai/textures.md#engravemodel' },
         'smoothModel':     { signature: 'await smoothModel({iterations?, subdivide?, preserveColor?}) -- BAKE a Taubin smoothing pass; saves a new version. In-code alternative: api.surface.smooth', docs: '/ai/textures.md' },
         'voxelizeModel':   { signature: 'await voxelizeModel({resolution?, smooth?, preserveColor?}) -- Convert the mesh to a voxel-language session (engine change — bake only)', docs: '/ai/voxel.md' },
+        'setVoxelRounding': { signature: "setVoxelRounding(opts | null) -- Voxel Studio corner rounding: null = hard blocks; {algorithm?: 'taubin'|'surfaceNets', strength?: 0..1, iterations?: 1..8, flatBottom?: bool, baseLayers?: int} = smooth. Requires activateVoxelPaint(). Returns {surfacing} or {error}", docs: '/ai/voxel.md' },
+        'getVoxelRounding': { signature: 'getVoxelRounding() -- Read the active grid surfacing -> {surfacing} (null when blocky) or {error}', docs: '/ai/voxel.md' },
         // Transform / placement (mode 'parametric' wraps the code; 'bake' rewrites the mesh; 'auto' picks)
         'canPlaceParametric': { signature: 'canPlaceParametric() -- Whether transforms can be written into the code parametrically (manifold-js sessions)', docs: '/ai/printing.md' },
         'previewScale':    { signature: 'previewScale(sx, sy, sz, {preserveColor?}?) -- Non-destructive viewport preview of a resize -> {ok} or {error}', docs: '/ai/printing.md' },

--- a/src/ui/insertPalette.ts
+++ b/src/ui/insertPalette.ts
@@ -1964,6 +1964,44 @@ function rangesOverlap(ranges: { from: number; to: number }[]): boolean {
 
 let pickCleanup: (() => void) | null = null;
 
+/** Wire a click-to-pick raycaster over the live model canvas. Builds a temp
+ *  mesh from `mesh`, and on a click (pointer that barely moved, so orbit-drag
+ *  still rotates) raycasts from the camera and invokes `onPick` with the
+ *  world-space hit point. Returns a teardown that unbinds the listeners and
+ *  frees the temp mesh's geometry + material. Shared by the operand-pick and
+ *  multi-select sessions below — both built this same wiring inline. */
+function attachPartPicker(
+  canvas: HTMLCanvasElement,
+  camera: THREE.Camera,
+  mesh: MeshData,
+  onPick: (pt: Vec3) => void,
+): () => void {
+  const raycaster = new THREE.Raycaster();
+  const geometry = meshDataToGeometry(mesh);
+  const tempMesh = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial({ side: THREE.DoubleSide }));
+  let downX = 0;
+  let downY = 0;
+  const onDown = (e: PointerEvent): void => { downX = e.clientX; downY = e.clientY; };
+  const onUp = (e: PointerEvent): void => {
+    if (Math.abs(e.clientX - downX) > 4 || Math.abs(e.clientY - downY) > 4) return;
+    const rect = canvas.getBoundingClientRect();
+    const ndcX = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+    raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
+    const hits = raycaster.intersectObject(tempMesh);
+    if (hits.length === 0) return;
+    onPick([hits[0].point.x, hits[0].point.y, hits[0].point.z]);
+  };
+  canvas.addEventListener('pointerdown', onDown);
+  canvas.addEventListener('pointerup', onUp);
+  return () => {
+    canvas.removeEventListener('pointerdown', onDown);
+    canvas.removeEventListener('pointerup', onUp);
+    geometry.dispose();
+    (tempMesh.material as THREE.Material).dispose();
+  };
+}
+
 function startPickSession(op: BooleanOpKind, operands: Operand[], validNames: Set<string>): void {
   if (!cb) return;
   const canvas = cb.getCanvas();
@@ -2003,26 +2041,7 @@ function startPickSession(op: BooleanOpKind, operands: Operand[], validNames: Se
   bar.appendChild(cancelBtn);
   document.body.appendChild(bar);
 
-  const raycaster = new THREE.Raycaster();
-  const geometry = meshDataToGeometry(mesh);
-  const tempMesh = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial({ side: THREE.DoubleSide }));
-
-  let downX = 0;
-  let downY = 0;
-  const onDown = (e: PointerEvent) => {
-    downX = e.clientX;
-    downY = e.clientY;
-  };
-  const onUp = (e: PointerEvent) => {
-    // Treat as a click only if the pointer barely moved (so orbit-drag still rotates).
-    if (Math.abs(e.clientX - downX) > 4 || Math.abs(e.clientY - downY) > 4) return;
-    const rect = canvas.getBoundingClientRect();
-    const ndcX = ((e.clientX - rect.left) / rect.width) * 2 - 1;
-    const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
-    raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
-    const hits = raycaster.intersectObject(tempMesh);
-    if (hits.length === 0) return;
-    const pt: Vec3 = [hits[0].point.x, hits[0].point.y, hits[0].point.z];
+  const detachPicker = attachPartPicker(canvas, camera, mesh, (pt) => {
     const name = resolvePartAtPoint(pt, validNames);
     if (!name) {
       cb!.showToast('Could not match that spot to an inserted part.', { variant: 'warn' });
@@ -2031,16 +2050,10 @@ function startPickSession(op: BooleanOpKind, operands: Operand[], validNames: Se
     operands.push({ name, statement: partStatementFor(name), range: partRangeFor(name) });
     msg.textContent = count();
     cb!.showToast(`Added "${name}".`, { variant: 'neutral' });
-  };
-
-  canvas.addEventListener('pointerdown', onDown);
-  canvas.addEventListener('pointerup', onUp);
+  });
 
   pickCleanup = () => {
-    canvas.removeEventListener('pointerdown', onDown);
-    canvas.removeEventListener('pointerup', onUp);
-    geometry.dispose();
-    (tempMesh.material as THREE.Material).dispose();
+    detachPicker();
     bar.remove();
     pickCleanup = null;
   };
@@ -2141,22 +2154,7 @@ function startSelectMode(): void {
   bar.appendChild(doneBtn);
   document.body.appendChild(bar);
 
-  const raycaster = new THREE.Raycaster();
-  const geometry = meshDataToGeometry(mesh);
-  const tempMesh = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial({ side: THREE.DoubleSide }));
-
-  let downX = 0;
-  let downY = 0;
-  const onDown = (e: PointerEvent): void => { downX = e.clientX; downY = e.clientY; };
-  const onUp = (e: PointerEvent): void => {
-    if (Math.abs(e.clientX - downX) > 4 || Math.abs(e.clientY - downY) > 4) return;
-    const rect = canvas.getBoundingClientRect();
-    const ndcX = ((e.clientX - rect.left) / rect.width) * 2 - 1;
-    const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
-    raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
-    const hits = raycaster.intersectObject(tempMesh);
-    if (hits.length === 0) return;
-    const pt: Vec3 = [hits[0].point.x, hits[0].point.y, hits[0].point.z];
+  const detachPicker = attachPartPicker(canvas, camera, mesh, (pt) => {
     const name = pickPart(pt, registry, validNames);
     if (!name) {
       cb!.showToast('Could not match that spot to an inserted part.', { variant: 'warn' });
@@ -2167,16 +2165,10 @@ function startSelectMode(): void {
     updateMsg();
     refreshHighlights();
     rerenderSelectionUI();
-  };
-
-  canvas.addEventListener('pointerdown', onDown);
-  canvas.addEventListener('pointerup', onUp);
+  });
 
   const endSession = (): void => {
-    canvas.removeEventListener('pointerdown', onDown);
-    canvas.removeEventListener('pointerup', onUp);
-    geometry.dispose();
-    (tempMesh.material as THREE.Material).dispose();
+    detachPicker();
     for (const c of [...highlightGroup.children]) {
       if (c instanceof THREE.LineSegments) {
         c.geometry.dispose();

--- a/tests/voxel-studio.spec.ts
+++ b/tests/voxel-studio.spec.ts
@@ -300,4 +300,45 @@ test.describe('voxel studio', () => {
     expect(r.added.voxelCount).toBe(r.importedCount + 1);
     expect(r.baked.error).toBeFalsy();
   });
+
+  test('setVoxelRounding / getVoxelRounding drive the Rounding panel from the API', async ({ page }) => {
+    const r = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.setActiveLanguage('voxel');
+      await pw.run(`return api.voxels().fillBox([-3,-3,0],[3,3,3], '#888');`);
+      pw.activateVoxelPaint();
+      // Bad input returns { error } (it must not throw out of the API method).
+      const badAlg = pw.setVoxelRounding({ algorithm: 'nope' });
+      const badBase = pw.setVoxelRounding({ baseLayers: -1 });
+      // Happy paths: surfaceNets, then taubin with a flat base, read back, then off.
+      const sn = pw.setVoxelRounding({ algorithm: 'surfaceNets' });
+      const tb = pw.setVoxelRounding({ algorithm: 'taubin', strength: 0.5, baseLayers: 3 });
+      const readBack = pw.getVoxelRounding();
+      const off = pw.setVoxelRounding(null);
+      return { badAlg, badBase, sn, tb, readBack, off };
+    });
+    expect(r.badAlg.error).toContain('algorithm');
+    expect(r.badBase.error).toContain('baseLayers');
+    expect(r.sn.surfacing.mode).toBe('smooth');
+    expect(r.sn.surfacing.algorithm).toBe('surfaceNets');
+    expect(r.tb.surfacing.algorithm).toBe('taubin');
+    expect(r.tb.surfacing.strength).toBeCloseTo(0.5);
+    expect(r.tb.surfacing.baseLayers).toBe(3);
+    expect(r.readBack.surfacing.algorithm).toBe('taubin');
+    expect(r.off.surfacing.mode).toBe('blocks');
+  });
+
+  test('setVoxelRounding / getVoxelRounding error when the studio is not active', async ({ page }) => {
+    const r = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.setActiveLanguage('voxel');
+      await pw.run(`return api.voxels().set(0,0,0,'#fff');`);
+      // No activateVoxelPaint() — both must report the studio is inactive.
+      return { set: pw.setVoxelRounding(null), get: pw.getVoxelRounding() };
+    });
+    expect(r.set.error).toContain('not active');
+    expect(r.get.error).toContain('not active');
+  });
 });


### PR DESCRIPTION
## Summary

Two pre-release follow-ups approved after the codebase review.

### 1. `setVoxelRounding` / `getVoxelRounding` API parity (`feat`)

The Voxel Studio **Rounding** panel (`voxelPaintUI` → `voxelPaint.setRounding`) was only reachable by clicking — a UI↔JS-API parity gap of exactly the kind the mid-2026 audit flagged. Added the console/MCP twin:

- **`setVoxelRounding(opts | null)`** on `partwrightAPI`, mirroring the sibling `setVoxelBrush`/`setVoxelLevelAxis` pattern: active-guard first, inline per-field validation returning `{ error }` (never throwing, per the value-returning-method rule), then `voxelPaint.setRounding` + `syncVoxelPaintUI()` so the panel reflects the change. Returns the resolved `{ surfacing }`; `null` → hard blocks.
- **Validation mirrors the engine's real bounds** so nothing reaches `VoxelGrid.smooth()` that it would *throw* on: `algorithm` ∈ {taubin,surfaceNets}, `strength` 0..1, `iterations` 1..8, `flatBottom` bool, `baseLayers` int 0..1024 (`0` = "no flat base", stripped because `smooth` requires `≥1`).
- **`getVoxelRounding()`** for read-back parity.
- Registered both in the `help()` table and documented in `public/ai/voxel.md` (code block + bullet).
- No `src/ai/tools.ts` chat tool: the chat AI's documented path for rounding is writing `.smooth({...})` in code; the Voxel Studio is interactive direct-manipulation, so the console API is the right level.

### 2. Dead-export + duplication cleanup (`refactor`)

Each candidate verified by grepping `src/` **and** `tests/` (knip can't see the e2e suite's dynamic `import('/src/...')`).

**Removed (verified dead):**
- `resetClient` in `src/ai/custom.ts` — a `// Stateless` no-op with zero importers (the anthropic/openai/gemini `resetClient`s are live and untouched).
- `onPrinterSettingsChange` in `printerSettings.ts` — a never-subscribed pub/sub, plus its now-write-never `listeners` Set and notify loop.

**Consolidated (genuinely identical):**
- Voxel 6-face neighbour offsets — one exported `FACE_NEIGHBORS` in `grid.ts` (the lower module; no new import edge), re-exported from `edits.ts` for back-compat.
- The twice-inlined insert-palette click-to-pick raycaster → a local `attachPartPicker()` helper that also owns geometry/material disposal.

**Kept after triage:**
- `addTarget` (used by `tests/unit/voxelEdits.test.ts` — not dead).
- `SurfaceModifierId` (advisory unused type, but the canonical documented modifier enumeration).
- The divergent Raycaster usages (4 distinct patterns) and the two `NUM` regexes (different numeric grammars) — merging either would be a bug.

## Test plan

- `npm run typecheck` ✅
- `npm run lint:deps` (no circular deps) ✅
- `npm run lint:deadcode` (knip clean of the removed symbols) ✅
- `npm run test:unit` — 1264 ✅
- `npx playwright test insert-palette insert-codegen` — 205 ✅ (exercises the refactored raycaster pick path)
- `npx playwright test voxel-studio --grep Rounding` — 2 new golden-path tests ✅
- Manual browser check: `setVoxelRounding` error/happy/null paths + the panel reflecting programmatic state (verified, screenshot in session)

https://claude.ai/code/session_011cMXaPDR8PpCetgRpKXNwL

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMXaPDR8PpCetgRpKXNwL)_