### PR TITLE
fix: keep the hints card from shrinking once it has grown

### DIFF
--- a/prompts/20260612-hints-height-no-shrink.md
+++ b/prompts/20260612-hints-height-no-shrink.md
@@ -1,0 +1,41 @@
+---
+date: 2026-06-12
+author: kriskemper@gmail.com
+prefix: fix
+---
+
+## Human
+
+The "Did you know?" box was changing the height of the interactive view,
+giving the page a stutter feeling. If the box increases in size for any
+reason, it should no longer decrease so it doesn't change the height/position
+of the panes below it.
+
+## Assistant
+
+Root cause: the hints card (`src/ui/hints/hintsTicker.ts`) flips between a
+single-row and a two-row arrangement, and in two-row mode the text wraps across
+1–3 lines (`line-clamp-3`). Each of those is a different height, and the card is
+the tallest child in the flex toolbar, so its height *is* the toolbar height.
+When a rotation or a width change shrank the card back down, the toolbar
+shrank with it and every pane below jumped up — the "stutter."
+
+Fix: a height high-water mark. `lockMinHeight()` runs at the end of `relayout()`
+(so it covers resize, breakpoint change, and each text rotation), reads the
+strip's `offsetHeight`, keeps a running max in `maxStripHeight`, and pins it back
+as an inline `min-height`. Because `offsetHeight` already includes any
+`min-height` we've set, the measured value is monotonic: it only ever reflects
+genuine growth, and a shorter hint or the single-row layout keeps the taller
+height instead of snapping the panes around. The running max resets to 0 in
+`renderStrip()` so a fresh mount (toggle off/on, new session) starts at its
+natural height.
+
+This intentionally does not touch the single-vs-two-row *decision* (still
+width-driven via `measureSingleNeeded()`); it only prevents the card from ever
+shrinking once it has grown, exactly as asked.
+
+Verified in the browser by forcing the toolbar middle narrow (card grows to the
+taller two-row layout) then wide again (would normally snap short) and
+confirming the card — and the session bar / viewport below it — held their
+position. Added a regression case to `tests/editor-hints.spec.ts` asserting the
+strip height does not decrease after going narrow→wide.

--- a/src/ui/hints/hintsTicker.ts
+++ b/src/ui/hints/hintsTicker.ts
@@ -49,6 +49,11 @@ let desktopMqCleanup: (() => void) | null = null;
  *  Set while a strip is mounted (closure over its elements), cleared on
  *  teardown. Called on resize, breakpoint change, and each text rotation. */
 let relayoutFn: (() => void) | null = null;
+/** High-water mark for the strip's height (px), reset on each fresh mount.
+ *  Once the card grows — switching to the two-row layout, wrapping to more
+ *  lines, a longer hint — we pin this as a min-height so it can never shrink
+ *  back and shove the panes below it up and down (the "stutter" on rotation). */
+let maxStripHeight = 0;
 /** Last session id seen, so we only restore hints on a real session transition
  *  (new / opened / switched session) — not on intra-session changes like
  *  version navigation, which also fire 'session-changed'. */
@@ -191,6 +196,7 @@ function renderStrip(): void {
 
   order = buildOrder();
   idx = 0;
+  maxStripHeight = 0;   // fresh card starts at its natural height
 
   // Centered, self-contained card in the toolbar's middle: a subtle bordered
   // box. It adapts between two arrangements (see relayout below):
@@ -307,8 +313,20 @@ function renderStrip(): void {
     // rows only when it would overflow the available width.
     setLayout('single');
     if (measureSingleNeeded() > w) setLayout('two');
+    lockMinHeight();
   };
   relayoutFn = relayout;
+
+  /** Pin the strip's height to its running maximum so it never shrinks back.
+   *  offsetHeight already includes any min-height we've set, so the measured
+   *  value is monotonic — it only ever reflects genuine growth, and a shorter
+   *  hint or the single-row layout keeps the taller height instead of snapping
+   *  the panes below up and down. */
+  const lockMinHeight = (): void => {
+    const h = stripEl.offsetHeight;
+    if (h > maxStripHeight) maxStripHeight = h;
+    stripEl.style.minHeight = maxStripHeight ? `${maxStripHeight}px` : '';
+  };
 
   resizeObs?.disconnect();
   resizeObs = new ResizeObserver(() => {

--- a/tests/editor-hints.spec.ts
+++ b/tests/editor-hints.spec.ts
@@ -82,6 +82,32 @@ test.describe('editor hints ticker', () => {
     expect(await rowsAtWidth(430)).toBe('two');
   });
 
+  test('keeps its grown height instead of snapping back (no pane stutter)', async ({ page }) => {
+    await page.goto('/editor');
+    const strip = page.locator('#editor-hints');
+    await expect(strip).toBeVisible({ timeout: 15_000 });
+
+    const setWidth = async (w: number) => {
+      await page.evaluate((px) => {
+        const host = document.getElementById('editor-hints-host')!;
+        host.style.flex = `0 0 ${px}px`;
+        host.style.maxWidth = `${px}px`;
+      }, w);
+      await page.waitForTimeout(350);
+    };
+    const height = async () => (await strip.boundingBox())!.height;
+
+    // Tight → the card grows to the taller two-row arrangement.
+    await setWidth(430);
+    const tall = await height();
+
+    // Roomy again → the single-row layout would normally be shorter, which would
+    // shove the panes below up and down. The high-water-mark min-height pins it,
+    // so it must NOT shrink back below the height it already reached.
+    await setWidth(1100);
+    expect(await height()).toBeGreaterThanOrEqual(tall);
+  });
+
   test('a coach CTA pulses an arrow at the target control', async ({ page }) => {
     await page.goto('/editor');
     const strip = page.locator('#editor-hints');


### PR DESCRIPTION
## Summary

The "Did you know?" hints card (`src/ui/hints/hintsTicker.ts`) changes height as it rotates: it flips between a single-row and a two-row arrangement, and in two-row mode the text wraps across 1–3 lines (`line-clamp-3`). Because the card is the tallest child in the flex toolbar, its height *is* the toolbar height — so when a rotation or width change shrank it back down, the toolbar shrank too and every pane below jumped up. That up/down motion is the "stutter" the user reported.

This pins a **height high-water mark**: once the card grows, it never shrinks back.

- `lockMinHeight()` runs at the end of `relayout()` (covering resize, breakpoint change, and each text rotation), reads the strip's `offsetHeight`, keeps a running max in `maxStripHeight`, and re-applies it as an inline `min-height`.
- Because `offsetHeight` already includes the `min-height` we set, the measured value is monotonic — it only ever reflects genuine growth, and a shorter hint or the single-row layout keeps the taller height instead of snapping the panes around.
- The running max resets to `0` in `renderStrip()`, so a fresh mount (toggle off/on, new session) starts at its natural height.

The single-vs-two-row **decision** is unchanged (still width-driven via `measureSingleNeeded()`); this only stops the card from ever shrinking once it has grown — exactly the requested behavior.

## Test plan

- `npm run typecheck` ✅ · `npm run test:unit` ✅
- Manual browser check: forced the toolbar middle narrow (card grows to the taller two-row layout) then wide again (would normally snap short) and confirmed the card — and the session bar / viewport below it — held their position (no upward jump).
- Added a regression case to `tests/editor-hints.spec.ts` asserting the strip height does not decrease after going narrow→wide. Full `editor-hints` e2e suite green across repeated runs.

https://claude.ai/code/session_01TvxxaqJJtYgoNWzRaFaMnk

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvxxaqJJtYgoNWzRaFaMnk)_