### PR TITLE
chore: add issue-hygiene norm + Stop-hook reconciliation nudge

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "input=$(cat); [ \"$(printf '%s' \"$input\" | jq -r '.stop_hook_active // false')\" = \"true\" ] && exit 0; [ -z \"$(git status --porcelain 2>/dev/null)\" ] && exit 0; jq -nc '{decision:\"block\",reason:\"This session changed files. If you finished a meaningful task and have not already, consider running /retro to capture a short 4-Ls reflection in retros/inbox/ for the weekly facilitator. If nothing was notable or you already did, reply in one line and end your turn.\"}'",
+            "command": "input=$(cat); [ \"$(printf '%s' \"$input\" | jq -r '.stop_hook_active // false')\" = \"true\" ] && exit 0; [ -z \"$(git status --porcelain 2>/dev/null)\" ] && exit 0; jq -nc '{decision:\"block\",reason:\"This session changed files. Before ending, reconcile GitHub issues so nothing is lost: if you finished or merged work, confirm the source issue is closed-as-complete or has tracked follow-ups for anything deferred, and file a GitHub issue for any defect or gap you discovered while implementing (do not leave it only in chat). Separately, if the task was meaningful, consider running /retro for a short 4-Ls note in retros/inbox/. If none of this applies or you have already handled it, reply in one line and end your turn.\"}'",
             "statusMessage": "Checking for retro-worthy work…"
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,6 +464,16 @@ The module graph is **cycle-free** and CI gates on it (`lint:deps`). To keep it 
 
 When you add a feature that would otherwise import "sideways" or "down into" a lower layer, reach for one of these leaf patterns rather than adding the back-edge. Run `npm run lint:deps` before pushing.
 
+### Issue hygiene — don't lose work or discoveries at a boundary
+
+GitHub issues are the durable memory; a chat session is not. Insights, defects, and half-finished scope that live only in chat replies vanish when the session ends. You do **not** need to open an issue before starting ad-hoc work (that friction would kill the fast chat-driven flow) — but you **must reconcile issues at every completion boundary** (a PR opened/merged, or a task declared done). Before you say "done":
+
+1. **Discoveries get filed.** Any defect, gap, or "we should also…" you find *while implementing* — something out of scope for the current change — becomes a GitHub issue **before you move on**, not just a sentence in chat. (Example: the carved-mouth-at-small-head defect found while adding figures → filed as its own bug.)
+2. **Partial implementation never closes silently.** If a PR merges but doesn't fully satisfy its originating issue, that issue stays **open** with a checklist of what's left — or you file an explicit follow-up issue. Only close a source issue when **every** acceptance criterion is actually met; a merged PR is not automatically a completed issue.
+3. **Close-out reconciliation.** When you finish a task (and again after a merge), state in chat: *did this fully satisfy the source issue? what was deferred, and where is it tracked? what did I discover, and did I file it?* Resolve each — done, or tracked in an issue — before ending the turn.
+
+This is boundary hygiene, not bureaucracy: the test is "could the next session pick up everything important without reading this chat?" The `Stop` hook nudges you toward this reconciliation when the tree has changed; the call on *what* warrants an issue is yours, but "nothing tracked it" is the failure mode to avoid.
+
 ### Retros — continuous improvement loop
 
 This repo runs a lightweight self-improving loop so agents make the *next* agent faster and more reliable. See `retros/README.md` for the full picture.

--- a/prompts/agent-issue-hygiene-norm.md
+++ b/prompts/agent-issue-hygiene-norm.md
@@ -1,0 +1,38 @@
+---
+date: 2026-06-14
+branch: claude/vibrant-hopper-j3xpuf
+files_changed:
+  - CLAUDE.md
+  - .claude/settings.json
+---
+
+## Human
+
+Worried that valuable work and discoveries made ad-hoc in a chat session get
+lost — wanted the harness to ensure (a) discoveries become tracked issues and
+(b) a merged PR can't quietly leave its source issue partially implemented.
+Asked whether/how to update the agent instructions. Chose, via AskUserQuestion:
+"boundary hygiene" scope (not issue-first-for-everything) + "instruction +
+Stop-hook nudge" enforcement.
+
+## Assistant
+
+Pushed back on the literal "an issue before all work" framing — that friction
+would kill the fast chat-driven flow and train everyone to route around it. The
+real goal is "no work or discovery lost at a boundary," so I encoded boundary
+hygiene rather than issue-first.
+
+- **CLAUDE.md** — new "Issue hygiene" section (before Retros): you need NO issue
+  to start ad-hoc work, but at every completion boundary (PR opened/merged, task
+  done) you must (1) file discoveries as issues before moving on, (2) never let a
+  partial implementation close its source issue silently — keep it open with a
+  remaining-work checklist or file a follow-up, (3) do an explicit close-out
+  reconciliation in chat (source issue done? deferred → tracked? discovered →
+  filed?). The test: "could the next session pick up everything important
+  without reading this chat?"
+- **Enforcement** — folded the reconciliation reminder into the EXISTING retro
+  `Stop` hook reason (one nudge at the dirty-tree boundary) rather than adding a
+  second always-on Stop hook (avoids Stop-noise). Honest limit, noted to the
+  user: a hook can't semantically verify "issue fully implemented" — it can only
+  nudge; the instruction + work-reviewer carry the judgment. Verified the hook
+  still emits on a dirty tree and exits silently when `stop_hook_active`.


### PR DESCRIPTION
## Summary

Codifies **issue hygiene at completion boundaries** so work and discoveries made ad-hoc in a chat session aren't lost when the session ends.

Deliberately **not** "an issue before all work" — that friction would kill the fast chat-driven flow. Instead, the norm fires at boundaries (a PR opened/merged, or a task declared done):

- **`CLAUDE.md`** — new **"Issue hygiene"** section:
  1. **Discoveries get filed** — a defect/gap found *while implementing* becomes a GitHub issue before moving on, not just a chat sentence.
  2. **Partial implementation never closes silently** — a merged PR doesn't auto-complete its source issue; keep it open with a remaining-work checklist, or file a follow-up. Close only when every acceptance criterion is met.
  3. **Close-out reconciliation** — when finishing (and after a merge), state in chat: source issue fully done? deferred → tracked where? discovered → filed? Resolve each before ending.
- **`.claude/settings.json`** — folds the reconciliation reminder into the **existing retro `Stop` hook** (one nudge at the dirty-tree boundary) rather than adding a second always-on Stop hook, to avoid Stop-noise.

## Honest limit

A `Stop` hook can't *semantically* verify "the issue was fully implemented" — that's a judgment call. The hook nudges; the instruction + the `work-reviewer` carry the judgment. This catches the *forgetting*, which is most of the value.

## Background

Came out of a retro-style discussion: a long figure-building session produced several valuable discoveries (a mouth-meshing defect, a `faceDetail`-centering gotcha, a deferred eyelid re-bake) that lived only in chat — only one became a tracked issue (#652). This norm makes that capture the default.

## Test plan

- [x] `settings.json` is valid JSON
- [x] Dry-ran the Stop hook: emits the combined reconciliation + retro reminder on a dirty tree, exits silently when `stop_hook_active`
- [x] Docs/process-only change — no app code touched

`chore:` / process change — suggest `ignore-for-release`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0119fZHRH6pNRdw5emnsETbw)_