### PR TITLE
feat: stamp app-version provenance into sessions and exports

### DIFF
--- a/prompts/app-version-provenance.md
+++ b/prompts/app-version-provenance.md
@@ -1,0 +1,71 @@
+---
+date: 2026-06-14
+branch: claude/version-metadata-stamping
+files_changed:
+  - src/storage/db.ts
+  - src/storage/sessionManager.ts
+  - src/storage/appVersionCompat.ts
+  - tests/unit/appVersionCompat.test.ts
+  - tests/chat-export.spec.ts
+---
+
+## Human
+
+Phase 2 of the versioned-deployment strategy: stamp the "last known good" app
+semver into the session schema + exported files, so we're ready for the first
+breaking change and the eventual cross-version migration flow. (Follows the
+release-tagging PR #651 which made package.json the version source of truth.)
+User: "I just want to be ready for the first time we do a breaking change and
+need version management."
+
+## Assistant
+
+Recorded the **app** semver (package.json `version`, surfaced via
+`buildInfo.version`) onto persisted geometry, and wired the read-side seam where
+a future major will hook forward-migration.
+
+Key design decisions:
+
+- **App version is a distinct axis from the export schema version.**
+  `SCHEMA_VERSION` (the `partwright: "1.x"` file-format number) and the app
+  semver ("1.0.0") move independently, so I did NOT reuse the schema number.
+  Added `appVersion` as new metadata and bumped the schema 1.14 → 1.15 (additive,
+  back-compatible — old readers ignore it).
+
+- **Stamped at two granularities.** Per-version `Version.appVersion` (the build
+  that saved each snapshot — the true "last known good" provenance) AND a
+  top-level `ExportedSession.appVersion` (the exporting build — the file-level
+  migration signal). On import the per-version stamp is *preserved verbatim*,
+  not re-stamped, so provenance follows the geometry.
+
+- **Pure logic split into `appVersionCompat.ts`** (mirrors the
+  `languageFallback.ts` precedent) so it's unit-testable under the node tier —
+  `sessionManager.ts` can't be imported there (DOM/IndexedDB/engine deps). The
+  module defines a local structural type rather than importing `ExportedSession`,
+  keeping the dependency graph acyclic (sessionManager → appVersionCompat, never
+  the reverse). `lint:deps` confirms no cycle.
+
+- **The migration seam is explicit.** `appVersionCompatibility()` classifies a
+  file's authoring major vs the running build: newer-major warns
+  (forward-incompatible), same/unknown is silent, and **older-major is the
+  documented hook point** — when v2 ships, the forward codemod runs in that
+  branch. Wired into `importSession` alongside the existing schema warning,
+  routing through the same `onWarning` path.
+
+- **No DB version bump needed.** IndexedDB tolerates extra fields on records, so
+  adding `appVersion` to the `versions` store needs no `onupgradeneeded` change —
+  old records simply lack it. The `saveVersion` API already takes an options
+  object (the CLAUDE.md "16 positional args" warning is stale), so threading the
+  field was a one-liner per call site.
+
+- **Dev/test stamp nothing.** When `buildInfo.version` is 'unknown' (no define
+  applied) we store `undefined` rather than persisting the placeholder.
+
+No UI/API-parity gap: this is automatic provenance, not a new affordance; the
+compat warning surfaces via the existing import-warning toast path.
+
+Verified: typecheck clean; full unit tier 1364 pass (incl. 11 new
+`appVersionCompat` cases); `lint:deps` acyclic; `npm run build` clean;
+`chat-export` e2e green with a new `appVersion` round-trip assertion; and a
+throwaway browser probe confirmed both the top-level and per-version stamps come
+through the real runAndSave→export path as "1.0.0" (deleted before commit).

--- a/prompts/app-version-provenance.md
+++ b/prompts/app-version-provenance.md
@@ -69,3 +69,8 @@ Verified: typecheck clean; full unit tier 1364 pass (incl. 11 new
 `chat-export` e2e green with a new `appVersion` round-trip assertion; and a
 throwaway browser probe confirmed both the top-level and per-version stamps come
 through the real runAndSave→export path as "1.0.0" (deleted before commit).
+
+Follow-up after a work-reviewer pass (0 blocking, 0 should-fix): added a
+clarifying comment on `compareSemver` noting it assumes plain numeric X.Y.Z
+(a pre-release tag would coerce to 0 — harmless since only the major drives
+decisions, but flagged for if pre-release versions ever ship).

--- a/src/storage/appVersionCompat.ts
+++ b/src/storage/appVersionCompat.ts
@@ -36,7 +36,11 @@ export function parseAppMajor(version: string | null | undefined): number | null
 }
 
 /** Compare two semver-ish strings. Returns >0 if a is newer, <0 if older, 0 if
- *  equal/incomparable. Missing components count as 0 (so "1.2" === "1.2.0"). */
+ *  equal/incomparable. Missing components count as 0 (so "1.2" === "1.2.0").
+ *  Assumes plain numeric `X.Y.Z` (this project's release scheme); a pre-release
+ *  tag like "1.2.0-rc1" would coerce its tagged component to 0 — only the major
+ *  ultimately drives any decision (via parseAppMajor), so that's harmless, but
+ *  revisit here if pre-release versions ever ship. */
 function compareSemver(a: string, b: string): number {
   const pa = a.split('.').map(n => parseInt(n, 10) || 0);
   const pb = b.split('.').map(n => parseInt(n, 10) || 0);

--- a/src/storage/appVersionCompat.ts
+++ b/src/storage/appVersionCompat.ts
@@ -1,0 +1,118 @@
+// App-version provenance + cross-major compatibility — the pure, dependency-free
+// seam that records which app (semver) version authored a session/file and
+// decides what to do when that differs from the running build.
+//
+// This is deliberately split out of sessionManager.ts (which can't be imported
+// under the node unit tier — it drags in IndexedDB, the engine, and the DOM),
+// mirroring languageFallback.ts. Keep it free of browser/engine deps so
+// tests/unit/appVersionCompat.test.ts can exercise it directly.
+//
+// IMPORTANT distinction: this is the **app** version (package.json `version`,
+// e.g. "1.0.0", surfaced via buildInfo.version) — NOT the export **schema**
+// version (`partwright: "1.15"`, handled by parseSchemaVersion in
+// sessionManager). The two axes move independently.
+//
+// MIGRATION SEAM: when the first breaking major ships, the forward-migration
+// codemod hooks in at appVersionCompatibility() below — see the `older` branch.
+
+import { buildInfo } from '../buildInfo';
+
+/** The structural slice of an exported session this module reads. Defined
+ *  locally (not imported from sessionManager) so the dependency graph stays
+ *  acyclic — sessionManager imports us, never the reverse. */
+export interface AppVersionedExport {
+  /** App semver the file was exported with (top-level, schema 1.15+). */
+  appVersion?: string;
+  /** Per-version app-version stamps; used as a fallback provenance source. */
+  versions?: { appVersion?: string }[];
+}
+
+/** Parse the major component of a semver-ish string, or null if unusable
+ *  (empty, 'unknown', non-numeric). */
+export function parseAppMajor(version: string | null | undefined): number | null {
+  if (!version || version === 'unknown') return null;
+  const major = parseInt(String(version).split('.')[0], 10);
+  return Number.isFinite(major) ? major : null;
+}
+
+/** Compare two semver-ish strings. Returns >0 if a is newer, <0 if older, 0 if
+ *  equal/incomparable. Missing components count as 0 (so "1.2" === "1.2.0"). */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(n => parseInt(n, 10) || 0);
+  const pb = b.split('.').map(n => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
+/** The app (semver) version recorded on an exported file, or null if it
+ *  predates app-version stamping (schema < 1.15). Top-level wins; falls back to
+ *  the newest per-version stamp so a hand-assembled or partial file still
+ *  yields a sensible "authored with" value. */
+export function exportedAppVersion(data: AppVersionedExport): string | null {
+  if (typeof data.appVersion === 'string' && data.appVersion && data.appVersion !== 'unknown') {
+    return data.appVersion;
+  }
+  let newest: string | null = null;
+  for (const v of data.versions ?? []) {
+    const ver = v?.appVersion;
+    if (typeof ver !== 'string' || !ver || ver === 'unknown') continue;
+    if (newest === null || compareSemver(ver, newest) > 0) newest = ver;
+  }
+  return newest;
+}
+
+export interface AppVersionCompatibility {
+  /** How the file's authoring major relates to the running build. 'unknown'
+   *  when the file predates stamping or either version is unparseable. */
+  relation: 'same' | 'newer' | 'older' | 'unknown';
+  /** App semver recorded on the file, if any. */
+  fileVersion: string | null;
+  /** The running build's app semver. */
+  runningVersion: string;
+  /** A user-facing warning, or null when none is warranted. Only the 'newer'
+   *  case warns today (forward-incompatible); 'older' is silent — it's where a
+   *  future major will run its migration codemod instead. */
+  warning: string | null;
+}
+
+/**
+ * Classify an exported file's authoring app version against the running build.
+ *
+ * - **newer major** ⇒ warn (the file may use capabilities/schema this build
+ *   doesn't understand; best-effort import, unknown fields dropped).
+ * - **older major** ⇒ silent today. THIS IS THE MIGRATION SEAM: when v2 ships,
+ *   branch here to run the forward codemod on `data` before it's imported.
+ * - **same major / no stamp / unparseable** ⇒ silent.
+ *
+ * `runningVersion` defaults to the build's version but is injectable for tests.
+ */
+export function appVersionCompatibility(
+  data: AppVersionedExport,
+  runningVersion: string = buildInfo.version,
+): AppVersionCompatibility {
+  const fileVersion = exportedAppVersion(data);
+  const fileMajor = parseAppMajor(fileVersion);
+  const runningMajor = parseAppMajor(runningVersion);
+
+  if (fileMajor === null || runningMajor === null) {
+    return { relation: 'unknown', fileVersion, runningVersion, warning: null };
+  }
+  if (fileMajor > runningMajor) {
+    return {
+      relation: 'newer',
+      fileVersion,
+      runningVersion,
+      warning:
+        `This file was created with a newer major version of Partwright ` +
+        `(v${fileVersion}). You're on v${runningVersion}; some data may be ` +
+        `missing or import incorrectly.`,
+    };
+  }
+  if (fileMajor < runningMajor) {
+    return { relation: 'older', fileVersion, runningVersion, warning: null };
+  }
+  return { relation: 'same', fileVersion, runningVersion, warning: null };
+}

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -149,6 +149,12 @@ export interface Version {
   /** The operation that produced this version. Set alongside
    *  {@link parentVersionId} when the version is derived from another. */
   operation?: VersionOperation | null;
+  /** App semver (package.json `version`, from `buildInfo.version`) that authored
+   *  this version — the "last known good" app version for this snapshot. Stamped
+   *  at save time. Absent on versions saved before this field existed, and in
+   *  dev/test builds where the version resolves to 'unknown' (we store nothing
+   *  rather than the placeholder). Read by the cross-major migration seam. */
+  appVersion?: string;
 }
 
 /** Editor working buffer scoped to (session, part, language). One slot per
@@ -790,6 +796,10 @@ export interface SaveVersionOptions {
   operation?: VersionOperation | null;
   /** Computed `api.surface.*` texture (key + mesh) — see {@link Version.surfaceTexture}. */
   surfaceTexture?: unknown;
+  /** App semver that authored this version — see {@link Version.appVersion}.
+   *  Caller passes `buildInfo.version` (omit/undefined in dev where it's
+   *  'unknown'); the db layer just stores it opaquely. */
+  appVersion?: string;
 }
 
 export async function saveVersion(
@@ -812,6 +822,7 @@ export async function saveVersion(
     parentVersionId,
     operation,
     surfaceTexture,
+    appVersion,
   } = options ?? {};
   // Compute the next index and write the version inside ONE readwrite
   // transaction. IndexedDB serializes overlapping readwrite transactions on
@@ -853,6 +864,7 @@ export async function saveVersion(
         ...(parentVersionId ? { parentVersionId } : {}),
         ...(operation ? { operation } : {}),
         ...(surfaceTexture ? { surfaceTexture } : {}),
+        ...(appVersion ? { appVersion } : {}),
       };
       const putReq = store.put(v);
       putReq.onsuccess = () => resolve(v);

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -62,6 +62,8 @@ import type { PersistedSurfaceTexture } from '../surface/surfaceOpSpec';
 import { setCompanionFiles, companionFilesEqual } from '../import/companionFiles';
 import { getActiveLanguage } from '../geometry/engine';
 import { effectiveVersionLanguage, asLanguage } from './languageFallback';
+import { buildInfo } from '../buildInfo';
+import { appVersionCompatibility } from './appVersionCompat';
 
 /**
  * Current schema version for `.partwright.json` exports.
@@ -155,10 +157,24 @@ import { effectiveVersionLanguage, asLanguage } from './languageFallback';
  *           texture's appearance is pinned at save time. Self-validating via
  *           the key (a stale key just recomputes); absent ⇒ recompute on
  *           demand. Older readers ignore the field.
+ *  - `1.15` — app-version provenance. Records the Partwright **app** semver
+ *           (package.json `version`, e.g. "1.0.0") that authored the file: a
+ *           top-level `appVersion` (the exporting build) and per-version
+ *           `versions[].appVersion` (the build that saved each snapshot — its
+ *           "last known good" version). This is a *different axis* from this
+ *           schema number; it's the signal the cross-major migration flow keys
+ *           off (see appVersionCompat.ts). Absent on pre-1.15 files and on
+ *           dev/test builds (version 'unknown'); older readers ignore it.
  */
-export const SCHEMA_VERSION = '1.14';
+export const SCHEMA_VERSION = '1.15';
 
 const CURRENT_MAJOR = 1;
+
+/** The running build's app semver (package.json `version`). 'unknown' in
+ *  dev/test, where we stamp nothing rather than persist the placeholder. */
+const APP_VERSION = buildInfo.version;
+const stampedAppVersion: string | undefined =
+  APP_VERSION && APP_VERSION !== 'unknown' ? APP_VERSION : undefined;
 
 /** Name given to the implicit first part of every session. */
 const DEFAULT_PART_NAME = 'Part 1';
@@ -176,6 +192,15 @@ export interface ExportedSession {
   partwright?: string;
   /** Legacy alias from the pre-rebrand era. Read as a fallback only. */
   mainifold?: string;
+  /**
+   * The Partwright **app** semver (package.json `version`, e.g. "1.0.0") of the
+   * build that exported this file — distinct from the `partwright` schema
+   * version above. The file-level "authored with" signal the cross-major
+   * migration flow reads (see {@link appVersionCompatibility}). Absent on
+   * pre-1.15 files and dev/test builds.
+   * @since 1.15
+   */
+  appVersion?: string;
   /** Images may be the array form or the legacy object map ({front, right, ...}).
    * Both also exist under `referenceImages` for pre-rename exports. */
   session: { name: string; created: number; updated: number; images?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; referenceImages?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; language?: 'manifold-js' | 'scad' | 'replicad' | 'voxel'; thumbCamera?: { azimuth: number; elevation: number }; workCamera?: { position: [number, number, number]; target: [number, number, number] } };
@@ -256,6 +281,15 @@ export interface ExportedSession {
      * @since 1.14
      */
     surfaceTexture?: ExportedSurfaceTexture;
+    /**
+     * App semver (package.json `version`) of the build that saved this version —
+     * its "last known good" app version. Absent on versions saved before this
+     * field existed and on dev/test builds. Preserved verbatim on import (the
+     * provenance follows the geometry; it is NOT re-stamped to the importing
+     * build).
+     * @since 1.15
+     */
+    appVersion?: string;
   }[];
   notes?: { text: string; timestamp: number }[];
   /**
@@ -1135,6 +1169,9 @@ export async function saveVersion(
       parentVersionId: options?.parentVersionId ?? null,
       operation: options?.operation ?? null,
       surfaceTexture: options?.surfaceTexture,
+      // Stamp the app version that authored this snapshot — its "last known
+      // good" version (undefined in dev where it's 'unknown').
+      appVersion: stampedAppVersion,
     }
   );
 
@@ -1757,6 +1794,7 @@ export async function exportSession(
 
   return {
     partwright: SCHEMA_VERSION,
+    ...(stampedAppVersion ? { appVersion: stampedAppVersion } : {}),
     session: { name: session.name, created: session.created, updated: session.updated, images: session.images ?? null, ...(session.language ? { language: session.language } : {}), ...(session.thumbCamera ? { thumbCamera: session.thumbCamera } : {}), ...(session.workCamera ? { workCamera: session.workCamera } : {}) },
     parts: parts.map(p => ({ name: p.name, order: p.order })),
     versions: flat.map(({ v, partOrder }, i) => {
@@ -1782,6 +1820,7 @@ export async function exportSession(
         ...(surfaceTexture ? { surfaceTexture } : {}),
         ...(v.paramValues && Object.keys(v.paramValues).length > 0 ? { paramValues: v.paramValues } : {}),
         ...(v.companionFiles && Object.keys(v.companionFiles).length > 0 ? { companionFiles: v.companionFiles } : {}),
+        ...(v.appVersion ? { appVersion: v.appVersion } : {}),
       };
     }),
     ...(notes.length > 0 ? { notes: notes.map(n => ({ text: n.text, timestamp: n.timestamp })) } : {}),
@@ -1799,6 +1838,11 @@ export async function importSession(
 ): Promise<Session> {
   const warning = getSchemaCompatibilityWarning(data);
   if (warning && onWarning) onWarning(warning);
+  // App-version provenance check — distinct axis from the schema warning above.
+  // Newer-major files warn; older-major is silent and is where a future major
+  // will hook its forward-migration codemod (see appVersionCompat.ts).
+  const appCompat = appVersionCompatibility(data);
+  if (appCompat.warning && onWarning) onWarning(appCompat.warning);
 
   // Validate before creating anything: a file with no `versions` array would
   // otherwise throw partway through (data.versions.reduce/for-of) and strand an
@@ -1945,6 +1989,10 @@ export async function importSession(
           // Persisted surface texture (schema 1.14+). Pre-1.14 files omit it;
           // the texture chain then recomputes on the version's first load.
           surfaceTexture: deserializeSurfaceTexture(v.surfaceTexture),
+          // App-version provenance (schema 1.15+). Preserved verbatim — the
+          // "last known good" version follows the geometry, so it is NOT
+          // re-stamped to the importing build.
+          appVersion: typeof v.appVersion === 'string' ? v.appVersion : undefined,
         }
       );
     }
@@ -2132,6 +2180,8 @@ export async function importSessionPartsIntoActive(
           operation: null,
           // Persisted surface texture (schema 1.14+); absent ⇒ recompute on load.
           surfaceTexture: deserializeSurfaceTexture(v.surfaceTexture),
+          // App-version provenance (schema 1.15+) — preserved, not re-stamped.
+          appVersion: typeof v.appVersion === 'string' ? v.appVersion : undefined,
         }
       );
       copiedVersions++;

--- a/tests/chat-export.spec.ts
+++ b/tests/chat-export.spec.ts
@@ -103,10 +103,13 @@ test.describe('Chat export', () => {
       const w = window as unknown as { partwright: { exportSessionData: (id: string) => Promise<{ data: unknown }> } };
       return (await w.partwright.exportSessionData(sid)).data as {
         partwright: string;
+        appVersion?: string;
         chat?: { id?: string; sessionId?: string; blocks: { type: string; text?: string }[] }[];
       };
     }, id);
-    expect(exported.partwright).toBe('1.14'); // tracks SCHEMA_VERSION (bumped to 1.14 for surfaceTexture)
+    expect(exported.partwright).toBe('1.15'); // tracks SCHEMA_VERSION (bumped to 1.15 for appVersion provenance)
+    // App-version provenance (schema 1.15): the dev build stamps package.json's semver.
+    expect(exported.appVersion).toMatch(/^\d+\.\d+\.\d+$/);
     expect(exported.chat?.length).toBe(3);
     expect(exported.chat?.[0].blocks[0].text).toBe('Design a widget bracket');
     expect(exported.chat?.[0].id).toBeUndefined();

--- a/tests/unit/appVersionCompat.test.ts
+++ b/tests/unit/appVersionCompat.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseAppMajor,
+  exportedAppVersion,
+  appVersionCompatibility,
+} from '../../src/storage/appVersionCompat';
+
+describe('parseAppMajor', () => {
+  it('reads the major component', () => {
+    expect(parseAppMajor('1.0.0')).toBe(1);
+    expect(parseAppMajor('2.5.9')).toBe(2);
+    expect(parseAppMajor('10.0.0')).toBe(10);
+    expect(parseAppMajor('3')).toBe(3);
+  });
+  it('returns null for unusable values', () => {
+    expect(parseAppMajor(undefined)).toBeNull();
+    expect(parseAppMajor(null)).toBeNull();
+    expect(parseAppMajor('')).toBeNull();
+    expect(parseAppMajor('unknown')).toBeNull();
+    expect(parseAppMajor('vX')).toBeNull();
+  });
+});
+
+describe('exportedAppVersion', () => {
+  it('prefers the top-level appVersion', () => {
+    expect(exportedAppVersion({ appVersion: '1.2.3', versions: [{ appVersion: '1.0.0' }] }))
+      .toBe('1.2.3');
+  });
+  it('falls back to the newest per-version stamp', () => {
+    expect(exportedAppVersion({ versions: [{ appVersion: '1.1.0' }, { appVersion: '1.4.2' }, { appVersion: '1.2.0' }] }))
+      .toBe('1.4.2');
+  });
+  it('ignores unknown/empty stamps', () => {
+    expect(exportedAppVersion({ appVersion: 'unknown', versions: [{ appVersion: 'unknown' }] }))
+      .toBeNull();
+    expect(exportedAppVersion({ versions: [{ appVersion: '' }, { appVersion: '2.0.0' }] }))
+      .toBe('2.0.0');
+  });
+  it('returns null when nothing is stamped (pre-1.15 file)', () => {
+    expect(exportedAppVersion({})).toBeNull();
+    expect(exportedAppVersion({ versions: [{}, {}] })).toBeNull();
+  });
+});
+
+describe('appVersionCompatibility', () => {
+  it('warns when the file is from a newer major', () => {
+    const r = appVersionCompatibility({ appVersion: '2.0.0' }, '1.4.0');
+    expect(r.relation).toBe('newer');
+    expect(r.fileVersion).toBe('2.0.0');
+    expect(r.warning).toMatch(/newer major/i);
+  });
+  it('is silent for an older major (the migration seam)', () => {
+    const r = appVersionCompatibility({ appVersion: '1.9.0' }, '2.1.0');
+    expect(r.relation).toBe('older');
+    expect(r.warning).toBeNull();
+  });
+  it('is silent within the same major', () => {
+    const r = appVersionCompatibility({ appVersion: '1.0.0' }, '1.5.2');
+    expect(r.relation).toBe('same');
+    expect(r.warning).toBeNull();
+  });
+  it('is silent/unknown when the file has no stamp', () => {
+    const r = appVersionCompatibility({}, '1.0.0');
+    expect(r.relation).toBe('unknown');
+    expect(r.warning).toBeNull();
+  });
+  it('is silent/unknown when the running version is unparseable', () => {
+    const r = appVersionCompatibility({ appVersion: '2.0.0' }, 'unknown');
+    expect(r.relation).toBe('unknown');
+    expect(r.warning).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 2 of the versioned-deployment strategy** (follows #651, which made `package.json` the version source of truth). Stamps the Partwright **app semver** that authored each saved version and exported file — the "last known good" version — and wires the read-side seam where a future major will hook cross-version migration. The goal: be ready for the first breaking change before it happens.

- **`Version.appVersion`** (per-snapshot, in IndexedDB) — the build that saved each version, stamped at save time from `buildInfo.version`.
- **`ExportedSession` `appVersion`** — both a top-level field (the exporting build, the file-level migration signal) and per-version stamps. Export schema bumped **1.14 → 1.15** (additive, back-compatible — old readers ignore it). On import the per-version stamp is **preserved verbatim**, not re-stamped, so provenance follows the geometry.
- **New `src/storage/appVersionCompat.ts`** — pure, dependency-free, unit-tested module (mirrors the `languageFallback.ts` precedent so it's importable under the node unit tier, which `sessionManager.ts` is not). Holds `exportedAppVersion()`, `parseAppMajor()`, and `appVersionCompatibility()`. Defines a local structural type instead of importing `ExportedSession`, keeping the dependency graph acyclic (`lint:deps` confirms).
- **The migration seam is explicit.** `appVersionCompatibility()` classifies a file's authoring major vs the running build: **newer-major warns** (forward-incompatible), same/unknown is silent, and **older-major is the documented hook point** — when v2 ships, its forward codemod runs in that branch. Wired into `importSession` alongside the existing schema-version warning.

### Why a separate field, not the schema number
`SCHEMA_VERSION` (the `partwright: "1.x"` file-format number) and the app semver (`"1.0.0"`) are **independent axes**. A schema bump ≠ an app major. So app-version provenance is its own field.

### Notes
- **No IndexedDB version bump** — the store tolerates extra record fields, so old versions simply lack `appVersion`.
- **Dev/test builds stamp nothing** (when `buildInfo.version` is `'unknown'`, we store `undefined` rather than the placeholder).
- **No UI/API-parity gap** — this is automatic provenance, not a new affordance; the compat warning surfaces via the existing import-warning path.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 1364 pass (incl. 11 new `appVersionCompat` cases)
- [x] `npm run lint:deps` — graph still acyclic
- [x] `npm run build` — clean
- [x] `chat-export` e2e green with a new top-level `appVersion` round-trip assertion
- [x] Manual browser probe: `runAndSave` → export stamps both top-level and per-version `appVersion` as `1.0.0` (throwaway spec, deleted)
- [ ] PR-checks shards (build + unit + 3 e2e) green on the draft

https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6

---
_Generated by [Claude Code](https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6)_