### PR TITLE
fix: clear CodeQL XSS and URL-sanitization alerts

### DIFF
--- a/prompts/20260612-050000-codeql-xss-url-cleanup.md
+++ b/prompts/20260612-050000-codeql-xss-url-cleanup.md
@@ -1,0 +1,63 @@
+---
+session: "6a833de5"
+timestamp: "2026-06-12T05:00:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+While preparing the June 12 staging → production release PR (#628), the CodeQL
+default-setup check failed with 12 alerts. "Can you review and decide if they
+are all false or won't-fix? Otherwise if they need to be addressed create PR
+targeting main with the fixes/cleanup." (Alert list was pasted from the
+Security ▸ Code scanning tab because this session has no gh/token access to the
+code-scanning API.)
+
+## Assistant
+
+## Triage
+
+Twelve alerts, none introduced by the release PR itself (it's a pure
+`staging → production` promotion — same code already on `main`). Split three
+ways:
+
+**By design — leave as won't-fix (UI dismissal, can't suppress in code):**
+
+- 6× Critical `js/code-injection` (`manifoldJs.ts:645,774`, `replicad.ts:76,183`,
+  `voxel.ts:86,146`) — every one is `new Function('api', userCode)`, the
+  intentional client-side modeling sandbox. The user runs their own code in
+  their own browser; there is no server and no cross-user trust boundary, so
+  this is the product's core mechanism, not a vulnerability. The repo uses
+  CodeQL **default setup**, which honors neither inline `// codeql[...]`
+  suppressions nor a `codeql-config.yml` query filter, so these can only be
+  dismissed from the Security UI (needs security-write — left to the human).
+
+- 1× High `js/unvalidated-dynamic-method-call` (`agentWorker.ts:90`) — `resolve`
+  is a Promise resolver we created and stored in `pendingToolCalls`, fetched by
+  a `callId` we generate and already null-guarded. Not arbitrary dispatch;
+  false positive.
+
+**Real / code-addressable — fixed here:**
+
+- 2× High XSS (`exportConfirmModal.ts:74,90`). The interpolated values are
+  actually numbers (bbox dimensions, `componentCount`), so the practical risk
+  is nil, but they are genuine `innerHTML` sinks. Rather than argue
+  false-positive, escape them defensively via `escapeHtml(...)` — consistent
+  with the recent filament-slot-name XSS fix (`e23a4c3`) and cheap insurance if
+  the source types ever widen to strings.
+
+- 3× High `js/incomplete-url-substring-sanitization`
+  (`ai-autoresume.spec.ts:55,118,174`). Test-only mock routing did
+  `url.includes('generativelanguage.googleapis.com')`, which a crafted URL
+  could satisfy as a substring. Switched to
+  `new URL(url, location.origin).hostname !== '...'` — correct host matching,
+  resolves relative URLs (e.g. `/ai.md`) to the test origin so they still pass
+  through to the real fetch, and clears the alert. Test code, but the fix is
+  also simply correct.
+
+## Decision
+
+Fixes land on a branch into **`main`** (not the release branch — the superset
+rule forbids release-branch-only content). The by-design code-injection alerts
+are recommended for UI dismissal as "won't fix"; migrating to CodeQL advanced
+setup purely to filter them in-config would be a larger change and wasn't done.

--- a/src/ui/exportConfirmModal.ts
+++ b/src/ui/exportConfirmModal.ts
@@ -13,6 +13,7 @@
 import { createModalShell } from './modalShell';
 import { BUTTON_PRIMARY, BUTTON_CANCEL } from './styleConstants';
 import { formatDimension } from '../geometry/units';
