### PR TITLE
feat: prerender /ideas as static HTML + add subpage JSON-LD for crawlers

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ideas — What to Make with Partwright | Partwright</title>
+  <meta name="description" content="Ideas to get started with Partwright: ready-made AI prompts to drop into the chat, technique showcases (implicit surfaces, true CAD fillets, voxels), and interactive flows that turn your own photo into a voxel portrait or a smooth relief." />
+  <meta name="author" content="Partwright" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Partwright" />
+  <meta property="og:title" content="Ideas — What to Make with Partwright" />
+  <meta property="og:description" content="Starter prompts, technique showcases, and photo-to-model flows to get going with Partwright's browser CAD." />
+  <meta property="og:image" content="/og-image.png" />
+  <meta property="og:url" content="/ideas" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Ideas — What to Make with Partwright" />
+  <meta name="twitter:description" content="Starter prompts, technique showcases, and photo-to-model flows to get going with Partwright." />
+  <meta name="twitter:image" content="/og-image.png" />
+  <link rel="canonical" href="/ideas" />
+
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+  <meta name="theme-color" content="#18181b" />
+  <link rel="manifest" href="/manifest.json" />
+  <link rel="stylesheet" href="/src/style.css" />
+  <link rel="preload" href="/fonts/spacegrotesk-400.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+  <link rel="preload" href="/fonts/spacegrotesk-600.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+  <link rel="preload" href="/fonts/sora-700.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+</head>
+<body class="bg-zinc-900 text-zinc-100 min-h-screen" style="font-family:'Space Grotesk',system-ui,-apple-system,sans-serif">
+  <!--PW-CONTENT-->
+</body>
+</html>

--- a/prompts/20260612-130000-ideas-prerender-jsonld-seo.md
+++ b/prompts/20260612-130000-ideas-prerender-jsonld-seo.md
@@ -1,0 +1,71 @@
+---
+session: "8e3748ca"
+timestamp: "2026-06-12T13:00:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+"I've noticed my app isn't showing up on Google AI overviews. if searched by
+name it comes up in the listings. is there more I could be doing to get it
+picked up by the crawlers?"
+
+After an audit (robots.txt welcomes all AI crawlers, sitemap + per-route meta
+present, content pages already prerendered, landing-page JSON-LD present), the
+user chose two of the gaps to implement: **prerender `/ideas`** and **add
+JSON-LD to subpages**.
+
+## Assistant
+
+## Why these two
+
+The site was already crawl-friendly — the blocker wasn't a robots/crawl block
+but content left on the table. Two concrete, in-our-control gaps:
+
+1. `/ideas` was the only content route with **no** prerendered HTML — it fell
+   through the SPA fallback to a spinner, so crawlers saw zero idea text despite
+   sitemap priority 0.8.
+2. Only the landing page carried JSON-LD; `/help` and `/catalog` had rich
+   content but no structured data for AI extraction.
+
+## Key decisions
+
+**Mirror the `/catalog` dual model, don't replace the SPA page.** `/catalog`
+already ships *both* a static prerendered page (hard-nav/crawlers) and an in-app
+overlay (soft-nav). I followed that exactly for `/ideas`: added `ideas.html` +
+an `ideasBody()` renderer in `src/content/build/render.ts` (registered in
+`CONTENT_PAGES` and the Vite Rollup inputs), and kept the existing
+`createIdeasPage` overlay for in-app soft-nav. Lower risk than ripping out the
+overlay, and consistent with the established pattern.
+
+**Preserve interactivity via a deep-link.** A static page can't hand an
+in-memory tile click to the editor, so every static tile is an
+`<a href="/editor?idea=<id>">`. Added `loadIdeaIntoEditor(id)` in `main.ts`
+(invoked from `syncEditorFromURL`, parallel to the existing `?catalog=` path):
+prompt ideas prefill the AI panel; interactive ideas open a photo picker and run
+the same voxel/relief flow the in-app tile would. Extracted `openReliefForIdea`
+to avoid duplicating the luminance-mode relief logic. Removed the now-dead
+`/ideas` boot-spinner special-case (hard-nav no longer boots the SPA there).
+
+**JSON-LD via the existing build pipeline.** `prerenderContentPages`
+(`order: 'pre'`) injects the body before `absoluteUrls` runs, so relative
+`"url"` fields in injected JSON-LD get absolutized at build for free. Added a
+`jsonLdScript()` helper (escapes `<` so a model name can't break out of the
+script) and emitted: `CollectionPage` + `ItemList` for `/ideas` and `/catalog`
+(122 models), `TechArticle` for `/help`. Verified the `/editor?idea=` and
+`/editor?catalog=` ListItem URLs come out absolute in the production build.
+
+**Bug the e2e caught (and the fix).** The targeted spec flagged that
+`loadIdeaIntoEditor` runs inside `syncEditorFromURL` during boot — *before*
+`initAiPanel` builds the drawer — so `prefillAiInput` hit `if (!inputEl) return`
+and silently no-opped. Fixed in `aiPanel.ts` by queuing the text in
+`pendingPrefill` when the input doesn't exist yet and flushing it at the end of
+`initAiPanel` once the drawer is built. The SPA soft-nav path is unaffected (it
+runs post-boot). Rewrote `tests/ideas.spec.ts` to drive the static page (link
+tiles, no `#ideas-page`/spinner) instead of the old SPA overlay; all 5 pass.
+
+## Verification
+
+typecheck clean · 1273 unit tests pass · production build emits
+`dist/ideas.html` with crawlable content + absolutized JSON-LD · sitemap still
+lists `/ideas` · 5/5 ideas e2e green · screenshot of the static page posted.

