### PR TITLE
docs: add June 12–13 what's-new entry for the latest release

### DIFF
--- a/prompts/release-2026-06-13-changelog.md
+++ b/prompts/release-2026-06-13-changelog.md
@@ -1,0 +1,42 @@
+---
+date: 2026-06-13
+branch: claude/charming-euler-b9xe1c
+files_changed:
+  - src/content/data/whatsNew.ts
+---
+
+## Human
+
+Create a PR to update production from the latest staging. Update the docs and
+public changelog as needed since the last release. Create a new branch that is a
+copy of the current staging branch.
+
+## Assistant
+
+The request bundles two things the deployment pipeline keeps strictly separate,
+so I split them to respect the production-promotion invariant (a production PR
+must be a *pure promotion* — zero content beyond `main`; the
+`production-promotion-guard` Action fails otherwise, and CLAUDE.md says
+changelog edits land on `main` first, never on the release branch):
+
+1. **Release promotion** — created `release/2026-06-13` as an exact copy of
+   `origin/staging` and opened a draft PR into `production`. Verified the branch
+   is identical to staging and a clean subset of `main`
+   (`git log origin/main..HEAD` empty), so the guard passes. No edits ride on it.
+
+2. **Changelog** — the "public changelog" is the `/whats-new` page backed by
+   `src/content/data/whatsNew.ts` (help/llms.txt only link to it). Production
+   (#628) shipped with the changelog identical across main/staging/production,
+   so everything that landed after the release — figure diversity (skin tones,
+   faces, hair, cornrows/locs), footwear (shoes/boots, soles, F.standOn), layered
+   iris/pupil eyes, headwear + new hair, the ⚙ editor settings menu and line-wrap
+   toggle, sliding AI/code panes + preserved camera, inline export units, the
+   8-model catalog refresh, setVoxelRounding/getVoxelRounding, and stale-deploy /
+   stuck-turn recovery — was uncovered. Added a new "June 12 – 13, 2026" week
+   entry at the top of `WHATS_NEW_WEEKS` grouping these by theme. This goes onto
+   `main` via a `docs:` PR so it flows main → gate → staging → a later release,
+   per the one-directional pipeline; it deliberately does not ride the promotion
+   branch.
+
+Verified with typecheck, the unit tier (1343 passing), and a `/whats-new`
+screenshot showing the new entry at the top.

--- a/src/content/data/whatsNew.ts
+++ b/src/content/data/whatsNew.ts
@@ -26,6 +26,87 @@ export const WHATS_NEW_INTRO =
 // Most recent first. Each entry is a calendar week (Mon–Sun) of shipped work.
 export const WHATS_NEW_WEEKS: WeekEntry[] = [
   {
+    range: 'June 12 – 13, 2026',
+    headline: 'Diverse figures, footwear and expressive faces, plus editor and viewport polish',
+    groups: [
+      {
+        label: 'Figures',
+        items: [
+          {
+            title: 'Diverse figures — skin tones, faces, and hair',
+            body: 'The figure builder gained diversity axes: a range of skin tones, face shapes, and hair styles (including cornrows and locs). Ready-made catalog figures were diversified to match, and each bakes as one clean printable piece.',
+          },
+          {
+            title: 'Footwear — shoes and boots',
+            body: 'A clothing.shoes / clothing.boots builder gives figures real footwear, with soles that follow the foot’s curvature (welt or flush styles), a paintable sole, and an F.standOn / F.ground helper to stand a figure level on a surface. A new “Sneakers Character” joins the catalog.',
+          },
+          {
+            title: 'Expressive eyes',
+            body: 'Figure eyes now read as a recognizable layered iris and pupil painted onto a smooth eyeball, instead of raised beads, with smoother eye meshing across all the figures.',
+          },
+          {
+            title: 'Headwear and richer hair',
+            body: 'F.placeOnHead positions headwear, and the hair system expanded with new styles — a tousled mop, a face-framing afro, and Bart-style spikes — plus a printable relief texture.',
+          },
+        ],
+      },
+      {
+        label: 'Editor',
+        items: [
+          {
+            title: 'Editor settings menu',
+            body: 'A ⚙ settings menu adds font-size and line-number controls, and a line-wrap toggle landed in the editor header.',
+          },
+        ],
+      },
+      {
+        label: 'Viewport & UX',
+        items: [
+          {
+            title: 'Smoother panels and steadier camera',
+            body: 'The AI panel and code pane now slide open and closed instead of snapping, and the AI panel steps aside when you open a viewport tool. Opening the Customizer or applying a surface modifier now keeps your current camera angle instead of resetting the view.',
+          },
+        ],
+      },
+      {
+        label: 'Export',
+        items: [
+          {
+            title: 'Set units inline on export',
+            body: 'The export warning modal now lets you set the model’s units right there, instead of cancelling out to change them first.',
+          },
+        ],
+      },
+      {
+        label: 'Catalog',
+        items: [
+          {
+            title: 'Catalog refresh',
+            body: 'Eight catalog models were redone with richer colors, paint, and surface textures.',
+          },
+        ],
+      },
+      {
+        label: 'Voxel & API',
+        items: [
+          {
+            title: 'Voxel rounding from the console API',
+            body: 'setVoxelRounding / getVoxelRounding were added to the window.partwright console API, so agents can drive voxel edge rounding the way the UI does.',
+          },
+        ],
+      },
+      {
+        label: 'Reliability',
+        items: [
+          {
+            title: 'Recover from stale deploys and stuck AI turns',
+            body: 'The app now recovers from stale-deploy chunk-load failures instead of spinning forever, and the AI assistant recovers from tool-call timeouts and orphaned tool history rather than wedging the chat.',
+          },
+        ],
+      },
+    ],
+  },
+  {
     range: 'June 8 – 12, 2026',
     headline: 'Pose-able figures, Tinkercad-style Arrange mode, scoped textures, and engraving',
     groups: [


### PR DESCRIPTION
## Summary

Adds a new **"June 12 – 13, 2026"** entry to the top of the public changelog (`src/content/data/whatsNew.ts`, the `/whats-new` page) covering everything shipped since the last production release (#628, June 12). The changelog was identical across `main`/`staging`/`production`, so all post-release, user-visible work was uncovered.

New entry groups:

- **Figures** — diverse skin tones / faces / hair (cornrows, locs); shoes & boots footwear with curvature-following soles and `F.standOn`; layered iris/pupil eyes; headwear + new hair styles
- **Editor** — ⚙ settings menu (font size, line numbers) and line-wrap toggle
- **Viewport & UX** — sliding AI/code panes, steadier camera on Customizer / surface modifiers
- **Export** — set units inline in the export warning modal
- **Catalog** — 8-model refresh
- **Voxel & API** — `setVoxelRounding` / `getVoxelRounding` console API
- **Reliability** — stale-deploy and stuck-AI-turn recovery

This is the changelog counterpart to the `release/2026-06-13` → `production` promotion PR. Per the deployment pipeline, release notes land on `main` first (this PR), then flow main → gate → staging → the next release — they never ride the production promotion branch (the `production-promotion-guard` would reject them).

## Test plan

- `npm run typecheck` — clean
- `npm run test:unit` — 1343 passing
- Screenshotted `/whats-new` and confirmed the new entry renders at the top

https://claude.ai/code/session_0125D6PLXSEDTJ6KLaAHk4gM

---
_Generated by [Claude Code](https://claude.ai/code/session_0125D6PLXSEDTJ6KLaAHk4gM)_