### PR TITLE
feat: let users set units inline in the export warning modal

### DIFF
--- a/prompts/export-modal-inline-units.md
+++ b/prompts/export-modal-inline-units.md
@@ -1,0 +1,46 @@
+---
+session: "01XER6"
+timestamp: "2026-06-13T13:50:00Z"
+---
+
+## Human
+
+When exporting a model, there's a modal window that pops up and says "Warning,
+no unit set yet." That modal would make a lot more sense if it gave the user
+the ability to set the units in the modal (or leave them unset), in addition to
+the warning message, so the user can actually do something right away that might
+be more correct. Implement and create a PR.
+
+## Assistant
+
+## Key decisions
+
+**Put an actionable units selector inside the unitless warning block, not a
+separate section.** The pre-export confirm modal's "No units set" warning
+(`src/ui/exportConfirmModal.ts`) now carries an inline `<select>` (Leave
+unitless / mm / cm / in) right under the copy. The select reuses the same
+options and persisting `setUnits` call the toolbar Export-menu selector uses, so
+a choice made here sticks for the tab exactly like the menu — fixing the
+warning where the user hit it instead of forcing a cancel → open Export menu →
+re-export round-trip.
+
+**Picking a unit clears the warning live rather than just dismissing it.** A
+`syncUnitsBlock()` closure re-renders the block on each change: choosing a
+concrete unit flips it from amber warning to an emerald confirmation ("Units set
+to mm…") and re-formats the bounding-box dims through `formatDimension`, which
+now reflects the just-set unit (e.g. `10.00 mm × 10.00 mm × 10.00 mm`).
+"Leave unitless" restores the original warning, so the deliberate-unitless path
+is still one click.
+
+**Relax the primary button from "Export anyway" to "Export" once nothing is
+wrong.** `updateExportLabel()` reads a precomputed `otherWarning` (manifold /
+component / colour / surface-stale) plus the live `unitsResolved` flag, so the
+button only says "Export anyway" while a real warning remains. If the unitless
+warning was the only issue and the user sets a unit, the button honestly reads
+"Export".
+
+**Tests + docs.** Added an e2e case to `tests/export-safety.spec.ts` that drives
+the inline selector, asserts the warning→confirmation flip, the mm-formatted
+dims, the button label change, and that the choice persists to the toolbar
+`#export-units-select`. Updated the modal's header comment. No schema or API
+change — this is a pure UI affordance over the existing `setUnits`.

--- a/src/ui/exportConfirmModal.ts
+++ b/src/ui/exportConfirmModal.ts
@@ -5,6 +5,9 @@
 // Surfaces up to two warnings in a single modal:
 //   1. Unitless geometry — most slicers assume millimeters, so the printed
 //      part will be the wrong size if the model was authored at another scale.
+//      This block carries an inline units selector so the user can set (or
+//      deliberately leave unset) the unit right here instead of cancelling and
+//      reopening the Export menu; picking a unit clears the warning live.
 //   2. Printability — the geometry is non-manifold (not watertight) and/or
 //      has multiple disconnected components, which many slicers choke on.
 //
@@ -12,7 +15,7 @@
 
 import { createModalShell } from './modalShell';
 import { BUTTON_PRIMARY, BUTTON_CANCEL } from './styleConstants';
-import { formatDimension } from '../geometry/units';
+import { formatDimension, getUnits, setUnits, type UnitSystem } from '../geometry/units';
 import { escapeHtml } from './htmlUtils';
 
 export interface ExportWarningInfo {
@@ -61,18 +64,83 @@ export function showExportConfirm(info: ExportWarningInfo): Promise<boolean> {
       },
     });
 
