### PR TITLE
fix: keep the camera angle when customizing (and applying surface modifiers)

### DIFF
--- a/prompts/20260613-001919-customizer-camera-preserve.md
+++ b/prompts/20260613-001919-customizer-camera-preserve.md
@@ -1,0 +1,51 @@
+---
+date: 2026-06-13
+author: kriskemper@gmail.com
+title: Stop the Customizer (and surface modifiers) from resetting the camera angle
+---
+
+## Human
+
+Using the Customize menu resets the angle/perspective on the interactive
+viewport. I previously added camera persistence for other situations (orbiting
+then switching versions back and forth no longer resets), but the Customize menu
+still does it. Fix that, and investigate whether other places in the app reset
+the view in surprising/annoying ways — fix those too and tell me about it.
+
+## Assistant
+
+Root cause: camera persistence was already wired through `runCodeSync`
+(`opts.preserveCamera` → `captureCameraToPreserve()` → `setCameraPose()`), and
+the Customizer panel's `onChange` does call `runCode()`, which defaults
+`preserveCamera: true`. So manifold-js customizing already worked. The break was
+**SCAD-specific**: SCAD renders progressively, and its `onScadPreview` callback
+calls `updateMesh()` (auto-framing) *mid-run*, while the preserve-snapshot was
+taken *after* `executeCodeAsync` returned. By then the preview had already
+reframed the camera to the default 3/4 view, so the snapshot captured (and
+"restored") the reset pose. The Customizer is most commonly used on parametric
+SCAD models, which is why it surfaced there. The existing camera-persistence
+e2e test only exercises manifold-js, so SCAD was never covered.
+
+Fix:
+- Capture `preservedCameraPose` at the **top** of `runCodeSync` (before the
+  engine runs), and make `onScadPreview` skip auto-framing while a pose is being
+  preserved. Robust for every engine; identical behavior for manifold-js (no
+  mid-run camera move to poison the pose).
+
+Other reset points found and addressed (the "investigate" half):
+- **`setParams` console/AI-tool path** re-rendered via `runCodeSync` with no
+  `preserveCamera`, so tweaking a parameter from the console or the AI customizer
+  tool always reframed — inconsistent with the panel. Now passes
+  `preserveCamera: true`.
+- **Surface modifiers** (`commitSurfaceModifier`, both the manifold-js and voxel
+  result branches) reframed on apply. A texture/voxelize decorates the model in
+  place (same bounds), so they now preserve the camera.
+
+Deliberately left reframing: **transforms** (scale / rotate / translate /
+lay-flat in `commitTransform`) genuinely move or resize the model, where an
+auto-fit is the helpful behavior. Flagged this choice to the user to veto.
+
+Verified: reproduced the bug (test fails on unfixed code, passes with the fix),
+added a permanent SCAD-customizer regression test to
+`viewport-camera-persistence.spec.ts`, and captured before/after screenshots
+showing the SCAD cube growing 20→55 while the orbited angle holds.

--- a/src/main.ts
+++ b/src/main.ts
@@ -7545,7 +7545,10 @@ async function main() {
       };
       setActiveImports([comp]);
       setValue(result.code);
-      const ok = await runCodeSync(result.code);
+      // A surface modifier decorates the existing model in place (same bounds),
+      // so keep the user's camera angle instead of snapping back to the default
+      // framing when the baked result renders.
+      const ok = await runCodeSync(result.code, { preserveCamera: true });
       if (!ok) return { error: `Failed to apply ${result.label}` };
       let geoData = getGeometryDataObj();
       let carried = 0;