+import { escapeHtml } from './htmlUtils';
 
 export interface ExportWarningInfo {
   /** True when the active unit system is 'unitless'. */
@@ -70,7 +71,7 @@ export function showExportConfirm(info: ExportWarningInfo): Promise<boolean> {
       block.innerHTML =
         '<strong>No units set.</strong> Most slicers assume <strong>millimeters</strong>. ' +
         'If you modeled at another scale, the printed part will be the wrong size. ' +
-        (dimText ? `This model\'s bounding box is <span class="font-mono">${dimText}</span>. ` : '') +
+        (dimText ? `This model\'s bounding box is <span class="font-mono">${escapeHtml(dimText)}</span>. ` : '') +
         'Set units in the Export menu to silence this check.';
       shell.body.appendChild(block);
     }
@@ -83,7 +84,7 @@ export function showExportConfirm(info: ExportWarningInfo): Promise<boolean> {
         lines.push('the geometry is <strong>not manifold</strong> (not watertight)');
       }
       if (info.componentCount > 1) {
-        lines.push(`it has <strong>${info.componentCount} disconnected components</strong>`);
+        lines.push(`it has <strong>${escapeHtml(String(info.componentCount))} disconnected components</strong>`);
       }
       block.innerHTML =
         '<strong>Printability warning:</strong> ' + lines.join(' and ') +

--- a/tests/ai-autoresume.spec.ts
+++ b/tests/ai-autoresume.spec.ts
@@ -52,7 +52,7 @@ test.describe('Auto-continue (finish-tool resume)', () => {
         const url = String(input);
         // Let the system-prompt (/ai.md) and any other fetch pass through;
         // only the Gemini stream is canned.
-        if (!url.includes('generativelanguage.googleapis.com')) {
+        if (new URL(url, location.origin).hostname !== 'generativelanguage.googleapis.com') {
           return origFetch(input as RequestInfo, init);
         }
         n++;
@@ -115,7 +115,7 @@ test.describe('Auto-continue (finish-tool resume)', () => {
       // @ts-expect-error test stub
       window.fetch = async (input: unknown, init?: RequestInit) => {
         const url = String(input);
-        if (!url.includes('generativelanguage.googleapis.com')) return origFetch(input as RequestInfo, init);
+        if (new URL(url, location.origin).hostname !== 'generativelanguage.googleapis.com') return origFetch(input as RequestInfo, init);
         n++;
         bodies.push(String(init?.body ?? ''));
         // Call 1: a truly empty end_turn (no parts). Call 2: finish.
@@ -171,7 +171,7 @@ test.describe('Auto-continue (finish-tool resume)', () => {
       // @ts-expect-error test stub
       window.fetch = async (input: unknown, init?: RequestInit) => {
         const url = String(input);
-        if (!url.includes('generativelanguage.googleapis.com')) return origFetch(input as RequestInfo, init);
+        if (new URL(url, location.origin).hostname !== 'generativelanguage.googleapis.com') return origFetch(input as RequestInfo, init);
         n++;
         // Always a plain text end_turn — the model never calls finish.
         const frame = 'data: {"candidates":[{"content":{"parts":[{"text":"still going"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1}}';


### PR DESCRIPTION
## Summary

CodeQL (default setup) flagged **12 alerts** on the June 12 release PR (#628). None were introduced by that PR — it's a pure `staging → production` promotion, so the same code is already on `main`. This PR cleans up the **code-addressable** subset; the rest are by-design and recommended for UI dismissal (see below).

### Fixed here (5 alerts)

- **2× High XSS** — `src/ui/exportConfirmModal.ts:74,90` (`js/xss`, `js/html-reinterpreted-as-html`). The values interpolated into `innerHTML` are numeric today (bbox dimensions, `componentCount`), so real risk is nil, but they're genuine sinks — now wrapped in `escapeHtml(...)`. Defensive, consistent with the recent slot-name XSS fix (`e23a4c3`).
- **3× High** — `tests/ai-autoresume.spec.ts:55,118,174` (`js/incomplete-url-substring-sanitization`). The Gemini `fetch` mock-stubs matched the host with `url.includes('generativelanguage.googleapis.com')`; switched to `new URL(url, location.origin).hostname === '…'`. Relative URLs (e.g. `/ai.md`) resolve to the test origin and still pass through to the real fetch. Test-only, but also simply correct.

### Not changed — won't-fix / by design (7 alerts)

These can't be suppressed in code under CodeQL **default setup** (no inline-suppression / config-filter support), so they need a **"Won't fix" dismissal in Security ▸ Code scanning**:

| Alert | Location | Why |
|---|---|---|
| 6× Critical `js/code-injection` | `manifoldJs.ts:645,774`, `replicad.ts:76,183`, `voxel.ts:86,146` | All `new Function('api', userCode)` — the **intentional client-side modeling sandbox**. User runs their own code in their own browser; no server, no cross-user trust boundary. Core product mechanism, not a vulnerability. |
| 1× High `js/unvalidated-dynamic-method-call` | `agentWorker.ts:90` | `resolve` is a Promise resolver we created and stored, fetched by a `callId` we generate and already null-guarded. False positive. |

(Filtering these in-config would mean migrating off default setup to advanced setup — a larger change, deliberately not done here.)

## Test plan

- `npm run typecheck` ✓ (clean)
- PR-checks build + unit + e2e shards (the `ai-autoresume` spec exercises the edited stubs)
- After merge → gate → CodeQL re-run on `main` should drop these 5 alerts.

https://claude.ai/code/session_0173T3kUTgGrcdr9hYnEBpqX

---
_Generated by [Claude Code](https://claude.ai/code/session_0173T3kUTgGrcdr9hYnEBpqX)_