+    // When the unit is satisfied (a concrete unit was picked, or it wasn't
+    // unitless to begin with), the export button reads "Export"; while any
+    // warning is still live it reads "Export anyway". `syncUnitsBlock` keeps
+    // both the unit warning copy and the button label in sync as the user
+    // picks a unit right here in the modal.
+    const otherWarning = !info.isManifold || info.componentCount > 1
+      || info.colorOverBudget != null || info.colorDropped === true
+      || info.surfaceStale === true;
+    let unitsResolved = !info.unitless;
+
     if (info.unitless) {
       const block = document.createElement('div');
-      block.className = 'rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 leading-snug';
+      const message = document.createElement('div');
       const dims = info.dimensions;
       const dimText = dims
         ? `${formatDimension(dims[0])} × ${formatDimension(dims[1])} × ${formatDimension(dims[2])}`
         : null;
-      block.innerHTML =
-        '<strong>No units set.</strong> Most slicers assume <strong>millimeters</strong>. ' +
-        'If you modeled at another scale, the printed part will be the wrong size. ' +
-        (dimText ? `This model\'s bounding box is <span class="font-mono">${escapeHtml(dimText)}</span>. ` : '') +
-        'Set units in the Export menu to silence this check.';
+
+      // Inline units control — lets the user fix the warning right here instead
+      // of cancelling, opening the Export menu, and starting over.
+      const controlRow = document.createElement('div');
+      controlRow.className = 'mt-2 flex items-center gap-2';
+      const selectLabel = document.createElement('label');
+      selectLabel.className = 'text-xs font-medium';
+      selectLabel.textContent = 'Set units:';
+      selectLabel.htmlFor = 'export-confirm-units-select';
+      const unitsSelect = document.createElement('select');
+      unitsSelect.id = 'export-confirm-units-select';
+      unitsSelect.className = 'text-xs bg-zinc-900 border border-zinc-600 rounded px-2 py-1 text-zinc-200 focus:outline-none focus:border-blue-500';
+      const UNIT_LABELS: Record<UnitSystem, string> = {
+        unitless: 'Leave unitless',
+        mm: 'Millimeters (mm)',
+        cm: 'Centimeters (cm)',
+        in: 'Inches (in)',
+      };
+      for (const u of ['unitless', 'mm', 'cm', 'in'] as const) {
+        const opt = document.createElement('option');
+        opt.value = u;
+        opt.textContent = UNIT_LABELS[u];
+        unitsSelect.appendChild(opt);
+      }
+      unitsSelect.value = getUnits();
+      selectLabel.appendChild(unitsSelect);
+      controlRow.append(selectLabel);
+
+      // Re-render the warning copy + restyle the block for the current unit.
+      // Dimensions re-format through `formatDimension`, which reflects the unit
+      // we just set, so the bounding box reads in the chosen unit.
+      const syncUnitsBlock = () => {
+        const unit = getUnits();
+        unitsResolved = unit !== 'unitless';
+        const liveDimText = dims
+          ? `${formatDimension(dims[0])} × ${formatDimension(dims[1])} × ${formatDimension(dims[2])}`
+          : null;
+        if (unitsResolved) {
+          block.className = 'rounded border border-emerald-700/50 bg-emerald-900/20 px-3 py-2 text-xs text-emerald-200 leading-snug';
+          message.innerHTML =
+            `<strong>Units set to ${escapeHtml(unit)}.</strong> The exported model will declare this unit. ` +
+            (liveDimText ? `Bounding box: <span class="font-mono">${escapeHtml(liveDimText)}</span>.` : '');
+        } else {
+          block.className = 'rounded border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 leading-snug';
+          message.innerHTML =
+            '<strong>No units set.</strong> Most slicers assume <strong>millimeters</strong>. ' +
+            'If you modeled at another scale, the printed part will be the wrong size. ' +
+            (dimText ? `This model\'s bounding box is <span class="font-mono">${escapeHtml(dimText)}</span>. ` : '') +
+            'Choose a unit below to silence this check.';
+        }
+      };
+
+      unitsSelect.addEventListener('change', () => {
+        setUnits(unitsSelect.value as UnitSystem);
+        syncUnitsBlock();
+        updateExportLabel();
+      });
+
+      block.append(message, controlRow);
+      syncUnitsBlock();
       shell.body.appendChild(block);
     }
 
