### PR TITLE
fix: recover from AI tool-call timeouts and orphaned tool history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,7 @@ The AI chat input supports `/command` shortcuts (`src/ai/slashCommands.ts`). A l
 |---|---|
 | `/compact` | Summarize older turns and promote insights to session notes |
 | `/clear` | Delete this chat (saved versions & notes are kept) |
+| `/repair` (alias `/fix`) | Repair corrupted tool history (orphaned tool calls) so a chat wedged on a provider 400 can send again |
 | `/review` | Open the cross-provider review modal |
 | `/export` | Download the conversation as Markdown |
 | `/models` (alias `/settings`) | Open AI settings modal |

--- a/prompts/fix-ai-tool-timeout-hang-and-history-repair.md
+++ b/prompts/fix-ai-tool-timeout-hang-and-history-repair.md
@@ -1,0 +1,73 @@
+---
+date: 2026-06-13
+branch: claude/affectionate-archimedes-scwe5u
+files_changed:
+  - src/ai/agentWorker.ts
+  - src/ai/agentWorkerClient.ts
+  - src/ai/chatLoop.ts
+  - src/ai/gemini.ts
+  - src/ai/historyRepair.ts
+  - src/ai/slashCommands.ts
+  - src/config/appConfig.ts
+  - src/ui/aiPanel.ts
+  - src/ui/advancedSettingsModal.tsx
+  - tests/unit/historyRepair.test.ts
+  - CLAUDE.md
+---
+
+## Human
+
+An AI session appeared to hang on a `runAndSave` tool call; the diagnostic log
+showed "Tool call \"runAndSave\" (tc-10) timed out after 60s". The Stop button
+in the AI pane did nothing — only a page refresh stopped it, and there was no
+"Rendering…" / Cancel affordance. After refreshing, every turn then failed with
+an unrecoverable provider 400 ("tool_use ids were found without tool_result
+blocks"), and rewinding the conversation didn't escape it. Asked for a thorough
+investigation and a plan covering the multiple improvements. Chosen scope: all
+four fix areas; raise the default tool-call timeout to 300s; expose history
+repair as an explicit button only (no silent on-load mutation).
+
+## Assistant
+
+Four interlocking failures, fixed together:
+
+1. **Tool timeout hard-hung the whole panel.** The Worker-side tool-call
+   timeout rejected, and that rejection propagated uncaught through
+   `timedExecuteTool` → `executeAllWithRetry` → `runTurn`, so the agent Worker
+   posted a fatal `error` and the panel's `await runTurn(...)` rejected with no
+   cleanup — `state.inFlight` stayed true forever (Send disabled, Stop dead).
+   Fix: `timedExecuteTool` now catches a thrown tool execution and returns an
+   `isError` tool *result* so the loop survives and the model can react;
+   `runTurnWithStallRetry` wraps `await runTurn(...)` in try/catch as a backstop
+   so the panel can never be left wedged in-flight again.
+
+2. **The timeout never cancelled the actual render** (it only abandoned the
+   Worker's wait; the main-thread execution kept burning CPU and froze the
+   page). The Worker now posts `cancel_tool` on timeout and the client calls
+   `cancelCurrentExecution()`. Default timeout raised 60s → 300s (legit complex
+   renders exceeded 60s); still user-adjustable in Advanced Settings.
+
+3. **AI Stop couldn't interrupt an in-flight tool.** The abort signal is only
+   checked between tool calls, and nothing cancelled the engine. `stopActiveTurn`
+   now also calls `cancelCurrentExecution()`, so an in-flight render is killed,
+   the tool returns an error result, and the between-calls signal check ends the
+   turn. The AI-pane progress line gained a live elapsed counter on the `tool`
+   phase ("🔧 running … Ns") so a long render is visibly cancellable via Stop.
+
+4. **Orphaned `tool_use` → unrecoverable 400, and rewind couldn't escape it.**
+   Added `src/ai/historyRepair.ts` — one shared `ChatMessage`-level repair that
+   pairs every orphaned tool_use with a synthetic error tool_result (nothing is
+   deleted; incomplete calls are marked failed). Wired as an explicit, user-only
+   affordance: a `/repair` (alias `/fix`) slash command and a "🛠 Repair history"
+   button on the Turn-failed bubble (shown only when an orphan exists) — never a
+   silent on-load mutation, per the chosen scope. `rewindTurn` now runs the same
+   repair after its cut so the post-rewind history is always sendable (it
+   previously only cut at the last *typed* user message, leaving mid-history
+   orphans). Closed the Gemini gap too: `buildGeminiContents` had no orphan
+   sanitizer (unlike anthropic.ts / openai.ts), so it now repairs the history
+   before emitting `functionResponse` parts.
+
+Verified: typecheck, 1331 unit tests (incl. new `historyRepair.test.ts`),
+madge acyclic, production build, and a throwaway Playwright spec that seeded an
+orphaned history, confirmed `/repair` is discoverable, ran it, and asserted the
+persisted history became pair-consistent.

--- a/src/ai/agentWorker.ts
+++ b/src/ai/agentWorker.ts
@@ -70,6 +70,13 @@ async function executeToolViaMessage(
     const ms = activeToolCallTimeoutMs;
     const timer = setTimeout(() => {
       pendingToolCalls.delete(callId);
+      // Tell the main thread to cancel the in-flight execution. The tool runs
+      // on the main thread (window.partwright → engine Worker); abandoning our
+      // wait here does NOT stop that work, so without this a runaway render
+      // keeps chewing CPU and freezing the page, then resolves into a result
+      // nobody is listening for. cancel_tool terminates the engine Worker so
+      // the execution rejects promptly.
+      self.postMessage({ type: 'cancel_tool', callId, name });
       reject(new Error(`Tool call "${name}" (${callId}) timed out after ${ms / 1000}s`));
     }, ms);
     pendingToolCalls.set(callId, (result) => {

--- a/src/ai/agentWorkerClient.ts
+++ b/src/ai/agentWorkerClient.ts
@@ -16,6 +16,7 @@ import type { ChatBlock, ChatMessage, PersistedToolResult } from './types';
 import type { AgentWorkerInput } from './agentWorker';
 import { getConfig } from '../config/appConfig';
 import { registerWorker, markWorkerStarted, markWorkerRestarted } from '../diagnostics/workerStats';
+import { cancelCurrentExecution } from '../geometry/engine';
 
 let worker: Worker | null = null;
 let currentCallbacks: RunTurnCallbacks | null = null;
@@ -86,6 +87,15 @@ async function handleMessage(event: MessageEvent): Promise<void> {
     }
     const result = await executeTool(name, input);
     getWorker().postMessage({ type: 'tool_result', callId, result });
+    return;
+  }
+
+  // ── cancel_tool: the Worker's tool-call timeout fired. Cancel the in-flight
+  //    engine execution so a runaway render stops immediately instead of
+  //    finishing into a result nobody is waiting for. Harmless when nothing is
+  //    running (the engine Worker simply restarts on the next call). ──
+  if (msg.type === 'cancel_tool') {
+    cancelCurrentExecution();
     return;
   }
 

--- a/src/ai/chatLoop.ts
+++ b/src/ai/chatLoop.ts
@@ -17,7 +17,7 @@ import { streamTurn as streamTurnGemini, type StreamCallbacks as GeminiStreamCal
 import { streamTurn as streamTurnCustom } from './custom';
 import { getKey, recordUsage, putMessages } from './db';
 import { recordEvent } from './diagnostics';
-import { buildToolList, executeTool, CONFIRM_REQUIRED_TOOLS, RETRY_SAFE_TOOLS } from './tools';
+import { buildToolList, executeTool, CONFIRM_REQUIRED_TOOLS, RETRY_SAFE_TOOLS, type ToolExecResult } from './tools';
 import { buildLocalSystemPrompt, buildMediumLocalSystemPrompt, buildSystemPrompt, loadAiMd, toggleSuffix } from './systemPrompt';
 import { loadSettings } from './settings';
 import { turnCostUsd } from './cost';
@@ -765,9 +765,24 @@ async function timedExecuteTool(
   name: string,
   input: Record<string, unknown>,
   fn: RunTurnInput['executeToolFn'] = executeTool,
-) {
+): Promise<ToolExecResult> {
   const t0 = performance.now();
-  const result = await (fn ?? executeTool)(name, input);
+  let result: ToolExecResult;
+  try {
+    result = await (fn ?? executeTool)(name, input);
+  } catch (err) {
+    // A *thrown* tool execution — most commonly the Worker-side tool-call
+    // timeout (executeToolViaMessage rejects), but also a crashed main-thread
+    // handler — must NOT tear the whole turn down. Before this catch the
+    // rejection propagated uncaught out of runTurn, the agent Worker posted a
+    // fatal `error`, and the panel's runTurn promise rejected with no cleanup —
+    // leaving the chat permanently "in-flight" until a page reload. Convert it
+    // into an error tool_result instead: the loop continues, the model sees the
+    // failure and can react (e.g. simplify the model or retry), and a slow
+    // render that blew the timeout no longer bricks the session.
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: `Tool execution failed: ${message}`, isError: true };
+  }
   const elapsed = performance.now() - t0;
   const slowMs = getSlowToolMs();
   if (elapsed > slowMs) {

--- a/src/ai/gemini.ts
+++ b/src/ai/gemini.ts
@@ -12,6 +12,7 @@ import type {
 } from './types';
 import type { ToolDefinition } from './tools';
 import { readSseStream } from './sse';
+import { repairToolHistory } from './historyRepair';
 import { getConfig } from '../config/appConfig';
 
 const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
@@ -415,7 +416,14 @@ function mapStopReason(reason: string): string {
   return reason.toLowerCase();
 }
 
-function buildGeminiContents(history: ChatMessage[]): GeminiContent[] {
+function buildGeminiContents(rawHistory: ChatMessage[]): GeminiContent[] {
+  // Pair any orphaned tool calls with synthetic error results first. Unlike
+  // anthropic.ts (sanitizeToolUse) and openai.ts (sanitizeChatToolMessages),
+  // Gemini had no repair pass, so an assistant turn whose functionCall lacked a
+  // following functionResponse (an interrupted/timed-out tool round) produced a
+  // malformed history. repairToolHistory injects the missing results so the
+  // synthetic functionResponse parts are emitted below.
+  const history = repairToolHistory(rawHistory).messages;
   const out: GeminiContent[] = [];
   for (const msg of history) {
     if (msg.role === 'assistant') {

--- a/src/ai/historyRepair.ts
+++ b/src/ai/historyRepair.ts
@@ -1,0 +1,109 @@
+// Tool-history repair — the single ChatMessage-level fix for the
+// tool_use/tool_result invariant that every hosted provider enforces: an
+// assistant message that emitted tool calls MUST be followed by a user message
+// carrying a tool_result for every one of those calls, or the next request
+// 400s ("tool_use ids were found without tool_result blocks").
+//
+// The per-provider request builders (anthropic.ts / openai.ts / gemini.ts) each
+// repair this transiently for the message array they send, but a corrupted
+// *persisted* history keeps tripping the 400 on every turn until the stored
+// messages themselves are fixed. This module operates on the persisted
+// ChatMessage[] so the repair can be written back to IndexedDB and the chat
+// becomes sendable again — the backing logic for the explicit "Repair tool
+// history" action and the reliable-rewind guard.
+//
+// Pure logic (no DOM, no IndexedDB) so it lives in the fast unit tier
+// (tests/unit/historyRepair.test.ts). generateId is a pure id factory.
+
+import { generateId } from '../storage/db';
+import type { ChatMessage, PersistedToolResult } from './types';
+
+export interface HistoryRepairResult {
+  /** The repaired, correctly-ordered message list. New array; untouched
+   *  messages are reused by reference. */
+  messages: ChatMessage[];
+  /** Messages that are new or were mutated and must be re-persisted
+   *  (putMessages). */
+  toPersist: ChatMessage[];
+  /** True when anything was changed (drives "nothing to repair" feedback). */
+  changed: boolean;
+}
+
+const INTERRUPTED_CONTENT =
+  'Tool call did not complete (the turn was interrupted; history was repaired so the chat can continue).';
+
+/** Pair up every orphaned assistant `tool_use` with a synthetic, error-marked
+ *  `tool_result` so the persisted history satisfies the provider invariant.
+ *
+ *  Three shapes are handled:
+ *   1. assistant(tool_use) → user(tool_results) missing some/all ids — the
+ *      missing results are prepended into that existing user message.
+ *   2. assistant(tool_use) → another assistant (the tool_result carrier was
+ *      lost entirely) — a synthetic tool_result user message is inserted
+ *      between them.
+ *   3. assistant(tool_use) at the tail (no following message) — a synthetic
+ *      tool_result user message is appended, leaving the chat in a normal
+ *      "ready for the model to respond" state (resumable, nothing dropped). */
+export function repairToolHistory(history: ChatMessage[]): HistoryRepairResult {
+  const messages = [...history];
+  const toPersist: ChatMessage[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role !== 'assistant' || !msg.toolCalls || msg.toolCalls.length === 0) continue;
+
+    const ids = msg.toolCalls.map(tc => tc.id);
+    const next = messages[i + 1];
+    const covered = new Set(
+      next && next.role === 'user'
+        ? (next.toolResults ?? []).map(r => r.toolUseId)
+        : [],
+    );
+    const missing = ids.filter(id => !covered.has(id));
+    if (missing.length === 0) continue;
+
+    const synthetic: PersistedToolResult[] = missing.map(id => ({
+      toolUseId: id,
+      content: INTERRUPTED_CONTENT,
+      isError: true,
+    }));
+
+    if (next && next.role === 'user') {
+      // Case 1: inject the missing results into the existing carrier. Results
+      // must lead the block list (providers require tool_result before any
+      // user text), so prepend.
+      const repaired: ChatMessage = {
+        ...next,
+        toolResults: [...synthetic, ...(next.toolResults ?? [])],
+      };
+      messages[i + 1] = repaired;
+      toPersist.push(repaired);
+    } else {
+      // Cases 2 & 3: insert/append a fresh synthetic tool_result user message.
+      // Seq sits strictly between the assistant and whatever follows so
+      // listMessages' seq-sort keeps the pair adjacent across a reload.
+      const seq = next && next.seq > msg.seq ? (msg.seq + next.seq) / 2 : msg.seq + 0.5;
+      const inserted: ChatMessage = {
+        id: generateId(),
+        sessionId: msg.sessionId,
+        role: 'user',
+        blocks: [],
+        toolResults: synthetic,
+        createdAt: msg.createdAt + 1,
+        seq,
+      };
+      messages.splice(i + 1, 0, inserted);
+      toPersist.push(inserted);
+      i++; // skip past the message we just inserted
+    }
+  }
+
+  return { messages, toPersist, changed: toPersist.length > 0 };
+}
+
+/** Cheap predicate: does this history contain an orphaned tool_use that would
+ *  make the next provider request fail? Used to conditionally surface the
+ *  "Repair tool history" affordance. */
+export function hasOrphanedToolCalls(history: ChatMessage[]): boolean {
+  return repairToolHistory(history).changed;
+}

--- a/src/ai/slashCommands.ts
+++ b/src/ai/slashCommands.ts
@@ -20,6 +20,7 @@ export interface SlashCommandSpec {
 export const SLASH_COMMANDS = [
   { name: 'compact', summary: 'Summarize older turns and promote insights to session notes' },
   { name: 'clear', summary: 'Delete this chat from your browser (saved versions & notes are kept)' },
+  { name: 'repair', summary: 'Fix corrupted tool history (orphaned tool calls) so the chat can send again', aliases: ['fix'] },
   { name: 'review', summary: 'Have a different provider/model review the current session' },
   { name: 'export', summary: 'Download the conversation as a Markdown file' },
   { name: 'models', summary: 'Open AI settings — provider, model, and API key', aliases: ['model', 'settings'] },

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -265,7 +265,7 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     slowToolMs: 250,
     diagnosticsRingSize: 50,
     maxAttachments: 20,
-    toolCallTimeoutMs: 60_000,
+    toolCallTimeoutMs: 300_000,
     thinkingBudgetAnthropicLow: 2048,
     thinkingBudgetAnthropicMedium: 8192,
     thinkingBudgetAnthropicHigh: 16384,

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -239,8 +239,8 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
         <Field
           label="Tool-call timeout (Worker)"
           unit="ms"
-          hint="If the main thread doesn't reply to a tool call within this time, the Worker aborts it."
-          tooltip="The AI agent runs in a background Worker and calls tools (geometry execution, rendering, etc.) on the main thread. If the main thread doesn't respond within this timeout — e.g. because WASM initialization is still in progress or the browser is paused — the Worker treats the call as failed and surfaces an error. Increase for very slow machines or complex BREP/SCAD evaluations."
+          hint="If a tool call (e.g. a render) hasn't finished within this time, it's cancelled and reported back to the agent as a failed step — the turn keeps going."
+          tooltip="The AI agent runs in a background Worker and calls tools (geometry execution, rendering, etc.) on the main thread. If a tool doesn't finish within this timeout — e.g. a very heavy boolean/BREP/SCAD evaluation, or WASM still initializing — the in-flight execution is cancelled and the agent receives an error result for that step, so it can react (simplify, retry) without the chat getting stuck. Increase for very slow machines or genuinely heavy models."
           defaultValue={APP_CONFIG_DEFAULTS.ai.toolCallTimeoutMs}
           value={c.ai.toolCallTimeoutMs}
           min={5_000} max={600_000} integer

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -34,6 +34,8 @@ import { onOwnershipChange } from '../storage/sessionLock';
 import { ensureModelLoaded, effectiveContextCeiling, interruptLocal, isModelLoaded, resolveLocalModel } from '../ai/local';
 import { activeModel, SPEND_CAP_USD, type ChatBlock, type ChatMessage, type ChatToggles, type ImageSource, type PersistedToolResult, type Preset, type Provider, type TurnOutcomeReason } from '../ai/types';
 import { matchSlashCommands, parseSlashCommand, slashMenuPrefix, type SlashCommandName, type SlashCommandSpec } from '../ai/slashCommands';
+import { repairToolHistory, hasOrphanedToolCalls } from '../ai/historyRepair';
+import { cancelCurrentExecution } from '../geometry/engine';
 import { errorLog } from '../diagnostics/errorLog';
 import { showToast } from './toast';
 import { createVoiceController, isVoiceInputSupported, type VoiceController } from './voiceInput';
@@ -736,6 +738,14 @@ function stopActiveTurn(): void {
   // Anthropic stops via AbortSignal through the SDK; local (WebLLM) ignores the
   // signal, so interruptLocal() is what halts it mid-token.
   state.inFlightController?.abort();
+  // A tool call (runAndSave / a render) may be executing in the engine Worker
+  // right now. The abort signal is only checked BETWEEN tool calls — never
+  // mid-render — so without this, an in-flight heavy render keeps running and
+  // Stop appears to do nothing (the symptom that forced a page reload).
+  // Terminate the engine Worker so the current execution rejects immediately;
+  // the tool returns an error result and the loop's between-calls signal check
+  // then ends the turn.
+  cancelCurrentExecution();
   void interruptLocal();
 }
 
@@ -1868,6 +1878,42 @@ async function clearCurrentChat(): Promise<void> {
   setTransientStatus('Chat cleared.');
 }
 
+/** Repair corrupted tool history: pair every orphaned assistant `tool_use`
+ *  with a synthetic error `tool_result` and persist the fix, so a chat that
+ *  was wedged on a provider 400 ("tool_use ids were found without tool_result
+ *  blocks") becomes sendable again without deleting the whole conversation.
+ *  Explicit, user-triggered only (the error-bubble button + the /repair
+ *  command) — never run silently on load. Refuses mid-turn so it can't race
+ *  the agent's own writes. */
+async function repairCurrentChat(): Promise<void> {
+  if (state.inFlight) {
+    setTransientStatus('Wait for the current turn to finish before repairing.');
+    return;
+  }
+  if (!writeOwner) {
+    setTransientStatus('Take control of this session in this tab before repairing its chat.');
+    return;
+  }
+  const result = repairToolHistory(state.history);
+  if (!result.changed) {
+    setTransientStatus('No corrupted tool history found — nothing to repair.');
+    return;
+  }
+  try {
+    await putMessages(result.toPersist);
+  } catch (err) {
+    setTransientStatus(`Couldn't repair chat: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  // Keep the repaired (persisted) messages; drop any in-memory error bubble so
+  // the user can continue immediately.
+  state.history = result.messages.filter(m => !m.errored);
+  broadcastChatChanged();
+  renderTranscript();
+  updateRewindButtons();
+  showToast(`Repaired tool history — ${result.toPersist.length} message(s) fixed. You can continue now.`, { variant: 'success', source: 'ai' });
+}
+
 function formatDuration(ms: number): string {
   return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
 }
@@ -2218,6 +2264,19 @@ function renderErrorBubble(msg: ChatMessage): HTMLElement {
   retryBtn.title = 'Resume the agent from where it failed — all completed work above is kept, nothing is replayed.';
   retryBtn.addEventListener('click', () => { void retryFailedTurn(msg.id); });
   actions.appendChild(retryBtn);
+
+  // When the failure is a wedged tool-history invariant (an orphaned tool_use
+  // with no matching tool_result — the unrecoverable provider 400 that even a
+  // rewind couldn't escape), offer a one-click repair right where the user is
+  // stuck. The button only appears when there's actually something to fix.
+  if (hasOrphanedToolCalls(state.history)) {
+    const repairBtn = document.createElement('button');
+    repairBtn.className = 'px-2 py-1 rounded text-[11px] text-zinc-100 bg-zinc-700 hover:bg-zinc-600 border border-zinc-600';
+    repairBtn.textContent = '🛠 Repair history';
+    repairBtn.title = 'Fix orphaned tool calls left by an interrupted turn so this chat can send again. Nothing is deleted — the incomplete calls are just marked as failed.';
+    repairBtn.addEventListener('click', () => { void repairCurrentChat(); });
+    actions.appendChild(repairBtn);
+  }
 
   const dismissBtn = document.createElement('button');
   dismissBtn.className = 'px-2 py-1 rounded text-[11px] text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800';
@@ -2865,6 +2924,16 @@ async function rewindTurn(): Promise<void> {
   const removed = state.history.splice(cutIndex);
   state.rewindStack.push(removed);
   await deleteMessages(removed.map(m => m.id));
+  // Cutting at the last *typed* user message can expose an earlier orphaned
+  // tool_use (mid-history tool calls whose results lived in the messages we
+  // just removed), which would 400 the very next send — so a rewind meant to
+  // "step back and start over" wouldn't actually recover. Repair the exposed
+  // history and persist it so the post-rewind state is always sendable.
+  const repair = repairToolHistory(state.history);
+  if (repair.changed) {
+    await putMessages(repair.toPersist);
+    state.history = repair.messages;
+  }
   renderTranscript();
   updateRewindButtons();
 }
@@ -2988,6 +3057,7 @@ async function preflightTurn(
 const SLASH_HANDLERS: Record<SlashCommandName, () => void> = {
   compact: () => { void runCompact(); },
   clear: () => { void clearCurrentChat(); },
+  repair: () => { void repairCurrentChat(); },
   review: () => { void launchReview(); },
   export: () => { exportCurrentChat(); },
   models: () => { void showAiSettingsModal({ onChange: afterAiSettingsChange }); },
@@ -3367,6 +3437,7 @@ async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatTo
     let liveThinkingEl: HTMLElement | null = null;
     const blocksForThisAttempt = attempt === 1 ? userBlocks : [];
 
+    try {
     await runTurn({
       apiKey,
       toggles,
@@ -3534,6 +3605,35 @@ async function runTurnWithStallRetry(apiKey: string | undefined, toggles: ChatTo
         lastTurnOutcome = info;
       },
     });
+    } catch (err) {
+      // Backstop: the turn promise rejected outright (Worker crash, an
+      // undeserializable message, or any tool execution that still threw
+      // despite chatLoop's per-tool catch). chatLoop's own `onError` resolves
+      // normally rather than rejecting, so this only fires for genuinely
+      // unexpected rejections — but without it the cleanup below is skipped and
+      // the panel is left permanently "in-flight" (Send disabled, Stop dead),
+      // recoverable only by a page reload. Surface it as an error bubble and
+      // fall through to the shared teardown.
+      const e = err instanceof Error ? err : new Error(String(err));
+      errorLog.capture({ level: 'error', source: 'ai', message: e.message, detail: e.stack });
+      if (!state.history.some(m => m.errored)) {
+        const idx = activeAssistantId ? state.history.findIndex(m => m.id === activeAssistantId) : -1;
+        const errorMsg: ChatMessage = {
+          id: activeAssistantId ?? generateId(),
+          sessionId: state.sessionId,
+          role: 'assistant',
+          blocks: [{ type: 'text', text: e.message }],
+          createdAt: Date.now(),
+          seq: idx >= 0 ? state.history[idx].seq : (state.history[state.history.length - 1]?.seq ?? 0) + 1,
+          errored: true,
+        };
+        if (idx >= 0) state.history[idx] = errorMsg;
+        else state.history.push(errorMsg);
+        renderTranscript();
+      }
+      setTransientStatus(`Error: ${e.message}`);
+      lastTurnOutcome = { totalCostUsd: 0, toolCalls: 0, reason: 'error', detail: e.message, iterations: 0 };
+    }
 
     state.inFlight = false;
     state.inFlightController = null;
@@ -3738,7 +3838,7 @@ function renderProgress(): void {
   const label =
     progressState.phase === 'thinking' ? `🧠 thinking…${silentSuffix}` :
     progressState.phase === 'streaming' ? `✎ streaming response…${silentSuffix}` :
-    progressState.phase === 'tool' ? `🔧 ${progressState.detail ?? 'running tool'}…` :
+    progressState.phase === 'tool' ? `🔧 ${progressState.detail ?? 'running tool'}…${elapsedSec > 1 ? ` ${elapsedSec}s` : ''}` :
     progressState.phase === 'final' ? (progressState.detail ?? '✓ done') :
     '';
   progressEl.replaceChildren();

--- a/tests/unit/historyRepair.test.ts
+++ b/tests/unit/historyRepair.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { repairToolHistory, hasOrphanedToolCalls } from '../../src/ai/historyRepair';
+import type { ChatMessage } from '../../src/ai/types';
+
+function assistant(seq: number, toolCallIds: string[], text = ''): ChatMessage {
+  return {
+    id: `a${seq}`,
+    sessionId: 's',
+    role: 'assistant',
+    blocks: text ? [{ type: 'text', text }] : [],
+    toolCalls: toolCallIds.map(id => ({ id, name: 'runAndSave', input: {} })),
+    createdAt: seq * 1000,
+    seq,
+  };
+}
+
+function toolResults(seq: number, ids: string[]): ChatMessage {
+  return {
+    id: `r${seq}`,
+    sessionId: 's',
+    role: 'user',
+    blocks: [],
+    toolResults: ids.map(id => ({ toolUseId: id, content: 'ok', isError: false })),
+    createdAt: seq * 1000,
+    seq,
+  };
+}
+
+function userText(seq: number, text: string): ChatMessage {
+  return { id: `u${seq}`, sessionId: 's', role: 'user', blocks: [{ type: 'text', text }], createdAt: seq * 1000, seq };
+}
+
+describe('repairToolHistory', () => {
+  it('leaves a correctly-paired history untouched', () => {
+    const history = [userText(0, 'hi'), assistant(1, ['t1']), toolResults(2, ['t1'])];
+    const r = repairToolHistory(history);
+    expect(r.changed).toBe(false);
+    expect(r.toPersist).toHaveLength(0);
+    expect(r.messages).toEqual(history);
+  });
+
+  it('appends a synthetic result for a trailing orphaned tool_use', () => {
+    const history = [userText(0, 'hi'), assistant(1, ['t1'], 'working on it')];
+    const r = repairToolHistory(history);
+    expect(r.changed).toBe(true);
+    expect(r.toPersist).toHaveLength(1);
+    const inserted = r.messages[2];
+    expect(inserted.role).toBe('user');
+    expect(inserted.toolResults).toHaveLength(1);
+    expect(inserted.toolResults![0]).toMatchObject({ toolUseId: 't1', isError: true });
+    // The assistant's text is preserved (nothing dropped).
+    expect(r.messages[1].blocks[0]).toEqual({ type: 'text', text: 'working on it' });
+    // Seq keeps the pair adjacent on reload.
+    expect(inserted.seq).toBeGreaterThan(1);
+    expect(inserted.seq).toBeLessThan(2);
+  });
+
+  it('injects only the MISSING results into a partial carrier', () => {
+    const history = [
+      userText(0, 'hi'),
+      assistant(1, ['t1', 't2']),
+      toolResults(2, ['t2']), // t1 missing
+    ];
+    const r = repairToolHistory(history);
+    expect(r.changed).toBe(true);
+    const carrier = r.messages[2];
+    const ids = carrier.toolResults!.map(x => x.toolUseId);
+    expect(ids).toContain('t1');
+    expect(ids).toContain('t2');
+    // The synthetic (t1) is prepended so results lead the block list.
+    expect(carrier.toolResults![0].toolUseId).toBe('t1');
+    expect(carrier.toolResults![0].isError).toBe(true);
+  });
+
+  it('inserts a synthetic carrier when the tool_result message was lost entirely', () => {
+    // assistant(tool_use) followed directly by another assistant turn.
+    const history = [userText(0, 'hi'), assistant(1, ['t1']), assistant(2, [], 'next')];
+    const r = repairToolHistory(history);
+    expect(r.changed).toBe(true);
+    expect(r.messages).toHaveLength(4);
+    expect(r.messages[2].role).toBe('user');
+    expect(r.messages[2].toolResults![0]).toMatchObject({ toolUseId: 't1', isError: true });
+    expect(r.messages[2].seq).toBeGreaterThan(1);
+    expect(r.messages[2].seq).toBeLessThan(2);
+  });
+
+  it('repairs a mid-history orphan (the unrecoverable-400 case)', () => {
+    const history = [
+      userText(0, 'first'),
+      assistant(1, ['t1']),
+      // tool_result for t1 lost; conversation continued with a new user turn
+      userText(2, 'second'),
+      assistant(3, ['t2']),
+      toolResults(4, ['t2']),
+    ];
+    expect(hasOrphanedToolCalls(history)).toBe(true);
+    const r = repairToolHistory(history);
+    expect(r.changed).toBe(true);
+    // After repair there must be no orphan left.
+    expect(hasOrphanedToolCalls(r.messages)).toBe(false);
+  });
+
+  it('hasOrphanedToolCalls is false for a clean history', () => {
+    const history = [userText(0, 'hi'), assistant(1, ['t1']), toolResults(2, ['t1'])];
+    expect(hasOrphanedToolCalls(history)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a cascade of four interlocking AI-chat failures that started with a `runAndSave` tool-call timeout and ended with a session that couldn't send at all. Reported from a real session: the panel appeared hung, the **Stop** button did nothing (only a page refresh stopped it), there was no "Rendering…/Cancel" affordance, and after refreshing every turn failed with an unrecoverable provider 400 (`tool_use ids were found without tool_result blocks`) that **rewinding couldn't escape**.

### 1. Tool timeout no longer hard-hangs the panel
The Worker-side tool-call timeout rejected, and that rejection propagated **uncaught** through `timedExecuteTool` → `executeAllWithRetry` → `runTurn`. The agent Worker posted a fatal `error`, the panel's `await runTurn(...)` rejected with no cleanup, and `state.inFlight` stayed `true` forever (Send disabled, Stop dead).
- `chatLoop.timedExecuteTool` now catches a thrown tool execution and returns an `isError` tool **result** — the loop survives and the model can react (simplify/retry) instead of the turn tearing down.
- `runTurnWithStallRetry` wraps `await runTurn(...)` in try/catch as a permanent backstop so the panel can never be left wedged in-flight again.

### 2. Timeout & Stop now actually cancel the render
The timeout only abandoned the Worker's *wait* — the real render kept running on the main thread, freezing the page, then resolved into a dropped result.
- On timeout the Worker posts `cancel_tool`; the client calls `cancelCurrentExecution()` to terminate the engine Worker.
- The AI **Stop** button now also calls `cancelCurrentExecution()`, so an in-flight render is killed, the tool returns an error result, and the loop's between-calls signal check ends the turn.
- Default tool-call timeout **60s → 300s** (legitimate complex renders exceeded 60s; still user-adjustable in Advanced Settings).
- The AI-pane progress line shows a live elapsed counter on the `tool` phase (`🔧 running … Ns`) so a long render is visibly cancellable.

### 3. Recoverable history + reliable rewind
- New `src/ai/historyRepair.ts`: one shared `ChatMessage`-level repair that pairs every orphaned `tool_use` with a synthetic error `tool_result` (nothing deleted — incomplete calls are marked failed).
- Exposed as an **explicit** affordance only (no silent on-load mutation): a `/repair` (alias `/fix`) slash command and a **🛠 Repair history** button on the *Turn failed* bubble, shown only when an orphan actually exists.
- `rewindTurn` now runs the repair after its cut, so the post-rewind history is always sendable (it previously only cut at the last *typed* user message, leaving mid-history orphans behind).
- Closed the **Gemini** gap: `buildGeminiContents` had no orphan sanitizer (unlike `anthropic.ts` / `openai.ts`); it now repairs the history before emitting `functionResponse` parts.

## Test plan
- `npm run typecheck` ✓
- `npm run test:unit` ✓ — 1331 tests, incl. new `tests/unit/historyRepair.test.ts` (trailing/partial/lost/mid-history orphan cases)
- `npm run lint:deps` ✓ (acyclic) · `npm run lint:consistency` ✓ (no error-severity) · `npm run build` ✓
- Manual browser check (throwaway Playwright spec): seeded an orphaned `tool_use` history, confirmed `/repair` is discoverable in the slash menu, ran it, and asserted the persisted history became pair-consistent. Screenshot posted in the session.
- PR-checks will run the full e2e shards.

https://claude.ai/code/session_01Tgcp6PkE1kupxZj3mE1wYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tgcp6PkE1kupxZj3mE1wYi)_