### PR TITLE
feat: base-aware deployment foundation + asset paths

### DIFF
--- a/prompts/versioned-deploy-base-aware-foundation.md
+++ b/prompts/versioned-deploy-base-aware-foundation.md
@@ -62,3 +62,12 @@ cases covering the `/v2/` parsing + a joinBase/routeFromPath round-trip);
 `lint:deps` acyclic; `npm run build` clean; and a browser snapshot of /catalog
 confirmed the manifest still loads (tiles + language counts render) — i.e. the
 conversion is a true no-op at base `/`.
+
+Follow-up after a work-reviewer pass: it caught three MISSED per-entry catalog
+payload fetches (`/catalog/${file}`) — the manifest fetch beside each was
+converted but the entry-payload fetch was not, so catalog tile clicks /
+thumbnails / `?catalog=` deep-links would 404 under a real `/vN/` mount (a gap
+the base-`/` no-op checks can't surface). Routed all three through `assetPath()`
+(`src/ui/catalog.ts`, `src/landing/landingEntry.ts`, and the deep-link loader in
+`src/main.ts`, which also gained the import). Swept for any other root-absolute
+public-asset fetches — none remain.

--- a/prompts/versioned-deploy-base-aware-foundation.md
+++ b/prompts/versioned-deploy-base-aware-foundation.md
@@ -1,0 +1,64 @@
+---
+date: 2026-06-14
+branch: claude/versioned-deploy-base-aware
+files_changed:
+  - src/deployment.ts
+  - tests/unit/deployment.test.ts
+  - src/ai/systemPrompt.ts
+  - src/ai/tools.ts
+  - src/ui/catalog.ts
+  - src/landing/landingEntry.ts
+  - src/geometry/bosl2Loader.ts
+  - src/geometry/fontsLoader.ts
+  - src/geometry/textGlyphs.ts
+---
+
+## Human
+
+"start phase 3" of the versioned-deployment strategy — path-mounting each major
+under its own base (`/v1/`, `/v2/`) on one origin, base-aware routing, SEO, and
+cross-tab storage scoping. (Follows Phase 1 release tagging #651 and Phase 2
+app-version provenance #653.)
+
+## Assistant
+
+Phase 3 is large and architecturally significant, so I mapped every touch-point
+first (via the explore agent) and sliced it into reviewable PRs rather than one
+risky diff. The map's decisive finding: NOTHING in the app read
+`import.meta.env.BASE_URL` — every path was a literal or built from
+`location.origin` — so changing vite `base` alone fixes nothing. ~50 route sites
++ ~30 localStorage keys would need to become base-aware/version-scoped.
+
+This PR is **slice 1 of 5: the base-aware foundation**, deliberately scoped to
+be a **no-op at the current `/` mount** so it's safe and verifiable:
+
+- **New `src/deployment.ts`** — the single source of truth for the deployment
+  base and the major it serves. Pure, dependency-free helpers (`normalizeBase`,
+  `majorFromBase`, `joinBase`, `routeFromPath`) take the base explicitly so
+  they're unit-testable without stubbing `import.meta.env`; thin wrappers
+  (`BASE`, `currentMajor`, `appPath`, `appRoute`, `assetPath`) bind the build's
+  actual base. At base `/` every helper is the identity.
+- **Converted the asset `fetch()` paths** that would 404 under `/vN/`:
+  `ai.md`, `ai/<subdoc>.md`, the catalog manifest (two call sites), and the
+  OpenSCAD BOSL2 + fonts prefixes — all routed through `assetPath()`. These
+  fetch from `public/`, which vite serves under the base, so they must follow it.
+- Kept `src/deployment.ts` dependency-free specifically so `landingEntry.ts`
+  (which documents a "tiny import graph only" rule) can use it.
+
+Deliberately deferred to later slices (documented in
+.plans/versioned-deployments-design.md): PR2 runtime route layer (main.ts
+predicates+writers, updateURL, switchTab, entry/route-init); PR3
+SEO/content-prerender/HTML/redirects; PR4 root launcher + actually mounting at
+`/v1/`; PR5 (v2-time) storage share-vs-isolate decisions + DB-by-major +
+migration. Storage-key scoping was pulled out of this PR on purpose — the map
+showed session-scoped keys use per-DB UUIDs (no real cross-major collision) and
+some prefs (theme) are arguably desirable to share, so it needs per-key judgment
+best made when v2 is concrete, not a blind namespacing now. No vite `base`
+change here either: `import.meta.env.BASE_URL` is already '/', and when a later
+PR sets the base these fetches become base-aware automatically.
+
+Verified: typecheck clean; full unit tier 1373 pass (incl. 9 new `deployment`
+cases covering the `/v2/` parsing + a joinBase/routeFromPath round-trip);
+`lint:deps` acyclic; `npm run build` clean; and a browser snapshot of /catalog
+confirmed the manifest still loads (tiles + language counts render) — i.e. the
+conversion is a true no-op at base `/`.

--- a/src/ai/systemPrompt.ts
+++ b/src/ai/systemPrompt.ts
@@ -7,6 +7,7 @@
 import { MAX_ITERATIONS, MAX_SPEND, activeModel, type ChatToggles } from './types';
 import type { Language } from '../geometry/engines/types';
 import { loadQualitySettings, getDefaultCircularSegments, QUALITY_OPTIONS } from '../geometry/qualitySettings';
+import { assetPath } from '../deployment';
 
 let aiMdCache: string | null = null;
 let aiMdPromise: Promise<string> | null = null;
@@ -106,7 +107,7 @@ Current Partwright API surface and conventions follow.
 export function loadAiMd(): Promise<string> {
   if (aiMdCache !== null) return Promise.resolve(aiMdCache);
   if (aiMdPromise) return aiMdPromise;
-  aiMdPromise = fetch('/ai.md')
+  aiMdPromise = fetch(assetPath('/ai.md'))
     .then(r => {
       if (!r.ok) throw new Error(`/ai.md HTTP ${r.status}`);
       return r.text();

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -18,6 +18,7 @@ import type { ChatToggles } from './types';
 import type { Language } from '../geometry/engines/types';
 import { RENDER_VIEW_MODES, EDGE_MODES } from '../renderer/multiview';
 import { getRenderBudget } from './settings';
+import { assetPath } from '../deployment';
 import { applyLiteralPatch, applyPatches } from './patch';
 
 export interface ToolDefinition {
@@ -1584,7 +1585,7 @@ async function readSubdoc(name: string): Promise<{ content: string; isError: boo
     return { content: `Unknown subdoc "${name}". Valid names: ${Array.from(SUBDOC_NAMES).join(', ')}.`, isError: true };
   }
   try {
-    const res = await fetch(`/ai/${name}.md`, { cache: 'force-cache' });
+    const res = await fetch(assetPath(`/ai/${name}.md`), { cache: 'force-cache' });
     if (!res.ok) return { content: `Failed to fetch /ai/${name}.md: ${res.status} ${res.statusText}`, isError: true };
     const text = await res.text();
     return { content: text, isError: false };

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -1,0 +1,88 @@
+// Single source of truth for *where this build is mounted* — the deployment
+// base path and the major version it serves. The versioned-deployment strategy
+// (see .plans/versioned-deployments-design.md) will eventually serve each major
+// under its own path base (`/v1/`, `/v2/`, …) on one origin, with the site root
+// a launcher. Today the app is mounted at `/` (major 1, unprefixed).
+//
+// Vite injects the build-time base as `import.meta.env.BASE_URL` (from the
+// `base` config). NOTHING in the app read it before — every path was a literal
+// or built from `location.origin` — so changing `base` alone fixed nothing.
+// This module is the seam that makes paths base-aware. At base `/` every helper
+// is the identity (a true no-op), so wiring it in changes no current behavior.
+//
+// The pure functions take the base explicitly so they're unit-testable without
+// stubbing import.meta.env; the exported convenience wrappers bind the build's
+// actual base.
+
+/** Normalize a raw base to always have a single leading and trailing slash:
+ *  '' → '/', '/v2' → '/v2/', '/v2/' → '/v2/'. */
+export function normalizeBase(raw: string | undefined | null): string {
+  let b = (raw ?? '/').trim();
+  if (b === '') b = '/';
+  if (!b.startsWith('/')) b = '/' + b;
+  if (!b.endsWith('/')) b = b + '/';
+  return b;
+}
+
+/** The major version a base path serves: `/v2/` → 2, `/` (or any non-versioned
+ *  base) → 1. The unversioned root deploy is, by definition, major 1. */
+export function majorFromBase(base: string): number {
+  const m = normalizeBase(base).match(/^\/v(\d+)\//);
+  return m ? parseInt(m[1], 10) : 1;
+}
+
+/** Join an app-relative route or asset path onto a base. The route may be given
+ *  with or without a leading slash; '/' maps to the base itself.
+ *    joinBase('/',   '/editor') → '/editor'
+ *    joinBase('/v2/', '/editor') → '/v2/editor'
+ *    joinBase('/v2/', '/')       → '/v2/' */
+export function joinBase(base: string, route: string): string {
+  const b = normalizeBase(base);
+  const r = route.startsWith('/') ? route.slice(1) : route;
+  return b + r; // b already ends with '/'
+}
+
+/** Strip the base off a `location.pathname` to get the app-relative route
+ *  (always leading-slash). The base itself maps to '/'. A path outside the base
+ *  is returned unchanged (defensive — shouldn't happen in practice).
+ *    routeFromPath('/',    '/editor')    → '/editor'
+ *    routeFromPath('/v2/', '/v2/editor') → '/editor'
+ *    routeFromPath('/v2/', '/v2/')       → '/'
+ *    routeFromPath('/v2/', '/v2')        → '/' */
+export function routeFromPath(base: string, pathname: string): string {
+  const b = normalizeBase(base);
+  if (b === '/') return pathname === '' ? '/' : pathname;
+  const bNoSlash = b.slice(0, -1); // '/v2'
+  if (pathname === b || pathname === bNoSlash) return '/';
+  if (pathname.startsWith(b)) return '/' + pathname.slice(b.length);
+  return pathname;
+}
+
+/** The build's normalized base path ('/', '/v2/', …). */
+export const BASE: string = normalizeBase(
+  typeof import.meta !== 'undefined' ? import.meta.env?.BASE_URL : '/',
+);
+
+/** The major version this build serves (1 for the unversioned root deploy). */
+export function currentMajor(): number {
+  return majorFromBase(BASE);
+}
+
+/** An app route resolved to a full path under this build's base. Use when
+ *  writing history entries / building links. '/editor' → BASE+'editor'. */
+export function appPath(route: string): string {
+  return joinBase(BASE, route);
+}
+
+/** The app-relative route for a `location.pathname` under this build's base.
+ *  Use in route predicates instead of comparing pathname to a literal. */
+export function appRoute(pathname: string): string {
+  return routeFromPath(BASE, pathname);
+}
+
+/** The URL for a public/ asset under this build's base. Use for `fetch()` of
+ *  static files (ai.md, catalog manifest, OpenSCAD libs, fonts) so they resolve
+ *  under `/vN/` instead of the origin root. '/ai.md' → BASE+'ai.md'. */
+export function assetPath(path: string): string {
+  return joinBase(BASE, path);
+}

--- a/src/geometry/bosl2Loader.ts
+++ b/src/geometry/bosl2Loader.ts
@@ -16,11 +16,13 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { assetPath } from '../deployment';
+
 interface Bosl2Manifest {
   files: string[];
 }
 
-const BOSL2_PREFIX = '/openscad-libs/BOSL2';
+const BOSL2_PREFIX = assetPath('/openscad-libs/BOSL2');
 const MEMFS_DIR = '/BOSL2';
 
 let manifestPromise: Promise<Bosl2Manifest> | null = null;

--- a/src/geometry/fontsLoader.ts
+++ b/src/geometry/fontsLoader.ts
@@ -15,7 +15,9 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-const FONTS_PREFIX = '/openscad-libs/fonts';
+import { assetPath } from '../deployment';
+
+const FONTS_PREFIX = assetPath('/openscad-libs/fonts');
 const FONT_MEMFS_DIR = '/usr/share/fonts';
 const FONTCONFIG_FILE_PATH = '/etc/fonts/fonts.conf';
 const FONTS_CONF_XML = `<?xml version="1.0"?>

--- a/src/geometry/textGlyphs.ts
+++ b/src/geometry/textGlyphs.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Font } from 'opentype.js';
+import { assetPath } from '../deployment';
 
 type Vec2 = [number, number];
 
@@ -22,7 +23,7 @@ const FONT_FILES: Record<FontVariant, string> = {
   italic: 'LiberationSans-Italic.ttf',
   'bold-italic': 'LiberationSans-BoldItalic.ttf',
 };
-const FONTS_PREFIX = '/openscad-libs/fonts';
+const FONTS_PREFIX = assetPath('/openscad-libs/fonts');
 
 const fontCache = new Map<FontVariant, Font>();
 let loadPromise: Promise<void> | null = null;

--- a/src/landing/landingEntry.ts
+++ b/src/landing/landingEntry.ts
@@ -141,7 +141,7 @@ async function fillCatalog(): Promise<void> {
     const picked = shuffle(manifest.entries).slice(0, FEATURED_CATALOG_COUNT);
     entries = await Promise.all(picked.map(async (m) => {
       try {
-        const r = await fetch(`/catalog/${m.file}`, { cache: 'no-cache' });
+        const r = await fetch(assetPath(`/catalog/${m.file}`), { cache: 'no-cache' });
         if (!r.ok) return { manifest: m, thumbnailUrl: null };
         const payload = await r.json() as { versions?: { thumbnail?: string | null }[] };
         const versions = payload.versions ?? [];

--- a/src/landing/landingEntry.ts
+++ b/src/landing/landingEntry.ts
@@ -24,6 +24,8 @@ import {
   type Session,
   type Version,
 } from '../storage/db';
+// deployment.ts is dependency-free, so it respects this module's tiny-import rule.
+import { assetPath } from '../deployment';
 
 /** Minimal shape of a catalog manifest entry (avoids importing ui/catalog). */
 interface ManifestEntry {
@@ -133,7 +135,7 @@ async function fillCatalog(): Promise<void> {
   if (!grid) return;
   let entries: { manifest: ManifestEntry; thumbnailUrl: string | null }[] = [];
   try {
-    const res = await fetch('/catalog/manifest.json', { cache: 'no-cache' });
+    const res = await fetch(assetPath('/catalog/manifest.json'), { cache: 'no-cache' });
     if (!res.ok) return; // leave skeletons rather than flashing an error
     const manifest = await res.json() as { entries: ManifestEntry[] };
     const picked = shuffle(manifest.entries).slice(0, FEATURED_CATALOG_COUNT);

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@
 
 import './style.css';
 import { errorLog } from './diagnostics/errorLog';
+import { assetPath } from './deployment';
 import { initDiagnosticsPanel, toggleDiagnosticsPanel } from './ui/diagnosticsPanel';
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, detectScadIncludesAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, exportLastBrepAsSTEP, importSTEPToBrep, importSTEPToMesh, clearBrepImports, clearBrepShape, simplifyInWorker, enhanceInWorker, cancelCurrentExecution, type Language } from './geometry/engine';
 import { formatEngineMemory } from './geometry/engineMemory';
@@ -5196,7 +5197,7 @@ async function main() {
   // rewrites the URL to /editor?session=<id>.
   async function loadCatalogFileIntoEditor(file: string): Promise<void> {
     try {
-      const res = await fetch(`/catalog/${file}`, { cache: 'no-cache' });
+      const res = await fetch(assetPath(`/catalog/${file}`), { cache: 'no-cache' });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const payload = await res.json() as ExportedSession;
       await importSessionPayload(payload);

--- a/src/ui/catalog.ts
+++ b/src/ui/catalog.ts
@@ -159,7 +159,7 @@ export async function createCatalogPage(
   const loaded: LoadedEntry[] = await Promise.all(
     manifest.entries.map(async (entry): Promise<LoadedEntry> => {
       try {
-        const res = await fetch(`/catalog/${entry.file}`, { cache: 'no-cache' });
+        const res = await fetch(assetPath(`/catalog/${entry.file}`), { cache: 'no-cache' });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const payload = await res.json() as ExportedSession;
         // Latest version is the highest index; pull thumbnail from it.

--- a/src/ui/catalog.ts
+++ b/src/ui/catalog.ts
@@ -3,6 +3,7 @@
 // embedded thumbnail (when present) and imports the session on click.
 
 import type { ExportedSession } from '../storage/sessionManager';
+import { assetPath } from '../deployment';
 import { partwrightMarkSvg } from './brand';
 import { languageBadge } from './languageBadge';
 import { getTheme, onThemeChange, toggleTheme } from './theme';
@@ -134,7 +135,7 @@ export async function createCatalogPage(
   // shows a placeholder tile rather than blocking the whole page.
   let manifest: CatalogManifest;
   try {
-    const res = await fetch('/catalog/manifest.json', { cache: 'no-cache' });
+    const res = await fetch(assetPath('/catalog/manifest.json'), { cache: 'no-cache' });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     manifest = await res.json() as CatalogManifest;
   } catch (e) {

--- a/tests/unit/deployment.test.ts
+++ b/tests/unit/deployment.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeBase,
+  majorFromBase,
+  joinBase,
+  routeFromPath,
+} from '../../src/deployment';
+
+describe('normalizeBase', () => {
+  it('guarantees a single leading + trailing slash', () => {
+    expect(normalizeBase('/')).toBe('/');
+    expect(normalizeBase('')).toBe('/');
+    expect(normalizeBase(undefined)).toBe('/');
+    expect(normalizeBase(null)).toBe('/');
+    expect(normalizeBase('/v2')).toBe('/v2/');
+    expect(normalizeBase('/v2/')).toBe('/v2/');
+    expect(normalizeBase('v2')).toBe('/v2/');
+  });
+});
+
+describe('majorFromBase', () => {
+  it('parses /vN/ bases', () => {
+    expect(majorFromBase('/v2/')).toBe(2);
+    expect(majorFromBase('/v10/')).toBe(10);
+    expect(majorFromBase('/v1')).toBe(1);
+  });
+  it('defaults to 1 for the unversioned root', () => {
+    expect(majorFromBase('/')).toBe(1);
+    expect(majorFromBase('')).toBe(1);
+    expect(majorFromBase('/preview/')).toBe(1);
+  });
+});
+
+describe('joinBase', () => {
+  it('is the identity at the root base', () => {
+    expect(joinBase('/', '/editor')).toBe('/editor');
+    expect(joinBase('/', 'editor')).toBe('/editor');
+    expect(joinBase('/', '/')).toBe('/');
+    expect(joinBase('/', '/ai/textures.md')).toBe('/ai/textures.md');
+  });
+  it('mounts under a versioned base', () => {
+    expect(joinBase('/v2/', '/editor')).toBe('/v2/editor');
+    expect(joinBase('/v2/', 'editor')).toBe('/v2/editor');
+    expect(joinBase('/v2/', '/')).toBe('/v2/');
+    expect(joinBase('/v2/', '/ai.md')).toBe('/v2/ai.md');
+  });
+});
+
+describe('routeFromPath', () => {
+  it('is the identity at the root base', () => {
+    expect(routeFromPath('/', '/editor')).toBe('/editor');
+    expect(routeFromPath('/', '/')).toBe('/');
+    expect(routeFromPath('/', '')).toBe('/');
+  });
+  it('strips a versioned base back to the app route', () => {
+    expect(routeFromPath('/v2/', '/v2/editor')).toBe('/editor');
+    expect(routeFromPath('/v2/', '/v2/')).toBe('/');
+    expect(routeFromPath('/v2/', '/v2')).toBe('/');
+    expect(routeFromPath('/v2/', '/v2/help')).toBe('/help');
+  });
+  it('round-trips with joinBase', () => {
+    for (const base of ['/', '/v2/', '/v10/']) {
+      for (const route of ['/', '/editor', '/help', '/catalog']) {
+        expect(routeFromPath(base, joinBase(base, route))).toBe(route);
+      }
+    }
+  });
+  it('returns an out-of-base path unchanged (defensive)', () => {
+    expect(routeFromPath('/v2/', '/v3/editor')).toBe('/v3/editor');
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 3, slice 1 of 5** of the versioned-deployment strategy (follows #651 release tagging and #653 app-version provenance). The eventual goal: serve each major under its own path base (`/v1/`, `/v2/`, …) on one origin, with the root a launcher.

A full touch-point audit found the decisive fact: **nothing in the app reads `import.meta.env.BASE_URL`** — every path is a literal or built from `location.origin` — so changing vite `base` alone fixes nothing. ~50 route sites + ~30 storage keys need to become base-aware. Rather than one massive risky diff, this is sliced; **this PR is the foundation, engineered as a no-op at the current `/` mount.**

- **New `src/deployment.ts`** — single source of truth for the deployment base + the major it serves. Pure, dependency-free helpers (`normalizeBase`, `majorFromBase`, `joinBase`, `routeFromPath`) take the base explicitly so they're unit-testable without stubbing `import.meta.env`; thin wrappers (`BASE`, `currentMajor`, `appPath`, `appRoute`, `assetPath`) bind the build's actual base. **At base `/` every helper is the identity.**
- **Converted the public-asset `fetch()` paths** that would 404 under `/vN/` — `ai.md`, `ai/<subdoc>.md`, the catalog manifest (×2), and the OpenSCAD BOSL2 + fonts prefixes — through `assetPath()`. These fetch from `public/`, which vite serves under the base.
- Kept `deployment.ts` dependency-free so `landingEntry.ts` (which mandates a tiny import graph) can use it.

### Sliced roadmap (rest deferred, documented in `.plans/versioned-deployments-design.md`)
- **PR2:** runtime route layer (`main.ts` predicates + writers, `updateURL`, `switchTab`, `entry`/`route-init`)
- **PR3:** SEO / content-prerender / HTML / redirects base-awareness
- **PR4:** root launcher + actually mount at `/v1/`
- **PR5 (v2-time):** storage share-vs-isolate decisions + DB-by-major + migration

> Storage-key scoping was pulled out on purpose: session-scoped keys use per-DB UUIDs (no real cross-major collision) and some prefs (theme) are arguably desirable to *share*, so it needs per-key judgment when v2 is concrete — not a blind namespacing now. No vite `base` change here either; when a later PR sets it, these fetches follow automatically.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 1373 pass (incl. 9 new `deployment` cases: `/v2/` parsing + a joinBase/routeFromPath round-trip)
- [x] `npm run lint:deps` — acyclic
- [x] `npm run build` — clean
- [x] Browser snapshot of `/catalog` — manifest still loads (tiles + language counts render), confirming the no-op at base `/`
- [ ] PR-checks shards green on the draft

https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6

---
_Generated by [Claude Code](https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6)_