### PR TITLE
test: de-flake bucket-fill reconcile spec by suppressing the first-run tour

### DIFF
--- a/prompts/20260614-022300-bucket-fill-reconcile-test-flake.md
+++ b/prompts/20260614-022300-bucket-fill-reconcile-test-flake.md
@@ -1,0 +1,55 @@
+---
+date: 2026-06-14
+branch: claude/bucket-fill-reconcile-test-fj6b9b
+files_changed:
+  - tests/paint-controls-extended.spec.ts
+---
+
+## Human
+
+CI flake: `tests/paint-controls-extended.spec.ts:311` — "color bucket fill over a
+brush-painted blob commits and survives reconcile" — failed once (expected 2
+regions, got 1) and passed on retry (reported flaky). Investigate and fix.
+
+## Assistant
+
+Reproduced the flake locally with `--repeat-each` (~2/8 runs failed). The visible
+symptom varied — sometimes `afterBucket.length === 1`, sometimes
+`afterBrush.length === 0` — but both are the *same* root cause: a mouse-driven
+paint stroke never committed a region.
+
+**Root cause — the first-run guided tour backdrop swallowed the real mouse
+events.** `src/ui/tour.ts` fires `setTimeout(() => startTour(), 800)` on a fresh
+`/editor` visit (no tour-completion flag, no suppressing query param) and mounts a
+full-screen `.tour-backdrop`. The test drives the brush/bucket with **real**
+`page.mouse.down/move/up`, which go through the browser's hit-testing, so once the
+backdrop is up the pointerdown lands on it — not the canvas — and
+`paintMode.onPointerDown` bails at `event.target !== renderer.domElement` (no
+stroke, no region). The test's only defense was a best-effort `Skip` click guarded
+by `if (await skip.count())`, evaluated immediately after `run()` — a race: when
+the button hadn't rendered yet the click was skipped and the backdrop later ate
+the paint events. This is exactly the hazard the file header already flags ("Uses
+dispatchEvent('click') … to dodge the onboarding tour backdrop") but the
+mouse-driven flow can't use dispatchEvent.
+
+**Fix (deterministic, no production change):**
+1. In the shared `openEditor` helper, `page.addInitScript` sets
+   `localStorage['partwright-tour-completed']` before any page script runs, so
+   `maybeStartTour()` returns early and the backdrop never appears. Synthetic
+   `page.mouse` events now always reach the viewport.
+2. Replaced the two fragile `waitForTimeout(700)` settles in the bucket-fill test
+   with `await partwright.waitForPaint()` (the existing test-facing paint-idle
+   promise), so the assertions read region state only after the async
+   worker-backed reconcile has actually landed — not after a fixed timeout that
+   can expire mid-reconcile on a loaded CI shard.
+
+Verified: the target test passes 12/12 under `--repeat-each=12` (was ~2/8
+failing), and the full `paint-controls-extended.spec.ts` file passes 13/13.
+Typecheck + unit tier green.
+
+Note: the CI run's hard failure was a *different* test
+(`keyboard-shortcuts.spec.ts:72`), which drives paint programmatically
+(`paintFaces` + `dispatchEvent`/`focus`, no real mouse events) so it's unaffected
+by the tour backdrop. It passed 6/6 locally; it looks like a separate, low-rate
+flake outside this branch's named scope — flagged in the PR rather than chased
+here.

--- a/tests/paint-controls-extended.spec.ts
+++ b/tests/paint-controls-extended.spec.ts
@@ -10,6 +10,16 @@
 import { test, expect } from 'playwright/test';
 
 async function openEditor(page: import('playwright/test').Page) {
+  // Mark the first-run guided tour as already completed BEFORE any page script
+  // runs. Otherwise tour.ts fires `setTimeout(startTour, 800)` and its
+  // full-screen `.tour-backdrop` swallows the real page.mouse pointer events the
+  // brush/bucket flows below rely on — the press lands on the backdrop, not the
+  // canvas, so no region commits (the intermittent 0-/1-region flake). Setting
+  // the flag here makes `maybeStartTour()` return early, so the backdrop never
+  // appears and the synthetic mouse events always reach the viewport.
+  await page.addInitScript(() => {
+    try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ }
+  });
   await page.goto('/editor');
   await page.waitForSelector('text=Ready', { timeout: 15000 });
   // Run a tiny model so paint operations have a real mesh to operate on.
@@ -335,11 +345,15 @@ test.describe('extended paint controls', () => {
     await page.mouse.down();
     for (let i = -40; i <= 40; i += 8) await page.mouse.move(cx + i, cy + Math.sin(i / 10) * 8);
     await page.mouse.up();
-    await page.waitForTimeout(700);
 
-    const afterBrush = await page.evaluate(() => {
+    // The interactive brush commits through the async worker-backed pipeline, so
+    // wait for the subdivision job to settle (deterministic) rather than a fixed
+    // timeout that can expire mid-reconcile on a loaded CI shard.
+    const afterBrush = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (window as any).partwright.listRegions().map((r: any) => r.triangles);
+      const pw = (window as any).partwright;
+      await pw.waitForPaint();
+      return pw.listRegions().map((r: any) => r.triangles);
     });
     expect(afterBrush.length).toBe(1);
     expect(afterBrush[0]).toBeGreaterThan(50); // the refined red blob
@@ -357,11 +371,13 @@ test.describe('extended paint controls', () => {
     await page.mouse.move(cx - 4, cy); await page.mouse.move(cx, cy);
     await page.waitForTimeout(250);
     await page.mouse.down(); await page.waitForTimeout(40); await page.mouse.up();
-    await page.waitForTimeout(700); // let the async reconcile re-resolve regions
 
-    const afterBucket = await page.evaluate(() => {
+    // Wait for the async reconcile to re-resolve the regions before reading them.
+    const afterBucket = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (window as any).partwright.listRegions().map((r: any) => ({ tris: r.triangles, color: r.color }));
+      const pw = (window as any).partwright;
+      await pw.waitForPaint();
+      return pw.listRegions().map((r: any) => ({ tris: r.triangles, color: r.color }));
     });
     // Two regions; the bucket region must NOT collapse to zero after reconcile,
     // and it carries the new (yellow) color over the blob it matched.


### PR DESCRIPTION
## Summary

Fixes the intermittent CI flake in `tests/paint-controls-extended.spec.ts` →
"color bucket fill over a brush-painted blob commits and survives reconcile"
(expected 2 regions, got 1).

**Root cause:** the test drives the brush/bucket with **real** `page.mouse`
events, but the first-run guided tour (`src/ui/tour.ts` fires
`setTimeout(startTour, 800)` on a fresh `/editor` visit) mounts a full-screen
`.tour-backdrop`. Real pointer events go through the browser's hit-testing, so
once the backdrop is up the pointerdown lands on it — not the canvas — and
`paintMode.onPointerDown` bails at `event.target !== renderer.domElement`. No
stroke, no region. The test's only defense was a best-effort `Skip` click
guarded by `if (await skip.count())` evaluated immediately after `run()` — a
race that lost whenever the button hadn't rendered yet. Reproduced locally at
~2/8 runs (symptom varied between `afterBrush.length === 0` and
`afterBucket.length === 1` — same mechanism, a swallowed mouse press).

**Fix (test-only, no production change):**
1. The shared `openEditor` helper now `addInitScript`s the
   `partwright-tour-completed` localStorage flag before any page script runs, so
   `maybeStartTour()` returns early and the backdrop never appears — synthetic
   `page.mouse` events always reach the viewport.
2. Replaced the two fragile `waitForTimeout(700)` settles in the bucket-fill test
   with `await partwright.waitForPaint()` (the existing test-facing paint-idle
   promise), so assertions read region state only after the async worker-backed
   reconcile has landed — not after a fixed timeout that can expire mid-reconcile
   on a loaded CI shard.

## Test plan

- `--repeat-each=12` on the target test: **12/12 pass** (was ~2/8 failing).
- Full `paint-controls-extended.spec.ts`: **13/13 pass**.
- `npm run typecheck` + `npm run test:unit` green (1372 unit tests).

## Out of scope (note)

The CI run's hard `1 failed` was a *different* test —
`keyboard-shortcuts.spec.ts:72` ("undo is not hijacked while a text input is
focused"). It drives paint **programmatically** (`paintFaces` + `dispatchEvent` /
`focus`, no real mouse events), so it's unaffected by the tour backdrop. It
passed 6/6 locally; it looks like a separate, low-rate flake outside this
branch's named scope. Flagging here rather than chasing an unreproducible
failure in an unrelated test — happy to file a tracking issue if it recurs.

https://claude.ai/code/session_016ciBbJh8aCtcwjxf9BkW8G

---
_Generated by [Claude Code](https://claude.ai/code/session_016ciBbJh8aCtcwjxf9BkW8G)_