--- a/prompts/20260612-130000-ideas-prerender-jsonld-seo.md
+++ b/prompts/20260612-130000-ideas-prerender-jsonld-seo.md
@@ -69,3 +69,14 @@ tiles, no `#ideas-page`/spinner) instead of the old SPA overlay; all 5 pass.
 typecheck clean · 1273 unit tests pass · production build emits
 `dist/ideas.html` with crawlable content + absolutized JSON-LD · sitemap still
 lists `/ideas` · 5/5 ideas e2e green · screenshot of the static page posted.
+
+## Follow-up (work-reviewer nits)
+
+The work-reviewer found no blocking/should-fix issues, just three nits, all
+applied:
+1. The transient file `<input>` for an interactive deep-link leaked if the user
+   *cancelled* the picker (no `change` event). Added a one-shot window-`focus`
+   cleanup (deferred so a real selection's `change` runs first) to reclaim it.
+2. & 3. Refreshed the "four content pages" comments that hadn't counted the new
+   ideas page — `prerenderPlugin.ts`, `public/_redirects`, `vite.config.ts`,
+   and `shell.ts` now say five and list `ideas`.

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,7 +3,7 @@
 /api /ai.md 301
 
 # Pre-rendered, app-free content pages (catalog.html / help.html / legal.html /
-# whats-new.html) are served by Cloudflare Pages at their CLEAN URLs
+# whats-new.html / ideas.html) are served by Cloudflare Pages at their CLEAN URLs
 # (/catalog, /help, …) automatically — Pages maps an `.html` asset to its
 # extensionless path and canonicalizes /foo.html → /foo with a 308. So NO
 # explicit rule is needed here; an explicit `/catalog /catalog.html 200` rewrite

--- a/src/content/build/prerenderPlugin.ts
+++ b/src/content/build/prerenderPlugin.ts
@@ -1,5 +1,5 @@
-// Vite plugin that turns the four content HTML shells (catalog/help/legal/
-// whats-new) into fully pre-rendered static pages: it injects the build-time
+// Vite plugin that turns the five content HTML shells (catalog/help/legal/
+// whats-new/ideas) into fully pre-rendered static pages: it injects the build-time
 // content (nav + page body + footer) into each shell's `<!--PW-CONTENT-->`
 // placeholder. The result is real HTML with real content for crawlers, with
 // no app JavaScript on the page.

--- a/src/content/build/render.ts
+++ b/src/content/build/render.ts
@@ -9,6 +9,7 @@ import { WHATS_NEW_INTRO, WHATS_NEW_WEEKS, type WeekEntry } from '../data/whatsN
 import { HELP_INTRO, HELP_STATIC_SECTIONS, helpDynamicSections } from '../data/help';
 import { getShortcutDocs, IS_MAC, MOD_LABEL, SHIFT_LABEL, ALT_LABEL } from '../../ui/shortcutDefs';
 import { languageBadge } from '../../ui/languageBadge';
+import { IDEAS, IDEA_CATEGORIES, type Idea, type IdeaCategoryDef } from '../../ideas/ideas';
 import {
   CATEGORIES,
   categorizeOf,
@@ -40,7 +41,7 @@ function escAttr(s: string): string {
   return esc(s).replace(/"/g, '&quot;');
 }
 
-export type ContentPage = 'catalog' | 'help' | 'legal' | 'whats-new';
+export type ContentPage = 'catalog' | 'help' | 'legal' | 'whats-new' | 'ideas';
 
 /** Map a clean route to its content-page id (and back). */
 export const CONTENT_PAGES: Record<ContentPage, { path: string; htmlFile: string }> = {
@@ -48,7 +49,16 @@ export const CONTENT_PAGES: Record<ContentPage, { path: string; htmlFile: string
   help: { path: '/help', htmlFile: 'help.html' },
   legal: { path: '/legal', htmlFile: 'legal.html' },
   'whats-new': { path: '/whats-new', htmlFile: 'whats-new.html' },
+  ideas: { path: '/ideas', htmlFile: 'ideas.html' },
 };
+
+/** Serialize a JSON-LD object into a `<script>` for a static page. Relative
+ *  `"url"` fields are rewritten to absolute at build time by the absoluteUrls
+ *  plugin (vite.config.ts); `<` is escaped so a name can't break out of the
+ *  script element. */
+function jsonLdScript(data: unknown): string {
+  return `<script type="application/ld+json">${JSON.stringify(data).replace(/</g, '\\u003c')}</script>`;
+}
 
 /** Render a list of `{id, heading, body}` sections as the app's pages do:
  *  an uppercase section heading followed by its trusted HTML body. */
@@ -136,6 +146,18 @@ function helpBody(): string {
     <span class="text-sm text-zinc-300">New to the editor? Walk through the key features.</span>
     <a href="/editor?tour=1" class="px-4 py-1.5 rounded text-xs bg-blue-600 hover:bg-blue-500 text-white transition-colors shrink-0">Take the guided tour</a>
   </div>
+  ${jsonLdScript({
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: 'How Partwright works',
+    description:
+      'A complete guide to Partwright: the code editor, modeling engines (JavaScript/manifold-3d, OpenSCAD, BREP, voxel, SDF), viewport tools, painting, sessions, import/export, and the in-browser AI assistant.',
+    url: '/help',
+    image: '/og-image.png',
+    inLanguage: 'en',
+    isPartOf: { '@type': 'WebSite', name: 'Partwright', url: '/' },
+    publisher: { '@type': 'Organization', name: 'Partwright', url: '/' },
+  })}
 </div>`;
 }
 
@@ -294,7 +316,25 @@ function catalogBody(): string {
 </section>`;
   }).join('');
   const empty = '<div data-catalog-empty class="hidden text-center py-12 text-zinc-500 text-sm">No models match your search and filters.</div>';
-  return `<div>${intro}${catalogControlsHtml(tiles)}${sections}${empty}</div>`;
+  const jsonLd = jsonLdScript({
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'Catalog — Partwright',
+    description:
+      'A curated catalog of premade Partwright 3D models across JavaScript (manifold-3d), implicit-surface SDF, voxel, OpenSCAD, and solid-CAD (BREP).',
+    url: '/catalog',
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: tiles.length,
+      itemListElement: tiles.map((tile, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: tile.entry.name,
+        url: `/editor?catalog=${encodeURIComponent(tile.entry.file)}`,
+      })),
+    },
+  });
+  return `<div>${intro}${catalogControlsHtml(tiles)}${sections}${empty}${jsonLd}</div>`;
 }
 
 /** Search box + language filter pills for the static page, tagged with the
@@ -318,6 +358,85 @@ function catalogControlsHtml(tiles: BuiltTile[]): string {
 </div>`;
 }
 
+// === Ideas page ===
+//
+// The static twin of the in-app /ideas overlay (src/ui/ideasPage.ts), built
+// from the same IDEAS dataset so the two never drift. Because a static page
+// can't hand an in-memory tile click to the editor, every tile is a real link
+// into /editor?idea=<id>; the editor reads that param and either prefills the
+// AI panel (prompt ideas) or opens the photo flow (interactive ideas).
+
+function ideaTileHtml(idea: Idea): string {
+  const cta =
+    idea.category === 'interactive'
+      ? '<div class="text-[10px] font-semibold mt-1 text-emerald-300">\u{1F4F7} Upload a photo →</div>'
+      : '<div class="text-[10px] font-semibold mt-1 text-blue-300">✨ Use this prompt →</div>';
+  const learnMore = idea.learnMore
+    ? `<div class="px-4 pb-3 -mt-1"><a href="${escAttr(idea.learnMore)}" target="_blank" rel="noopener" class="text-[10px] text-zinc-500 hover:text-zinc-300 underline decoration-dotted">Learn how it works →</a></div>`
+    : '';
+  return `<div class="flex flex-col bg-zinc-800 rounded-lg border border-zinc-700 hover:border-zinc-500 transition-colors overflow-hidden" data-idea-id="${escAttr(idea.id)}">
+  <a href="/editor?idea=${encodeURIComponent(idea.id)}" class="flex flex-col items-start gap-1.5 text-left px-4 py-3.5 w-full no-underline">
+    <div class="flex items-center gap-2"><span class="text-xl leading-none">${esc(idea.emoji)}</span><div class="text-sm font-medium text-zinc-100">${esc(idea.title)}</div></div>
+    <div class="text-[11px] text-zinc-400 leading-snug">${esc(idea.blurb)}</div>
+    ${cta}
+  </a>
+  ${learnMore}
+</div>`;
+}
+
+function ideasCategoryHtml(def: IdeaCategoryDef, ideas: Idea[]): string {
+  return `<section class="mb-10" data-category="${def.id}">
+  <div class="flex items-baseline gap-2">
+    <h2 class="text-lg font-semibold text-zinc-100">${esc(def.title)}</h2>
+    <span class="text-xs text-zinc-500 tabular-nums">${ideas.length}</span>
+  </div>
+  <p class="text-xs text-zinc-400 mt-0.5 mb-3 leading-relaxed">${esc(def.blurb)}</p>
+  <div class="grid gap-4" style="grid-template-columns:repeat(auto-fill,minmax(240px,1fr))">${ideas.map(ideaTileHtml).join('')}</div>
+</section>`;
+}
+
+function ideasBody(): string {
+  // Bucket ideas by category, then emit the non-empty sections in
+  // IDEA_CATEGORIES order (entry order within a section follows the dataset) —
+  // mirrors the runtime ideas page.
+  const buckets = new Map<string, Idea[]>();
+  for (const idea of IDEAS) {
+    const arr = buckets.get(idea.category);
+    if (arr) arr.push(idea);
+    else buckets.set(idea.category, [idea]);
+  }
+  const sections = IDEA_CATEGORIES.map((def) => {
+    const ideas = buckets.get(def.id);
+    return ideas && ideas.length > 0 ? ideasCategoryHtml(def, ideas) : '';
+  }).join('');
+  const intro =
+    'Not sure what Partwright can do? Start here. Pick a starter prompt to hand the AI, try a technique you didn’t know was possible, or turn one of your own photos into a model.';
+  const jsonLd = jsonLdScript({
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'Ideas — Partwright',
+    description:
+      'Starter prompts, technique showcases, and photo-to-model flows to get started with Partwright.',
+    url: '/ideas',
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: IDEAS.length,
+      itemListElement: IDEAS.map((idea, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: idea.title,
+        url: `/editor?idea=${encodeURIComponent(idea.id)}`,
+      })),
+    },
+  });
+  return `<div>
+  <h1 class="text-3xl font-bold tracking-tight mb-2">Ideas</h1>
+  <p class="text-sm text-zinc-400 leading-relaxed mb-6 max-w-3xl">${esc(intro)} Looking for finished models to remix instead? <a href="/catalog" class="text-teal-300 hover:text-teal-200 underline decoration-dotted">Browse the catalog →</a></p>
+  ${sections}
+  ${jsonLd}
+</div>`;
+}
+
 /** Return the fully-wrapped inner HTML (nav + content + footer) for a page. */
 export function renderContentBody(page: ContentPage): string {
   switch (page) {
@@ -329,5 +448,7 @@ export function renderContentBody(page: ContentPage): string {
       return pageShell('/help', helpBody());
     case 'catalog':
       return pageShell('/catalog', catalogBody());
+    case 'ideas':
+      return pageShell('/ideas', ideasBody());
   }
 }

--- a/src/content/build/shell.ts
+++ b/src/content/build/shell.ts
@@ -1,5 +1,5 @@
 // Shared chrome (nav + footer) for the statically pre-rendered content pages
-// (/catalog, /help, /legal, /whats-new). Pure HTML-string builders, run at
+// (/catalog, /help, /legal, /whats-new, /ideas). Pure HTML-string builders, run at
 // build time in Node. Tailwind classes here are picked up by Tailwind's
 // source scan (this is a .ts file under src/), so the utilities ship in the
 // app CSS that every content page links.

--- a/src/main.ts
+++ b/src/main.ts
@@ -5251,6 +5251,14 @@ async function main() {
         { once: true },
       );
       input.click();
+      // Cancelling the native picker fires no 'change' — reclaim the orphaned
+      // input once focus returns (deferred so a real selection's change runs
+      // first and removes it).
+      window.addEventListener(
+        'focus',
+        () => setTimeout(() => { if (input.isConnected && !input.files?.length) input.remove(); }, 0),
+        { once: true },
+      );
     } else {
       prefillAiInput(idea.prompt ?? '');
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,7 @@ import { showExportOptionsDialog } from './ui/exportOptionsDialog';
 import { showExportConfirm, hasExportWarning, type ExportWarningInfo } from './ui/exportConfirmModal';
 import { createCatalogPage, type CatalogManifestEntry } from './ui/catalog';
 import { createIdeasPage } from './ui/ideasPage';
-import type { Idea } from './ideas/ideas';
+import { IDEAS, type Idea } from './ideas/ideas';
 import { createWhatsNewPage } from './ui/whatsNew';
 import { createNotFoundPage } from './ui/notFound';
 import { applyRouteMeta, routeTitle, type RouteName } from './seo/meta';
@@ -1950,17 +1950,10 @@ async function main() {
     if (keyed.some(Boolean)) void requestPersistentStorage();
   })();
 