@@ -129,9 +197,15 @@ export function showExportConfirm(info: ExportWarningInfo): Promise<boolean> {
 
     const exportBtn = document.createElement('button');
     exportBtn.className = BUTTON_PRIMARY;
-    exportBtn.textContent = `Export anyway`;
     exportBtn.addEventListener('click', () => { result = true; shell.close(); });
     shell.footer.appendChild(exportBtn);
+
+    // "Export anyway" while any warning is still live; once every warning is
+    // cleared (e.g. the user picked a unit inline) it relaxes to "Export".
+    function updateExportLabel() {
+      exportBtn.textContent = (otherWarning || !unitsResolved) ? 'Export anyway' : 'Export';
+    }
+    updateExportLabel();
 
     function onEnter(e: KeyboardEvent) {
       if (e.key === 'Enter') { e.preventDefault(); result = true; shell.close(); }

--- a/tests/export-safety.spec.ts
+++ b/tests/export-safety.spec.ts
@@ -79,6 +79,39 @@ test.describe('Export safety confirmation', () => {
     await expect(dialog).toContainText('disconnected components');
   });
 
+  test('unitless modal lets the user set units inline', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    await runManifold(page, CUBE);
+
+    await page.locator('#btn-export').click();
+    await page.locator('#export-dropdown').getByText('STL', { exact: true }).click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('No units set');
+    // Inline selector is present, defaulting to unitless; button warns.
+    const select = dialog.locator('#export-confirm-units-select');
+    await expect(select).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Export anyway' })).toBeVisible();
+
+    // Pick millimeters right in the modal — warning clears to a confirmation,
+    // dims re-format in mm, and the button relaxes to "Export".
+    await select.selectOption('mm');
+    await expect(dialog).toContainText('Units set to mm');
+    await expect(dialog).toContainText('10.00 mm × 10.00 mm × 10.00 mm');
+    await expect(dialog.getByRole('button', { name: 'Export', exact: true })).toBeVisible();
+
+    // The choice persists to the toolbar selector and proceeds with the export.
+    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
+    await expect(dialog).toBeHidden();
+    await expect(
+      page.locator('div[role="status"]').filter({ hasText: /Exported/ }),
+    ).toBeVisible({ timeout: 5_000 });
+    await page.locator('#btn-export').click();
+    await expect(page.locator('#export-units-select')).toHaveValue('mm');
+  });
+
   test('setting a unit suppresses the unitless modal', async ({ page }) => {
     await page.goto('/editor');
     await waitForEngine(page);


### PR DESCRIPTION
## Summary

When exporting, the pre-export confirm modal shows a **"No units set"** warning. Previously the only fix was to cancel, open the Export menu, pick a unit, and re-export. Now the warning carries an **inline units selector** so the user can act on it immediately.

- The unitless warning block now has a `Set units:` dropdown (Leave unitless / mm / cm / in), reusing the same persisting `setUnits` the toolbar Export-menu selector uses — so a choice made here sticks for the tab.
- Picking a concrete unit flips the block from an amber **warning** to an emerald **confirmation** ("Units set to mm…") and re-formats the bounding-box dims in the chosen unit (e.g. `10.00 mm × 10.00 mm × 10.00 mm`).
- The primary button relaxes from **"Export anyway"** to **"Export"** once no warning remains (it stays "Export anyway" when a printability/colour/surface-stale warning is also present, or the user keeps it unitless).
- "Leave unitless" restores the original warning, so the deliberate-unitless path is still one click.

No schema or API change — this is a pure UI affordance over the existing `setUnits`.

### Before / After

| Before (warning) | After (unit picked) |
|---|---|
| Amber "No units set" + `Set units:` dropdown, button "Export anyway" | Emerald "Units set to mm", dims in mm, button "Export" |

## Test plan

- `npm run typecheck` ✅
- `npm run test:unit` ✅ (1325 passed)
- `npm run build` ✅
- `npx playwright test export-safety` ✅ (4 passed) — includes a new case driving the inline selector: asserts the warning→confirmation flip, the mm-formatted dims, the button-label change, and that the choice persists to the toolbar `#export-units-select`.
- Manual browser check: screenshotted both the amber-warning state and the emerald-confirmation state via a throwaway spec.

https://claude.ai/code/session_01XER6Zpej65evePGPrzBd6F

---
_Generated by [Claude Code](https://claude.ai/code/session_01XER6Zpej65evePGPrzBd6F)_