### PR TITLE
feat: expand figure mouth options (expressions, two-lip lips, teeth, #652 fix)

### DIFF
--- a/examples/faces/bust_grin_teeth.js
+++ b/examples/faces/bust_grin_teeth.js
@@ -1,0 +1,34 @@
+// FACE LAB — a big painted SMILE showing teeth, print-safe (no carved cavity,
+// so no support material lands inside the mouth). The toothy grin is built from
+// paintable accents: a red lip ring bowed into a smile + a white teeth plate
+// sitting flush in the opening. Pass `mouth: false` to assemble so the skin
+// doesn't ALSO weld a lip ring that would bury the painted parts.
+// Quick review:  npm run model:preview -- examples/faces/bust_grin_teeth.js --view 270,-2
+const { sdf } = api;
+const F = sdf.figure;
+
+const rig = F.rig({ height: 60, headsTall: 5 });
+const head = F.head(rig);
+
+// `expression` picks the level (bigSmile … deepFrown); `render: 'painted'`
+// keeps it a flat print-safe mouth; `teeth: 'both'` shows upper + lower teeth.
+const mouthOpts = { style: 'open', open: 0.5, width: rig.r.head * 0.62, expression: 'bigSmile', render: 'painted', teeth: 'both' };
+const face = F.face.assemble(head, rig, { eyes: false, mouth: false });
+
+const cutZ = rig.joints.chest[2] - rig.r.chestY;
+const body = F.weld(rig, [face, F.neck(rig), F.torso(rig)])
+  .subtract(sdf.box([200, 200, 200]).translate([0, 0, cutZ - 100]))
+  .label('skin');
+
+const eyes = F.face.eyes(rig);
+const mouthParts = F.face.mouthAccents(rig, mouthOpts);  // 'teeth' + 'lips'
+
+api.paint.label('skin', '#e8b48f');
+api.paint.label('eyes', '#f6f4ef');
+api.paint.label('iris', '#5a4632');
+api.paint.label('pupil', '#1c1c1c');
+api.paint.label('teeth', '#fbfaf5');
+api.paint.label('lips', '#c4574e');
+
+return sdf.union(body, eyes, mouthParts)
+  .build({ edgeLength: 0.5, detail: F.faceDetail(rig) });

--- a/examples/faces/bust_natural_lips.js
+++ b/examples/faces/bust_natural_lips.js
@@ -1,0 +1,31 @@
+// FACE LAB — natural two-lip mouth: a distinct UPPER and LOWER lip (the
+// `divided` lip style) instead of a single flat line. Additive + painted, so it
+// prints clean. `expression` / `curve` bows the lips (here a gentle smile);
+// `fullness` sets lip thickness. Pass `mouth: false` to assemble so the labelled
+// ridge from mouthAccents IS the mouth (a welded copy would swallow the label).
+// Quick review:  npm run model:preview -- examples/faces/bust_natural_lips.js --view 270,-2
+const { sdf } = api;
+const F = sdf.figure;
+
+const rig = F.rig({ height: 60, headsTall: 5 });
+const head = F.head(rig);
+
+const mouthOpts = { style: 'lips', divided: true, fullness: 1.4, expression: 'slightSmile', width: rig.r.head * 0.5 };
+const face = F.face.assemble(head, rig, { eyes: false, mouth: false, brows: {} });
+
+const cutZ = rig.joints.chest[2] - rig.r.chestY;
+const body = F.weld(rig, [face, F.neck(rig), F.torso(rig)])
+  .subtract(sdf.box([200, 200, 200]).translate([0, 0, cutZ - 100]))
+  .label('skin');
+
+const eyes = F.face.eyes(rig);
+const lips = F.face.mouthAccents(rig, mouthOpts);  // upper + lower lip, labelled 'lips'
+
+api.paint.label('skin', '#dba882');
+api.paint.label('eyes', '#f6f4ef');
+api.paint.label('iris', '#4a3826');
+api.paint.label('pupil', '#1c1c1c');
+api.paint.label('lips', '#b8506a');
+
+return sdf.union(body, eyes, lips)
+  .build({ edgeLength: 0.5, detail: F.faceDetail(rig) });

--- a/prompts/20260614-150000-mouth-options-expansion.md
+++ b/prompts/20260614-150000-mouth-options-expansion.md
@@ -1,0 +1,74 @@
+---
+date: 2026-06-14
+branch: claude/mouth-options-expansion-2ua421
+files_changed:
+  - src/geometry/sdfFigure.ts
+  - tests/unit/sdfFigure.test.ts
+  - public/ai/figure.md
+  - examples/faces/bust_grin_teeth.js
+  - examples/faces/bust_natural_lips.js
+---
+
+## Human
+
+The figure mouth options are very basic. There's a GitHub issue about corruption
+when a mouth is carved into the head. Wanted: more mouth options — natural lips
+with a distinct upper and lower lip; smiles that show teeth (upper, lower, or
+both); frowny / neutral / smile / big-smile presets ("levels"). Flat / painted-on
+mouths are acceptable for now (carving can come later). Key print constraint:
+avoid freestanding teeth, because support material would have to go inside the
+mouth. Plan and implement an upgrade to the figure-API mouths.
+
+## Assistant
+
+Scoped with the user to **painted-flat first, one cohesive PR**. Kept the design
+additive + paint-labelled so it prints support-free and sidesteps the carve
+corruption (#652) entirely; the historical carved-smile default stays
+byte-identical, all new capability is opt-in.
+
+**Expression axis (the headline).** The old `'smile'` line hardcoded
+`curl·(t²−0.3)`, which *always* lifts the corners — no frown was possible. Added
+a signed `curve` (−1 frown … +1 smile) plus an `expression` preset enum
+(`bigSmile … deepFrown`). Generalized the line profile to `grooveCurl·bend·(t²−0.3)
++ smirk·…`; `bend=1` reproduces the old smile exactly (calibration anchor), `0` is
+straight, `<0` frowns. `resolveMouthCurve` returns `undefined` when neither
+`curve` nor `expression` is set, so each style keeps its historical bend — un-set
+mouths are byte-identical. The bend also bows the lip ridge and the open-mouth lip
+ring.
+
+**Natural two-lip lips.** `style:'lips'` gains `divided:true` → a distinct upper +
+lower lip (two bowed capsule arcs with a seam). The non-divided, no-curve path is
+preserved verbatim (single straight ridge) for back-compat.
+
+**Teeth.** `mouthAccents` `teeth` now takes `'upper'|'lower'|'both'` (plus the
+back-compat `true`=upper / `false`). Added a lower band (vertical mirror of the
+existing upper band). Under `render:'painted'` the teeth are a flat plate sitting
+**flush/proud in the lip-ring opening** and **fused into the head** (no cavity, no
+internal overhang → no support inside the mouth). The carved path keeps the
+recessed-behind-the-rim band.
+
+**#652 fix (carved-mouth tearing on small heads).** Added `render: 'auto' |
+'carved' | 'painted'`. `auto` carves only when `carveIsSafe(rig)` — an *absolute*
+groove-size floor (`r.head·0.07 ≥ 0.245`, i.e. `r.head ≥ 3.5`), because the
+groove-to-march-cell ratio is scale-invariant (~3.5 at any head) so only an
+absolute floor separates a clean carve from a torn one. Below it `auto` paints a
+clean additive ridge. Verified the exact #652 Yoga repro: `minEdgeLength` went
+0.0002 (torn) → 0.004, manifold, one component, no warnings. Back-compat: standard
+`headsTall:5` figures (`r.head≈6`) still carve unchanged.
+
+`mouthAccents('smile')` now returns a paintable lip *line* labelled `'lips'`
+(was: threw) so a coloured expressive mouth line is possible.
+
+**Verification.** `model:preview` (real engine, Node): the colored expression
+spectrum reads deep-frown→big-smile; the painted grin shows white teeth framed by
+red lips (teeth/lips labels resolve to real triangles only after the double-ring
+fix — pass `mouth:false` to assemble when using accents, mirroring the existing
+`'lips'` guidance); the divided lips render as a clear pout. Confirmed the painted
+grin builds manifold/1-component in the real browser too. `minEdge 0` on some
+busts is pre-existing (the plain default baseline shows it; genus 0, no warning) —
+not introduced here. 175 figure unit tests + full unit tier green; preflight exit
+0 (no circular deps).
+
+Issue hygiene: this resolves #652 (additive auto-fallback) and chips at #589's
+lips/mouth gaps; the deferred **deep carved-cavity teeth with upper/lower gum
+separation** is filed as a follow-up rather than forced into this print-safe pass.

--- a/prompts/20260614-150000-mouth-options-expansion.md
+++ b/prompts/20260614-150000-mouth-options-expansion.md
@@ -72,3 +72,13 @@ not introduced here. 175 figure unit tests + full unit tier green; preflight exi
 Issue hygiene: this resolves #652 (additive auto-fallback) and chips at #589's
 lips/mouth gaps; the deferred **deep carved-cavity teeth with upper/lower gum
 separation** is filed as a follow-up rather than forced into this print-safe pass.
+
+**Review follow-up (work-reviewer):** two should-fix items addressed. (1) The
+`auto` carve floor was `r.head ≥ 3.5`, which flipped mainstream 60-unit
+`headsTall:8` adults (`r.head ≈ 3.45`) from carved to additive — not just the
+Yoga-class edge. Re-calibrated empirically to `grooveR ≥ 0.21` (`r.head ≥ 3.0`):
+the documented #652 Yoga repro (2.82) and very-lanky `headsTall:10` (2.76) still
+flip to the clean additive mouth, while every height-60 figure (`headsTall` 5–8)
+keeps carving exactly as before. Added a regression test pinning the adult case
+to `'carve'`. (2) `divided` was coerced (`=== true`) instead of validated; now
+uses `assertBoolean` and rejects non-booleans, matching the other mouth fields.

--- a/public/ai/figure.md
+++ b/public/ai/figure.md
@@ -372,7 +372,7 @@ before aiming a prop at it.
 F.face.assemble(head, rig, {
   eyes:  true | { radius, style, lids, gaze, gazeL, gazeR } | false,  // OFF by default — see note below
   nose:  true | { tipRadius, length, width, bridge, flare } | false,
-  mouth: true | { style, width, smirk, open, fullness } | false,
+  mouth: true | { style, expression, curve, width, smirk, open, fullness, divided, render, teeth } | false,
   ears:  true | { size } | false,
   brows: { thickness, lift } | false, // off by default; pass {} or a tuning object to add
 })
@@ -402,6 +402,12 @@ The explicit knobs multiply **on top of** the preset, so `{ faceShape: 'square',
   size alone — e.g. `{ width: 1.4, bridge: 0.6, flare: 1.0 }` vs `{ width: 0.8, bridge: 1.3 }`.
 - **`mouth.fullness`** (0.4–2.2) scales lip thickness independently of `width`
   (works on the `'lips'` ridge and the open-mouth lip ring).
+- **`mouth.expression`** picks the emotion *level*: `'bigSmile'` · `'smile'` ·
+  `'slightSmile'` · `'neutral'` · `'slightFrown'` · `'frown'` · `'deepFrown'`.
+  Or set **`mouth.curve`** directly (−1 deep frown … 0 neutral … +1 big smile;
+  the numeric `curve` overrides the preset). It bows EVERY style — the carved
+  line, the lip ridge, and the open mouth's opening all smile or frown. Un-set,
+  each style keeps its historical bend (smile bows up, lips/open stay straight).
 
 > **Eyes default to OFF in `assemble`.** The recommended flow welds the face into
 > the body and `.label('skin')`s it — which would flatten any in-face eyes into
@@ -419,17 +425,30 @@ exposed if you want to place a feature yourself.
 
 ### Mouth styles
 
+`style` is the *representation*; `expression`/`curve` is the *emotion* (it bows
+any style — see above). `render` chooses how the mouth meets the head.
+
 | `style` | What you get | Add or carve |
 |---|---|---|
-| `'smile'` (default) | a curved smile **line** carved into the face — the classic cartoon mouth. `smirk` (−1..1) skews it. | carve |
-| `'open'` | an open mouth cavity (laughing / talking / singing). `open` (0..1) sets the gape; passing `open > 0` without a style selects this. Pair it with `mouthAccents` for teeth + lips. | carve |
-| `'lips'` | a protruding lip ridge. | add |
+| `'smile'` (default) | a smile/frown **line** through the face — the classic cartoon mouth. Carved as a groove when the head is big enough, else raised as a clean ridge (`render` overrides). `smirk` (−1..1) skews it; `expression`/`curve` bows it. | carve / add |
+| `'open'` | an open mouth (laughing / talking / singing). `open` (0..1) sets the gape; passing `open > 0` without a style selects this. Pair it with `mouthAccents` for teeth + lips. | carve / add |
+| `'lips'` | a protruding lip ridge. `divided: true` splits it into a natural **upper + lower lip**. | add |
 
 ```js
-mouth: { smirk: 0.4 }                       // happy carved smile (default style)
-mouth: { open: 0.7, width: rig.r.head*0.6 } // big laughing mouth
-mouth: { style: 'lips', smirk: -0.3 }       // pouty sculpted lips
+mouth: { expression: 'bigSmile' }                      // super-smiley
+mouth: { expression: 'deepFrown' }                     // sad
+mouth: { curve: -0.4, smirk: 0.2 }                     // mild frown, skewed
+mouth: { style: 'lips', divided: true, fullness: 1.4 } // natural full upper+lower lips
+mouth: { open: 0.5, expression: 'smile', render: 'painted', teeth: 'both' } // toothy grin
 ```
+
+**`render`** — `'auto'` (default) carves the mouth into the head when the head
+is big enough for a clean carve, and otherwise paints it additively; `'carved'`
+forces the groove/cavity; `'painted'` forces a flat, additive, **print-safe**
+mouth (no carved-out cavity, so no support material lands inside the mouth).
+*Small / high-`headsTall` heads auto-fall-back to painted* — that's the fix for
+the carved-mouth tearing on tiny heads. Use `render: 'painted'` whenever you
+want a clean print of a toothy or open mouth.
 
 `F.face.mouth(rig, opts)` returns the mouth **geometry node**: for the carved
 styles that's the *cutter* — `smoothSubtract` it from the head yourself, or
@@ -438,23 +457,28 @@ just let `assemble` handle the bookkeeping.
 ### Teeth & painted lips — `F.face.mouthAccents(rig, mouthOpts)`
 
 Pre-labelled solid parts that complement the mouth. Build them from the **same
-options object** you passed as `mouth:` so they always agree with the carve,
-and hard-union them at the figure's TOP level (next to the eyes):
+options object** you passed as `mouth:` so they always agree, and hard-union
+them at the figure's TOP level (next to the eyes). For a clean print of a toothy
+smile use `render: 'painted'` and pass `mouth: false` to `assemble` (so the skin
+doesn't also weld a lip ring that buries the painted parts):
 
 ```js
-const mouthOpts = { style: 'open', open: 0.65, width: rig.r.head * 0.6 };
-const face = F.face.assemble(head, rig, { eyes: false, mouth: mouthOpts });
+const mouthOpts = { style: 'open', open: 0.5, expression: 'bigSmile', render: 'painted', teeth: 'both' };
+const face = F.face.assemble(head, rig, { eyes: false, mouth: false });
 const mouthParts = F.face.mouthAccents(rig, mouthOpts);  // 'teeth' + 'lips'
 return sdf.union(skin, eyes, mouthParts, hair, base).build({ ... });
 ```
 
-- `'open'` style: a **`'teeth'`** band hanging from the cavity ceiling and a
-  **`'lips'`** capsule ring around the opening (disable with `teeth: false` /
-  `lips: false`).
-- `'lips'` style: the ridge labelled `'lips'` — in this case pass
-  `mouth: false` to `assemble` (a smooth-welded copy would swallow the
-  labelled one).
-- `'smile'` has no accents — the carved line needs no paint.
+- `'open'` style: a **`'teeth'`** band (`teeth: 'upper'` (default) · `'lower'` ·
+  `'both'` · `false`) and a **`'lips'`** ring around the opening (skip with
+  `lips: false`), both bowed by the expression so a grin's opening smiles. Under
+  `render: 'painted'` the teeth sit as a flat plate flush in the opening (no
+  cavity, prints support-free); carved, they recess behind the rim.
+- `'lips'` style: the ridge labelled `'lips'` (honours `divided`) — pass
+  `mouth: false` to `assemble` (a smooth-welded copy would swallow the label).
+- `'smile'` style: a paintable lip **line** labelled `'lips'` — the additive
+  form of the groove, for a coloured expressive mouth line (frown → smile). Pass
+  `mouth: false` to `assemble` if you want *only* the painted line.
 
 ### Eyes — `style: 'iris'` (default) or `'solid'`
 

--- a/src/geometry/sdfFigure.ts
+++ b/src/geometry/sdfFigure.ts
@@ -23,6 +23,7 @@ import {
   assertNumber,
   assertNumberTuple,
   assertEnum,
+  assertBoolean,
   assertObject,
   assertNoUnknownKeys,
   ValidationError,
@@ -1517,16 +1518,25 @@ function resolveMouthCurve(o: Record<string, unknown>, name: string): number | u
 }
 
 /** Is a CARVED mouth safe to mesh at this head size? The subtractive carve
- *  tears into degenerate sub-cell slivers when the absolute groove/cavity
- *  feature gets small (issue #652 — torn mouth on small / high-`headsTall`
- *  heads; the Yoga repro sits at `r.head ≈ 2.8`). Above the floor we carve as
- *  before; below it the default `render: 'auto'` falls back to a clean ADDITIVE
- *  mouth (the documented Yoga workaround, now automatic). The floor is an
- *  ABSOLUTE world size, not a cell ratio: the groove-to-march-edge ratio is
- *  scale-invariant (≈3.5 at any head), so only an absolute floor distinguishes
- *  a clean carve from a torn one. `grooveR = r.head·0.07`, so this is `r.head ≥ 3.5`. */
+ *  tears into degenerate, visibly-spiky sub-cell geometry when the absolute
+ *  groove feature gets small (issue #652 — torn mouth on small / high-`headsTall`
+ *  heads). The floor is an ABSOLUTE world size, not a cell ratio: the
+ *  groove-to-march-edge ratio is scale-invariant (≈3.5 at any head), so only an
+ *  absolute floor distinguishes a clean carve from a torn one. Above it we carve
+ *  as before; below it the default `render: 'auto'` falls back to a clean
+ *  ADDITIVE mouth (the documented Yoga workaround, now automatic).
+ *
+ *  Calibrated empirically (`grooveR = r.head·0.07`):
+ *    - #652 Yoga repro `r.head ≈ 2.82` (grooveR 0.197) — VISIBLY TORN → paint.
+ *    - 60-unit `headsTall:8` adult `r.head ≈ 3.45` (grooveR 0.242) — carves
+ *      clean → must stay carved (back-compat for mainstream figures).
+ *  The floor sits between them at `grooveR ≥ 0.21` (`r.head ≥ 3.0`): it catches
+ *  the documented torn cases (Yoga, very-lanky `headsTall:10`) while leaving
+ *  every height-60 figure (`headsTall` 5–8) carving exactly as before. A
+ *  figure in the narrow torn band below 3.0 changes from a TORN carve to a
+ *  clean painted mouth — the #652 fix, not a regression of good output. */
 function carveIsSafe(rig: Rig): boolean {
-  return rig.r.head * 0.07 >= 0.245;
+  return rig.r.head * 0.07 >= 0.21;
 }
 
 /** Orient an origin-built node into the posed head frame, so axis-aligned
@@ -1569,7 +1579,7 @@ function buildMouthPart(sdf: SdfApi, rig: Rig, opts?: unknown): MouthPart {
   const fullness = num(o.fullness, 1, 'mouth.fullness', 0.4, 2.2);
   // `divided` splits the lip ridge into a distinct upper + lower lip (the
   // natural two-lip look) — only meaningful for style 'lips'.
-  const divided = o.divided === true;
+  const divided = assertBoolean(o.divided, 'mouth.divided', { optional: true }) ?? false;
   const render = assertEnum(o.render ?? 'auto', ['auto', 'carved', 'painted'] as const, 'mouth.render') as MouthRender;
   // Signed expression curve, or undefined → each style keeps its historical bend.
   const curveOpt = resolveMouthCurve(o, 'mouth');

--- a/src/geometry/sdfFigure.ts
+++ b/src/geometry/sdfFigure.ts
@@ -1485,13 +1485,49 @@ function buildNose(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
 }
 
 type MouthStyle = 'smile' | 'lips' | 'open';
+type MouthRender = 'auto' | 'carved' | 'painted';
 
-/** How the mouth combines with the head: protruding lips are ADDED
- *  (smoothUnion), while smile lines and open mouths are CARVED
- *  (smoothSubtract). assembleFace dispatches on this. */
+/** How the mouth combines with the head: protruding lips (and the print-safe
+ *  additive fallbacks) are ADDED (smoothUnion), while carved smile lines and
+ *  open cavities are CARVED (smoothSubtract). assembleFace dispatches on this. */
 interface MouthPart { node: Node; mode: 'add' | 'carve' }
 
-const MOUTH_FIELDS = ['width', 'smirk', 'open', 'style', 'teeth', 'lips', 'fullness'];
+const MOUTH_FIELDS = ['width', 'smirk', 'open', 'style', 'teeth', 'lips', 'fullness', 'expression', 'curve', 'divided', 'render'];
+
+/** Named expression presets → a signed mouth curve (−1 deep frown … 0 neutral
+ *  … +1 big smile). The curve bows the mouth line: positive lifts the corners
+ *  (happy), zero is a straight line (neutral), negative drops them (sad). These
+ *  are the artist-facing "levels" — super-smiley through deep-frown. */
+const MOUTH_EXPRESSIONS = ['bigSmile', 'smile', 'slightSmile', 'neutral', 'slightFrown', 'frown', 'deepFrown'] as const;
+type MouthExpression = (typeof MOUTH_EXPRESSIONS)[number];
+const EXPRESSION_CURVE: Record<MouthExpression, number> = {
+  bigSmile: 1, smile: 0.7, slightSmile: 0.35, neutral: 0,
+  slightFrown: -0.35, frown: -0.7, deepFrown: -1,
+};
+
+/** Resolve the signed expression curve (−1..+1) from `curve` / `expression`, or
+ *  `undefined` when the caller set neither — in which case each style keeps its
+ *  HISTORICAL default bend (smile bows up, lips/open stay straight), so an
+ *  un-set mouth is byte-identical to before. An explicit numeric `curve` wins
+ *  over the `expression` preset. */
+function resolveMouthCurve(o: Record<string, unknown>, name: string): number | undefined {
+  if (o.curve !== undefined) return num(o.curve, 0, `${name}.curve`, -1, 1);
+  if (o.expression !== undefined) return EXPRESSION_CURVE[assertEnum(o.expression, MOUTH_EXPRESSIONS, `${name}.expression`)];
+  return undefined;
+}
+
+/** Is a CARVED mouth safe to mesh at this head size? The subtractive carve
+ *  tears into degenerate sub-cell slivers when the absolute groove/cavity
+ *  feature gets small (issue #652 — torn mouth on small / high-`headsTall`
+ *  heads; the Yoga repro sits at `r.head ≈ 2.8`). Above the floor we carve as
+ *  before; below it the default `render: 'auto'` falls back to a clean ADDITIVE
+ *  mouth (the documented Yoga workaround, now automatic). The floor is an
+ *  ABSOLUTE world size, not a cell ratio: the groove-to-march-edge ratio is
+ *  scale-invariant (≈3.5 at any head), so only an absolute floor distinguishes
+ *  a clean carve from a torn one. `grooveR = r.head·0.07`, so this is `r.head ≥ 3.5`. */
+function carveIsSafe(rig: Rig): boolean {
+  return rig.r.head * 0.07 >= 0.245;
+}
 
 /** Orient an origin-built node into the posed head frame, so axis-aligned
  *  mouth/eye parts follow the head pose. `tilt` is a ROLL about the (canonical)
@@ -1531,54 +1567,124 @@ function buildMouthPart(sdf: SdfApi, rig: Rig, opts?: unknown): MouthPart {
   // ring). 1 = the default; >1 for fuller lips, <1 for thinner — another real
   // axis of facial variation that decouples lip volume from mouth width.
   const fullness = num(o.fullness, 1, 'mouth.fullness', 0.4, 2.2);
+  // `divided` splits the lip ridge into a distinct upper + lower lip (the
+  // natural two-lip look) — only meaningful for style 'lips'.
+  const divided = o.divided === true;
+  const render = assertEnum(o.render ?? 'auto', ['auto', 'carved', 'painted'] as const, 'mouth.render') as MouthRender;
+  // Signed expression curve, or undefined → each style keeps its historical bend.
+  const curveOpt = resolveMouthCurve(o, 'mouth');
   // `open > 0` implies the open style unless the caller said otherwise.
   const style: MouthStyle = o.style !== undefined
     ? assertEnum(o.style, ['smile', 'lips', 'open'] as const, 'mouth.style')
     : open > 0 ? 'open' : 'smile';
-  const u = rig.dir.headUp, right = rig.dir.headLeft;
+  const u = rig.dir.headUp, right = rig.dir.headLeft, fwd = rig.dir.headForward;
   const m = rig.face.mouth;
   const halfW = width * 0.5;
+  // Carve when explicitly asked, or under 'auto' only when the head is big
+  // enough for a clean carve; otherwise paint the mouth additively (#652).
+  const wantCarve = render === 'carved' || (render === 'auto' && carveIsSafe(rig));
+
+  // Vertical profile of the mouth LINE across t∈[−1,1], scaled by the signed
+  // `bend` (−1 frown … +1 smile). bend=1 reproduces the historical smile
+  // (corners +0.7·curl, centre −0.3·curl); bend=0 is straight; bend<0 frowns.
+  // `smirk` skews the whole line asymmetrically.
+  const grooveCurl = rig.r.head * 0.14;
+  const arcVert = (t: number, bend: number): number =>
+    grooveCurl * bend * (t * t - 0.3) + smirk * halfW * 0.35 * t;
 
   if (style === 'lips') {
-    // A protruding lip ridge, pushed forward of the anchor so it clearly
-    // stands proud of the face (an on-surface capsule reads as nothing when
-    // it isn't smooth-welded). Smirk tips one corner up.
     const lipR = rig.r.head * 0.085 * fullness;
-    const fwd = scale3(rig.dir.headForward, lipR * 0.6);
-    const a = add3(add3(add3(m, fwd), scale3(right, halfW)), scale3(u, smirk * width * 0.25));
-    const b = add3(add3(add3(m, fwd), scale3(right, -halfW)), scale3(u, -smirk * width * 0.25));
-    return { node: sdf.capsule(a, b, lipR), mode: 'add' };
+    const fwdPush = scale3(fwd, lipR * 0.6);
+    if (!divided && curveOpt === undefined) {
+      // Historical single straight ridge (byte-identical) — smirk tips a corner.
+      const a = add3(add3(add3(m, fwdPush), scale3(right, halfW)), scale3(u, smirk * width * 0.25));
+      const b = add3(add3(add3(m, fwdPush), scale3(right, -halfW)), scale3(u, -smirk * width * 0.25));
+      return { node: sdf.capsule(a, b, lipR), mode: 'add' };
+    }
+    // Bowed lip ridge(s) — a 6-segment arc so the lips follow the expression.
+    const bend = curveOpt ?? 0;
+    const ridge = (zOff: number, rad: number): Node => {
+      const pt = (t: number): Vec3 => add3(add3(add3(m, fwdPush),
+        scale3(right, halfW * t)), scale3(u, arcVert(t, bend) + zOff));
+      let arc: Node | undefined;
+      for (let i = 0; i < 6; i++) {
+        const seg = sdf.capsule(pt(-1 + (2 * i) / 6), pt(-1 + (2 * (i + 1)) / 6), rad);
+        arc = arc === undefined ? seg : arc.union(seg);
+      }
+      return arc!;
+    };
+    if (divided) {
+      // Upper + lower lip separated by a thin seam — the natural two-lip look.
+      const gap = lipR * 0.55;
+      return { node: ridge(gap, lipR * 0.9).union(ridge(-gap, lipR * 1.05)), mode: 'add' };
+    }
+    return { node: ridge(0, lipR), mode: 'add' };
   }
 
   if (style === 'open') {
-    // A carved mouth cavity — the cartoon "laughing / talking" mouth. The
-    // ellipsoid straddles the surface and reaches inward so the opening reads
-    // as a dark interior, not a shallow dent.
-    const { halfW: hw, cavH, center } = mouthCavityFrame(rig, width, open);
-    const cavity = orientToHeadPose(sdf.ellipsoid(hw, rig.r.head * 0.38, cavH), rig)
-      .translate(center);
-    return { node: cavity, mode: 'carve' };
+    if (wantCarve) {
+      // A carved mouth cavity — the cartoon "laughing / talking" mouth. The
+      // ellipsoid straddles the surface and reaches inward so the opening reads
+      // as a dark interior, not a shallow dent.
+      const { halfW: hw, cavH, center } = mouthCavityFrame(rig, width, open);
+      const cavity = orientToHeadPose(sdf.ellipsoid(hw, rig.r.head * 0.38, cavH), rig)
+        .translate(center);
+      return { node: cavity, mode: 'carve' };
+    }
+    // Print-safe / small-head fallback: an ADDITIVE lip ring bowed by the
+    // expression instead of a deep carved cavity (which tears at small head
+    // sizes — #652 — and needs internal print supports). Colored teeth + lips
+    // come from mouthAccents; this is the skin-welded mouth presence.
+    return { node: buildLipRing(sdf, rig, width, open, fullness, curveOpt ?? 0), mode: 'add' };
   }
 
-  // 'smile' (default): a carved smile LINE — an arc of capsules through the
-  // mouth anchor, corners curling up, carved into the face as a groove.
-  // Cartoon faces read a carved line far better than a protruding ridge.
-  const curl = rig.r.head * 0.14;          // corner lift at t = ±1
+  // 'smile' (default): the cartoon mouth LINE through the anchor, bowed by the
+  // expression (default bend=1 = the historical happy smile). Carved as a
+  // groove when safe; otherwise raised as a clean additive ridge (#652 fix) —
+  // a carved line tears into slivers below ~r.head 3.5.
+  const bend = curveOpt === undefined ? 1 : curveOpt;
   const grooveR = rig.r.head * 0.07;
-  const SEGS = 6;
+  const lineFwd = wantCarve ? ([0, 0, 0] as Vec3) : scale3(fwd, grooveR * 0.6);
   const pt = (t: number): Vec3 => add3(
-    add3(m, scale3(right, halfW * t)),
-    // t² curl dips the middle 30% of `curl` below the anchor and lifts the
-    // corners 70% above it; smirk skews the whole line.
-    scale3(u, curl * (t * t - 0.3) + smirk * halfW * 0.35 * t),
+    add3(add3(m, lineFwd), scale3(right, halfW * t)),
+    scale3(u, arcVert(t, bend)),
   );
   let arc: Node | undefined;
-  for (let i = 0; i < SEGS; i++) {
-    const t0 = -1 + (2 * i) / SEGS, t1 = -1 + (2 * (i + 1)) / SEGS;
+  for (let i = 0; i < 6; i++) {
+    const t0 = -1 + (2 * i) / 6, t1 = -1 + (2 * (i + 1)) / 6;
     const seg = sdf.capsule(pt(t0), pt(t1), grooveR);
     arc = arc === undefined ? seg : arc.union(seg);
   }
-  return { node: arc!, mode: 'carve' };
+  return { node: arc!, mode: wantCarve ? 'carve' : 'add' };
+}
+
+/** The open-mouth lip ring: a chain of capsules around the opening ellipse,
+ *  bowed by the expression `bend`. Shared by the additive open-mouth fallback
+ *  (skin-welded mouth presence) and `mouthAccents` (the painted 'lips' region).
+ *  A thin ellipsoid-minus-tunnel shell fragments into shards when marched —
+ *  capsule chains are unconditionally robust. */
+function buildLipRing(sdf: SdfApi, rig: Rig, width: number, open: number, fullness: number, bend: number): Node {
+  const { halfW, cavH } = mouthCavityFrame(rig, width, open);
+  const u = rig.dir.headUp, right = rig.dir.headLeft, R = rig.r.head;
+  const lipR = Math.min(R * 0.10, cavH * 0.55) * fullness;
+  // Ring centre: the cavity opening projected onto the face. Centred ON the
+  // surface — half the capsule is buried, so the lips read as part of the face.
+  const cc = add3(rig.face.mouth, scale3(u, -cavH * 0.25));
+  const SEGS = 14;
+  const ringPt = (theta: number): Vec3 => add3(cc, add3(
+    scale3(right, halfW * 1.02 * Math.cos(theta)),
+    // sin → the ellipse height; the bend term lifts the corners (|cos| large)
+    // and dips the centre, so a positive bend gives a smiling opening. Vanishes
+    // at bend=0, keeping an un-set ring byte-identical.
+    scale3(u, cavH * 1.08 * Math.sin(theta) + bend * halfW * 0.4 * (Math.cos(theta) ** 2 - 0.3)),
+  ));
+  let ring: Node | undefined;
+  for (let i = 0; i < SEGS; i++) {
+    const t0 = (2 * Math.PI * i) / SEGS, t1 = (2 * Math.PI * (i + 1)) / SEGS;
+    const seg = sdf.capsule(ringPt(t0), ringPt(t1), lipR);
+    ring = ring === undefined ? seg : ring.union(seg);
+  }
+  return ring!;
 }
 
 /** Public `F.face.mouth(rig, opts)` — returns the mouth geometry node. For
@@ -1592,13 +1698,15 @@ function buildMouth(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
  *  TOP level of the figure (next to the eyes), complementing the carve that
  *  `face.assemble` applies. Pass the SAME options object you gave `mouth`.
  *
- *  - style 'open': a 'teeth' band hanging from the cavity ceiling (skip with
- *    `teeth: false`) and a 'lips' ring around the opening (skip with
- *    `lips: false`).
- *  - style 'lips': the lip ridge labelled 'lips' — pass `mouth: false` to
- *    `face.assemble` in this case so the ridge isn't ALSO smooth-welded
+ *  - style 'open': a 'teeth' band (`teeth: 'upper'` (default) | 'lower' | 'both'
+ *    | false) and a 'lips' ring around the opening (skip with `lips: false`),
+ *    both bowed by the expression so a grin's opening smiles.
+ *  - style 'lips': the lip ridge labelled 'lips' (honours `divided`) — pass
+ *    `mouth: false` to `face.assemble` so the ridge isn't ALSO smooth-welded
  *    (a welded copy would swallow the labelled one).
- *  - style 'smile' has no accents (the carved line needs no paint). */
+ *  - style 'smile': a paintable lip LINE labelled 'lips' — the additive form of
+ *    the carved groove, for a coloured expressive mouth line. Pass `mouth: false`
+ *    to `assemble` if you want ONLY the painted line (no carved groove too). */
 function buildMouthAccents(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
   const o = obj(opts, 'mouthAccents(opts)');
   assertNoUnknownKeys(o, MOUTH_FIELDS, 'mouthAccents(opts)');
@@ -1613,80 +1721,86 @@ function buildMouthAccents(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
   if (style === 'lips') {
     return buildMouthPart(sdf, rig, { ...o, style: 'lips' }).node.label('lips');
   }
-  if (style !== 'open') {
-    throw new ValidationError(
-      "face.mouthAccents: only the 'open' and 'lips' mouth styles have paintable accents — "
-      + "the carved 'smile' line is shading, not a part. See /ai/figure.md#mouth-styles.",
-    );
+  if (style === 'smile') {
+    // A paintable lip LINE — the additive form of the smile/frown groove, so a
+    // coloured (e.g. pink) EXPRESSIVE mouth line can be painted on. Bowed by
+    // the expression like the carve. (The carved groove `assemble` makes is
+    // shading, not paintable; pass `mouth: false` to assemble for ONLY this.)
+    return buildMouthPart(sdf, rig, { ...o, style: 'smile', render: 'painted' }).node.label('lips');
   }
 
   const { halfW, cavH, center } = mouthCavityFrame(rig, width, open);
+  const fineEdge = Math.max(R * 0.02, 0.03);
+  // Painted (print-safe, no cavity) when render says so or `auto` on a small
+  // head — mirrors buildMouthPart's carve/paint split so teeth and the carve
+  // agree on the same mouth.
+  const render = assertEnum(o.render ?? 'auto', ['auto', 'carved', 'painted'] as const, 'mouthAccents.render') as MouthRender;
+  const painted = render === 'painted' || (render === 'auto' && !carveIsSafe(rig));
+  const fullness = num(o.fullness, 1, 'mouthAccents.fullness', 0.4, 2.2);
+  const lipR = Math.min(R * 0.10, cavH * 0.55) * fullness;
+  const cc = add3(rig.face.mouth, scale3(u, -cavH * 0.25));
   const parts: Node[] = [];
-  if (o.teeth !== false) {
-    // A white band hanging from the cavity ceiling: top edge buried in the
-    // head above the opening (fuses into one component), front face recessed
-    // just behind the face surface. The recess scales with the cavity so a
-    // slim gritted-teeth mouth (small `open`) still shows the band — a fixed
-    // recess deeper than the opening buries it entirely.
-    // Slightly NARROWER than the opening with a cavity-proportional recess:
-    // a band wider than the opening (or flush with the rim) grazes the
-    // carved skin and sheds zero-volume boolean slivers, while a recess
-    // deeper than the cavity buries the band entirely (body welds can
-    // inflate the face surface past any fixed offset).
-    const td = R * 0.5;
-    // Every face of the band must clear (or decisively cross) the cavity
-    // surfaces by a couple of MARCH CELLS, not by a proportion of cavH — on
-    // a slim gritted mouth the proportional margins drop below one cell and
-    // the near-tangent surfaces shred into dozens of micro-handles (genus
-    // explosion). fineEdge mirrors faceDetail's mouth-region march edge.
-    const fineEdge = Math.max(R * 0.02, 0.03);
-    // Front face: recessed behind the carved rim by at least ~1.5 cells.
-    const recess = Math.max(cavH * 0.18, fineEdge * 1.5);
-    // roundedBox takes FULL sizes (not half-extents). Width spans most of
-    // the opening but stays NARROWER than it, so the flat front face lies
-    // inside the aperture and meets only air — a band wider than the slot
-    // grazes the curved rim at a shallow angle all around it (a ring of
-    // near-tangent boolean crossings → micro-handles).
-    const bandW = halfW * 1.7;
-    // Height: hang the band above the floor (dark gap under the teeth — the
-    // open-laugh look); when that gap would be sub-cell, close it instead:
-    // run the band through the floor into the jaw — a transversal weld, and
-    // the right look for gritted teeth.
-    const hangGap = cavH * 0.7; // bottom edge at 0.45·cavH − 0.75·cavH
-    const bandH = hangGap < fineEdge * 2.5 ? cavH * 2.9 + fineEdge * 3 : cavH * 1.5;
-    const teeth = orientToHeadPose(
-      sdf.roundedBox([bandW, td, bandH], Math.min(cavH, halfW) * 0.18), rig,
-    ).translate(add3(center, add3(scale3(u, cavH * 0.45), scale3(f, -recess - td * 0.5))));
-    parts.push(teeth.label('teeth'));
-  }
-  if (o.lips !== false) {
-    // A lip ring: a chain of capsules around the opening ellipse. (A thin
-    // ellipsoid-minus-tunnel shell fragments into dozens of shards when
-    // marched — capsule chains are unconditionally robust.)
-    const right = rig.dir.headLeft;
-    const fullness = num(o.fullness, 1, 'mouthAccents.fullness', 0.4, 2.2);
-    const lipR = Math.min(R * 0.10, cavH * 0.55) * fullness;
-    // Ring centre: the cavity opening projected onto the face. Centred ON
-    // the surface — half the capsule is buried, so the lips read as part of
-    // the face instead of a donut stuck onto it.
-    const cc = add3(rig.face.mouth, scale3(u, -cavH * 0.25));
-    const SEGS = 14;
-    const ringPt = (theta: number): Vec3 => add3(cc, add3(
-      scale3(right, halfW * 1.02 * Math.cos(theta)),
-      scale3(u, cavH * 1.08 * Math.sin(theta)),
-    ));
-    let ring: Node | undefined;
-    for (let i = 0; i < SEGS; i++) {
-      const t0 = (2 * Math.PI * i) / SEGS, t1 = (2 * Math.PI * (i + 1)) / SEGS;
-      const seg = sdf.capsule(ringPt(t0), ringPt(t1), lipR);
-      ring = ring === undefined ? seg : ring.union(seg);
+  // A white teeth band, mirrorable to upper (sign +1) or lower (sign −1).
+  // CARVED mouths recess the band behind the rim so it shows through the
+  // cavity; PAINTED mouths (no cavity) sit a flat plate PROUD in the lip-ring
+  // opening so the teeth read on the surface (and print without internal
+  // supports). `teeth: 'both'` builds both, leaving a thin mouth line between.
+  const teethBand = (sign: 1 | -1): Node => {
+    if (painted) {
+      const td = R * 0.45;                      // depth into head (fused); front proud
+      const plateW = halfW * 1.45;              // inside the lip-ring opening
+      const plateH = cavH * 0.85;
+      // The mouth anchor sits ~lipR behind the skin surface, so the plate's
+      // front face must reach past that (just shy of the lip-ring front) to
+      // show on the surface instead of staying buried in solid skin.
+      const front = lipR * 1.05;
+      return orientToHeadPose(sdf.roundedBox([plateW, td, plateH], Math.min(cavH, halfW) * 0.18), rig)
+        .translate(add3(cc, add3(scale3(u, sign * cavH * 0.5), scale3(f, front - td * 0.5))));
     }
-    parts.push(ring!.label('lips'));
+    // Slightly NARROWER than the opening with a cavity-proportional recess: a
+    // band wider than the opening (or flush with the rim) grazes the carved
+    // skin and sheds zero-volume slivers; a recess deeper than the cavity
+    // buries the band (body welds can inflate the face past any fixed offset).
+    const td = R * 0.5;
+    // Every face must clear (or decisively cross) the cavity surfaces by a
+    // couple of MARCH CELLS, not a proportion of cavH — on a slim gritted
+    // mouth the proportional margins drop below one cell and near-tangent
+    // surfaces shred into micro-handles. fineEdge mirrors faceDetail's edge.
+    const recess = Math.max(cavH * 0.18, fineEdge * 1.5);
+    const bandW = halfW * 1.7;
+    // Hang the band off the rim (dark gap behind the teeth — the open-laugh
+    // look); when that gap would be sub-cell, close it by running the band
+    // into the jaw (a transversal weld — the gritted-teeth look).
+    const hangGap = cavH * 0.7;
+    const bandH = hangGap < fineEdge * 2.5 ? cavH * 2.9 + fineEdge * 3 : cavH * 1.5;
+    return orientToHeadPose(
+      sdf.roundedBox([bandW, td, bandH], Math.min(cavH, halfW) * 0.18), rig,
+    ).translate(add3(center, add3(scale3(u, sign * cavH * 0.45), scale3(f, -recess - td * 0.5))));
+  };
+  let teeth: Node | undefined;
+  for (const side of resolveTeeth(o.teeth)) {
+    const band = teethBand(side === 'upper' ? 1 : -1);
+    teeth = teeth === undefined ? band : teeth.union(band);
+  }
+  if (teeth !== undefined) parts.push(teeth.label('teeth'));
+  if (o.lips !== false) {
+    const ring = buildLipRing(sdf, rig, width, open, fullness, resolveMouthCurve(o, 'mouthAccents') ?? 0);
+    parts.push(ring.label('lips'));
   }
   if (parts.length === 0) {
     throw new ValidationError('face.mouthAccents: both teeth and lips are disabled — nothing to build.');
   }
   return parts.length === 1 ? parts[0] : parts[0].union(parts[1]);
+}
+
+/** Resolve the `teeth` option to the set of bands to build: `false` → none;
+ *  `true`/unset → the historical upper band; `'upper'` / `'lower'` / `'both'`
+ *  pick explicitly. (Upper-only stays byte-identical to the old behaviour.) */
+function resolveTeeth(v: unknown): Array<'upper' | 'lower'> {
+  if (v === false) return [];
+  if (v === undefined || v === true) return ['upper'];
+  const sel = assertEnum(v, ['upper', 'lower', 'both'] as const, 'mouthAccents.teeth');
+  return sel === 'both' ? ['upper', 'lower'] : [sel];
 }
 
 function buildEars(sdf: SdfApi, rig: Rig, opts?: unknown): Node {

--- a/tests/unit/sdfFigure.test.ts
+++ b/tests/unit/sdfFigure.test.ts
@@ -484,6 +484,58 @@ describe('figure mouth — styles', () => {
     expect(() => buildMouthPart(api, rig, { open: 2 })).toThrow();
     expect(() => buildMouthPart(api, rig, { fangs: true })).toThrow();
   });
+
+  // The arc corner height vs centre height tells smile (corners up) from frown
+  // (corners down). Sample the cutter just below each corner and the centre.
+  const cornerVsCentre = (opts: Record<string, unknown>): number => {
+    const node = buildMouthPart(api, rig, opts).node;
+    const m = rig.face.mouth, u = rig.dir.headUp, right = rig.dir.headLeft;
+    const hw = rig.r.head * 0.25;
+    // Walk up from the anchor until outside the cutter, at the corner vs centre.
+    const topOf = (lat: number): number => {
+      const base = [m[0] + right[0] * lat, m[1] + right[1] * lat, m[2] + right[2] * lat];
+      let z = -rig.r.head;
+      for (let s = -rig.r.head; s <= rig.r.head; s += rig.r.head * 0.02) {
+        const p = [base[0] + u[0] * s, base[1] + u[1] * s, base[2] + u[2] * s];
+        if (node.evaluate(p[0], p[1], p[2]) < 0) z = s;
+      }
+      return z;
+    };
+    return topOf(hw) - topOf(0); // corner-top minus centre-top
+  };
+
+  it('expression bends the mouth: smile lifts corners, frown drops them', () => {
+    expect(cornerVsCentre({ expression: 'bigSmile' })).toBeGreaterThan(0);
+    expect(cornerVsCentre({ expression: 'deepFrown' })).toBeLessThan(0);
+    // A bigger smile lifts the corners more than a slight one.
+    expect(cornerVsCentre({ expression: 'bigSmile' }))
+      .toBeGreaterThan(cornerVsCentre({ expression: 'slightSmile' }));
+  });
+
+  it('numeric curve overrides the preset and rejects out-of-range', () => {
+    expect(cornerVsCentre({ curve: -1 })).toBeLessThan(0);
+    expect(() => buildMouthPart(api, rig, { curve: 2 })).toThrow(/curve/);
+    expect(() => buildMouthPart(api, rig, { expression: 'grimace' })).toThrow(/expression/);
+  });
+
+  it("divided lips build a taller two-ridge stack than a single ridge", () => {
+    const single = buildMouthPart(api, rig, { style: 'lips' }).node.bounds();
+    const two = buildMouthPart(api, rig, { style: 'lips', divided: true }).node.bounds();
+    expect(two.max[2] - two.min[2]).toBeGreaterThan(single.max[2] - single.min[2]);
+  });
+
+  it('render: painted makes the smile line additive (the #652-class fallback)', () => {
+    expect(buildMouthPart(api, rig, { render: 'painted' }).mode).toBe('add');
+    expect(buildMouthPart(api, rig, { render: 'carved' }).mode).toBe('carve');
+  });
+
+  it('auto-render falls back to additive on a small head, carves on a large one', () => {
+    // Yoga-class proportions (#652): tiny head → carve would tear, so paint.
+    const tiny = buildRig({ height: 46, headsTall: 7.5, build: 'slim' });
+    expect(buildMouthPart(api, tiny, { smirk: 0.15 }).mode).toBe('add');
+    // A normal figure still carves the smile groove (back-compat).
+    expect(buildMouthPart(api, rig).mode).toBe('carve');
+  });
 });
 
 describe('figure eyes — styles and labels', () => {
@@ -969,9 +1021,21 @@ describe('figure mouthAccents — paintable teeth and lips', () => {
     expect(labelsOf(buildMouthAccents(api, rig, { style: 'lips' }))).toEqual(['lips']);
   });
 
-  it("smile style and fully-disabled accents throw with guidance", () => {
-    expect(() => buildMouthAccents(api, rig, { style: 'smile' })).toThrow(/smile/);
+  it('smile style yields a paintable lip line labelled lips', () => {
+    expect(labelsOf(buildMouthAccents(api, rig, { style: 'smile' }))).toEqual(['lips']);
+  });
+
+  it('fully-disabled open accents throw with guidance', () => {
     expect(() => buildMouthAccents(api, rig, { open: 0.6, teeth: false, lips: false })).toThrow(/nothing/);
+  });
+
+  it("teeth: 'lower'/'both' add a lower band (more vertical teeth extent)", () => {
+    const upper = (buildMouthAccents(api, rig, { open: 0.6, lips: false }) as SdfNode).bounds();
+    const both = (buildMouthAccents(api, rig, { open: 0.6, lips: false, teeth: 'both' }) as SdfNode).bounds();
+    // 'both' grows the band set downward past the upper-only band.
+    expect(both.min[2]).toBeLessThan(upper.min[2] - 1e-6);
+    // 'lower' alone is still a single 'teeth' region.
+    expect(labelsOf(buildMouthAccents(api, rig, { open: 0.6, teeth: 'lower' }))).toEqual(['lips', 'teeth']);
   });
 
   it('accents straddle the mouth anchor (they will fuse into the face)', () => {

--- a/tests/unit/sdfFigure.test.ts
+++ b/tests/unit/sdfFigure.test.ts
@@ -529,12 +529,20 @@ describe('figure mouth — styles', () => {
     expect(buildMouthPart(api, rig, { render: 'carved' }).mode).toBe('carve');
   });
 
-  it('auto-render falls back to additive on a small head, carves on a large one', () => {
-    // Yoga-class proportions (#652): tiny head → carve would tear, so paint.
+  it('auto-render falls back to additive only on genuinely small heads', () => {
+    // Yoga-class proportions (#652): tiny head (r.head≈2.82) → carve would tear,
+    // so paint.
     const tiny = buildRig({ height: 46, headsTall: 7.5, build: 'slim' });
     expect(buildMouthPart(api, tiny, { smirk: 0.15 }).mode).toBe('add');
     // A normal figure still carves the smile groove (back-compat).
     expect(buildMouthPart(api, rig).mode).toBe('carve');
+    // Mainstream adult proportions (60-unit, headsTall 8, r.head≈3.45) must
+    // STAY carved — the floor sits below them, not above (regression guard).
+    expect(buildMouthPart(api, buildRig({ height: 60, headsTall: 8 })).mode).toBe('carve');
+  });
+
+  it('rejects a non-boolean `divided`', () => {
+    expect(() => buildMouthPart(api, rig, { style: 'lips', divided: 'yes' })).toThrow(/divided/);
   });
 });
 


### PR DESCRIPTION
## Summary

Expands the figure-API mouth (`api.sdf.figure`) from 3 basic styles to a full
expressive, print-safe system — and fixes the carved-mouth corruption (#652).
Design is **additive + paint-labelled first** so mouths print support-free; the
historical carved-smile default stays unchanged for mainstream figures and all
new capability is opt-in.

### New capability

- **Expression axis** — `mouth.curve` (−1 deep frown … 0 neutral … +1 big smile)
  and an `expression` preset enum (`bigSmile · smile · slightSmile · neutral ·
  slightFrown · frown · deepFrown`). Bows **every** style. The old `'smile'` line
  could only ever smile (hardcoded corner-lift); now it spans the full range.
- **Natural two-lip lips** — `style:'lips'` + `divided:true` builds a distinct
  upper + lower lip (a real pout) instead of a single flat line.
- **Teeth** — `mouthAccents` `teeth: 'upper' | 'lower' | 'both'` (back-compat:
  `true`=upper, `false`=none). Painted teeth sit as a flat plate flush in the
  lip-ring opening, **fused into the head** — no cavity, so **no support material
  inside the mouth**.
- **`render: 'auto' | 'carved' | 'painted'`** — `auto` carves into the head when
  it's big enough for a clean carve, else paints additively.

### #652 — carved mouth tears into slivers on small heads

`auto` falls back to a clean additive mouth below an **empirically calibrated**
absolute groove-size floor (`grooveR ≥ 0.21`, i.e. `r.head ≥ 3.0`). The
groove-to-march-cell ratio is scale-invariant (~3.5 at any head), so only an
absolute floor separates a clean carve from a torn one. Calibration:

| figure | `r.head` | result |
|---|---|---|
| #652 Yoga repro (h46, ht7.5, slim) | 2.82 | **was torn → now additive** (`minEdge` 0.0002 → 0.004) |
| lanky h60 ht10 | 2.76 | additive |
| **h60 ht8 adult** | **3.45** | **stays carved (back-compat)** |
| h60 ht5–7.5 | 3.7–5.5 | carved (unchanged) |

So every height-60 figure (`headsTall` 5–8) carves exactly as before; only the
narrow torn band below `r.head 3.0` changes — from a *torn* carve to a clean
painted mouth (the fix, not a regression of good output).

## Back-compat

- Un-set mouths are byte-identical at mainstream scale (verified by SDF sampling,
  maxDiff 0): default carved smile, the non-divided/no-curve `'lips'` ridge, and
  the default `'open'` cavity + upper teeth band.
- `mouthAccents('smile')` now returns a paintable lip *line* labelled `'lips'`
  (previously threw) — a coloured expressive mouth line.

## Test plan

- `tests/unit/sdfFigure.test.ts` — expression bend (smile vs frown corner
  height), numeric `curve` override + range rejection, `divided` height + bad-type
  rejection, teeth upper/lower/both, `render` modes, and the small-head
  auto→additive fallback **with a regression guard pinning the `headsTall:8` adult
  to carved**. 176 figure tests + full unit tier green.
- `model:preview` (real engine): colored expression spectrum reads
  deep-frown→big-smile; painted grin shows white teeth framed by red lips;
  divided lips render as a clear pout. Painted grin builds manifold/1-component in
  the real browser too.
- `npm run preflight` exit 0 (no circular deps).
- New example faces: `examples/faces/bust_grin_teeth.js`,
  `examples/faces/bust_natural_lips.js`.

## Review

work-reviewer pass folded in: recalibrated the carve floor (was `r.head ≥ 3.5`,
which flipped mainstream adults) and switched `divided` from silent coercion to
`assertBoolean` validation.

## Issue hygiene

- Resolves **#652** via the additive auto-fallback (with a regression test).
- Chips at #589's lips/mouth gaps.
- Deferred: deep carved-cavity teeth with upper/lower **gum separation** — filed
  as **#665**.

https://claude.ai/code/session_018ro9RcpVUeVhqtsNrhvntG