### PR TITLE
feat: base-aware SEO metadata, in-app content links, and sitemap

### DIFF
--- a/prompts/versioned-deploy-seo.md
+++ b/prompts/versioned-deploy-seo.md
@@ -1,0 +1,60 @@
+---
+date: 2026-06-14
+branch: claude/versioned-deploy-seo
+files_changed:
+  - src/seo/meta.ts
+  - src/seo/sitemap.ts
+  - src/ui/help.ts
+  - src/ui/whatsNew.ts
+  - src/ui/legal.ts
+  - vite.config.ts
+  - tests/unit/sitemap.test.ts
+---
+
+## Human
+
+Continue Phase 3 (versioned deployments). User picked "PR3: SEO/content
+base-aware" from the options after PR2 (#660, runtime routing) merged.
+
+## Assistant
+
+Phase 3 **slice 3: SEO/content base-awareness** — but re-scoped after
+discovering the build-time/runtime split, so it stays a clean no-op at base `/`.
+
+**Key discovery that drove the scope:** the static content pages
+(catalog/help/legal/whats-new/ideas HTML) are PRE-RENDERED in a Vite plugin
+(`prerenderPlugin.ts` → `render.ts`/`chrome.ts`/`shell.ts`) running in the
+**Node build context**, where `import.meta.env.BASE_URL` is NOT defined — so
+`appPath` (which reads it) can't make those hrefs base-aware. And `chrome.ts` is
+**dual-context** (also imported by the runtime `ideasPage.ts`). Threading the
+base into that whole build chain (`config.base` → prerender → render → shell →
+chrome) plus the six static `.html` files, `_redirects`, the `absoluteUrls`
+plugin, and the actual `base` flip is intricate and only *exercisable once the
+base actually changes*. So I folded all of that into **PR4 (the mount)** where it
+can be built and verified together, and kept PR3 to the surface that is cleanly
+base-aware and verifiable at `/` today:
+
+- **`src/seo/meta.ts`** (runtime, browser): canonical / og:url / og:image /
+  twitter:image now resolve through `appPath`/`assetPath` before `absolutize`,
+  so a `/vN/` build emits canonical URLs under its own mount. No-op at `/`.
+- **In-app content-page hrefs** (`help.ts`, `whatsNew.ts`, `legal.ts`): the
+  self-contained inline `<a href>`s (`/whats-new`, `/help`, `/ai.md`) routed
+  through `appPath`/`assetPath`. These run at runtime so the helpers resolve
+  correctly; they don't go through the dual-context `chrome.ts`.
+- **`src/seo/sitemap.ts`**: `buildSitemapXml` gained a 3rd `base` param
+  (appended, so the existing positional `routes` callers/test don't break).
+  Kept dependency-free (vite.config imports it in Node) by inlining the
+  base-prefix join instead of importing `src/deployment`. Wired
+  `dynamicSitemap` to pass Vite's resolved `config.base`. Byte-identical at
+  base `/`/`''`.
+
+Explicitly deferred to PR4 (the base flip): the build-time prerender nav
+(`render.ts`/`chrome.ts`/`shell.ts`/`prerenderPlugin.ts` + `ideasPage` chrome),
+the six static `.html` canonical/og/asset refs, `public/_redirects`/`_headers`,
+and the `absoluteUrls` base — all activate with the base and verify together.
+
+Verified: typecheck clean; `lint:deps` acyclic; full unit tier 1403 pass (incl.
+2 new sitemap cases: `/v2/` mounting + base-`/`/`''` no-op equality);
+`npm run build` clean; and the content/SEO e2e — content-pages (incl. help-page
+metadata + canonical/og assertions), legal, smoke — all pass (30/30),
+confirming the change is a strict no-op at base `/`.

--- a/retros/inbox/20260614-versioned-deploy-base-aware.md
+++ b/retros/inbox/20260614-versioned-deploy-base-aware.md
@@ -1,0 +1,53 @@
+# Retro — versioned-deployment readiness (Phase 1–3: PRs #651, #653, #656, #660, #679)
+
+## Liked
+- **No-op slicing.** Every slice was engineered to be byte-identical at the
+  current `base: '/'` (or major 1), so each PR was independently verifiable and
+  mergeable with near-zero risk despite touching scary surfaces (`main.ts`
+  routing, the schema ladder). "Make it ready, change nothing yet" kept five PRs
+  shippable without a flag day.
+- **`work-reviewer` earned its keep on the no-op PRs specifically.** Because the
+  changes were no-ops at `/`, CI and browser checks *couldn't* catch base-leak
+  gaps — the reviewer found the missed `/catalog/${file}` fetches (#656), the
+  `sessionList.ts` writers + base-prefixed back-target predicates (#660), and the
+  dual-context `content/data/help.ts` links (#679). Latent-under-`/vN/` bugs are
+  invisible to a base-`/` test suite; a human/LLM diff review is the only net.
+- The pure-helper-in-a-leaf pattern (`deployment.ts`, mirroring
+  `languageFallback.ts`/`appVersionCompat.ts`) made the foundation unit-testable
+  and kept the dep graph acyclic.
+
+## Lacked
+- **No way to actually exercise a `/vN/` base.** Everything is verified as a
+  no-op at `/`; the real correctness (does it work mounted at `/v2/`?) can't be
+  tested until PR4 flips the base. A `DEPLOY_BASE=/v2/ npm run build` smoke path
+  + one Playwright run against a `/v2/`-served preview would have let each slice
+  prove the non-trivial half, not just the no-op half.
+- **The build-time vs runtime context split wasn't obvious up front.** I scoped
+  PR3 as "SEO/content" assuming `appPath` would work everywhere, then discovered
+  the content pages prerender in the Node build context (no
+  `import.meta.env.BASE_URL`) and that `chrome.ts`/`content/data` are
+  dual-context. Re-scoping mid-PR was clean but the upfront touch-point audit
+  (explore agent) didn't flag the execution-context axis.
+
+## Learned
+- `import.meta.env.BASE_URL` is inlined only into the client/worker bundles.
+  Anything that runs in the Vite config / plugin Node context (prerender,
+  sitemap) must take the base as a **threaded parameter** (`config.base`), not
+  read it from `deployment.ts`. Pure helpers (`joinBase`) are safe to share
+  across both contexts; the `BASE`-reading wrappers are runtime-only.
+- `updateAppHistory`'s self-guard compares against the raw base-prefixed URL, so
+  a writer that pushes a *bare* `/editor` under `/vN/` isn't suppressed by the
+  guard — it actually navigates out of the deployment. Base-leak in a history
+  writer is worse than in a predicate.
+- The export **schema version** (`partwright: "1.x"`) and the **app semver**
+  (`1.0.0`) are independent axes; conflating them into one number would have
+  broken the migration seam. Keeping them separate (#653) was the right call.
+
+## Longed for
+- A lint rule (ast-grep) that flags root-absolute string literals in
+  `history.pushState`/`replaceState`/`location.assign`/`fetch`/`href=` outside
+  `deployment.ts` — the exact class of base-leak the reviewer caught by hand
+  three times. That would turn "diff-review catches it" into "CI catches it."
+- A single capability/route registry both the router and the helpers derive
+  from, so route literals exist in exactly one place (also the standing
+  UI↔API-parity wish in CLAUDE.md).

--- a/src/seo/meta.ts
+++ b/src/seo/meta.ts
@@ -7,6 +7,8 @@
 // the path it's given (which is fine — the browser resolves relative URLs
 // against the current origin, and unfurl bots fetch each route fresh).
 
+import { appPath, assetPath } from '../deployment';
+
 export type RouteName = 'landing' | 'editor' | 'help' | 'catalog' | 'ideas' | 'legal' | 'whats-new' | '404';
 
 interface RouteMeta {
@@ -96,8 +98,11 @@ function setLink(rel: string, href: string) {
 export function applyRouteMeta(route: RouteName, overrides?: { title?: string }) {
   const meta = ROUTE_META[route];
   const title = overrides?.title ?? meta.title;
-  const url = absolutize(meta.path);
-  const ogImage = absolutize(meta.ogImage ?? '/og-image.png');
+  // Resolve route + asset paths under the deployment base (`/`, `/vN/`) so the
+  // canonical/OG URLs point at this major's mount, not the origin root. No-op
+  // at base `/`.
+  const url = absolutize(appPath(meta.path));
+  const ogImage = absolutize(assetPath(meta.ogImage ?? '/og-image.png'));
 
   document.title = title;
   setMeta('meta[name="description"]', meta.description);

--- a/src/seo/sitemap.ts
+++ b/src/seo/sitemap.ts
@@ -32,13 +32,25 @@ export const SITEMAP_ROUTES: SitemapRoute[] = [
 /** Build the sitemap.xml text for the given site origin + routes. `siteUrl`
  *  may be empty — the fallback origin is substituted so every <loc> is a
  *  fully-qualified absolute URL. Any trailing slash on `siteUrl` is stripped
- *  so joining with the leading-slash path never double-slashes. */
-export function buildSitemapXml(siteUrl: string, routes: SitemapRoute[] = SITEMAP_ROUTES): string {
+ *  so joining with the leading-slash path never double-slashes.
+ *
+ *  `base` is the deployment base path this build is mounted under (`/`, `/v2/`,
+ *  …, from Vite's resolved `config.base`) so every <loc> sits under the right
+ *  major. A no-op at base `/` (kept dependency-free, so the join is inlined
+ *  rather than importing src/deployment — vite.config imports this in Node). */
+export function buildSitemapXml(
+  siteUrl: string,
+  routes: SitemapRoute[] = SITEMAP_ROUTES,
+  base = '/',
+): string {
   const origin = (siteUrl || SITEMAP_FALLBACK_URL).replace(/\/$/, '');
+  // Trailing slash off the base so `${basePrefix}${r.path}` never double-slashes;
+  // base '/' (or '') collapses to '' → byte-identical to the unversioned output.
+  const basePrefix = base.endsWith('/') ? base.slice(0, -1) : base;
   const entries = routes
     .map((r) => {
       // Root path '/' keeps its trailing slash; others are appended as-is.
-      const loc = `${origin}${r.path}`;
+      const loc = `${origin}${basePrefix}${r.path}`;
       const parts = [`    <loc>${loc}</loc>`];
       if (r.changefreq) parts.push(`    <changefreq>${r.changefreq}</changefreq>`);
       if (typeof r.priority === 'number') parts.push(`    <priority>${r.priority.toFixed(1)}</priority>`);

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -2,6 +2,7 @@
 
 import { getShortcutDocs, IS_MAC, MOD_LABEL, SHIFT_LABEL, ALT_LABEL } from './shortcutDefs';
 import { HELP_INTRO, HELP_STATIC_SECTIONS, helpDynamicSections } from '../content/data/help';
+import { appPath, assetPath } from '../deployment';
 
 export interface HelpCallbacks {
   onBack: () => void;
@@ -52,7 +53,7 @@ export function createHelpPage(
 
   // "What's new" callout — points at the recently-shipped-features changelog.
   const whatsNewCallout = document.createElement('a');
-  whatsNewCallout.href = '/whats-new';
+  whatsNewCallout.href = appPath('/whats-new');
   whatsNewCallout.className = 'inline-flex items-center gap-2 mb-8 text-sm text-blue-400 hover:text-blue-300 transition-colors';
   whatsNewCallout.innerHTML = '<span class="text-[10px] font-semibold uppercase tracking-wider rounded bg-blue-500/15 text-blue-300 px-1.5 py-0.5">New</span> See what’s shipped recently →';
   content.appendChild(whatsNewCallout);
@@ -120,7 +121,7 @@ export function createHelpPage(
   // Footer with agent link
   const footer = document.createElement('div');
   footer.className = 'mt-12 pt-6 border-t border-zinc-800 text-xs text-zinc-600';
-  footer.innerHTML = 'Full AI agent documentation: <a href="/ai.md" class="text-zinc-500 hover:text-zinc-300 transition-colors">/ai.md</a>';
+  footer.innerHTML = `Full AI agent documentation: <a href="${assetPath('/ai.md')}" class="text-zinc-500 hover:text-zinc-300 transition-colors">/ai.md</a>`;
   content.appendChild(footer);
 
   page.appendChild(content);

--- a/src/ui/legal.ts
+++ b/src/ui/legal.ts
@@ -3,6 +3,7 @@
 // pre-rendered /legal page); this module is the in-app DOM renderer.
 
 import { LEGAL_INTRO, LEGAL_SECTIONS } from '../content/data/legal';
+import { appPath } from '../deployment';
 
 export interface LegalCallbacks {
   onBack: () => void;
@@ -50,7 +51,7 @@ export function createLegalPage(
 
   const footer = document.createElement('div');
   footer.className = 'mt-12 pt-6 border-t border-zinc-800 text-xs text-zinc-600';
-  footer.innerHTML = 'More about how the app works: <a href="/help" class="text-zinc-500 hover:text-zinc-300 transition-colors">/help</a>';
+  footer.innerHTML = `More about how the app works: <a href="${appPath('/help')}" class="text-zinc-500 hover:text-zinc-300 transition-colors">/help</a>`;
   content.appendChild(footer);
 
   page.appendChild(content);

--- a/src/ui/whatsNew.ts
+++ b/src/ui/whatsNew.ts
@@ -5,6 +5,7 @@
 // week's entry here (and to public/llms.txt / the help page if it warrants it).
 
 import { partwrightMarkSvg } from './brand';
+import { appPath, assetPath } from '../deployment';
 import { getTheme, onThemeChange, toggleTheme } from './theme';
 import { WHATS_NEW_INTRO, WHATS_NEW_WEEKS, type WeekEntry } from '../content/data/whatsNew';
 
@@ -86,7 +87,7 @@ export function createWhatsNewPage(
   const footer = document.createElement('div');
   footer.className = 'mt-10 pt-6 border-t border-zinc-800 text-xs text-zinc-600';
   footer.innerHTML =
-    'More detail in the <a href="/help" class="text-zinc-500 hover:text-zinc-300 transition-colors">help guide</a> and the <a href="/ai.md" class="text-zinc-500 hover:text-zinc-300 transition-colors">AI agent docs</a>.';
+    `More detail in the <a href="${appPath('/help')}" class="text-zinc-500 hover:text-zinc-300 transition-colors">help guide</a> and the <a href="${assetPath('/ai.md')}" class="text-zinc-500 hover:text-zinc-300 transition-colors">AI agent docs</a>.`;
   content.appendChild(footer);
 
   page.appendChild(content);

--- a/tests/unit/sitemap.test.ts
+++ b/tests/unit/sitemap.test.ts
@@ -32,6 +32,21 @@ describe('buildSitemapXml', () => {
     expect(xml).not.toMatch(/<loc>\/[^<]*<\/loc>/);
   });
 
+  it('mounts every <loc> under a versioned base, without double-slashing', () => {
+    const xml = buildSitemapXml('https://example.com', undefined, '/v2/');
+    expect(xml).toContain('<loc>https://example.com/v2/editor</loc>');
+    expect(xml).toContain('<loc>https://example.com/v2/</loc>'); // root → base itself
+    expect(xml).not.toContain('https://example.com/v2//');
+    // The bare (unversioned) paths must NOT appear under a versioned base.
+    expect(xml).not.toContain('<loc>https://example.com/editor</loc>');
+  });
+
+  it('is byte-identical at base "/" (or "") to omitting the base — a no-op', () => {
+    const baseline = buildSitemapXml('https://example.com');
+    expect(buildSitemapXml('https://example.com', undefined, '/')).toBe(baseline);
+    expect(buildSitemapXml('https://example.com', undefined, '')).toBe(baseline);
+  });
+
   it('renders valid sitemap envelope with changefreq + priority', () => {
     const xml = buildSitemapXml('https://example.com', [
       { path: '/', changefreq: 'weekly', priority: 1.0 },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,15 +64,19 @@ function absoluteUrls(): Plugin {
 // which is why public/sitemap.xml has been removed (it would clobber this).
 function dynamicSitemap(): Plugin {
   let outDir = 'dist';
+  let base = '/';
   return {
     name: 'partwright-dynamic-sitemap',
     apply: 'build',
     configResolved(config) {
       outDir = config.build.outDir;
+      // Deployment base (`/`, `/v2/`, …) so each <loc> sits under this major's
+      // mount. No-op while base is `/`.
+      base = config.base;
     },
     closeBundle() {
       const siteUrl = (process.env.SITE_URL || process.env.CF_PAGES_URL || '').replace(/\/$/, '');
-      const xml = buildSitemapXml(siteUrl);
+      const xml = buildSitemapXml(siteUrl, undefined, base);
       writeFileSync(resolve(outDir, 'sitemap.xml'), xml, 'utf8');
     },
   };


### PR DESCRIPTION
## Summary

**Phase 3, slice 3 of 5** of the versioned-deployment strategy (follows #656 foundation + #660 routing). Makes the **runtime-resolvable SEO/content surface** deployment-base-aware. **Strict no-op at base `/`.**

- **`src/seo/meta.ts`** (runtime): canonical / `og:url` / `og:image` / `twitter:image` now resolve through `appPath`/`assetPath` before `absolutize`, so a `/vN/` build emits canonical URLs under its own mount.
- **In-app content-page hrefs** (`help.ts`, `whatsNew.ts`, `legal.ts`): the self-contained inline `<a href>`s (`/whats-new`, `/help`, `/ai.md`) routed through `appPath`/`assetPath`.
- **`src/seo/sitemap.ts`**: `buildSitemapXml` gained a 3rd `base` param (appended so existing positional `routes` callers/test don't break), kept dependency-free (vite.config imports it in Node) by inlining the base-prefix join. `dynamicSitemap` passes Vite's resolved `config.base`.

### Re-scope note (important)
While implementing I found the static content pages are **pre-rendered in a Vite plugin (Node build context)** where `import.meta.env.BASE_URL` is undefined, and `chrome.ts` is **dual-context** (also used by the runtime `ideasPage`). Threading the base through that whole build chain + the six static `.html` files + `_redirects` + the `absoluteUrls` plugin only takes effect once the base actually flips and is best verified *with* it — so **that build-time content/static-HTML work moves into PR4 (the mount)**. This PR keeps to what's cleanly base-aware and verifiable at `/` today.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint:deps` — acyclic
- [x] `npm run test:unit` — 1403 pass (incl. 2 new sitemap cases: `/v2/` mounting + base-`/`/`''` no-op equality)
- [x] `npm run build` — clean
- [x] Content/SEO e2e — content-pages (incl. help-page metadata + canonical/og assertions), legal, smoke — **30/30 pass** (strict no-op at `/`)
- [ ] PR-checks shards green on the draft

https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6

---
_Generated by [Claude Code](https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6)_