### PR TITLE
feat: editor settings menu — word wrap, line numbers, font size

### DIFF
--- a/prompts/20260612-141200-editor-line-wrap-toggle.md
+++ b/prompts/20260612-141200-editor-line-wrap-toggle.md
@@ -1,0 +1,32 @@
+---
+date: 2026-06-12
+branch: claude/quirky-hypatia-2gegil
+title: Add line-wrap toggle to the editor header
+---
+
+## Human
+
+In the editor view, asked for a small toggle at the top to enable/disable line
+wrap, and to be told about any other common/useful editor toggles worth adding.
+
+## Assistant
+
+Added a "Wrap" toggle to the editor pane header, mirroring the existing
+auto-format toggle exactly so the two read as a pair.
+
+Key decisions:
+
+- **Followed the auto-format pattern end to end** rather than inventing a new
+  surface: per-tab persisted pref (`editor-line-wrap` via `readPerTabPref` /
+  `writePerTabPref`), a CodeMirror `Compartment` (`lineWrapCompartment`) holding
+  `EditorView.lineWrapping` so the live editor reconfigures without a rebuild,
+  and `getLineWrap` / `setLineWrap` exports parallel to `getAutoFormat` /
+  `setAutoFormat`. The button is created in `layout.ts`, surfaced through the
+  `LayoutElements` return, and wired (sync + click) in `main.ts`, reusing the
+  same on/off class constants for visual consistency.
+- **Default off** — matches the conventional code-editor default (horizontal
+  scroll), and persists per-tab so one window's choice doesn't flip another's,
+  consistent with the cross-tab isolation rule.
+- Verified in-browser with a throwaway Playwright spec: confirmed the
+  `.cm-content` `white-space` flips `pre` → `break-spaces` on toggle and that a
+  long line visibly wraps; deleted the scratch spec before committing.

