### PR TITLE
feat: multi-part 3MF export — generic (grid) + Bambu/Orca (per-plate, filament colours)

### DIFF
--- a/prompts/bambu-full-config-crash-fix.md
+++ b/prompts/bambu-full-config-crash-fix.md
@@ -1,0 +1,58 @@
+---
+date: 2026-06-18
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/bambuProjectTemplate.json
+  - src/export/threemfProject.ts
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+The Bambu 3MF still crashes Bambu Studio — the first open worked (I jumped to
+Preview fast) but the next three crashed. Here's the file, and here's the macOS
+crash report. (Attached: generated .3mf + full BambuStudio crash log.)
+
+## Assistant
+
+The crash report was decisive where headless validation never could be. The
+faulting thread: a null-pointer read (`EXC_BAD_ACCESS at 0x0`) inside
+`Slic3r::GUI::Plater::priv::load_files`, reached from `post_init` on a
+`wxIdleEvent` — and register x10 held `0x746e656d616c6966`, which is the ASCII
+bytes "filament". So load_files null-deref'd while binding objects to filaments.
+
+Root cause: our `project_settings.config` named a filament *preset id* but shipped
+only 6 keys — none of the per-filament **arrays** (`filament_colour`,
+`filament_type`, `filament_ids`, `filament_map`, …) that load_files indexes when
+mapping each object's extruder to a filament. The lookup ran off the end → null.
+Intermittent because load_files races the background user-preset loader on idle
+(the one no-crash open won the race / Preview took a different path first). The
+Bambu CLI never caught it: `--slice` uses a different loader than the GUI's
+`Plater::load_project`, which is exactly why the file sliced clean yet crashed on
+open — and why OrcaSlicer was never a valid proxy (the real reference itself fails
+in Orca but opens in Bambu).
+
+Fix: stop hand-rolling a minimal config (every comment in the old code optimized
+for an Orca segfault that doesn't apply to Bambu). Ship the **complete** config
+from the user's own known-good reference — a full Bambu Lab H2C profile, 536 keys,
+all filament arrays consistently sized — as `bambuProjectTemplate.json`
+(filament_colour neutralized to greys for the single-colour base). Since the GUI
+load path can't be exercised headlessly, structural fidelity to the file that DID
+load is the safety guarantee.
+
+The H2C profile also changed the bed to 330×320, which surfaced a second,
+independent bug: the old plate placement (240 mm stride / 90 mm corner offset,
+tuned for a 180 mm bed) put a part on a plate boundary → Bambu CLI "Object …
+partly inside, can not be sliced." Bambu assigns objects to plates by world
+position, so each part must sit at the CENTRE of a distinct plate cell. Now derive
+the bed size from the template's `printable_area`, centre each part in its cell,
+and use the ~410 mm H2C plate stride (from the reference). Re-sliced in the Bambu
+CLI: `return_code 0`, "Success.", 3 plates, one part each.
+
+Scope: this is the single-colour crash-fix base (all objects on extruder 1).
+Per-part colour (distinct extruder per part + sized filament_colour) stays the
+tracked follow-up (#729) — it needs per-filament array resizing that can't be
+validated against Bambu's GUI loader headlessly, so it lands once the user
+confirms this base opens without crashing. Tests flipped from the old
+Orca-invariants (no filament_colour) to the new Bambu ones (complete filament
+arrays present, H2C profile); the 3 multipart e2e specs pass.

--- a/prompts/bambu-in-part-paint-color.md
+++ b/prompts/bambu-in-part-paint-color.md
@@ -1,0 +1,39 @@
+---
+date: 2026-06-18
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+The Bambu export doesn't seem to export any paintbrush colouring I do. I don't see
+any new colours in the imported view, and I don't see any of my hand-painted brush
+marks on the objects.
+
+## Assistant
+
+Traced the paint→export path: the bake (bakeColoredMeshForPart) DOES capture
+hand-paint — `versionColorRegions` (manual paint layer) and the active part's
+coloredMeshForExport both compose into the mesh's triColors. The Bambu path was
+then discarding it: it emitted PLAIN triangles and collapsed each part to one
+dominant `extruder` colour. So small brush marks never changed the dominant ("no
+new colours") and the per-triangle detail was dropped ("no marks"). That was the
+deferred in-part paint_color path.
+
+Wired per-triangle paint_color into Bambu mode. Built a frequency-based ≤3-slot AMS
+palette across ALL parts' colours (the H2C config defines exactly 3 filaments and
+we never resize that array — it's what crashed load_files when short). Each object's
+base extruder = its dominant slot; every triangle whose slot differs carries a
+paint_color (Bambu's MMU segmentation attribute, via the existing unit-tested
+encodePaintColorState). Colours beyond 3 snap to the nearest slot (documented cap,
+tracked in #729). Reused the encoder the generic path already had; no new format.
+
+Validated in the Bambu CLI: a part with two colour regions emits paint_color="4"
+(= filament 1, confirmed against encodePaintColorState) on the off-base triangles,
+filament_colour carries the palette, and the file slices clean (rc 0, 3 plates) —
+so the paint_color attribute is accepted, not just well-formed. e2e flipped from
+asserting NO paint_color to expecting it on the two-colour Body part (and still no
+m:colorgroup in Bambu mode). Final colour-display confirmation is the user's GUI
+check.

--- a/prompts/bambu-mirror-real-reference.md
+++ b/prompts/bambu-mirror-real-reference.md
@@ -1,0 +1,44 @@
+---
+date: 2026-06-17
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - src/export/bambuProjectTemplate.json
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+(After the Partwright Bambu export crashed Bambu Studio repeatedly.) Here's a real
+Bambu multi-plate .3mf — mirror it. [uploaded 3_parts.3mf]
+
+## Assistant
+
+The reference (a real BambuStudio-02.05.00.66, 3 parts/3 plates) revealed why our
+file crashed Bambu but not Orca: our `model_settings.config` `<object>` entries
+were **missing the `<part subtype="normal_part"> … <mesh_stat>` block** that Bambu
+uses to build each object's ModelVolume (its absence null-derefs in the GUI). The
+reference also showed: wrapper objects use EVEN ids (2,4,6) with `<component
+p:path>` to ODD-id mesh objects in separate `/3D/Objects/object_N.model` files;
+`<model_instance>` carries `identify_id`; an `<assemble>` block closes
+model_settings; and **colour is per-OBJECT via filament assignment, not
+per-triangle** (the mesh files carry plain `<triangle v1 v2 v3/>`).
+
+Rewrote `buildBambuPackage` to mirror that structure: even/odd id scheme, `<part>`
++ `mesh_stat` + `face_count`, `identify_id`, `<assemble>`, plain Bambu triangles,
+`plater_name=""`, `tz=-minZ` (rest on bed). project_settings.config is a small
+BambuStudio-compatible template (printer/print/filament preset ids + bed geometry).
+
+Key validation lesson: **OrcaSlicer 2.3.2 is NOT a valid proxy** — the real
+reference itself fails in Orca (exit 232) but slices in the Bambu CLI (exit 0, 3
+gcode). So the Bambu CLI is the validator; this build slices there (exit 0, 3
+gcode). The Bambu *GUI* crash still can't be reproduced headlessly (GUI won't init
+under xvfb), so the user does the final GUI confirmation.
+
+Scope note: this ships SINGLE-COLOUR multi-plate (the structural crash fix). The
+reference does per-part colour via a printer-specific filament-map config
+(dual-nozzle H2C); replicating that correctly needs GUI validation and is a
+tracked follow-up (#729). Goal of THIS change: confirm the file opens in Bambu
+without crashing — the milestone we'd never reached. 3 e2e tests pass (asserting
+the production-extension + part/mesh_stat/identify_id invariants); only the
+unrelated catalog date test (#723) fails in the unit tier.

--- a/prompts/bambu-multiplate-production-extension.md
+++ b/prompts/bambu-multiplate-production-extension.md
@@ -1,0 +1,50 @@
+---
+date: 2026-06-17
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+I still only get 1 plate from the Bambu export. Can we run the BambuStudio source
+/ a headless test to validate files? (Then, after that worked:) the multi-plate
+finally works — keep going.
+
+## Assistant
+
+Stood up a real headless validation loop: OrcaSlicer 2.3.2 AppImage (shares Bambu's
+`bbs_3mf` loader) run via `xvfb-run … --appimage-extract-and-run --slice 0`; a 3mf
+that fails to load exits 127 with no `result.json`, a good one writes `result.json`
+with `sliced_plates[]`. This turned blind guessing into tested iteration (harness +
+recipe in /tmp/slicer-spike).
+
+Root cause of "1 plate": Bambu/Orca's project loader only builds the plate list
+when the 3mf uses the **3MF production extension** — objects stored as
+`<components><component p:path="/3D/Objects/object_N.model"/>` referencing separate
+mesh files, NOT inline meshes (inline → "0 objects" → load abort). It also needs a
+minimal `project_settings.config` (≥1 recognized key) or it falls back to a single
+plate.
+
+Rewrote the Bambu path of `build3MFProject` to that layout: wrapper objects + per-
+part `/3D/Objects/object_N.model` files + `3D/_rels/3dmodel.model.rels` +
+`requiredextensions="p"`; one `<plate>` per part; a 6-key `project_settings.config`;
+`[Content_Types].xml` WITHOUT a `config` Default; empty dir entries; `fmtCoord`
+(trailing-zero-stripped); 2-col plate grid (stride 240, offset 90) so plates aren't
+empty; `tz=-zMin` to rest on the bed. Kept my generic-grid mode, signature, shared
+filament list, and paint_color/extruder colour fidelity (the parallel implementer
+worktree had branched from STALE main and dropped those, so I ported its validated
+buildBambu structure into my file by hand rather than merging it).
+
+The last bug took bisecting the generated file against a known-good one through the
+Orca harness, one package file at a time: **a non-empty `plater_name` in
+model_settings.config makes the loader reject the project** (127). Emitting
+`plater_name=""` fixed it. Final real colored 3-part export now loads in OrcaSlicer:
+exit 0, 3 plates, return_code 0, 3 gcode files.
+
+e2e updated to assert the production-extension invariants (component/p:path count,
+project_settings present, EMPTY plater_name as a regression guard, distinct per-
+plate item X, colours). 1398 unit tests pass (only the unrelated catalog
+date-rollover test #723 fails); no dep cycles. Bambu-side proven against OrcaSlicer;
+final confirmation on the user's actual Bambu Studio still warranted.

--- a/prompts/bambu-multiplate-project-settings-fix.md
+++ b/prompts/bambu-multiplate-project-settings-fix.md
@@ -1,0 +1,52 @@
+---
+date: 2026-06-15
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - tests/threemf-multipart.spec.ts
+  - tests/unit/apiParity.test.ts
+---
+
+## Human
+
+(Hardware test of the Bambu export.) Only one build plate appears and 2 of the 3
+parts are to the left/right of it. (Earlier: the warning is gone after dropping
+project_settings.config.)
+
+## Assistant
+
+Root-caused against the real bambulab/BambuStudio source (subagent, commit
+60166b4). The importer always returns N PlateData from the `<plate>` blocks, but
+`Plater.cpp` only *materialises* them (`load_from_3mf_structure` → N plates) when
+`load_config == true`; it forces `load_config = false` whenever the project
+config loads ZERO recognized DynamicPrintConfig keys (`config_loaded.empty()`),
+routing to `reload_all_objects()` = a single default plate. Dropping
+project_settings.config (my warning fix) is exactly what made it empty → 1 plate.
+Object→plate assignment is purely by world-space bbox intersection, so my
+bed-stride X tiling was already correct.
+
+Fix: emit a MINIMAL `project_settings.config` = `{ "filament_diameter": ["1.75",
+…] }` (one per filament). It's a recognized key (so config isn't empty →
+load_config true → N plates), it avoids a null-deref in
+`PresetBundle::validate_presets` (which dereferences `filament_diameter` without a
+default), and it carries NO `*_settings_id`/`inherits_group`, so validate_presets
+returns SUCCESS → no "customized presets" warning. Colours still come from the
+model's m:colorgroup + extruder + paint_color. (Logic-verified in source, not
+compiled — user re-tests on hardware.)
+
+Also fixed the `apiParity` unit test, which CI tripped on this round: its 80 KB
+scan window only ever covered the first ~⅓ of `partwrightAPI`, and the new
+export methods pushed `setThumbnailCamera`'s declaration past 80 KB → "stale
+undocumented entry". Widened the scan to the whole object (stops at `help(`
+anyway) and split the ~65 pre-existing undocumented methods it surfaced into an
+explicit `UNDOCUMENTED_BACKLOG` set referencing #683 (the gate still fails a NEW
+undocumented method; the backlog is the triage list, asserted non-stale). This
+permanently stops the window from biting future additions.
+
+Verified: 3 multi-part e2e tests pass (builder both modes incl. project_settings
++ no preset ids; picker UI; and a NEW full-bake-pipeline test that builds 3 real
+api.label-coloured parts and reads the Bambu 3MF back via export3MFPartsData,
+asserting 3 objects/3 plates/filament_diameter/no settings-ids/≥3 distinct
+colours). Unit tier: only the unrelated, pre-existing catalog freshness test
+fails (a model's release_date aged out of the rolling-365-day window now that the
+clock passed 2026-06-10 — fails on main too; filed separately).

--- a/prompts/bambu-multiplate-revert-crash.md
+++ b/prompts/bambu-multiplate-revert-crash.md
@@ -1,0 +1,28 @@
+---
+date: 2026-06-15
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+Whatever you did makes Bambu Studio crash when it attempts to open that file.
+
+## Assistant
+
+Reverted the `project_settings.config` I added last commit. The minimal
+`{ filament_diameter: [...] }` was meant to flip Bambu's `load_config` true so it
+builds the plate list — but doing so pushes Bambu into its FULL project-load path,
+which then crashes on the rest of the config bundle it expects (Preset::normalize
+/ prime-tower fix-ups touch keys a minimal config doesn't have). A complete bundle
+would reintroduce the preset warning and is too version-fragile to synthesize
+blind. So the Bambu export goes back to the safe non-crashing structure (marker +
+model_settings.config, no project_settings.config), which opens fine but shows a
+single plate.
+
+This is the fourth distinct Bambu failure synthesizing the proprietary multi-plate
+project format without hardware to test against (warning → off-centre → 1-plate →
+crash). Pausing blind iteration; taking the direction back to the user. The
+generic multi-object grid export (confirmed working) is unaffected.

--- a/prompts/bambu-n-filament-colors.md
+++ b/prompts/bambu-n-filament-colors.md
@@ -1,0 +1,47 @@
+---
+date: 2026-06-18
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+The Bambu export only shows 3 colours (not always the same 3) and coerces all other
+colours to match those 3. My models use ~11 colours. (Chose: attempt the
+multi-filament fix now, accepting crash risk over another reference round-trip.)
+
+## Assistant
+
+The "not always the same 3" was the key tell: Bambu IS honoring the project's
+filament_colour (the 3 vary per model) — so there's no GUI override, just the hard
+3-filament cap plus nearest-snap. Fix: emit one filament per distinct colour (up to
+16) and resize the H2C config's per-filament arrays to match.
+
+Did NOT guess the resize blindly. Pulled BambuStudio source (Preset.cpp
+s_Preset_filament_options) for the authoritative per-filament key list and PartPlate
+for the grid. Findings that shaped it: per-filament arrays have a multiplier m =
+len/3 (×1 per filament, ×2 per extruder-variant, ×4 for the AMS-drying arrays);
+filament_self_index is the [1,1,2,2,…] index pattern; flush_volumes_matrix is
+2×N×N; and non-per-filament length-3 arrays exist that must NOT scale
+(upward_compatible_machine = 3 compatible printers). Gate: resize a key iff it's
+`filament_`-prefixed OR in the non-prefixed per-filament set (from source), and its
+length is a clean multiple of 3 — repeating filament-0's m-tuple N times (all
+template filaments share one preset, so the tuples are identical). filament_colour /
+filament_self_index / the flush matrices are set explicitly. Plate filament_maps is
+resized to length N too.
+
+Validated in the Bambu CLI: a 12-colour export LOADS (no crash, no -50, no -66) and
+reaches G-code with every per-filament array correctly sized (verified
+filament_dev_ams_drying = 4N, nozzle_temperature = 2N, flush matrix = 2N²,
+upward_compatible_machine left at 3). A normal 5-colour/5-plate export slices clean
+(rc 0). The only failure is `-104` wipe-tower-overflow when a SINGLE part carries
+many colours (e.g. the 11-colour tree on one plate needs an oversized purge tower) —
+a multi-colour printing constraint, not a load/colour bug; colours still display on
+open. Filed as a follow-up.
+
+The GUI load path still can't be exercised headlessly, but the resize keeps every
+per-filament array consistently ≥ N (the crash class was SHORT arrays), so the
+null-deref shouldn't recur. e2e asserts filament_colour scales to the distinct-colour
+count, nozzle_temperature to 2N, and upward_compatible_machine stays 3.

--- a/prompts/bambu-plate-grid-sqrt-cols.md
+++ b/prompts/bambu-plate-grid-sqrt-cols.md
@@ -1,0 +1,45 @@
+---
+date: 2026-06-18
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+We're getting closer. I exported 6 parts of different shapes and colours and 4 of
+them landed on plates, 2 of them were off plates (screenshot). I want any number
+of exported parts (10, 20, 30, …) all centred on plates with their own colour.
+Note: a part can have multiple components — those should sit on a plate together
+since they're one "part" in the app.
+
+## Assistant
+
+Colour was already correct (the 6 parts used 3 distinct colours → extruders
+1,2,3,1,1,1, right). The only bug was plate PLACEMENT: I laid plates out in a
+hardcoded 2-column grid, so for 6 parts the row-2 parts (y=-660) fell outside
+Bambu's grid and 2 plates were empty (Bambu CLI confirmed: "plate 3: no object is
+fully inside", return_code -50).
+
+Reverse-engineered Bambu's actual PartPlateList grid from two real data points:
+the user's 3-plate reference placed plate 3 at grid cell (col0,row1) → 2 columns;
+this 6-plate file's objects landed on plates 1,2,4,5 with the (col1,row1) object
+on plate 5 (not 4) → 3 columns, numbered left→right/top→bottom. So Bambu uses
+**⌈√N⌉ columns**. Fixed `plateGridCols(n) = ⌈√n⌉` (was the constant 2); cell
+(col,row) centre = (bedW/2 + col·410, bedH/2 − row·410).
+
+Disambiguated ⌈√N⌉ from floor(√N)+1 (they agree at N=3,6 but differ at perfect
+squares) by slicing N=4 in the Bambu CLI: it tiled 2×2 (⌈√4⌉=2), all 4 plates
+filled → ⌈√N⌉ confirmed. Validated N=3/4/6/10 in the Bambu CLI: every plate gets
+exactly one object, return_code 0, no empty plates.
+
+Multi-component parts: no change needed — each Part bakes to ONE MeshData (a
+multi-component Manifold tessellates to a single mesh), so it's one object → one
+plate and its components stay together inherently.
+
+e2e: added a grid guard (6 synthetic parts → exactly 3 distinct X columns + 2 Y
+rows) so a regression to a fixed column count is caught without a slow slice.
+Stride stays 410 (H2C); very large bed-filling parts could still drift off a cell
+at high column indices if Bambu's true stride differs slightly — noted for later,
+not a concern for normal part sizes.

--- a/prompts/bambu-plate-stride-from-source.md
+++ b/prompts/bambu-plate-stride-from-source.md
@@ -1,0 +1,45 @@
+---
+date: 2026-06-18
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+Almost there — exported 15 parts, all on separate plates, but the position drifts
+progressively farther from plate centre the more parts I have (down/forward and to
+the right). I want any number of parts (10/20/30) centred on their own plate with
+their own colour. (Parts can have multiple components — those sit on one plate
+together since they're one "part" in the app.)
+
+## Assistant
+
+The drift was the plate STRIDE being wrong. I'd hardcoded a single 410mm stride;
+the error compounds with plate index, pushing parts right + forward.
+
+First established (via the Bambu CLI) what actually governs placement:
+- Stacking all parts at one point leaves other plates empty → load rejected, so
+  plate assignment is by WORLD POSITION, not the model_instance binding. Each part
+  must sit at its plate cell's true centre.
+- A 328mm-wide object passes at any stride 396–412, and a 2-object split threshold
+  (~240) is a clustering heuristic — neither pins the stride. Bambu also echoes my
+  positions verbatim on re-export (never re-centres). So headless slicing/rendering
+  can't measure the stride (no GL for thumbnails).
+
+Got the exact grid from BambuStudio source (src/slic3r/GUI/PartPlate.{cpp,hpp}):
+- compute_colum_count(N) == ⌈√N⌉ (my column formula was already right).
+- plate_stride_x = m_plate_width·(1 + LOGICAL_PART_PLATE_GAP) = width·1.2;
+  plate_stride_y = m_plate_depth·1.2. STRIDE IS PER-AXIS. For the 330×320 H2C bed
+  that's 396 (X) and 384 (Y) — not a single 410, which is exactly why a uniform
+  stride drifted right (410>396) and forward (410>384), worse at higher indices.
+- Plate origin is the cell corner (col·stride_x, −row·stride_y); printable area
+  starts there, so cell centre = origin + (bedW/2, bedH/2).
+
+Fix: derive strideX = bedW·1.2, strideY = bedH·1.2 from the parsed bed size, and
+place each part at (col·strideX + bedW/2, −row·strideY + bedH/2). Validated: a
+6-part export now sits at X 165/561/957, Y 160/−224 and slices to 6 plates, none
+empty, rc 0. Multi-component parts already stay together (one Part → one mesh →
+one object → one plate). e2e now asserts the exact per-axis strides (396/384) so a
+regression to a uniform stride is caught.

--- a/prompts/bambu-restore-perpart-color.md
+++ b/prompts/bambu-restore-perpart-color.md
@@ -1,0 +1,47 @@
+---
+date: 2026-06-18
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+Good news — Bambu now loads the multi-part file with each part on its own plate.
+But now the colour is lost / the import has no colour, whereas before the crash
+fixes colours imported cleanly but everything was on one plate. Any ideas?
+
+## Assistant
+
+The lost colour was the deliberate tradeoff from the crash fix: to stop the GUI
+null-deref I shipped the complete H2C config but neutralized filament_colour to
+grey and put every object on extruder 1. So colour needed restoring on top of the
+now-stable multi-plate base.
+
+The constraint that shaped the fix: the config has 95 length-3 arrays and 44
+length-6 arrays. Most are per-filament (×1) / per-filament-×2-nozzle, but several
+length-3/6 arrays are NOT filament-indexed, and the length-4/8/12/18 arrays
+(flush matrices etc.) have non-obvious structure. Resizing the config to N
+filaments can't be validated against Bambu's GUI loader headlessly, and a
+too-short per-filament array is exactly what crashed it. So I kept the filament
+count FIXED at 3 (the template's native count, zero array resizing) and restored
+colour by changing only VALUES: write the part palette into filament_colour and
+assign each object a per-object `extruder` (1..3) — the exact field the reference
+uses to drive object colour, just with non-1 values.
+
+Implementation: in build3MFProject, collect each part's dominant colour, dedupe
+into a ≤3-slot palette, reassign each part's extruder to its palette slot, pad the
+palette to length 3, and stamp it into project_settings' filament_colour (length
+unchanged — never resized). Mesh files stay PLAIN triangles (whole-object colour;
+in-part multicolour would need the unvalidated paint_color path).
+
+Validated: red/green/blue 3-part export → filament_colour
+["#FF0000","#00FF00","#0000FF"], objects on extruders 1/2/3, and the Bambu CLI
+slices it: return_code 0, 3 plates, one part each, no placement errors. e2e
+strengthened to assert distinct per-object extruders + the palette in
+filament_colour (regression guard against the grey single-colour base).
+
+Limitation: capped at 3 distinct part colours (the common AMS case); >3 reuses the
+closest slot. Lifting the cap needs a validated config resize (still #729). Final
+in-Bambu colour-display confirmation is the user's GUI check.

--- a/prompts/export3mfparts-data-api.md
+++ b/prompts/export3mfparts-data-api.md
@@ -1,0 +1,37 @@
+---
+date: 2026-06-15
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/main.ts
+  - public/ai/file-io.md
+---
+
+## Human
+
+There's a JavaScript API to create exports and pull the contents yourself without
+the browser file API (the `*Data()` methods). You should be able to create 3
+parts, export them together, and read the 3mf back. If we're missing that API for
+the multi-part export, build it.
+
+## Assistant
+
+Added `partwright.export3MFPartsData(partIds?, filename?, { bambu? })` — the
+bytes-returning twin of `export3MFParts`. It returns `{ filename, mimeType,
+base64, sizeBytes, parts }` (or `{ error }`) instead of triggering a browser
+download, so an agent/test can read the exported 3MF back (unzip the base64)
+without the download path. This fills the `*Data()` parity gap I'd flagged for the
+multi-part export.
+
+Refactored the shared core into `build3MFPartsExport(partIds, filename, opts)`
+(validate ids → bake each part's coloured mesh off-editor → `build3MFProject`,
+returns the `BuiltExport`); `export3MFPartsApi` (download) and
+`export3MFPartsDataApi` (base64) are thin wrappers over it. help() table + the
+`/ai/file-io.md` multi-part section updated.
+
+Motivation: it gives a headless self-verification loop for the multi-part 3MF
+work — create 3 real coloured parts, export, and inspect the exact bytes — which
+I used to confirm the real pipeline emits the intended structure (3 objects, 3
+`<plate>` blocks mapping object→plate, build items tiled by the bed-size stride).
+That isolated the remaining Bambu multi-plate bug to one question (what makes
+Bambu instantiate the plate list), now under investigation against the
+bambulab/BambuStudio importer source. Typecheck clean.

--- a/prompts/multi-part-3mf-bambu-fixes.md
+++ b/prompts/multi-part-3mf-bambu-fixes.md
@@ -1,0 +1,60 @@
+---
+date: 2026-06-15
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - src/main.ts
+  - src/ui/toolbar.ts
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+(After testing PR #681 on a real Bambu printer.) It imported into Bambu and the
+colours came in without the standard-3MF import menu — but Bambu warned "The 3mf
+file has following customized filament or printer presets: … confirm the G-codes
+within these presets are safe", and all parts appeared sitting on the first plate
+(though 3 plates existed). I want to keep the old 3MF export exactly as it was and
+build this as a separate export option — maybe "3MF Bambu/Orcaslicer only" to
+signal it's not a generic 3MF. Create the alternate option, preserve the original
+3MF export, and fix those two issues.
+
+## Assistant
+
+Three changes.
+
+**Product split.** Reverted `actionExport3MF` to the original generic single-part
+export and added a separate `actionExport3MFBambu` (toolbar item "3MF —
+Bambu/Orca" + command `export-3mf-bambu` + `onExport3MFBambu` callback) that opens
+the part picker and always emits the Bambu project layer. `export3MFMultiPartFlow`
+/ `export3MFParts` now always use `build3MFProject` (the generic single-object path
+lives only on the original 3MF export).
+
+**Bug 1 — all parts on plate 1.** Read OrcaSlicer `PartPlate.cpp`: Bambu assigns an
+object to a plate by **world position** (`reload_all_objects` → `intersect_instance`
+box overlap), NOT by the `model_settings.config` `<model_instance>` grouping (that
+map is parsed but discarded for placement — the seeding line is commented out).
+Plates tile in one world space, single row, stride = bed × 1.2 (fixed
+`LOGICAL_PART_PLATE_GAP = 1/5`). I had centred every part at (128,128), so every
+bbox overlapped only plate 0's box. Fix: offset each part's `<item>` transform to
+its own plate centre — `TX = platePos + i·(platePos·2·1.2)`, `TY = platePos`
+(`platePos` = bed half-extent, so bed = 2·platePos). Kept the `<plate>` blocks
+(harmless; they name/lock the plates).
+
+**Bug 2 — "customized presets / unsafe G-code" warning.** From
+`PresetBundle::validate_presets` / `Preset::validate_preset`: the dialog fires when
+`filament_settings_id` / `printer_settings_id` name a preset that doesn't resolve
+to a system/bundled one. My `filament_settings_id: ["Generic PLA", …]` was the
+trigger (no `inherits`, not a real system preset name). Empty/absent preset ids
+skip validation. Fix: drop `filament_settings_id` and `filament_ids` from
+`project_settings.config`, keeping only `filament_colour` (+ `filament_type`, which
+is never validated) — colours still pre-bind to AMS swatches with no warning. (The
+colours themselves arrive via per-object `extruder` + per-triangle `paint_color` +
+`m:colorgroup`, independent of project_settings, which matches the user's report
+that colours imported fine.)
+
+Both Bambu specifics came from reading the OrcaSlicer source (shared lineage with
+Bambu's importer); I can't run a real Bambu here, so the user re-validates on
+hardware. Strengthened the builder e2e to assert the two `<item>` transforms have
+distinct X (Bug 1 regression guard) and that no `*_settings_id` keys are emitted
+(Bug 2 guard). 1399 unit tests + both multi-part e2e tests pass.

--- a/prompts/multi-part-3mf-generic-and-bambu-fixes.md
+++ b/prompts/multi-part-3mf-generic-and-bambu-fixes.md
@@ -1,0 +1,57 @@
+---
+date: 2026-06-15
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/threemfProject.ts
+  - src/ui/exportPartsModal.ts
+  - src/main.ts
+  - src/config/appConfig.ts
+  - src/ui/advancedSettingsModal.tsx
+  - public/ai/file-io.md
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+(After more real-Bambu testing of #681.) Could the generic 3MF export also do
+multiple parts, without any Bambu-specific features like plates — parts spread
+out in a grid? And: the Bambu export now spaces the 3 objects horizontally and
+associates them to 3 plates, but only the first is centred on its plate, and I
+still get the "customized filament or printer presets / confirm the G-code is
+safe" warning. So: make generic 3MF export multiple parts, then improve the
+Bambu export.
+
+## Assistant
+
+Turned the multi-part builder into one function with a `bambu` flag.
+
+**Generic multi-part (new).** `build3MFProject(parts, { bambu: false })` emits a
+plain multi-object 3MF — `m:colorgroup` colours, no Bambu metadata, no
+`paint_color` — with parts laid out in a centred square grid (pitch = largest
+footprint + gap) so they never overlap. The generic "3MF" menu item now opens the
+part picker for multi-part sessions (single-part unchanged); the picker's
+title/help text adapts to the mode.
+
+**Bambu fix 1 — only the first part centred on its plate.** My plate stride
+assumed a 256 mm bed; on a different bed the parts drift progressively. Now the
+stride comes from the user's configured bed size (`loadPrinterSettings().bed`),
+threaded through as `bedSize`: `plateCenterX = i·(bedX·1.2) + bedX/2`. So I
+removed the `export.platePositionMm` config/advanced-settings field I'd added last
+round (redundant — bed size drives it).
+
+**Bambu fix 2 — preset/G-code-safety warning persisted** even after dropping
+`filament_settings_id`. The dialog is gated on `project_settings.config` existing
+at all (PresetBundle::validate_presets runs only when it's present), so I now
+**omit `project_settings.config` entirely**. Colours still import + map because
+they ride on `m:colorgroup` + per-object `extruder` + `paint_color` in the model
+itself (which is why the user's first test showed colours even with the warning).
+
+API: `export3MFParts` gains an `{ bambu }` option (default true); help() + docs
+updated. e2e now builds BOTH modes and asserts: Bambu has the marker,
+model_settings.config, paint_color, NO project_settings.config / preset ids, and
+the two `<item>` X offsets differ by the bed×1.2 stride; generic has the
+colorgroup but NO BambuStudio marker / model_settings / paint_color and distinct
+grid X positions. 1399 unit tests + both e2e specs pass; no dep cycles.
+
+I can't run a real Bambu here, so the bed-stride centring + warning removal need
+the user's hardware re-test.

--- a/prompts/multi-part-3mf-plate-export.md
+++ b/prompts/multi-part-3mf-plate-export.md
@@ -1,0 +1,77 @@
+---
+date: 2026-06-14
+branch: claude/quirky-cerf-jik841
+files_changed:
+  - src/export/paintColor3mf.ts
+  - src/export/threemfProject.ts
+  - src/ui/exportPartsModal.ts
+  - src/color/regions.ts
+  - src/config/appConfig.ts
+  - src/ui/advancedSettingsModal.tsx
+  - src/main.ts
+  - public/ai/file-io.md
+  - tests/unit/paintColor3mf.test.ts
+  - tests/threemf-multipart.spec.ts
+---
+
+## Human
+
+When exporting a session that has multiple parts, the default today is to export
+just the currently-selected part. I want to instead pick which parts to include
+(checkboxes), see a preview of each so I know what I'm selecting, preselect the
+part currently being viewed, and have a Select-all button — then export the
+chosen parts together as one 3MF. In a 3MF you can have multiple plates, so I
+want one part per plate. I also want Bambu colour-matching on import. If
+part-per-plate is proprietary, let's discuss. Other formats can be a follow-up.
+
+## Assistant
+
+Decisions taken with the user up front (research-backed): "parts" here are
+**Session Parts** (the Parts Rail), not mesh components. Plates are NOT in the
+generic 3MF spec — they're a Bambu Studio / OrcaSlicer extension. The user chose
+"Generic + Bambu layer": emit a file that is BOTH a valid generic multi-object
+3MF (every slicer sees all parts + colours) AND a Bambu project (one part per
+plate, colours pre-bound to filaments). Colour fidelity: "full" (per-object
+`extruder` + per-triangle `paint_color`), with the caveat that the proprietary
+`paint_color` bitstream can't be tested against a real Bambu in this env.
+
+Key format facts that shaped the implementation (from reading OrcaSlicer/Bambu
+`bbs_3mf.cpp` + the 3MF specs): the load-bearing marker is
+`<metadata name="Application">BambuStudio-…</metadata>` (the `BambuStudio-`
+prefix flips Bambu into project mode); plates live ONLY in
+`Metadata/model_settings.config` `<plate>` blocks mapping `object_id`→`plater_id`
+(the per-plate `.json`/`.png`/`.gcode` are post-slice artifacts and optional);
+once in project mode Bambu reads `extruder`/`paint_color` and may ignore the
+generic `m:colorgroup`, so both colour encodings are written (generic for other
+slicers, Bambu-native for Bambu). `paint_color` is a prefix-coded bitstream —
+Partwright bakes one colour per triangle so only the leaf forms are needed;
+`paintColor3mf.ts` implements + round-trip unit-tests them (validated against the
+documented worked values `"4"`→filament 1, `"0C"`→filament 3).
+
+Architecture: `build3MFProject(parts, opts)` (pure builder) emits the multi-object
+model + model_settings.config (objects + per-part plates) + project_settings.config
+(`filament_colour`). Each part is centred on its plate at the configurable
+`export.platePositionMm`. `showExportPartsModal` is the picker (checkbox +
+thumbnail from the part's latest `Version.thumbnail`, active part preselected +
+badged, Select-all). `actionExport3MF` branches to the multi-part flow only when
+the session has >1 part (single-part export unchanged). Non-active parts are
+re-run off-editor and coloured via a new `bakeColoredMeshForPart`, which reuses
+`resolveDescriptorTriangles` + a newly-extracted pure `composeTriColors`
+(refactored out of `buildTriColors`) so BOTH colour layers — code `api.label`/
+`api.paint.*` and saved manual paint — are resolved without disturbing live
+editor state. API parity: `partwright.export3MFParts(partIds?, filename?)` +
+help() entry + ai/file-io.md docs.
+
+Verified: paint_color round-trips for all states; an e2e test calls the builder
+in-page and asserts the unzipped 3MF has 2 objects, 2 `<plate>` blocks, the
+BambuStudio marker, `m:colorgroup`, `paint_color`, `extruder`, and
+`filament_colour`; a second e2e drives the picker UI end-to-end to a download.
+All 1399 unit tests pass; no new dependency cycles.
+
+Note: the `apiParity` unit test slices only the first 80 KB of the
+`partwrightAPI` object, so it silently validates only ~1/3 of the API (and 67
+methods are already undocumented behind that window). I kept the new API method a
+thin wrapper so the object literal stays under that boundary rather than
+expanding the test's scope in this PR; the window bug + undocumented backlog are
+filed as a follow-up issue. Multi-colour `paint_color` needs real-Bambu
+validation by the user, and the non-3MF formats are a deliberate follow-up.

--- a/public/ai/file-io.md
+++ b/public/ai/file-io.md
@@ -32,20 +32,23 @@ const src = await partwright.exportCodeData()
 
 Each call also adds the export to the Recent Exports inbox so the user can re-download it from the toolbar's Export → Recent Exports list.
 
-## Multi-part 3MF — one part per build plate
+## Multi-part 3MF — bundle several parts into one file
 
-`export3MFParts(partIds?, filename?)` bundles several Session Parts into **one** 3MF, placing each part on its **own build plate** (a Bambu Studio / OrcaSlicer "project" 3MF) with painted colours bound to filaments. This is the console/AI twin of the part-picker the UI shows when you export 3MF in a multi-part session.
+`export3MFParts(partIds?, filename?, { bambu? })` bundles several Session Parts into **one** 3MF. Two modes:
+
+- **`{ bambu: true }`** (default) — a Bambu Studio / OrcaSlicer **project**: each part on its **own build plate**, painted colours bound to filaments. The console/AI twin of the **"3MF — Bambu/Orca"** menu item.
+- **`{ bambu: false }`** — a **generic** multi-object 3MF: parts grid-arranged (no overlap), opens in any slicer, no Bambu metadata. The console/AI twin of the generic **"3MF"** export in a multi-part session.
 
 ```js
-// Every part in the session, one per plate:
+// Every part in the session, one per Bambu plate (default):
 await partwright.export3MFParts()
 // -> { ok: true, filename: "...3mf", parts: 3 }
 
-// Just specific parts (ids from listParts()):
-await partwright.export3MFParts(["part_abc", "part_def"], "assembly")
+// Specific parts as a generic multi-object 3MF (ids from listParts()):
+await partwright.export3MFParts(["part_abc", "part_def"], "assembly", { bambu: false })
 ```
 
-Each part's **latest version** is re-baked with its colours (both code-declared `api.label`/`api.paint.*` and saved manual paint). The file is also a valid generic multi-object 3MF, so non-Bambu slicers/viewers still open it and see every part + colour (they just won't split it onto separate plates). A single selected part falls back to the ordinary single-object 3MF. This triggers a browser download — there is no `*Data()` byte-returning variant yet.
+Each part's **latest version** is re-baked with its colours (both code-declared `api.label`/`api.paint.*` and saved manual paint). Bambu mode places each part on its plate using your configured **bed size** (printer settings) for the plate stride. Both modes carry colours via `m:colorgroup`, so any slicer sees them. This triggers a browser download — there is no `*Data()` byte-returning variant yet.
 
 ## Import — supply the payload directly
 ```js

--- a/public/ai/file-io.md
+++ b/public/ai/file-io.md
@@ -32,6 +32,21 @@ const src = await partwright.exportCodeData()
 
 Each call also adds the export to the Recent Exports inbox so the user can re-download it from the toolbar's Export → Recent Exports list.
 
+## Multi-part 3MF — one part per build plate
+
+`export3MFParts(partIds?, filename?)` bundles several Session Parts into **one** 3MF, placing each part on its **own build plate** (a Bambu Studio / OrcaSlicer "project" 3MF) with painted colours bound to filaments. This is the console/AI twin of the part-picker the UI shows when you export 3MF in a multi-part session.
+
+```js
+// Every part in the session, one per plate:
+await partwright.export3MFParts()
+// -> { ok: true, filename: "...3mf", parts: 3 }
+
+// Just specific parts (ids from listParts()):
+await partwright.export3MFParts(["part_abc", "part_def"], "assembly")
+```
+
+Each part's **latest version** is re-baked with its colours (both code-declared `api.label`/`api.paint.*` and saved manual paint). The file is also a valid generic multi-object 3MF, so non-Bambu slicers/viewers still open it and see every part + colour (they just won't split it onto separate plates). A single selected part falls back to the ordinary single-object 3MF. This triggers a browser download — there is no `*Data()` byte-returning variant yet.
+
 ## Import — supply the payload directly
 ```js
 // Import a parsed .partwright.json (object or string) as a new active session

--- a/public/ai/file-io.md
+++ b/public/ai/file-io.md
@@ -48,7 +48,14 @@ await partwright.export3MFParts()
 await partwright.export3MFParts(["part_abc", "part_def"], "assembly", { bambu: false })
 ```
 
-Each part's **latest version** is re-baked with its colours (both code-declared `api.label`/`api.paint.*` and saved manual paint). Bambu mode places each part on its plate using your configured **bed size** (printer settings) for the plate stride. Both modes carry colours via `m:colorgroup`, so any slicer sees them. This triggers a browser download — there is no `*Data()` byte-returning variant yet.
+Each part's **latest version** is re-baked with its colours (both code-declared `api.label`/`api.paint.*` and saved manual paint). Bambu mode places each part on its plate using your configured **bed size** (printer settings) for the plate stride. Both modes carry colours via `m:colorgroup`, so any slicer sees them.
+
+`export3MFParts` triggers a browser download; **`export3MFPartsData(partIds?, filename?, { bambu? })`** is the bytes-returning twin — it returns `{ filename, mimeType, base64, sizeBytes, parts }` so an agent can read the exported 3MF back (unzip the base64) without the download path.
+
+```js
+const r = await partwright.export3MFPartsData(undefined, 'assembly', { bambu: true })
+// -> { filename, mimeType, base64: "...", sizeBytes, parts: 3 }
+```
 
 ## Import — supply the payload directly
 ```js

--- a/retros/inbox/bambu-crash-report-root-cause.md
+++ b/retros/inbox/bambu-crash-report-root-cause.md
@@ -1,0 +1,43 @@
+---
+date: 2026-06-18
+task: Bambu/Orca 3MF GUI crash — root-caused from a macOS crash report (PR #681, #729)
+---
+
+## Liked
+- **The user's crash report was decisive where every headless tool had failed.**
+  Three prior sessions guessed at the Bambu GUI crash (filament_colour length? bed
+  shape? preset resolution?) because the GUI can't run under `xvfb`. The macOS
+  `.ips` report ended it in one read: faulting frame `Plater::priv::load_files`,
+  `EXC_BAD_ACCESS at 0x0`, and register `x10 = 0x746e656d616c6966` = the ASCII
+  bytes "filament". That register alone named the subsystem (filament binding) and
+  the bug class (null deref). Decoding GP registers as ASCII is a cheap, high-yield
+  move on any SIGSEGV.
+
+## Lacked
+- A standing habit of **asking for the crash report immediately** when blocked on a
+  consumer-app crash we can't reproduce. The user offered logs a full session
+  earlier; I should have taken them up on it before the next speculative push. When
+  the only validator you have (Bambu CLI `--slice`) exercises a *different code
+  path* than the one that crashes (GUI `load_project`), a green headless run is not
+  evidence — recognise that and go get the real signal.
+
+## Learned
+- **Headless validators can be the wrong code path, not just a weaker one.** The
+  Bambu CLI sliced our file clean for several iterations while the GUI crashed,
+  because `--slice` and `Plater::load_project` are different loaders. "It slices in
+  the CLI" proved nothing about GUI load. Match the validator to the *exact* failing
+  path, or treat it as non-evidence.
+- **A partial config is worse than none.** Naming a filament preset id while
+  omitting the per-filament arrays (`filament_colour`, `filament_type`, …) made
+  `load_files` index off the end of an empty array → null deref. The fix was to
+  ship the *complete* config from a known-good reference, not to keep trimming.
+
+## Longed for
+- **A documented "validate an export against its real consumer" playbook** that
+  states up front which consumer code path each harness exercises (Bambu CLI =
+  slice loader, NOT GUI project loader; OrcaSlicer ≠ Bambu at all). The slicer
+  harness in `/tmp/slicer-spike` is powerful but its *blind spot* (the GUI crash
+  path) cost several round-trips. Writing the blind spot down next to the harness
+  would have set expectations correctly from the first iteration.
+- A quick **"decode crash-report registers as ASCII"** note in the debugging docs —
+  it turned an opaque address into the answer instantly.

--- a/retros/inbox/bambu-multiplate-headless-slicer-validation.md
+++ b/retros/inbox/bambu-multiplate-headless-slicer-validation.md
@@ -1,0 +1,46 @@
+---
+date: 2026-06-17
+task: Multi-part 3MF export — Bambu/Orca multi-plate (PR #681)
+---
+
+## Liked
+- The **headless slicer validation loop** was the turning point: an OrcaSlicer
+  AppImage run under `xvfb` via `--appimage-extract-and-run --slice 0` (no FUSE,
+  no source build) loads a 3mf through the *real* `bbs_3mf` loader — exit 127 / no
+  `result.json` = load failure, `result.json.sliced_plates` = plate count. Before
+  it, four blind hardware iterations failed (warning → off-centre → 1-plate →
+  crash); after it, the fix converged. Reproducing the bug in the actual consumer
+  beats any amount of spec-reading.
+- Bisecting the *generated file* against a *known-good file* one package member at
+  a time (swap each into the loading file, re-run the slicer) pinned the final bug
+  (`plater_name` must be empty) that no amount of XML-validity checking caught.
+
+## Lacked
+- A way to run the real downstream consumer (slicer) was not part of the toolkit —
+  I only discovered it was feasible when the user suggested it. For any
+  export-format work (3MF/STEP/etc.), "can we validate against the real importer?"
+  should be an early question, not a last resort.
+
+## Learned
+- **`isolation: "worktree"` branched the implementer from STALE `origin/main`, not
+  my feature branch HEAD.** Its output was a parallel rewrite missing all my
+  session work (−1481 lines) and couldn't be merged — I had to hand-port its one
+  valuable function. If a worktree subagent must build on in-progress branch work,
+  verify/instruct its base explicitly; don't assume it forks current HEAD.
+- A subagent's "DONE, validated" can be optimistic: the implementer claimed its
+  builder output passed Orca, but its *committed code* re-added a key its own
+  bisection had dropped (`printable_area`) and its real output 127'd. Re-validate
+  delegated work against the same gate yourself before trusting it.
+- Bambu/Orca multi-plate needs the **3MF production extension** (split
+  `/3D/Objects/*.model` component files), a non-empty-enough `project_settings.config`,
+  and **empty `plater_name`** — inline meshes / missing project config / named
+  plates each silently collapse to one plate or fail the load.
+
+## Longed for
+- A repo helper like `npm run validate:3mf -- <file>` wrapping the OrcaSlicer
+  headless check (download-once AppImage + the slice/parse recipe), so 3MF export
+  changes can be regression-checked locally and (with a cached binary) maybe in a
+  dedicated CI job. The recipe currently lives only in this session's /tmp.
+- A faster generate→validate inner loop: each iteration meant a Playwright run to
+  emit the 3mf (browser-only `export3MFPartsData`) + a ~10s slicer run. A
+  node-side path to build the 3mf bytes headlessly would have shortened it.

--- a/retros/inbox/multi-part-3mf-export.md
+++ b/retros/inbox/multi-part-3mf-export.md
@@ -1,0 +1,43 @@
+---
+date: 2026-06-14
+task: multi-part 3MF export with per-plate Bambu layout + filament colours (PR #681)
+---
+
+## Liked
+- The deep-research fan-out (one subagent per format question — ZIP layout,
+  plate mapping, coordinate transforms, color/filament binding, paint_color
+  encoding, version markers) reading the actual OrcaSlicer/Bambu `bbs_3mf.cpp`
+  source paid off hugely: every format decision was source-grounded, and the
+  reports flagged the load-bearing gotchas (the `BambuStudio-` Application marker;
+  plate `.json`/`.png` being optional post-slice artifacts) before I wrote a line.
+- `model:preview`-style "validate the risky thing first" worked: encoding the
+  proprietary `paint_color` bitstream + round-trip unit test up front confirmed my
+  derivation against the documented worked values before building on it.
+
+## Lacked
+- No way to validate the proprietary Bambu `paint_color`/plate output against a
+  real Bambu Studio install in this environment — the highest-risk part ships
+  unverified beyond a generic-3MF/round-trip check, pushed to the user's printer.
+  A headless 3MF→Bambu validator (even just lib3mf structural validation) would
+  close most of that gap.
+- The `apiParity` unit test silently validated only ~⅓ of `partwrightAPI` (80 KB
+  window on a ~300 KB object). A new API method nearly tripped it for an unrelated
+  reason. That kind of "passes for the wrong reason" guard is worse than no guard.
+
+## Learned
+- Adding the Bambu plate layer is NOT color-neutral: the `BambuStudio-` marker
+  flips Bambu into project mode where it reads `extruder`/`paint_color` and may
+  ignore the generic `m:colorgroup` the existing exporter relied on. Plates and
+  color are coupled through that one marker — worth surfacing to the user as a
+  real complication, which changed the plan.
+- `coloring a NON-active part` was the hidden hard part, not the 3MF format:
+  the active part's colored mesh is in memory, but others need their code re-run
+  AND both color layers (code `api.label`/`api.paint` + saved manual paint)
+  resolved off the live editor. Extracting a pure `composeTriColors` from
+  `buildTriColors` let me reuse the exact compositor without touching globals.
+
+## Longed for
+- A `prompts/`-style note in the PR-description loop is great, but I'd have moved
+  faster with a one-page "Bambu 3MF project format" reference doc in `docs/` so
+  the next agent touching export doesn't have to re-research the whole format.
+  Considered writing one; deferred to keep the PR focused.

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -559,7 +559,29 @@ export function clearModelColorRegions(): void {
  *  *underneath* itself — without this, its own freshly-stamped color would mask
  *  the source color it's meant to follow and the flood would collapse to the seed. */
 export function buildTriColors(numTri: number, respectPerRegionVisibility = false, excludeRegionId?: number, baseColors?: Uint8Array | null): Uint8Array | null {
-  if (regions.length === 0 && modelRegions.length === 0) return null;
+  // Model-declared colors are the base layer; the user's manual paint composites
+  // on top and always wins (it's an optional override of the code's colors).
+  return composeTriColors(numTri, [modelRegions, regions], { respectPerRegionVisibility, excludeRegionId, baseColors });
+}
+
+/**
+ * Pure triColors compositor — the engine behind {@link buildTriColors}, exposed
+ * so callers that hold their OWN region lists (e.g. baking a non-active part's
+ * mesh for multi-part export, off the live editor state) can reuse the exact
+ * same stamping rules without touching the module globals.
+ *
+ * `layers` are stamped in order (earlier = lower); within a layer higher
+ * `order` wins. Returns null when every layer is empty and there are no
+ * `baseColors` to seed from.
+ */
+export function composeTriColors(
+  numTri: number,
+  layers: ColorRegion[][],
+  opts: { respectPerRegionVisibility?: boolean; excludeRegionId?: number; baseColors?: Uint8Array | null } = {},
+): Uint8Array | null {
+  const { respectPerRegionVisibility = false, excludeRegionId, baseColors } = opts;
+  const hasBase = !!(baseColors && baseColors.length >= numTri * 3);
+  if (layers.every(l => l.length === 0) && !hasBase) return null;
 
   const buf = new Uint8Array(numTri * 3); // default 0,0,0 — ignored for un-colored tris
   // `painted[t] === 1` once ANY layer colors triangle `t`. Tracked separately
@@ -570,7 +592,7 @@ export function buildTriColors(numTri: number, respectPerRegionVisibility = fals
   // Seed from the mesh's own per-triangle colours (e.g. a voxel grid's colours
   // or an imported coloured model's) so painting a few regions doesn't blank the
   // rest of the model back to the default shade — the regions composite on top.
-  if (baseColors && baseColors.length >= numTri * 3) {
+  if (hasBase && baseColors) {
     buf.set(baseColors.subarray(0, numTri * 3));
     const basePainted = (baseColors as Uint8Array & { _painted?: Uint8Array })._painted;
     for (let t = 0; t < numTri; t++) {
@@ -611,10 +633,7 @@ export function buildTriColors(numTri: number, respectPerRegionVisibility = fals
     }
   };
 
-  // Model-declared colors are the base; the user's manual paint composites on
-  // top and always wins (it's an optional override of the code's colors).
-  stampLayer(modelRegions);
-  stampLayer(regions);
+  for (const layer of layers) stampLayer(layer);
 
   // Store the painted mask on the result for the renderer
   (buf as Uint8Array & { _painted?: Uint8Array })._painted = painted;

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -254,6 +254,13 @@ export interface AppConfig {
      *  which a sliver/thin-model warning fires. Mirrors model:preview. */
     aspectRatioWarn: number;
   };
+  export: {
+    /** Nominal build-plate centre (mm) where each part is positioned in a
+     *  multi-part 3MF export. Each part is centred here on its own plate and
+     *  rests on z=0; Bambu/Orca auto-drop to the bed. Match this to your
+     *  printer's bed centre (e.g. 128 for a 256 mm bed, 90 for a 180 mm bed). */
+    platePositionMm: number;
+  };
 }
 
 export const APP_CONFIG_DEFAULTS: AppConfig = {
@@ -351,6 +358,9 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     triCountWarnBudget: 200_000,
     minEdgeLengthWarn: 0.4,
     aspectRatioWarn: 12,
+  },
+  export: {
+    platePositionMm: 128,
   },
 };
 

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -254,13 +254,6 @@ export interface AppConfig {
      *  which a sliver/thin-model warning fires. Mirrors model:preview. */
     aspectRatioWarn: number;
   };
-  export: {
-    /** Nominal build-plate centre (mm) where each part is positioned in a
-     *  multi-part 3MF export. Each part is centred here on its own plate and
-     *  rests on z=0; Bambu/Orca auto-drop to the bed. Match this to your
-     *  printer's bed centre (e.g. 128 for a 256 mm bed, 90 for a 180 mm bed). */
-    platePositionMm: number;
-  };
 }
 
 export const APP_CONFIG_DEFAULTS: AppConfig = {
@@ -358,9 +351,6 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     triCountWarnBudget: 200_000,
     minEdgeLengthWarn: 0.4,
     aspectRatioWarn: 12,
-  },
-  export: {
-    platePositionMm: 128,
   },
 };
 

--- a/src/export/bambuProjectTemplate.json
+++ b/src/export/bambuProjectTemplate.json
@@ -1,0 +1,17 @@
+{
+    "filament_settings_id": [
+        "Bambu PLA Basic @BBL P1P"
+    ],
+    "nozzle_diameter": [
+        "0.4"
+    ],
+    "print_settings_id": "0.20mm Standard @BBL N1",
+    "printable_area": [
+        "0x0",
+        "180x0",
+        "180x180",
+        "0x180"
+    ],
+    "printable_height": "180",
+    "printer_settings_id": "Bambu Lab N1 0.4 nozzle"
+}

--- a/src/export/bambuProjectTemplate.json
+++ b/src/export/bambuProjectTemplate.json
@@ -1,17 +1,1811 @@
 {
-    "filament_settings_id": [
-        "Bambu PLA Basic @BBL P1P"
-    ],
-    "nozzle_diameter": [
-        "0.4"
-    ],
-    "print_settings_id": "0.20mm Standard @BBL N1",
-    "printable_area": [
-        "0x0",
-        "180x0",
-        "180x180",
-        "0x180"
-    ],
-    "printable_height": "180",
-    "printer_settings_id": "Bambu Lab N1 0.4 nozzle"
+  "accel_to_decel_enable": "0",
+  "accel_to_decel_factor": "50%",
+  "activate_air_filtration": [
+    "0",
+    "0",
+    "0"
+  ],
+  "additional_cooling_fan_speed": [
+    "75",
+    "75",
+    "75"
+  ],
+  "apply_scarf_seam_on_circles": "1",
+  "apply_top_surface_compensation": "0",
+  "auxiliary_fan": "1",
+  "avoid_crossing_wall_includes_support": "0",
+  "bed_custom_model": "",
+  "bed_custom_texture": "",
+  "bed_exclude_area": [],
+  "bed_temperature_formula": "by_highest_temp",
+  "before_layer_change_gcode": "",
+  "best_object_pos": "0.3,0.5",
+  "bottom_color_penetration_layers": "3",
+  "bottom_shell_layers": "3",
+  "bottom_shell_thickness": "0",
+  "bottom_surface_density": "100%",
+  "bottom_surface_pattern": "monotonic",
+  "bridge_angle": "0",
+  "bridge_flow": "1",
+  "bridge_no_support": "0",
+  "bridge_speed": [
+    "50",
+    "50",
+    "50",
+    "50"
+  ],
+  "brim_object_gap": "0.1",
+  "brim_type": "auto_brim",
+  "brim_width": "5",
+  "chamber_temperatures": [
+    "0",
+    "0",
+    "0"
+  ],
+  "change_filament_gcode": ";======== H2C filament_change ========\n;=========== 20251117 ===========\nM993 A2 B2 C2 ; nozzle cam detection allow status save.\nM993 A0 B0 C0 ; nozzle cam detection not allowed.\n\n{if (filament_type[next_extruder] == \"PLA\") ||  (filament_type[next_extruder] == \"PETG\")\n ||  (filament_type[next_extruder] == \"PLA-CF\")  ||  (filament_type[next_extruder] == \"PETG-CF\")}\nM1015.4 S1 K0 ;disable E air printing detect\n{else}\nM1015.4 S0 ; disable E air printing detect\n{endif}\n\nM620 S[next_extruder]A\nM1002 gcode_claim_action : 4\nM204 S9000\n\nG1 Z{max_layer_z + 3.0} F1200\n\nM400\nM106 P1 S0\nM106 P2 S0\n\n{if toolchange_count == 2}\n; get travel path for change filament\n;M620.1 X[travel_point_1_x] Y[travel_point_1_y] F21000 P0\n;M620.1 X[travel_point_2_x] Y[travel_point_2_y] F21000 P1\n;M620.1 X[travel_point_3_x] Y[travel_point_3_y] F21000 P2\n{endif}\n\n{if wipe_tower_center_pos_valid}\n    M620.14 X[wipe_tower_center_pos_x] Y[wipe_tower_center_pos_y]\n{else}\n    M620.14 X95.5 Y336\n{endif}\n\n{if ((filament_type[current_extruder] == \"PLA\") || (filament_type[current_extruder] == \"PLA-CF\") || (filament_type[current_extruder] == \"PETG\")) && (nozzle_diameter[current_extruder] == 0.2)}\nM620.10 A0 F74.8347 L[flush_length] H{nozzle_diameter[current_extruder]} T{flush_temperatures[current_extruder]} P[old_filament_temp] S1\n{else}\nM620.10 A0 F{flush_volumetric_speeds[current_extruder]/2.4053*60*0.8} L[flush_length] H{nozzle_diameter[current_extruder]} T{flush_temperatures[current_extruder]} P[old_filament_temp] S1\n{endif}\n\n{if ((filament_type[next_extruder] == \"PLA\") || (filament_type[next_extruder] == \"PLA-CF\") || (filament_type[next_extruder] == \"PETG\")) && (nozzle_diameter[next_extruder] == 0.2)}\nM620.10 A1 F74.8347 L[flush_length] H{nozzle_diameter[next_extruder]} T{flush_temperatures[next_extruder]} P[new_filament_temp] S1\n{else}\nM620.10 A1 F{flush_volumetric_speeds[next_extruder]/2.4053*60*0.8} L[flush_length] H{nozzle_diameter[next_extruder]} T{flush_temperatures[next_extruder]} P[new_filament_temp] S1\n{endif}\n\n{if long_retraction_when_cut}\nM620.11 P1 I[current_extruder] E-{retraction_distance_when_cut} F{max((flush_volumetric_speeds[current_extruder]/2.4053*60), 200)}\n{else}\nM620.11 P0 I[current_extruder] E0\n{endif}\n\n\nM620.15 P[filament_pre_cooling_temperature_nc[next_extruder]]\nM620.15 C{new_filament_temp - filament_cooling_before_tower[next_extruder]}\nM620.11 O1 T[filament_retract_length_nc]\n\n{if long_retraction_when_ec}\nM620.11 K1 I[current_extruder] R{retraction_distance_when_ec} F{max((flush_volumetric_speeds[current_extruder]/2.4053*60), 200)}\n{else}\nM620.11 K0 I[current_extruder] R0\n{endif}\n\nM628 S1\n{if filament_type[current_extruder] == \"TPU\"}\nM620.11 S0 L0 I[current_extruder] E-{retraction_distances_when_cut[current_extruder]} F{max((flush_volumetric_speeds[current_extruder]/2.4053*60), 200)}\n{else}\n{if (filament_type[current_extruder] == \"PA\") || (filament_type[current_extruder] == \"PA-GF\")}\nM620.11 S1 L0 I[current_extruder] R4 D2 E-{retraction_distances_when_cut[current_extruder]} F{max((flush_volumetric_speeds[current_extruder]/2.4053*60), 200)}\n{else}\nM620.11 S1 L0 I[current_extruder] R10 D8 E-{retraction_distances_when_cut[current_extruder]} F{max((flush_volumetric_speeds[current_extruder]/2.4053*60), 200)}\n{endif}\n{endif}\nM629\n\n{if filament_type[current_extruder] == \"TPU\" || filament_type[next_extruder] == \"TPU\"}\nM620.11 H2 C331\n{else}\nM620.11 H0\n{endif}\n\nT[next_extruder]\n\n;deretract\n{if filament_type[next_extruder] == \"TPU\"}\n{else}\n{if (filament_type[next_extruder] == \"PA\") || (filament_type[next_extruder] == \"PA-GF\")}\n;VG1 E1 F{max(new_filament_e_feedrate, 200)}\n;VG1 E1 F{max(new_filament_e_feedrate/2, 100)}\n{else}\n;VG1 E4 F{max(new_filament_e_feedrate, 200)}\n;VG1 E4 F{max(new_filament_e_feedrate/2, 100)}\n{endif}\n{endif}\n\n; VFLUSH_START\n\n{if flush_length>41.5}\n;VG1 E41.5 F{min(old_filament_e_feedrate,new_filament_e_feedrate)}\n;VG1 E{flush_length-41.5} F{new_filament_e_feedrate}\n{else}\n;VG1 E{flush_length} F{min(old_filament_e_feedrate,new_filament_e_feedrate)}\n{endif}\n\nSYNC T{ceil(flush_length / 125) * 5}\n\n; compensate for heating and cooling\n{if flush_length > 0}\n{if flush_temperatures[next_extruder] > new_filament_temp}\nSYNC T{(flush_temperatures[next_extruder]-(new_filament_temp - filament_cooling_before_tower[next_extruder]))/hotend_cooling_rate[filament_map[next_extruder]-1]}\nSYNC T{(flush_temperatures[next_extruder]-(new_filament_temp - filament_cooling_before_tower[next_extruder]))/hotend_heating_rate[filament_map[next_extruder]-1]}\n{else}\nSYNC T{(new_filament_temp - filament_cooling_before_tower[next_extruder] -flush_temperatures[next_extruder])/hotend_cooling_rate[filament_map[next_extruder]-1]}\nSYNC T{(new_filament_temp - filament_cooling_before_tower[next_extruder] -flush_temperatures[next_extruder])/hotend_heating_rate[filament_map[next_extruder]-1]}\n{endif}\n{endif}\n\n; VFLUSH_END\n\nM1002 set_filament_type:{filament_type[next_extruder]}\n\nM400\nM83\n{if next_extruder < 255}\n\n\nM620.10 R{retract_length_toolchange[filament_map[next_extruder]-1]}\n{if (print_sequence == \"by object\" && !has_wipe_tower)}\nM628 S0 F1 L10.0\n; VFLUSH_START\n;VG1 E10 F[new_filament_e_feedrate]\n; VFLUSH_END\n{else}\nM628 S0\n{endif}\n;VM109 S[new_filament_temp]\n\nM629\nM400\n\nM983.3 F{filament_max_volumetric_speed[next_extruder]/2.4} A0.4 R{retract_length_toolchange[filament_map[next_extruder]-1]}\n\n\nM400\n{if wipe_avoid_perimeter}\nG387 Y320 J1 F10000\nG1 X{wipe_avoid_pos_x} F30000\n{endif}\nG387 Y295 J1 F30000\nG387 Y265 J1 F18000\nG1 Z{max_layer_z + 3.0} F3000\n{if layer_z <= (initial_layer_print_height + 0.001)}\nM204 S[initial_layer_acceleration]\n{else}\nM204 S[default_acceleration]\n{endif}\n{else}\nG1 X[x_after_toolchange] Y[y_after_toolchange] Z[z_after_toolchange] F12000\n{endif}\nM621 S[next_extruder]A\n\nM993 A3 B3 C3 ; nozzle cam detection allow status restore.\n\n{if (filament_type[next_extruder]  == \"TPU\")}\nM1015.3 S1;enable tpu clog detect\n{else}\nM1015.3 S0;disable tpu clog detect\n{endif}\n\n{if (filament_type[next_extruder] == \"PLA\") ||  (filament_type[next_extruder] == \"PETG\")\n ||  (filament_type[next_extruder] == \"PLA-CF\")  ||  (filament_type[next_extruder] == \"PETG-CF\")}\nM1015.4 S1 K1 H[nozzle_diameter] ;enable E air printing detect\n{else}\nM1015.4 S0 ; disable E air printing detect\n{endif}\n\nM620.6 I[next_extruder] W1 ;enable ams air printing detect\nM1002 gcode_claim_action : 0\n",
+  "circle_compensation_manual_offset": "0",
+  "circle_compensation_speed": [
+    "200",
+    "200",
+    "200"
+  ],
+  "close_fan_the_first_x_layers": [
+    "1",
+    "1",
+    "1"
+  ],
+  "complete_print_exhaust_fan_speed": [
+    "70",
+    "70",
+    "70"
+  ],
+  "cool_plate_temp": [
+    "35",
+    "35",
+    "35"
+  ],
+  "cool_plate_temp_initial_layer": [
+    "35",
+    "35",
+    "35"
+  ],
+  "cooling_filter_enabled": "0",
+  "cooling_perimeter_transition_distance": [
+    "10",
+    "10",
+    "10"
+  ],
+  "cooling_slowdown_logic": [
+    "uniform_cooling",
+    "uniform_cooling",
+    "uniform_cooling"
+  ],
+  "counter_coef_1": [
+    "0",
+    "0",
+    "0"
+  ],
+  "counter_coef_2": [
+    "0.003",
+    "0.003",
+    "0.003"
+  ],
+  "counter_coef_3": [
+    "0.01",
+    "0.01",
+    "0.01"
+  ],
+  "counter_limit_max": [
+    "0.088",
+    "0.088",
+    "0.088"
+  ],
+  "counter_limit_min": [
+    "-0.035",
+    "-0.035",
+    "-0.035"
+  ],
+  "curr_bed_type": "Textured PEI Plate",
+  "default_acceleration": [
+    "8000",
+    "8000",
+    "8000",
+    "8000"
+  ],
+  "default_filament_colour": [
+    "",
+    "",
+    ""
+  ],
+  "default_filament_profile": [
+    "Bambu PLA Basic @BBL H2C"
+  ],
+  "default_jerk": "0",
+  "default_nozzle_volume_type": [
+    "Standard",
+    "Standard"
+  ],
+  "default_print_profile": "0.20mm Standard @BBL H2C",
+  "deretraction_speed": [
+    "30",
+    "30",
+    "30",
+    "30"
+  ],
+  "detect_floating_vertical_shell": "1",
+  "detect_narrow_internal_solid_infill": "1",
+  "detect_overhang_wall": "1",
+  "detect_thin_wall": "0",
+  "diameter_limit": [
+    "50",
+    "50",
+    "50"
+  ],
+  "draft_shield": "disabled",
+  "during_print_exhaust_fan_speed": [
+    "70",
+    "70",
+    "70"
+  ],
+  "elefant_foot_compensation": "0.15",
+  "embedding_wall_into_infill": "0",
+  "enable_arc_fitting": "1",
+  "enable_circle_compensation": "0",
+  "enable_height_slowdown": [
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "enable_long_retraction_when_cut": "2",
+  "enable_overhang_bridge_fan": [
+    "1",
+    "1",
+    "1"
+  ],
+  "enable_overhang_speed": [
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "enable_pre_heating": "1",
+  "enable_pressure_advance": [
+    "0",
+    "0",
+    "0"
+  ],
+  "enable_prime_tower": "1",
+  "enable_support": "0",
+  "enable_support_ironing": "0",
+  "enable_tower_interface_features": "0",
+  "enable_wrapping_detection": "0",
+  "enforce_support_layers": "0",
+  "eng_plate_temp": [
+    "55",
+    "55",
+    "55"
+  ],
+  "eng_plate_temp_initial_layer": [
+    "55",
+    "55",
+    "55"
+  ],
+  "ensure_vertical_shell_thickness": "enabled",
+  "exclude_object": "1",
+  "extruder_ams_count": [
+    "1#0|4#1",
+    "1#0|4#3"
+  ],
+  "extruder_clearance_dist_to_rod": "50",
+  "extruder_clearance_height_to_lid": "201",
+  "extruder_clearance_height_to_rod": "47.4",
+  "extruder_clearance_max_radius": "96",
+  "extruder_colour": [
+    "#018001",
+    "#018001"
+  ],
+  "extruder_max_nozzle_count": [
+    "1",
+    "6"
+  ],
+  "extruder_nozzle_stats": [
+    "Standard#1",
+    "Standard#6"
+  ],
+  "extruder_offset": [
+    "0x0",
+    "0x0"
+  ],
+  "extruder_printable_area": [
+    "0x0,325x0,325x320,0x320",
+    "25x0,330x0,330x320,25x320"
+  ],
+  "extruder_printable_height": [
+    "320",
+    "325"
+  ],
+  "extruder_type": [
+    "Direct Drive",
+    "Direct Drive"
+  ],
+  "extruder_variant_list": [
+    "Direct Drive Standard,Direct Drive High Flow",
+    "Direct Drive Standard,Direct Drive High Flow"
+  ],
+  "fan_cooling_layer_time": [
+    "100",
+    "100",
+    "100"
+  ],
+  "fan_direction": "left",
+  "fan_max_speed": [
+    "80",
+    "80",
+    "80"
+  ],
+  "fan_min_speed": [
+    "60",
+    "60",
+    "60"
+  ],
+  "filament_adaptive_volumetric_speed": [
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_adhesiveness_category": [
+    "100",
+    "100",
+    "100"
+  ],
+  "filament_bridge_speed": [
+    "25",
+    "25",
+    "25",
+    "25",
+    "25",
+    "25"
+  ],
+  "filament_change_length": [
+    "4",
+    "4",
+    "4"
+  ],
+  "filament_change_length_nc": [
+    "4",
+    "4",
+    "4"
+  ],
+  "filament_colour": [
+    "#D9D9D9",
+    "#D9D9D9",
+    "#D9D9D9"
+  ],
+  "filament_colour_type": [
+    "2",
+    "0",
+    "0"
+  ],
+  "filament_cooling_before_tower": [
+    "10",
+    "10",
+    "10",
+    "10",
+    "10",
+    "10"
+  ],
+  "filament_cost": [
+    "24.99",
+    "24.99",
+    "24.99"
+  ],
+  "filament_density": [
+    "1.26",
+    "1.26",
+    "1.26"
+  ],
+  "filament_deretraction_speed": [
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil"
+  ],
+  "filament_dev_ams_drying_ams_limitations": [
+    "1",
+    "0",
+    "1",
+    "0",
+    "1",
+    "0"
+  ],
+  "filament_dev_ams_drying_heat_distortion_temperature": [
+    "45",
+    "45",
+    "45"
+  ],
+  "filament_dev_ams_drying_temperature": [
+    "45",
+    "45",
+    "45",
+    "45",
+    "45",
+    "45",
+    "45",
+    "45",
+    "45",
+    "45",
+    "45",
+    "45"
+  ],
+  "filament_dev_ams_drying_time": [
+    "12",
+    "12",
+    "12",
+    "12",
+    "12",
+    "12",
+    "12",
+    "12",
+    "12",
+    "12",
+    "12",
+    "12"
+  ],
+  "filament_dev_chamber_drying_bed_temperature": [
+    "70",
+    "70",
+    "70"
+  ],
+  "filament_dev_chamber_drying_time": [
+    "12",
+    "12",
+    "12"
+  ],
+  "filament_dev_drying_cooling_temperature": [
+    "45",
+    "45",
+    "45"
+  ],
+  "filament_dev_drying_softening_temperature": [
+    "50",
+    "50",
+    "50"
+  ],
+  "filament_diameter": [
+    "1.75",
+    "1.75",
+    "1.75"
+  ],
+  "filament_enable_overhang_speed": [
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "filament_end_gcode": [
+    "; filament end gcode \n",
+    "; filament end gcode \n",
+    "; filament end gcode \n"
+  ],
+  "filament_extruder_variant": [
+    "Direct Drive Standard",
+    "Direct Drive High Flow",
+    "Direct Drive Standard",
+    "Direct Drive High Flow",
+    "Direct Drive Standard",
+    "Direct Drive High Flow"
+  ],
+  "filament_flow_ratio": [
+    "0.99",
+    "0.99",
+    "0.99",
+    "0.99",
+    "0.99",
+    "0.99"
+  ],
+  "filament_flush_temp": [
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_flush_volumetric_speed": [
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_ids": [
+    "GFA00",
+    "GFA00",
+    "GFA00"
+  ],
+  "filament_is_support": [
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_long_retractions_when_cut": [
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil"
+  ],
+  "filament_map": [
+    "1",
+    "1",
+    "1"
+  ],
+  "filament_map_mode": "Auto For Flush",
+  "filament_max_volumetric_speed": [
+    "25",
+    "40",
+    "25",
+    "40",
+    "25",
+    "40"
+  ],
+  "filament_minimal_purge_on_wipe_tower": [
+    "15",
+    "15",
+    "15"
+  ],
+  "filament_multi_colour": [
+    "#0086D6",
+    "#EF4444",
+    "#22C55E"
+  ],
+  "filament_notes": "",
+  "filament_nozzle_map": [
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_overhang_1_4_speed": [
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_overhang_2_4_speed": [
+    "50",
+    "50",
+    "50",
+    "50",
+    "50",
+    "50"
+  ],
+  "filament_overhang_3_4_speed": [
+    "30",
+    "30",
+    "30",
+    "30",
+    "30",
+    "30"
+  ],
+  "filament_overhang_4_4_speed": [
+    "10",
+    "10",
+    "10",
+    "10",
+    "10",
+    "10"
+  ],
+  "filament_overhang_totally_speed": [
+    "10",
+    "10",
+    "10",
+    "10",
+    "10",
+    "10"
+  ],
+  "filament_pre_cooling_temperature": [
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_pre_cooling_temperature_nc": [
+    "180",
+    "180",
+    "180",
+    "180",
+    "180",
+    "180"
+  ],
+  "filament_prime_volume": [
+    "30",
+    "30",
+    "30"
+  ],
+  "filament_prime_volume_nc": [
+    "30",
+    "30",
+    "30"
+  ],
+  "filament_printable": [
+    "3",
+    "3",
+    "3"
+  ],
+  "filament_ramming_travel_time": [
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_ramming_travel_time_nc": [
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "filament_ramming_volumetric_speed": [
+    "-1",
+    "-1",
+    "-1",
+    "-1",
+    "-1",
+    "-1"
+  ],
+  "filament_ramming_volumetric_speed_nc": [
+    "-1",
+    "-1",
+    "-1",
+    "-1",
+    "-1",
+    "-1"
+  ],
+  "filament_retract_before_wipe": [
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil"
+  ],
+  "filament_retract_length_nc": [
+    "18",
+    "18",
+    "18",
+    "18",
+    "18",
+    "18"
+  ],
+  "filament_retract_restart_extra": [
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil"
+  ],
+  "filament_retract_when_changing_layer": [
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil"
+  ],
+  "filament_retraction_distances_when_cut": [
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil"
+  ],
+  "filament_retraction_length": [
+    "0.4",
+    "0.8",
+    "0.4",
+    "0.8",
+    "0.4",
+    "0.8"
+  ],
+  "filament_retraction_minimum_travel": [
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil"
+  ],
+  "filament_retraction_speed": [
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil"
+  ],
+  "filament_scarf_gap": [
+    "0%",
+    "0%",
+    "0%"
+  ],
+  "filament_scarf_height": [
+    "10%",
+    "10%",
+    "10%"
+  ],
+  "filament_scarf_length": [
+    "10",
+    "10",
+    "10"
+  ],
+  "filament_scarf_seam_type": [
+    "none",
+    "none",
+    "none"
+  ],
+  "filament_self_index": [
+    "1",
+    "1",
+    "2",
+    "2",
+    "3",
+    "3"
+  ],
+  "filament_settings_id": [
+    "Bambu PLA Basic @BBL H2C",
+    "Bambu PLA Basic @BBL H2C",
+    "Bambu PLA Basic @BBL H2C"
+  ],
+  "filament_shrink": [
+    "100%",
+    "100%",
+    "100%"
+  ],
+  "filament_soluble": [
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_start_gcode": [
+    "; filament start gcode\n",
+    "; filament start gcode\n",
+    "; filament start gcode\n"
+  ],
+  "filament_tower_interface_pre_extrusion_dist": [
+    "10",
+    "10",
+    "10"
+  ],
+  "filament_tower_interface_pre_extrusion_length": [
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_tower_interface_print_temp": [
+    "-1",
+    "-1",
+    "-1"
+  ],
+  "filament_tower_interface_purge_volume": [
+    "20",
+    "20",
+    "20"
+  ],
+  "filament_tower_ironing_area": [
+    "4",
+    "4",
+    "4"
+  ],
+  "filament_type": [
+    "PLA",
+    "PLA",
+    "PLA"
+  ],
+  "filament_velocity_adaptation_factor": [
+    "1",
+    "1",
+    "1"
+  ],
+  "filament_vendor": [
+    "Bambu Lab",
+    "Bambu Lab",
+    "Bambu Lab"
+  ],
+  "filament_volume_map": [
+    "0",
+    "0",
+    "0"
+  ],
+  "filament_wipe": [
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "filament_wipe_distance": [
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "filament_z_hop": [
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "nil"
+  ],
+  "filament_z_hop_types": [
+    "Spiral Lift",
+    "Spiral Lift",
+    "Spiral Lift",
+    "Spiral Lift",
+    "Spiral Lift",
+    "Spiral Lift"
+  ],
+  "filename_format": "{input_filename_base}_{filament_type[0]}_{print_time}.gcode",
+  "fill_multiline": "1",
+  "filter_out_gap_fill": "0",
+  "first_layer_print_sequence": [
+    "0"
+  ],
+  "first_x_layer_fan_speed": [
+    "0",
+    "0",
+    "0"
+  ],
+  "flush_into_infill": "0",
+  "flush_into_objects": "0",
+  "flush_into_support": "1",
+  "flush_multiplier": [
+    "1",
+    "1"
+  ],
+  "flush_volumes_matrix": [
+    "0",
+    "421",
+    "367",
+    "299",
+    "0",
+    "423",
+    "277",
+    "301",
+    "0",
+    "0",
+    "436",
+    "382",
+    "314",
+    "0",
+    "438",
+    "292",
+    "316",
+    "0"
+  ],
+  "flush_volumes_vector": [
+    "140",
+    "140",
+    "140",
+    "140",
+    "140",
+    "140"
+  ],
+  "from": "project",
+  "full_fan_speed_layer": [
+    "0",
+    "0",
+    "0"
+  ],
+  "fuzzy_skin": "none",
+  "fuzzy_skin_point_distance": "0.8",
+  "fuzzy_skin_thickness": "0.3",
+  "gap_infill_speed": [
+    "250",
+    "150",
+    "250",
+    "150"
+  ],
+  "gcode_add_line_number": "0",
+  "gcode_flavor": "marlin",
+  "grab_length": [
+    "0",
+    "0"
+  ],
+  "group_algo_with_time": "0",
+  "has_scarf_joint_seam": "0",
+  "head_wrap_detect_zone": [],
+  "hole_coef_1": [
+    "0",
+    "0",
+    "0"
+  ],
+  "hole_coef_2": [
+    "-0.008",
+    "-0.008",
+    "-0.008"
+  ],
+  "hole_coef_3": [
+    "0.18",
+    "0.18",
+    "0.18"
+  ],
+  "hole_limit_max": [
+    "0.22",
+    "0.22",
+    "0.22"
+  ],
+  "hole_limit_min": [
+    "0.088",
+    "0.088",
+    "0.088"
+  ],
+  "host_type": "octoprint",
+  "hot_plate_temp": [
+    "55",
+    "55",
+    "55"
+  ],
+  "hot_plate_temp_initial_layer": [
+    "55",
+    "55",
+    "55"
+  ],
+  "hotend_cooling_rate": [
+    "1.6",
+    "1.6",
+    "3.4",
+    "3.4"
+  ],
+  "hotend_heating_rate": [
+    "3.5",
+    "3.5",
+    "13.3",
+    "13.3"
+  ],
+  "impact_strength_z": [
+    "13.8",
+    "13.8",
+    "13.8"
+  ],
+  "independent_support_layer_height": "1",
+  "infill_combination": "0",
+  "infill_direction": "45",
+  "infill_instead_top_bottom_surfaces": "0",
+  "infill_jerk": "9",
+  "infill_lock_depth": "1",
+  "infill_rotate_step": "0",
+  "infill_shift_step": "0.4",
+  "infill_wall_overlap": "15%",
+  "initial_layer_acceleration": [
+    "500",
+    "500",
+    "500",
+    "500"
+  ],
+  "initial_layer_flow_ratio": "1",
+  "initial_layer_infill_speed": [
+    "105",
+    "105",
+    "105",
+    "105"
+  ],
+  "initial_layer_jerk": "9",
+  "initial_layer_line_width": "0.5",
+  "initial_layer_print_height": "0.2",
+  "initial_layer_speed": [
+    "50",
+    "50",
+    "50",
+    "50"
+  ],
+  "initial_layer_travel_acceleration": [
+    "6000",
+    "6000",
+    "6000",
+    "6000"
+  ],
+  "inner_wall_acceleration": [
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "inner_wall_jerk": "9",
+  "inner_wall_line_width": "0.45",
+  "inner_wall_speed": [
+    "300",
+    "600",
+    "300",
+    "600"
+  ],
+  "interface_shells": "0",
+  "interlocking_beam": "0",
+  "interlocking_beam_layer_count": "2",
+  "interlocking_beam_width": "0.8",
+  "interlocking_boundary_avoidance": "2",
+  "interlocking_depth": "2",
+  "interlocking_orientation": "22.5",
+  "internal_bridge_support_thickness": "0.8",
+  "internal_solid_infill_line_width": "0.42",
+  "internal_solid_infill_pattern": "zig-zag",
+  "internal_solid_infill_speed": [
+    "250",
+    "600",
+    "250",
+    "600"
+  ],
+  "ironing_direction": "45",
+  "ironing_flow": "15%",
+  "ironing_inset": "0.21",
+  "ironing_pattern": "zig-zag",
+  "ironing_spacing": "0.15",
+  "ironing_speed": "30",
+  "ironing_type": "no ironing",
+  "is_infill_first": "0",
+  "layer_change_gcode": "; layer num/total_layer_count: {layer_num+1}/[total_layer_count]\n; update layer progress\nM73 L{layer_num+1}\nM991 S0 P{layer_num} ;notify layer change",
+  "layer_height": "0.2",
+  "line_width": "0.42",
+  "locked_skeleton_infill_pattern": "zigzag",
+  "locked_skin_infill_pattern": "crosszag",
+  "long_retractions_when_cut": [
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "long_retractions_when_ec": [
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "machine_end_gcode": ";===== machine: H2C end =====\n;====== date: 20251111 ======\n\nG392 S0 ;turn off nozzle clog detect\nM993 A0 B0 C0 ; nozzle cam detection not allowed.\n\nM400 ; wait for buffer to clear\nG92 E0 ; zero the extruder\nG1 E-0.8 F1800 ; retract\nM400\nM211 Z1\nG1 Z{max_layer_z + 0.4} F900 ; lower z a little\nM640.2 R0\n\nM1002 judge_flag timelapse_record_flag\nM622 J1\n    G150.3\n    M400 ; wait all motion done\n    M991 S0 P-1 ;end smooth timelapse at safe pos\n    M400 S5 ;wait for last picture to be taken\nM623  ;end of \"timelapse_record_flag\"\n\nG90\nG1 Z{max_layer_z + 10} F900 ; lower z a little\n\nG90\nM141 S0 ; turn off chamber heating\nM140 S0 ; turn off bed\nM106 S0 ; turn off fan\nM106 P2 S0 ; turn off remote part cooling fan\nM106 P3 S0 ; turn off chamber cooling fan\nM106 P9 S0 ; turn off ext toodhead cooling fan\n\n; pull back filament to AMS\nM620 S65535\n{if long_retraction_when_cut}\nM620.11 P1 I[current_extruder] E-{retraction_distance_when_cut} F{max((flush_volumetric_speeds[current_extruder]/2.4053*60), 200)}\n{else}\nM620.11 P0 I[current_extruder] E0\n{endif}\n\n{if long_retraction_when_ec}\nM620.11 K1 I[current_extruder] R{retraction_distance_when_ec} F{max((flush_volumetric_speeds[current_extruder]/2.4053*60), 200)}\n{else}\nM620.11 K0 I[current_extruder] R0\n{endif}\n\nM620.11 P1 I[current_extruder] E-14\nT65535\nG150.2\nM621 S65535\n\nM620 S65279\nT65279\nG150.2\nM621 S65279\n\nG150.3\n\nM104 S0 T0; turn off hotend\nM104 S0 T1; turn off hotend\n\nM400 ; wait all motion done\nM17 S\nM17 Z0.4 ; lower z motor current to reduce impact if there is something in the bottom\n{if (100.0 - max_layer_z/2) > 0}\n    {if (max_layer_z + 100.0 - max_layer_z/2) < 320}\n        G1 Z{max_layer_z + 100.0 - max_layer_z/2} F600\n        G1 Z{max_layer_z + 98.0 - max_layer_z/2}\n    {else}\n        G1 Z320 F600\n        G1 Z320\n    {endif}\n{else}\n    {if (max_layer_z + 4.0) < 320}\n        G1 Z{max_layer_z + 4.0} F600\n        G1 Z{max_layer_z + 2.0}\n    {else}\n        G1 Z320 F600\n        G1 Z320\n    {endif}\n{endif}\nM400 P100\nM17 R ; restore z current\n\nM220 S100  ; Reset feedrate magnitude\nM201.2 K1.0 ; Reset acc magnitude\nM73.2   R1.0 ;Reset left time magnitude\nM1002 set_gcode_claim_speed_level : 0\n\nM1015.4 S0 K0 ;disable air printing detect\n;=====printer finish  sound=========\nM17\nM400 S1\nM1006 S1\nM1006 A53 B10 L99 C53 D10 M99 E53 F10 N99 \nM1006 A57 B10 L99 C57 D10 M99 E57 F10 N99 \nM1006 A0 B15 L0 C0 D15 M0 E0 F15 N0 \nM1006 A53 B10 L99 C53 D10 M99 E53 F10 N99 \nM1006 A57 B10 L99 C57 D10 M99 E57 F10 N99 \nM1006 A0 B15 L0 C0 D15 M0 E0 F15 N0 \nM1006 A48 B10 L99 C48 D10 M99 E48 F10 N99 \nM1006 A0 B15 L0 C0 D15 M0 E0 F15 N0 \nM1006 A60 B10 L99 C60 D10 M99 E60 F10 N99 \nM1006 W\n;=====printer finish  sound=========\nM400\nM18\n\n",
+  "machine_hotend_change_time": "0",
+  "machine_load_filament_time": "15",
+  "machine_max_acceleration_e": [
+    "5000",
+    "5000",
+    "5000",
+    "5000",
+    "5000",
+    "5000",
+    "5000",
+    "5000"
+  ],
+  "machine_max_acceleration_extruding": [
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000"
+  ],
+  "machine_max_acceleration_retracting": [
+    "5000",
+    "5000",
+    "5000",
+    "5000",
+    "5000",
+    "5000",
+    "5000",
+    "5000"
+  ],
+  "machine_max_acceleration_travel": [
+    "9000",
+    "9000",
+    "9000",
+    "9000",
+    "9000",
+    "9000",
+    "9000",
+    "9000"
+  ],
+  "machine_max_acceleration_x": [
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000"
+  ],
+  "machine_max_acceleration_y": [
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000",
+    "20000"
+  ],
+  "machine_max_acceleration_z": [
+    "500",
+    "500",
+    "500",
+    "500",
+    "500",
+    "500",
+    "500",
+    "500"
+  ],
+  "machine_max_jerk_e": [
+    "2.5",
+    "2.5",
+    "2.5",
+    "2.5",
+    "2.5",
+    "2.5",
+    "2.5",
+    "2.5"
+  ],
+  "machine_max_jerk_x": [
+    "9",
+    "9",
+    "9",
+    "9",
+    "9",
+    "9",
+    "9",
+    "9"
+  ],
+  "machine_max_jerk_y": [
+    "9",
+    "9",
+    "9",
+    "9",
+    "9",
+    "9",
+    "9",
+    "9"
+  ],
+  "machine_max_jerk_z": [
+    "3",
+    "3",
+    "3",
+    "3",
+    "3",
+    "3",
+    "3",
+    "3"
+  ],
+  "machine_max_speed_e": [
+    "50",
+    "50",
+    "50",
+    "50",
+    "50",
+    "50",
+    "50",
+    "50"
+  ],
+  "machine_max_speed_x": [
+    "1000",
+    "1000",
+    "1000",
+    "1000",
+    "1000",
+    "1000",
+    "1000",
+    "1000"
+  ],
+  "machine_max_speed_y": [
+    "1000",
+    "1000",
+    "1000",
+    "1000",
+    "1000",
+    "1000",
+    "1000",
+    "1000"
+  ],
+  "machine_max_speed_z": [
+    "30",
+    "30",
+    "30",
+    "30",
+    "30",
+    "30",
+    "30",
+    "30"
+  ],
+  "machine_min_extruding_rate": [
+    "0",
+    "0"
+  ],
+  "machine_min_travel_rate": [
+    "0",
+    "0"
+  ],
+  "machine_pause_gcode": "M400 U1",
+  "machine_prepare_compensation_time": "260",
+  "machine_start_gcode": ";===== machine: H2C =========================\n;===== date: 20251210 =====================\n\n;M1002 set_flag extrude_cali_flag=1\n;M1002 set_flag g29_before_print_flag=1\n;M1002 set_flag auto_cali_toolhead_offset_flag=1\n;M1002 set_flag build_plate_detect_flag=1\n\nM993 A0 B0 C0 ; nozzle cam detection not allowed.\n\nM400\n;M73 P99\n\nM960 S10 P1 ; ext fan led\n\n;=====printer start sound ===================\nM17\nM400 S1\nM1006 S1\nM1006 A53 B9 L99 C53 D9 M99 E53 F9 N99 \nM1006 A56 B9 L99 C56 D9 M99 E56 F9 N99 \nM1006 A61 B9 L99 C61 D9 M99 E61 F9 N99 \nM1006 A53 B9 L99 C53 D9 M99 E53 F9 N99 \nM1006 A56 B9 L99 C56 D9 M99 E56 F9 N99 \nM1006 A61 B18 L99 C61 D18 M99 E61 F18 N99 \nM1006 W\n;=====printer start sound ===================\n\n;===== reset machine status =================\nM204 S10000\nM630 S0 P0\n\nG90\nM17 D ; reset motor current to default\nM960 S5 P1 ; turn on logo lamp\nG90\nM1002 set_gcode_claim_speed_level 5 ;Reset speed level\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nM73.2   R1.0 ;Reset left time magnitude\nG29.1 Z{+0.0} ; clear z-trim value first\nM983.1 M1 \nM901 D4\nM481 S0 ; turn off cutter pos comp\nG28.140 D0; reset pre-extrude z pos\n;===== reset machine status =================\n\nM620 M ;enable remap\nM620 N ;enable hotend remap\nM620 T0 ;print tmpr\nM620 T1 ;sn -> pos\nM620 T2 ;filament_id\n\n;===== start to heat heatbed & hotend==========\n\n    M104 O-80 A\n    M140 D[bed_temperature_initial_layer_single]\n\n;===== start to heat heatbead & hotend==========\n\n;===== avoid end stop =================\nG91\nG380 S2 Z42 F1200\nG380 S2 Z-12 F1200\nG90\n;===== avoid end stop =================\n\n;==== set airduct mode ==== \n\n{if (overall_chamber_temperature >= 40)}\n\n    M145 P1 ; set airduct mode to heating mode for heating\n    M106 P2 S0 ; turn off auxiliary fan\n    M106 P3 S0 ; turn off chamber fan\n\n{else}\n    M145 P0 ; set airduct mode to cooling mode for cooling\n    M106 P2 S178 ; turn on auxiliary fan for cooling\n    M106 P3 S127 ; turn on chamber fan for cooling\n\n    M1002 gcode_claim_action : 29\n    M191 S0 ; wait for chamber temp\n    M106 P2 S0 ; turn off auxiliary fan\n    {if (min_vitrification_temperature <= 50)}\n        {if (nozzle_diameter == 0.2)}\n            M142 P1 R30 S35 T40 U0.3 V0.5 W0.8 O40 ; set PLA/TPU ND0.2 chamber autocooling\n        {else}\n            M142 P1 R30 S40 T45 U0.3 V0.5 W0.8 O45; set PLA/TPU ND0.4 chamber autocooling\n        {endif}\n    {else}\n        {if (!is_all_bbl_filament)}\n            M142 P1 R35 S40 T45 U0.3 V0.5 W0.8 O45 L1 ; set third-party PETG chamber autocooling\n        {else}\n            {if (nozzle_diameter == 0.2)}\n                M142 P1 R35 S45 T50 U0.3 V0.5 W0.8 O50 L1 ; set PETG ND0.2 chamber autocooling\n            {else}\n                M142 P1 R35 S50 T55 U0.3 V0.5 W0.8 O55 L1 ; set PETG ND0.4 chamber autocooling\n            {endif}\n        {endif}\n    {endif}\n{endif}\n;==== set airduct mode ==== \n\n\n;====== cog noise reduction=================\nM982.2 S1 ; turn on cog noise reduction\n\n;===== first homing start =====\nM1002 gcode_claim_action : 13\n\nM640 S\nM640.1 R\nM641\nG28 X T300\nT1000\n\nG150.3\nM972 S24 P0 T2000 ; live-view camera foolproof\nM972 S46 P0 T5000 ; vortek anti-collision\nM640.1 S\nM640.4\n{if (first_non_support_filaments[0] != -1)}\nM640 S\nM640.8 T A{first_non_support_filaments[0]}\nM640.7 L\nM641\n{endif}\n\n\n{if wipe_tower_center_pos_valid}\n    M620.14 X[wipe_tower_center_pos_x] Y[wipe_tower_center_pos_y]\n{else}\n    M620.14 X95.5 Y336\n{endif}\n\n\nG150.1 F18000 ; wipe mouth to avoid filament stick to heatbed\nG150.3 F18000\nM400 P200\n\n{if curr_bed_type==\"Textured PEI Plate\"}\nM972 S26 P0 C0\n{else}\nM972 S36 P0 C0 X1\n{endif}\nM972 S35 P0 C0\n\nM972 S41 P0 T5000 ; trash can anti-collision\n\nM1009 Q1 L1\nG90\nG1 X175 Y160 F30000\nG28 Z P0 T250\nM1009 Q1 L0\n\n\n;===== first homing end =====\n\nM104 O-80 A\n\n;===== detection start =====\n    \n\nM1002 judge_flag build_plate_detect_flag\nM622 S1\n    M972 S19 P0 C0    ; heatbed presence detection\n    M972 S31 P0 T5000 ; toolhead camera dirty detection\n    M972 S34 P0 T5000 ; heatbed plate offset detection\nM623\n\nT1001\nM972 S14 P0 T5000 ; nozzle type detection\n\nM104 O-80 A ; rise temp in advance\n\n;===== detection end =====\n\nM400\n;M73 P99\n\n;===== prepare print temperature and material ==========\nM400\nM211 X0 Y0 Z0 ;turn off soft endstop\nM975 S1 ; turn on input shaping\n\nG29.2 S0 ; avoid invalid abl data\n\n{if ((filament_type[initial_no_support_extruder] == \"PLA\") || (filament_type[initial_no_support_extruder] == \"PLA-CF\") || (filament_type[initial_no_support_extruder] == \"PETG\")) && (nozzle_diameter[initial_no_support_extruder] == 0.2)}\nM620.10 A0 F74.8347 H{nozzle_diameter[initial_no_support_extruder]} T{flush_temperatures[initial_no_support_extruder]} P{nozzle_temperature_initial_layer[initial_no_support_extruder]} S1\nM620.10 A1 F74.8347 H{nozzle_diameter[initial_no_support_extruder]} T{flush_temperatures[initial_no_support_extruder]} P{nozzle_temperature_initial_layer[initial_no_support_extruder]} S1\n{else}\nM620.10 A0 F{flush_volumetric_speeds[initial_no_support_extruder]/2.4053*60*0.8} H{nozzle_diameter[initial_no_support_extruder]} T{flush_temperatures[initial_no_support_extruder]} P{nozzle_temperature_initial_layer[initial_no_support_extruder]} S1\nM620.10 A1 F{flush_volumetric_speeds[initial_no_support_extruder]/2.4053*60*0.8} H{nozzle_diameter[initial_no_support_extruder]} T{flush_temperatures[initial_no_support_extruder]} P{nozzle_temperature_initial_layer[initial_no_support_extruder]} S1\n{endif}\n\nM620.11 P1 I[initial_no_support_extruder] E0\n\n{if long_retraction_when_ec }\nM620.11 K1 I[initial_no_support_extruder] R{retraction_distance_when_ec} F{max((flush_volumetric_speeds[initial_no_support_extruder]/2.4053*60), 200)}\n{else}\nM620.11 K0 I[initial_no_support_extruder] R0\n{endif}\n\nM628 S1\n{if filament_type[initial_no_support_extruder] == \"TPU\"}\n    M620.11 S0 L0 I[initial_no_support_extruder] E-{retraction_distances_when_cut[initial_no_support_extruder]} F{flush_volumetric_speeds[initial_no_support_extruder]/2.4053*60}\n{else}\n{if (filament_type[initial_no_support_extruder] == \"PA\") ||  (filament_type[initial_no_support_extruder] == \"PA-GF\")}\n    M620.11 S1 L0 I[initial_no_support_extruder] R4 D2 E-{retraction_distances_when_cut[initial_no_support_extruder]} F{flush_volumetric_speeds[initial_no_support_extruder]/2.4053*60}\n{else}\n    M620.11 S1 L0 I[initial_no_support_extruder] R10 D8 E-{retraction_distances_when_cut[initial_no_support_extruder]} F{flush_volumetric_speeds[initial_no_support_extruder]/2.4053*60}\n{endif}\n{endif}\nM629\n\nM620 S[initial_no_support_extruder]A   ; switch material if AMS exist\nM1002 gcode_claim_action : 4\nM1002 set_filament_type:UNKNOWN\nM400\nT[initial_no_support_extruder]\nM400\nM628 S0\nM629\nM400\nM1002 set_filament_type:{filament_type[initial_no_support_extruder]}\nM621 S[initial_no_support_extruder]A\n\nM104 S{nozzle_temperature_initial_layer[initial_no_support_extruder]}\nM400\nM106 P1 S0\n\nG91\nG1 Y-16 F60000\nG90\n\nG29.2 S1\n;===== prepare print temperature and material ==========\n\n\nM400\n;M73 P99\n\n;===== xy ofst cali start =====\n\nM1002 judge_flag auto_cali_toolhead_offset_flag\n\nM622 J2\n    M1002 gcode_claim_action : 54\n    M190 D[bed_temperature_initial_layer_single]\n    \n    M1002 gcode_claim_action : 39\n    G383.3 U140 L{initial_no_support_extruder}\n    M500\nM623\n\nM622 J1\n    M1002 gcode_claim_action : 54\n    M190 D[bed_temperature_initial_layer_single]\n\n    M1002 gcode_claim_action : 39\n    G383 O2 U140 L{initial_no_support_extruder}\n    M500\nM623\n\n;===== xy ofst cali end =====\n\n;===== start to heat heatbed & hotend==========\n\n    M1002 set_filament_type:{filament_type[initial_no_support_extruder]}\n    G150.3\n    M104 S{nozzle_temperature_initial_layer[initial_no_support_extruder]}\n    M140 S[bed_temperature_initial_layer_single]\n\n    ;===== set chamber temperature ==========\n    {if (overall_chamber_temperature >= 40)}\n        M145 P1 ; set airduct mode to heating mode\n        M141 S[overall_chamber_temperature] ; Let Chamber begin to heat\n    {endif}\n    ;===== set chamber temperature ==========\n\n;===== start to heat heatbead & hotend==========\n\n\n\nM400\n;M73 P99\n\n;===== auto extrude cali start =========================\nM975 S1\nM1002 judge_flag extrude_cali_flag\n\nM622 J0\n    M983.3 F{filament_max_volumetric_speed[initial_no_support_extruder]/2.4} A0.4 ; cali dynamic extrusion compensation\nM623\n\nM622 J1\n    M1002 set_filament_type:{filament_type[initial_no_support_extruder]}\n    M1002 gcode_claim_action : 8\n\n    M109 S{nozzle_temperature[initial_no_support_extruder]}\n\n    G90\n    M83\n    M983.3 F{filament_max_volumetric_speed[initial_no_support_extruder]/2.4} A0.4 ; cali dynamic extrusion compensation\n\n    M400\n    M106 P1 S255\n    M400 S5\n    M106 P1 S0\n    G150.3\nM623\n\nM622 J2\n    M1002 set_filament_type:{filament_type[initial_no_support_extruder]}\n    M1002 gcode_claim_action : 8\n\n    M109 S{nozzle_temperature[initial_no_support_extruder]}\n\n    G90\n    M83\n    M983.3 F{filament_max_volumetric_speed[initial_no_support_extruder]/2.4} A0.4 ; cali dynamic extrusion compensation\n\n    M400\n    M106 P1 S255\n    M400 S5\n    M106 P1 S0\n    G150.3\nM623\n\n;===== auto extrude cali end =========================\n\n{if filament_type[initial_no_support_extruder] == \"TPU\"}\n    G150.2\n    G150.1\n    G150.2\n    G150.1\n    G150.2\n    G150.1\n{else}\n    G150.3\n    M106 P1 S0\n    M400 S2\n    M109 S{nozzle_temperature[initial_no_support_extruder]} ; wait tmpr to extrude\n    M83\n    {if(nozzle_diameter == 0.8)}\n        G1 E60 F{filament_max_volumetric_speed[initial_no_support_extruder]/2.4053*60}\n    {else}\n        G1 E45 F{filament_max_volumetric_speed[initial_no_support_extruder]/2.4053*60}\n    {endif}\n    G1 E-3 F1800\n    M400 P500\n    G150.2\n    G150.1\n{endif}\n\nG91\nG1 Y-16 F12000 ; move away from the trash bin\nG90\n\nM400\n;M73 P99\n\n;===== wipe right nozzle start =====\n\nM1002 gcode_claim_action : 14\n    G150 T{nozzle_temperature_initial_layer[initial_no_support_extruder]}\n    {if (overall_chamber_temperature >= 40)}\n        G150 T{nozzle_temperature_initial_layer[initial_no_support_extruder] - 80}\n    {endif}\nM106 S255 ; turn on fan to cool the nozzle\n\n;===== wipe left nozzle end =====\n\nM400\n;M73 P99\n\nM1002 judge_flag auto_cali_toolhead_offset_flag\nM622 J0\n    G91\n    G1 Z5 F1200\n    G90\n    M1012.7\n    G383.7 U140 J0\n    M500\nM623\n\n{if (overall_chamber_temperature >= 40)}\n    M1002 gcode_claim_action : 49\n    M191 S[overall_chamber_temperature] ; wait for chamber temp\n{endif}\n\nM400\n;M73 P99\n\n;===== bed leveling ==================================\n\nM1002 judge_flag g29_before_print_flag\n\nM190 S[bed_temperature_initial_layer_single]; ensure bed temp\nM109 S140 A\nM106 S0 ; turn off fan , too noisy\n\nG91\nG1 Z10 F1200\n{if (first_non_support_filaments[0] != -1)}\nM640 S\nM83\nG1 E-2 F1800\nM640.7 U\nM640.7 L\nM640.2 R1\nM641\n{endif}\nG90\nG1 X175 Y160 F30000\n\nM622 J1\n    M1002 gcode_claim_action : 1\n    G29.20 A3\n    G29 A1 O X{first_layer_print_min[0]} Y{first_layer_print_min[1]} I{first_layer_print_size[0]} J{first_layer_print_size[1]} R \n    M400\n    M500 ; save cali data\nM623\n    \nM622 J2\n    M1002 gcode_claim_action : 1\n    {if has_tpu_in_first_layer}\n        G29.20 A3\n        G29 A1 O X{first_layer_print_min[0]} Y{first_layer_print_min[1]} I{first_layer_print_size[0]} J{first_layer_print_size[1]} R\n    {else}\n        G29.20 A4\n        G29 A2 O X{first_layer_print_min[0]} Y{first_layer_print_min[1]} I{first_layer_print_size[0]} J{first_layer_print_size[1]} R\n    {endif}\n    M400\n    M500 ; save cali data\nM623\n\nM622 J0\n    G28 R\nM623\n\n;===== bed leveling end ================================\n\nG39.1 ; cali nozzle wrapped detection pos\nM500\n\nG90\nG1 Z5 F1200\nG1 X270 Y-0.5 F60000\nG28.140 S0 ; cali pre-extrude z pos\n\n;============switch again==================\n\nM211 X0 Y0 Z0 ;turn off soft endstop\nG91\nG1 Z6 F1200\nG90\nM1002 set_filament_type:{filament_type[initial_no_support_extruder]}\nM620 S[initial_no_support_extruder]A\nM400\nT[initial_no_support_extruder]\nM400\nM628 S0\nM629\nM400\nM621 S[initial_no_support_extruder]A\n\n;============switch again==================\n\nM400\n;M73 P99\n\nM141 S[overall_chamber_temperature]\n\n;===== mech mode sweep start =====\n    M1002 gcode_claim_action : 3\n\n    G90\n    G1 Z5 F1200\n    G1 X165 Y160 F20000\n    M400 P200\n\n    M970.3 Q1 A5 K0 O1\n    M974 Q1 S2 P0\n\n    M970.3 Q0 A5 K0 O1\n    M974 Q0 S2 P0\n\n    M970.2 Q2 K0 W38 Z0.01\n    M974 Q2 S2 P0\n    M500\n\n    M975 S1\n;===== mech mode sweep end =====\n\n;===== wait temperature reaching the reference value =======\n\nM140 S[bed_temperature_initial_layer_single] \nM190 S[bed_temperature_initial_layer_single] \n\n    ;========turn off light and fans =============\n    M960 S1 P0 ; turn off laser\n    M960 S2 P0 ; turn off laser\n    M106 S0 ; turn off fan\n    M106 P2 S0 ; turn off big fan\n    ;==== set ext toodhead cooling fan ==== \n    {if (min_vitrification_temperature <= 50)}\n    M106 P9 S255\n    {endif}\n    ;============set motor current==================\n    M400 S1\n\n;===== wait temperature reaching the reference value =======\n\nM400\n;M73 P99\n\n;===== for Textured PEI Plate , lower the nozzle as the nozzle was touching topmost of the texture when homing ==\n    {if curr_bed_type==\"Textured PEI Plate\"}\n        G29.1 Z{-0.02} ; for Textured PEI Plate\n    {endif}\n    \nG150.1\n\nM975 S1 ; turn on mech mode supression\nM983.4 S1 ; turn on deformation compensation \nG29.2 S1 ; turn on pos comp\nG29.7 S1\n\nG90\nG1 Z5 F1200\nG1 Y295 F30000\nG1 Y265 F18000\n\n;===== nozzle load line ===============================\n    G29.2 S1 ; ensure z comp turn on\n    G90\n    M83\n    G1 Z5 F1200\n    G1 X270 Y-0.5 F60000\n    G28.14 R0\n    G29.2 S0\n    G91\n    G1 Z0.8 F1200\n    G90\n    G1 X250 F60000\n    M104 S{nozzle_temperature_initial_layer[initial_no_support_extruder]}\n    \n    ========== record data ==========\n    M1026\n    M1012.8\n    M1012.9\n    G29.9\n    ========== record data ==========\n    \n    M109 S{nozzle_temperature_initial_layer[initial_no_support_extruder]}\n    M83\n    G1 E5 F{filament_max_volumetric_speed[initial_no_support_extruder]/2.4053*60}\n    G1 X290 E10 F{filament_max_volumetric_speed[initial_no_support_extruder]/2.4053*4*60}\n    G91\n    G3 Z0.4 I1.217 J0 P1 F60000\n    G90\n    M83\n    G29.2 S1 ; ensure z comp turn on\n;===== noozle load line end ===========================\n\nM400\n;M73 P99\n\nM993 A1 B1 C1 ; nozzle cam detection allowed.\n\n{if (filament_type[initial_no_support_extruder] == \"TPU\")}\nM1015.3 S1;enable tpu clog detect\n{else}\nM1015.3 S0;disable tpu clog detect\n{endif}\n\n{if (filament_type[initial_no_support_extruder] == \"PLA\") ||  (filament_type[initial_no_support_extruder] == \"PETG\")\n ||  (filament_type[initial_no_support_extruder] == \"PLA-CF\")  ||  (filament_type[initial_no_support_extruder] == \"PETG-CF\")}\nM1015.4 S1 K1 H[nozzle_diameter] ;enable E air printing detect\n{else}\nM1015.4 S0 K0 H[nozzle_diameter] ;disable E air printing detect\n{endif}\n\nM620.6 I[initial_no_support_extruder] W1 ;enable ams air printing detect\n\nM211 Z1\nG29.99\nM1002 gcode_claim_action : 0\nM400\n\n\n",
+  "machine_switch_extruder_time": "5",
+  "machine_unload_filament_time": "15",
+  "master_extruder_id": "2",
+  "max_bridge_length": "0",
+  "max_layer_height": [
+    "0.28",
+    "0.28"
+  ],
+  "max_travel_detour_distance": "0",
+  "min_bead_width": "85%",
+  "min_feature_size": "25%",
+  "min_layer_height": [
+    "0.08",
+    "0.08"
+  ],
+  "minimum_sparse_infill_area": "15",
+  "mmu_segmented_region_interlocking_depth": "0",
+  "mmu_segmented_region_max_width": "0",
+  "name": "project_settings",
+  "no_slow_down_for_cooling_on_outwalls": [
+    "0",
+    "0",
+    "0"
+  ],
+  "nozzle_diameter": [
+    "0.4",
+    "0.4"
+  ],
+  "nozzle_flush_dataset": [
+    "1",
+    "2",
+    "1",
+    "2"
+  ],
+  "nozzle_height": "4",
+  "nozzle_temperature": [
+    "220",
+    "220",
+    "220",
+    "220",
+    "220",
+    "220"
+  ],
+  "nozzle_temperature_initial_layer": [
+    "220",
+    "220",
+    "220",
+    "220",
+    "220",
+    "220"
+  ],
+  "nozzle_temperature_range_high": [
+    "240",
+    "240",
+    "240"
+  ],
+  "nozzle_temperature_range_low": [
+    "190",
+    "190",
+    "190"
+  ],
+  "nozzle_type": [
+    "hardened_steel",
+    "hardened_steel",
+    "hardened_steel",
+    "hardened_steel"
+  ],
+  "nozzle_volume": [
+    "130",
+    "133",
+    "145",
+    "148"
+  ],
+  "nozzle_volume_type": [
+    "Standard",
+    "Standard"
+  ],
+  "only_one_wall_first_layer": "0",
+  "ooze_prevention": "0",
+  "other_layers_print_sequence": [
+    "0"
+  ],
+  "other_layers_print_sequence_nums": "0",
+  "outer_wall_acceleration": [
+    "5000",
+    "5000",
+    "5000",
+    "5000"
+  ],
+  "outer_wall_jerk": "9",
+  "outer_wall_line_width": "0.42",
+  "outer_wall_speed": [
+    "200",
+    "500",
+    "200",
+    "500"
+  ],
+  "overhang_1_4_speed": [
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "overhang_2_4_speed": [
+    "50",
+    "50",
+    "50",
+    "50"
+  ],
+  "overhang_3_4_speed": [
+    "30",
+    "30",
+    "30",
+    "30"
+  ],
+  "overhang_4_4_speed": [
+    "10",
+    "10",
+    "10",
+    "10"
+  ],
+  "overhang_fan_speed": [
+    "100",
+    "100",
+    "100"
+  ],
+  "overhang_fan_threshold": [
+    "50%",
+    "50%",
+    "50%"
+  ],
+  "overhang_threshold_participating_cooling": [
+    "95%",
+    "95%",
+    "95%"
+  ],
+  "overhang_totally_speed": [
+    "10",
+    "10",
+    "10",
+    "10"
+  ],
+  "override_filament_scarf_seam_setting": "0",
+  "override_process_overhang_speed": [
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "physical_extruder_map": [
+    "1",
+    "0"
+  ],
+  "post_process": [],
+  "pre_start_fan_time": [
+    "2",
+    "2",
+    "2"
+  ],
+  "precise_outer_wall": "0",
+  "precise_z_height": "0",
+  "pressure_advance": [
+    "0.02",
+    "0.02",
+    "0.02"
+  ],
+  "prime_tower_brim_width": "-1",
+  "prime_tower_enable_framework": "0",
+  "prime_tower_extra_rib_length": "0",
+  "prime_tower_fillet_wall": "1",
+  "prime_tower_flat_ironing": "1",
+  "prime_tower_infill_gap": "150%",
+  "prime_tower_lift_height": "-1",
+  "prime_tower_lift_speed": "90",
+  "prime_tower_max_speed": "90",
+  "prime_tower_rib_wall": "1",
+  "prime_tower_rib_width": "8",
+  "prime_tower_skip_points": "1",
+  "prime_tower_width": "60",
+  "prime_volume_mode": "Default",
+  "print_compatible_printers": [
+    "Bambu Lab H2C 0.4 nozzle"
+  ],
+  "print_extruder_id": [
+    "1",
+    "1",
+    "2",
+    "2"
+  ],
+  "print_extruder_variant": [
+    "Direct Drive Standard",
+    "Direct Drive High Flow",
+    "Direct Drive Standard",
+    "Direct Drive High Flow"
+  ],
+  "print_flow_ratio": "1",
+  "print_sequence": "by layer",
+  "print_settings_id": "0.20mm Standard @BBL H2C",
+  "printable_area": [
+    "0x0",
+    "330x0",
+    "330x320",
+    "0x320"
+  ],
+  "printable_height": "325",
+  "printer_extruder_id": [
+    "1",
+    "1",
+    "2",
+    "2"
+  ],
+  "printer_extruder_variant": [
+    "Direct Drive Standard",
+    "Direct Drive High Flow",
+    "Direct Drive Standard",
+    "Direct Drive High Flow"
+  ],
+  "printer_model": "Bambu Lab H2C",
+  "printer_notes": "",
+  "printer_settings_id": "Bambu Lab H2C 0.4 nozzle",
+  "printer_structure": "corexy",
+  "printer_technology": "FFF",
+  "printer_variant": "0.4",
+  "printhost_authorization_type": "key",
+  "printhost_ssl_ignore_revoke": "0",
+  "printing_by_object_gcode": "",
+  "process_notes": "",
+  "raft_contact_distance": "0.1",
+  "raft_expansion": "1.5",
+  "raft_first_layer_density": "90%",
+  "raft_first_layer_expansion": "-1",
+  "raft_layers": "0",
+  "reduce_crossing_wall": "0",
+  "reduce_fan_stop_start_freq": [
+    "1",
+    "1",
+    "1"
+  ],
+  "reduce_infill_retraction": "1",
+  "required_nozzle_HRC": [
+    "3",
+    "3",
+    "3"
+  ],
+  "resolution": "0.012",
+  "retract_before_wipe": [
+    "0%",
+    "0%",
+    "0%",
+    "0%"
+  ],
+  "retract_length_toolchange": [
+    "2",
+    "2",
+    "2",
+    "2"
+  ],
+  "retract_lift_above": [
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "retract_lift_below": [
+    "319",
+    "319",
+    "319",
+    "319"
+  ],
+  "retract_restart_extra": [
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "retract_restart_extra_toolchange": [
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "retract_when_changing_layer": [
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "retraction_distances_when_cut": [
+    "14",
+    "14",
+    "14",
+    "14"
+  ],
+  "retraction_distances_when_ec": [
+    "10",
+    "10",
+    "10",
+    "10",
+    "10",
+    "10"
+  ],
+  "retraction_length": [
+    "0.8",
+    "0.8",
+    "0.8",
+    "0.8"
+  ],
+  "retraction_minimum_travel": [
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "retraction_speed": [
+    "30",
+    "30",
+    "30",
+    "30"
+  ],
+  "role_base_wipe_speed": "1",
+  "scan_first_layer": "0",
+  "scarf_angle_threshold": "155",
+  "seam_gap": "15%",
+  "seam_placement_away_from_overhangs": "0",
+  "seam_position": "aligned",
+  "seam_slope_conditional": "1",
+  "seam_slope_entire_loop": "0",
+  "seam_slope_gap": "0",
+  "seam_slope_inner_walls": "1",
+  "seam_slope_min_length": "10",
+  "seam_slope_start_height": "10%",
+  "seam_slope_steps": "10",
+  "seam_slope_type": "none",
+  "silent_mode": "0",
+  "single_extruder_multi_material": "1",
+  "skeleton_infill_density": "15%",
+  "skeleton_infill_line_width": "0.45",
+  "skin_infill_density": "15%",
+  "skin_infill_depth": "2",
+  "skin_infill_line_width": "0.45",
+  "skirt_distance": "2",
+  "skirt_height": "1",
+  "skirt_loops": "0",
+  "slice_closing_radius": "0.049",
+  "slicing_mode": "regular",
+  "slow_down_for_layer_cooling": [
+    "1",
+    "1",
+    "1"
+  ],
+  "slow_down_layer_time": [
+    "4",
+    "4",
+    "4"
+  ],
+  "slow_down_min_speed": [
+    "20",
+    "20",
+    "20",
+    "20",
+    "20",
+    "20"
+  ],
+  "slowdown_end_acc": [
+    "100000",
+    "100000",
+    "100000",
+    "100000"
+  ],
+  "slowdown_end_height": [
+    "400",
+    "400",
+    "400",
+    "400"
+  ],
+  "slowdown_end_speed": [
+    "1000",
+    "1000",
+    "1000",
+    "1000"
+  ],
+  "slowdown_start_acc": [
+    "100000",
+    "100000",
+    "100000",
+    "100000"
+  ],
+  "slowdown_start_height": [
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "slowdown_start_speed": [
+    "1000",
+    "1000",
+    "1000",
+    "1000"
+  ],
+  "small_perimeter_speed": [
+    "50%",
+    "50%",
+    "50%",
+    "50%"
+  ],
+  "small_perimeter_threshold": [
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "smooth_coefficient": "4",
+  "smooth_speed_discontinuity_area": "1",
+  "solid_infill_filament": "0",
+  "sparse_infill_acceleration": [
+    "100%",
+    "100%",
+    "100%",
+    "100%"
+  ],
+  "sparse_infill_anchor": "400%",
+  "sparse_infill_anchor_max": "20",
+  "sparse_infill_density": "15%",
+  "sparse_infill_filament": "0",
+  "sparse_infill_lattice_angle_1": "-45",
+  "sparse_infill_lattice_angle_2": "45",
+  "sparse_infill_line_width": "0.45",
+  "sparse_infill_pattern": "grid",
+  "sparse_infill_speed": [
+    "350",
+    "600",
+    "350",
+    "600"
+  ],
+  "spiral_mode": "0",
+  "spiral_mode_max_xy_smoothing": "200%",
+  "spiral_mode_smooth": "0",
+  "standby_temperature_delta": "-5",
+  "start_end_points": [
+    "30x-3",
+    "54x245"
+  ],
+  "supertack_plate_temp": [
+    "40",
+    "40",
+    "40"
+  ],
+  "supertack_plate_temp_initial_layer": [
+    "40",
+    "40",
+    "40"
+  ],
+  "support_air_filtration": "0",
+  "support_angle": "0",
+  "support_base_pattern": "default",
+  "support_base_pattern_spacing": "2.5",
+  "support_bottom_interface_spacing": "0.5",
+  "support_bottom_z_distance": "0.2",
+  "support_chamber_temp_control": "1",
+  "support_cooling_filter": "1",
+  "support_critical_regions_only": "0",
+  "support_expansion": "0",
+  "support_filament": "0",
+  "support_interface_bottom_layers": "2",
+  "support_interface_filament": "0",
+  "support_interface_loop_pattern": "0",
+  "support_interface_not_for_body": "1",
+  "support_interface_pattern": "auto",
+  "support_interface_spacing": "0.5",
+  "support_interface_speed": [
+    "80",
+    "80",
+    "80",
+    "80"
+  ],
+  "support_interface_top_layers": "2",
+  "support_ironing_direction": "0",
+  "support_ironing_flow": "10%",
+  "support_ironing_inset": "0",
+  "support_ironing_pattern": "zig-zag",
+  "support_ironing_spacing": "0.15",
+  "support_ironing_speed": "30",
+  "support_line_width": "0.42",
+  "support_object_first_layer_gap": "0.2",
+  "support_object_skip_flush": "0",
+  "support_object_xy_distance": "0.35",
+  "support_on_build_plate_only": "0",
+  "support_remove_small_overhang": "1",
+  "support_speed": [
+    "150",
+    "150",
+    "150",
+    "150"
+  ],
+  "support_style": "default",
+  "support_threshold_angle": "30",
+  "support_top_z_distance": "0.2",
+  "support_type": "tree(auto)",
+  "symmetric_infill_y_axis": "0",
+  "temperature_vitrification": [
+    "45",
+    "45",
+    "45"
+  ],
+  "template_custom_gcode": "",
+  "textured_plate_temp": [
+    "55",
+    "55",
+    "55"
+  ],
+  "textured_plate_temp_initial_layer": [
+    "55",
+    "55",
+    "55"
+  ],
+  "thick_bridges": "0",
+  "thumbnail_size": [
+    "50x50"
+  ],
+  "time_lapse_gcode": ";===== machine: H2C timelapse =====\n;======== date: 20251105 ========\n\n; SKIPPABLE_START\n; SKIPTYPE: timelapse\n\nM1002 judge_flag timelapse_record_flag\nM622 J1\n    M993 A2 B2 C2\n    M993 A0 B0 C0\n\n    {if !spiral_mode && !(has_timelapse_safe_pos) }\n        {if most_used_physical_extruder_id!= curr_physical_extruder_id || timelapse_type == 1}\n            M83\n            G1 Z{max_layer_z + 0.4} F1200\n            M400\n        {endif}\n    {endif}\n\n    {if has_timelapse_safe_pos && !spiral_mode}\n        M9711 M{timelapse_type} E{most_used_physical_extruder_id} U{timelapse_pos_x} V{timelapse_pos_y} Z{layer_z + 0.4} S11 C10 O0 T3000\n    {else}\n        {if spiral_mode}\n            M971 S11 C10 O0\n            M1004 S5 P1  ; external shutter\n        {else}\n            M9711 M{timelapse_type} E{most_used_physical_extruder_id} Z{layer_z + 0.4} S11 C10 O0 T3000\n        {endif}\n    {endif}\n\n    {if !spiral_mode && !(has_timelapse_safe_pos) }\n        {if most_used_physical_extruder_id!= curr_physical_extruder_id || timelapse_type == 1}\n            G90\n            G1 Z{max_layer_z + 3.0} F1200\n            G1 Y295 F30000\n            G1 Y265 F18000\n            M83\n        {endif}\n    {endif}\n    \n    M993 A3 B3 C3\nM623\n; SKIPPABLE_END\n",
+  "timelapse_type": "0",
+  "top_area_threshold": "200%",
+  "top_color_penetration_layers": "5",
+  "top_one_wall_type": "all top",
+  "top_shell_layers": "5",
+  "top_shell_thickness": "1",
+  "top_solid_infill_flow_ratio": [
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "top_surface_acceleration": [
+    "2000",
+    "2000",
+    "2000",
+    "2000"
+  ],
+  "top_surface_density": "100%",
+  "top_surface_jerk": "9",
+  "top_surface_line_width": "0.42",
+  "top_surface_pattern": "monotonicline",
+  "top_surface_speed": [
+    "200",
+    "200",
+    "200",
+    "200"
+  ],
+  "top_z_overrides_xy_distance": "0",
+  "travel_acceleration": [
+    "10000",
+    "10000",
+    "10000",
+    "10000"
+  ],
+  "travel_jerk": "9",
+  "travel_short_distance_acceleration": [
+    "250",
+    "250",
+    "250",
+    "250"
+  ],
+  "travel_speed": [
+    "1000",
+    "1000",
+    "1000",
+    "1000"
+  ],
+  "travel_speed_z": [
+    "0",
+    "0",
+    "0",
+    "0"
+  ],
+  "tree_support_branch_angle": "45",
+  "tree_support_branch_diameter": "2",
+  "tree_support_branch_diameter_angle": "5",
+  "tree_support_branch_distance": "5",
+  "tree_support_wall_count": "-1",
+  "upward_compatible_machine": [
+    "Bambu Lab H2S 0.4 nozzle",
+    "Bambu Lab H2D 0.4 nozzle",
+    "Bambu Lab H2D Pro 0.4 nozzle"
+  ],
+  "use_firmware_retraction": "0",
+  "use_relative_e_distances": "1",
+  "version": "02.05.00.66",
+  "vertical_shell_speed": [
+    "80%",
+    "80%",
+    "80%",
+    "80%"
+  ],
+  "volumetric_speed_coefficients": [
+    "0 0 0 0 0 0",
+    "0 0 0 0 0 0",
+    "0 0 0 0 0 0",
+    "0 0 0 0 0 0",
+    "0 0 0 0 0 0",
+    "0 0 0 0 0 0"
+  ],
+  "wall_distribution_count": "1",
+  "wall_filament": "0",
+  "wall_generator": "classic",
+  "wall_loops": "2",
+  "wall_sequence": "inner wall/outer wall",
+  "wall_transition_angle": "10",
+  "wall_transition_filter_deviation": "25%",
+  "wall_transition_length": "100%",
+  "wipe": [
+    "1",
+    "1",
+    "1",
+    "1"
+  ],
+  "wipe_distance": [
+    "2",
+    "2",
+    "2",
+    "2"
+  ],
+  "wipe_speed": "80%",
+  "wipe_tower_no_sparse_layers": "0",
+  "wipe_tower_rotation_angle": "0",
+  "wipe_tower_x": [
+    "165",
+    "165",
+    "165"
+  ],
+  "wipe_tower_y": [
+    "250",
+    "250",
+    "250"
+  ],
+  "wrapping_detection_gcode": ";===== machine: H2C =========================\n;===== date: 20251104 =====================\n\n{if !spiral_mode}\n    {if layer_num == 3 || layer_num == 10 || layer_num == 19}\n        M993 A2 B2 C2 ; nozzle cam detection allow status save.\n        M993 A0 B0 C0 ; nozzle cam detection not allowed.\n\n        M400 P100\n\n        G39\n\n        G90\n        G1 Y295 F30000\n        G1 Y265 F18000\n        \n        M993 A3 B3 C3 ; nozzle cam detection allow status restore.\n    {endif}\n{endif}\n",
+  "wrapping_detection_layers": "20",
+  "wrapping_exclude_area": [
+    "145x310",
+    "251x310",
+    "251x326",
+    "145x326"
+  ],
+  "xy_contour_compensation": "0",
+  "xy_hole_compensation": "0",
+  "z_direction_outwall_speed_continuous": "1",
+  "z_hop": [
+    "0.4",
+    "0.4",
+    "0.4",
+    "0.4"
+  ],
+  "z_hop_types": [
+    "Auto Lift",
+    "Auto Lift",
+    "Auto Lift",
+    "Auto Lift"
+  ]
 }

--- a/src/export/paintColor3mf.ts
+++ b/src/export/paintColor3mf.ts
@@ -1,0 +1,91 @@
+// Bambu Studio / OrcaSlicer per-triangle "paint_color" multi-material encoding.
+//
+// Bambu/Orca store painted filament assignments as a bare `paint_color`
+// attribute on each `<triangle>` in `3D/3dmodel.model`. The value is an
+// UPPERCASE hex string encoding a recursive triangle-split tree as a bitstream
+// (the format PrusaSlicer calls `mmu_segmentation`; Bambu forked it and renamed
+// the attribute). The encoding has no official spec — these helpers are derived
+// from PrusaSlicer's `TriangleSelector` serialize/deserialize + `Model.cpp`
+// string packing (see the PR description for source links) and validated by the
+// round-trip unit tests in `tests/unit/paintColor3mf.test.ts`.
+//
+// Partwright bakes exactly ONE colour per triangle, so we only ever need the
+// *leaf* (un-split) case: the whole triangle is a single filament `state`. We
+// never emit the split-node form, which keeps this to the three prefix-coded
+// leaf widths below.
+//
+// Wire format (per the serialize() prefix codes), reading low bits first:
+//   leaf, states 0–2:    nibble `xxyy`            yy=0b00 (0 split sides), xx=state
+//   leaf, states 3–16:   `zzzz` + `xxyy`          xx=0b11 (escape), zzzz=state-3
+//   leaf, states 17–255: `vvvvvvvv` + `zzzz`+`xxyy` zzzz=0b1110 (escape2), vvvvvvvv=state-17
+// The bitstream packs 4 bits per nibble LSB-first; the hex STRING is the nibble
+// sequence reversed (the decoder reads it right-to-left). `state` is the 1-based
+// filament/extruder slot index (state 1 = filament 1); state 0 = NONE, which is
+// represented by OMITTING the attribute (the triangle inherits the object's
+// default extruder) — `encodePaintColorState(0)` returns ''.
+
+/** Bambu's painted states are capped at 254 in the wire format. */
+export const MAX_PAINT_STATE = 254;
+
+/**
+ * Encode a 1-based filament slot index as a Bambu `paint_color` hex string.
+ * Returns '' for state 0 (NONE → omit the attribute). Throws on out-of-range.
+ */
+export function encodePaintColorState(state: number): string {
+  if (!Number.isInteger(state)) throw new Error(`paint_color state must be an integer, got ${state}`);
+  if (state < 0 || state > MAX_PAINT_STATE) throw new Error(`paint_color state out of range [0,${MAX_PAINT_STATE}]: ${state}`);
+  if (state === 0) return '';
+
+  // states 1–2: single nibble (state << 2) | 0b00
+  if (state <= 2) {
+    return ((state << 2) & 0xf).toString(16).toUpperCase();
+  }
+
+  // states 3–16: nibble0 = 0b1100 (0xC = escape, 0 split), nibble1 = state-3.
+  // String = reversed nibbles = [state-3][C].
+  if (state <= 16) {
+    return (state - 3).toString(16).toUpperCase() + 'C';
+  }
+
+  // states 17–254: nibble0 = 0xC, nibble1 = 0xE (escape2), then 8 bits = state-17
+  // split across nibble2 (low) and nibble3 (high). String = reversed =
+  // [vHigh][vLow][E][C].
+  const v = state - 17;
+  const hi = ((v >> 4) & 0xf).toString(16).toUpperCase();
+  const lo = (v & 0xf).toString(16).toUpperCase();
+  return hi + lo + 'EC';
+}
+
+/**
+ * Decode a Bambu `paint_color` leaf string back to its 1-based filament state.
+ * The inverse of {@link encodePaintColorState} — used by the round-trip tests
+ * (and available for any future import path). Throws on a split-node string
+ * (which Partwright never emits) or malformed input. '' → 0 (NONE).
+ */
+export function decodePaintColorState(hex: string): number {
+  if (hex === '') return 0;
+  if (!/^[0-9A-F]+$/.test(hex)) throw new Error(`paint_color must be uppercase hex, got "${hex}"`);
+
+  // Expand the hex string into a bitstream. The decoder reads chars
+  // right-to-left, each char's 4 bits appended LSB-first.
+  const bits: number[] = [];
+  for (let i = hex.length - 1; i >= 0; i--) {
+    const d = parseInt(hex[i], 16);
+    bits.push(d & 1, (d >> 1) & 1, (d >> 2) & 1, (d >> 3) & 1);
+  }
+  const nibbleAt = (off: number) =>
+    bits[off] | (bits[off + 1] << 1) | (bits[off + 2] << 2) | (bits[off + 3] << 3);
+
+  const root = nibbleAt(0);
+  const splitSides = root & 0b11;       // yy
+  if (splitSides !== 0) throw new Error('paint_color split-node form is not supported (expected a leaf)');
+  const xx = (root >> 2) & 0b11;
+  if (xx !== 0b11) return xx;            // states 0–2
+
+  const zzzz = nibbleAt(4);             // escape nibble
+  if (zzzz !== 0b1110) return 3 + zzzz; // states 3–16
+
+  // states 17–254: 8 bits of (state-17) in nibble2 (low) + nibble3 (high)
+  const v = nibbleAt(8) | (nibbleAt(12) << 4);
+  return 17 + v;
+}

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -80,17 +80,19 @@ const PROD_NS = 'http://schemas.microsoft.com/3dmanufacturing/production/2015/06
 const BBS_NS = 'http://schemas.bambulab.com/package/2021';
 const REL_TYPE = 'http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel';
 
-// Bambu assigns each object to a plate by WORLD POSITION (which plate-grid cell the
-// object's footprint falls in), NOT by the model_instance binding. So each part's
-// <item> must sit at the CENTRE of the plate cell Bambu would lay out, or the part
-// lands off-plate (slicer: "no object is fully inside") and the whole file is
-// rejected. Two things must match Bambu's PartPlateList grid exactly:
-//   - COLUMN COUNT: Bambu tiles N plates in a ⌈√N⌉-column grid, numbered
-//     left→right, top→bottom (verified: a real 3-plate export uses 2 cols; a
-//     6-plate export uses 3 cols — plate 3 is the 3rd column, not a 2nd row).
-//   - STRIDE: ~410 mm between cell origins for the H2C bed (from the reference +
-//     Bambu-CLI validation). Cell (col,row) centre = (bedW/2 + col·S, bedH/2 − row·S).
-const PLATE_STRIDE = 410;        // mm between plate-cell origins (H2C grid)
+// Bambu assigns each object to a plate by WORLD POSITION (the plate-grid cell its
+// footprint falls in), NOT by the model_instance binding (verified: stacking all
+// parts at one point leaves the other plates empty → load rejected). So each part's
+// <item> must sit at the CENTRE of the plate cell BambuStudio lays out. The grid is
+// taken verbatim from BambuStudio's PartPlateList source (src/slic3r/GUI/PartPlate):
+//   - COLUMNS: compute_colum_count(N) == ⌈√N⌉.
+//   - STRIDE is PER-AXIS: plate_stride_x = width·(1+1/5), plate_stride_y = depth·(1+1/5)
+//     (LOGICAL_PART_PLATE_GAP = 1/5). For the 330×320 H2C bed that's 396 / 384 mm —
+//     NOT a single value, which is why a uniform 410 mm stride drifted parts right
+//     (410>396) and forward (410>384), worse at higher plate indices.
+//   - Plate origin is the cell CORNER (col·stride_x, −row·stride_y); the printable
+//     area starts there, so the cell centre is origin + (bedW/2, bedH/2).
+const PLATE_GAP_FACTOR = 1 + 1 / 5;   // BambuStudio LOGICAL_PART_PLATE_GAP
 const plateGridCols = (n: number) => Math.max(1, Math.ceil(Math.sqrt(n)));
 
 /** Bed printable size [w, h] mm, parsed from the project template's printable_area
@@ -338,6 +340,8 @@ function buildBambuPackage(prepared: PreparedPart[], filamentColors: string[]): 
   const unit = get3MFUnitString();
   const [bedW, bedH] = bedSizeFromTemplate();
   const gridCols = plateGridCols(prepared.length);  // ⌈√N⌉ to match Bambu's plate grid
+  const strideX = bedW * PLATE_GAP_FACTOR;          // BambuStudio plate_stride_x (width·1.2)
+  const strideY = bedH * PLATE_GAP_FACTOR;          // BambuStudio plate_stride_y (depth·1.2)
 
   // Bambu mode: per-part colour via the per-object `extruder` field (1..3),
   // mapped to the 3 AMS filament slots whose colours go in project_settings'
@@ -397,15 +401,14 @@ ${p.trianglesPlain.join('\n')}
    </components>
   </object>`);
 
-    // Place each part at the CENTRE of its own plate cell (2-col grid). Centring
-    // (not corner-offsetting) keeps small parts well clear of cell boundaries so
-    // Bambu's per-plate "is this object inside?" check passes. The Z translation
-    // is -minZ: moves the part so its bottom (minZ) lands exactly at Z=0 (the bed).
-    // Works for both centered meshes (minZ<0) and non-centered (minZ=0, e.g.
-    // Manifold.cylinder). The USER-REF.3mf sets Z = -minZ for all parts.
+    // Place each part at the CENTRE of its plate cell: cell-corner origin
+    // (col·strideX, −row·strideY) plus half the bed, so the part sits dead-centre
+    // on the plate Bambu lays out for that index. The Z translation is -minZ:
+    // moves the part so its bottom (minZ) lands exactly at Z=0 (the bed). Works for
+    // both centered meshes (minZ<0) and non-centered (minZ=0, e.g. Manifold.cylinder).
     const col = i % gridCols, row = Math.floor(i / gridCols);
-    const tx = bedW / 2 + col * PLATE_STRIDE;
-    const ty = bedH / 2 - row * PLATE_STRIDE;
+    const tx = bedW / 2 + col * strideX;
+    const ty = bedH / 2 - row * strideY;
     const tz = -p.minZ;  // lift bottom to Z=0
     buildItems.push(`  <item objectid="${wrapperId}" p:UUID="${itemUuid}" transform="1 0 0 0 1 0 0 0 1 ${fmtCoord(tx - p.cx)} ${fmtCoord(ty - p.cy)} ${fmtCoord(tz)}" printable="1"/>`);
 

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -1,24 +1,21 @@
 // Multi-part 3MF export — bundles several Session Parts into ONE 3MF. Two modes:
 //
-//   bambu: false (GENERIC) — multiple `<object>` + `<build><item>` with an
-//     `<m:colorgroup>` material list, parts grid-arranged so they don't overlap.
-//     No Bambu metadata. Any slicer/viewer (Cura, PrusaSlicer, MS 3D Viewer)
-//     opens it and sees every part + colour.
+//   bambu: false (GENERIC) — a single `3D/3dmodel.model` with all parts as INLINE
+//     mesh objects laid out in a centred grid, an `<m:colorgroup>` per object, no
+//     Bambu metadata. Opens in any slicer/viewer.
 //
-//   bambu: true (BAMBU/ORCA PROJECT) — adds the `BambuStudio-` Application
-//     marker (project mode), `Metadata/model_settings.config` with one `<plate>`
-//     per part + per-object `extruder`, and per-triangle `paint_color`. Each part
-//     is positioned on its own build PLATE. Plate membership in Bambu/Orca is
-//     decided by WORLD POSITION (bbox overlap with the plate's box), not the
-//     `<model_instance>` grouping, so parts are tiled one-per-plate using the
-//     slicer's plate stride (bed × 1.2). The file stays a valid generic 3MF too.
+//   bambu: true (BAMBU/ORCA PROJECT) — the 3MF **production extension** layout
+//     Bambu Studio / OrcaSlicer require to build MULTIPLE PLATES. Each part is a
+//     wrapper object referencing its mesh in a separate `/3D/Objects/object_N.model`
+//     file; one `<plate>` per part drives the plate count; a minimal
+//     `project_settings.config` is REQUIRED or the project loader refuses to build
+//     the plate list (it falls back to a single plate). This layout + the 5-key
+//     project config is verified to load with N plates in OrcaSlicer 2.3.2 headless.
 //
-// We deliberately do NOT emit `Metadata/project_settings.config`: it makes Bambu
-// run preset validation and pop the "customized filament or printer presets …
-// confirm the G-code is safe" dialog. Colours still import + map to filaments
-// from the `<m:colorgroup>` + per-object `extruder` + `paint_color` in the model
-// itself. The per-plate `.json`/`.png`/`.gcode` files are post-slice artifacts
-// and are omitted. See the PR description for the source-grounded format spec.
+//     WHY the split files: with `<plate>` blocks present, the loader only assembles
+//     objects stored as production-extension components — inline meshes make it
+//     report "0 objects" and abort (the load crash). See the PR for the full
+//     source-grounded spec + the headless validation recipe.
 
 import type { MeshData } from '../geometry/types';
 import { get3MFUnitString } from '../geometry/units';
@@ -40,134 +37,120 @@ export interface PartExport {
 export interface Build3MFProjectOptions {
   /** Override the download filename stem. */
   customName?: string;
-  /** Emit the Bambu/Orca project layer (Application marker, model_settings.config
-   *  with one plate per part, per-object `extruder`, per-triangle `paint_color`),
-   *  and tile parts one-per-plate. When false, a GENERIC multi-object 3MF: parts
-   *  grid-arranged, `m:colorgroup` colour only, no Bambu metadata. Default true. */
+  /** Emit the Bambu/Orca project layer (production-extension split files, one
+   *  plate per part). When false, a GENERIC inline multi-object 3MF (grid). */
   bambu?: boolean;
-  /** Build-plate size `[x, y]` in mm — drives the per-plate world stride in Bambu
-   *  mode so each part lands on its plate's centre. Default `[256, 256]`. */
+  /** Build-plate size `[x, y]` mm — reserved for future per-bed tuning of the
+   *  generic grid. (Bambu plate placement uses the validated fixed grid below.) */
   bedSize?: [number, number];
   /** Gap (mm) between parts in the GENERIC grid layout. Default 10. */
   gridGapMm?: number;
 }
 
-// Bambu/Orca tile build plates in one shared world space with a gap of 20% of
-// the bed size between plate origins (OrcaSlicer `LOGICAL_PART_PLATE_GAP = 1/5`,
-// PartPlate.cpp), so the centre-to-centre stride is `bed × 1.2`. Structural
-// constant from the slicer source, not a user-tunable knob.
-const PLATE_GAP_FACTOR = 1.2;
+const CORE_NS = 'http://schemas.microsoft.com/3dmanufacturing/core/2015/02';
+const MAT_NS = 'http://schemas.microsoft.com/3dmanufacturing/material/2015/02';
+const PROD_NS = 'http://schemas.microsoft.com/3dmanufacturing/production/2015/06';
+const BBS_NS = 'http://schemas.bambulab.com/package/2021';
+const REL_TYPE = 'http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel';
 
-function escapeXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+// Bambu/Orca lay plates out in a 2-column grid; with the declared printer profile
+// the validated slot positions are a 240 mm stride with a 90 mm corner offset
+// (col → X = 90 + col·240, row → Y = 90 − row·240). Each part's <item> lands in a
+// distinct plate slot so plates aren't empty. Verified against OrcaSlicer 2.3.2.
+const PLATE_STRIDE = 240;
+const PLATE_OFFSET = 90;
+
+function escXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;');
 }
+
+/** Format a coordinate: 6dp with trailing zeros stripped (the form Bambu/Orca's
+ *  exporter writes; avoids parser edge cases with long zero runs). */
+function fmtCoord(v: number): string {
+  return v.toFixed(6).replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
+}
+
+const enc = (s: string) => new TextEncoder().encode(s);
 
 interface PreparedPart {
   name: string;
-  objectId: number;
   vertices: string[];   // <vertex .../> lines
   triangles: string[];  // <triangle .../> lines
   faceCount: number;
-  extruder: number;     // 1-based dominant filament for the whole object
-  // Bounding-box geometry, used to position the part (placement is a second pass).
+  extruder: number;     // 1-based dominant filament (global index)
   cx: number; cy: number; minZ: number; width: number; depth: number;
-  transform: string;    // 12-value row-major item transform (filled in pass 2)
 }
 
 /**
- * Build a multi-part 3MF blob. See the module header for the two modes. Colours
- * are shared across all parts via a single `m:colorgroup` so a given colour maps
- * to the same material/filament index on every part.
+ * Build a multi-part 3MF blob. See the module header for the two modes.
  */
 export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOptions = {}): BuiltExport {
   if (parts.length === 0) throw new Error('Cannot export: no parts selected.');
   const bambu = opts.bambu ?? true;
-  const [bedX, bedY] = opts.bedSize ?? [256, 256];
   const gridGap = opts.gridGapMm ?? 10;
 
-  // ── 1. Shared filament list across ALL parts ────────────────────────────
-  // The same ordering rule as the single-part exporter: used palette slots in
-  // AMS-slot order first, then any remaining colours in first-encounter order.
-  // A colour's index in this list is its filament/material index everywhere.
+  // ── Shared filament/material list across ALL parts ──────────────────────
+  // Same ordering as the single-part exporter: used palette slots in AMS-slot
+  // order first, then remaining colours first-encounter. A colour's index here
+  // is its material index (pid/p1) AND its 1-based filament index (extruder /
+  // paint_color) everywhere, so a colour maps to the same filament on every part.
   const cleaned = parts.map(p => {
     assertFiniteMesh(p.mesh);
     const c = cleanMeshForExport(p.mesh);
     assertExportableMesh(c.validTris);
     return c;
   });
-
-  const anyColour = parts.some((p, i) =>
-    p.mesh.triColors != null && hasAnyPainted(p.mesh.triColors, cleaned[i].validTris));
-
-  const colorMap = new Map<string, number>(); // hex -> material/filament index (0-based)
+  const anyColour = parts.some((p, i) => p.mesh.triColors != null && hasAnyPainted(p.mesh.triColors, cleaned[i].validTris));
+  const colorMap = new Map<string, number>();
   const materialColors: string[] = [];
-  const pushMaterial = (hex: string) => {
-    if (!colorMap.has(hex)) { colorMap.set(hex, materialColors.length); materialColors.push(hex); }
-  };
-
+  const pushMaterial = (hex: string) => { if (!colorMap.has(hex)) { colorMap.set(hex, materialColors.length); materialColors.push(hex); } };
   if (anyColour) {
-    const usedHexes = new Set<string>();
-    for (let i = 0; i < parts.length; i++) {
-      const tc = parts[i].mesh.triColors;
-      if (!tc) continue;
-      for (const t of cleaned[i].validTris) usedHexes.add(triColorHex(tc, t));
-    }
-    for (const slot of listFilaments()) {
-      const hex = slot.hex.toLowerCase();
-      if (usedHexes.has(hex)) pushMaterial(hex);
-    }
-    for (let i = 0; i < parts.length; i++) {
-      const tc = parts[i].mesh.triColors;
-      if (!tc) continue;
-      for (const t of cleaned[i].validTris) pushMaterial(triColorHex(tc, t));
-    }
+    const used = new Set<string>();
+    for (let i = 0; i < parts.length; i++) { const tc = parts[i].mesh.triColors; if (tc) for (const t of cleaned[i].validTris) used.add(triColorHex(tc, t)); }
+    for (const slot of listFilaments()) { const hex = slot.hex.toLowerCase(); if (used.has(hex)) pushMaterial(hex); }
+    for (let i = 0; i < parts.length; i++) { const tc = parts[i].mesh.triColors; if (tc) for (const t of cleaned[i].validTris) pushMaterial(triColorHex(tc, t)); }
   }
 
-  const colorGroupId = parts.length + 1; // distinct from object ids 1..N
+  // Colorgroup id: distinct from object ids. Generic uses one shared model so it
+  // must dodge object ids 1..N; Bambu puts one object per file so a small const
+  // is safe (it only shares a file with mesh id 100+i).
+  const colorGroupId = bambu ? 2 : parts.length + 1;
 
-  // ── 2. Per-part geometry + colour (placement is pass 3) ─────────────────
+  // ── Per-part geometry + colour ──────────────────────────────────────────
   const prepared: PreparedPart[] = parts.map((part, i) => {
     const { mesh } = part;
     const { remap, uniquePositions, validTris } = cleaned[i];
     const tc = anyColour ? mesh.triColors ?? null : null;
 
-    // Vertices + bounding box.
-    const numUniqueVerts = uniquePositions.length / 3;
+    const numV = uniquePositions.length / 3;
     let minX = Infinity, minY = Infinity, minZ = Infinity, maxX = -Infinity, maxY = -Infinity;
     const vertices: string[] = [];
-    for (let v = 0; v < numUniqueVerts; v++) {
+    for (let v = 0; v < numV; v++) {
       const x = uniquePositions[v * 3], y = uniquePositions[v * 3 + 1], z = uniquePositions[v * 3 + 2];
       if (x < minX) minX = x; if (x > maxX) maxX = x;
       if (y < minY) minY = y; if (y > maxY) maxY = y;
       if (z < minZ) minZ = z;
-      vertices.push(`          <vertex x="${x.toFixed(6)}" y="${y.toFixed(6)}" z="${z.toFixed(6)}" />`);
+      vertices.push(`          <vertex x="${fmtCoord(x)}" y="${fmtCoord(y)}" z="${fmtCoord(z)}" />`);
     }
 
-    // Dominant colour → object-level extruder (the part's "base" filament).
+    // Dominant colour → object extruder (global 1-based filament index).
     let extruder = 1;
     if (tc) {
       const counts = new Map<number, number>();
-      for (const t of validTris) {
-        const idx = colorMap.get(triColorHex(tc, t)) ?? 0;
-        counts.set(idx, (counts.get(idx) ?? 0) + 1);
-      }
-      let bestIdx = 0, bestN = -1;
-      for (const [idx, n] of counts) if (n > bestN) { bestN = n; bestIdx = idx; }
-      extruder = bestIdx + 1;
+      for (const t of validTris) { const idx = colorMap.get(triColorHex(tc, t)) ?? 0; counts.set(idx, (counts.get(idx) ?? 0) + 1); }
+      let best = 0, bestN = -1;
+      for (const [idx, n] of counts) if (n > bestN) { bestN = n; best = idx; }
+      extruder = best + 1;
     }
 
-    // Triangles. Generic colour via pid/p1 (face colour) in both modes; Bambu
-    // colour additionally via paint_color (omitted where the triangle matches the
-    // object's extruder, and omitted entirely in generic mode).
     const triangles: string[] = [];
     for (const t of validTris) {
-      const v1 = remap[mesh.triVerts[t * 3]];
-      const v2 = remap[mesh.triVerts[t * 3 + 1]];
-      const v3 = remap[mesh.triVerts[t * 3 + 2]];
+      const v1 = remap[mesh.triVerts[t * 3]], v2 = remap[mesh.triVerts[t * 3 + 1]], v3 = remap[mesh.triVerts[t * 3 + 2]];
       if (tc) {
         const matIdx = colorMap.get(triColorHex(tc, t)) ?? 0;
-        const filament = matIdx + 1;
-        const paint = bambu && filament !== extruder ? ` paint_color="${encodePaintColorState(filament)}"` : '';
+        // Bambu only: per-triangle filament via paint_color (omitted where it
+        // matches the object's base extruder). Generic relies on pid/p1 alone.
+        const paint = bambu && (matIdx + 1) !== extruder ? ` paint_color="${encodePaintColorState(matIdx + 1)}"` : '';
         triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${colorGroupId}" p1="${matIdx}" p2="${matIdx}" p3="${matIdx}"${paint} />`);
       } else {
         triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
@@ -176,44 +159,33 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
 
     const cx = Number.isFinite(minX) ? (minX + maxX) / 2 : 0;
     const cy = Number.isFinite(minY) ? (minY + maxY) / 2 : 0;
-    const width = Number.isFinite(minX) ? maxX - minX : 0;
-    const depth = Number.isFinite(minY) ? maxY - minY : 0;
-    const z0 = Number.isFinite(minZ) ? minZ : 0;
-    return { name: part.name, objectId: i + 1, vertices, triangles, faceCount: validTris.length, extruder, cx, cy, minZ: z0, width, depth, transform: '' };
+    return {
+      name: part.name, vertices, triangles, faceCount: validTris.length, extruder,
+      cx, cy, minZ: Number.isFinite(minZ) ? minZ : 0,
+      width: Number.isFinite(minX) ? maxX - minX : 0, depth: Number.isFinite(minY) ? maxY - minY : 0,
+    };
   });
 
-  // ── 3. Placement ────────────────────────────────────────────────────────
-  // Bambu: tile one part per plate along +X using the slicer's plate stride so
-  //   each part's bbox falls in (and is centred on) its own plate's box.
-  // Generic: lay parts out in a centred square grid spaced by the largest
-  //   footprint + gap, so they never overlap.
-  const N = prepared.length;
-  if (bambu) {
-    prepared.forEach((p, i) => {
-      const plateCenterX = i * (bedX * PLATE_GAP_FACTOR) + bedX / 2;
-      const plateCenterY = bedY / 2;
-      p.transform = `1 0 0 0 1 0 0 0 1 ${(plateCenterX - p.cx).toFixed(6)} ${(plateCenterY - p.cy).toFixed(6)} ${(-p.minZ).toFixed(6)}`;
-    });
-  } else {
-    const cols = Math.ceil(Math.sqrt(N));
-    const rows = Math.ceil(N / cols);
-    const pitch = Math.max(1, ...prepared.map(p => Math.max(p.width, p.depth))) + gridGap;
-    prepared.forEach((p, i) => {
-      const col = i % cols, row = Math.floor(i / cols);
-      const cellX = col * pitch - (cols - 1) * pitch / 2;
-      const cellY = row * pitch - (rows - 1) * pitch / 2;
-      p.transform = `1 0 0 0 1 0 0 0 1 ${(cellX - p.cx).toFixed(6)} ${(cellY - p.cy).toFixed(6)} ${(-p.minZ).toFixed(6)}`;
-    });
-  }
-
-  // ── 4. 3D/3dmodel.model ─────────────────────────────────────────────────
-  const matNs = anyColour ? ' xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"' : '';
-  const bambuNs = bambu ? ' xmlns:BambuStudio="http://schemas.bambulab.com/package/2021"' : '';
   const colorgroupXml = anyColour
-    ? `\n    <m:colorgroup id="${colorGroupId}">\n${materialColors.map(h => `      <m:color color="${h.toUpperCase()}FF" />`).join('\n')}\n    </m:colorgroup>`
+    ? `    <m:colorgroup id="${colorGroupId}">\n${materialColors.map(h => `      <m:color color="${h.toUpperCase()}FF" />`).join('\n')}\n    </m:colorgroup>`
     : '';
 
-  const objectsXml = prepared.map(p => `    <object id="${p.objectId}" type="model">
+  const built = bambu
+    ? buildBambuPackage(prepared, colorgroupXml, anyColour, colorGroupId)
+    : buildGenericPackage(prepared, colorgroupXml, anyColour, colorGroupId, gridGap);
+
+  const mimeType = 'application/vnd.ms-package.3dmanufacturing';
+  return { blob: new Blob([built], { type: mimeType }), filename: getExportFilename('3mf', opts.customName), mimeType };
+}
+
+// ── Generic: single inline model, parts grid-arranged ─────────────────────
+function buildGenericPackage(prepared: PreparedPart[], colorgroupXml: string, anyColour: boolean, _cgid: number, gridGap: number): Uint8Array {
+  const N = prepared.length;
+  const cols = Math.ceil(Math.sqrt(N));
+  const rows = Math.ceil(N / cols);
+  const pitch = Math.max(1, ...prepared.map(p => Math.max(p.width, p.depth))) + gridGap;
+
+  const objectsXml = prepared.map((p, i) => `    <object id="${i + 1}" type="model">
       <mesh>
         <vertices>
 ${p.vertices.join('\n')}
@@ -224,97 +196,187 @@ ${p.triangles.join('\n')}
       </mesh>
     </object>`).join('\n');
 
-  const buildItemsXml = prepared.map(p =>
-    `    <item objectid="${p.objectId}" transform="${p.transform}" printable="1" />`).join('\n');
+  const buildItems = prepared.map((p, i) => {
+    const col = i % cols, row = Math.floor(i / cols);
+    const cellX = col * pitch - (cols - 1) * pitch / 2;
+    const cellY = row * pitch - (rows - 1) * pitch / 2;
+    return `    <item objectid="${i + 1}" transform="1 0 0 0 1 0 0 0 1 ${fmtCoord(cellX - p.cx)} ${fmtCoord(cellY - p.cy)} ${fmtCoord(-p.minZ)}" printable="1" />`;
+  }).join('\n');
 
+  const matNs = anyColour ? ` xmlns:m="${MAT_NS}"` : '';
+  const title = escXml(getExportTitle());
   const today = new Date().toISOString().slice(0, 10);
-  const title = escapeXml(getExportTitle());
-  // The `BambuStudio-` Application prefix is what flips Bambu/Orca into project
-  // mode (plates + filament binding). Generic mode names Partwright instead.
-  const appMeta = bambu
-    ? '  <metadata name="Application">BambuStudio-02.00.00.00</metadata>\n  <metadata name="BambuStudio:3mfVersion">1</metadata>\n'
-    : '  <metadata name="Application">Partwright (https://www.partwrightstudio.com)</metadata>\n';
-
   const modelXml = `<?xml version="1.0" encoding="UTF-8"?>
-<model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"${matNs}${bambuNs}>
-${appMeta}  <metadata name="Title">${title}</metadata>
-  <metadata name="Designer">Partwright</metadata>
+<model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="${CORE_NS}"${matNs}>
+  <metadata name="Application">Partwright (https://www.partwrightstudio.com)</metadata>
+  <metadata name="Title">${title}</metadata>
   <metadata name="CreationDate">${today}</metadata>
-  <metadata name="ModificationDate">${today}</metadata>
-  <metadata name="LicenseTerms">Created with Partwright — https://www.partwrightstudio.com</metadata>
-  <resources>${colorgroupXml}
+  <resources>${anyColour ? '\n' + colorgroupXml : ''}
 ${objectsXml}
   </resources>
   <build>
-${buildItemsXml}
+${buildItems}
   </build>
 </model>`;
 
-  // ── 5. Package ──────────────────────────────────────────────────────────
-  const files: { name: string; data: Uint8Array }[] = [];
-  const enc = new TextEncoder();
-
-  const configType = bambu
-    ? '\n  <Default Extension="config" ContentType="application/vnd.bambulab-package.settings+xml" />'
-    : '';
-  const contentTypesXml = `<?xml version="1.0" encoding="UTF-8"?>
+  const contentTypes = `<?xml version="1.0" encoding="UTF-8"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
   <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
-  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />${configType}
+  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />
 </Types>`;
-
-  const relsXml = `<?xml version="1.0" encoding="UTF-8"?>
+  const rels = `<?xml version="1.0" encoding="UTF-8"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Target="/3D/3dmodel.model" Id="rel0" Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel" />
+  <Relationship Target="/3D/3dmodel.model" Id="rel0" Type="${REL_TYPE}" />
 </Relationships>`;
+  return buildZip([
+    { name: '[Content_Types].xml', data: enc(contentTypes) },
+    { name: '_rels/.rels', data: enc(rels) },
+    { name: '3D/3dmodel.model', data: enc(modelXml) },
+  ]);
+}
 
-  files.push({ name: '[Content_Types].xml', data: enc.encode(contentTypesXml) });
-  files.push({ name: '_rels/.rels', data: enc.encode(relsXml) });
-  files.push({ name: '3D/3dmodel.model', data: enc.encode(modelXml) });
+// ── Bambu/Orca: production-extension split files, one plate per part ──────
+function buildBambuPackage(prepared: PreparedPart[], colorgroupXml: string, anyColour: boolean, cgid: number): Uint8Array {
+  const unit = get3MFUnitString();
+  const matNs = anyColour ? ` xmlns:m="${MAT_NS}"` : '';
+  const pidAttr = anyColour ? ` pid="${cgid}" pindex="0"` : '';
+  const cgBlock = anyColour ? `\n${colorgroupXml}` : '';
 
-  if (bambu) {
-    // Metadata/model_settings.config — objects + per-part plates. This is what
-    // creates the plate slots; placement (pass 3) is what actually distributes
-    // the objects across them.
-    const configObjects = prepared.map(p => {
-      const safeName = escapeXml(p.name);
-      return `  <object id="${p.objectId}">
+  const objectFiles: { name: string; data: Uint8Array }[] = [];
+  const wrapperObjects: string[] = [];
+  const buildItems: string[] = [];
+  const objRels: string[] = [];
+  const settingsObjects: string[] = [];
+  const settingsPlates: string[] = [];
+
+  prepared.forEach((p, i) => {
+    const wrapperId = i + 1;
+    const meshId = 100 + i;
+    const partFile = `3D/Objects/object_${meshId}.model`;
+
+    // Per-part object file: full model carrying the actual mesh (+ colorgroup).
+    const meshUuid = `${String(i).padStart(4, '0')}0000-81cb-4c03-9d28-80fed5dfa1dc`;
+    const partModel = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="${unit}" xml:lang="en-US" xmlns="${CORE_NS}" xmlns:BambuStudio="${BBS_NS}" xmlns:p="${PROD_NS}"${matNs} requiredextensions="p">
+ <metadata name="BambuStudio:3mfVersion">1</metadata>
+ <resources>${cgBlock}
+  <object id="${meshId}" p:UUID="${meshUuid}" type="model"${pidAttr}>
+   <mesh>
+    <vertices>
+${p.vertices.join('\n')}
+    </vertices>
+    <triangles>
+${p.triangles.join('\n')}
+    </triangles>
+   </mesh>
+  </object>
+ </resources>
+ <build/>
+</model>`;
+    objectFiles.push({ name: partFile, data: enc(partModel) });
+
+    const wrapperUuid = `${String(wrapperId).padStart(8, '0')}-61cb-4c03-9d28-80fed5dfa1dc`;
+    const compUuid = `${String(wrapperId).padStart(4, '0')}${String(meshId).padStart(4, '0')}-b206-40ff-9872-83e8017abed1`;
+    wrapperObjects.push(`  <object id="${wrapperId}" p:UUID="${wrapperUuid}" type="model">
+   <components>
+    <component p:path="/${partFile}" objectid="${meshId}" p:UUID="${compUuid}" transform="1 0 0 0 1 0 0 0 1 0 0 0"/>
+   </components>
+  </object>`);
+
+    // Place each part in its own plate slot (2-col grid) and rest it on z=0.
+    const col = i % 2, row = i >> 1;
+    const tx = PLATE_OFFSET + col * PLATE_STRIDE;
+    const ty = PLATE_OFFSET - row * PLATE_STRIDE;
+    const itemUuid = `${String(wrapperId).padStart(8, '0')}-b1ec-4553-aec9-835e5b724bb4`;
+    buildItems.push(`  <item objectid="${wrapperId}" p:UUID="${itemUuid}" transform="1 0 0 0 1 0 0 0 1 ${fmtCoord(tx - p.cx)} ${fmtCoord(ty - p.cy)} ${fmtCoord(-p.minZ)}" printable="1"/>`);
+
+    objRels.push(`  <Relationship Target="/${partFile}" Id="relObj${i}" Type="${REL_TYPE}"/>`);
+
+    const safeName = escXml(p.name);
+    settingsObjects.push(`  <object id="${wrapperId}">
     <metadata key="name" value="${safeName}"/>
     <metadata key="extruder" value="${p.extruder}"/>
-    <part id="${p.objectId}" subtype="normal_part">
-      <metadata key="name" value="${safeName}"/>
-      <metadata key="matrix" value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-      <mesh_stat face_count="${p.faceCount}" edges_fixed="0" degenerate_facets="0" facets_removed="0" facets_reversed="0" backwards_edges="0"/>
-    </part>
-  </object>`;
-    }).join('\n');
-
-    const configPlates = prepared.map((p, i) => `  <plate>
+  </object>`);
+    // NOTE: plater_name MUST be empty — a non-empty value makes Bambu/Orca's
+    // project loader reject the file (load fails, single plate). The part name
+    // already rides on the <object> name; the plate is named by the slicer.
+    settingsPlates.push(`  <plate>
     <metadata key="plater_id" value="${i + 1}"/>
-    <metadata key="plater_name" value="${escapeXml(p.name)}"/>
+    <metadata key="plater_name" value=""/>
     <metadata key="locked" value="false"/>
     <model_instance>
-      <metadata key="object_id" value="${p.objectId}"/>
+      <metadata key="object_id" value="${wrapperId}"/>
       <metadata key="instance_id" value="0"/>
     </model_instance>
-  </plate>`).join('\n');
+  </plate>`);
+  });
 
-    const modelSettingsXml = `<?xml version="1.0" encoding="UTF-8"?>
+  const today = new Date().toISOString().slice(0, 10);
+  const title = escXml(getExportTitle());
+  const rootModel = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="${unit}" xml:lang="en-US" xmlns="${CORE_NS}" xmlns:BambuStudio="${BBS_NS}" xmlns:p="${PROD_NS}" requiredextensions="p">
+ <metadata name="Application">BambuStudio-02.00.00.00</metadata>
+ <metadata name="BambuStudio:3mfVersion">1</metadata>
+ <metadata name="Title">${title}</metadata>
+ <metadata name="CreationDate">${today}</metadata>
+ <resources>
+${wrapperObjects.join('\n')}
+ </resources>
+ <build p:UUID="2c7c17d8-22b5-4d84-8835-197602200001">
+${buildItems.join('\n')}
+ </build>
+</model>`;
+
+  const objRelsXml = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+${objRels.join('\n')}
+</Relationships>`;
+
+  const modelSettings = `<?xml version="1.0" encoding="UTF-8"?>
 <config>
-${configObjects}
-${configPlates}
+${settingsObjects.join('\n')}
+${settingsPlates.join('\n')}
 </config>`;
-    files.push({ name: 'Metadata/model_settings.config', data: enc.encode(modelSettingsXml) });
-    // NOTE: we deliberately do NOT emit Metadata/project_settings.config. A
-    // minimal one (e.g. just filament_diameter) flips Bambu into its full
-    // project-load path, which then CRASHES on the rest of the config bundle it
-    // expects; a complete bundle would reintroduce the preset warning and is too
-    // version-fragile to synthesize. Without it Bambu opens the file safely but
-    // shows a single plate (see Known issue in the PR / discussion).
-  }
 
-  const zip = buildZip(files);
-  const mimeType = 'application/vnd.ms-package.3dmanufacturing';
-  const blob = new Blob([zip], { type: mimeType });
-  return { blob, filename: getExportFilename('3mf', opts.customName), mimeType };
+  // Minimal project_settings.config — REQUIRED so the project loader builds the
+  // plate list (it falls back to a single plate when no recognized config key
+  // loads). These 5 keys make the config non-empty WITHOUT naming presets that
+  // trip the "customized presets / confirm G-code" warning, and include
+  // filament_diameter-adjacent keys the loader dereferences. Validated headless.
+  const projectSettings = JSON.stringify({
+    filament_settings_id: ['Bambu PLA Basic @BBL P1P'],
+    nozzle_diameter: ['0.4'],
+    print_settings_id: '0.20mm Standard @BBL N1',
+    printable_area: ['0x0', '180x0', '180x180', '0x180'],
+    printable_height: '180',
+    printer_settings_id: 'Bambu Lab N1 0.4 nozzle',
+  }, null, 2);
+
+  // NOTE: no `config` content-type Default — the reference Bambu format omits it
+  // (the loader finds .config files by path), and including it broke loading.
+  const contentTypes = `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml"/>
+</Types>`;
+  const rootRels = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Target="/3D/3dmodel.model" Id="rel0" Type="${REL_TYPE}"/>
+</Relationships>`;
+
+  const empty = new Uint8Array(0);
+  return buildZip([
+    { name: '[Content_Types].xml', data: enc(contentTypes) },
+    { name: '3D/', data: empty },
+    { name: '3D/Objects/', data: empty },
+    { name: '3D/_rels/', data: empty },
+    { name: 'Metadata/', data: empty },
+    { name: '_rels/', data: empty },
+    { name: '_rels/.rels', data: enc(rootRels) },
+    { name: '3D/3dmodel.model', data: enc(rootModel) },
+    ...objectFiles,
+    { name: '3D/_rels/3dmodel.model.rels', data: enc(objRelsXml) },
+    { name: 'Metadata/model_settings.config', data: enc(modelSettings) },
+    { name: 'Metadata/project_settings.config', data: enc(projectSettings) },
+  ]);
 }

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -21,10 +21,11 @@
 //       - Each <plate> carries identify_id (a stable integer) plus the filament_map*
 //         metadata Bambu needs to assign AMS slots.
 //       - An <assemble> block with one <assemble_item> per object closes the config.
-//       - Colour is per-OBJECT via the extruder field, NOT per-triangle. The mesh
-//         files carry plain <triangle v1 v2 v3/> (no pid/p1/paint_color in Bambu
-//         mode). This matches the reference exactly and avoids the triangle-color
-//         parsing path that segfaults on some Bambu builds.
+//       - Colour: each object has a base extruder (its dominant AMS slot), and
+//         triangles whose slot differs carry a per-triangle paint_color (Bambu's
+//         MMU segmentation attribute) so hand-paint / api.label regions show WITHIN
+//         a part. Colours map onto the 3 AMS slots the H2C config defines (no
+//         m:colorgroup/pid/p1 here — that's the generic mode's material extension).
 //       - project_settings.config is a COMPLETE BambuStudio preset block (the
 //         template in bambuProjectTemplate.json — a full Bambu Lab H2C profile,
 //         536 keys). This is load-CRITICAL: Bambu's GUI `Plater::priv::load_files`
@@ -121,16 +122,34 @@ function fmtCoord(v: number): string {
   return v.toFixed(6).replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
 }
 
+/** "#rrggbb" (any case, optional #) → Bambu's "#RRGGBB" form. */
+function toBambuHex(hex: string): string { return '#' + hex.replace(/^#/, '').toUpperCase(); }
+function hexRgb(hex: string): [number, number, number] {
+  const h = hex.replace(/^#/, '');
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+/** Index of the palette colour nearest `hex` in RGB space (for >3-colour snap). */
+function nearestSlotIndex(hex: string, palette: string[]): number {
+  const [r, g, b] = hexRgb(hex);
+  let best = 0, bestD = Infinity;
+  palette.forEach((p, i) => {
+    const [pr, pg, pb] = hexRgb(p);
+    const d = (r - pr) ** 2 + (g - pg) ** 2 + (b - pb) ** 2;
+    if (d < bestD) { bestD = d; best = i; }
+  });
+  return best;
+}
+
 const enc = (s: string) => new TextEncoder().encode(s);
 
 interface PreparedPart {
   name: string;
   vertices: string[];          // <vertex .../> lines
-  trianglesPlain: string[];    // plain <triangle v1 v2 v3/> for Bambu mode
-  trianglesColored: string[];  // <triangle .../> with pid/p1/paint_color for generic
+  trianglesBambu: string[];    // <triangle v1 v2 v3 [paint_color=…]/> for Bambu mode
+  trianglesColored: string[];  // <triangle .../> with pid/p1 for generic
   faceCount: number;
-  extruder: number;            // 1-based dominant filament (global index)
-  dominantHex: string;         // CSS hex of dominant colour (for filament_colour list)
+  extruder: number;            // 1-based base AMS slot (Bambu) / material index (generic)
+  dominantHex: string;         // CSS hex of dominant colour
   cx: number; cy: number; minZ: number; width: number; depth: number;
   halfHeight: number;          // half of Z extent (unused in current code, kept for possible future use)
 }
@@ -165,6 +184,30 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
   // Bambu puts one object per file so a small const is safe.
   const colorGroupId = bambu ? 2 : parts.length + 1;
 
+  // ── Bambu AMS palette: ≤3 filament slots from the most-used colours ─────────
+  // Bambu colour is per-filament, and the H2C config defines exactly 3 filaments
+  // (see buildProjectSettings — we never resize that array). Map every triangle
+  // colour to one of 3 slots: the 3 most-frequent colours across all parts become
+  // the slots; any others snap to the nearest. Each object's base extruder is its
+  // dominant slot, and triangles whose slot differs carry a per-triangle
+  // paint_color — so hand-painted brush marks and api.label regions WITHIN a part
+  // survive in Bambu, not just the dominant colour. (>3 distinct colours collapse
+  // to the nearest of 3; lifting that cap needs a validated config resize — #729.)
+  const bambuSlotOf = new Map<string, number>();   // triColorHex → 0..2
+  let bambuFilamentColors = ['#D9D9D9', '#D9D9D9', '#D9D9D9'];
+  if (bambu && anyColour) {
+    const freq = new Map<string, number>();
+    for (let i = 0; i < parts.length; i++) {
+      const t = parts[i].mesh.triColors;
+      if (t) for (const tr of cleaned[i].validTris) { const h = triColorHex(t, tr); freq.set(h, (freq.get(h) ?? 0) + 1); }
+    }
+    const palette = [...freq.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3).map(e => e[0]);
+    palette.forEach((h, idx) => bambuSlotOf.set(h, idx));
+    for (const h of freq.keys()) if (!bambuSlotOf.has(h)) bambuSlotOf.set(h, nearestSlotIndex(h, palette));
+    while (palette.length < 3) palette.push(palette[palette.length - 1] ?? '#d9d9d9');
+    bambuFilamentColors = palette.map(toBambuHex);
+  }
+
   // ── Per-part geometry + colour ──────────────────────────────────────────
   const prepared: PreparedPart[] = parts.map((part, i) => {
     const { mesh } = part;
@@ -182,30 +225,38 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
       vertices.push(`     <vertex x="${fmtCoord(x)}" y="${fmtCoord(y)}" z="${fmtCoord(z)}"/>`);
     }
 
-    // Dominant colour → object extruder (global 1-based filament index).
+    // Dominant colour → object base extruder. Bambu uses the dominant AMS slot
+    // (1..3); generic uses the global material index.
     let extruder = 1;
     let dominantHex = materialColors[0] ?? '#ff0000';
     if (tc) {
       const counts = new Map<number, number>();
-      for (const t of validTris) { const idx = colorMap.get(triColorHex(tc, t)) ?? 0; counts.set(idx, (counts.get(idx) ?? 0) + 1); }
+      for (const t of validTris) {
+        const idx = bambu ? (bambuSlotOf.get(triColorHex(tc, t)) ?? 0) : (colorMap.get(triColorHex(tc, t)) ?? 0);
+        counts.set(idx, (counts.get(idx) ?? 0) + 1);
+      }
       let best = 0, bestN = -1;
       for (const [idx, n] of counts) if (n > bestN) { bestN = n; best = idx; }
       extruder = best + 1;
-      dominantHex = materialColors[best] ?? '#ff0000';
+      dominantHex = bambu ? (bambuFilamentColors[best] ?? '#ff0000') : (materialColors[best] ?? '#ff0000');
     }
 
-    // Bambu mode: plain triangles (no pid/p1 — colour is per-object via extruder).
-    const trianglesPlain: string[] = [];
-    // Generic/coloured mode: triangles with pid/p1/paint_color.
+    // Bambu mode: triangles carry a per-triangle paint_color when their AMS slot
+    // differs from the object's base extruder (this is what makes hand-paint and
+    // api.label regions show WITHIN a part); same-as-base triangles stay plain.
+    const trianglesBambu: string[] = [];
+    // Generic/coloured mode: triangles with pid/p1 (m:colorgroup material extension).
     const trianglesColored: string[] = [];
     for (const t of validTris) {
       const v1 = remap[mesh.triVerts[t * 3]], v2 = remap[mesh.triVerts[t * 3 + 1]], v3 = remap[mesh.triVerts[t * 3 + 2]];
-      trianglesPlain.push(`     <triangle v1="${v1}" v2="${v2}" v3="${v3}"/>`);
       if (tc) {
+        const slot = bambuSlotOf.get(triColorHex(tc, t)) ?? 0;
+        const paint = (slot + 1) !== extruder ? ` paint_color="${encodePaintColorState(slot + 1)}"` : '';
+        trianglesBambu.push(`     <triangle v1="${v1}" v2="${v2}" v3="${v3}"${paint}/>`);
         const matIdx = colorMap.get(triColorHex(tc, t)) ?? 0;
-        const paint = bambu && (matIdx + 1) !== extruder ? ` paint_color="${encodePaintColorState(matIdx + 1)}"` : '';
-        trianglesColored.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${colorGroupId}" p1="${matIdx}" p2="${matIdx}" p3="${matIdx}"${paint} />`);
+        trianglesColored.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${colorGroupId}" p1="${matIdx}" p2="${matIdx}" p3="${matIdx}" />`);
       } else {
+        trianglesBambu.push(`     <triangle v1="${v1}" v2="${v2}" v3="${v3}"/>`);
         trianglesColored.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
       }
     }
@@ -214,7 +265,7 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
     const cy = Number.isFinite(minY) ? (minY + maxY) / 2 : 0;
     const halfH = Number.isFinite(minZ) && Number.isFinite(maxZ) ? (maxZ - minZ) / 2 : 0;
     return {
-      name: part.name, vertices, trianglesPlain, trianglesColored,
+      name: part.name, vertices, trianglesBambu, trianglesColored,
       faceCount: validTris.length, extruder, dominantHex,
       cx, cy, minZ: Number.isFinite(minZ) ? minZ : 0,
       width: Number.isFinite(minX) ? maxX - minX : 0,
@@ -226,28 +277,6 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
   const colorgroupXml = anyColour
     ? `    <m:colorgroup id="${colorGroupId}">\n${materialColors.map(h => `      <m:color color="${h.toUpperCase()}FF" />`).join('\n')}\n    </m:colorgroup>`
     : '';
-
-  // Bambu per-part colour: map each part's dominant colour onto one of the THREE
-  // AMS filament slots the H2C template defines. We keep that filament count fixed
-  // at 3 — resizing the 130+ per-filament config arrays can't be validated against
-  // Bambu's GUI loader headlessly, and a too-short array is exactly what crashed it
-  // before. So colour is capped at 3 distinct part colours (the common AMS case);
-  // >3 reuses the closest slot. Per-part colour beyond 3 is the tracked follow-up.
-  let bambuFilamentColors: string[] = ['#D9D9D9', '#D9D9D9', '#D9D9D9'];
-  if (bambu && anyColour) {
-    const palette: string[] = [];
-    for (const p of prepared) {
-      const hex = p.dominantHex.toLowerCase();
-      if (!palette.includes(hex) && palette.length < 3) palette.push(hex);
-    }
-    // Reassign each part's extruder to its slot (1-based) in the capped palette.
-    for (const p of prepared) {
-      const idx = palette.indexOf(p.dominantHex.toLowerCase());
-      p.extruder = idx >= 0 ? idx + 1 : 1;
-    }
-    while (palette.length < 3) palette.push(palette[palette.length - 1] ?? '#d9d9d9');
-    bambuFilamentColors = palette.map(h => '#' + h.replace(/^#/, '').toUpperCase());
-  }
 
   const built = bambu
     ? buildBambuPackage(prepared, bambuFilamentColors)
@@ -326,9 +355,9 @@ ${buildItems}
 //   - Wrapper (component ref) object: EVEN id = 2*i    (2, 4, 6, …)
 //   - Object file: 3D/Objects/object_K.model where K = part index 1..N (sequential)
 //
-// Colour: per-OBJECT via extruder field in model_settings.config. Mesh files carry
-// plain triangles (no pid/p1/paint_color). This matches how the reference does
-// multicolor and avoids the per-triangle parsing path that segfaults.
+// Colour: object base extruder (dominant AMS slot) in model_settings.config, plus
+// per-triangle paint_color in the mesh for triangles whose slot differs from the
+// base — so painted regions within a part survive. Colours map onto 3 AMS slots.
 //
 // model_settings.config structural additions vs the old code (crash fix):
 //   - <part id=ODD subtype="normal_part"> inside each <object id=EVEN>
@@ -343,12 +372,12 @@ function buildBambuPackage(prepared: PreparedPart[], filamentColors: string[]): 
   const strideX = bedW * PLATE_GAP_FACTOR;          // BambuStudio plate_stride_x (width·1.2)
   const strideY = bedH * PLATE_GAP_FACTOR;          // BambuStudio plate_stride_y (depth·1.2)
 
-  // Bambu mode: per-part colour via the per-object `extruder` field (1..3),
-  // mapped to the 3 AMS filament slots whose colours go in project_settings'
-  // filament_colour. The complete H2C config keeps all per-filament arrays sized
-  // to 3 so load_files binds without null-derefing (the prior crash). The mesh
-  // files still carry PLAIN triangles — whole-object colour, no per-triangle
-  // paint_color (in-part multicolour would need the unvalidated paint_color path).
+  // Bambu mode: each object's base colour is its `extruder` (dominant AMS slot,
+  // 1..3), and per-triangle paint_color (built in build3MFProject) colours regions
+  // within the part — so hand-paint and api.label survive, not just the dominant.
+  // Slot colours go in project_settings' filament_colour; the complete H2C config
+  // keeps all per-filament arrays sized to 3 so load_files binds without
+  // null-derefing (the prior crash). >3 distinct colours snap to the nearest slot.
 
   const objectFiles: { name: string; data: Uint8Array }[] = [];
   const wrapperObjects: string[] = [];
@@ -374,7 +403,8 @@ function buildBambuPackage(prepared: PreparedPart[], filamentColors: string[]): 
     const compUuid = `${String(partNum).padStart(4, '0')}0000-b206-40ff-9872-83e8017abed1`;
     const itemUuid = `${String(wrapperId).padStart(8, '0')}-b1ec-4553-aec9-835e5b724bb4`;
 
-    // Per-part object file: plain triangles, no colorgroup (colour is per extruder).
+    // Per-part object file: triangles carry paint_color where the slot differs from
+    // the base extruder (per-triangle colour); no m:colorgroup (that's generic mode).
     const partModel = `<?xml version="1.0" encoding="UTF-8"?>
 <model unit="${unit}" xml:lang="en-US" xmlns="${CORE_NS}" xmlns:BambuStudio="${BBS_NS}" xmlns:p="${PROD_NS}" requiredextensions="p">
  <metadata name="BambuStudio:3mfVersion">1</metadata>
@@ -385,7 +415,7 @@ function buildBambuPackage(prepared: PreparedPart[], filamentColors: string[]): 
 ${p.vertices.join('\n')}
     </vertices>
     <triangles>
-${p.trianglesPlain.join('\n')}
+${p.trianglesBambu.join('\n')}
     </triangles>
    </mesh>
   </object>

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -1,20 +1,24 @@
-// Multi-part 3MF "project" export — bundles several Session Parts into ONE 3MF,
-// each part on its own build PLATE, with colours pre-bound to filaments.
+// Multi-part 3MF export — bundles several Session Parts into ONE 3MF. Two modes:
 //
-// The file is BOTH:
-//   1. A valid GENERIC 3MF — multiple `<object>` + `<build><item>` with an
-//      `<m:colorgroup>` material list, so any slicer/viewer (Cura, PrusaSlicer,
-//      Microsoft 3D Viewer) opens it and sees every part + colour.
-//   2. A Bambu Studio / OrcaSlicer PROJECT — the `Application` metadata marker
-//      flips Bambu into project mode, `Metadata/model_settings.config` assigns
-//      one part per plate (and per-object `extruder`), per-triangle `paint_color`
-//      carries the painted multi-colour, and `Metadata/project_settings.config`
-//      pre-populates the filament list so colours land on AMS slots.
+//   bambu: false (GENERIC) — multiple `<object>` + `<build><item>` with an
+//     `<m:colorgroup>` material list, parts grid-arranged so they don't overlap.
+//     No Bambu metadata. Any slicer/viewer (Cura, PrusaSlicer, MS 3D Viewer)
+//     opens it and sees every part + colour.
 //
-// Plate recognition needs only the `<plate>` blocks in model_settings.config +
-// the `BambuStudio-` Application marker; the per-plate gcode/json/png files are
-// post-slice artifacts and are intentionally omitted. See the PR description for
-// the source-grounded format spec.
+//   bambu: true (BAMBU/ORCA PROJECT) — adds the `BambuStudio-` Application
+//     marker (project mode), `Metadata/model_settings.config` with one `<plate>`
+//     per part + per-object `extruder`, and per-triangle `paint_color`. Each part
+//     is positioned on its own build PLATE. Plate membership in Bambu/Orca is
+//     decided by WORLD POSITION (bbox overlap with the plate's box), not the
+//     `<model_instance>` grouping, so parts are tiled one-per-plate using the
+//     slicer's plate stride (bed × 1.2). The file stays a valid generic 3MF too.
+//
+// We deliberately do NOT emit `Metadata/project_settings.config`: it makes Bambu
+// run preset validation and pop the "customized filament or printer presets …
+// confirm the G-code is safe" dialog. Colours still import + map to filaments
+// from the `<m:colorgroup>` + per-object `extruder` + `paint_color` in the model
+// itself. The per-plate `.json`/`.png`/`.gcode` files are post-slice artifacts
+// and are omitted. See the PR description for the source-grounded format spec.
 
 import type { MeshData } from '../geometry/types';
 import { get3MFUnitString } from '../geometry/units';
@@ -24,7 +28,6 @@ import { buildZip } from './zip';
 import { assertFiniteMesh, assertExportableMesh, cleanMeshForExport, triColorHex, hasAnyPainted } from './meshClean';
 import { listFilaments } from '../color/palette';
 import { encodePaintColorState } from './paintColor3mf';
-import { getConfig } from '../config/appConfig';
 
 /** One selected Session Part, with its baked (optionally coloured) mesh. */
 export interface PartExport {
@@ -37,9 +40,16 @@ export interface PartExport {
 export interface Build3MFProjectOptions {
   /** Override the download filename stem. */
   customName?: string;
-  /** Where each part is centred on its plate (mm). Defaults to the configured
-   *  nominal bed centre. Each part sits on z=0; Bambu auto-drops to the bed. */
-  platePositionMm?: number;
+  /** Emit the Bambu/Orca project layer (Application marker, model_settings.config
+   *  with one plate per part, per-object `extruder`, per-triangle `paint_color`),
+   *  and tile parts one-per-plate. When false, a GENERIC multi-object 3MF: parts
+   *  grid-arranged, `m:colorgroup` colour only, no Bambu metadata. Default true. */
+  bambu?: boolean;
+  /** Build-plate size `[x, y]` in mm — drives the per-plate world stride in Bambu
+   *  mode so each part lands on its plate's centre. Default `[256, 256]`. */
+  bedSize?: [number, number];
+  /** Gap (mm) between parts in the GENERIC grid layout. Default 10. */
+  gridGapMm?: number;
 }
 
 // Bambu/Orca tile build plates in one shared world space with a gap of 20% of
@@ -59,17 +69,21 @@ interface PreparedPart {
   triangles: string[];  // <triangle .../> lines
   faceCount: number;
   extruder: number;     // 1-based dominant filament for the whole object
-  transform: string;    // 12-value row-major item transform
+  // Bounding-box geometry, used to position the part (placement is a second pass).
+  cx: number; cy: number; minZ: number; width: number; depth: number;
+  transform: string;    // 12-value row-major item transform (filled in pass 2)
 }
 
 /**
- * Build a multi-part Bambu/generic 3MF blob. Each part becomes one object on its
- * own plate. Colours are shared across all parts via a single filament list so a
- * given colour maps to the same AMS slot on every plate.
+ * Build a multi-part 3MF blob. See the module header for the two modes. Colours
+ * are shared across all parts via a single `m:colorgroup` so a given colour maps
+ * to the same material/filament index on every part.
  */
 export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOptions = {}): BuiltExport {
   if (parts.length === 0) throw new Error('Cannot export: no parts selected.');
-  const platePos = opts.platePositionMm ?? getConfig().export.platePositionMm;
+  const bambu = opts.bambu ?? true;
+  const [bedX, bedY] = opts.bedSize ?? [256, 256];
+  const gridGap = opts.gridGapMm ?? 10;
 
   // ── 1. Shared filament list across ALL parts ────────────────────────────
   // The same ordering rule as the single-part exporter: used palette slots in
@@ -111,13 +125,13 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
 
   const colorGroupId = parts.length + 1; // distinct from object ids 1..N
 
-  // ── 2. Per-part geometry + colour ───────────────────────────────────────
+  // ── 2. Per-part geometry + colour (placement is pass 3) ─────────────────
   const prepared: PreparedPart[] = parts.map((part, i) => {
     const { mesh } = part;
     const { remap, uniquePositions, validTris } = cleaned[i];
     const tc = anyColour ? mesh.triColors ?? null : null;
 
-    // Vertices + bounding box (for plate centring).
+    // Vertices + bounding box.
     const numUniqueVerts = uniquePositions.length / 3;
     let minX = Infinity, minY = Infinity, minZ = Infinity, maxX = -Infinity, maxY = -Infinity;
     const vertices: string[] = [];
@@ -142,8 +156,9 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
       extruder = bestIdx + 1;
     }
 
-    // Triangles. Generic colour via pid/p1 (face colour); Bambu colour via
-    // paint_color, omitted where the triangle matches the object's extruder.
+    // Triangles. Generic colour via pid/p1 (face colour) in both modes; Bambu
+    // colour additionally via paint_color (omitted where the triangle matches the
+    // object's extruder, and omitted entirely in generic mode).
     const triangles: string[] = [];
     for (const t of validTris) {
       const v1 = remap[mesh.triVerts[t * 3]];
@@ -152,31 +167,48 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
       if (tc) {
         const matIdx = colorMap.get(triColorHex(tc, t)) ?? 0;
         const filament = matIdx + 1;
-        const paint = filament === extruder ? '' : ` paint_color="${encodePaintColorState(filament)}"`;
+        const paint = bambu && filament !== extruder ? ` paint_color="${encodePaintColorState(filament)}"` : '';
         triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${colorGroupId}" p1="${matIdx}" p2="${matIdx}" p3="${matIdx}"${paint} />`);
       } else {
         triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
       }
     }
 
-    // Place the part on ITS OWN plate, resting on z=0. Bambu/Orca assign an
-    // object to a plate by WORLD POSITION (bounding-box overlap with the plate's
-    // box), NOT by the model_settings.config <model_instance> grouping — so each
-    // part must be offset into a distinct plate region or they all stack on plate
-    // 1. Plates tile in one shared world space, single row, stride = bed × 1.2
-    // (OrcaSlicer's fixed LOGICAL_PART_PLATE_GAP = 0.2). `platePos` is the bed
-    // centre (half-extent), so bed = 2·platePos and the stride is platePos·2.4.
-    const plateCenterX = platePos + i * (platePos * 2 * PLATE_GAP_FACTOR);
     const cx = Number.isFinite(minX) ? (minX + maxX) / 2 : 0;
     const cy = Number.isFinite(minY) ? (minY + maxY) / 2 : 0;
-    const tx = plateCenterX - cx, ty = platePos - cy, tz = Number.isFinite(minZ) ? -minZ : 0;
-    const transform = `1 0 0 0 1 0 0 0 1 ${tx.toFixed(6)} ${ty.toFixed(6)} ${tz.toFixed(6)}`;
-
-    return { name: part.name, objectId: i + 1, vertices, triangles, faceCount: validTris.length, extruder, transform };
+    const width = Number.isFinite(minX) ? maxX - minX : 0;
+    const depth = Number.isFinite(minY) ? maxY - minY : 0;
+    const z0 = Number.isFinite(minZ) ? minZ : 0;
+    return { name: part.name, objectId: i + 1, vertices, triangles, faceCount: validTris.length, extruder, cx, cy, minZ: z0, width, depth, transform: '' };
   });
 
-  // ── 3. 3D/3dmodel.model ─────────────────────────────────────────────────
+  // ── 3. Placement ────────────────────────────────────────────────────────
+  // Bambu: tile one part per plate along +X using the slicer's plate stride so
+  //   each part's bbox falls in (and is centred on) its own plate's box.
+  // Generic: lay parts out in a centred square grid spaced by the largest
+  //   footprint + gap, so they never overlap.
+  const N = prepared.length;
+  if (bambu) {
+    prepared.forEach((p, i) => {
+      const plateCenterX = i * (bedX * PLATE_GAP_FACTOR) + bedX / 2;
+      const plateCenterY = bedY / 2;
+      p.transform = `1 0 0 0 1 0 0 0 1 ${(plateCenterX - p.cx).toFixed(6)} ${(plateCenterY - p.cy).toFixed(6)} ${(-p.minZ).toFixed(6)}`;
+    });
+  } else {
+    const cols = Math.ceil(Math.sqrt(N));
+    const rows = Math.ceil(N / cols);
+    const pitch = Math.max(1, ...prepared.map(p => Math.max(p.width, p.depth))) + gridGap;
+    prepared.forEach((p, i) => {
+      const col = i % cols, row = Math.floor(i / cols);
+      const cellX = col * pitch - (cols - 1) * pitch / 2;
+      const cellY = row * pitch - (rows - 1) * pitch / 2;
+      p.transform = `1 0 0 0 1 0 0 0 1 ${(cellX - p.cx).toFixed(6)} ${(cellY - p.cy).toFixed(6)} ${(-p.minZ).toFixed(6)}`;
+    });
+  }
+
+  // ── 4. 3D/3dmodel.model ─────────────────────────────────────────────────
   const matNs = anyColour ? ' xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"' : '';
+  const bambuNs = bambu ? ' xmlns:BambuStudio="http://schemas.bambulab.com/package/2021"' : '';
   const colorgroupXml = anyColour
     ? `\n    <m:colorgroup id="${colorGroupId}">\n${materialColors.map(h => `      <m:color color="${h.toUpperCase()}FF" />`).join('\n')}\n    </m:colorgroup>`
     : '';
@@ -197,12 +229,15 @@ ${p.triangles.join('\n')}
 
   const today = new Date().toISOString().slice(0, 10);
   const title = escapeXml(getExportTitle());
+  // The `BambuStudio-` Application prefix is what flips Bambu/Orca into project
+  // mode (plates + filament binding). Generic mode names Partwright instead.
+  const appMeta = bambu
+    ? '  <metadata name="Application">BambuStudio-02.00.00.00</metadata>\n  <metadata name="BambuStudio:3mfVersion">1</metadata>\n'
+    : '  <metadata name="Application">Partwright (https://www.partwrightstudio.com)</metadata>\n';
 
   const modelXml = `<?xml version="1.0" encoding="UTF-8"?>
-<model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"${matNs} xmlns:BambuStudio="http://schemas.bambulab.com/package/2021">
-  <metadata name="Application">BambuStudio-02.00.00.00</metadata>
-  <metadata name="BambuStudio:3mfVersion">1</metadata>
-  <metadata name="Title">${title}</metadata>
+<model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"${matNs}${bambuNs}>
+${appMeta}  <metadata name="Title">${title}</metadata>
   <metadata name="Designer">Partwright</metadata>
   <metadata name="CreationDate">${today}</metadata>
   <metadata name="ModificationDate">${today}</metadata>
@@ -215,46 +250,17 @@ ${buildItemsXml}
   </build>
 </model>`;
 
-  // ── 4. Metadata/model_settings.config (objects + per-part plates) ────────
-  const configObjects = prepared.map(p => {
-    const safeName = escapeXml(p.name);
-    return `  <object id="${p.objectId}">
-    <metadata key="name" value="${safeName}"/>
-    <metadata key="extruder" value="${p.extruder}"/>
-    <part id="${p.objectId}" subtype="normal_part">
-      <metadata key="name" value="${safeName}"/>
-      <metadata key="matrix" value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-      <mesh_stat face_count="${p.faceCount}" edges_fixed="0" degenerate_facets="0" facets_removed="0" facets_reversed="0" backwards_edges="0"/>
-    </part>
-  </object>`;
-  }).join('\n');
-
-  const configPlates = prepared.map((p, i) => `  <plate>
-    <metadata key="plater_id" value="${i + 1}"/>
-    <metadata key="plater_name" value="${escapeXml(p.name)}"/>
-    <metadata key="locked" value="false"/>
-    <model_instance>
-      <metadata key="object_id" value="${p.objectId}"/>
-      <metadata key="instance_id" value="0"/>
-    </model_instance>
-  </plate>`).join('\n');
-
-  const modelSettingsXml = `<?xml version="1.0" encoding="UTF-8"?>
-<config>
-${configObjects}
-${configPlates}
-</config>`;
-
-  // ── 5. Metadata/project_settings.config (filament colours) ───────────────
+  // ── 5. Package ──────────────────────────────────────────────────────────
   const files: { name: string; data: Uint8Array }[] = [];
   const enc = new TextEncoder();
 
+  const configType = bambu
+    ? '\n  <Default Extension="config" ContentType="application/vnd.bambulab-package.settings+xml" />'
+    : '';
   const contentTypesXml = `<?xml version="1.0" encoding="UTF-8"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
   <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
-  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />
-  <Default Extension="config" ContentType="application/vnd.bambulab-package.settings+xml" />
-  <Default Extension="json" ContentType="application/json" />
+  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />${configType}
 </Types>`;
 
   const relsXml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -265,24 +271,40 @@ ${configPlates}
   files.push({ name: '[Content_Types].xml', data: enc.encode(contentTypesXml) });
   files.push({ name: '_rels/.rels', data: enc.encode(relsXml) });
   files.push({ name: '3D/3dmodel.model', data: enc.encode(modelXml) });
-  files.push({ name: 'Metadata/model_settings.config', data: enc.encode(modelSettingsXml) });
 
-  if (anyColour && materialColors.length > 0) {
-    // Pin the AMS swatch colours via `filament_colour` ONLY. We deliberately omit
-    // `filament_settings_id` / `printer_settings_id` / `inherits_group`: Bambu's
-    // PresetBundle::validate_presets pops the "customized filament or printer
-    // presets … confirm the G-code is safe" dialog when those name a preset it
-    // can't resolve to a system/bundled one (e.g. a bare "Generic PLA"). Empty /
-    // absent preset ids skip validation, so colours still pre-bind with no
-    // warning. `filament_type` is never validated, so it's safe to include.
-    const upper = materialColors.map(h => h.toUpperCase());
-    const projectSettings = {
-      filament_colour: upper,
-      filament_type: upper.map(() => 'PLA'),
-      version: '1',
-      from: 'Partwright',
-    };
-    files.push({ name: 'Metadata/project_settings.config', data: enc.encode(JSON.stringify(projectSettings, null, 4)) });
+  if (bambu) {
+    // Metadata/model_settings.config — objects + per-part plates. This is what
+    // creates the plate slots; placement (pass 3) is what actually distributes
+    // the objects across them.
+    const configObjects = prepared.map(p => {
+      const safeName = escapeXml(p.name);
+      return `  <object id="${p.objectId}">
+    <metadata key="name" value="${safeName}"/>
+    <metadata key="extruder" value="${p.extruder}"/>
+    <part id="${p.objectId}" subtype="normal_part">
+      <metadata key="name" value="${safeName}"/>
+      <metadata key="matrix" value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
+      <mesh_stat face_count="${p.faceCount}" edges_fixed="0" degenerate_facets="0" facets_removed="0" facets_reversed="0" backwards_edges="0"/>
+    </part>
+  </object>`;
+    }).join('\n');
+
+    const configPlates = prepared.map((p, i) => `  <plate>
+    <metadata key="plater_id" value="${i + 1}"/>
+    <metadata key="plater_name" value="${escapeXml(p.name)}"/>
+    <metadata key="locked" value="false"/>
+    <model_instance>
+      <metadata key="object_id" value="${p.objectId}"/>
+      <metadata key="instance_id" value="0"/>
+    </model_instance>
+  </plate>`).join('\n');
+
+    const modelSettingsXml = `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+${configObjects}
+${configPlates}
+</config>`;
+    files.push({ name: 'Metadata/model_settings.config', data: enc.encode(modelSettingsXml) });
   }
 
   const zip = buildZip(files);

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -9,8 +9,8 @@
 //     wrapper object referencing its mesh in a separate `/3D/Objects/object_N.model`
 //     file; one `<plate>` per part drives the plate count. The layout mirrors a
 //     real BambuStudio-02.05.00.66 project file (structurally equivalent, same
-//     element/field kinds). Application version is BambuStudio-2.3.2 so OrcaSlicer
-//     2.3.2 headless accepts the file (02.05.00.66 triggers its version gate):
+//     element/field kinds, same Application version) so Bambu Studio's GUI loader
+//     accepts it without crashing:
 //
 //       - Wrapper objects have EVEN ids (2, 4, 6, …), mesh objects have ODD ids
 //         (1, 3, 5, …). Object files are named object_1.model / object_2.model / …
@@ -25,12 +25,22 @@
 //         files carry plain <triangle v1 v2 v3/> (no pid/p1/paint_color in Bambu
 //         mode). This matches the reference exactly and avoids the triangle-color
 //         parsing path that segfaults on some Bambu builds.
-//       - project_settings.config is a minimal BambuStudio-compatible preset block
-//         (the template in bambuProjectTemplate.json): printer profile, print
-//         profile, filament_settings_id, nozzle_diameter, bed geometry.
-//         IMPORTANT: filament_colour must NOT appear in project_settings — OrcaSlicer
-//         2.3.2 segfaults on any N1-profile file that carries that key there. Part
-//         colour is communicated via the per-object extruder field in model_settings.
+//       - project_settings.config is a COMPLETE BambuStudio preset block (the
+//         template in bambuProjectTemplate.json — a full Bambu Lab H2C profile,
+//         536 keys). This is load-CRITICAL: Bambu's GUI `Plater::priv::load_files`
+//         indexes the per-filament arrays (filament_colour, filament_type,
+//         filament_ids, filament_map, …) when binding each object's extruder to a
+//         filament. A *partial* config (we previously shipped 6 keys, omitting the
+//         filament arrays) makes that lookup dereference null → SIGSEGV on project
+//         open. The crash is intermittent because load_files runs on a wxIdleEvent
+//         racing the background user-preset loader. (A macOS crash report pinned it:
+//         null read in load_files with the string "filament" live in a register.)
+//         The Bambu CLI's --slice path uses a DIFFERENT loader and never hit this,
+//         which is why headless slicing passed while the GUI crashed. The fix is to
+//         mirror a real, known-good H2C project's full config verbatim.
+//         NOTE: this targets Bambu Studio (the H2C profile is real and complete).
+//         OrcaSlicer 2.3.2 is NOT a valid proxy for Bambu's loader (the real
+//         reference itself fails to slice in Orca yet opens fine in Bambu).
 
 import type { MeshData } from '../geometry/types';
 import { get3MFUnitString } from '../geometry/units';
@@ -70,12 +80,33 @@ const PROD_NS = 'http://schemas.microsoft.com/3dmanufacturing/production/2015/06
 const BBS_NS = 'http://schemas.bambulab.com/package/2021';
 const REL_TYPE = 'http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel';
 
-// Bambu/Orca lay plates out in a 2-column grid; with the declared printer profile
-// the validated slot positions are a 240 mm stride with a 90 mm corner offset
-// (col → X = 90 + col·240, row → Y = 90 − row·240). Each part's <item> lands in a
-// distinct plate slot so plates aren't empty. Verified against OrcaSlicer 2.3.2.
-const PLATE_STRIDE = 240;
-const PLATE_OFFSET = 90;
+// Bambu assigns each object to a plate by WORLD POSITION (which plate-grid cell the
+// object's footprint falls in), NOT by the model_instance binding. So each part's
+// <item> must sit at the CENTRE of a distinct plate cell, or the slicer reports
+// "Object … partly inside, can not be sliced" (when it straddles a cell boundary).
+// Plates tile in a 2-column grid: cell (col,row) origin = (col·STRIDE_X, −row·STRIDE_Y),
+// and we centre the part in its cell at (bedW/2, bedH/2) within that origin.
+// STRIDE must match BambuStudio's actual plate grid for the declared printer; the
+// real H2C reference export places its 3 plates ~410 mm apart. Derived empirically
+// (Bambu CLI catches mis-placement) and from the reference.
+const PLATE_GRID_COLS = 2;
+const PLATE_STRIDE = 410;        // mm between plate-cell origins (H2C grid)
+
+/** Bed printable size [w, h] mm, parsed from the project template's printable_area
+ *  (a list of "XxY" corner strings). Falls back to the H2C bed if unparseable. */
+function bedSizeFromTemplate(): [number, number] {
+  const area = (BAMBU_TEMPLATE as { printable_area?: string[] }).printable_area;
+  if (Array.isArray(area)) {
+    let w = 0, h = 0;
+    for (const corner of area) {
+      const [x, y] = String(corner).split('x').map(Number);
+      if (Number.isFinite(x) && x > w) w = x;
+      if (Number.isFinite(y) && y > h) h = y;
+    }
+    if (w > 0 && h > 0) return [w, h];
+  }
+  return [330, 320];
+}
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;');
@@ -282,10 +313,14 @@ ${buildItems}
 //   - <assemble> block at the end
 function buildBambuPackage(prepared: PreparedPart[], _colorgroupXml: string, _anyColour: boolean, _cgid: number): Uint8Array {
   const unit = get3MFUnitString();
+  const [bedW, bedH] = bedSizeFromTemplate();
 
-  // Bambu mode: colour is per-object extruder=1 (single nozzle, AMS handles
-  // the rest). filament_colour is NOT written to project_settings — see the
-  // buildProjectSettings() comment for why (OrcaSlicer 2.3.2 segfault).
+  // Bambu mode: SINGLE-COLOUR crash-fix base. Every object is on extruder 1; the
+  // complete H2C project_settings.config defines 3 filaments so load_files can bind
+  // without null-derefing. Per-part colour (distinct extruder per part + matching
+  // filament_colour) is the tracked follow-up (#729) — it requires resizing the
+  // per-filament arrays, which can't be validated against Bambu's GUI loader
+  // headlessly, so it lands once this stable base is user-confirmed.
 
   const objectFiles: { name: string; data: Uint8Array }[] = [];
   const wrapperObjects: string[] = [];
@@ -300,9 +335,8 @@ function buildBambuPackage(prepared: PreparedPart[], _colorgroupXml: string, _an
     const meshId = 2 * partNum - 1; // ODD:  1, 3, 5, …
     const wrapperId = 2 * partNum;  // EVEN: 2, 4, 6, …
     const partFile = `3D/Objects/object_${partNum}.model`;
-    // extruder is always 1: the N1 has a single nozzle; filament colour is
-    // tracked at the AMS slot level (filament_maps), not the nozzle level.
-    // The reference file confirms all objects are extruder="1".
+    // extruder is always 1 for now (single-colour base). The reference file
+    // confirms all objects are extruder="1"; per-part extruder assignment is #729.
     const extruder = 1;
 
     // UUID patterns mirror the reference file.
@@ -338,14 +372,15 @@ ${p.trianglesPlain.join('\n')}
    </components>
   </object>`);
 
-    // Place each part in its own plate slot (2-col grid). The Z translation
-    // is -minZ: this moves the part so its bottom (minZ) lands exactly at Z=0
-    // (the bed). Works for both centered meshes (minZ<0) and non-centered ones
-    // (minZ=0, e.g. Manifold.cylinder). The USER-REF.3mf sets Z = -minZ = |minZ|
-    // for all three parts (verified against source_offset_z in model_settings).
-    const col = i % 2, row = i >> 1;
-    const tx = PLATE_OFFSET + col * PLATE_STRIDE;
-    const ty = PLATE_OFFSET - row * PLATE_STRIDE;
+    // Place each part at the CENTRE of its own plate cell (2-col grid). Centring
+    // (not corner-offsetting) keeps small parts well clear of cell boundaries so
+    // Bambu's per-plate "is this object inside?" check passes. The Z translation
+    // is -minZ: moves the part so its bottom (minZ) lands exactly at Z=0 (the bed).
+    // Works for both centered meshes (minZ<0) and non-centered (minZ=0, e.g.
+    // Manifold.cylinder). The USER-REF.3mf sets Z = -minZ for all parts.
+    const col = i % PLATE_GRID_COLS, row = Math.floor(i / PLATE_GRID_COLS);
+    const tx = bedW / 2 + col * PLATE_STRIDE;
+    const ty = bedH / 2 - row * PLATE_STRIDE;
     const tz = -p.minZ;  // lift bottom to Z=0
     buildItems.push(`  <item objectid="${wrapperId}" p:UUID="${itemUuid}" transform="1 0 0 0 1 0 0 0 1 ${fmtCoord(tx - p.cx)} ${fmtCoord(ty - p.cy)} ${fmtCoord(tz)}" printable="1"/>`);
 
@@ -379,12 +414,14 @@ ${p.trianglesPlain.join('\n')}
     // identify_id: stable integer per object instance (reference uses arbitrary values;
     // we use a simple deterministic value: 100 + wrapperId * 10 + i).
     const identifyId = 100 + wrapperId * 10 + i;
-    // filament_maps: must have exactly 1 entry to match the 1-filament project_settings.
-    // Using N entries (one per distinct colour) while project_settings only defines 1
-    // filament causes OrcaSlicer to segfault when <part> elements are present.
-    // Single "1" means "first filament → AMS slot 1"; the slicer remaps on slice.
-    const filamentMaps = '1';
-    const filamentVolMaps = '0';
+    // filament_maps / filament_volume_maps: one entry PER FILAMENT in
+    // project_settings.config (the H2C template defines 3), NOT per object. The
+    // reference uses "2 1 1" / "0 0 0" (filament→nozzle map for the dual-nozzle
+    // H2C); we mirror it so the plate's filament list stays consistent with the
+    // config — a length mismatch here is another way load_files indexes past the
+    // end of a filament array.
+    const filamentMaps = '2 1 1';
+    const filamentVolMaps = '0 0 0';
     // NOTE: plater_name MUST be empty — a non-empty value makes Bambu/Orca's
     // project loader reject the file (load fails, single plate).
     settingsPlates.push(`  <plate>
@@ -410,7 +447,7 @@ ${p.trianglesPlain.join('\n')}
   const title = escXml(getExportTitle());
   const rootModel = `<?xml version="1.0" encoding="UTF-8"?>
 <model unit="${unit}" xml:lang="en-US" xmlns="${CORE_NS}" xmlns:BambuStudio="${BBS_NS}" xmlns:p="${PROD_NS}" requiredextensions="p">
- <metadata name="Application">BambuStudio-2.3.2</metadata>
+ <metadata name="Application">BambuStudio-02.05.00.66</metadata>
  <metadata name="BambuStudio:3mfVersion">1</metadata>
  <metadata name="Copyright"></metadata>
  <metadata name="CreationDate">${today}</metadata>
@@ -446,9 +483,7 @@ ${assembleItems.join('\n')}
   </assemble>
 </config>`;
 
-  // project_settings.config: start from the full BambuStudio template and stamp
-  // per-filament arrays to length N so they're consistent with the actual filament
-  // count. A short filament_colour indexed by extruder is a known Bambu segfault.
+  // project_settings.config: the complete H2C template (see buildProjectSettings).
   const projectSettings = buildProjectSettings();
 
   // Content types: rels + model + png (for potential plate thumbnails) + gcode.
@@ -487,11 +522,12 @@ ${assembleItems.join('\n')}
 /**
  * Build the project_settings.config JSON from the BambuStudio template.
  *
- * The template is minimal: printer profile, print profile, filament_settings_id,
- * nozzle_diameter, and bed geometry. It intentionally OMITS filament_colour
- * because OrcaSlicer 2.3.2 segfaults on any N1-profile file that carries that
- * key in project_settings (verified by binary search against the extracted binary).
- * Part colour is communicated via the per-object extruder field in model_settings.
+ * The template is a COMPLETE Bambu Lab H2C profile (536 keys, copied verbatim from
+ * a real known-good project export, with filament_colour neutralized to greys for
+ * the single-colour base). Completeness is load-critical: Bambu's GUI
+ * `Plater::priv::load_files` indexes the per-filament arrays (filament_colour,
+ * filament_type, filament_ids, filament_map, …) when binding objects to filaments,
+ * and a partial config makes that index null-deref → SIGSEGV on project open.
  */
 function buildProjectSettings(): string {
   // Deep-copy the template so we don't mutate the module-level import.

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -7,15 +7,30 @@
 //   bambu: true (BAMBU/ORCA PROJECT) — the 3MF **production extension** layout
 //     Bambu Studio / OrcaSlicer require to build MULTIPLE PLATES. Each part is a
 //     wrapper object referencing its mesh in a separate `/3D/Objects/object_N.model`
-//     file; one `<plate>` per part drives the plate count; a minimal
-//     `project_settings.config` is REQUIRED or the project loader refuses to build
-//     the plate list (it falls back to a single plate). This layout + the 5-key
-//     project config is verified to load with N plates in OrcaSlicer 2.3.2 headless.
+//     file; one `<plate>` per part drives the plate count. The layout mirrors a
+//     real BambuStudio-02.05.00.66 project file (structurally equivalent, same
+//     element/field kinds). Application version is BambuStudio-2.3.2 so OrcaSlicer
+//     2.3.2 headless accepts the file (02.05.00.66 triggers its version gate):
 //
-//     WHY the split files: with `<plate>` blocks present, the loader only assembles
-//     objects stored as production-extension components — inline meshes make it
-//     report "0 objects" and abort (the load crash). See the PR for the full
-//     source-grounded spec + the headless validation recipe.
+//       - Wrapper objects have EVEN ids (2, 4, 6, …), mesh objects have ODD ids
+//         (1, 3, 5, …). Object files are named object_1.model / object_2.model / …
+//         (sequential by part number, matching the mesh ODD id).
+//       - model_settings.config carries <part id=ODD subtype="normal_part"> with
+//         matrix, source_* metadata, and mesh_stat (the element that was MISSING
+//         before this rewrite and caused the Bambu GUI crash on load).
+//       - Each <plate> carries identify_id (a stable integer) plus the filament_map*
+//         metadata Bambu needs to assign AMS slots.
+//       - An <assemble> block with one <assemble_item> per object closes the config.
+//       - Colour is per-OBJECT via the extruder field, NOT per-triangle. The mesh
+//         files carry plain <triangle v1 v2 v3/> (no pid/p1/paint_color in Bambu
+//         mode). This matches the reference exactly and avoids the triangle-color
+//         parsing path that segfaults on some Bambu builds.
+//       - project_settings.config is a minimal BambuStudio-compatible preset block
+//         (the template in bambuProjectTemplate.json): printer profile, print
+//         profile, filament_settings_id, nozzle_diameter, bed geometry.
+//         IMPORTANT: filament_colour must NOT appear in project_settings — OrcaSlicer
+//         2.3.2 segfaults on any N1-profile file that carries that key there. Part
+//         colour is communicated via the per-object extruder field in model_settings.
 
 import type { MeshData } from '../geometry/types';
 import { get3MFUnitString } from '../geometry/units';
@@ -25,6 +40,8 @@ import { buildZip } from './zip';
 import { assertFiniteMesh, assertExportableMesh, cleanMeshForExport, triColorHex, hasAnyPainted } from './meshClean';
 import { listFilaments } from '../color/palette';
 import { encodePaintColorState } from './paintColor3mf';
+// Static import so Vite bundles the JSON at build time (no fetch needed).
+import BAMBU_TEMPLATE from './bambuProjectTemplate.json';
 
 /** One selected Session Part, with its baked (optionally coloured) mesh. */
 export interface PartExport {
@@ -74,11 +91,14 @@ const enc = (s: string) => new TextEncoder().encode(s);
 
 interface PreparedPart {
   name: string;
-  vertices: string[];   // <vertex .../> lines
-  triangles: string[];  // <triangle .../> lines
+  vertices: string[];          // <vertex .../> lines
+  trianglesPlain: string[];    // plain <triangle v1 v2 v3/> for Bambu mode
+  trianglesColored: string[];  // <triangle .../> with pid/p1/paint_color for generic
   faceCount: number;
-  extruder: number;     // 1-based dominant filament (global index)
+  extruder: number;            // 1-based dominant filament (global index)
+  dominantHex: string;         // CSS hex of dominant colour (for filament_colour list)
   cx: number; cy: number; minZ: number; width: number; depth: number;
+  halfHeight: number;          // half of Z extent (unused in current code, kept for possible future use)
 }
 
 /**
@@ -90,10 +110,6 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
   const gridGap = opts.gridGapMm ?? 10;
 
   // ── Shared filament/material list across ALL parts ──────────────────────
-  // Same ordering as the single-part exporter: used palette slots in AMS-slot
-  // order first, then remaining colours first-encounter. A colour's index here
-  // is its material index (pid/p1) AND its 1-based filament index (extruder /
-  // paint_color) everywhere, so a colour maps to the same filament on every part.
   const cleaned = parts.map(p => {
     assertFiniteMesh(p.mesh);
     const c = cleanMeshForExport(p.mesh);
@@ -111,9 +127,8 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
     for (let i = 0; i < parts.length; i++) { const tc = parts[i].mesh.triColors; if (tc) for (const t of cleaned[i].validTris) pushMaterial(triColorHex(tc, t)); }
   }
 
-  // Colorgroup id: distinct from object ids. Generic uses one shared model so it
-  // must dodge object ids 1..N; Bambu puts one object per file so a small const
-  // is safe (it only shares a file with mesh id 100+i).
+  // Colorgroup id: generic uses one shared model so it must dodge object ids 1..N;
+  // Bambu puts one object per file so a small const is safe.
   const colorGroupId = bambu ? 2 : parts.length + 1;
 
   // ── Per-part geometry + colour ──────────────────────────────────────────
@@ -123,46 +138,54 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
     const tc = anyColour ? mesh.triColors ?? null : null;
 
     const numV = uniquePositions.length / 3;
-    let minX = Infinity, minY = Infinity, minZ = Infinity, maxX = -Infinity, maxY = -Infinity;
+    let minX = Infinity, minY = Infinity, minZ = Infinity, maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
     const vertices: string[] = [];
     for (let v = 0; v < numV; v++) {
       const x = uniquePositions[v * 3], y = uniquePositions[v * 3 + 1], z = uniquePositions[v * 3 + 2];
       if (x < minX) minX = x; if (x > maxX) maxX = x;
       if (y < minY) minY = y; if (y > maxY) maxY = y;
-      if (z < minZ) minZ = z;
-      vertices.push(`          <vertex x="${fmtCoord(x)}" y="${fmtCoord(y)}" z="${fmtCoord(z)}" />`);
+      if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+      vertices.push(`     <vertex x="${fmtCoord(x)}" y="${fmtCoord(y)}" z="${fmtCoord(z)}"/>`);
     }
 
     // Dominant colour → object extruder (global 1-based filament index).
     let extruder = 1;
+    let dominantHex = materialColors[0] ?? '#ff0000';
     if (tc) {
       const counts = new Map<number, number>();
       for (const t of validTris) { const idx = colorMap.get(triColorHex(tc, t)) ?? 0; counts.set(idx, (counts.get(idx) ?? 0) + 1); }
       let best = 0, bestN = -1;
       for (const [idx, n] of counts) if (n > bestN) { bestN = n; best = idx; }
       extruder = best + 1;
+      dominantHex = materialColors[best] ?? '#ff0000';
     }
 
-    const triangles: string[] = [];
+    // Bambu mode: plain triangles (no pid/p1 — colour is per-object via extruder).
+    const trianglesPlain: string[] = [];
+    // Generic/coloured mode: triangles with pid/p1/paint_color.
+    const trianglesColored: string[] = [];
     for (const t of validTris) {
       const v1 = remap[mesh.triVerts[t * 3]], v2 = remap[mesh.triVerts[t * 3 + 1]], v3 = remap[mesh.triVerts[t * 3 + 2]];
+      trianglesPlain.push(`     <triangle v1="${v1}" v2="${v2}" v3="${v3}"/>`);
       if (tc) {
         const matIdx = colorMap.get(triColorHex(tc, t)) ?? 0;
-        // Bambu only: per-triangle filament via paint_color (omitted where it
-        // matches the object's base extruder). Generic relies on pid/p1 alone.
         const paint = bambu && (matIdx + 1) !== extruder ? ` paint_color="${encodePaintColorState(matIdx + 1)}"` : '';
-        triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${colorGroupId}" p1="${matIdx}" p2="${matIdx}" p3="${matIdx}"${paint} />`);
+        trianglesColored.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${colorGroupId}" p1="${matIdx}" p2="${matIdx}" p3="${matIdx}"${paint} />`);
       } else {
-        triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
+        trianglesColored.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
       }
     }
 
     const cx = Number.isFinite(minX) ? (minX + maxX) / 2 : 0;
     const cy = Number.isFinite(minY) ? (minY + maxY) / 2 : 0;
+    const halfH = Number.isFinite(minZ) && Number.isFinite(maxZ) ? (maxZ - minZ) / 2 : 0;
     return {
-      name: part.name, vertices, triangles, faceCount: validTris.length, extruder,
+      name: part.name, vertices, trianglesPlain, trianglesColored,
+      faceCount: validTris.length, extruder, dominantHex,
       cx, cy, minZ: Number.isFinite(minZ) ? minZ : 0,
-      width: Number.isFinite(minX) ? maxX - minX : 0, depth: Number.isFinite(minY) ? maxY - minY : 0,
+      width: Number.isFinite(minX) ? maxX - minX : 0,
+      depth: Number.isFinite(minY) ? maxY - minY : 0,
+      halfHeight: halfH,
     };
   });
 
@@ -185,16 +208,21 @@ function buildGenericPackage(prepared: PreparedPart[], colorgroupXml: string, an
   const rows = Math.ceil(N / cols);
   const pitch = Math.max(1, ...prepared.map(p => Math.max(p.width, p.depth))) + gridGap;
 
-  const objectsXml = prepared.map((p, i) => `    <object id="${i + 1}" type="model">
+  // Generic mode uses coloured triangles (pid/p1) and the standard indented vertex format.
+  const objectsXml = prepared.map((p, i) => {
+    // Re-indent vertices to the deeper generic indentation (10 spaces).
+    const vertLines = p.vertices.map(v => '          ' + v.trimStart());
+    return `    <object id="${i + 1}" type="model">
       <mesh>
         <vertices>
-${p.vertices.join('\n')}
+${vertLines.join('\n')}
         </vertices>
         <triangles>
-${p.triangles.join('\n')}
+${p.trianglesColored.join('\n')}
         </triangles>
       </mesh>
-    </object>`).join('\n');
+    </object>`;
+  }).join('\n');
 
   const buildItems = prepared.map((p, i) => {
     const col = i % cols, row = Math.floor(i / cols);
@@ -236,11 +264,28 @@ ${buildItems}
 }
 
 // ── Bambu/Orca: production-extension split files, one plate per part ──────
-function buildBambuPackage(prepared: PreparedPart[], colorgroupXml: string, anyColour: boolean, cgid: number): Uint8Array {
+//
+// ID scheme (mirrors USER-REF.3mf exactly):
+//   - Mesh (real geometry) object: ODD id  = 2*i - 1  (1, 3, 5, …)
+//   - Wrapper (component ref) object: EVEN id = 2*i    (2, 4, 6, …)
+//   - Object file: 3D/Objects/object_K.model where K = part index 1..N (sequential)
+//
+// Colour: per-OBJECT via extruder field in model_settings.config. Mesh files carry
+// plain triangles (no pid/p1/paint_color). This matches how the reference does
+// multicolor and avoids the per-triangle parsing path that segfaults.
+//
+// model_settings.config structural additions vs the old code (crash fix):
+//   - <part id=ODD subtype="normal_part"> inside each <object id=EVEN>
+//   - <mesh_stat ...> inside <part>
+//   - identify_id in each <model_instance>
+//   - filament_map_mode / filament_maps / filament_volume_maps / thumbnail* in <plate>
+//   - <assemble> block at the end
+function buildBambuPackage(prepared: PreparedPart[], _colorgroupXml: string, _anyColour: boolean, _cgid: number): Uint8Array {
   const unit = get3MFUnitString();
-  const matNs = anyColour ? ` xmlns:m="${MAT_NS}"` : '';
-  const pidAttr = anyColour ? ` pid="${cgid}" pindex="0"` : '';
-  const cgBlock = anyColour ? `\n${colorgroupXml}` : '';
+
+  // Bambu mode: colour is per-object extruder=1 (single nozzle, AMS handles
+  // the rest). filament_colour is NOT written to project_settings — see the
+  // buildProjectSettings() comment for why (OrcaSlicer 2.3.2 segfault).
 
   const objectFiles: { name: string; data: Uint8Array }[] = [];
   const wrapperObjects: string[] = [];
@@ -248,25 +293,36 @@ function buildBambuPackage(prepared: PreparedPart[], colorgroupXml: string, anyC
   const objRels: string[] = [];
   const settingsObjects: string[] = [];
   const settingsPlates: string[] = [];
+  const assembleItems: string[] = [];
 
   prepared.forEach((p, i) => {
-    const wrapperId = i + 1;
-    const meshId = 100 + i;
-    const partFile = `3D/Objects/object_${meshId}.model`;
+    const partNum = i + 1;          // 1-based, matches file name + mesh ODD id
+    const meshId = 2 * partNum - 1; // ODD:  1, 3, 5, …
+    const wrapperId = 2 * partNum;  // EVEN: 2, 4, 6, …
+    const partFile = `3D/Objects/object_${partNum}.model`;
+    // extruder is always 1: the N1 has a single nozzle; filament colour is
+    // tracked at the AMS slot level (filament_maps), not the nozzle level.
+    // The reference file confirms all objects are extruder="1".
+    const extruder = 1;
 
-    // Per-part object file: full model carrying the actual mesh (+ colorgroup).
-    const meshUuid = `${String(i).padStart(4, '0')}0000-81cb-4c03-9d28-80fed5dfa1dc`;
+    // UUID patterns mirror the reference file.
+    const meshUuid = `${String(partNum).padStart(4, '0')}0000-81cb-4c03-9d28-80fed5dfa1dc`;
+    const wrapperUuid = `${String(partNum).padStart(8, '0')}-61cb-4c03-9d28-80fed5dfa1dc`;
+    const compUuid = `${String(partNum).padStart(4, '0')}0000-b206-40ff-9872-83e8017abed1`;
+    const itemUuid = `${String(wrapperId).padStart(8, '0')}-b1ec-4553-aec9-835e5b724bb4`;
+
+    // Per-part object file: plain triangles, no colorgroup (colour is per extruder).
     const partModel = `<?xml version="1.0" encoding="UTF-8"?>
-<model unit="${unit}" xml:lang="en-US" xmlns="${CORE_NS}" xmlns:BambuStudio="${BBS_NS}" xmlns:p="${PROD_NS}"${matNs} requiredextensions="p">
+<model unit="${unit}" xml:lang="en-US" xmlns="${CORE_NS}" xmlns:BambuStudio="${BBS_NS}" xmlns:p="${PROD_NS}" requiredextensions="p">
  <metadata name="BambuStudio:3mfVersion">1</metadata>
- <resources>${cgBlock}
-  <object id="${meshId}" p:UUID="${meshUuid}" type="model"${pidAttr}>
+ <resources>
+  <object id="${meshId}" p:UUID="${meshUuid}" type="model">
    <mesh>
     <vertices>
 ${p.vertices.join('\n')}
     </vertices>
     <triangles>
-${p.triangles.join('\n')}
+${p.trianglesPlain.join('\n')}
     </triangles>
    </mesh>
   </object>
@@ -275,50 +331,99 @@ ${p.triangles.join('\n')}
 </model>`;
     objectFiles.push({ name: partFile, data: enc(partModel) });
 
-    const wrapperUuid = `${String(wrapperId).padStart(8, '0')}-61cb-4c03-9d28-80fed5dfa1dc`;
-    const compUuid = `${String(wrapperId).padStart(4, '0')}${String(meshId).padStart(4, '0')}-b206-40ff-9872-83e8017abed1`;
+    // Wrapper object in root model.
     wrapperObjects.push(`  <object id="${wrapperId}" p:UUID="${wrapperUuid}" type="model">
    <components>
     <component p:path="/${partFile}" objectid="${meshId}" p:UUID="${compUuid}" transform="1 0 0 0 1 0 0 0 1 0 0 0"/>
    </components>
   </object>`);
 
-    // Place each part in its own plate slot (2-col grid) and rest it on z=0.
+    // Place each part in its own plate slot (2-col grid). The Z translation
+    // is -minZ: this moves the part so its bottom (minZ) lands exactly at Z=0
+    // (the bed). Works for both centered meshes (minZ<0) and non-centered ones
+    // (minZ=0, e.g. Manifold.cylinder). The USER-REF.3mf sets Z = -minZ = |minZ|
+    // for all three parts (verified against source_offset_z in model_settings).
     const col = i % 2, row = i >> 1;
     const tx = PLATE_OFFSET + col * PLATE_STRIDE;
     const ty = PLATE_OFFSET - row * PLATE_STRIDE;
-    const itemUuid = `${String(wrapperId).padStart(8, '0')}-b1ec-4553-aec9-835e5b724bb4`;
-    buildItems.push(`  <item objectid="${wrapperId}" p:UUID="${itemUuid}" transform="1 0 0 0 1 0 0 0 1 ${fmtCoord(tx - p.cx)} ${fmtCoord(ty - p.cy)} ${fmtCoord(-p.minZ)}" printable="1"/>`);
+    const tz = -p.minZ;  // lift bottom to Z=0
+    buildItems.push(`  <item objectid="${wrapperId}" p:UUID="${itemUuid}" transform="1 0 0 0 1 0 0 0 1 ${fmtCoord(tx - p.cx)} ${fmtCoord(ty - p.cy)} ${fmtCoord(tz)}" printable="1"/>`);
 
-    objRels.push(`  <Relationship Target="/${partFile}" Id="relObj${i}" Type="${REL_TYPE}"/>`);
+    objRels.push(`  <Relationship Target="/${partFile}" Id="rel-${partNum}" Type="${REL_TYPE}"/>`);
 
     const safeName = escXml(p.name);
+    // model_settings.config per-object block (EVEN wrapper id):
+    //   - name + extruder metadata
+    //   - face_count metadata
+    //   - <part id=ODD subtype="normal_part"> — this was MISSING before and caused
+    //     the Bambu GUI crash. It must carry: name, matrix (identity), source_*,
+    //     and <mesh_stat face_count=N ...> (all other fields 0).
+    const sourceOffsetZ = fmtCoord(Math.abs(p.minZ)); // reference writes |minZ| as source_offset_z
     settingsObjects.push(`  <object id="${wrapperId}">
     <metadata key="name" value="${safeName}"/>
-    <metadata key="extruder" value="${p.extruder}"/>
+    <metadata key="extruder" value="${extruder}"/>
+    <metadata face_count="${p.faceCount}"/>
+    <part id="${meshId}" subtype="normal_part">
+      <metadata key="name" value="${safeName}"/>
+      <metadata key="matrix" value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
+      <metadata key="source_file" value="${safeName}.stl"/>
+      <metadata key="source_object_id" value="0"/>
+      <metadata key="source_volume_id" value="0"/>
+      <metadata key="source_offset_x" value="0"/>
+      <metadata key="source_offset_y" value="0"/>
+      <metadata key="source_offset_z" value="${sourceOffsetZ}"/>
+      <mesh_stat face_count="${p.faceCount}" edges_fixed="0" degenerate_facets="0" facets_removed="0" facets_reversed="0" backwards_edges="0"/>
+    </part>
   </object>`);
+
+    // identify_id: stable integer per object instance (reference uses arbitrary values;
+    // we use a simple deterministic value: 100 + wrapperId * 10 + i).
+    const identifyId = 100 + wrapperId * 10 + i;
+    // filament_maps: must have exactly 1 entry to match the 1-filament project_settings.
+    // Using N entries (one per distinct colour) while project_settings only defines 1
+    // filament causes OrcaSlicer to segfault when <part> elements are present.
+    // Single "1" means "first filament → AMS slot 1"; the slicer remaps on slice.
+    const filamentMaps = '1';
+    const filamentVolMaps = '0';
     // NOTE: plater_name MUST be empty — a non-empty value makes Bambu/Orca's
-    // project loader reject the file (load fails, single plate). The part name
-    // already rides on the <object> name; the plate is named by the slicer.
+    // project loader reject the file (load fails, single plate).
     settingsPlates.push(`  <plate>
-    <metadata key="plater_id" value="${i + 1}"/>
+    <metadata key="plater_id" value="${partNum}"/>
     <metadata key="plater_name" value=""/>
     <metadata key="locked" value="false"/>
+    <metadata key="filament_map_mode" value="Auto For Flush"/>
+    <metadata key="filament_maps" value="${filamentMaps}"/>
+    <metadata key="filament_volume_maps" value="${filamentVolMaps}"/>
     <model_instance>
       <metadata key="object_id" value="${wrapperId}"/>
       <metadata key="instance_id" value="0"/>
+      <metadata key="identify_id" value="${identifyId}"/>
     </model_instance>
   </plate>`);
+
+    // assemble_item: assembly view transform. Z = -minZ matches the item
+    // transform so the assembly view mirrors the plate layout.
+    assembleItems.push(`   <assemble_item object_id="${wrapperId}" instance_id="0" transform="1 0 0 0 1 0 0 0 1 ${fmtCoord(tx - p.cx)} ${fmtCoord(ty - p.cy)} ${fmtCoord(tz)}" offset="0 0 0" />`);
   });
 
   const today = new Date().toISOString().slice(0, 10);
   const title = escXml(getExportTitle());
   const rootModel = `<?xml version="1.0" encoding="UTF-8"?>
 <model unit="${unit}" xml:lang="en-US" xmlns="${CORE_NS}" xmlns:BambuStudio="${BBS_NS}" xmlns:p="${PROD_NS}" requiredextensions="p">
- <metadata name="Application">BambuStudio-02.00.00.00</metadata>
+ <metadata name="Application">BambuStudio-2.3.2</metadata>
  <metadata name="BambuStudio:3mfVersion">1</metadata>
- <metadata name="Title">${title}</metadata>
+ <metadata name="Copyright"></metadata>
  <metadata name="CreationDate">${today}</metadata>
+ <metadata name="Description"></metadata>
+ <metadata name="Designer"></metadata>
+ <metadata name="DesignerCover"></metadata>
+ <metadata name="License"></metadata>
+ <metadata name="ModificationDate">${today}</metadata>
+ <metadata name="Origin"></metadata>
+ <metadata name="ProfileCover"></metadata>
+ <metadata name="ProfileDescription"></metadata>
+ <metadata name="ProfileTitle"></metadata>
+ <metadata name="Title">${title}</metadata>
  <resources>
 ${wrapperObjects.join('\n')}
  </resources>
@@ -336,32 +441,30 @@ ${objRels.join('\n')}
 <config>
 ${settingsObjects.join('\n')}
 ${settingsPlates.join('\n')}
+  <assemble>
+${assembleItems.join('\n')}
+  </assemble>
 </config>`;
 
-  // Minimal project_settings.config — REQUIRED so the project loader builds the
-  // plate list (it falls back to a single plate when no recognized config key
-  // loads). These 5 keys make the config non-empty WITHOUT naming presets that
-  // trip the "customized presets / confirm G-code" warning, and include
-  // filament_diameter-adjacent keys the loader dereferences. Validated headless.
-  const projectSettings = JSON.stringify({
-    filament_settings_id: ['Bambu PLA Basic @BBL P1P'],
-    nozzle_diameter: ['0.4'],
-    print_settings_id: '0.20mm Standard @BBL N1',
-    printable_area: ['0x0', '180x0', '180x180', '0x180'],
-    printable_height: '180',
-    printer_settings_id: 'Bambu Lab N1 0.4 nozzle',
-  }, null, 2);
+  // project_settings.config: start from the full BambuStudio template and stamp
+  // per-filament arrays to length N so they're consistent with the actual filament
+  // count. A short filament_colour indexed by extruder is a known Bambu segfault.
+  const projectSettings = buildProjectSettings();
 
-  // NOTE: no `config` content-type Default — the reference Bambu format omits it
-  // (the loader finds .config files by path), and including it broke loading.
+  // Content types: rels + model + png (for potential plate thumbnails) + gcode.
+  // Matches the reference [Content_Types].xml exactly.
   const contentTypes = `<?xml version="1.0" encoding="UTF-8"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
-  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
-  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml"/>
+ <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+ <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml"/>
+ <Default Extension="png" ContentType="image/png"/>
+ <Default Extension="gcode" ContentType="text/x.gcode"/>
 </Types>`;
+
+  // Root rels: only the 3D model relationship (no thumbnail rels — we emit no PNGs).
   const rootRels = `<?xml version="1.0" encoding="UTF-8"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Target="/3D/3dmodel.model" Id="rel0" Type="${REL_TYPE}"/>
+ <Relationship Target="/3D/3dmodel.model" Id="rel-1" Type="${REL_TYPE}"/>
 </Relationships>`;
 
   const empty = new Uint8Array(0);
@@ -379,4 +482,19 @@ ${settingsPlates.join('\n')}
     { name: 'Metadata/model_settings.config', data: enc(modelSettings) },
     { name: 'Metadata/project_settings.config', data: enc(projectSettings) },
   ]);
+}
+
+/**
+ * Build the project_settings.config JSON from the BambuStudio template.
+ *
+ * The template is minimal: printer profile, print profile, filament_settings_id,
+ * nozzle_diameter, and bed geometry. It intentionally OMITS filament_colour
+ * because OrcaSlicer 2.3.2 segfaults on any N1-profile file that carries that
+ * key in project_settings (verified by binary search against the extracted binary).
+ * Part colour is communicated via the per-object extruder field in model_settings.
+ */
+function buildProjectSettings(): string {
+  // Deep-copy the template so we don't mutate the module-level import.
+  const cfg: Record<string, unknown> = JSON.parse(JSON.stringify(BAMBU_TEMPLATE));
+  return JSON.stringify(cfg, null, 4);
 }

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -96,6 +96,41 @@ const REL_TYPE = 'http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel';
 const PLATE_GAP_FACTOR = 1 + 1 / 5;   // BambuStudio LOGICAL_PART_PLATE_GAP
 const plateGridCols = (n: number) => Math.max(1, Math.ceil(Math.sqrt(n)));
 
+// Max distinct colours (= AMS filament slots) a Bambu export carries. Bambu's
+// practical multi-AMS ceiling; beyond this, least-used colours snap to a kept slot.
+const MAX_BAMBU_FILAMENTS = 16;
+
+// Number of filaments in the bundled H2C template (bambuProjectTemplate.json) — the
+// divisor for per-filament array lengths when resizing to N filaments.
+const TEMPLATE_FILAMENT_COUNT = 3;
+
+// Per-filament config keys that are NOT `filament_`-prefixed (the prefixed ones are
+// matched by name). Sourced verbatim from BambuStudio's `s_Preset_filament_options`
+// (src/libslic3r/Preset.cpp): every key here is indexed by filament, so its array
+// must be resized when the filament count changes. Keys absent from the template are
+// simply skipped. (Metadata-ish members of that list — compatible_printers, inherits,
+// bed_type — are absent from a project config, so they never false-positive here.)
+const NONPREFIXED_PER_FILAMENT_KEYS = new Set<string>([
+  'activate_air_filtration', 'additional_cooling_fan_speed', 'additional_fan_full_speed_layer',
+  'chamber_temperatures', 'circle_compensation_speed', 'close_additional_fan_first_x_layers',
+  'close_fan_the_first_x_layers', 'complete_print_exhaust_fan_speed', 'cool_plate_temp',
+  'cool_plate_temp_initial_layer', 'cooling_perimeter_transition_distance', 'cooling_slowdown_logic',
+  'counter_coef_1', 'counter_coef_2', 'counter_coef_3', 'counter_limit_max', 'counter_limit_min',
+  'default_filament_colour', 'diameter_limit', 'during_print_exhaust_fan_speed',
+  'enable_overhang_bridge_fan', 'enable_pressure_advance', 'eng_plate_temp', 'eng_plate_temp_initial_layer',
+  'fan_cooling_layer_time', 'fan_max_speed', 'fan_min_speed', 'first_x_layer_fan_speed',
+  'first_x_layer_part_fan_speed', 'full_fan_speed_layer', 'hole_coef_1', 'hole_coef_2', 'hole_coef_3',
+  'hole_limit_max', 'hole_limit_min', 'hot_plate_temp', 'hot_plate_temp_initial_layer', 'impact_strength_z',
+  'ironing_fan_speed', 'long_retractions_when_ec', 'no_slow_down_for_cooling_on_outwalls',
+  'nozzle_temperature', 'nozzle_temperature_initial_layer', 'nozzle_temperature_range_high',
+  'nozzle_temperature_range_low', 'overhang_fan_speed', 'overhang_fan_threshold',
+  'overhang_threshold_participating_cooling', 'override_process_overhang_speed', 'pre_start_fan_time',
+  'pressure_advance', 'reduce_fan_stop_start_freq', 'retraction_distances_when_ec',
+  'slow_down_for_layer_cooling', 'slow_down_layer_time', 'slow_down_min_speed', 'supertack_plate_temp',
+  'supertack_plate_temp_initial_layer', 'temperature_vitrification', 'textured_plate_temp',
+  'textured_plate_temp_initial_layer', 'volumetric_speed_coefficients',
+]);
+
 /** Bed printable size [w, h] mm, parsed from the project template's printable_area
  *  (a list of "XxY" corner strings). Falls back to the H2C bed if unparseable. */
 function bedSizeFromTemplate(): [number, number] {
@@ -184,27 +219,28 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
   // Bambu puts one object per file so a small const is safe.
   const colorGroupId = bambu ? 2 : parts.length + 1;
 
-  // ── Bambu AMS palette: ≤3 filament slots from the most-used colours ─────────
-  // Bambu colour is per-filament, and the H2C config defines exactly 3 filaments
-  // (see buildProjectSettings — we never resize that array). Map every triangle
-  // colour to one of 3 slots: the 3 most-frequent colours across all parts become
-  // the slots; any others snap to the nearest. Each object's base extruder is its
-  // dominant slot, and triangles whose slot differs carry a per-triangle
-  // paint_color — so hand-painted brush marks and api.label regions WITHIN a part
-  // survive in Bambu, not just the dominant colour. (>3 distinct colours collapse
-  // to the nearest of 3; lifting that cap needs a validated config resize — #729.)
-  const bambuSlotOf = new Map<string, number>();   // triColorHex → 0..2
-  let bambuFilamentColors = ['#D9D9D9', '#D9D9D9', '#D9D9D9'];
+  // ── Bambu AMS palette: one filament slot per distinct colour ────────────────
+  // Bambu colour is per-filament. We emit ONE filament per distinct colour used
+  // (across all parts), up to MAX_BAMBU_FILAMENTS; the project_settings per-filament
+  // arrays are resized to match (see buildProjectSettings). Each object's base
+  // extruder is its dominant slot, and triangles whose slot differs carry a
+  // per-triangle paint_color — so hand-paint and api.label regions survive in their
+  // ACTUAL colours. (If a model exceeds the max, the least-used colours snap to the
+  // nearest kept slot.) Slots are ordered by frequency so the most-used colour is
+  // filament 1.
+  const bambuSlotOf = new Map<string, number>();   // triColorHex → filament slot 0..N-1
+  let bambuFilamentColors = ['#D9D9D9'];
   if (bambu && anyColour) {
     const freq = new Map<string, number>();
     for (let i = 0; i < parts.length; i++) {
       const t = parts[i].mesh.triColors;
       if (t) for (const tr of cleaned[i].validTris) { const h = triColorHex(t, tr); freq.set(h, (freq.get(h) ?? 0) + 1); }
     }
-    const palette = [...freq.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3).map(e => e[0]);
+    const ranked = [...freq.entries()].sort((a, b) => b[1] - a[1]).map(e => e[0]);
+    const palette = ranked.slice(0, MAX_BAMBU_FILAMENTS);
     palette.forEach((h, idx) => bambuSlotOf.set(h, idx));
-    for (const h of freq.keys()) if (!bambuSlotOf.has(h)) bambuSlotOf.set(h, nearestSlotIndex(h, palette));
-    while (palette.length < 3) palette.push(palette[palette.length - 1] ?? '#d9d9d9');
+    // Any colours beyond the max snap to the nearest kept slot.
+    for (const h of ranked) if (!bambuSlotOf.has(h)) bambuSlotOf.set(h, nearestSlotIndex(h, palette));
     bambuFilamentColors = palette.map(toBambuHex);
   }
 
@@ -369,6 +405,7 @@ function buildBambuPackage(prepared: PreparedPart[], filamentColors: string[]): 
   const unit = get3MFUnitString();
   const [bedW, bedH] = bedSizeFromTemplate();
   const gridCols = plateGridCols(prepared.length);  // ⌈√N⌉ to match Bambu's plate grid
+  const filamentCount = filamentColors.length;       // AMS slots = distinct colours
   const strideX = bedW * PLATE_GAP_FACTOR;          // BambuStudio plate_stride_x (width·1.2)
   const strideY = bedH * PLATE_GAP_FACTOR;          // BambuStudio plate_stride_y (depth·1.2)
 
@@ -472,14 +509,12 @@ ${p.trianglesBambu.join('\n')}
     // identify_id: stable integer per object instance (reference uses arbitrary values;
     // we use a simple deterministic value: 100 + wrapperId * 10 + i).
     const identifyId = 100 + wrapperId * 10 + i;
-    // filament_maps / filament_volume_maps: one entry PER FILAMENT in
-    // project_settings.config (the H2C template defines 3), NOT per object. The
-    // reference uses "2 1 1" / "0 0 0" (filament→nozzle map for the dual-nozzle
-    // H2C); we mirror it so the plate's filament list stays consistent with the
-    // config — a length mismatch here is another way load_files indexes past the
-    // end of a filament array.
-    const filamentMaps = '2 1 1';
-    const filamentVolMaps = '0 0 0';
+    // filament_maps / filament_volume_maps: ONE entry per filament (= N), indexed by
+    // filament — a short array here is another way load_files reads past the end. The
+    // values are the filament→nozzle hint; with "Auto For Flush" Bambu recomputes the
+    // assignment, so we map all to nozzle 1 (valid) at length N.
+    const filamentMaps = Array(filamentCount).fill('1').join(' ');
+    const filamentVolMaps = Array(filamentCount).fill('0').join(' ');
     // NOTE: plater_name MUST be empty — a non-empty value makes Bambu/Orca's
     // project loader reject the file (load fails, single plate).
     settingsPlates.push(`  <plate>
@@ -578,24 +613,70 @@ ${assembleItems.join('\n')}
   ]);
 }
 
+/** True if `key` holds a per-filament array (so it must scale with filament count). */
+function isPerFilamentKey(key: string): boolean {
+  return key.startsWith('filament_') || NONPREFIXED_PER_FILAMENT_KEYS.has(key);
+}
+
 /**
- * Build the project_settings.config JSON from the BambuStudio template, stamping
- * the part-colour palette into filament_colour.
+ * Build the project_settings.config JSON from the BambuStudio template, RESIZED to
+ * `filamentColors.length` (N) filaments with those colours.
  *
- * The template is a COMPLETE Bambu Lab H2C profile (536 keys, copied verbatim from
- * a real known-good project export). Completeness is load-critical: Bambu's GUI
- * `Plater::priv::load_files` indexes the per-filament arrays (filament_colour,
- * filament_type, filament_ids, filament_map, …) when binding objects to filaments,
- * and a partial config makes that index null-deref → SIGSEGV on project open. We
- * therefore only overwrite filament_colour's VALUES (keeping its length at 3, the
- * template's filament count) — never resize any array.
+ * The template is a complete Bambu Lab H2C profile with 3 filaments. Every
+ * per-filament array (filament_colour, nozzle_temperature, the plate temps, …) is
+ * indexed by filament when Bambu's GUI `Plater::priv::load_files` binds objects to
+ * filaments — an array shorter than the max filament index null-derefs → SIGSEGV on
+ * open. So to support N colours we must resize EVERY per-filament array to N (or its
+ * multiple), consistently. Each such array has a multiplier m = len/3 (×1 per
+ * filament, ×2 per extruder-variant, ×4 …); since all template filaments share one
+ * preset, every m-tuple is identical, so we repeat filament-0's m-tuple N times.
+ * Non-per-filament arrays (machine limits, printable_area, compatible-machine list)
+ * are left untouched. `isPerFilamentKey` is the gate, derived from BambuStudio's
+ * `s_Preset_filament_options`. Structural arrays that don't follow the repeat rule
+ * (filament_colour, filament_self_index, the flush matrices) are set explicitly.
  */
 function buildProjectSettings(filamentColors: string[]): string {
   // Deep-copy the template so we don't mutate the module-level import.
   const cfg: Record<string, unknown> = JSON.parse(JSON.stringify(BAMBU_TEMPLATE));
-  const existing = cfg.filament_colour;
-  if (Array.isArray(existing) && filamentColors.length === existing.length) {
-    cfg.filament_colour = filamentColors;
+  const N = Math.max(1, filamentColors.length);
+  const T = TEMPLATE_FILAMENT_COUNT;
+
+  // Resize every per-filament array: repeat filament-0's m-tuple N times.
+  for (const key of Object.keys(cfg)) {
+    const v = cfg[key];
+    if (!Array.isArray(v) || v.length === 0 || v.length % T !== 0) continue;
+    if (!isPerFilamentKey(key)) continue;
+    const m = v.length / T;
+    const tuple = v.slice(0, m);
+    const out: unknown[] = [];
+    for (let i = 0; i < N; i++) out.push(...tuple);
+    cfg[key] = out;
   }
+
+  // Explicit structural overrides (don't follow the plain repeat rule):
+  cfg.filament_colour = filamentColors;                                  // N colours, one per filament
+  // filament_self_index is the 1-based filament index, doubled per extruder variant:
+  // [1,1,2,2,…,N,N].
+  if (Array.isArray(cfg.filament_self_index)) {
+    const si: string[] = [];
+    for (let i = 1; i <= N; i++) { si.push(String(i), String(i)); }
+    cfg.filament_self_index = si;
+  }
+  // flush_volumes_matrix is per-nozzle (2) × N×N: diagonal 0, off-diagonal a default
+  // purge volume. Bambu recomputes flush on slice ("Auto For Flush"); size is what
+  // matters for load.
+  if (Array.isArray(cfg.flush_volumes_matrix)) {
+    const FLUSH = '280';
+    const mat: string[] = [];
+    for (let nozzle = 0; nozzle < 2; nozzle++)
+      for (let i = 0; i < N; i++)
+        for (let j = 0; j < N; j++) mat.push(i === j ? '0' : FLUSH);
+    cfg.flush_volumes_matrix = mat;
+  }
+  // flush_volumes_vector is per-nozzle (2) × N (a per-filament purge volume).
+  if (Array.isArray(cfg.flush_volumes_vector)) {
+    cfg.flush_volumes_vector = Array(2 * N).fill('140');
+  }
+
   return JSON.stringify(cfg, null, 4);
 }

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -224,8 +224,30 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
     ? `    <m:colorgroup id="${colorGroupId}">\n${materialColors.map(h => `      <m:color color="${h.toUpperCase()}FF" />`).join('\n')}\n    </m:colorgroup>`
     : '';
 
+  // Bambu per-part colour: map each part's dominant colour onto one of the THREE
+  // AMS filament slots the H2C template defines. We keep that filament count fixed
+  // at 3 — resizing the 130+ per-filament config arrays can't be validated against
+  // Bambu's GUI loader headlessly, and a too-short array is exactly what crashed it
+  // before. So colour is capped at 3 distinct part colours (the common AMS case);
+  // >3 reuses the closest slot. Per-part colour beyond 3 is the tracked follow-up.
+  let bambuFilamentColors: string[] = ['#D9D9D9', '#D9D9D9', '#D9D9D9'];
+  if (bambu && anyColour) {
+    const palette: string[] = [];
+    for (const p of prepared) {
+      const hex = p.dominantHex.toLowerCase();
+      if (!palette.includes(hex) && palette.length < 3) palette.push(hex);
+    }
+    // Reassign each part's extruder to its slot (1-based) in the capped palette.
+    for (const p of prepared) {
+      const idx = palette.indexOf(p.dominantHex.toLowerCase());
+      p.extruder = idx >= 0 ? idx + 1 : 1;
+    }
+    while (palette.length < 3) palette.push(palette[palette.length - 1] ?? '#d9d9d9');
+    bambuFilamentColors = palette.map(h => '#' + h.replace(/^#/, '').toUpperCase());
+  }
+
   const built = bambu
-    ? buildBambuPackage(prepared, colorgroupXml, anyColour, colorGroupId)
+    ? buildBambuPackage(prepared, bambuFilamentColors)
     : buildGenericPackage(prepared, colorgroupXml, anyColour, colorGroupId, gridGap);
 
   const mimeType = 'application/vnd.ms-package.3dmanufacturing';
@@ -311,16 +333,16 @@ ${buildItems}
 //   - identify_id in each <model_instance>
 //   - filament_map_mode / filament_maps / filament_volume_maps / thumbnail* in <plate>
 //   - <assemble> block at the end
-function buildBambuPackage(prepared: PreparedPart[], _colorgroupXml: string, _anyColour: boolean, _cgid: number): Uint8Array {
+function buildBambuPackage(prepared: PreparedPart[], filamentColors: string[]): Uint8Array {
   const unit = get3MFUnitString();
   const [bedW, bedH] = bedSizeFromTemplate();
 
-  // Bambu mode: SINGLE-COLOUR crash-fix base. Every object is on extruder 1; the
-  // complete H2C project_settings.config defines 3 filaments so load_files can bind
-  // without null-derefing. Per-part colour (distinct extruder per part + matching
-  // filament_colour) is the tracked follow-up (#729) — it requires resizing the
-  // per-filament arrays, which can't be validated against Bambu's GUI loader
-  // headlessly, so it lands once this stable base is user-confirmed.
+  // Bambu mode: per-part colour via the per-object `extruder` field (1..3),
+  // mapped to the 3 AMS filament slots whose colours go in project_settings'
+  // filament_colour. The complete H2C config keeps all per-filament arrays sized
+  // to 3 so load_files binds without null-derefing (the prior crash). The mesh
+  // files still carry PLAIN triangles — whole-object colour, no per-triangle
+  // paint_color (in-part multicolour would need the unvalidated paint_color path).
 
   const objectFiles: { name: string; data: Uint8Array }[] = [];
   const wrapperObjects: string[] = [];
@@ -335,9 +357,10 @@ function buildBambuPackage(prepared: PreparedPart[], _colorgroupXml: string, _an
     const meshId = 2 * partNum - 1; // ODD:  1, 3, 5, …
     const wrapperId = 2 * partNum;  // EVEN: 2, 4, 6, …
     const partFile = `3D/Objects/object_${partNum}.model`;
-    // extruder is always 1 for now (single-colour base). The reference file
-    // confirms all objects are extruder="1"; per-part extruder assignment is #729.
-    const extruder = 1;
+    // Per-object extruder = the part's AMS slot (1..3), assigned in build3MFProject
+    // from its dominant colour. The reference confirms this field drives object
+    // colour in Bambu; values >1 are the minimal extension of its all-"1" layout.
+    const extruder = p.extruder;
 
     // UUID patterns mirror the reference file.
     const meshUuid = `${String(partNum).padStart(4, '0')}0000-81cb-4c03-9d28-80fed5dfa1dc`;
@@ -483,8 +506,9 @@ ${assembleItems.join('\n')}
   </assemble>
 </config>`;
 
-  // project_settings.config: the complete H2C template (see buildProjectSettings).
-  const projectSettings = buildProjectSettings();
+  // project_settings.config: the complete H2C template with filament_colour set to
+  // the part palette (see buildProjectSettings).
+  const projectSettings = buildProjectSettings(filamentColors);
 
   // Content types: rels + model + png (for potential plate thumbnails) + gcode.
   // Matches the reference [Content_Types].xml exactly.
@@ -520,17 +544,23 @@ ${assembleItems.join('\n')}
 }
 
 /**
- * Build the project_settings.config JSON from the BambuStudio template.
+ * Build the project_settings.config JSON from the BambuStudio template, stamping
+ * the part-colour palette into filament_colour.
  *
  * The template is a COMPLETE Bambu Lab H2C profile (536 keys, copied verbatim from
- * a real known-good project export, with filament_colour neutralized to greys for
- * the single-colour base). Completeness is load-critical: Bambu's GUI
+ * a real known-good project export). Completeness is load-critical: Bambu's GUI
  * `Plater::priv::load_files` indexes the per-filament arrays (filament_colour,
  * filament_type, filament_ids, filament_map, …) when binding objects to filaments,
- * and a partial config makes that index null-deref → SIGSEGV on project open.
+ * and a partial config makes that index null-deref → SIGSEGV on project open. We
+ * therefore only overwrite filament_colour's VALUES (keeping its length at 3, the
+ * template's filament count) — never resize any array.
  */
-function buildProjectSettings(): string {
+function buildProjectSettings(filamentColors: string[]): string {
   // Deep-copy the template so we don't mutate the module-level import.
   const cfg: Record<string, unknown> = JSON.parse(JSON.stringify(BAMBU_TEMPLATE));
+  const existing = cfg.filament_colour;
+  if (Array.isArray(existing) && filamentColors.length === existing.length) {
+    cfg.filament_colour = filamentColors;
+  }
   return JSON.stringify(cfg, null, 4);
 }

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -1,0 +1,274 @@
+// Multi-part 3MF "project" export — bundles several Session Parts into ONE 3MF,
+// each part on its own build PLATE, with colours pre-bound to filaments.
+//
+// The file is BOTH:
+//   1. A valid GENERIC 3MF — multiple `<object>` + `<build><item>` with an
+//      `<m:colorgroup>` material list, so any slicer/viewer (Cura, PrusaSlicer,
+//      Microsoft 3D Viewer) opens it and sees every part + colour.
+//   2. A Bambu Studio / OrcaSlicer PROJECT — the `Application` metadata marker
+//      flips Bambu into project mode, `Metadata/model_settings.config` assigns
+//      one part per plate (and per-object `extruder`), per-triangle `paint_color`
+//      carries the painted multi-colour, and `Metadata/project_settings.config`
+//      pre-populates the filament list so colours land on AMS slots.
+//
+// Plate recognition needs only the `<plate>` blocks in model_settings.config +
+// the `BambuStudio-` Application marker; the per-plate gcode/json/png files are
+// post-slice artifacts and are intentionally omitted. See the PR description for
+// the source-grounded format spec.
+
+import type { MeshData } from '../geometry/types';
+import { get3MFUnitString } from '../geometry/units';
+import { getExportFilename, getExportTitle } from './download';
+import type { BuiltExport } from './gltf';
+import { buildZip } from './zip';
+import { assertFiniteMesh, assertExportableMesh, cleanMeshForExport, triColorHex, hasAnyPainted } from './meshClean';
+import { listFilaments } from '../color/palette';
+import { encodePaintColorState } from './paintColor3mf';
+import { getConfig } from '../config/appConfig';
+
+/** One selected Session Part, with its baked (optionally coloured) mesh. */
+export interface PartExport {
+  /** Display name — becomes the object/plate name in the 3MF. */
+  name: string;
+  /** The part's mesh. `triColors` (if present) drives the per-triangle colour. */
+  mesh: MeshData;
+}
+
+export interface Build3MFProjectOptions {
+  /** Override the download filename stem. */
+  customName?: string;
+  /** Where each part is centred on its plate (mm). Defaults to the configured
+   *  nominal bed centre. Each part sits on z=0; Bambu auto-drops to the bed. */
+  platePositionMm?: number;
+}
+
+function escapeXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+interface PreparedPart {
+  name: string;
+  objectId: number;
+  vertices: string[];   // <vertex .../> lines
+  triangles: string[];  // <triangle .../> lines
+  faceCount: number;
+  extruder: number;     // 1-based dominant filament for the whole object
+  transform: string;    // 12-value row-major item transform
+}
+
+/**
+ * Build a multi-part Bambu/generic 3MF blob. Each part becomes one object on its
+ * own plate. Colours are shared across all parts via a single filament list so a
+ * given colour maps to the same AMS slot on every plate.
+ */
+export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOptions = {}): BuiltExport {
+  if (parts.length === 0) throw new Error('Cannot export: no parts selected.');
+  const platePos = opts.platePositionMm ?? getConfig().export.platePositionMm;
+
+  // ── 1. Shared filament list across ALL parts ────────────────────────────
+  // The same ordering rule as the single-part exporter: used palette slots in
+  // AMS-slot order first, then any remaining colours in first-encounter order.
+  // A colour's index in this list is its filament/material index everywhere.
+  const cleaned = parts.map(p => {
+    assertFiniteMesh(p.mesh);
+    const c = cleanMeshForExport(p.mesh);
+    assertExportableMesh(c.validTris);
+    return c;
+  });
+
+  const anyColour = parts.some((p, i) =>
+    p.mesh.triColors != null && hasAnyPainted(p.mesh.triColors, cleaned[i].validTris));
+
+  const colorMap = new Map<string, number>(); // hex -> material/filament index (0-based)
+  const materialColors: string[] = [];
+  const pushMaterial = (hex: string) => {
+    if (!colorMap.has(hex)) { colorMap.set(hex, materialColors.length); materialColors.push(hex); }
+  };
+
+  if (anyColour) {
+    const usedHexes = new Set<string>();
+    for (let i = 0; i < parts.length; i++) {
+      const tc = parts[i].mesh.triColors;
+      if (!tc) continue;
+      for (const t of cleaned[i].validTris) usedHexes.add(triColorHex(tc, t));
+    }
+    for (const slot of listFilaments()) {
+      const hex = slot.hex.toLowerCase();
+      if (usedHexes.has(hex)) pushMaterial(hex);
+    }
+    for (let i = 0; i < parts.length; i++) {
+      const tc = parts[i].mesh.triColors;
+      if (!tc) continue;
+      for (const t of cleaned[i].validTris) pushMaterial(triColorHex(tc, t));
+    }
+  }
+
+  const colorGroupId = parts.length + 1; // distinct from object ids 1..N
+
+  // ── 2. Per-part geometry + colour ───────────────────────────────────────
+  const prepared: PreparedPart[] = parts.map((part, i) => {
+    const { mesh } = part;
+    const { remap, uniquePositions, validTris } = cleaned[i];
+    const tc = anyColour ? mesh.triColors ?? null : null;
+
+    // Vertices + bounding box (for plate centring).
+    const numUniqueVerts = uniquePositions.length / 3;
+    let minX = Infinity, minY = Infinity, minZ = Infinity, maxX = -Infinity, maxY = -Infinity;
+    const vertices: string[] = [];
+    for (let v = 0; v < numUniqueVerts; v++) {
+      const x = uniquePositions[v * 3], y = uniquePositions[v * 3 + 1], z = uniquePositions[v * 3 + 2];
+      if (x < minX) minX = x; if (x > maxX) maxX = x;
+      if (y < minY) minY = y; if (y > maxY) maxY = y;
+      if (z < minZ) minZ = z;
+      vertices.push(`          <vertex x="${x.toFixed(6)}" y="${y.toFixed(6)}" z="${z.toFixed(6)}" />`);
+    }
+
+    // Dominant colour → object-level extruder (the part's "base" filament).
+    let extruder = 1;
+    if (tc) {
+      const counts = new Map<number, number>();
+      for (const t of validTris) {
+        const idx = colorMap.get(triColorHex(tc, t)) ?? 0;
+        counts.set(idx, (counts.get(idx) ?? 0) + 1);
+      }
+      let bestIdx = 0, bestN = -1;
+      for (const [idx, n] of counts) if (n > bestN) { bestN = n; bestIdx = idx; }
+      extruder = bestIdx + 1;
+    }
+
+    // Triangles. Generic colour via pid/p1 (face colour); Bambu colour via
+    // paint_color, omitted where the triangle matches the object's extruder.
+    const triangles: string[] = [];
+    for (const t of validTris) {
+      const v1 = remap[mesh.triVerts[t * 3]];
+      const v2 = remap[mesh.triVerts[t * 3 + 1]];
+      const v3 = remap[mesh.triVerts[t * 3 + 2]];
+      if (tc) {
+        const matIdx = colorMap.get(triColorHex(tc, t)) ?? 0;
+        const filament = matIdx + 1;
+        const paint = filament === extruder ? '' : ` paint_color="${encodePaintColorState(filament)}"`;
+        triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" pid="${colorGroupId}" p1="${matIdx}" p2="${matIdx}" p3="${matIdx}"${paint} />`);
+      } else {
+        triangles.push(`          <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
+      }
+    }
+
+    // Centre the part on its plate, resting on z=0.
+    const cx = Number.isFinite(minX) ? (minX + maxX) / 2 : 0;
+    const cy = Number.isFinite(minY) ? (minY + maxY) / 2 : 0;
+    const tx = platePos - cx, ty = platePos - cy, tz = Number.isFinite(minZ) ? -minZ : 0;
+    const transform = `1 0 0 0 1 0 0 0 1 ${tx.toFixed(6)} ${ty.toFixed(6)} ${tz.toFixed(6)}`;
+
+    return { name: part.name, objectId: i + 1, vertices, triangles, faceCount: validTris.length, extruder, transform };
+  });
+
+  // ── 3. 3D/3dmodel.model ─────────────────────────────────────────────────
+  const matNs = anyColour ? ' xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"' : '';
+  const colorgroupXml = anyColour
+    ? `\n    <m:colorgroup id="${colorGroupId}">\n${materialColors.map(h => `      <m:color color="${h.toUpperCase()}FF" />`).join('\n')}\n    </m:colorgroup>`
+    : '';
+
+  const objectsXml = prepared.map(p => `    <object id="${p.objectId}" type="model">
+      <mesh>
+        <vertices>
+${p.vertices.join('\n')}
+        </vertices>
+        <triangles>
+${p.triangles.join('\n')}
+        </triangles>
+      </mesh>
+    </object>`).join('\n');
+
+  const buildItemsXml = prepared.map(p =>
+    `    <item objectid="${p.objectId}" transform="${p.transform}" printable="1" />`).join('\n');
+
+  const today = new Date().toISOString().slice(0, 10);
+  const title = escapeXml(getExportTitle());
+
+  const modelXml = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="${get3MFUnitString()}" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"${matNs} xmlns:BambuStudio="http://schemas.bambulab.com/package/2021">
+  <metadata name="Application">BambuStudio-02.00.00.00</metadata>
+  <metadata name="BambuStudio:3mfVersion">1</metadata>
+  <metadata name="Title">${title}</metadata>
+  <metadata name="Designer">Partwright</metadata>
+  <metadata name="CreationDate">${today}</metadata>
+  <metadata name="ModificationDate">${today}</metadata>
+  <metadata name="LicenseTerms">Created with Partwright — https://www.partwrightstudio.com</metadata>
+  <resources>${colorgroupXml}
+${objectsXml}
+  </resources>
+  <build>
+${buildItemsXml}
+  </build>
+</model>`;
+
+  // ── 4. Metadata/model_settings.config (objects + per-part plates) ────────
+  const configObjects = prepared.map(p => {
+    const safeName = escapeXml(p.name);
+    return `  <object id="${p.objectId}">
+    <metadata key="name" value="${safeName}"/>
+    <metadata key="extruder" value="${p.extruder}"/>
+    <part id="${p.objectId}" subtype="normal_part">
+      <metadata key="name" value="${safeName}"/>
+      <metadata key="matrix" value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
+      <mesh_stat face_count="${p.faceCount}" edges_fixed="0" degenerate_facets="0" facets_removed="0" facets_reversed="0" backwards_edges="0"/>
+    </part>
+  </object>`;
+  }).join('\n');
+
+  const configPlates = prepared.map((p, i) => `  <plate>
+    <metadata key="plater_id" value="${i + 1}"/>
+    <metadata key="plater_name" value="${escapeXml(p.name)}"/>
+    <metadata key="locked" value="false"/>
+    <model_instance>
+      <metadata key="object_id" value="${p.objectId}"/>
+      <metadata key="instance_id" value="0"/>
+    </model_instance>
+  </plate>`).join('\n');
+
+  const modelSettingsXml = `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+${configObjects}
+${configPlates}
+</config>`;
+
+  // ── 5. Metadata/project_settings.config (filament colours) ───────────────
+  const files: { name: string; data: Uint8Array }[] = [];
+  const enc = new TextEncoder();
+
+  const contentTypesXml = `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
+  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />
+  <Default Extension="config" ContentType="application/vnd.bambulab-package.settings+xml" />
+  <Default Extension="json" ContentType="application/json" />
+</Types>`;
+
+  const relsXml = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Target="/3D/3dmodel.model" Id="rel0" Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel" />
+</Relationships>`;
+
+  files.push({ name: '[Content_Types].xml', data: enc.encode(contentTypesXml) });
+  files.push({ name: '_rels/.rels', data: enc.encode(relsXml) });
+  files.push({ name: '3D/3dmodel.model', data: enc.encode(modelXml) });
+  files.push({ name: 'Metadata/model_settings.config', data: enc.encode(modelSettingsXml) });
+
+  if (anyColour && materialColors.length > 0) {
+    const upper = materialColors.map(h => h.toUpperCase());
+    const projectSettings = {
+      filament_colour: upper,
+      filament_type: upper.map(() => 'PLA'),
+      filament_settings_id: upper.map(() => 'Generic PLA'),
+      filament_ids: upper.map(() => ''),
+      version: '1',
+      from: 'Partwright',
+    };
+    files.push({ name: 'Metadata/project_settings.config', data: enc.encode(JSON.stringify(projectSettings, null, 4)) });
+  }
+
+  const zip = buildZip(files);
+  const mimeType = 'application/vnd.ms-package.3dmanufacturing';
+  const blob = new Blob([zip], { type: mimeType });
+  return { blob, filename: getExportFilename('3mf', opts.customName), mimeType };
+}

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -305,21 +305,12 @@ ${configObjects}
 ${configPlates}
 </config>`;
     files.push({ name: 'Metadata/model_settings.config', data: enc.encode(modelSettingsXml) });
-
-    // Metadata/project_settings.config — REQUIRED for Bambu to build the plate
-    // list. On import the Plater sets `load_config = false` (→ a single plate via
-    // reload_all_objects, NOT load_from_3mf_structure) whenever the project config
-    // loads ZERO recognized DynamicPrintConfig keys. So an absent/empty config
-    // collapses our N plates to one. We emit the MINIMAL config that flips
-    // load_config true WITHOUT tripping the "customized presets / confirm G-code"
-    // warning: `filament_diameter` is a recognized key (so the config isn't empty)
-    // AND is dereferenced without a default in PresetBundle::validate_presets (so
-    // omitting it would crash), while carrying NO `*_settings_id` / `inherits_group`
-    // means validate_presets finds nothing to validate → no warning. Colours still
-    // come from the model's m:colorgroup + extruder + paint_color, not from here.
-    const filamentCount = Math.max(1, materialColors.length);
-    const projectSettings = { filament_diameter: Array(filamentCount).fill('1.75') };
-    files.push({ name: 'Metadata/project_settings.config', data: enc.encode(JSON.stringify(projectSettings, null, 4)) });
+    // NOTE: we deliberately do NOT emit Metadata/project_settings.config. A
+    // minimal one (e.g. just filament_diameter) flips Bambu into its full
+    // project-load path, which then CRASHES on the rest of the config bundle it
+    // expects; a complete bundle would reintroduce the preset warning and is too
+    // version-fragile to synthesize. Without it Bambu opens the file safely but
+    // shows a single plate (see Known issue in the PR / discussion).
   }
 
   const zip = buildZip(files);

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -305,6 +305,21 @@ ${configObjects}
 ${configPlates}
 </config>`;
     files.push({ name: 'Metadata/model_settings.config', data: enc.encode(modelSettingsXml) });
+
+    // Metadata/project_settings.config — REQUIRED for Bambu to build the plate
+    // list. On import the Plater sets `load_config = false` (→ a single plate via
+    // reload_all_objects, NOT load_from_3mf_structure) whenever the project config
+    // loads ZERO recognized DynamicPrintConfig keys. So an absent/empty config
+    // collapses our N plates to one. We emit the MINIMAL config that flips
+    // load_config true WITHOUT tripping the "customized presets / confirm G-code"
+    // warning: `filament_diameter` is a recognized key (so the config isn't empty)
+    // AND is dereferenced without a default in PresetBundle::validate_presets (so
+    // omitting it would crash), while carrying NO `*_settings_id` / `inherits_group`
+    // means validate_presets finds nothing to validate → no warning. Colours still
+    // come from the model's m:colorgroup + extruder + paint_color, not from here.
+    const filamentCount = Math.max(1, materialColors.length);
+    const projectSettings = { filament_diameter: Array(filamentCount).fill('1.75') };
+    files.push({ name: 'Metadata/project_settings.config', data: enc.encode(JSON.stringify(projectSettings, null, 4)) });
   }
 
   const zip = buildZip(files);

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -42,6 +42,12 @@ export interface Build3MFProjectOptions {
   platePositionMm?: number;
 }
 
+// Bambu/Orca tile build plates in one shared world space with a gap of 20% of
+// the bed size between plate origins (OrcaSlicer `LOGICAL_PART_PLATE_GAP = 1/5`,
+// PartPlate.cpp), so the centre-to-centre stride is `bed × 1.2`. Structural
+// constant from the slicer source, not a user-tunable knob.
+const PLATE_GAP_FACTOR = 1.2;
+
 function escapeXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
@@ -153,10 +159,17 @@ export function build3MFProject(parts: PartExport[], opts: Build3MFProjectOption
       }
     }
 
-    // Centre the part on its plate, resting on z=0.
+    // Place the part on ITS OWN plate, resting on z=0. Bambu/Orca assign an
+    // object to a plate by WORLD POSITION (bounding-box overlap with the plate's
+    // box), NOT by the model_settings.config <model_instance> grouping — so each
+    // part must be offset into a distinct plate region or they all stack on plate
+    // 1. Plates tile in one shared world space, single row, stride = bed × 1.2
+    // (OrcaSlicer's fixed LOGICAL_PART_PLATE_GAP = 0.2). `platePos` is the bed
+    // centre (half-extent), so bed = 2·platePos and the stride is platePos·2.4.
+    const plateCenterX = platePos + i * (platePos * 2 * PLATE_GAP_FACTOR);
     const cx = Number.isFinite(minX) ? (minX + maxX) / 2 : 0;
     const cy = Number.isFinite(minY) ? (minY + maxY) / 2 : 0;
-    const tx = platePos - cx, ty = platePos - cy, tz = Number.isFinite(minZ) ? -minZ : 0;
+    const tx = plateCenterX - cx, ty = platePos - cy, tz = Number.isFinite(minZ) ? -minZ : 0;
     const transform = `1 0 0 0 1 0 0 0 1 ${tx.toFixed(6)} ${ty.toFixed(6)} ${tz.toFixed(6)}`;
 
     return { name: part.name, objectId: i + 1, vertices, triangles, faceCount: validTris.length, extruder, transform };
@@ -255,12 +268,17 @@ ${configPlates}
   files.push({ name: 'Metadata/model_settings.config', data: enc.encode(modelSettingsXml) });
 
   if (anyColour && materialColors.length > 0) {
+    // Pin the AMS swatch colours via `filament_colour` ONLY. We deliberately omit
+    // `filament_settings_id` / `printer_settings_id` / `inherits_group`: Bambu's
+    // PresetBundle::validate_presets pops the "customized filament or printer
+    // presets … confirm the G-code is safe" dialog when those name a preset it
+    // can't resolve to a system/bundled one (e.g. a bare "Generic PLA"). Empty /
+    // absent preset ids skip validation, so colours still pre-bind with no
+    // warning. `filament_type` is never validated, so it's safe to include.
     const upper = materialColors.map(h => h.toUpperCase());
     const projectSettings = {
       filament_colour: upper,
       filament_type: upper.map(() => 'PLA'),
-      filament_settings_id: upper.map(() => 'Generic PLA'),
-      filament_ids: upper.map(() => ''),
       version: '1',
       from: 'Partwright',
     };

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -82,15 +82,16 @@ const REL_TYPE = 'http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel';
 
 // Bambu assigns each object to a plate by WORLD POSITION (which plate-grid cell the
 // object's footprint falls in), NOT by the model_instance binding. So each part's
-// <item> must sit at the CENTRE of a distinct plate cell, or the slicer reports
-// "Object … partly inside, can not be sliced" (when it straddles a cell boundary).
-// Plates tile in a 2-column grid: cell (col,row) origin = (col·STRIDE_X, −row·STRIDE_Y),
-// and we centre the part in its cell at (bedW/2, bedH/2) within that origin.
-// STRIDE must match BambuStudio's actual plate grid for the declared printer; the
-// real H2C reference export places its 3 plates ~410 mm apart. Derived empirically
-// (Bambu CLI catches mis-placement) and from the reference.
-const PLATE_GRID_COLS = 2;
+// <item> must sit at the CENTRE of the plate cell Bambu would lay out, or the part
+// lands off-plate (slicer: "no object is fully inside") and the whole file is
+// rejected. Two things must match Bambu's PartPlateList grid exactly:
+//   - COLUMN COUNT: Bambu tiles N plates in a ⌈√N⌉-column grid, numbered
+//     left→right, top→bottom (verified: a real 3-plate export uses 2 cols; a
+//     6-plate export uses 3 cols — plate 3 is the 3rd column, not a 2nd row).
+//   - STRIDE: ~410 mm between cell origins for the H2C bed (from the reference +
+//     Bambu-CLI validation). Cell (col,row) centre = (bedW/2 + col·S, bedH/2 − row·S).
 const PLATE_STRIDE = 410;        // mm between plate-cell origins (H2C grid)
+const plateGridCols = (n: number) => Math.max(1, Math.ceil(Math.sqrt(n)));
 
 /** Bed printable size [w, h] mm, parsed from the project template's printable_area
  *  (a list of "XxY" corner strings). Falls back to the H2C bed if unparseable. */
@@ -336,6 +337,7 @@ ${buildItems}
 function buildBambuPackage(prepared: PreparedPart[], filamentColors: string[]): Uint8Array {
   const unit = get3MFUnitString();
   const [bedW, bedH] = bedSizeFromTemplate();
+  const gridCols = plateGridCols(prepared.length);  // ⌈√N⌉ to match Bambu's plate grid
 
   // Bambu mode: per-part colour via the per-object `extruder` field (1..3),
   // mapped to the 3 AMS filament slots whose colours go in project_settings'
@@ -401,7 +403,7 @@ ${p.trianglesPlain.join('\n')}
     // is -minZ: moves the part so its bottom (minZ) lands exactly at Z=0 (the bed).
     // Works for both centered meshes (minZ<0) and non-centered (minZ=0, e.g.
     // Manifold.cylinder). The USER-REF.3mf sets Z = -minZ for all parts.
-    const col = i % PLATE_GRID_COLS, row = Math.floor(i / PLATE_GRID_COLS);
+    const col = i % gridCols, row = Math.floor(i / gridCols);
     const tx = bedW / 2 + col * PLATE_STRIDE;
     const ty = bedH / 2 - row * PLATE_STRIDE;
     const tz = -p.minZ;  // lift bottom to Z=0

--- a/src/main.ts
+++ b/src/main.ts
@@ -4170,13 +4170,12 @@ async function main() {
     }
   }
 
-  /** Console/AI twin of the multi-part 3MF export — bakes the requested parts
-   *  (default: all) and downloads one 3MF. `opts.bambu` (default true) → one part
-   *  per build plate (Bambu/Orca project); false → a generic multi-object 3MF.
-   *  Returns a result object (no UI modal). Kept as a standalone function so the
-   *  `partwrightAPI` object literal stays thin. */
-  async function export3MFPartsApi(partIds?: string[], filename?: string, opts?: { bambu?: boolean }): Promise<{ ok: true; filename: string; parts: number } | { error: string }> {
-    assertString(filename, 'export3MFParts(partIds, filename)', { optional: true });
+  /** Shared core for the multi-part 3MF exports: validate the part ids, bake each
+   *  selected part's coloured mesh off-editor, and build the 3MF. Returns the
+   *  BuiltExport (no download, no base64) so callers can either trigger a
+   *  download or return the bytes. `opts.bambu` (default true) → one part per
+   *  build plate (Bambu/Orca project); false → a generic multi-object 3MF. */
+  async function build3MFPartsExport(partIds?: string[], filename?: string, opts?: { bambu?: boolean }): Promise<{ built: import('./export/gltf').BuiltExport; parts: number } | { error: string }> {
     const bambu = opts?.bambu ?? true;
     const allParts = getState().parts;
     if (allParts.length === 0) return { error: 'No parts in this session.' };
@@ -4200,11 +4199,37 @@ async function main() {
     try {
       const bed = loadPrinterSettings().bed;
       const built = build3MFProject(baked, { customName: filename, bambu, bedSize: [bed[0], bed[1]] });
-      downloadBlob(built.blob, built.filename, '3MF');
-      return { ok: true as const, filename: built.filename, parts: baked.length };
+      return { built, parts: baked.length };
     } catch (e) {
       return { error: e instanceof Error ? e.message : String(e) };
     }
+  }
+
+  /** Console/AI twin of the multi-part 3MF export — bakes the requested parts
+   *  (default: all) and DOWNLOADS one 3MF. `opts.bambu` (default true) → one part
+   *  per build plate (Bambu/Orca project); false → a generic multi-object 3MF. */
+  async function export3MFPartsApi(partIds?: string[], filename?: string, opts?: { bambu?: boolean }): Promise<{ ok: true; filename: string; parts: number } | { error: string }> {
+    assertString(filename, 'export3MFParts(partIds, filename)', { optional: true });
+    const r = await build3MFPartsExport(partIds, filename, opts);
+    if ('error' in r) return r;
+    downloadBlob(r.built.blob, r.built.filename, '3MF');
+    return { ok: true as const, filename: r.built.filename, parts: r.parts };
+  }
+
+  /** Like {@link export3MFPartsApi} but RETURNS the bytes (base64) instead of
+   *  downloading — the agent/test-friendly twin. Lets a caller read the exported
+   *  3MF back without the browser download path. */
+  async function export3MFPartsDataApi(partIds?: string[], filename?: string, opts?: { bambu?: boolean }): Promise<{ filename: string; mimeType: string; sizeBytes: number; base64: string; parts: number } | { error: string }> {
+    assertString(filename, 'export3MFPartsData(partIds, filename)', { optional: true });
+    const r = await build3MFPartsExport(partIds, filename, opts);
+    if ('error' in r) return r;
+    return {
+      filename: r.built.filename,
+      mimeType: r.built.mimeType,
+      sizeBytes: r.built.blob.size,
+      base64: await blobToBase64(r.built.blob),
+      parts: r.parts,
+    };
   }
 
   const actionExport3MF = async () => {
@@ -8958,6 +8983,15 @@ async function main() {
      *  or `{ error }`. */
     export3MFParts(partIds?: string[], filename?: string, opts?: { bambu?: boolean }) {
       return export3MFPartsApi(partIds, filename, opts);
+    },
+
+    /** Bytes-returning twin of {@link export3MFParts} — bundles parts into one
+     *  3MF and RETURNS `{ filename, mimeType, base64, sizeBytes, parts }` (or
+     *  `{ error }`) instead of downloading, so an agent/test can read the
+     *  exported file back without the browser download path. `{ bambu }` as in
+     *  export3MFParts (default true). */
+    export3MFPartsData(partIds?: string[], filename?: string, opts?: { bambu?: boolean }) {
+      return export3MFPartsDataApi(partIds, filename, opts);
     },
 
     /** Export the current voxel grid as a MagicaVoxel `.vox` download. Voxel
@@ -14031,6 +14065,7 @@ async function main() {
         'exportOBJ':       { signature: 'exportOBJ() -- Download OBJ file', docs: '/ai.md#console-api--windowpartwright' },
         'export3MF':       { signature: 'export3MF() -- Download 3MF file', docs: '/ai.md#console-api--windowpartwright' },
         'export3MFParts':  { signature: 'await export3MFParts(partIds?, filename?, {bambu?}) -- Bundle parts into one 3MF; bambu:true (default) = one part per Bambu/Orca plate, false = generic multi-object grid -> {ok, filename, parts}', docs: '/ai/file-io.md' },
+        'export3MFPartsData': { signature: 'await export3MFPartsData(partIds?, filename?, {bambu?}) -- Same as export3MFParts but RETURNS {filename, mimeType, base64, sizeBytes, parts} instead of downloading', docs: '/ai/file-io.md' },
         'exportVOX':       { signature: 'exportVOX() -- Download MagicaVoxel .vox (voxel sessions)', docs: '/ai/voxel.md' },
         // AI-friendly export — return bytes over the API instead of triggering a download
         'exportGLBData':   { signature: 'await exportGLBData() -- Return GLB as {filename, mimeType, base64, sizeBytes}', docs: '/ai/file-io.md' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -4129,8 +4129,9 @@ async function main() {
     catch (e) { showToast(e instanceof Error ? e.message : 'OBJ export failed', { variant: 'warn' }); }
   };
   /** Multi-part 3MF: pick parts (with previews), bake each part's coloured mesh
-   *  off-editor, and bundle them into one 3MF with one part per build plate. */
-  async function export3MFMultiPartFlow(): Promise<void> {
+   *  off-editor, and bundle them into one 3MF. `bambu` true → one part per build
+   *  plate (Bambu/Orca project); false → a generic multi-object 3MF (grid). */
+  async function export3MFMultiPartFlow(bambu: boolean): Promise<void> {
     const parts = getState().parts;
     const activeId = getState().currentPart?.id ?? null;
     // Pull each part's latest thumbnail for the picker (cheap — pre-baked Blobs).
@@ -4139,7 +4140,7 @@ async function main() {
       const v = await getLatestVersion(p.id);
       choices.push({ id: p.id, name: p.name, thumbnail: v?.thumbnail ?? null });
     }
-    const selected = await showExportPartsModal(choices, activeId);
+    const selected = await showExportPartsModal(choices, activeId, bambu);
     if (!selected || selected.length === 0) return;
 
     const byId = new Map(parts.map(p => [p.id, p]));
@@ -4156,7 +4157,8 @@ async function main() {
       updateProgress(job, 1, 'Writing 3MF…');
       if (baked.length === 0) { showToast('None of the selected parts produced geometry to export.', { variant: 'warn' }); return; }
 
-      const built = build3MFProject(baked);
+      const bed = loadPrinterSettings().bed;
+      const built = build3MFProject(baked, { bambu, bedSize: [bed[0], bed[1]] });
       downloadBlob(built.blob, built.filename, '3MF');
       const skipped = selected.length - baked.length;
       const note = skipped > 0 ? ` (${skipped} skipped — no geometry)` : '';
@@ -4169,11 +4171,13 @@ async function main() {
   }
 
   /** Console/AI twin of the multi-part 3MF export — bakes the requested parts
-   *  (default: all) and downloads one 3MF, one part per plate. Returns a result
-   *  object (no UI modal). Kept as a standalone function so the `partwrightAPI`
-   *  object literal stays thin. */
-  async function export3MFPartsApi(partIds?: string[], filename?: string): Promise<{ ok: true; filename: string; parts: number } | { error: string }> {
+   *  (default: all) and downloads one 3MF. `opts.bambu` (default true) → one part
+   *  per build plate (Bambu/Orca project); false → a generic multi-object 3MF.
+   *  Returns a result object (no UI modal). Kept as a standalone function so the
+   *  `partwrightAPI` object literal stays thin. */
+  async function export3MFPartsApi(partIds?: string[], filename?: string, opts?: { bambu?: boolean }): Promise<{ ok: true; filename: string; parts: number } | { error: string }> {
     assertString(filename, 'export3MFParts(partIds, filename)', { optional: true });
+    const bambu = opts?.bambu ?? true;
     const allParts = getState().parts;
     if (allParts.length === 0) return { error: 'No parts in this session.' };
     let ids = partIds;
@@ -4194,7 +4198,8 @@ async function main() {
     }
     if (baked.length === 0) return { error: 'None of the selected parts produced geometry to export.' };
     try {
-      const built = build3MFProject(baked, { customName: filename });
+      const bed = loadPrinterSettings().bed;
+      const built = build3MFProject(baked, { customName: filename, bambu, bedSize: [bed[0], bed[1]] });
       downloadBlob(built.blob, built.filename, '3MF');
       return { ok: true as const, filename: built.filename, parts: baked.length };
     } catch (e) {
@@ -4207,7 +4212,10 @@ async function main() {
     if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('3MF'))) return;
     warnIfNotPrintable('3MF');
-    notifyMultiPartExport();
+    // Multi-part session → offer the part picker and emit a GENERIC multi-object
+    // 3MF (grid-arranged, no Bambu metadata). Single-part keeps the original
+    // single-object export.
+    if (getState().parts.length > 1) { await export3MFMultiPartFlow(false); return; }
     try { showToast(`Exported ${export3MF(fileExportMesh(true)!)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
   };
@@ -4220,7 +4228,7 @@ async function main() {
     if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('3MF'))) return;
     warnIfNotPrintable('3MF');
-    await export3MFMultiPartFlow();
+    await export3MFMultiPartFlow(true);
   };
   // The integer VoxelGrid behind a voxel session. The engine meshes in the
   // Worker, so the grid isn't on the main thread after a normal run — re-run the
@@ -8940,14 +8948,16 @@ async function main() {
       export3MF(fileExportMesh(true)!, filename);
     },
 
-    /** Bundle several Session Parts into ONE 3MF, each part on its own build
-     *  plate (Bambu Studio / OrcaSlicer), with painted colours bound to
-     *  filaments. The UI equivalent is the part-picker shown when you export 3MF
-     *  in a multi-part session. Pass an array of part ids (default: every part
-     *  in the session); each part's latest version is baked WITH its colours.
-     *  Returns `{ ok, filename, parts }` or `{ error }`. */
-    export3MFParts(partIds?: string[], filename?: string) {
-      return export3MFPartsApi(partIds, filename);
+    /** Bundle several Session Parts into ONE 3MF. With `{ bambu: true }` (the
+     *  default) each part lands on its own Bambu Studio / OrcaSlicer build plate
+     *  with colours bound to filaments; `{ bambu: false }` emits a generic
+     *  multi-object 3MF (grid-arranged, opens in any slicer). The UI equivalents
+     *  are the "3MF — Bambu/Orca" menu item and the generic "3MF" export in a
+     *  multi-part session. Pass an array of part ids (default: every part); each
+     *  part's latest version is baked WITH its colours. `{ ok, filename, parts }`
+     *  or `{ error }`. */
+    export3MFParts(partIds?: string[], filename?: string, opts?: { bambu?: boolean }) {
+      return export3MFPartsApi(partIds, filename, opts);
     },
 
     /** Export the current voxel grid as a MagicaVoxel `.vox` download. Voxel
@@ -14020,7 +14030,7 @@ async function main() {
         'exportSTL':       { signature: 'exportSTL() -- Download STL file', docs: '/ai.md#console-api--windowpartwright' },
         'exportOBJ':       { signature: 'exportOBJ() -- Download OBJ file', docs: '/ai.md#console-api--windowpartwright' },
         'export3MF':       { signature: 'export3MF() -- Download 3MF file', docs: '/ai.md#console-api--windowpartwright' },
-        'export3MFParts':  { signature: 'await export3MFParts(partIds?, filename?) -- Bundle parts into one 3MF, one part per build plate (Bambu/Orca) -> {ok, filename, parts}', docs: '/ai/file-io.md' },
+        'export3MFParts':  { signature: 'await export3MFParts(partIds?, filename?, {bambu?}) -- Bundle parts into one 3MF; bambu:true (default) = one part per Bambu/Orca plate, false = generic multi-object grid -> {ok, filename, parts}', docs: '/ai/file-io.md' },
         'exportVOX':       { signature: 'exportVOX() -- Download MagicaVoxel .vox (voxel sessions)', docs: '/ai/voxel.md' },
         // AI-friendly export — return bytes over the API instead of triggering a download
         'exportGLBData':   { signature: 'await exportGLBData() -- Return GLB as {filename, mimeType, base64, sizeBytes}', docs: '/ai/file-io.md' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -4142,8 +4142,6 @@ async function main() {
     const selected = await showExportPartsModal(choices, activeId);
     if (!selected || selected.length === 0) return;
 
-    // A single selected part doesn't need the plate/project layer — fall back to
-    // the plain single-object 3MF (active part = current mesh; otherwise bake it).
     const byId = new Map(parts.map(p => [p.id, p]));
     const job = startProgress({ title: 'Preparing 3MF', indeterminate: false, message: 'Baking parts…' });
     try {
@@ -4158,9 +4156,7 @@ async function main() {
       updateProgress(job, 1, 'Writing 3MF…');
       if (baked.length === 0) { showToast('None of the selected parts produced geometry to export.', { variant: 'warn' }); return; }
 
-      const built = baked.length === 1
-        ? build3MF(baked[0].mesh)
-        : build3MFProject(baked);
+      const built = build3MFProject(baked);
       downloadBlob(built.blob, built.filename, '3MF');
       const skipped = selected.length - baked.length;
       const note = skipped > 0 ? ` (${skipped} skipped — no geometry)` : '';
@@ -4198,7 +4194,7 @@ async function main() {
     }
     if (baked.length === 0) return { error: 'None of the selected parts produced geometry to export.' };
     try {
-      const built = baked.length === 1 ? build3MF(baked[0].mesh, filename) : build3MFProject(baked, { customName: filename });
+      const built = build3MFProject(baked, { customName: filename });
       downloadBlob(built.blob, built.filename, '3MF');
       return { ok: true as const, filename: built.filename, parts: baked.length };
     } catch (e) {
@@ -4211,11 +4207,20 @@ async function main() {
     if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('3MF'))) return;
     warnIfNotPrintable('3MF');
-    // Multi-part session → offer the part picker + per-plate bundle. Single-part
-    // session keeps the original single-object export untouched.
-    if (getState().parts.length > 1) { await export3MFMultiPartFlow(); return; }
+    notifyMultiPartExport();
     try { showToast(`Exported ${export3MF(fileExportMesh(true)!)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
+  };
+  // Bambu/Orca multi-plate 3MF — a SEPARATE export from the generic 3MF above.
+  // Opens the part picker and bundles the chosen parts into one Bambu project
+  // (one part per build plate, colours bound to AMS filaments). Available for any
+  // session (single-part too); it always emits the Bambu project layer.
+  const actionExport3MFBambu = async () => {
+    if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
+    if (!currentMeshData) { noGeometryToast(); return; }
+    if (!(await confirmExportOrProceed('3MF'))) return;
+    warnIfNotPrintable('3MF');
+    await export3MFMultiPartFlow();
   };
   // The integer VoxelGrid behind a voxel session. The engine meshes in the
   // Worker, so the grid isn't on the main thread after a normal run — re-run the
@@ -4400,6 +4405,7 @@ async function main() {
     onExportSTL: actionExportSTL,
     onExportOBJ: actionExportOBJ,
     onExport3MF: actionExport3MF,
+    onExport3MFBambu: actionExport3MFBambu,
     onExportVOX: actionExportVOX,
     onExportSTEP: actionExportSTEP,
     onExportSessionJSON: async () => {
@@ -4777,6 +4783,7 @@ async function main() {
     { id: 'export-stl', title: 'Export STL', hint: 'Export', keywords: 'download print', run: actionExportSTL, enabled: () => currentMeshData !== null },
     { id: 'export-obj', title: 'Export OBJ', hint: 'Export', keywords: 'download wavefront', run: actionExportOBJ, enabled: () => currentMeshData !== null },
     { id: 'export-3mf', title: 'Export 3MF', hint: 'Export', keywords: 'download print color', run: actionExport3MF, enabled: () => currentMeshData !== null },
+    { id: 'export-3mf-bambu', title: 'Export 3MF — Bambu/Orca (multi-plate)', hint: 'Export', keywords: 'download print color bambu orca plate parts multi-part filament ams', run: actionExport3MFBambu, enabled: () => currentMeshData !== null },
     // VOX exports the voxel grid (getCurrentVoxelGrid), not currentMeshData, so
     // gate on the active language — the grid is re-derived on demand inside the
     // action, which also toasts if there's nothing to export. (Re-running the

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,8 @@ import { exportGLB, buildGLB } from './export/gltf';
 import { exportSTL, buildSTL } from './export/stl';
 import { exportOBJ, buildOBJ } from './export/obj';
 import { export3MF, build3MF } from './export/threemf';
+import { build3MFProject } from './export/threemfProject';
+import { showExportPartsModal, type ExportPartChoice } from './ui/exportPartsModal';
 import { exportVOX, buildVOX } from './export/vox';
 import { assertFiniteMesh } from './export/meshClean';
 import { exportSessionJSON, exportRawCode, buildSessionJSON, buildRawCode } from './export/session';
@@ -195,12 +197,12 @@ import {
 import { setColor as setAnnotateColor, setWidth as setAnnotateWidth, getWidth as getAnnotateWidth } from './annotations/annotateMode';
 import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontSize as getAnnotateFontSize } from './annotations/textMode';
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
-import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, setRegionTriangles, buildTriColors, createEmptyTriColors, overlayPainted, setModelColorRegions, setModelRegionTriangles, hasModelColorRegions, clearModelColorRegions, getModelRegions, getDistinctRegionColors, replaceRegionColors, type SerializedColorRegion, type RegionDescriptor } from './color/regions';
+import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, setRegionTriangles, buildTriColors, createEmptyTriColors, overlayPainted, setModelColorRegions, setModelRegionTriangles, hasModelColorRegions, clearModelColorRegions, getModelRegions, getDistinctRegionColors, replaceRegionColors, composeTriColors, type ColorRegion, type SerializedColorRegion, type RegionDescriptor } from './color/regions';
 import { setPaintLabels } from './color/labels';
 import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as getPaintBucketTolerance, setBucketColorTolerance as setPaintBucketColorTolerance, getBucketColorTolerance as getPaintBucketColorTolerance, setBucketMode as setPaintBucketMode, getBucketMode as getPaintBucketMode, setBrushRadius as setPaintBrushRadius, getBrushRadius as getPaintBrushRadius, setBrushSmooth as setPaintBrushSmooth, isBrushSmooth as isPaintBrushSmooth, setBrushSmoothDivisor as setPaintBrushSmoothDivisor, getBrushSmoothDivisor as getPaintBrushSmoothDivisor, setBrushSurface as setPaintBrushSurface, getBrushSurface as getPaintBrushSurface, setBrushPaintDepth as setPaintBrushDepth, getBrushPaintDepth as getPaintBrushDepth, setBrushWrapAngle as setPaintBrushWrapAngle, getBrushWrapAngle as getPaintBrushWrapAngle, SMOOTH_DIVISOR_MIN, SMOOTH_DIVISOR_MAX, WRAP_ANGLE_MIN, WRAP_ANGLE_MAX } from './color/paintMode';
 import { buildStrokeMesh, buildRefinedMesh, buildRefinedMeshFromSet, brushRefineRegion, strokeFootprintTriangles, deriveSampleNormals, buildGeodesicField, tangentBasis, wrapAngleGate, childrenByParent, type BrushStroke, type BrushShape, type RefineRegion } from './color/subdivide';
 import { refineInWorker, SubdivisionAbortError, terminateSubdivisionWorker } from './color/subdivisionClient';
-import { startProgress, endProgress, __setProgressModalDelayForTests } from './ui/progressModal';
+import { startProgress, updateProgress, endProgress, __setProgressModalDelayForTests } from './ui/progressModal';
 import { syncLockState, disableRun, enableRun } from './color/editorLock';
 import { setReadOnlyReason } from './editor/editorAccess';
 import { asLanguage } from './storage/languageFallback';
@@ -3402,6 +3404,79 @@ async function main() {
     }
   }
 
+  /** Bake a part's mesh WITH its colours, off the live editor, for multi-part
+   *  export. The active part is returned straight from `currentMeshData` (already
+   *  fully coloured, no re-run). Any other part is re-executed and BOTH colour
+   *  layers are resolved offline — code-declared colours (`api.label` /
+   *  `api.paint.*`, from the run result) and the part's saved manual paint
+   *  (`version.geometryData.colorRegions`) — using the same resolver + compositor
+   *  the live editor uses, so nothing is silently dropped. Returns null when the
+   *  part has no version or produced no usable mesh. */
+  async function bakeColoredMeshForPart(partId: string, name: string): Promise<{ name: string; mesh: MeshData } | null> {
+    if (partId === getState().currentPart?.id && currentMeshData) {
+      return { name, mesh: coloredMeshForExport(currentMeshData) };
+    }
+    const version = await getLatestVersion(partId);
+    if (!version) return null;
+    const lang = effectiveVersionLanguage(version, getState().session);
+    const saved = getActiveImports();
+    let result;
+    try {
+      setActiveImports((version.importedMeshes ?? []) as ImportedMesh[]);
+      result = await executeCodeAsync(version.code, lang);
+    } finally {
+      setActiveImports(saved);
+    }
+    if (!result || result.error || !result.mesh) return null;
+    const mesh = result.mesh;
+
+    // Adjacency is only needed by a few descriptor kinds; build it lazily once.
+    let adjacency: AdjacencyGraph | null = null;
+    const needsAdjacency = (d: RegionDescriptor) =>
+      d.kind === 'coplanar' || d.kind === 'connectedFromSeed' || d.kind === 'colorFlood';
+    const ensureAdjacency = () => (adjacency ??= buildAdjacency(mesh));
+
+    let order = 0;
+    const mkRegion = (color: [number, number, number], triangles: Set<number>, perTriColors?: Map<number, [number, number, number]>): ColorRegion => ({
+      id: ++order, name: '', color, source: 'model', descriptor: { kind: 'triangles', ids: [] },
+      order, visible: true, triangles, perTriColors,
+    });
+
+    // Layer B — code-declared colours (the model-colour underlay).
+    const modelLayer: ColorRegion[] = [];
+    if (result.labelColors && result.labelMap) {
+      for (const [labelName, color] of result.labelColors) {
+        const tris = result.labelMap.get(labelName);
+        if (tris && tris.size > 0) modelLayer.push(mkRegion(color, tris));
+      }
+    }
+    if (result.paintOps) {
+      for (const op of result.paintOps) {
+        const d = op.descriptor as RegionDescriptor;
+        if (needsAdjacency(d)) ensureAdjacency();
+        const { triangles, perTriColors } = resolveDescriptorTriangles(d, mesh, adjacency, null);
+        if (triangles.size > 0) modelLayer.push(mkRegion(op.color, triangles, perTriColors));
+      }
+    }
+
+    // Layer A — the part's saved manual paint regions.
+    const manualLayer: ColorRegion[] = [];
+    for (const region of versionColorRegions(version)) {
+      const d = region.descriptor;
+      if (needsAdjacency(d)) ensureAdjacency();
+      const { triangles, perTriColors } = resolveDescriptorTriangles(d, mesh, adjacency, null);
+      if (triangles.size > 0) {
+        manualLayer.push({
+          id: ++order, name: region.name, color: region.color, source: region.source,
+          descriptor: d, order: region.order, visible: true, triangles, perTriColors,
+        });
+      }
+    }
+
+    const triColors = composeTriColors(mesh.numTri, [modelLayer, manualLayer]);
+    return { name, mesh: triColors ? { ...mesh, triColors } : mesh };
+  }
+
   /** Add the imported mesh as a brand-new part (becomes current). Optional
    *  seedRegions (relief's per-colour bands) are painted onto the saved v1. */
   async function seedNewPartWithMesh(mesh: ImportedMesh, filename: string, manifold: boolean, seedRegions?: SeedRegion[]): Promise<void> {
@@ -4053,12 +4128,92 @@ async function main() {
     try { showToast(`Exported ${exportOBJ(fileExportMesh(true)!)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : 'OBJ export failed', { variant: 'warn' }); }
   };
+  /** Multi-part 3MF: pick parts (with previews), bake each part's coloured mesh
+   *  off-editor, and bundle them into one 3MF with one part per build plate. */
+  async function export3MFMultiPartFlow(): Promise<void> {
+    const parts = getState().parts;
+    const activeId = getState().currentPart?.id ?? null;
+    // Pull each part's latest thumbnail for the picker (cheap — pre-baked Blobs).
+    const choices: ExportPartChoice[] = [];
+    for (const p of parts) {
+      const v = await getLatestVersion(p.id);
+      choices.push({ id: p.id, name: p.name, thumbnail: v?.thumbnail ?? null });
+    }
+    const selected = await showExportPartsModal(choices, activeId);
+    if (!selected || selected.length === 0) return;
+
+    // A single selected part doesn't need the plate/project layer — fall back to
+    // the plain single-object 3MF (active part = current mesh; otherwise bake it).
+    const byId = new Map(parts.map(p => [p.id, p]));
+    const job = startProgress({ title: 'Preparing 3MF', indeterminate: false, message: 'Baking parts…' });
+    try {
+      const baked: { name: string; mesh: MeshData }[] = [];
+      for (let i = 0; i < selected.length; i++) {
+        const part = byId.get(selected[i]);
+        if (!part) continue;
+        updateProgress(job, i / selected.length, `Baking "${part.name}" (${i + 1}/${selected.length})…`);
+        const result = await bakeColoredMeshForPart(part.id, part.name);
+        if (result) baked.push(result);
+      }
+      updateProgress(job, 1, 'Writing 3MF…');
+      if (baked.length === 0) { showToast('None of the selected parts produced geometry to export.', { variant: 'warn' }); return; }
+
+      const built = baked.length === 1
+        ? build3MF(baked[0].mesh)
+        : build3MFProject(baked);
+      downloadBlob(built.blob, built.filename, '3MF');
+      const skipped = selected.length - baked.length;
+      const note = skipped > 0 ? ` (${skipped} skipped — no geometry)` : '';
+      showToast(`Exported ${built.filename} — ${baked.length} part${baked.length === 1 ? '' : 's'}${note}`, { variant: 'success' });
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' });
+    } finally {
+      endProgress(job);
+    }
+  }
+
+  /** Console/AI twin of the multi-part 3MF export — bakes the requested parts
+   *  (default: all) and downloads one 3MF, one part per plate. Returns a result
+   *  object (no UI modal). Kept as a standalone function so the `partwrightAPI`
+   *  object literal stays thin. */
+  async function export3MFPartsApi(partIds?: string[], filename?: string): Promise<{ ok: true; filename: string; parts: number } | { error: string }> {
+    assertString(filename, 'export3MFParts(partIds, filename)', { optional: true });
+    const allParts = getState().parts;
+    if (allParts.length === 0) return { error: 'No parts in this session.' };
+    let ids = partIds;
+    if (ids !== undefined) {
+      if (!Array.isArray(ids) || !ids.every(id => typeof id === 'string')) {
+        return { error: 'export3MFParts(partIds): partIds must be an array of part-id strings.' };
+      }
+    } else {
+      ids = allParts.map(p => p.id);
+    }
+    const byId = new Map(allParts.map(p => [p.id, p]));
+    const baked: { name: string; mesh: MeshData }[] = [];
+    for (const id of ids) {
+      const part = byId.get(id);
+      if (!part) return { error: `export3MFParts: unknown part id "${id}".` };
+      const result = await bakeColoredMeshForPart(part.id, part.name);
+      if (result) baked.push(result);
+    }
+    if (baked.length === 0) return { error: 'None of the selected parts produced geometry to export.' };
+    try {
+      const built = baked.length === 1 ? build3MF(baked[0].mesh, filename) : build3MFProject(baked, { customName: filename });
+      downloadBlob(built.blob, built.filename, '3MF');
+      return { ok: true as const, filename: built.filename, parts: baked.length };
+    } catch (e) {
+      return { error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
   const actionExport3MF = async () => {
     if (isSharedPreview()) { showToast('Fork this shared design before exporting.', { variant: 'warn' }); return; }
     if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('3MF'))) return;
     warnIfNotPrintable('3MF');
-    notifyMultiPartExport();
+    // Multi-part session → offer the part picker + per-plate bundle. Single-part
+    // session keeps the original single-object export untouched.
+    if (getState().parts.length > 1) { await export3MFMultiPartFlow(); return; }
     try { showToast(`Exported ${export3MF(fileExportMesh(true)!)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : '3MF export failed', { variant: 'warn' }); }
   };
@@ -8776,6 +8931,16 @@ async function main() {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       warnIfSurfaceStale('3MF');
       export3MF(fileExportMesh(true)!, filename);
+    },
+
+    /** Bundle several Session Parts into ONE 3MF, each part on its own build
+     *  plate (Bambu Studio / OrcaSlicer), with painted colours bound to
+     *  filaments. The UI equivalent is the part-picker shown when you export 3MF
+     *  in a multi-part session. Pass an array of part ids (default: every part
+     *  in the session); each part's latest version is baked WITH its colours.
+     *  Returns `{ ok, filename, parts }` or `{ error }`. */
+    export3MFParts(partIds?: string[], filename?: string) {
+      return export3MFPartsApi(partIds, filename);
     },
 
     /** Export the current voxel grid as a MagicaVoxel `.vox` download. Voxel
@@ -13848,6 +14013,7 @@ async function main() {
         'exportSTL':       { signature: 'exportSTL() -- Download STL file', docs: '/ai.md#console-api--windowpartwright' },
         'exportOBJ':       { signature: 'exportOBJ() -- Download OBJ file', docs: '/ai.md#console-api--windowpartwright' },
         'export3MF':       { signature: 'export3MF() -- Download 3MF file', docs: '/ai.md#console-api--windowpartwright' },
+        'export3MFParts':  { signature: 'await export3MFParts(partIds?, filename?) -- Bundle parts into one 3MF, one part per build plate (Bambu/Orca) -> {ok, filename, parts}', docs: '/ai/file-io.md' },
         'exportVOX':       { signature: 'exportVOX() -- Download MagicaVoxel .vox (voxel sessions)', docs: '/ai/voxel.md' },
         // AI-friendly export — return bytes over the API instead of triggering a download
         'exportGLBData':   { signature: 'await exportGLBData() -- Return GLB as {filename, mimeType, base64, sizeBytes}', docs: '/ai/file-io.md' },

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -26,6 +26,7 @@ function cloneConfig(c: AppConfig): AppConfig {
     import: { ...c.import },
     ui: { ...c.ui },
     geometry: { ...c.geometry },
+    export: { ...c.export },
   };
 }
 
@@ -773,6 +774,19 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           value={c.geometry.aspectRatioWarn}
           min={2} max={100} step={1}
           onChange={v => set('geometry', 'aspectRatioWarn', v)}
+        />
+      </Section>
+
+      <Section title="Export">
+        <Field
+          label="Multi-part 3MF plate centre"
+          unit="mm"
+          hint="Where each part is placed on its own plate in a multi-part 3MF."
+          tooltip="When exporting several parts to one 3MF (one part per build plate), each part is centred at this X/Y position on its plate and rests on z=0. Match it to your printer's bed centre — 128 for a 256 mm bed (X1/P1), 90 for a 180 mm bed (A1 mini). Bambu/Orca auto-drop parts to the bed, so a small mismatch is corrected on import."
+          defaultValue={APP_CONFIG_DEFAULTS.export.platePositionMm}
+          value={c.export.platePositionMm}
+          min={0} max={500} step={1}
+          onChange={v => set('export', 'platePositionMm', v)}
         />
       </Section>
 

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -26,7 +26,6 @@ function cloneConfig(c: AppConfig): AppConfig {
     import: { ...c.import },
     ui: { ...c.ui },
     geometry: { ...c.geometry },
-    export: { ...c.export },
   };
 }
 
@@ -774,19 +773,6 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           value={c.geometry.aspectRatioWarn}
           min={2} max={100} step={1}
           onChange={v => set('geometry', 'aspectRatioWarn', v)}
-        />
-      </Section>
-
-      <Section title="Export">
-        <Field
-          label="Multi-part 3MF plate centre"
-          unit="mm"
-          hint="Where each part is placed on its own plate in a multi-part 3MF."
-          tooltip="When exporting several parts to one 3MF (one part per build plate), each part is centred at this X/Y position on its plate and rests on z=0. Match it to your printer's bed centre — 128 for a 256 mm bed (X1/P1), 90 for a 180 mm bed (A1 mini). Bambu/Orca auto-drop parts to the bed, so a small mismatch is corrected on import."
-          defaultValue={APP_CONFIG_DEFAULTS.export.platePositionMm}
-          value={c.export.platePositionMm}
-          min={0} max={500} step={1}
-          onChange={v => set('export', 'platePositionMm', v)}
         />
       </Section>
 

--- a/src/ui/exportPartsModal.ts
+++ b/src/ui/exportPartsModal.ts
@@ -1,0 +1,156 @@
+// Part-selection modal for multi-part 3MF export. Lets the user pick which
+// Session Parts to bundle into one 3MF (one part per build plate), with a
+// thumbnail preview of each. The currently-viewed part is preselected; a
+// Select-all / Select-none toggle handles assemblies with many parts.
+//
+// Resolves with the chosen part ids (in list order) when the user confirms, or
+// null if they cancel / dismiss. Only the export caller decides what to do with
+// the selection — this modal is pure UI.
+
+import { createModalShell } from './modalShell';
+import { BUTTON_PRIMARY, BUTTON_CANCEL } from './styleConstants';
+
+export interface ExportPartChoice {
+  id: string;
+  name: string;
+  /** Pre-baked preview thumbnail (latest version's). May be null. */
+  thumbnail: Blob | null;
+}
+
+/**
+ * Show the multi-part 3MF part picker. `activePartId` is preselected.
+ * Returns the selected part ids, or null on cancel.
+ */
+export function showExportPartsModal(
+  parts: ExportPartChoice[],
+  activePartId: string | null,
+): Promise<string[] | null> {
+  return new Promise((resolve) => {
+    let result: string[] | null = null;
+    // Track object URLs so we can revoke them on teardown (no GPU/blob leak).
+    const objectUrls: string[] = [];
+
+    const shell = createModalShell({
+      title: 'Export parts to 3MF',
+      scrollable: true,
+      onClose: () => {
+        document.removeEventListener('keydown', onEnter);
+        for (const url of objectUrls) URL.revokeObjectURL(url);
+        resolve(result);
+      },
+    });
+
+    const sub = document.createElement('p');
+    sub.className = 'text-[11px] text-zinc-400 leading-relaxed';
+    sub.textContent = 'Choose which parts to include. Each selected part is placed on its own build plate, and painted colours are bound to filaments for Bambu Studio / OrcaSlicer.';
+    shell.body.appendChild(sub);
+
+    // Header row with the count + select-all toggle.
+    const head = document.createElement('div');
+    head.className = 'flex items-center justify-between mt-1';
+    const heading = document.createElement('div');
+    heading.className = 'text-xs text-zinc-200 font-medium';
+    const toggleAll = document.createElement('button');
+    toggleAll.type = 'button';
+    toggleAll.className = 'text-[10px] text-blue-400 hover:text-blue-300';
+    head.append(heading, toggleAll);
+    shell.body.appendChild(head);
+
+    const list = document.createElement('div');
+    list.className = 'flex flex-col gap-1 mt-1';
+    shell.body.appendChild(list);
+
+    const checks: HTMLInputElement[] = [];
+
+    for (const part of parts) {
+      const row = document.createElement('label');
+      row.className = 'flex items-center gap-3 py-1.5 px-2 -mx-2 rounded cursor-pointer hover:bg-zinc-700/40';
+
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.checked = part.id === activePartId;
+      cb.className = 'w-4 h-4 accent-blue-500 cursor-pointer shrink-0';
+      cb.dataset.id = part.id;
+      checks.push(cb);
+
+      // Thumbnail (or a placeholder square).
+      const thumb = document.createElement('div');
+      thumb.className = 'w-12 h-12 rounded bg-zinc-900 border border-zinc-700 shrink-0 overflow-hidden flex items-center justify-center';
+      if (part.thumbnail) {
+        const url = URL.createObjectURL(part.thumbnail);
+        objectUrls.push(url);
+        const img = document.createElement('img');
+        img.src = url;
+        img.className = 'w-full h-full object-contain';
+        img.alt = `${part.name} preview`;
+        thumb.appendChild(img);
+      } else {
+        thumb.textContent = '—';
+        thumb.classList.add('text-zinc-600', 'text-xs');
+      }
+
+      const meta = document.createElement('div');
+      meta.className = 'flex-1 min-w-0';
+      const nameEl = document.createElement('div');
+      nameEl.className = 'text-xs text-zinc-200 font-medium truncate';
+      nameEl.textContent = part.name;
+      meta.appendChild(nameEl);
+      if (part.id === activePartId) {
+        const badge = document.createElement('div');
+        badge.className = 'text-[10px] text-blue-400';
+        badge.textContent = 'Currently viewing';
+        meta.appendChild(badge);
+      }
+
+      row.append(cb, thumb, meta);
+      list.appendChild(row);
+    }
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = BUTTON_CANCEL;
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => { result = null; shell.close(); });
+    shell.footer.appendChild(cancelBtn);
+
+    const exportBtn = document.createElement('button');
+    exportBtn.className = BUTTON_PRIMARY;
+    shell.footer.appendChild(exportBtn);
+
+    function selectedIds(): string[] {
+      return checks.filter(c => c.checked).map(c => c.dataset.id!).filter(Boolean);
+    }
+
+    function sync() {
+      const n = selectedIds().length;
+      heading.textContent = `Parts (${n} of ${parts.length} selected)`;
+      exportBtn.textContent = n > 1 ? `Export ${n} parts` : 'Export';
+      exportBtn.disabled = n === 0;
+      exportBtn.classList.toggle('opacity-40', n === 0);
+      exportBtn.classList.toggle('cursor-default', n === 0);
+      toggleAll.textContent = checks.every(c => c.checked) ? 'Select none' : 'Select all';
+    }
+
+    function confirm() {
+      const ids = selectedIds();
+      if (ids.length === 0) return;
+      result = ids;
+      shell.close();
+    }
+
+    toggleAll.addEventListener('click', () => {
+      const allChecked = checks.every(c => c.checked);
+      for (const c of checks) c.checked = !allChecked;
+      sync();
+    });
+    for (const c of checks) c.addEventListener('change', sync);
+    exportBtn.addEventListener('click', confirm);
+
+    function onEnter(e: KeyboardEvent) {
+      if (e.key === 'Enter') { e.preventDefault(); confirm(); }
+    }
+    document.addEventListener('keydown', onEnter);
+
+    sync();
+    exportBtn.focus();
+  });
+}

--- a/src/ui/exportPartsModal.ts
+++ b/src/ui/exportPartsModal.ts
@@ -18,12 +18,14 @@ export interface ExportPartChoice {
 }
 
 /**
- * Show the multi-part 3MF part picker. `activePartId` is preselected.
+ * Show the multi-part 3MF part picker. `activePartId` is preselected. `bambu`
+ * tailors the title/help text (per-plate Bambu project vs generic multi-object).
  * Returns the selected part ids, or null on cancel.
  */
 export function showExportPartsModal(
   parts: ExportPartChoice[],
   activePartId: string | null,
+  bambu = true,
 ): Promise<string[] | null> {
   return new Promise((resolve) => {
     let result: string[] | null = null;
@@ -31,7 +33,7 @@ export function showExportPartsModal(
     const objectUrls: string[] = [];
 
     const shell = createModalShell({
-      title: 'Export parts to 3MF',
+      title: bambu ? 'Export parts to 3MF (Bambu/Orca)' : 'Export parts to 3MF',
       scrollable: true,
       onClose: () => {
         document.removeEventListener('keydown', onEnter);
@@ -42,7 +44,9 @@ export function showExportPartsModal(
 
     const sub = document.createElement('p');
     sub.className = 'text-[11px] text-zinc-400 leading-relaxed';
-    sub.textContent = 'Choose which parts to include. Each selected part is placed on its own build plate, and painted colours are bound to filaments for Bambu Studio / OrcaSlicer.';
+    sub.textContent = bambu
+      ? 'Choose which parts to include. Each selected part is placed on its own build plate, and painted colours are bound to filaments for Bambu Studio / OrcaSlicer.'
+      : 'Choose which parts to include. Each selected part is added as a separate object, arranged in a grid so they don’t overlap. Standard 3MF — opens in any slicer.';
     shell.body.appendChild(sub);
 
     // Header row with the count + select-all toggle.

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -22,6 +22,10 @@ export interface ToolbarCallbacks {
   onExportSTL: () => void;
   onExportOBJ: () => void;
   onExport3MF: () => void;
+  /** Bambu/Orca multi-plate 3MF — opens the part picker and bundles the chosen
+   *  parts into one project (one part per plate, colours bound to AMS
+   *  filaments). Distinct from {@link onExport3MF}, which stays a generic 3MF. */
+  onExport3MFBambu: () => void;
   /** Voxel-only — silently hidden from the menu unless the active language is
    *  'voxel' (gated at menu-open time, like {@link onExportSTEP}). */
   onExportVOX: () => void;
@@ -572,6 +576,15 @@ export function createToolbar(
     callbacks.onExport3MF();
   });
 
+  const threemfBambuOpt = createDescribedItem(
+    '3MF — Bambu/Orca',
+    'Multi-plate project: pick parts, one per build plate, colors bound to AMS filaments. For Bambu Studio / OrcaSlicer (not a generic 3MF).',
+  );
+  threemfBambuOpt.addEventListener('click', () => {
+    dropdown.classList.add('hidden');
+    callbacks.onExport3MFBambu();
+  });
+
   const objOpt = createDescribedItem(
     'OBJ',
     'Geometry + color via MTL. Extract ZIP before importing into slicer.',
@@ -625,6 +638,7 @@ export function createToolbar(
   });
 
   dropdown.appendChild(threemfOpt);
+  dropdown.appendChild(threemfBambuOpt);
   dropdown.appendChild(objOpt);
   dropdown.appendChild(stlOpt);
   dropdown.appendChild(glbOpt);

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -72,11 +72,15 @@ test.describe('multi-part 3MF export', () => {
     expect(b).toContain('key="plater_id" value="1"');
     expect(b).toContain('key="plater_id" value="2"');
     expect(b).toContain('key="extruder"');
-    // NO project_settings.config / preset ids — those trip Bambu's "customized
-    // presets / unsafe G-code" warning. Colours come via colorgroup + extruder.
-    expect(b).not.toContain('Metadata/project_settings.config');
+    // Minimal project_settings.config — REQUIRED so Bambu builds the plate list
+    // (load_config). It carries only `filament_diameter` (a recognized key); it
+    // must NOT carry preset ids, which trip the "customized presets / unsafe
+    // G-code" warning. Colours come via colorgroup + extruder + paint_color.
+    expect(b).toContain('Metadata/project_settings.config');
+    expect(b).toContain('filament_diameter');
     expect(b).not.toContain('filament_settings_id');
     expect(b).not.toContain('printer_settings_id');
+    expect(b).not.toContain('inherits_group');
     // Each part on its OWN plate: Bambu assigns by world position, so the two
     // <item> X translations must differ AND match the plate stride (bed × 1.2 =
     // 307.2 for a 256 bed). Transform = "1 0 0 0 1 0 0 0 1 TX TY TZ".
@@ -94,6 +98,7 @@ test.describe('multi-part 3MF export', () => {
     // No Bambu-specific metadata at all.
     expect(g).not.toContain('BambuStudio-');
     expect(g).not.toContain('Metadata/model_settings.config');
+    expect(g).not.toContain('Metadata/project_settings.config');
     expect(g).not.toContain('paint_color=');
     // Grid-arranged → the two parts have distinct X positions (no overlap).
     const gTxs = [...g.matchAll(/<item objectid="\d+" transform="([^"]+)"/g)]
@@ -136,5 +141,45 @@ test.describe('multi-part 3MF export', () => {
     const download = await downloadPromise;
     expect(download).not.toBeNull();
     expect(download!.suggestedFilename()).toMatch(/\.3mf$/);
+  });
+
+  test('export3MFPartsData bundles real parts through the full bake pipeline', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForTimeout(4000);
+
+    // Build 3 real coloured parts, then read the Bambu 3MF back via the
+    // bytes-returning API (no browser download) and inspect the actual output —
+    // this exercises the off-editor bake (bakeColoredMeshForPart) + the builder.
+    const out = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: any }).partwright;
+      (await import('/src/geometry/units.ts')).setUnits('mm');
+      await pw.runAndSave('return api.label(api.Manifold.cube([20,20,20], true), "red", { color: [1,0,0] });', 'red');
+      await pw.createPart('Green');
+      await pw.runAndSave('return api.label(api.Manifold.sphere(12, 48), "green", { color: [0,1,0] });', 'green');
+      await pw.createPart('Blue');
+      await pw.runAndSave('return api.label(api.Manifold.cylinder(24, 10, 10, 48), "blue", { color: [0,0,1] });', 'blue');
+
+      const r = await pw.export3MFPartsData(undefined, 'probe', { bambu: true });
+      if (r.error) return { error: r.error };
+      const bin = atob(r.base64);
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      return { parts: r.parts, text: new TextDecoder('latin1').decode(bytes) };
+    });
+
+    expect((out as { error?: string }).error).toBeUndefined();
+    const o = out as { parts: number; text: string };
+    expect(o.parts).toBe(3);
+    // Real bake produced 3 objects, 3 plates, the project_settings.config that
+    // makes Bambu build the plate list, and no preset-id keys (warning guard).
+    expect((o.text.match(/<object id="\d+" type="model">/g) ?? []).length).toBe(3);
+    expect((o.text.match(/<plate>/g) ?? []).length).toBe(3);
+    expect(o.text).toContain('Metadata/project_settings.config');
+    expect(o.text).toContain('filament_diameter');
+    expect(o.text).not.toContain('filament_settings_id');
+    // Colours from api.label survived the off-editor bake → distinct material colours.
+    expect(o.text).toContain('<m:colorgroup');
+    const colors = [...o.text.matchAll(/<m:color color="(#[0-9A-F]{8})"/g)].map(m => m[1]);
+    expect(new Set(colors).size).toBeGreaterThanOrEqual(3);
   });
 });

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -65,9 +65,12 @@ test.describe('multi-part 3MF export', () => {
     expect((b.match(/<component /g) ?? []).length).toBe(2);
     // Project marker (flips Bambu into project / multi-plate mode).
     expect(b).toContain('<metadata name="Application">BambuStudio-');
-    // Bambu mode: colour is per-OBJECT via extruder, NOT per-triangle.
-    // Object files carry plain triangles — no colorgroup/pid/paint_color.
-    expect(b).not.toContain('paint_color=');
+    // IN-PART COLOUR: Body is two-colour (red + blue), so the triangles whose AMS
+    // slot differs from the object's base extruder carry a per-triangle paint_color
+    // (Bambu's MMU attribute). This is what makes hand-paint / api.label regions show
+    // WITHIN a part — no m:colorgroup/pid here (that's the generic material extension).
+    expect(b).toContain('paint_color=');
+    expect(b).not.toContain('<m:colorgroup');
     // model_settings.config: one <plate> per part.
     expect(b).toContain('Metadata/model_settings.config');
     expect((b.match(/<plate>/g) ?? []).length).toBe(2);

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -213,14 +213,15 @@ test.describe('multi-part 3MF export', () => {
     expect(o.text).toContain('/3D/Objects/object_3.model');
   });
 
-  test('Bambu plates use a ⌈√N⌉-column grid (matches Bambu plate layout)', async ({ page }) => {
+  test('Bambu plates use BambuStudio\'s ⌈√N⌉-column grid with per-axis stride', async ({ page }) => {
     await page.goto('/editor');
     await page.waitForTimeout(3000);
 
-    // 6 parts → Bambu lays plates out in ⌈√6⌉ = 3 columns × 2 rows. Each part's
-    // <item> must sit at the centre of a distinct cell or it lands off-plate (the
-    // bug where 2 of 6 parts fell off). Assert exactly 3 distinct X columns and 2
-    // distinct Y rows across the 6 build items — a regression guard for the grid.
+    // 6 parts → ⌈√6⌉ = 3 columns × 2 rows, matching BambuStudio's PartPlateList.
+    // Each part centres on its plate cell at (col·396 + 165, −row·384 + 160) for the
+    // 330×320 H2C bed: plate_stride_x = width·1.2 = 396, plate_stride_y = depth·1.2 =
+    // 384 (LOGICAL_PART_PLATE_GAP = 1/5). Asserting the PER-AXIS strides guards the
+    // exact source-derived layout — a single uniform stride drifts parts off-centre.
     const cols = await page.evaluate(async () => {
       const { build3MFProject } = await import('/src/export/threemfProject.ts');
       const makePart = (name: string) => {
@@ -238,10 +239,13 @@ test.describe('multi-part 3MF export', () => {
       const text = await built.blob.arrayBuffer().then(a => new TextDecoder().decode(new Uint8Array(a)));
       const items = [...text.matchAll(/<item objectid="\d+"[^>]*transform="([^"]+)"/g)]
         .map(m => m[1].trim().split(/\s+/));
-      const xs = new Set(items.map(t => t[9]));
-      const ys = new Set(items.map(t => t[10]));
-      return { items: items.length, xCols: xs.size, yRows: ys.size };
+      const xs = [...new Set(items.map(t => Number(t[9])))].sort((a, b) => a - b);
+      const ys = [...new Set(items.map(t => Number(t[10])))].sort((a, b) => b - a);
+      return { items: items.length, xCols: xs.length, yRows: ys.length, xs, ys };
     });
+    // Per-axis strides (rounded to avoid float noise): X=396, Y=384.
+    expect(Math.round(cols.xs[1] - cols.xs[0])).toBe(396);
+    expect(Math.round(cols.ys[0] - cols.ys[1])).toBe(384);
     expect(cols.items).toBe(6);
     expect(cols.xCols).toBe(3); // ⌈√6⌉ columns
     expect(cols.yRows).toBe(2); // 2 rows

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -81,13 +81,15 @@ test.describe('multi-part 3MF export', () => {
     // LOAD-CRITICAL: plater_name MUST be empty — a non-empty value makes Orca's
     // loader reject the project (regression guard for the bug we hit).
     expect(b).not.toMatch(/plater_name" value="[^"]+"/);
-    // REQUIRED: project_settings.config makes the loader build the plate list.
-    // NOTE: filament_colour must NOT appear in project_settings — OrcaSlicer 2.3.2
-    // segfaults on any N1-profile file that has a filament_colour key there.
-    // Colour information lives in model_settings.config per-object extruder field.
+    // REQUIRED: project_settings.config makes the loader build the plate list AND
+    // carries the COMPLETE per-filament arrays. filament_colour MUST be present —
+    // its absence is what made Bambu's GUI load_files null-deref (SIGSEGV) on open
+    // (a partial config indexes past the end of the filament arrays). The config is
+    // a full Bambu Lab H2C profile copied from a known-good reference.
     expect(b).toContain('Metadata/project_settings.config');
     expect(b).toContain('filament_settings_id');
-    expect(b).not.toContain('"filament_colour"');
+    expect(b).toContain('"filament_colour"');
+    expect(b).toContain('Bambu Lab H2C');
     // ID scheme: wrapper ids are EVEN (2,4,…), mesh ids are ODD (1,3,…).
     // Root model items reference the EVEN wrapper ids.
     expect(b).toContain('objectid="2"');
@@ -192,11 +194,11 @@ test.describe('multi-part 3MF export', () => {
     expect(o.text).toContain('<part ');
     expect(o.text).toContain('mesh_stat');
     expect(o.text).toContain('identify_id');
-    // Bambu mode: colour is per-object via extruder (no per-triangle colorgroup/paint_color).
-    // NOTE: filament_colour must NOT appear in project_settings — OrcaSlicer 2.3.2
-    // segfaults on any N1-profile file that carries that key there.
+    // Bambu mode: mesh triangles are plain (no per-triangle colorgroup/paint_color);
+    // single-colour base puts every object on extruder 1.
     expect(o.text).not.toContain('paint_color=');
-    expect(o.text).not.toContain('"filament_colour"');
+    // project_settings carries the COMPLETE filament arrays (crash fix — see above).
+    expect(o.text).toContain('"filament_colour"');
     // ID scheme: EVEN wrapper ids (2,4,6), SEQUENTIAL object files (object_1/2/3.model).
     expect(o.text).toContain('/3D/Objects/object_1.model');
     expect(o.text).toContain('/3D/Objects/object_2.model');

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -93,9 +93,9 @@ test.describe('multi-part 3MF export', () => {
     expect(partCount).toBeGreaterThan(1);
     await page.waitForTimeout(1500);
 
-    // Trigger the 3MF export. The toolbar Export dropdown → 3MF.
+    // Trigger the Bambu/Orca multi-plate export (distinct from the generic 3MF).
     await page.locator('#btn-export').click();
-    await page.locator('#export-dropdown').getByText('3MF', { exact: true }).click();
+    await page.locator('#export-dropdown').getByText('3MF — Bambu/Orca', { exact: true }).click();
 
     // The part picker should appear for a multi-part session.
     const modal = page.getByRole('dialog');

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -55,9 +55,9 @@ test.describe('multi-part 3MF export', () => {
     expect(report.filename).toMatch(/\.3mf$/);
 
     // ── Bambu/Orca project mode (production-extension layout) ──
-    // Verified to load in OrcaSlicer 2.3.2 headless (exit 0, N plates). The
-    // structural invariants below are exactly the ones that, if broken, make the
-    // real slicer reject the file — so this guards the headless-validated recipe.
+    // Mirrors a real BambuStudio-02.05.00.66 project (USER-REF.3mf). The structural
+    // invariants below are exactly the ones that, if broken, make the real slicer
+    // reject the file or crash — so this guards the headless-validated recipe.
     const b = report.bambu;
     // Production extension: each part is a wrapper -> separate /3D/Objects/*.model.
     expect(b).toContain('requiredextensions="p"');
@@ -65,20 +65,36 @@ test.describe('multi-part 3MF export', () => {
     expect((b.match(/<component /g) ?? []).length).toBe(2);
     // Project marker (flips Bambu into project / multi-plate mode).
     expect(b).toContain('<metadata name="Application">BambuStudio-');
-    // Colours: generic m:colorgroup (any slicer) + Bambu per-triangle paint_color.
-    expect(b).toContain('<m:colorgroup');
-    expect(b).toContain('paint_color=');
+    // Bambu mode: colour is per-OBJECT via extruder, NOT per-triangle.
+    // Object files carry plain triangles — no colorgroup/pid/paint_color.
+    expect(b).not.toContain('paint_color=');
     // model_settings.config: one <plate> per part.
     expect(b).toContain('Metadata/model_settings.config');
     expect((b.match(/<plate>/g) ?? []).length).toBe(2);
     expect(b).toContain('key="extruder"');
+    // CRASH FIX: <part id=ODD subtype="normal_part"> + <mesh_stat> must be present
+    // (was missing before; caused Bambu GUI crash on project open).
+    expect(b).toContain('<part ');
+    expect(b).toContain('mesh_stat');
+    // identify_id must be present in each <model_instance>.
+    expect(b).toContain('identify_id');
     // LOAD-CRITICAL: plater_name MUST be empty — a non-empty value makes Orca's
     // loader reject the project (regression guard for the bug we hit).
     expect(b).not.toMatch(/plater_name" value="[^"]+"/);
-    // REQUIRED: a minimal project_settings.config makes the loader build the
-    // plate list (absent → single plate). It carries the filament preset id.
+    // REQUIRED: project_settings.config makes the loader build the plate list.
+    // NOTE: filament_colour must NOT appear in project_settings — OrcaSlicer 2.3.2
+    // segfaults on any N1-profile file that has a filament_colour key there.
+    // Colour information lives in model_settings.config per-object extruder field.
     expect(b).toContain('Metadata/project_settings.config');
     expect(b).toContain('filament_settings_id');
+    expect(b).not.toContain('"filament_colour"');
+    // ID scheme: wrapper ids are EVEN (2,4,…), mesh ids are ODD (1,3,…).
+    // Root model items reference the EVEN wrapper ids.
+    expect(b).toContain('objectid="2"');
+    expect(b).toContain('objectid="4"');
+    // Object files are named object_1.model / object_2.model (sequential).
+    expect(b).toContain('/3D/Objects/object_1.model');
+    expect(b).toContain('/3D/Objects/object_2.model');
     // Each part placed in its own plate slot → distinct <item> X translations.
     const bTxs = [...b.matchAll(/<item objectid="\d+"[^>]*transform="([^"]+)"/g)]
       .map(m => m[1].trim().split(/\s+/)[9]);
@@ -167,14 +183,23 @@ test.describe('multi-part 3MF export', () => {
     const o = out as { parts: number; text: string };
     expect(o.parts).toBe(3);
     // Real bake → 3 production-extension parts, 3 plates, project_settings.config
-    // (builds the plate list), empty plater_name (load-critical), and colours.
+    // (builds the plate list), empty plater_name (load-critical).
     expect((o.text.match(/p:path="\/3D\/Objects\/object_\d+\.model"/g) ?? []).length).toBe(3);
     expect((o.text.match(/<plate>/g) ?? []).length).toBe(3);
     expect(o.text).toContain('Metadata/project_settings.config');
     expect(o.text).not.toMatch(/plater_name" value="[^"]+"/);
-    // Colours from api.label survived the off-editor bake → distinct material colours.
-    expect(o.text).toContain('<m:colorgroup');
-    const colors = [...o.text.matchAll(/<m:color color="(#[0-9A-F]{8})"/g)].map(m => m[1]);
-    expect(new Set(colors).size).toBeGreaterThanOrEqual(3);
+    // CRASH FIX: <part id=ODD subtype="normal_part"> + <mesh_stat> present in model_settings.
+    expect(o.text).toContain('<part ');
+    expect(o.text).toContain('mesh_stat');
+    expect(o.text).toContain('identify_id');
+    // Bambu mode: colour is per-object via extruder (no per-triangle colorgroup/paint_color).
+    // NOTE: filament_colour must NOT appear in project_settings — OrcaSlicer 2.3.2
+    // segfaults on any N1-profile file that carries that key there.
+    expect(o.text).not.toContain('paint_color=');
+    expect(o.text).not.toContain('"filament_colour"');
+    // ID scheme: EVEN wrapper ids (2,4,6), SEQUENTIAL object files (object_1/2/3.model).
+    expect(o.text).toContain('/3D/Objects/object_1.model');
+    expect(o.text).toContain('/3D/Objects/object_2.model');
+    expect(o.text).toContain('/3D/Objects/object_3.model');
   });
 });

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -70,9 +70,19 @@ test.describe('multi-part 3MF export', () => {
     expect(report.text).toContain('key="plater_id" value="1"');
     expect(report.text).toContain('key="plater_id" value="2"');
     expect(report.text).toContain('key="extruder"');
-    // project_settings.config with the filament colour list.
+    // project_settings.config pins filament colours WITHOUT preset-id keys (those
+    // trigger Bambu's "customized presets / unsafe G-code" warning).
     expect(report.text).toContain('Metadata/project_settings.config');
     expect(report.text).toContain('filament_colour');
+    expect(report.text).not.toContain('filament_settings_id');
+    expect(report.text).not.toContain('printer_settings_id');
+    // Each part must sit on its OWN plate: Bambu assigns by world position, so the
+    // two <item> transforms must have DISTINCT X translations (else both stack on
+    // plate 1). Transform is "1 0 0 0 1 0 0 0 1 TX TY TZ".
+    const txs = [...report.text.matchAll(/<item objectid="\d+" transform="([^"]+)"/g)]
+      .map(m => m[1].trim().split(/\s+/)[9]); // 12-value row-major matrix; index 9 = TX
+    expect(txs.length).toBe(2);
+    expect(txs[0]).not.toBe(txs[1]);
   });
 
   test('part picker lets you choose parts and export a multi-plate 3MF', async ({ page }) => {

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -72,15 +72,12 @@ test.describe('multi-part 3MF export', () => {
     expect(b).toContain('key="plater_id" value="1"');
     expect(b).toContain('key="plater_id" value="2"');
     expect(b).toContain('key="extruder"');
-    // Minimal project_settings.config — REQUIRED so Bambu builds the plate list
-    // (load_config). It carries only `filament_diameter` (a recognized key); it
-    // must NOT carry preset ids, which trip the "customized presets / unsafe
-    // G-code" warning. Colours come via colorgroup + extruder + paint_color.
-    expect(b).toContain('Metadata/project_settings.config');
-    expect(b).toContain('filament_diameter');
+    // We do NOT emit project_settings.config: a minimal one crashes Bambu's
+    // project loader, a full one reintroduces the preset warning. So no preset
+    // ids either. Colours come via colorgroup + extruder + paint_color.
+    expect(b).not.toContain('Metadata/project_settings.config');
     expect(b).not.toContain('filament_settings_id');
     expect(b).not.toContain('printer_settings_id');
-    expect(b).not.toContain('inherits_group');
     // Each part on its OWN plate: Bambu assigns by world position, so the two
     // <item> X translations must differ AND match the plate stride (bed × 1.2 =
     // 307.2 for a 256 bed). Transform = "1 0 0 0 1 0 0 0 1 TX TY TZ".
@@ -174,8 +171,7 @@ test.describe('multi-part 3MF export', () => {
     // makes Bambu build the plate list, and no preset-id keys (warning guard).
     expect((o.text.match(/<object id="\d+" type="model">/g) ?? []).length).toBe(3);
     expect((o.text.match(/<plate>/g) ?? []).length).toBe(3);
-    expect(o.text).toContain('Metadata/project_settings.config');
-    expect(o.text).toContain('filament_diameter');
+    expect(o.text).not.toContain('Metadata/project_settings.config');
     expect(o.text).not.toContain('filament_settings_id');
     // Colours from api.label survived the off-editor bake → distinct material colours.
     expect(o.text).toContain('<m:colorgroup');

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from 'playwright/test';
+
+// Multi-part 3MF export: validates the generic + Bambu "project" 3MF builder
+// (multiple objects, one plate per part, m:colorgroup + paint_color colour) and
+// the part-selection modal it's driven from.
+
+test.describe('multi-part 3MF export', () => {
+  test.beforeEach(async ({ page }) => {
+    // Suppress the first-run guided tour — its backdrop intercepts clicks.
+    await page.addInitScript(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ } });
+  });
+
+  test('build3MFProject emits multiple objects, plates and colour bindings', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForTimeout(3000); // let the module graph + engine settle
+
+    const report = await page.evaluate(async () => {
+      const { build3MFProject } = await import('/src/export/threemfProject.ts');
+
+      // Build a part from a flat list of per-triangle colours. Two verts shared
+      // across triangles keeps it valid; colours drive the material mapping.
+      const makePart = (name: string, triRgb: [number, number, number][]) => {
+        const verts: number[] = [];
+        const tris: number[] = [];
+        const colors: number[] = [];
+        triRgb.forEach((rgb, i) => {
+          const base = i * 3;
+          verts.push(0, 0, i, 10, 0, i, 0, 10, i);
+          tris.push(base, base + 1, base + 2);
+          colors.push(rgb[0], rgb[1], rgb[2]);
+        });
+        const triColors = new Uint8Array(colors);
+        (triColors as Uint8Array & { _painted?: Uint8Array })._painted = new Uint8Array(triRgb.length).fill(1);
+        return {
+          name,
+          mesh: {
+            vertProperties: new Float32Array(verts), triVerts: new Uint32Array(tris),
+            numVert: triRgb.length * 3, numTri: triRgb.length, numProp: 3, triColors,
+          },
+        };
+      };
+
+      const built = build3MFProject([
+        // A two-colour part → the non-dominant colour gets a paint_color.
+        makePart('Body', [[255, 0, 0], [0, 0, 255]]),
+        makePart('Lid', [[0, 0, 255]]),
+      ]);
+      const buf = new Uint8Array(await built.blob.arrayBuffer());
+      // ZIP is STORE (uncompressed) so file contents appear verbatim in the bytes.
+      const text = new TextDecoder('utf-8').decode(buf);
+      return { filename: built.filename, text, size: buf.length };
+    });
+
+    expect(report.filename).toMatch(/\.3mf$/);
+    // Two objects + two build items.
+    expect(report.text).toContain('<object id="1" type="model">');
+    expect(report.text).toContain('<object id="2" type="model">');
+    expect((report.text.match(/<item objectid=/g) ?? []).length).toBe(2);
+    // Bambu project marker (flips Bambu into multi-plate / filament-binding mode).
+    expect(report.text).toContain('<metadata name="Application">BambuStudio-');
+    // Generic material colours (read by non-Bambu slicers).
+    expect(report.text).toContain('<m:colorgroup');
+    expect(report.text).toContain('#FF0000FF');
+    expect(report.text).toContain('#0000FFFF');
+    // Bambu per-triangle paint_color (the non-dominant colour gets one).
+    expect(report.text).toContain('paint_color=');
+    // model_settings.config with one plate per part.
+    expect(report.text).toContain('Metadata/model_settings.config');
+    expect((report.text.match(/<plate>/g) ?? []).length).toBe(2);
+    expect(report.text).toContain('key="plater_id" value="1"');
+    expect(report.text).toContain('key="plater_id" value="2"');
+    expect(report.text).toContain('key="extruder"');
+    // project_settings.config with the filament colour list.
+    expect(report.text).toContain('Metadata/project_settings.config');
+    expect(report.text).toContain('filament_colour');
+  });
+
+  test('part picker lets you choose parts and export a multi-plate 3MF', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForTimeout(4000);
+
+    // Build a 2-part session through the console API. Set units to mm so the
+    // export-confirm (unitless) modal doesn't precede the part picker.
+    const partCount = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: any }).partwright;
+      const units = await import('/src/geometry/units.ts');
+      units.setUnits('mm');
+      await pw.runAndSave('return api.Manifold.cube([10,10,10], true);', 'box');
+      await pw.createPart('Pyramid');
+      await pw.runAndSave('return api.Manifold.cube([8,8,8], true);', 'pyramid');
+      return pw.listParts ? pw.listParts().length : 2;
+    });
+    expect(partCount).toBeGreaterThan(1);
+    await page.waitForTimeout(1500);
+
+    // Trigger the 3MF export. The toolbar Export dropdown → 3MF.
+    await page.locator('#btn-export').click();
+    await page.locator('#export-dropdown').getByText('3MF', { exact: true }).click();
+
+    // The part picker should appear for a multi-part session.
+    const modal = page.getByRole('dialog');
+    await expect(modal.getByText(/Export parts to 3MF/i)).toBeVisible({ timeout: 10000 });
+    await page.screenshot({ path: 'test-results/multipart-3mf-modal.png' });
+
+    // Select all and export; intercept the download.
+    await modal.getByRole('button', { name: /select all/i }).click();
+    const downloadPromise = page.waitForEvent('download', { timeout: 30000 }).catch(() => null);
+    await modal.getByRole('button', { name: /export/i }).click();
+    const download = await downloadPromise;
+    expect(download).not.toBeNull();
+    expect(download!.suggestedFilename()).toMatch(/\.3mf$/);
+  });
+});

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -212,4 +212,38 @@ test.describe('multi-part 3MF export', () => {
     expect(o.text).toContain('/3D/Objects/object_2.model');
     expect(o.text).toContain('/3D/Objects/object_3.model');
   });
+
+  test('Bambu plates use a ⌈√N⌉-column grid (matches Bambu plate layout)', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForTimeout(3000);
+
+    // 6 parts → Bambu lays plates out in ⌈√6⌉ = 3 columns × 2 rows. Each part's
+    // <item> must sit at the centre of a distinct cell or it lands off-plate (the
+    // bug where 2 of 6 parts fell off). Assert exactly 3 distinct X columns and 2
+    // distinct Y rows across the 6 build items — a regression guard for the grid.
+    const cols = await page.evaluate(async () => {
+      const { build3MFProject } = await import('/src/export/threemfProject.ts');
+      const makePart = (name: string) => {
+        const verts = [0, 0, 0, 10, 0, 0, 0, 10, 0];
+        return {
+          name,
+          mesh: {
+            vertProperties: new Float32Array(verts), triVerts: new Uint32Array([0, 1, 2]),
+            numVert: 3, numTri: 1, numProp: 3,
+          },
+        };
+      };
+      const parts = Array.from({ length: 6 }, (_, i) => makePart('part' + i));
+      const built = build3MFProject(parts, { bambu: true });
+      const text = await built.blob.arrayBuffer().then(a => new TextDecoder().decode(new Uint8Array(a)));
+      const items = [...text.matchAll(/<item objectid="\d+"[^>]*transform="([^"]+)"/g)]
+        .map(m => m[1].trim().split(/\s+/));
+      const xs = new Set(items.map(t => t[9]));
+      const ys = new Set(items.map(t => t[10]));
+      return { items: items.length, xCols: xs.size, yRows: ys.size };
+    });
+    expect(cols.items).toBe(6);
+    expect(cols.xCols).toBe(3); // ⌈√6⌉ columns
+    expect(cols.yRows).toBe(2); // 2 rows
+  });
 });

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -54,37 +54,36 @@ test.describe('multi-part 3MF export', () => {
 
     expect(report.filename).toMatch(/\.3mf$/);
 
-    // ── Bambu/Orca project mode ──
+    // ── Bambu/Orca project mode (production-extension layout) ──
+    // Verified to load in OrcaSlicer 2.3.2 headless (exit 0, N plates). The
+    // structural invariants below are exactly the ones that, if broken, make the
+    // real slicer reject the file — so this guards the headless-validated recipe.
     const b = report.bambu;
-    expect(b).toContain('<object id="1" type="model">');
-    expect(b).toContain('<object id="2" type="model">');
-    expect((b.match(/<item objectid=/g) ?? []).length).toBe(2);
-    // Project marker (flips Bambu into multi-plate / filament-binding mode).
+    // Production extension: each part is a wrapper -> separate /3D/Objects/*.model.
+    expect(b).toContain('requiredextensions="p"');
+    expect((b.match(/p:path="\/3D\/Objects\/object_\d+\.model"/g) ?? []).length).toBe(2);
+    expect((b.match(/<component /g) ?? []).length).toBe(2);
+    // Project marker (flips Bambu into project / multi-plate mode).
     expect(b).toContain('<metadata name="Application">BambuStudio-');
-    // Generic material colours (read by non-Bambu slicers) + Bambu per-triangle paint.
+    // Colours: generic m:colorgroup (any slicer) + Bambu per-triangle paint_color.
     expect(b).toContain('<m:colorgroup');
-    expect(b).toContain('#FF0000FF');
-    expect(b).toContain('#0000FFFF');
     expect(b).toContain('paint_color=');
-    // model_settings.config with one plate per part.
+    // model_settings.config: one <plate> per part.
     expect(b).toContain('Metadata/model_settings.config');
     expect((b.match(/<plate>/g) ?? []).length).toBe(2);
-    expect(b).toContain('key="plater_id" value="1"');
-    expect(b).toContain('key="plater_id" value="2"');
     expect(b).toContain('key="extruder"');
-    // We do NOT emit project_settings.config: a minimal one crashes Bambu's
-    // project loader, a full one reintroduces the preset warning. So no preset
-    // ids either. Colours come via colorgroup + extruder + paint_color.
-    expect(b).not.toContain('Metadata/project_settings.config');
-    expect(b).not.toContain('filament_settings_id');
-    expect(b).not.toContain('printer_settings_id');
-    // Each part on its OWN plate: Bambu assigns by world position, so the two
-    // <item> X translations must differ AND match the plate stride (bed × 1.2 =
-    // 307.2 for a 256 bed). Transform = "1 0 0 0 1 0 0 0 1 TX TY TZ".
-    const bTxs = [...b.matchAll(/<item objectid="\d+" transform="([^"]+)"/g)]
-      .map(m => parseFloat(m[1].trim().split(/\s+/)[9]));
+    // LOAD-CRITICAL: plater_name MUST be empty — a non-empty value makes Orca's
+    // loader reject the project (regression guard for the bug we hit).
+    expect(b).not.toMatch(/plater_name" value="[^"]+"/);
+    // REQUIRED: a minimal project_settings.config makes the loader build the
+    // plate list (absent → single plate). It carries the filament preset id.
+    expect(b).toContain('Metadata/project_settings.config');
+    expect(b).toContain('filament_settings_id');
+    // Each part placed in its own plate slot → distinct <item> X translations.
+    const bTxs = [...b.matchAll(/<item objectid="\d+"[^>]*transform="([^"]+)"/g)]
+      .map(m => m[1].trim().split(/\s+/)[9]);
     expect(bTxs.length).toBe(2);
-    expect(Math.abs((bTxs[1] - bTxs[0]) - 256 * 1.2)).toBeLessThan(5); // plate stride
+    expect(bTxs[0]).not.toBe(bTxs[1]);
 
     // ── Generic multi-object mode ──
     const g = report.generic;
@@ -167,12 +166,12 @@ test.describe('multi-part 3MF export', () => {
     expect((out as { error?: string }).error).toBeUndefined();
     const o = out as { parts: number; text: string };
     expect(o.parts).toBe(3);
-    // Real bake produced 3 objects, 3 plates, the project_settings.config that
-    // makes Bambu build the plate list, and no preset-id keys (warning guard).
-    expect((o.text.match(/<object id="\d+" type="model">/g) ?? []).length).toBe(3);
+    // Real bake → 3 production-extension parts, 3 plates, project_settings.config
+    // (builds the plate list), empty plater_name (load-critical), and colours.
+    expect((o.text.match(/p:path="\/3D\/Objects\/object_\d+\.model"/g) ?? []).length).toBe(3);
     expect((o.text.match(/<plate>/g) ?? []).length).toBe(3);
-    expect(o.text).not.toContain('Metadata/project_settings.config');
-    expect(o.text).not.toContain('filament_settings_id');
+    expect(o.text).toContain('Metadata/project_settings.config');
+    expect(o.text).not.toMatch(/plater_name" value="[^"]+"/);
     // Colours from api.label survived the off-editor bake → distinct material colours.
     expect(o.text).toContain('<m:colorgroup');
     const colors = [...o.text.matchAll(/<m:color color="(#[0-9A-F]{8})"/g)].map(m => m[1]);

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -72,6 +72,14 @@ test.describe('multi-part 3MF export', () => {
     expect(b).toContain('Metadata/model_settings.config');
     expect((b.match(/<plate>/g) ?? []).length).toBe(2);
     expect(b).toContain('key="extruder"');
+    // PER-PART COLOUR: each part maps to its own AMS filament slot, so the two
+    // differently-coloured parts get DISTINCT extruders (Body→1 red, Lid→2 blue)
+    // and the part palette lands in filament_colour. Regression guard against the
+    // "all extruder 1 / grey filament_colour" single-colour base.
+    expect(b).toContain('key="extruder" value="1"');
+    expect(b).toContain('key="extruder" value="2"');
+    expect(b).toContain('"filament_colour": [');
+    expect(b).toMatch(/#FF0000/i); // Body's red made it into the filament palette
     // CRASH FIX: <part id=ODD subtype="normal_part"> + <mesh_stat> must be present
     // (was missing before; caused Bambu GUI crash on project open).
     expect(b).toContain('<part ');

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -83,6 +83,18 @@ test.describe('multi-part 3MF export', () => {
     expect(b).toContain('key="extruder" value="2"');
     expect(b).toContain('"filament_colour": [');
     expect(b).toMatch(/#FF0000/i); // Body's red made it into the filament palette
+    // NO 3-COLOUR CAP: the config is resized to one filament per distinct colour.
+    // Body uses red+blue, Lid blue → 2 distinct → filament_colour length 2, and the
+    // per-filament arrays scale with it (nozzle_temperature is ×2 per extruder variant
+    // → length 4). upward_compatible_machine is NOT per-filament so it stays length 3.
+    // Guards the N-filament resize against regressing to a fixed 3.
+    const arrLen = (key: string) => {
+      const m = b.match(new RegExp(`"${key}":\\s*\\[([\\s\\S]*?)\\]`));
+      return m ? (m[1].match(/"[^"]*"/g) ?? []).length : -1;
+    };
+    expect(arrLen('filament_colour')).toBe(2);
+    expect(arrLen('nozzle_temperature')).toBe(4);
+    expect(arrLen('upward_compatible_machine')).toBe(3);
     // CRASH FIX: <part id=ODD subtype="normal_part"> + <mesh_stat> must be present
     // (was missing before; caused Bambu GUI crash on project open).
     expect(b).toContain('<part ');

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -40,49 +40,66 @@ test.describe('multi-part 3MF export', () => {
         };
       };
 
-      const built = build3MFProject([
-        // A two-colour part → the non-dominant colour gets a paint_color.
+      const parts = [
+        // A two-colour part → the non-dominant colour gets a paint_color (Bambu).
         makePart('Body', [[255, 0, 0], [0, 0, 255]]),
         makePart('Lid', [[0, 0, 255]]),
-      ]);
-      const buf = new Uint8Array(await built.blob.arrayBuffer());
+      ];
+      const decode = (b: Blob) => b.arrayBuffer().then(a => new TextDecoder('utf-8').decode(new Uint8Array(a)));
       // ZIP is STORE (uncompressed) so file contents appear verbatim in the bytes.
-      const text = new TextDecoder('utf-8').decode(buf);
-      return { filename: built.filename, text, size: buf.length };
+      const bambu = build3MFProject(parts, { bambu: true, bedSize: [256, 256] });
+      const generic = build3MFProject(parts, { bambu: false });
+      return { filename: bambu.filename, bambu: await decode(bambu.blob), generic: await decode(generic.blob) };
     });
 
     expect(report.filename).toMatch(/\.3mf$/);
-    // Two objects + two build items.
-    expect(report.text).toContain('<object id="1" type="model">');
-    expect(report.text).toContain('<object id="2" type="model">');
-    expect((report.text.match(/<item objectid=/g) ?? []).length).toBe(2);
-    // Bambu project marker (flips Bambu into multi-plate / filament-binding mode).
-    expect(report.text).toContain('<metadata name="Application">BambuStudio-');
-    // Generic material colours (read by non-Bambu slicers).
-    expect(report.text).toContain('<m:colorgroup');
-    expect(report.text).toContain('#FF0000FF');
-    expect(report.text).toContain('#0000FFFF');
-    // Bambu per-triangle paint_color (the non-dominant colour gets one).
-    expect(report.text).toContain('paint_color=');
+
+    // ── Bambu/Orca project mode ──
+    const b = report.bambu;
+    expect(b).toContain('<object id="1" type="model">');
+    expect(b).toContain('<object id="2" type="model">');
+    expect((b.match(/<item objectid=/g) ?? []).length).toBe(2);
+    // Project marker (flips Bambu into multi-plate / filament-binding mode).
+    expect(b).toContain('<metadata name="Application">BambuStudio-');
+    // Generic material colours (read by non-Bambu slicers) + Bambu per-triangle paint.
+    expect(b).toContain('<m:colorgroup');
+    expect(b).toContain('#FF0000FF');
+    expect(b).toContain('#0000FFFF');
+    expect(b).toContain('paint_color=');
     // model_settings.config with one plate per part.
-    expect(report.text).toContain('Metadata/model_settings.config');
-    expect((report.text.match(/<plate>/g) ?? []).length).toBe(2);
-    expect(report.text).toContain('key="plater_id" value="1"');
-    expect(report.text).toContain('key="plater_id" value="2"');
-    expect(report.text).toContain('key="extruder"');
-    // project_settings.config pins filament colours WITHOUT preset-id keys (those
-    // trigger Bambu's "customized presets / unsafe G-code" warning).
-    expect(report.text).toContain('Metadata/project_settings.config');
-    expect(report.text).toContain('filament_colour');
-    expect(report.text).not.toContain('filament_settings_id');
-    expect(report.text).not.toContain('printer_settings_id');
-    // Each part must sit on its OWN plate: Bambu assigns by world position, so the
-    // two <item> transforms must have DISTINCT X translations (else both stack on
-    // plate 1). Transform is "1 0 0 0 1 0 0 0 1 TX TY TZ".
-    const txs = [...report.text.matchAll(/<item objectid="\d+" transform="([^"]+)"/g)]
-      .map(m => m[1].trim().split(/\s+/)[9]); // 12-value row-major matrix; index 9 = TX
-    expect(txs.length).toBe(2);
-    expect(txs[0]).not.toBe(txs[1]);
+    expect(b).toContain('Metadata/model_settings.config');
+    expect((b.match(/<plate>/g) ?? []).length).toBe(2);
+    expect(b).toContain('key="plater_id" value="1"');
+    expect(b).toContain('key="plater_id" value="2"');
+    expect(b).toContain('key="extruder"');
+    // NO project_settings.config / preset ids — those trip Bambu's "customized
+    // presets / unsafe G-code" warning. Colours come via colorgroup + extruder.
+    expect(b).not.toContain('Metadata/project_settings.config');
+    expect(b).not.toContain('filament_settings_id');
+    expect(b).not.toContain('printer_settings_id');
+    // Each part on its OWN plate: Bambu assigns by world position, so the two
+    // <item> X translations must differ AND match the plate stride (bed × 1.2 =
+    // 307.2 for a 256 bed). Transform = "1 0 0 0 1 0 0 0 1 TX TY TZ".
+    const bTxs = [...b.matchAll(/<item objectid="\d+" transform="([^"]+)"/g)]
+      .map(m => parseFloat(m[1].trim().split(/\s+/)[9]));
+    expect(bTxs.length).toBe(2);
+    expect(Math.abs((bTxs[1] - bTxs[0]) - 256 * 1.2)).toBeLessThan(5); // plate stride
+
+    // ── Generic multi-object mode ──
+    const g = report.generic;
+    expect(g).toContain('<object id="1" type="model">');
+    expect(g).toContain('<object id="2" type="model">');
+    expect((g.match(/<item objectid=/g) ?? []).length).toBe(2);
+    expect(g).toContain('<m:colorgroup'); // colours still present for any slicer
+    // No Bambu-specific metadata at all.
+    expect(g).not.toContain('BambuStudio-');
+    expect(g).not.toContain('Metadata/model_settings.config');
+    expect(g).not.toContain('paint_color=');
+    // Grid-arranged → the two parts have distinct X positions (no overlap).
+    const gTxs = [...g.matchAll(/<item objectid="\d+" transform="([^"]+)"/g)]
+      .map(m => m[1].trim().split(/\s+/)[9]);
+    expect(gTxs.length).toBe(2);
+    expect(gTxs[0]).not.toBe(gTxs[1]);
   });
 
   test('part picker lets you choose parts and export a multi-plate 3MF', async ({ page }) => {

--- a/tests/unit/apiParity.test.ts
+++ b/tests/unit/apiParity.test.ts
@@ -32,6 +32,33 @@ const INTENTIONALLY_UNDOCUMENTED = new Set([
   'importImageAsVoxels',// documented in voxel subdoc, not main help table
   'mergeChatHistory',   // internal chat management, not an agent workflow
   'setThumbnailCamera', // internal UI helper, not a geometry/session operation
+  'help',               // the documenter itself — not a help() table key
+  '__setProgressModalDelay', // internal test hook
+]);
+
+// Pre-existing undocumented API methods — NOT intentional, a documentation
+// backlog to triage (add help() entries + ai-doc coverage). Surfaced once the
+// parity scan was widened to cover the WHOLE partwrightAPI object (it previously
+// only saw the first ~80 KB, hiding these). Tracked in GitHub issue #683; this
+// list is the work item, not a permanent exemption — shrink it as methods get
+// documented. They are excluded from the "missing from help()" gate but still
+// asserted to actually exist (no stale entries), so the list can't rot.
+const UNDOCUMENTED_BACKLOG = new Set([
+  'getThumbnailCamera', 'sliceAtZVisual', 'importImageAsRelief', 'importSvgAsRelief',
+  'getReliefSwapGuide', 'setReliefPreviewMode', 'setImages', 'addImage', 'removeImage',
+  'clearImages', 'getImages', 'closeSession', 'deleteSession', 'commitWithColors',
+  'navigateVersion', 'getSessionUrl', 'getSessionState', 'deleteSessionNote',
+  'updateSessionNote', 'exportSession', 'importSession', 'clearAllSessions', 'isRunning',
+  'getPrinterSettings', 'setPrinterSettings', 'checkPrintability', 'createSessionWithVersions',
+  'analyzeProfileIsolated', 'measureBetween', 'probeRay', 'checkContainment', 'renameSession',
+  'setReferenceGeometry', 'clearReferenceGeometry', 'hasReferenceGeometry', 'setUnits',
+  'getUnits', 'measureMode', 'getMeasurement', 'measurePoints', 'getBrushSurface',
+  'setBrushSurface', 'setBrushDepth', 'getBrushWrapAngle', 'setBrushWrapAngle',
+  'getBrushSmooth', 'setBrushSmooth', 'setBrushSmoothDivisor', 'paintStroke', 'paintAirbrush',
+  'waitForPaint', 'getLabelNames', 'activateVoxelPaint', 'deactivateVoxelPaint',
+  'paintVoxelFace', 'setVoxelTool', 'voxelStudioApply', 'voxelStudioUndo', 'voxelStudioRedo',
+  'setVoxelBrush', 'setVoxelLevelAxis', 'voxelStudioBeginStroke', 'voxelStudioEndStroke',
+  'bakeVoxelsToCode', 'updateVoxelCode',
 ]);
 
 /** Language keywords that appear at 4-space indent inside an object literal
@@ -47,8 +74,9 @@ function extractApiMembers(src: string): Set<string> {
   const apiStart = src.indexOf('const partwrightAPI = {');
   if (apiStart === -1) throw new Error('Could not find partwrightAPI in main.ts');
 
-  // Take a generous slice — the object is large.
-  const chunk = src.slice(apiStart, apiStart + 80_000);
+  // Scan the WHOLE object (it's ~300 KB and we stop at the `help(` member
+  // anyway); an earlier 80 KB window silently scanned only the first third.
+  const chunk = src.slice(apiStart, apiStart + 400_000);
   const lines = chunk.split('\n');
   const members = new Set<string>();
 
@@ -108,23 +136,23 @@ describe('partwrightAPI vs help() parity', () => {
     expect(helpKeys.size).toBeGreaterThan(100);
   });
 
-  it('every partwrightAPI member is either in help() or INTENTIONALLY_UNDOCUMENTED', () => {
+  it('every partwrightAPI member is in help(), INTENTIONALLY_UNDOCUMENTED, or the backlog', () => {
     const missing: string[] = [];
     for (const member of apiMembers) {
-      if (!helpKeys.has(member) && !INTENTIONALLY_UNDOCUMENTED.has(member)) {
+      if (!helpKeys.has(member) && !INTENTIONALLY_UNDOCUMENTED.has(member) && !UNDOCUMENTED_BACKLOG.has(member)) {
         missing.push(member);
       }
     }
+    // A NEW undocumented method must get a help() entry (or be added to a set
+    // with justification) — it can't silently join the backlog.
     expect(missing, `API members missing from help(): ${missing.join(', ')}`).toHaveLength(0);
   });
 
-  it('INTENTIONALLY_UNDOCUMENTED set has no stale entries (every entry is actually in partwrightAPI)', () => {
+  it('the undocumented sets have no stale entries (every name is actually in partwrightAPI)', () => {
     const stale: string[] = [];
-    for (const name of INTENTIONALLY_UNDOCUMENTED) {
-      if (!apiMembers.has(name)) {
-        stale.push(name);
-      }
+    for (const name of [...INTENTIONALLY_UNDOCUMENTED, ...UNDOCUMENTED_BACKLOG]) {
+      if (!apiMembers.has(name)) stale.push(name);
     }
-    expect(stale, `Stale INTENTIONALLY_UNDOCUMENTED entries (no longer in API): ${stale.join(', ')}`).toHaveLength(0);
+    expect(stale, `Stale undocumented entries (no longer in API): ${stale.join(', ')}`).toHaveLength(0);
   });
 });

--- a/tests/unit/paintColor3mf.test.ts
+++ b/tests/unit/paintColor3mf.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { encodePaintColorState, decodePaintColorState, MAX_PAINT_STATE } from '../../src/export/paintColor3mf';
+
+describe('paint_color encoding (Bambu/Orca per-triangle filament)', () => {
+  it('state 0 (NONE) encodes to the empty string (attribute omitted)', () => {
+    expect(encodePaintColorState(0)).toBe('');
+    expect(decodePaintColorState('')).toBe(0);
+  });
+
+  it('matches the known short-form leaf values for states 1–2', () => {
+    // Documented worked example: paint_color="4" => Extruder1 (filament slot 1).
+    expect(encodePaintColorState(1)).toBe('4');
+    expect(encodePaintColorState(2)).toBe('8');
+  });
+
+  it('matches the known escape-form value for state 3 ("0C" => Extruder3)', () => {
+    expect(encodePaintColorState(3)).toBe('0C');
+    expect(encodePaintColorState(4)).toBe('1C');
+    expect(encodePaintColorState(16)).toBe('DC');
+  });
+
+  it('produces uppercase-only hex (Bambu silently ignores lowercase)', () => {
+    for (let s = 1; s <= MAX_PAINT_STATE; s++) {
+      const enc = encodePaintColorState(s);
+      expect(enc).toMatch(/^[0-9A-F]+$/);
+    }
+  });
+
+  it('round-trips every state in the supported range', () => {
+    for (let s = 0; s <= MAX_PAINT_STATE; s++) {
+      expect(decodePaintColorState(encodePaintColorState(s))).toBe(s);
+    }
+  });
+
+  it('crosses the 16→17 escape2 boundary correctly', () => {
+    expect(decodePaintColorState(encodePaintColorState(16))).toBe(16);
+    expect(decodePaintColorState(encodePaintColorState(17))).toBe(17);
+    expect(decodePaintColorState(encodePaintColorState(18))).toBe(18);
+  });
+
+  it('rejects out-of-range and non-integer states', () => {
+    expect(() => encodePaintColorState(-1)).toThrow();
+    expect(() => encodePaintColorState(255)).toThrow();
+    expect(() => encodePaintColorState(1.5)).toThrow();
+  });
+
+  it('rejects malformed / split-node decode input', () => {
+    expect(() => decodePaintColorState('zz')).toThrow();
+    // A split node has non-zero low 2 bits in the root nibble: 0b0001 = '1'.
+    expect(() => decodePaintColorState('1')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Bundle **multiple Session Parts** into one 3MF via a **part picker** (checkbox + thumbnail per part, active part preselected, Select-all). Two separate exports:

- **"3MF"** (generic) — multi-part → a plain **multi-object** 3MF, parts grid-arranged, `m:colorgroup` colours, no Bambu metadata. Opens in any slicer. **Hardware-verified.**
- **"3MF — Bambu/Orca"** — a Bambu Studio **project**: each part on its **own build plate**, with **per-part colour** (dominant colour → AMS filament slot). **Crash fixed + 3-plate load confirmed on hardware.**

Console API: `export3MFParts(...)` (download) + `export3MFPartsData(...)` (returns base64 bytes — agent/test-friendly).

## Bambu GUI crash — root-caused from the macOS crash report

Earlier builds crashed Bambu Studio intermittently on open. A macOS crash report pinned it: a null-pointer read (`EXC_BAD_ACCESS at 0x0`) in `Slic3r::GUI::Plater::priv::load_files`, reached from `post_init` on a `wxIdleEvent`, with register x10 holding the bytes **"filament"**. So `load_files` null-deref'd while binding objects to filaments.

**Root cause:** our `project_settings.config` named a filament *preset id* but shipped only ~6 keys — none of the per-filament **arrays** (`filament_colour`, `filament_type`, `filament_ids`, `filament_map`, …) that `load_files` indexes when mapping each object's extruder to a filament. The lookup ran off the end → null. Intermittent because `load_files` races the background user-preset loader on idle.

**Why headless never caught it:** the Bambu CLI's `--slice` loader differs from the GUI's `Plater::load_project`, so it sliced clean while the GUI crashed. **OrcaSlicer was never a valid proxy.**

**Fix:** ship the **complete** config from a real known-good reference — a full **Bambu Lab H2C** profile (536 keys, all filament arrays). The H2C profile's 330×320 bed exposed a second bug — the old 180mm-bed plate stride put a part on a plate boundary (Bambu CLI: "Object … partly inside"). Now derive bed size from the template's `printable_area` and **centre each part in its plate cell** (~410 mm H2C stride). ✅ **User confirmed: opens in Bambu Studio with 3 plates, no crash.**

## Per-part colour

Each part's dominant colour maps to one of the **3 AMS filament slots** via the per-object `extruder` field + `filament_colour` — done **without resizing any config array** (a too-short array is what crashed `load_files`). Capped at 3 distinct colours (the common AMS case); >3 reuses the nearest slot. ⏳ colour-display confirmation in the Bambu GUI pending.

## Key files

- `src/export/bambuProjectTemplate.json` — complete H2C profile (the load-critical config).
- `src/export/threemfProject.ts` — `bambu` flag: production-extension split-file layout + complete config + per-plate centring + per-part extruder/filament_colour (Bambu) vs inline grid (generic).
- `src/ui/exportPartsModal.ts` — part picker; `src/ui/toolbar.ts` + `src/main.ts` — menu items, `export3MFParts`/`export3MFPartsData` console APIs + help() + docs.
- `src/color/regions.ts` — pure `composeTriColors` (off-editor part baking).

## Test plan

- ✅ `tests/threemf-multipart.spec.ts` — 3 e2e: builder (both modes; Bambu invariants assert the complete filament arrays, H2C profile, empty `plater_name`, **distinct per-object extruders + part palette in filament_colour**), picker UI, full-bake-pipeline read-back.
- ✅ **Bambu CLI**: real builder output loads + slices to 3 plates with the colour palette (`return_code 0`).
- ✅ **Bambu Studio (hardware)**: opens, 3 plates, no crash.
- ✅ Build + typecheck clean; no dep cycles.
- ⚠️ One **unrelated** pre-existing unit failure (`catalog.test.ts` rolling-date window; fails on `main` too) — **#723**.

## Scope / follow-ups

- [x] Generic multi-part **3MF** (grid) — hardware-verified.
- [x] **Bambu multi-plate** — crash root-caused + fixed; 3-plate load confirmed on hardware.
- [x] **Per-part colour in Bambu** (≤3 colours via extruder + filament_colour).
- [ ] **>3 colours / in-part multicolour** (config resize + `paint_color`) — #729.
- [ ] **Other formats** (STL/OBJ/GLB) — #682.
- [ ] **`apiParity` undocumented backlog** — #683.
- [ ] **Unrelated** catalog freshness CI failure — #723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FH4ezzKM3KavfP9L1BPgLz