@@ -7589,7 +7592,9 @@ async function main() {
     if (getActiveLanguage() !== 'voxel') await switchLanguage('voxel');
     setActiveImports([]);
     setValue(result.code);
-    const ok = await runCodeSync(result.code);
+    // Same in-place decoration: a voxelize/voronoi-lamp bake keeps the model's
+    // bounds, so preserve the user's camera angle across the render.
+    const ok = await runCodeSync(result.code, { preserveCamera: true });
     if (!ok) return { error: `Failed to apply ${result.label}` };
     const thumbnail = await captureThumbnail();
     await saveVersion(result.code, getGeometryDataObj(), thumbnail, result.label, undefined, { force: true });
@@ -8703,7 +8708,11 @@ async function main() {
         return { error: 'The current model declares no parameters. Add an api.params({...}) call to the model code (and run it) first.' };
       }
       currentParamValues = { ...currentParamValues, ...(values as Record<string, ParamValue>) };
-      const applied = await runCodeSync(getValue());
+      // Tweaking a parameter re-renders the same model, so keep the user's (or
+      // AI's) current camera angle rather than snapping to the default framing —
+      // matching the Customizer panel's onChange path (runCode preserves by
+      // default). captureCameraToPreserve still auto-frames a session's first run.
+      const applied = await runCodeSync(getValue(), { preserveCamera: true });
       if (!applied) return { status: 'error', error: 'Run was superseded by a concurrent execution — retry' };
       const geometry = JSON.parse(geometryDataEl.textContent || '{}');
       return {
@@ -14972,13 +14981,25 @@ async function main() {
     const t0 = performance.now();
     startRunTimer(t0);
 
+    // Snapshot the camera to restore *before* the engine runs, not after, when
+    // this is a re-render of an already-framed session (opts.preserveCamera:
+    // version switch, live edit, Customizer change, quality change). The SCAD
+    // path renders progressively — onScadPreview below calls updateMesh mid-run,
+    // which auto-frames; capturing afterwards would record that reset pose and
+    // "preserve" the default framing instead of the user's angle (the Customizer
+    // reset bug on parametric SCAD models). captureCameraToPreserve returns null
+    // on a session's first render, so a genuinely new model still auto-frames.
+    const preservedCameraPose = opts.preserveCamera ? captureCameraToPreserve() : null;
+
     // SCAD preview callback: receives the fast Phase 1 mesh and updates the
-    // viewport immediately so the user sees geometry while Phase 2 renders.
+    // viewport immediately so the user sees geometry while Phase 2 renders. Skip
+    // its auto-frame while preserving the camera, so the mid-run preview doesn't
+    // momentarily snap to the default view before the final restore lands.
     const onScadPreview = getActiveLanguage() === 'scad'
       ? (previewResult: MeshResult) => {
           if (myGen !== _runGeneration || !previewResult.mesh) return;
           currentMeshData = previewResult.mesh;
-          updateMesh(previewResult.mesh);
+          updateMesh(previewResult.mesh, { skipAutoFrame: preservedCameraPose !== null });
         }
       : undefined;
 
@@ -15171,12 +15192,9 @@ async function main() {
       // strokes) so slab/box smooth regions rebuild too, exactly as the
       // visibility-toggle path does via reconcilePaintedGeometry.
       //
-      // Snapshot the camera before the auto-framing updateMesh runs when this
-      // run is a version switch (opts.preserveCamera) within an already-framed
-      // session: keep the user's interactive angle instead of snapping to the
-      // default 3/4 view. Genuine new-code runs (pw.run, live edits) leave this
-      // null so the new model auto-frames as before.
-      const preservedCameraPose = opts.preserveCamera ? captureCameraToPreserve() : null;
+      // preservedCameraPose was snapshotted at the top of runCodeSync (before
+      // the engine ran), so the auto-framing updateMesh calls below — and the
+      // SCAD progressive preview — don't poison the pose we restore at the end.
       if (hasColorRegions() && hasRefineDescriptors()) {
         rebuildPaintedGeometry();
         lastStrokeList = strokeDescriptors();

--- a/tests/viewport-camera-persistence.spec.ts
+++ b/tests/viewport-camera-persistence.spec.ts
@@ -176,6 +176,44 @@ test.describe('viewport camera persistence', () => {
     expect(Math.abs(afterBare.elevation - 35)).toBeLessThan(5);
   });
 
+  // The Customizer (panel slider / setParams) re-renders the same model with a
+  // new parameter, so it must keep the user's angle. SCAD is the tricky engine:
+  // it renders progressively, and that mid-run preview used to auto-frame the
+  // camera back to default *before* the preserve-snapshot ran — so customizing a
+  // parametric SCAD model snapped the view. Now the pose is captured before the
+  // engine runs and the preview skips auto-framing while preserving.
+  test('preserves the camera when customizing a parametric SCAD model', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('text=Ready', { timeout: 15000 });
+
+    const SCAD = ['width = 20; // [10:60]', 'cube([width, width, 10], center=true);'].join('\n');
+    await page.evaluate(async (code) => {
+      const pw = (window as unknown as { partwright: { createSession(n?: string): Promise<unknown>; setActiveLanguage(l: string): Promise<void> } & PW }).partwright;
+      await pw.createSession('scad-camera');
+      await pw.setActiveLanguage('scad'); // first SCAD run lazy-loads the WASM engine
+      await pw.run(code);
+    }, SCAD);
+    await page.waitForTimeout(1500);
+
+    await orbitAndZoom(page);
+    const before = await camera(page);
+    expect(Math.abs(before.azimuth - 45) > 5 || Math.abs(before.elevation - 35) > 5).toBe(true);
+
+    // Drive the Customize panel's Width slider — the exact path the user hits.
+    await page.evaluate(() => {
+      const panel = document.getElementById('params-panel')!;
+      const slider = panel.querySelector('input[type="range"]') as HTMLInputElement;
+      slider.value = '50';
+      slider.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await page.waitForTimeout(2500); // SCAD re-render (two-phase) + settle
+
+    const after = await camera(page);
+    expect(Math.abs(after.azimuth - before.azimuth)).toBeLessThan(2);
+    expect(Math.abs(after.elevation - before.elevation)).toBeLessThan(2);
+    expect(Math.abs(after.distance - before.distance)).toBeLessThan(2);
+  });
+
   // The orbited view is persisted per-session and restored on reload, instead of
   // snapping back to the default framing.
   test('persists the working-view camera across a reload', async ({ page }) => {


### PR DESCRIPTION
## Summary

Using the **Customize** menu reset the interactive viewport's angle/perspective on parametric **SCAD** models. Camera persistence was already wired through `runCodeSync` and the Customizer panel's `onChange` already opts in (`runCode()` defaults `preserveCamera: true`), so manifold-js customizing already worked — but SCAD broke it:

- SCAD renders **progressively**. Its `onScadPreview` callback calls `updateMesh()` (which auto-frames) *mid-run*, while the preserve-snapshot was taken *after* `executeCodeAsync` returned.
- By then the preview had already reframed the camera to the default 3/4 view, so the snapshot captured — and "restored" — the **reset** pose.
- The Customizer is most commonly used on parametric SCAD models, which is why the user hit it there. The existing camera-persistence e2e test only exercised manifold-js, so SCAD was never covered.

**Core fix:** capture `preservedCameraPose` at the **top** of `runCodeSync` (before the engine runs), and have `onScadPreview` skip auto-framing while a pose is being preserved. Identical behavior for manifold-js (no mid-run camera move to poison the pose); robust for SCAD.

### Other reset points fixed (the "investigate other places" half)

- **`setParams` (console / AI-tool path)** re-rendered with no `preserveCamera`, so tweaking a parameter from the console or the AI customizer tool always reframed — inconsistent with the panel. Now preserves, matching the panel.
- **Surface modifiers** (`commitSurfaceModifier`, both manifold-js and voxel result branches) reframed on apply. A texture / voxelize / voronoi-lamp bake decorates the model **in place** (same bounds), so they now preserve the camera.

### Deliberately left reframing

- **Transforms** — scale / rotate / translate / lay-flat (`commitTransform`). These genuinely move or resize the model, where an auto-fit is the helpful behavior (e.g. lay-flat-to-floor wants you to see it sitting on the bed). If you'd rather these preserve too, say so and I'll flip them.

## Test plan

- New regression test in `tests/viewport-camera-persistence.spec.ts`: orbit a parametric SCAD model, drag the Customize panel's Width slider, assert azimuth/elevation/distance unchanged. **Confirmed it fails on the unfixed code and passes with the fix.**
- `npm run typecheck` and `npm run test:unit` (1279 tests) green.
- Manually verified in-browser: changed Width 20→55 on a SCAD cube — it grows in place while the orbited corner-on angle holds, instead of snapping back to default framing (before/after screenshots captured during verification).

https://claude.ai/code/session_0126Ld6Kq2JzQ5Z3ZD8qHddD

---
_Generated by [Claude Code](https://claude.ai/code/session_0126Ld6Kq2JzQ5Z3ZD8qHddD)_