-  // Remove loading overlays as soon as JS takes over — EXCEPT on /ideas, the
-  // one app-rendered overlay page. It boots the whole app before painting any
-  // content, so dropping the spinner here would leave a blank screen until the
-  // page renders; instead showIdeasPage() removes it once the content is up
-  // (with a timeout fallback so it can never get stuck).
-  const onIdeasRoute = window.location.pathname === '/ideas';
-  if (!onIdeasRoute) {
-    document.getElementById('loading-splash')?.remove();
-  } else {
-    setTimeout(() => document.getElementById('loading-splash')?.remove(), 12000);
-  }
+  // Remove loading overlays as soon as JS takes over. (/ideas is served as a
+  // static, app-free page now, so there's no boot-spinner special-case here —
+  // a soft-nav to the in-app ideas overlay happens after boot.)
+  document.getElementById('loading-splash')?.remove();
   if (!shouldShowLanding()) {
     document.getElementById('landing-inline')?.remove();
   }
@@ -5194,18 +5187,73 @@ async function main() {
     updateDocumentTitle({ page: 'editor' });
   }
 
+  // Open the Relief import wizard in 'luminance' (tonal) mode — the "smooth
+  // relief / lithophane" idea promises a non-blocky result, unlike the global
+  // 'quantized' default (flat blocky colour clusters). Shared by the in-app
+  // tile and the /editor?idea= deep-link. Clone the defaults so we only
+  // override the mode.
+  function openReliefForIdea(file: File): void {
+    const initialOptions: ReliefOptions = { ...structuredClone(DEFAULT_RELIEF_OPTIONS), mode: 'luminance' };
+    openReliefImportFlow(file, initialOptions);
+  }
+
   // An interactive idea: emboss the user's photo as a smooth relief tile
   // (reuses the existing Relief import wizard).
   async function handleIdeaPhotoToRelief(file: File): Promise<void> {
     await enterEditorForIdea();
     if (window.location.pathname !== '/editor') return;
-    // The "smooth relief / lithophane" idea tile promises a non-blocky, tonal
-    // result, so open the wizard in 'luminance' mode rather than the global
-    // default ('quantized' — flat blocky colour clusters). Clone the defaults
-    // so we only override the mode.
-    const initialOptions: ReliefOptions = { ...structuredClone(DEFAULT_RELIEF_OPTIONS), mode: 'luminance' };
-    openReliefImportFlow(file, initialOptions);
+    openReliefForIdea(file);
     updateDocumentTitle({ page: 'editor' });
+  }
+
+  // Deep-link from the static /ideas page: /editor?idea=<id>. The static page
+  // can't hand an in-memory tile click across a real navigation, so it links
+  // here and we resolve the id against the IDEAS dataset. A prompt idea
+  // prefills the AI panel; an interactive idea opens a photo picker, then runs
+  // the same flow the in-app tile would. The editor is already entered (this
+  // runs inside syncEditorFromURL), so there's no history push — we just strip
+  // the one-shot ?idea= param for a clean URL.
+  async function loadIdeaIntoEditor(id: string): Promise<void> {
+    const clearIdeaParam = () => {
+      const url = new URL(window.location.href);
+      if (url.searchParams.has('idea')) {
+        url.searchParams.delete('idea');
+        history.replaceState(history.state, '', url.pathname + url.search);
+      }
+    };
+    const idea = IDEAS.find((i) => i.id === id);
+    // Ensure a live session exists either way (mirrors handleIdeaUsePrompt).
+    if (!getState().session) {
+      await createSession();
+      setStatus(statusBar, 'ready', 'Ready');
+      void seedStarter('manifold-js');
+    }
+    clearIdeaParam();
+    updateDocumentTitle({ page: 'editor' });
+    if (!idea) return; // unknown id — just land in a fresh editor session
+    if (idea.category === 'interactive' && idea.action) {
+      const action = idea.action;
+      // No file came across the navigation — pick one here, then run the flow.
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = 'image/*';
+      input.style.display = 'none';
+      document.body.appendChild(input);
+      input.addEventListener(
+        'change',
+        () => {
+          const file = input.files?.[0];
+          input.remove();
+          if (!file) return;
+          if (action === 'photoToVoxel') void handleImageImport(file);
+          else openReliefForIdea(file);
+        },
+        { once: true },
+      );
+      input.click();
+    } else {
+      prefillAiInput(idea.prompt ?? '');
+    }
   }
 
   let ideasEl: HTMLElement | null = null;