--- a/prompts/20260612-172800-editor-settings-menu-font-line-numbers.md
+++ b/prompts/20260612-172800-editor-settings-menu-font-line-numbers.md
@@ -1,0 +1,44 @@
+---
+date: 2026-06-12
+branch: claude/quirky-hypatia-2gegil
+title: Consolidate editor toggles into a ⚙ settings menu; add font size + line numbers
+---
+
+## Human
+
+Follow-up on the line-wrap PR: add font-size and line-numbers toggles, and move
+the editor settings (Format, Auto-format, Word wrap, + the new ones) into an
+"editor settings" submenu.
+
+## Assistant
+
+Added two new editor controls and collapsed all editor settings into a single
+"⚙ Editor" popover in the editor-pane header.
+
+Key decisions:
+
+- **New controls follow the line-wrap pattern**: `getLineNumbers` / `setLineNumbers`
+  and `getFontSize` / `setFontSize` in `codeEditor.ts`, each backed by a CodeMirror
+  `Compartment` that reconfigures the live editor, with the value persisted per-tab
+  (`editor-line-numbers`, `editor-font-size`) like the existing prefs.
+- **Line numbers** are hidden via a scoped `.cm-lineNumbers { display: none !important }`
+  theme rather than rebuilding `basicSetup` without its bundled `lineNumbers()`.
+  The `!important` is required because CodeMirror's core gutter style is itself
+  `display: flex !important` — verified in-browser (computed display went `flex` →
+  `none` only after adding it). The fold/lint gutters stay.
+- **Font size** moved out of the editor's base theme (was a hardcoded `13px`) into
+  a `fontSizeCompartment`. The default/min/max are tunable knobs, so per the repo's
+  no-hardcoded-constants rule they live in `appConfig.ui`
+  (`editorFontSizeDefault/Min/Max`) and are exposed in the Advanced Settings modal.
+  The live size is a per-tab pref clamped to those bounds; the −/+ stepper disables
+  at the edges.
+- **The ⚙ popover** is a self-contained dropdown in the editor header (open/close +
+  click-outside + Escape, sticky on inner clicks), mirroring the toolbar
+  Import/Export dropdown convention and reusing `createMenuSectionHeader` /
+  `createMenuDivider`. Find/Replace and Hide-code stay as header buttons (they're
+  actions, not settings). Toggles render as compact On/Off pills via one shared
+  `syncTogglePill` helper.
+
+Verified in-browser (throwaway Playwright spec, since deleted): opened the menu,
+bumped font 13→17 px, toggled line numbers off (gutter hidden) and word wrap on;
+screenshotted the result. build + 1273 unit tests + lint:deps (no cycles) green.

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -228,6 +228,13 @@ export interface AppConfig {
     /** How long each "Did you know?" hint stays before the strip rotates to the
      *  next one (ms). */
     hintRotationMs: number;
+    /** Default code-editor font size (px). The live size is a per-tab pref
+     *  (editor-font-size); this seeds a fresh tab and the Reset-to-default. */
+    editorFontSizeDefault: number;
+    /** Smallest code-editor font size (px) the −/+ stepper allows. */
+    editorFontSizeMin: number;
+    /** Largest code-editor font size (px) the −/+ stepper allows. */
+    editorFontSizeMax: number;
   };
   geometry: {
     /** Triangle count above which the live model warns it may be too heavy for
@@ -330,6 +337,9 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     workerPanelRefreshMs: 1000,
     editorHintsEnabled: true,
     hintRotationMs: 12_000,
+    editorFontSizeDefault: 13,
+    editorFontSizeMin: 9,
+    editorFontSizeMax: 28,
   },
   geometry: {
     triCountWarnBudget: 200_000,

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -49,9 +49,13 @@ let currentLanguage: EditorLanguage = 'manifold-js';
 // Per-tab (with a shared seed for fresh tabs) so toggling auto-format in one
 // window doesn't flip it in another open window.
 let autoFormatEnabled: boolean = readPerTabPref('editor-auto-format') !== 'false';
+// Soft-wrap long lines. Off by default (matches the usual code-editor default of
+// a horizontal scrollbar); persisted per-tab like auto-format.
+let lineWrapEnabled: boolean = readPerTabPref('editor-line-wrap') === 'true';
 const languageCompartment = new Compartment();
 const readOnlyCompartment = new Compartment();
 const themeCompartment = new Compartment();
+const lineWrapCompartment = new Compartment();
 
 function themeExt(theme: Theme): Extension {
   return theme === 'dark' ? oneDark : [];
@@ -345,6 +349,7 @@ export function initEditor(
       lintGutter(),
       readOnlyCompartment.of(EditorState.readOnly.of(false)),
       themeCompartment.of(themeExt(getTheme())),
+      lineWrapCompartment.of(lineWrapEnabled ? EditorView.lineWrapping : []),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
           if (activeDiagnostics.length > 0) {
@@ -477,6 +482,20 @@ export function getAutoFormat(): boolean {
 export function setAutoFormat(enabled: boolean): void {
   autoFormatEnabled = enabled;
   writePerTabPref('editor-auto-format', enabled ? 'true' : 'false');
+}
+
+export function getLineWrap(): boolean {
+  return lineWrapEnabled;
+}
+
+/** Toggle soft-wrapping of long lines. Reconfigures the live editor's
+ *  line-wrap compartment and persists the choice per-tab. */
+export function setLineWrap(enabled: boolean): void {
+  lineWrapEnabled = enabled;
+  writePerTabPref('editor-line-wrap', enabled ? 'true' : 'false');
+  editorView?.dispatch({
+    effects: lineWrapCompartment.reconfigure(enabled ? EditorView.lineWrapping : []),
+  });
 }
 
 export function setEditorDiagnostics(diagnostics: SourceDiagnostic[]): void {

--- a/src/editor/codeEditor.ts
+++ b/src/editor/codeEditor.ts
@@ -52,10 +52,42 @@ let autoFormatEnabled: boolean = readPerTabPref('editor-auto-format') !== 'false
 // Soft-wrap long lines. Off by default (matches the usual code-editor default of
 // a horizontal scrollbar); persisted per-tab like auto-format.
 let lineWrapEnabled: boolean = readPerTabPref('editor-line-wrap') === 'true';
+// Line-number gutter — on by default; persisted per-tab.
+let lineNumbersEnabled: boolean = readPerTabPref('editor-line-numbers') !== 'false';
+
+/** Clamp a requested font size into the configured [min, max] px bounds,
+ *  rounding to a whole pixel. Falls back to the configured default when the
+ *  input isn't a finite number. */
+function clampFontSize(px: number): number {
+  const { editorFontSizeMin, editorFontSizeMax, editorFontSizeDefault } = getConfig().ui;
+  if (!Number.isFinite(px)) return editorFontSizeDefault;
+  return Math.round(Math.min(editorFontSizeMax, Math.max(editorFontSizeMin, px)));
+}
+
+// Editor font size (px) — per-tab pref seeded from the configured default.
+let fontSizePx: number = clampFontSize(
+  parseInt(readPerTabPref('editor-font-size') ?? '', 10) || getConfig().ui.editorFontSizeDefault,
+);
+
 const languageCompartment = new Compartment();
 const readOnlyCompartment = new Compartment();
 const themeCompartment = new Compartment();
 const lineWrapCompartment = new Compartment();
+const lineNumbersCompartment = new Compartment();
+const fontSizeCompartment = new Compartment();
+
+function fontSizeExt(px: number): Extension {
+  return EditorView.theme({ '&': { fontSize: `${px}px` } });
+}
+
+/** basicSetup already installs the line-number gutter, so "off" hides it with a
+ *  scoped theme rule rather than rebuilding the extension set. The fold/lint
+ *  gutters stay visible. */
+function lineNumbersExt(on: boolean): Extension {
+  // CodeMirror's core gutter style sets `display: flex !important`, so the hide
+  // rule must also be `!important` to win.
+  return on ? [] : EditorView.theme({ '.cm-lineNumbers': { display: 'none !important' } });
+}
 
 function themeExt(theme: Theme): Extension {
   return theme === 'dark' ? oneDark : [];
@@ -350,6 +382,8 @@ export function initEditor(
       readOnlyCompartment.of(EditorState.readOnly.of(false)),
       themeCompartment.of(themeExt(getTheme())),
       lineWrapCompartment.of(lineWrapEnabled ? EditorView.lineWrapping : []),
+      lineNumbersCompartment.of(lineNumbersExt(lineNumbersEnabled)),
+      fontSizeCompartment.of(fontSizeExt(fontSizePx)),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
           if (activeDiagnostics.length > 0) {
@@ -370,7 +404,7 @@ export function initEditor(
         blur: () => { hooks.onBlur?.(); return false; },
       }),
       EditorView.theme({
-        '&': { height: '100%', fontSize: '13px' },
+        '&': { height: '100%' },
         '.cm-scroller': { overflow: 'auto' },
         '.cm-content': { fontFamily: 'monospace' },
         '.cm-lint-marker-error': { cursor: 'help' },
@@ -495,6 +529,41 @@ export function setLineWrap(enabled: boolean): void {
   writePerTabPref('editor-line-wrap', enabled ? 'true' : 'false');
   editorView?.dispatch({
     effects: lineWrapCompartment.reconfigure(enabled ? EditorView.lineWrapping : []),
+  });
+}
+
+export function getLineNumbers(): boolean {
+  return lineNumbersEnabled;
+}
+
+/** Toggle the line-number gutter. Reconfigures the live editor and persists
+ *  the choice per-tab. */
+export function setLineNumbers(enabled: boolean): void {
+  lineNumbersEnabled = enabled;
+  writePerTabPref('editor-line-numbers', enabled ? 'true' : 'false');
+  editorView?.dispatch({
+    effects: lineNumbersCompartment.reconfigure(lineNumbersExt(enabled)),
+  });
+}
+
+export function getFontSize(): number {
+  return fontSizePx;
+}
+
+/** Configured [min, max] px bounds for the editor font size, so callers can
+ *  disable the −/+ stepper at the edges. */
+export function getFontSizeBounds(): { min: number; max: number } {
+  const { editorFontSizeMin, editorFontSizeMax } = getConfig().ui;
+  return { min: editorFontSizeMin, max: editorFontSizeMax };
+}
+
+/** Set the editor font size (px), clamped to the configured bounds.
+ *  Reconfigures the live editor and persists per-tab. */
+export function setFontSize(px: number): void {
+  fontSizePx = clampFontSize(px);
+  writePerTabPref('editor-font-size', String(fontSizePx));
+  editorView?.dispatch({
+    effects: fontSizeCompartment.reconfigure(fontSizeExt(fontSizePx)),
   });
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ import './renderer/viewportSubsystems';
 import { renderCompositeCanvas, renderSingleView, renderSingleViewCanvas, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, EDGE_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode, type EdgeMode } from './renderer/multiview';
 import { generateId, getLatestVersion } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
-import { initEditor, setValue, getValue, getSelection, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, openFindReplace, getAutoFormat, setAutoFormat, getLineWrap, setLineWrap, editorContentDiffersFrom, createCompanionEditor, setCompanionEditorContent } from './editor/codeEditor';
+import { initEditor, setValue, getValue, getSelection, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, openFindReplace, getAutoFormat, setAutoFormat, getLineWrap, setLineWrap, getLineNumbers, setLineNumbers, getFontSize, setFontSize, getFontSizeBounds, editorContentDiffersFrom, createCompanionEditor, setCompanionEditorContent } from './editor/codeEditor';
 import type { EditorView as CMEditorView } from '@codemirror/view';
 import { createLayout, type TabName } from './ui/layout';
 import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState, setRunState } from './ui/toolbar';
@@ -4359,7 +4359,7 @@ async function main() {
   });
 
   // Create layout
-  const { editorContainer, companionFilesBar, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, cancelInlineBtn, clipControls, findReplaceBtn, formatBtn, autoFormatToggle, lineWrapToggle, switchTab, partsRail, togglePartsRail, collapseEditor, expandEditor } = createLayout(editorUI, {
+  const { editorContainer, companionFilesBar, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, cancelInlineBtn, clipControls, findReplaceBtn, formatBtn, autoFormatToggle, lineWrapToggle, lineNumbersToggle, fontSizeDecBtn, fontSizeIncBtn, fontSizeValueEl, switchTab, partsRail, togglePartsRail, collapseEditor, expandEditor } = createLayout(editorUI, {
     onToggleAi: () => { void toggleAiPanelFromToolbar(); },
     onOpenCatalog: () => { void showCatalogPage(); },
     onToggleDiagnostics: () => { toggleDiagnosticsPanel(); },
@@ -4475,27 +4475,34 @@ async function main() {
   syncEditorTitle(getState());
   onStateChange(syncEditorTitle);
 
-  // Format button and auto-format toggle
-  const AUTO_FORMAT_ON_CLASS = 'shrink-0 px-2 py-0.5 rounded text-xs leading-none border text-emerald-400 border-emerald-700 bg-emerald-950/40 hover:bg-emerald-900/40';
-  const AUTO_FORMAT_OFF_CLASS = 'shrink-0 px-2 py-0.5 rounded text-xs leading-none border text-zinc-500 border-zinc-700 hover:text-zinc-300';
-  function syncAutoFormatToggleUI(): void {
-    const on = getAutoFormat();
-    autoFormatToggle.textContent = on ? 'Auto ✓' : 'Auto';
-    autoFormatToggle.title = on ? 'Auto-format on — click to disable' : 'Auto-format off — click to enable';
-    autoFormatToggle.className = on ? AUTO_FORMAT_ON_CLASS : AUTO_FORMAT_OFF_CLASS;
+  // Editor settings menu (⚙) — Format / Auto-format / Word wrap / Line numbers /
+  // Font size. Each toggle renders as a compact On/Off pill via a shared helper.
+  const TOGGLE_ON_CLASS = 'shrink-0 px-2 py-0.5 rounded text-[11px] leading-none border text-emerald-400 border-emerald-700 bg-emerald-950/40 hover:bg-emerald-900/40 min-w-[2.75rem] text-center';
+  const TOGGLE_OFF_CLASS = 'shrink-0 px-2 py-0.5 rounded text-[11px] leading-none border text-zinc-400 border-zinc-700 hover:text-zinc-200 min-w-[2.75rem] text-center';
+  function syncTogglePill(btn: HTMLButtonElement, on: boolean, name: string): void {
+    btn.textContent = on ? 'On' : 'Off';
+    btn.title = `${name}: ${on ? 'on' : 'off'} — click to toggle`;
+    btn.setAttribute('aria-pressed', String(on));
+    btn.className = on ? TOGGLE_ON_CLASS : TOGGLE_OFF_CLASS;
+  }
+  const syncAutoFormatToggleUI = (): void => syncTogglePill(autoFormatToggle, getAutoFormat(), 'Auto-format on load');
+  const syncLineWrapToggleUI = (): void => syncTogglePill(lineWrapToggle, getLineWrap(), 'Word wrap');
+  const syncLineNumbersToggleUI = (): void => syncTogglePill(lineNumbersToggle, getLineNumbers(), 'Line numbers');
+  function syncFontSizeUI(): void {
+    const px = getFontSize();
+    const { min, max } = getFontSizeBounds();
+    fontSizeValueEl.textContent = `${px}px`;
+    fontSizeDecBtn.disabled = px <= min;
+    fontSizeIncBtn.disabled = px >= max;
+    fontSizeDecBtn.classList.toggle('opacity-40', fontSizeDecBtn.disabled);
+    fontSizeDecBtn.classList.toggle('cursor-not-allowed', fontSizeDecBtn.disabled);
+    fontSizeIncBtn.classList.toggle('opacity-40', fontSizeIncBtn.disabled);
+    fontSizeIncBtn.classList.toggle('cursor-not-allowed', fontSizeIncBtn.disabled);
   }
   syncAutoFormatToggleUI();
-
-  // Line-wrap toggle — soft-wraps long lines instead of horizontal scrolling.
-  const LINE_WRAP_ON_CLASS = AUTO_FORMAT_ON_CLASS;
-  const LINE_WRAP_OFF_CLASS = AUTO_FORMAT_OFF_CLASS;
-  function syncLineWrapToggleUI(): void {
-    const on = getLineWrap();
-    lineWrapToggle.textContent = on ? 'Wrap ✓' : 'Wrap';
-    lineWrapToggle.title = on ? 'Word wrap on — click to disable' : 'Word wrap off — click to enable';
-    lineWrapToggle.className = on ? LINE_WRAP_ON_CLASS : LINE_WRAP_OFF_CLASS;
-  }
   syncLineWrapToggleUI();
+  syncLineNumbersToggleUI();
+  syncFontSizeUI();
 
   findReplaceBtn.addEventListener('click', () => openFindReplace());
   formatBtn.addEventListener('click', () => formatCode());
@@ -4506,6 +4513,18 @@ async function main() {
   lineWrapToggle.addEventListener('click', () => {
     setLineWrap(!getLineWrap());
     syncLineWrapToggleUI();
+  });
+  lineNumbersToggle.addEventListener('click', () => {
+    setLineNumbers(!getLineNumbers());
+    syncLineNumbersToggleUI();
+  });
+  fontSizeDecBtn.addEventListener('click', () => {
+    setFontSize(getFontSize() - 1);
+    syncFontSizeUI();
+  });
+  fontSizeIncBtn.addEventListener('click', () => {
+    setFontSize(getFontSize() + 1);
+    syncFontSizeUI();
   });
   document.addEventListener('keydown', (e) => {
     // Use e.code (physical key) — on macOS, Option+Shift+F composes a dead-key

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ import './renderer/viewportSubsystems';
 import { renderCompositeCanvas, renderSingleView, renderSingleViewCanvas, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, EDGE_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode, type EdgeMode } from './renderer/multiview';
 import { generateId, getLatestVersion } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
-import { initEditor, setValue, getValue, getSelection, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, openFindReplace, getAutoFormat, setAutoFormat, editorContentDiffersFrom, createCompanionEditor, setCompanionEditorContent } from './editor/codeEditor';
+import { initEditor, setValue, getValue, getSelection, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, openFindReplace, getAutoFormat, setAutoFormat, getLineWrap, setLineWrap, editorContentDiffersFrom, createCompanionEditor, setCompanionEditorContent } from './editor/codeEditor';
 import type { EditorView as CMEditorView } from '@codemirror/view';
 import { createLayout, type TabName } from './ui/layout';
 import { createToolbar, isAutoRun, setAutoRun, setToolbarLanguage, setAiToolbarState, setRunState } from './ui/toolbar';
@@ -4359,7 +4359,7 @@ async function main() {
   });
 
   // Create layout
-  const { editorContainer, companionFilesBar, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, cancelInlineBtn, clipControls, findReplaceBtn, formatBtn, autoFormatToggle, switchTab, partsRail, togglePartsRail, collapseEditor, expandEditor } = createLayout(editorUI, {
+  const { editorContainer, companionFilesBar, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, cancelInlineBtn, clipControls, findReplaceBtn, formatBtn, autoFormatToggle, lineWrapToggle, switchTab, partsRail, togglePartsRail, collapseEditor, expandEditor } = createLayout(editorUI, {
     onToggleAi: () => { void toggleAiPanelFromToolbar(); },
     onOpenCatalog: () => { void showCatalogPage(); },
     onToggleDiagnostics: () => { toggleDiagnosticsPanel(); },
@@ -4485,11 +4485,27 @@ async function main() {
     autoFormatToggle.className = on ? AUTO_FORMAT_ON_CLASS : AUTO_FORMAT_OFF_CLASS;
   }
   syncAutoFormatToggleUI();
+
+  // Line-wrap toggle — soft-wraps long lines instead of horizontal scrolling.
+  const LINE_WRAP_ON_CLASS = AUTO_FORMAT_ON_CLASS;
+  const LINE_WRAP_OFF_CLASS = AUTO_FORMAT_OFF_CLASS;
+  function syncLineWrapToggleUI(): void {
+    const on = getLineWrap();
+    lineWrapToggle.textContent = on ? 'Wrap ✓' : 'Wrap';
+    lineWrapToggle.title = on ? 'Word wrap on — click to disable' : 'Word wrap off — click to enable';
+    lineWrapToggle.className = on ? LINE_WRAP_ON_CLASS : LINE_WRAP_OFF_CLASS;
+  }
+  syncLineWrapToggleUI();
+
   findReplaceBtn.addEventListener('click', () => openFindReplace());
   formatBtn.addEventListener('click', () => formatCode());
   autoFormatToggle.addEventListener('click', () => {
     setAutoFormat(!getAutoFormat());
     syncAutoFormatToggleUI();
+  });
+  lineWrapToggle.addEventListener('click', () => {
+    setLineWrap(!getLineWrap());
+    syncLineWrapToggleUI();
   });
   document.addEventListener('keydown', (e) => {
     // Use e.code (physical key) — on macOS, Option+Shift+F composes a dead-key

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -833,6 +833,36 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           onChange={v => set('ui', 'tooltipDelayMs', v)}
         />
         <Field
+          label="Default editor font size"
+          unit="px"
+          hint="Seeds a fresh tab; change the live size from the editor's ⚙ menu (−/+)."
+          tooltip="The code editor's starting font size. The active size is remembered per browser tab via the ⚙ Editor menu's −/+ stepper; this default applies to a fresh tab and is the value the stepper returns to. Must sit within the min/max bounds below."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.editorFontSizeDefault}
+          value={c.ui.editorFontSizeDefault}
+          min={6} max={48} integer
+          onChange={v => set('ui', 'editorFontSizeDefault', v)}
+        />
+        <Field
+          label="Min editor font size"
+          unit="px"
+          hint="Lower bound for the editor's −/+ font stepper."
+          tooltip="The smallest font size the editor's ⚙ menu −/+ stepper will go down to."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.editorFontSizeMin}
+          value={c.ui.editorFontSizeMin}
+          min={6} max={24} integer
+          onChange={v => set('ui', 'editorFontSizeMin', v)}
+        />
+        <Field
+          label="Max editor font size"
+          unit="px"
+          hint="Upper bound for the editor's −/+ font stepper."
+          tooltip="The largest font size the editor's ⚙ menu −/+ stepper will go up to."
+          defaultValue={APP_CONFIG_DEFAULTS.ui.editorFontSizeMax}
+          value={c.ui.editorFontSizeMax}
+          min={12} max={64} integer
+          onChange={v => set('ui', 'editorFontSizeMax', v)}
+        />
+        <Field
           label="Code editor error idle delay"
           unit="ms"
           tooltip="After you stop typing, the code editor waits this long before showing error annotations (red underlines, error panel). This prevents the error display from flickering while you're mid-edit. Lower it for faster feedback; raise it if error annotations distract you while typing."

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -2,7 +2,7 @@ import { getMobilePane, onMobilePaneChange, setMobilePane } from './mobilePane';
 import { showAdvancedSettingsModal } from './advancedSettingsModal';
 import { showAboutModal } from './aboutModal';
 import { loadSettings, saveSettings } from '../ai/settings';
-import { createPopoverGroup } from './popoverMenu';
+import { createPopoverGroup, createMenuSectionHeader, createMenuDivider } from './popoverMenu';
 import { MOD_LABEL, combo } from './shortcutDefs';
 
 export type TabName = 'interactive' | 'gallery' | 'versions' | 'images' | 'diff' | 'notes' | 'data';
@@ -29,6 +29,10 @@ export interface LayoutElements {
   formatBtn: HTMLButtonElement;
   autoFormatToggle: HTMLButtonElement;
   lineWrapToggle: HTMLButtonElement;
+  lineNumbersToggle: HTMLButtonElement;
+  fontSizeDecBtn: HTMLButtonElement;
+  fontSizeIncBtn: HTMLButtonElement;
+  fontSizeValueEl: HTMLElement;
   switchTab: (tab: TabName, options?: SwitchTabOptions) => void;
   /** Collapse/expand the parts rail (wired to the rail's own collapse button). */
   togglePartsRail: () => void;
@@ -105,22 +109,120 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
 
   const formatBtn = document.createElement('button');
   formatBtn.id = 'format-btn';
-  formatBtn.className = 'shrink-0 px-2 py-0.5 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700 text-xs leading-none border border-transparent hover:border-zinc-600';
-  formatBtn.textContent = 'Format';
+  formatBtn.className = 'block w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-700 transition-colors';
+  formatBtn.textContent = 'Format code now';
   formatBtn.title = 'Format code (Shift+Alt+F)';
-  editorHeader.appendChild(formatBtn);
 
   const autoFormatToggle = document.createElement('button');
   autoFormatToggle.id = 'auto-format-toggle';
-  autoFormatToggle.className = 'shrink-0 px-2 py-0.5 rounded text-xs leading-none border';
   autoFormatToggle.title = 'Toggle automatic formatting when code is loaded';
-  editorHeader.appendChild(autoFormatToggle);
 
   const lineWrapToggle = document.createElement('button');
   lineWrapToggle.id = 'line-wrap-toggle';
-  lineWrapToggle.className = 'shrink-0 px-2 py-0.5 rounded text-xs leading-none border';
   lineWrapToggle.title = 'Toggle soft word wrap for long lines';
-  editorHeader.appendChild(lineWrapToggle);
+
+  const lineNumbersToggle = document.createElement('button');
+  lineNumbersToggle.id = 'line-numbers-toggle';
+  lineNumbersToggle.title = 'Toggle the line-number gutter';
+
+  // Font-size stepper — main.ts wires the −/+ buttons and writes the value label.
+  const fontSizeDecBtn = document.createElement('button');
+  fontSizeDecBtn.id = 'font-size-dec';
+  fontSizeDecBtn.type = 'button';
+  fontSizeDecBtn.textContent = '−'; // minus sign
+  fontSizeDecBtn.title = 'Smaller editor font';
+  fontSizeDecBtn.setAttribute('aria-label', 'Decrease editor font size');
+  fontSizeDecBtn.className = 'w-6 h-6 rounded border border-zinc-600 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 text-sm leading-none flex items-center justify-center';
+
+  const fontSizeValueEl = document.createElement('span');
+  fontSizeValueEl.id = 'font-size-value';
+  fontSizeValueEl.className = 'text-xs text-zinc-300 font-mono tabular-nums w-10 text-center';
+
+  const fontSizeIncBtn = document.createElement('button');
+  fontSizeIncBtn.id = 'font-size-inc';
+  fontSizeIncBtn.type = 'button';
+  fontSizeIncBtn.textContent = '+';
+  fontSizeIncBtn.title = 'Larger editor font';
+  fontSizeIncBtn.setAttribute('aria-label', 'Increase editor font size');
+  fontSizeIncBtn.className = 'w-6 h-6 rounded border border-zinc-600 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 text-sm leading-none flex items-center justify-center';
+
+  // "⚙ Editor settings" popover — collapses Format / Auto-format / Word wrap /
+  // Line numbers / Font size into one menu so the header stays uncluttered.
+  // Self-contained open/close (mirrors the toolbar Import/Export dropdowns); the
+  // inner controls' behavior is wired in main.ts.
+  const settingsWrapper = document.createElement('div');
+  settingsWrapper.className = 'relative shrink-0';
+
+  const editorSettingsBtn = document.createElement('button');
+  editorSettingsBtn.id = 'editor-settings-btn';
+  editorSettingsBtn.type = 'button';
+  editorSettingsBtn.className = 'shrink-0 px-2 py-0.5 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700 text-xs leading-none border border-transparent hover:border-zinc-600 flex items-center gap-1';
+  editorSettingsBtn.title = 'Editor settings — formatting, word wrap, line numbers, font size';
+  editorSettingsBtn.setAttribute('aria-haspopup', 'true');
+  editorSettingsBtn.setAttribute('aria-expanded', 'false');
+  editorSettingsBtn.innerHTML = '<span aria-hidden="true">⚙</span><span>Editor</span><span class="text-[9px] leading-none opacity-70" aria-hidden="true">▾</span>';
+  settingsWrapper.appendChild(editorSettingsBtn);
+
+  const settingsDropdown = document.createElement('div');
+  settingsDropdown.id = 'editor-settings-dropdown';
+  settingsDropdown.className = 'absolute right-0 top-full mt-1 hidden z-30 w-56 bg-zinc-800 border border-zinc-600 rounded shadow-lg py-1';
+
+  // Build a label/control row for a toggle.
+  const settingRow = (labelText: string, control: HTMLElement): HTMLElement => {
+    const row = document.createElement('div');
+    row.className = 'flex items-center justify-between gap-2 px-3 py-1.5';
+    const label = document.createElement('span');
+    label.className = 'text-xs text-zinc-300';
+    label.textContent = labelText;
+    row.appendChild(label);
+    row.appendChild(control);
+    return row;
+  };
+
+  settingsDropdown.appendChild(createMenuSectionHeader('Formatting'));
+  settingsDropdown.appendChild(formatBtn);
+  settingsDropdown.appendChild(settingRow('Auto-format on load', autoFormatToggle));
+  settingsDropdown.appendChild(createMenuDivider());
+  settingsDropdown.appendChild(createMenuSectionHeader('View'));
+  settingsDropdown.appendChild(settingRow('Word wrap', lineWrapToggle));
+  settingsDropdown.appendChild(settingRow('Line numbers', lineNumbersToggle));
+
+  const fontRow = document.createElement('div');
+  fontRow.className = 'flex items-center justify-between gap-2 px-3 py-1.5';
+  const fontLabel = document.createElement('span');
+  fontLabel.className = 'text-xs text-zinc-300';
+  fontLabel.textContent = 'Font size';
+  const fontStepper = document.createElement('div');
+  fontStepper.className = 'flex items-center gap-1';
+  fontStepper.appendChild(fontSizeDecBtn);
+  fontStepper.appendChild(fontSizeValueEl);
+  fontStepper.appendChild(fontSizeIncBtn);
+  fontRow.appendChild(fontLabel);
+  fontRow.appendChild(fontStepper);
+  settingsDropdown.appendChild(fontRow);
+
+  settingsWrapper.appendChild(settingsDropdown);
+
+  const isSettingsOpen = (): boolean => !settingsDropdown.classList.contains('hidden');
+  const closeSettings = (): void => {
+    settingsDropdown.classList.add('hidden');
+    editorSettingsBtn.setAttribute('aria-expanded', 'false');
+  };
+  editorSettingsBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    settingsDropdown.classList.toggle('hidden');
+    editorSettingsBtn.setAttribute('aria-expanded', String(isSettingsOpen()));
+  });
+  // Click-outside and Escape dismiss; flipping a setting inside keeps it open
+  // (sticky, like the viewport popover groups) so several can be changed at once.
+  document.addEventListener('click', (e) => {
+    if (isSettingsOpen() && !settingsWrapper.contains(e.target as Node)) closeSettings();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && isSettingsOpen()) closeSettings();
+  });
+
+  editorHeader.appendChild(settingsWrapper);
 
   // Status row: an absolutely-positioned flex strip that holds the status text
   // and an inline cancel button. Lives on rightPane so it stays visible even
@@ -694,7 +796,7 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
     window.dispatchEvent(new Event('resize'));
   });
 
-  return { editorPane, partsRail, editorContainer, companionFilesBar, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, cancelInlineBtn, clipControls, findReplaceBtn, formatBtn, autoFormatToggle, lineWrapToggle, switchTab, togglePartsRail, collapseEditor, expandEditor };
+  return { editorPane, partsRail, editorContainer, companionFilesBar, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, cancelInlineBtn, clipControls, findReplaceBtn, formatBtn, autoFormatToggle, lineWrapToggle, lineNumbersToggle, fontSizeDecBtn, fontSizeIncBtn, fontSizeValueEl, switchTab, togglePartsRail, collapseEditor, expandEditor };
 }
 
 // Rail item base — a bottom accent border on mobile (horizontal strip) becomes

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -28,6 +28,7 @@ export interface LayoutElements {
   findReplaceBtn: HTMLButtonElement;
   formatBtn: HTMLButtonElement;
   autoFormatToggle: HTMLButtonElement;
+  lineWrapToggle: HTMLButtonElement;
   switchTab: (tab: TabName, options?: SwitchTabOptions) => void;
   /** Collapse/expand the parts rail (wired to the rail's own collapse button). */
   togglePartsRail: () => void;
@@ -114,6 +115,12 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   autoFormatToggle.className = 'shrink-0 px-2 py-0.5 rounded text-xs leading-none border';
   autoFormatToggle.title = 'Toggle automatic formatting when code is loaded';
   editorHeader.appendChild(autoFormatToggle);
+
+  const lineWrapToggle = document.createElement('button');
+  lineWrapToggle.id = 'line-wrap-toggle';
+  lineWrapToggle.className = 'shrink-0 px-2 py-0.5 rounded text-xs leading-none border';
+  lineWrapToggle.title = 'Toggle soft word wrap for long lines';
+  editorHeader.appendChild(lineWrapToggle);
 
   // Status row: an absolutely-positioned flex strip that holds the status text
   // and an inline cancel button. Lives on rightPane so it stays visible even
@@ -687,7 +694,7 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
     window.dispatchEvent(new Event('resize'));
   });
 
-  return { editorPane, partsRail, editorContainer, companionFilesBar, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, cancelInlineBtn, clipControls, findReplaceBtn, formatBtn, autoFormatToggle, switchTab, togglePartsRail, collapseEditor, expandEditor };
+  return { editorPane, partsRail, editorContainer, companionFilesBar, editorErrorPanel, viewportPane, galleryContainer, versionsContainer, imagesContainer, diffContainer, notesContainer, dataContainer, statusBar, cancelInlineBtn, clipControls, findReplaceBtn, formatBtn, autoFormatToggle, lineWrapToggle, switchTab, togglePartsRail, collapseEditor, expandEditor };
 }
 
 // Rail item base — a bottom accent border on mobile (horizontal strip) becomes


### PR DESCRIPTION
## Summary

Adds editor view controls and consolidates them into a single **"⚙ Editor"** popover in the editor-pane header (replacing the loose Format / Auto buttons):

- **Word wrap** toggle — soft-wraps long lines (CodeMirror `lineWrapping`) instead of horizontal scrolling.
- **Line numbers** toggle — hides the line-number gutter via a scoped `.cm-lineNumbers { display: none !important }` theme rule (the `!important` is needed to beat CodeMirror's core `display: flex !important` gutter style). Fold/lint gutters stay.
- **Font size** −/+ stepper — was a hardcoded `13px` in the editor's base theme; now lives in a `fontSizeCompartment`, clamped to configurable bounds.
- **Format** and **Auto-format on load** moved into the same menu. Find/Replace and Hide-code stay as header buttons (they're actions, not settings).

Each setting reconfigures the live editor instantly via a CodeMirror `Compartment` and persists **per-tab** (`editor-line-wrap`, `editor-line-numbers`, `editor-font-size`), matching the existing auto-format pref. Toggles render as compact On/Off pills via one shared `syncTogglePill` helper.

### Config

Font-size default/min/max are tunable knobs, so per the repo's no-hardcoded-constants rule they're in `appConfig.ui` (`editorFontSizeDefault` = 13, `editorFontSizeMin` = 9, `editorFontSizeMax` = 28) and exposed in the **Advanced Settings** modal.

## Files

- `src/editor/codeEditor.ts` — compartments + `get/setLineWrap`, `get/setLineNumbers`, `get/setFontSize`, `getFontSizeBounds`.
- `src/ui/layout.ts` — the ⚙ popover (self-contained open/close + click-outside + Escape, sticky on inner clicks), reusing `createMenuSectionHeader`/`createMenuDivider`.
- `src/main.ts` — wiring + the shared toggle-pill / font-stepper sync.
- `src/config/appConfig.ts` + `src/ui/advancedSettingsModal.tsx` — font-size config fields.

## Test plan

- `npm run typecheck` ✅ / `npm run build` ✅
- `npm run test:unit` ✅ (1273 passed)
- `npm run lint:deps` ✅ (no circular deps)
- Manual browser check (throwaway Playwright spec, since deleted): opened the ⚙ menu, bumped font 13→17 px (`.cm-content` font-size + label both update), toggled line numbers off (gutter `display` → `none`) and word wrap on; screenshotted the unobstructed result.

https://claude.ai/code/session_01Le39nkYsrcVqdaE8BGZPKh