### PR TITLE
feat: make the runtime route layer deployment-base-aware

### DIFF
--- a/prompts/versioned-deploy-routing.md
+++ b/prompts/versioned-deploy-routing.md
@@ -1,0 +1,53 @@
+---
+date: 2026-06-14
+branch: claude/versioned-deploy-routing
+files_changed:
+  - src/main.ts
+  - src/storage/sessionManager.ts
+  - src/ui/layout.ts
+  - src/ui/uninstallModal.tsx
+---
+
+## Human
+
+"proceed to the next step" of Phase 3 (versioned deployments) — after the
+base-aware foundation merged (#656), wire the runtime route layer to use it.
+
+## Assistant
+
+Phase 3 **slice 2 of 5: the runtime route layer**. Converted every in-app route
+read and write to go through the `appRoute`/`appPath` helpers from
+`src/deployment.ts` (added in #656), so the app routes correctly whether mounted
+at `/` or a future `/vN/`. A strict no-op at base `/` (both helpers are the
+identity there).
+
+- **Route predicates** (`src/main.ts`): added a `currentRoute()` helper
+  (`appRoute(location.pathname)`) and routed `shouldShowLanding`,
+  `shouldShowHelp/Catalog/Ideas/WhatsNew/Legal`, `shouldShow404`,
+  `isEditorActive`, and the four `pathname !== '/editor'` guards through it.
+- **Route writers**: wrapped every `updateAppHistory('/...')`, the two direct
+  `history.replaceState(…, '/editor'…)` (incl. the `history.state` one the
+  `?tour=1` handler uses), and the `location.assign('/')` calls (close+clear,
+  uninstall, `showLandingPage`) in `appPath(...)`.
+- **`updateURL`** (`sessionManager.ts`) basePath + the share/gallery URL
+  builders (`origin + appPath('/editor')`); **`switchTab`** (`layout.ts`)
+  basePath; **uninstall** redirect (`uninstallModal.tsx`).
+
+Deliberately deferred:
+- **The pre-paint landing-detection pair** — `src/entry.ts` `isLandingRoute()`
+  and `public/route-init.js` — left as literal `'/'` checks. They're a matched
+  pair that runs before the app bundle; `route-init.js` is a static file that
+  can't import `deployment.ts`, so making them base-aware needs a base-injection
+  mechanism that belongs with the actual `/vN/` mount (PR4). At base `/` all
+  three landing predicates (these two + `shouldShowLanding`) still agree exactly,
+  so the matching invariant holds for every real deployment today.
+- SEO / content-page hrefs / redirects (PR3); launcher + base mount (PR4);
+  storage scoping (PR5).
+
+Verified: typecheck clean; `lint:deps` acyclic; `npm run build` clean; the
+routing-critical e2e — smoke, landing-static, content-pages, version-nav,
+versions-tab — all pass (35/35) confirming landing↔editor↔content-page
+navigation, tab switching, the back button, catalog-into-editor, and share-hash
+handling are unchanged; and a browser snapshot of /editor shows the engine boots
+and renders. Swept `src/` (NUL-safe) for any remaining route literals in
+nav/history writers — none outside the deferred content/SEO layer.

--- a/prompts/versioned-deploy-routing.md
+++ b/prompts/versioned-deploy-routing.md
@@ -6,6 +6,8 @@ files_changed:
   - src/storage/sessionManager.ts
   - src/ui/layout.ts
   - src/ui/uninstallModal.tsx
+  - src/ui/sessionList.ts
+  - src/ui/appHistory.ts
 ---
 
 ## Human
@@ -51,3 +53,18 @@ navigation, tab switching, the back button, catalog-into-editor, and share-hash
 handling are unchanged; and a browser snapshot of /editor shows the engine boots
 and renders. Swept `src/` (NUL-safe) for any remaining route literals in
 nav/history writers — none outside the deferred content/SEO layer.
+
+Follow-up after a work-reviewer pass:
+- **Blocking fix** — three `updateAppHistory('/editor', 'push')` writers in
+  `src/ui/sessionList.ts` (import/open-session paths) had escaped the main.ts
+  sweep; wrapped them in `appPath()`. Under `/vN/` these would have escaped the
+  base (and `updateAppHistory`'s self-guard wouldn't suppress them, since it
+  compares against the base-prefixed real URL).
+- **Completeness fix** — five content-page "back-target" predicates in `main.ts`
+  (`helpHasAppBackTarget = currentURLPathAndSearch() !== '/help'`, + legal /
+  catalog / whats-new / ideas) compared the base-prefixed raw URL against bare
+  literals → always-true under `/vN/`. Added a base-stripped
+  `currentRouteAndSearch()` helper and routed all five through it. This removed
+  the last `currentURLPathAndSearch` consumer in main.ts, so I un-exported that
+  helper in `appHistory.ts` (now internal-only) per the no-dead-exports rule.
+- Re-ran content-pages + smoke + landing-static (30/30) — still a clean no-op.

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ import { showAdvancedSettingsModal } from './ui/advancedSettingsModal';
 import { combo, MOD_LABEL, SHIFT_LABEL, ALT_LABEL } from './ui/shortcutDefs';
 import { showToast } from './ui/toast';
 import { confirmDialog, promptDialog } from './ui/dialogs';
-import { updateAppHistory, currentURLPathAndSearch } from './ui/appHistory';
+import { updateAppHistory } from './ui/appHistory';
 import { initAiPanel, setActiveSession as setAiActiveSession, toggleAiPanel, toggleAiPanelFromToolbar, prefillAiInput, setAiPanelRouteActive, closeAiPanel, isAiTurnInFlight, onAiTurnEnd } from './ui/aiPanel';
 import { onViewportPanelOpen } from './ui/viewportPanelRegistry';
 import { getKey, mergeChatBucket } from './ai/db';
@@ -1886,6 +1886,14 @@ function resolvePartTarget(target: unknown, caller: string): Part | { error: str
 // base `/`. See src/deployment.ts.
 function currentRoute(): string {
   return appRoute(window.location.pathname);
+}
+
+// Like appHistory's currentURLPathAndSearch(), but with the deployment base
+// stripped — so "did we arrive here from elsewhere in the app" back-target
+// checks compare against bare routes ('/help') regardless of the /vN/ mount.
+// A no-op at base `/`.
+function currentRouteAndSearch(): string {
+  return `${currentRoute()}${window.location.search}`;
 }
 
 // Determine which page to show based on URL path and query params
@@ -5053,7 +5061,7 @@ async function main() {
   function showHelp(options: { history?: 'push' | 'replace' | 'none' } = {}) {
     const historyMode = options.history ?? 'push';
     if (historyMode !== 'none') {
-      helpHasAppBackTarget = currentURLPathAndSearch() !== '/help';
+      helpHasAppBackTarget = currentRouteAndSearch() !== '/help';
       updateAppHistory(appPath('/help'), historyMode);
     }
     if (!helpEl) {
@@ -5086,7 +5094,7 @@ async function main() {
   function showLegal(options: { history?: 'push' | 'replace' | 'none' } = {}) {
     const historyMode = options.history ?? 'push';
     if (historyMode !== 'none') {
-      legalHasAppBackTarget = currentURLPathAndSearch() !== '/legal';
+      legalHasAppBackTarget = currentRouteAndSearch() !== '/legal';
       updateAppHistory(appPath('/legal'), historyMode);
     }
     if (!legalEl) {
@@ -5118,7 +5126,7 @@ async function main() {
   async function showCatalogPage(options: { history?: 'push' | 'replace' | 'none' } = {}) {
     const historyMode = options.history ?? 'push';
     if (historyMode !== 'none') {
-      catalogHasAppBackTarget = currentURLPathAndSearch() !== '/catalog';
+      catalogHasAppBackTarget = currentRouteAndSearch() !== '/catalog';
       updateAppHistory(appPath('/catalog'), historyMode);
     }
     if (!catalogEl) {
@@ -5153,7 +5161,7 @@ async function main() {
   function showWhatsNewPage(options: { history?: 'push' | 'replace' | 'none' } = {}) {
     const historyMode = options.history ?? 'push';
     if (historyMode !== 'none') {
-      whatsNewHasAppBackTarget = currentURLPathAndSearch() !== '/whats-new';
+      whatsNewHasAppBackTarget = currentRouteAndSearch() !== '/whats-new';
       updateAppHistory(appPath('/whats-new'), historyMode);
     }
     if (!whatsNewEl) {
@@ -5342,7 +5350,7 @@ async function main() {
   function showIdeasPage(options: { history?: 'push' | 'replace' | 'none' } = {}) {
     const historyMode = options.history ?? 'push';
     if (historyMode !== 'none') {
-      ideasHasAppBackTarget = currentURLPathAndSearch() !== '/ideas';
+      ideasHasAppBackTarget = currentRouteAndSearch() !== '/ideas';
       updateAppHistory(appPath('/ideas'), historyMode);
     }
     if (!ideasEl) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@
 
 import './style.css';
 import { errorLog } from './diagnostics/errorLog';
-import { assetPath } from './deployment';
+import { assetPath, appPath, appRoute } from './deployment';
 import { initDiagnosticsPanel, toggleDiagnosticsPanel } from './ui/diagnosticsPanel';
 import { initEngine, executeCode, executeCodeAsync, validateCodeAsync, detectScadIncludesAsync, ensureEngineReady, getModule, getActiveLanguage, setActiveLanguage, exportLastBrepAsSTEP, importSTEPToBrep, importSTEPToMesh, clearBrepImports, clearBrepShape, simplifyInWorker, enhanceInWorker, cancelCurrentExecution, type Language } from './geometry/engine';
 import { formatEngineMemory } from './geometry/engineMemory';
@@ -1880,43 +1880,51 @@ function resolvePartTarget(target: unknown, caller: string): Part | { error: str
   return part;
 }
 
+// The app-relative route for the current URL, with the deployment base
+// (`/`, `/v2/`, …) stripped — so route predicates compare against bare routes
+// ('/editor', '/help') regardless of where this major is mounted. A no-op at
+// base `/`. See src/deployment.ts.
+function currentRoute(): string {
+  return appRoute(window.location.pathname);
+}
+
 // Determine which page to show based on URL path and query params
 function shouldShowLanding(): boolean {
-  const path = window.location.pathname;
+  const path = currentRoute();
   const params = new URLSearchParams(window.location.search);
   // Landing if at root path AND no query params that indicate a specific view
   // AND no share-link hash (a bare `/#share=…` must open the shared preview, not
   // the landing page).
-  const isRootPath = path === '/' || path === '';
+  const isRootPath = path === '/';
   return isRootPath && !hasShareHash() && !params.has('view') && !params.has('session') && !params.has('gallery') && !params.has('versions') && !params.has('images') && !params.has('diff') && !params.has('notes') && !params.has('data');
 }
 
 function shouldShowHelp(): boolean {
   // A `/help#share=…` link must open the shared preview (editor), not Help —
   // mirrors shouldShowLanding's share-hash exclusion.
-  return window.location.pathname === '/help' && !hasShareHash();
+  return currentRoute() === '/help' && !hasShareHash();
 }
 
 function shouldShowCatalog(): boolean {
-  return window.location.pathname === '/catalog' && !hasShareHash();
+  return currentRoute() === '/catalog' && !hasShareHash();
 }
 
 function shouldShowIdeas(): boolean {
-  return window.location.pathname === '/ideas' && !hasShareHash();
+  return currentRoute() === '/ideas' && !hasShareHash();
 }
 
 function shouldShowWhatsNew(): boolean {
-  return window.location.pathname === '/whats-new';
+  return currentRoute() === '/whats-new';
 }
 
 function shouldShowLegal(): boolean {
-  return window.location.pathname === '/legal';
+  return currentRoute() === '/legal';
 }
 
 function shouldShow404(): boolean {
   if (hasShareHash()) return false;
-  const path = window.location.pathname;
-  return path !== '/' && path !== '' && path !== '/help' && path !== '/editor' && path !== '/catalog' && path !== '/ideas' && path !== '/legal' && path !== '/whats-new';
+  const path = currentRoute();
+  return path !== '/' && path !== '/help' && path !== '/editor' && path !== '/catalog' && path !== '/ideas' && path !== '/legal' && path !== '/whats-new';
 }
 
 /** True when the editor view is the active page. Editor-scoped command-palette
@@ -1925,7 +1933,7 @@ function shouldShow404(): boolean {
  *  `/editor?…` and toggle hidden panes without ever transitioning into the
  *  editor. A `#share=…` link also lands in the editor, so it counts too. */
 function isEditorActive(): boolean {
-  return window.location.pathname === '/editor' || hasShareHash();
+  return currentRoute() === '/editor' || hasShareHash();
 }
 
 function getTabFromURL(): TabName {
@@ -4238,7 +4246,7 @@ async function main() {
     onGoHome: () => {
       // The landing page is a separate static document that does NOT load this
       // app bundle, so going home is a real navigation, not an in-app render.
-      window.location.assign('/');
+      window.location.assign(appPath('/'));
     },
     onRun: () => runCode(),
     onExportGLB: actionExportGLB,
@@ -4981,10 +4989,10 @@ async function main() {
   }
 
   async function openEditorFromLanding() {
-    updateAppHistory('/editor', 'push');
+    updateAppHistory(appPath('/editor'), 'push');
     transitionToEditor();
     await ensureEditorReady();
-    if (window.location.pathname !== '/editor') return;
+    if (currentRoute() !== '/editor') return;
     await ensureEngineStarted();
     if (!engineOk) return;
     await createSession();
@@ -4997,7 +5005,7 @@ async function main() {
   // CTA or the help page button): the tour spotlights editor chrome, so make
   // sure we're in the editor with a live session before it starts.
   async function takeGuidedTour() {
-    updateAppHistory('/editor', 'push');
+    updateAppHistory(appPath('/editor'), 'push');
     transitionToEditor();
     await ensureEditorReady();
     await ensureEngineStarted();
@@ -5016,14 +5024,14 @@ async function main() {
   // the lightweight landing entry instead of this bundle. (Callers: the boot
   // router and syncRouteFromURL's popstate handler.)
   function showLandingPage() {
-    window.location.assign('/');
+    window.location.assign(appPath('/'));
   }
 
   function showNotFoundPage() {
     if (!notFoundEl) {
       notFoundEl = createNotFoundPage(overlayContainer, {
         onGoHome: () => {
-          updateAppHistory('/', 'push');
+          updateAppHistory(appPath('/'), 'push');
           void syncRouteFromURL();
         },
       });
@@ -5046,7 +5054,7 @@ async function main() {
     const historyMode = options.history ?? 'push';
     if (historyMode !== 'none') {
       helpHasAppBackTarget = currentURLPathAndSearch() !== '/help';
-      updateAppHistory('/help', historyMode);
+      updateAppHistory(appPath('/help'), historyMode);
     }
     if (!helpEl) {
       helpEl = createHelpPage(overlayContainer, {
@@ -5054,7 +5062,7 @@ async function main() {
           if (helpHasAppBackTarget) {
             window.history.back();
           } else {
-            updateAppHistory('/editor', 'replace');
+            updateAppHistory(appPath('/editor'), 'replace');
             void syncEditorFromURL();
           }
         },
@@ -5079,7 +5087,7 @@ async function main() {
     const historyMode = options.history ?? 'push';
     if (historyMode !== 'none') {
       legalHasAppBackTarget = currentURLPathAndSearch() !== '/legal';
-      updateAppHistory('/legal', historyMode);
+      updateAppHistory(appPath('/legal'), historyMode);
     }
     if (!legalEl) {
       legalEl = createLegalPage(overlayContainer, {
@@ -5087,7 +5095,7 @@ async function main() {
           if (legalHasAppBackTarget) {
             window.history.back();
           } else {
-            updateAppHistory('/editor', 'replace');
+            updateAppHistory(appPath('/editor'), 'replace');
             void syncEditorFromURL();
           }
         },
@@ -5111,7 +5119,7 @@ async function main() {
     const historyMode = options.history ?? 'push';
     if (historyMode !== 'none') {
       catalogHasAppBackTarget = currentURLPathAndSearch() !== '/catalog';
-      updateAppHistory('/catalog', historyMode);
+      updateAppHistory(appPath('/catalog'), historyMode);
     }
     if (!catalogEl) {
       catalogEl = await createCatalogPage(overlayContainer, {
@@ -5119,7 +5127,7 @@ async function main() {
           if (catalogHasAppBackTarget) {
             window.history.back();
           } else {
-            updateAppHistory('/', 'replace');
+            updateAppHistory(appPath('/'), 'replace');
             void syncRouteFromURL();
           }
         },
@@ -5146,7 +5154,7 @@ async function main() {
     const historyMode = options.history ?? 'push';
     if (historyMode !== 'none') {
       whatsNewHasAppBackTarget = currentURLPathAndSearch() !== '/whats-new';
-      updateAppHistory('/whats-new', historyMode);
+      updateAppHistory(appPath('/whats-new'), historyMode);
     }
     if (!whatsNewEl) {
       whatsNewEl = createWhatsNewPage(overlayContainer, {
@@ -5154,7 +5162,7 @@ async function main() {
           if (whatsNewHasAppBackTarget) {
             window.history.back();
           } else {
-            updateAppHistory('/', 'replace');
+            updateAppHistory(appPath('/'), 'replace');
             void syncRouteFromURL();
           }
         },
@@ -5180,7 +5188,7 @@ async function main() {
     // sessionManager.updateURL). Without an earlier push, that replaceState
     // would clobber whatever page we came from (e.g. /catalog) and break the
     // browser back button.
-    updateAppHistory('/editor', 'push');
+    updateAppHistory(appPath('/editor'), 'push');
     transitionToEditor();
     await ensureEditorReady();
     await ensureEngineStarted();
@@ -5225,7 +5233,7 @@ async function main() {
    *  (pushing the history entry BEFORE any session mutation, same reason as
    *  handleCatalogEntryLoad). */
   async function enterEditorForIdea(): Promise<void> {
-    updateAppHistory('/editor', 'push');
+    updateAppHistory(appPath('/editor'), 'push');
     transitionToEditor();
     await ensureEditorReady();
   }
@@ -5233,7 +5241,7 @@ async function main() {
   // A starter/technique idea — drop its prompt into the AI panel (don't send).
   async function handleIdeaUsePrompt(idea: Idea): Promise<void> {
     await enterEditorForIdea();
-    if (window.location.pathname !== '/editor') return;
+    if (currentRoute() !== '/editor') return;
     if (!getState().session) {
       await createSession();
       setStatus(statusBar, 'ready', 'Ready');
@@ -5247,7 +5255,7 @@ async function main() {
   // (reuses the existing image→voxel import flow, modal and all).
   async function handleIdeaPhotoToVoxel(file: File): Promise<void> {
     await enterEditorForIdea();
-    if (window.location.pathname !== '/editor') return;
+    if (currentRoute() !== '/editor') return;
     await handleImageImport(file);
     updateDocumentTitle({ page: 'editor' });
   }
@@ -5266,7 +5274,7 @@ async function main() {
   // (reuses the existing Relief import wizard).
   async function handleIdeaPhotoToRelief(file: File): Promise<void> {
     await enterEditorForIdea();
-    if (window.location.pathname !== '/editor') return;
+    if (currentRoute() !== '/editor') return;
     openReliefForIdea(file);
     updateDocumentTitle({ page: 'editor' });
   }
@@ -5335,7 +5343,7 @@ async function main() {
     const historyMode = options.history ?? 'push';
     if (historyMode !== 'none') {
       ideasHasAppBackTarget = currentURLPathAndSearch() !== '/ideas';
-      updateAppHistory('/ideas', historyMode);
+      updateAppHistory(appPath('/ideas'), historyMode);
     }
     if (!ideasEl) {
       ideasEl = createIdeasPage(overlayContainer, {
@@ -5343,7 +5351,7 @@ async function main() {
           if (ideasHasAppBackTarget) {
             window.history.back();
           } else {
-            updateAppHistory('/', 'replace');
+            updateAppHistory(appPath('/'), 'replace');
             void syncRouteFromURL();
           }
         },
@@ -5434,7 +5442,7 @@ async function main() {
     // to /editor — otherwise pasting #share=… onto /catalog or /help would
     // leave the URL claiming a non-editor page while the editor is on screen.
     // App-generated links already use /editor#share=, so this is a no-op there.
-    window.history.replaceState(null, '', '/editor' + window.location.search);
+    window.history.replaceState(null, '', appPath('/editor') + window.location.search);
   }
 
   /** Open a `#share=…` link as a read-only preview. Decodes + validates the
@@ -5515,7 +5523,7 @@ async function main() {
     // execution guard.
     exitSharedMode();
     pendingSharedPayload = null;
-    updateAppHistory('/editor', 'push');
+    updateAppHistory(appPath('/editor'), 'push');
     transitionToEditor();
     await ensureEditorReady();
     await importSessionPayload(payload);
@@ -6899,7 +6907,7 @@ async function main() {
   // the now-clean editor URL.
   if (new URLSearchParams(window.location.search).get('tour') === '1') {
     resetTour();
-    history.replaceState(history.state, '', '/editor');
+    history.replaceState(history.state, '', appPath('/editor'));
   }
 
   if (!showLanding && !showHelpPage && !showCatalog && !showIdeas && !showLegalPage && !showWhatsNew && !show404 && !hasShareHash()) {
@@ -7008,7 +7016,7 @@ async function main() {
     try {
       await initAiPanel({
         onNavigateToEditor: async () => {
-          updateAppHistory('/editor', 'push');
+          updateAppHistory(appPath('/editor'), 'push');
           await syncRouteFromURL();
         },
         mountInto: appRow,

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -64,6 +64,7 @@ import { getActiveLanguage } from '../geometry/engine';
 import { effectiveVersionLanguage, asLanguage } from './languageFallback';
 import { buildInfo } from '../buildInfo';
 import { appVersionCompatibility } from './appVersionCompat';
+import { appPath } from '../deployment';
 
 /**
  * Current schema version for `.partwright.json` exports.
@@ -539,7 +540,7 @@ export function getState(): SessionState {
 
 function updateURL() {
   const params = new URLSearchParams(window.location.search);
-  const basePath = '/editor';
+  const basePath = appPath('/editor');
   if (currentState.session) {
     params.set('session', currentState.session.id);
     // Only pin the part in the URL when the session has more than one — a
@@ -1356,13 +1357,13 @@ export async function renameVersion(versionId: string, label: string): Promise<V
 
 export function getSessionUrl(): string {
   if (!currentState.session) return window.location.href;
-  const base = window.location.origin + '/editor';
+  const base = window.location.origin + appPath('/editor');
   return `${base}?session=${currentState.session.id}`;
 }
 
 export function getGalleryUrl(): string {
   if (!currentState.session) return window.location.href;
-  const base = window.location.origin + '/editor';
+  const base = window.location.origin + appPath('/editor');
   return `${base}?session=${currentState.session.id}&gallery`;
 }
 

--- a/src/ui/appHistory.ts
+++ b/src/ui/appHistory.ts
@@ -8,7 +8,7 @@
 // and the Back button skips the previous session. See
 // CLAUDE.md › "Browser History (Back Button) Preservation".
 
-export function currentURLPathAndSearch(): string {
+function currentURLPathAndSearch(): string {
   return `${window.location.pathname}${window.location.search}`;
 }
 

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,4 +1,5 @@
 import { getMobilePane, onMobilePaneChange, setMobilePane } from './mobilePane';
+import { appPath } from '../deployment';
 import { showAdvancedSettingsModal } from './advancedSettingsModal';
 import { showAboutModal } from './aboutModal';
 import { loadSettings, saveSettings } from '../ai/settings';
@@ -722,7 +723,7 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
     // tapped rail item actually surfaces its content.
     if (!mqDesktop.matches) setMobilePane('viewport');
 
-    const basePath = '/editor';
+    const basePath = appPath('/editor');
     const params = new URLSearchParams(window.location.search);
     // Clear every tab-owned param, then set the one this tab owns. Unrelated
     // params (e.g. `session`, `v`) are preserved. `view` is a legacy param

--- a/src/ui/sessionList.ts
+++ b/src/ui/sessionList.ts
@@ -18,6 +18,7 @@ import { languageBadge } from './languageBadge';
 import { showToast } from './toast';
 import { confirmDialog, promptDialog } from './dialogs';
 import { updateAppHistory } from './appHistory';
+import { appPath } from '../deployment';
 
 let modalEl: HTMLElement | null = null;
 let onLoadVersion: ((code: string) => void | Promise<void>) | null = null;
@@ -86,7 +87,7 @@ export async function showSessionList(): Promise<void> {
         const session = await importSession(data, regenerateThumbnailFn ?? undefined, (msg) => showToast(msg, { variant: 'warn', source: 'import' }));
         // Push the editor entry before the session-mutating open so the Back
         // button returns to the prior session (updateURL only replaceState's).
-        updateAppHistory('/editor', 'push');
+        updateAppHistory(appPath('/editor'), 'push');
         const version = await openSession(session.id);
         if (version && onLoadVersion) onLoadVersion(version.code);
         closeModal();
@@ -115,7 +116,7 @@ export async function showSessionList(): Promise<void> {
   newBtn.addEventListener('click', async () => {
     const name = await promptDialog('Session name:', { title: 'New session', placeholder: 'Untitled' });
     if (name === null) return;
-    updateAppHistory('/editor', 'push'); // push before mutating so Back returns to the prior session
+    updateAppHistory(appPath('/editor'), 'push'); // push before mutating so Back returns to the prior session
     await createSession(name || undefined);
     onNewSessionFn?.();
     closeModal();
@@ -173,7 +174,7 @@ async function createSessionRow(session: Session): Promise<HTMLElement> {
   row.className = 'flex items-center gap-3 px-5 py-3 hover:bg-zinc-700/50 cursor-pointer border-b border-zinc-700/50 transition-colors';
 
   row.addEventListener('click', async () => {
-    updateAppHistory('/editor', 'push'); // push before mutating so Back returns to the prior session
+    updateAppHistory(appPath('/editor'), 'push'); // push before mutating so Back returns to the prior session
     const version = await openSession(session.id);
     if (version && onLoadVersion) {
       await onLoadVersion(version.code);

--- a/src/ui/uninstallModal.tsx
+++ b/src/ui/uninstallModal.tsx
@@ -6,6 +6,7 @@
 import { signal, type Signal } from '@preact/signals';
 import { useEffect } from 'preact/hooks';
 import { mountPreactModal } from './preact/mount';
+import { appPath } from '../deployment';
 import { BUTTON_DANGER } from './styleConstants';
 import {
   getStoreCounts,
@@ -115,7 +116,7 @@ function UninstallFooter(props: {
     try { await wipeData(selection.value); }
     catch (err) { console.error('Uninstall failed:', err); }
     // Reload so all in-memory state is rebuilt from the now-empty stores.
-    window.location.assign('/');
+    window.location.assign(appPath('/'));
   }
 
   return (


### PR DESCRIPTION
## Summary

**Phase 3, slice 2 of 5** of the versioned-deployment strategy (follows #656's base-aware foundation). Wires the **runtime route layer** to the `appRoute`/`appPath` helpers from `src/deployment.ts`, so the app routes correctly whether mounted at `/` or a future `/vN/`. **Strict no-op at base `/`** — both helpers are the identity there.

- **Route predicates** (`src/main.ts`): new `currentRoute()` = `appRoute(location.pathname)`; routed `shouldShowLanding`, `shouldShowHelp/Catalog/Ideas/WhatsNew/Legal`, `shouldShow404`, `isEditorActive`, and the four `pathname !== '/editor'` guards through it.
- **Route writers**: wrapped every `updateAppHistory('/...')`, both direct `history.replaceState(…, '/editor'…)` (incl. the `?tour=1` `history.state` one), and the `location.assign('/')` calls (close+clear, uninstall, `showLandingPage`) in `appPath(...)`.
- **`updateURL`** (`sessionManager.ts`) basePath + the share/gallery URL builders; **`switchTab`** (`layout.ts`) basePath; **uninstall** redirect (`uninstallModal.tsx`).

### Deferred (by design)
- **The pre-paint landing pair** — `src/entry.ts` `isLandingRoute()` and `public/route-init.js` — left as literal `'/'` checks. They run before the app bundle, and `route-init.js` is a static file that can't import `deployment.ts`, so base-injecting them belongs with the actual `/vN/` mount (**PR4**). At base `/` all three landing predicates still agree exactly, so the matching invariant holds for every real deployment today.
- SEO / content-page hrefs / redirects → **PR3**; launcher + base mount → **PR4**; storage scoping → **PR5**.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint:deps` — acyclic
- [x] `npm run build` — clean
- [x] Routing e2e: smoke, landing-static, content-pages, version-nav-language, versions-tab — **35/35 pass** (landing↔editor↔content-page nav, tab switching, back button, catalog-into-editor, share-hash handling all unchanged)
- [x] Browser snapshot of `/editor` — engine boots and renders
- [x] NUL-safe sweep of `src/` for remaining nav/history route literals — none outside the deferred content/SEO layer
- [ ] PR-checks shards green on the draft

https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6

---
_Generated by [Claude Code](https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6)_