@@ -5448,6 +5496,13 @@ async function main() {
     const catalogFile = new URLSearchParams(window.location.search).get('catalog');
     if (catalogFile) {
       await loadCatalogFileIntoEditor(catalogFile);
+      return;
+    }
+
+    // Ideas deep-link: /editor?idea=<id> hands off from the static /ideas page.
+    const ideaId = new URLSearchParams(window.location.search).get('idea');
+    if (ideaId) {
+      await loadIdeaIntoEditor(ideaId);
       return;
     }
 

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -162,6 +162,10 @@ let forwardBtnRef: HTMLButtonElement | null = null;
 let drawerEl: HTMLElement | null = null;
 let transcriptEl: HTMLElement | null = null;
 let inputEl: HTMLTextAreaElement | null = null;
+// A prefill requested before the drawer was built (e.g. the /editor?idea=
+// deep-link runs during boot, ahead of initAiPanel). initAiPanel flushes it
+// once the input exists. See prefillAiInput.
+let pendingPrefill: string | null = null;
 let voiceController: VoiceController | null = null;
 let planApprovalBarEl: HTMLElement | null = null;
 
@@ -298,6 +302,14 @@ export async function initAiPanel(opts: AiPanelOptions = {}): Promise<void> {
     // later. The drawer element already starts with the `hidden` class.
     state.open = false;
   } else hideDrawer();
+  // Apply any prefill that arrived before the drawer existed (e.g. a boot-time
+  // /editor?idea= deep-link). Done last so the input is fully built; this also
+  // opens the drawer so the user sees the queued prompt.
+  if (pendingPrefill !== null) {
+    const text = pendingPrefill;
+    pendingPrefill = null;
+    prefillAiInput(text);
+  }
 }
 
 /** Called by main.ts whenever the active session changes (open / close).
@@ -344,8 +356,13 @@ export function toggleAiPanel(): void {
  *  sending it — the user reads/tweaks it and hits send themselves. Used by the
  *  prompt library and the /ideas page so picking a prompt lands here. */
 export function prefillAiInput(text: string): void {
+  if (!inputEl) {
+    // Drawer not built yet — queue it; initAiPanel applies it once the input
+    // exists (covers the /editor?idea= deep-link that runs during boot).
+    pendingPrefill = text;
+    return;
+  }
   if (!state.open) showDrawer(false);
-  if (!inputEl) return;
   inputEl.value = text;
   inputEl.focus();
   const end = text.length;

--- a/tests/ideas.spec.ts
+++ b/tests/ideas.spec.ts
@@ -1,39 +1,40 @@
 // The /ideas page is a discovery surface: category sections of starter
 // prompts, technique showcases, and interactive "use your own photo" flows.
-// Picking a starter prompt lands the user in the editor with the prompt
-// pre-filled in the AI panel (populate, don't send). This drives the real
-// page + routing against the static IDEAS dataset.
+// It ships as a STATIC, app-free pre-rendered page (like /catalog) so crawlers
+// see the full content with no JS. Each tile is a real link into the editor —
+// /editor?idea=<id> — which prefills the AI panel (prompt ideas) or opens the
+// photo flow (interactive ideas). This drives the real page + routing against
+// the static IDEAS dataset.
 
 import { test, expect, type Page } from 'playwright/test';
 
 async function gotoIdeas(page: Page) {
   await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
   await page.goto('/ideas');
-  await page.waitForSelector('#ideas-page section[data-category]', { timeout: 20_000 });
+  await page.waitForSelector('main section[data-category]', { timeout: 20_000 });
 }
 
 test.describe('Ideas page', () => {
-  test('carries the shared header and is not squished by the docked AI panel', async ({ page }) => {
+  test('is a static, app-free page with the shared header at full width', async ({ page }) => {
     await gotoIdeas(page);
     // Same shared header as the landing + static content pages.
-    const header = page.locator('#ideas-page header.pw-header');
+    const header = page.locator('header.pw-header');
     await expect(header).toHaveCount(1);
     await expect(header).toContainText('Partwright');
     await expect(header.locator('nav.pw-navlinks a')).toHaveCount(5);
-    // The docked AI panel is an editor tool — it must NOT take layout space on
-    // /ideas, so the page (and its header) render full-width.
-    await expect(page.locator('#ai-panel')).toBeHidden();
+    // No app JS on this page — the docked AI panel never mounts, so the page
+    // renders full-width (not squished by the editor's side panel).
+    await expect(page.locator('#ai-panel')).toHaveCount(0);
     const headerWidth = await header.evaluate((el) => el.getBoundingClientRect().width);
-    expect(headerWidth).toBeGreaterThan(1000); // full width, not the ~860px panel-squished width
-    // The boot spinner (held over the app load on /ideas) is removed once the
-    // content is up — never left covering the page.
+    expect(headerWidth).toBeGreaterThan(1000);
+    // A static page boots no app, so there's no loading splash to clear.
     await expect(page.locator('#loading-splash')).toHaveCount(0);
   });
 
   test('renders category sections in order, each with a count, blurb, and tiles', async ({ page }) => {
     await gotoIdeas(page);
 
-    const sections = page.locator('#ideas-page section[data-category]');
+    const sections = page.locator('main section[data-category]');
     await expect(sections).toHaveCount(3);
 
     const ids = await sections.evaluateAll((els) => els.map((e) => (e as HTMLElement).dataset.category));
@@ -44,29 +45,32 @@ test.describe('Ideas page', () => {
       const sec = sections.nth(i);
       await expect(sec.locator('h2')).toBeVisible();
       await expect(sec.locator('h2 + span')).toHaveText(/^\d+$/);
-      await expect(sec.locator('p')).not.toBeEmpty();
+      await expect(sec.locator('p').first()).not.toBeEmpty();
       expect(await sec.locator('div.grid > div').count()).toBeGreaterThan(0);
     }
   });
 
-  test('interactive tiles carry a hidden image file input', async ({ page }) => {
+  test('every tile is a deep-link into the editor (/editor?idea=…)', async ({ page }) => {
     await gotoIdeas(page);
-    const interactive = page.locator('#ideas-page section[data-category="interactive"]');
-    const fileInputs = interactive.locator('input[type="file"]');
-    expect(await fileInputs.count()).toBeGreaterThan(0);
-    await expect(fileInputs.first()).toHaveAttribute('accept', 'image/*');
+    // Interactive tiles deep-link too — the photo picker opens in the editor.
+    const interactive = page.locator('main section[data-category="interactive"] div.grid > div > a');
+    expect(await interactive.count()).toBeGreaterThan(0);
+    for (const href of await interactive.evaluateAll((els) => els.map((e) => (e as HTMLAnchorElement).getAttribute('href')))) {
+      expect(href).toMatch(/^\/editor\?idea=/);
+    }
   });
 
   test('clicking a starter prompt opens the editor with the prompt pre-filled (not sent)', async ({ page }) => {
     await gotoIdeas(page);
-    const starter = page.locator('#ideas-page section[data-category="starter"] div.grid > div button').first();
-    await expect(starter).toBeEnabled();
+    const starter = page.locator('main section[data-category="starter"] div.grid > div > a').first();
     await starter.click();
 
     await expect(page).toHaveURL(/\/editor/, { timeout: 20_000 });
 
     // The AI panel opens and its input carries the chosen prompt — and the
-    // transcript shows no sent user message (populate, don't send).
+    // transcript shows no sent user message (populate, don't send). The
+    // one-shot ?idea= param is stripped for a clean editor URL.
+    await expect(page).not.toHaveURL(/[?&]idea=/, { timeout: 20_000 });
     const input = page.locator('#ai-panel textarea');
     await expect(input).toBeVisible({ timeout: 20_000 });
     await expect(input).not.toHaveValue('', { timeout: 20_000 });
@@ -75,7 +79,7 @@ test.describe('Ideas page', () => {
   test('the prompt library button in the AI panel lists example prompts', async ({ page }) => {
     await gotoIdeas(page);
     // Get into the editor first (any starter does it).
-    await page.locator('#ideas-page section[data-category="starter"] div.grid > div button').first().click();
+    await page.locator('main section[data-category="starter"] div.grid > div > a').first().click();
     await expect(page).toHaveURL(/\/editor/, { timeout: 20_000 });
     await expect(page.locator('#ai-panel')).toBeVisible({ timeout: 20_000 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -158,7 +158,7 @@ export default defineConfig({
   build: {
     chunkSizeWarningLimit: 520,
     rollupOptions: {
-      // Multi-page: the editor SPA (index.html) plus the four pre-rendered,
+      // Multi-page: the editor SPA (index.html) plus the five pre-rendered,
       // app-free content pages. Each content page ships only the shared
       // Tailwind CSS — no app JS — so it paints instantly for users + crawlers.
       input: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -167,6 +167,7 @@ export default defineConfig({
         help: resolve(__dirname, 'help.html'),
         legal: resolve(__dirname, 'legal.html'),
         'whats-new': resolve(__dirname, 'whats-new.html'),
+        ideas: resolve(__dirname, 'ideas.html'),
       },
       output: {
         // Function form (not the object map) so we can isolate Vite's


### PR DESCRIPTION
## Summary

Improves crawler / Google AI Overview discoverability. The audit found the site already crawl-friendly (robots.txt welcomes AI crawlers, sitemap + per-route meta present, most content pages prerendered, landing-page JSON-LD present) — so this targets the two concrete, in-our-control gaps:

1. **`/ideas` was the only content route with no prerendered HTML.** It fell through the SPA fallback to a loading spinner, so crawlers (and AI Overviews) saw zero idea content despite its sitemap priority of 0.8.
2. **Only the landing page carried JSON-LD.** `/help` and `/catalog` have rich content but no structured data for AI extraction.

## What changed

**Prerender `/ideas`** — mirrors the existing `/catalog` dual model:
- New `ideas.html` shell + `ideasBody()` renderer in `src/content/build/render.ts`, registered in `CONTENT_PAGES` and the Vite Rollup inputs. `/ideas` now ships as static, app-free HTML — every idea title, blurb, and category heading is in the first byte.
- The in-app overlay (`createIdeasPage`) still handles soft-nav; the static page serves hard navigations and crawlers.
- Static tiles deep-link to `/editor?idea=<id>`, resolved by `loadIdeaIntoEditor` in `main.ts` (parallel to the existing `?catalog=` path): prompt ideas prefill the AI panel; interactive ideas open the photo picker and run the same voxel/relief flow. Extracted `openReliefForIdea` to share the luminance-mode logic.
- Removed the now-dead `/ideas` boot-spinner special-case.

**Subpage JSON-LD** (via the existing build pipeline — `prerenderContentPages` injects before `absoluteUrls`, so relative `"url"` fields are absolutized at build):
- `/ideas` → `CollectionPage` + `ItemList`
- `/catalog` → `CollectionPage` + `ItemList` (122 models)
- `/help` → `TechArticle`
- `jsonLdScript()` helper escapes `<` so a model name can't break out of the script element.

**Bug fix surfaced by e2e** — `prefillAiInput` now queues a prefill requested before the AI drawer is built (the `/editor?idea=` deep-link runs during boot, ahead of `initAiPanel`) and flushes it once the input exists. The SPA soft-nav path is unaffected.

## Test plan

- ✅ `npm run typecheck` clean
- ✅ `npm run test:unit` — 1273 pass
- ✅ Production build emits `dist/ideas.html` with crawlable content + absolutized JSON-LD (`https://www.partwrightstudio.com/editor?idea=…`); sitemap still lists `/ideas`
- ✅ `tests/ideas.spec.ts` rewritten for the static page — 5/5 pass (the two AI-prefill tests caught the boot-ordering bug above)
- ✅ Manual browser screenshot of the static `/ideas` page posted in-session

Note: production canonical/OG/JSON-LD absolutization depends on `SITE_URL` (or `CF_PAGES_URL`) being set in the Cloudflare Pages **production** environment — confirm `SITE_URL=https://www.partwrightstudio.com` there so preview deploys aren't indexed as canonical.

https://claude.ai/code/session_01QvP8TYupJWryGhwhwvNeXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvP8TYupJWryGhwhwvNeXY)_