### PR TITLE
test: wait for window.partwright before driving it in e2e specs

### DIFF
--- a/prompts/fix-ready-before-partwright-race.md
+++ b/prompts/fix-ready-before-partwright-race.md
@@ -1,0 +1,43 @@
+---
+date: 2026-06-15
+branch: claude/magical-wozniak-9xjylu
+files_changed:
+  - tests/multi-tab-lock.spec.ts
+  - tests/paint-cancel.spec.ts
+  - tests/paint-coverage.spec.ts
+  - tests/paint-preview-shapes.spec.ts
+---
+
+## Human
+
+"i have failing test on main" — pasted a CI run (shard 2 of 3) where
+`tests/multi-tab-lock.spec.ts` hard-failed and three paint specs
+(`paint-cancel`, `paint-coverage`, `paint-preview-shapes`) flaked with
+`TypeError: Cannot read properties of undefined (reading 'run')` inside a
+`page.evaluate`.
+
+## Assistant
+
+Root cause: a boot race in the e2e setup, not a product bug. These specs wait
+for `waitForSelector('text=Ready')` and then immediately reach for
+`window.partwright`. But the "Ready" status can paint a frame *before*
+`window.partwright` is assigned — that wiring (`apiWindow.partwright = …`) lives
+near the very end of `main()`, after a top-level await that lets the initial
+render set "Ready" first. On a loaded CI shard the status wins the race, so
+`pw` is `undefined` and `pw.run(...)` throws `reading 'run'`. The same
+anti-pattern explains the multi-tab hard failure (its first `pw.createSession`
+on the leader tab races identically); it passed 3/3 locally, consistent with a
+load-dependent flake.
+
+The robust specs (e.g. `insert-palette`) already avoid this by waiting on the
+API object itself (`waitForFunction(() => !!window.partwright?.help)`) rather
+than the status text. Applied the same guard to the four reported specs: after
+the existing `text=Ready` wait, a `waitForFunction(() => …partwright?.run)`
+before any `page.evaluate` that drives the API (both tabs in the multi-tab
+spec). Minimal and proven — kept scope to the four failing specs rather than
+rewriting the ~70 that share the `text=Ready` pattern but aren't flaking, since
+most don't immediately touch `partwright` and the broad rewrite is a separate
+refactor.
+
+Verified: the four specs run 8/8 green (multi-tab also passed 3/3 on repeat
+before the change, confirming load-sensitivity); `tsc --noEmit` clean.

--- a/tests/multi-tab-lock.spec.ts
+++ b/tests/multi-tab-lock.spec.ts
@@ -9,6 +9,11 @@ test.describe('Multi-tab single-writer leader', () => {
     const page1 = await context.newPage();
     await page1.goto('/editor');
     await page1.waitForSelector('text=Ready', { timeout: 15000 });
+    // "Ready" can paint before window.partwright is assigned (wired up near the
+    // end of main()); wait for the API itself before driving it.
+    await page1.waitForFunction(
+      () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    );
 
     const sessionId = await page1.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,6 +43,9 @@ test.describe('Multi-tab single-writer leader', () => {
 
     // page2 (leader) saves a new version; page1 (read-only viewer) should mirror
     // to it rather than freezing on the version it had.
+    await page2.waitForFunction(
+      () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    );
     await page2.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const pw = (window as any).partwright;

--- a/tests/paint-cancel.spec.ts
+++ b/tests/paint-cancel.spec.ts
@@ -15,6 +15,12 @@ import { test, expect } from 'playwright/test';
 async function openEditor(page: import('playwright/test').Page) {
   await page.goto('/editor');
   await page.waitForSelector('text=Ready', { timeout: 15000 });
+  // The "Ready" status can paint a frame before window.partwright is assigned
+  // (it's wired up near the end of main()), so wait for the API itself before
+  // driving it — otherwise a loaded CI shard reads `run` off undefined.
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+  );
   await page.evaluate(async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const pw = (window as any).partwright;

--- a/tests/paint-coverage.spec.ts
+++ b/tests/paint-coverage.spec.ts
@@ -10,6 +10,11 @@ test.describe('paint coverage filters', () => {
   test('coverageMode and area stats defang fan-topology bleed', async ({ page }) => {
     await page.goto('/editor');
     await page.waitForSelector('text=Ready', { timeout: 15000 });
+    // "Ready" can paint before window.partwright is assigned (wired up near the
+    // end of main()); wait for the API itself before driving it.
+    await page.waitForFunction(
+      () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    );
 
     // Build a 12-segment cylinder of radius 10 centered at origin. The top
     // face at z=2 is a fan of 12 triangles, each one a thin wedge from

--- a/tests/paint-preview-shapes.spec.ts
+++ b/tests/paint-preview-shapes.spec.ts
@@ -10,6 +10,11 @@ test.describe('paintPreview analytic shapes', () => {
   test('cylinder and slab previews select triangles and match the paint op', async ({ page }) => {
     await page.goto('/editor');
     await page.waitForSelector('text=Ready', { timeout: 15000 });
+    // "Ready" can paint before window.partwright is assigned (wired up near the
+    // end of main()); wait for the API itself before driving it.
+    await page.waitForFunction(
+      () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    );
 
     // A hollow tube: outer R=10, inner R=6, height 20. Its inner wall is the
     // canonical paintInCylinder target.


### PR DESCRIPTION
## Summary

Fixes the CI flake/failure reported on `main` (shard 2 of 3):

- **Hard failure:** `tests/multi-tab-lock.spec.ts`
- **Flaky** (`TypeError: Cannot read properties of undefined (reading 'run')`): `tests/paint-cancel.spec.ts`, `tests/paint-coverage.spec.ts`, `tests/paint-preview-shapes.spec.ts`

### Root cause — a boot race, not a product bug

These specs `waitForSelector('text=Ready')` and then immediately reach for `window.partwright`. But the "Ready" status can paint a frame **before** `window.partwright` is assigned — that wiring (`apiWindow.partwright = …`) lives near the very end of `main()`, after a top-level await that lets the initial render set "Ready" first. On a loaded CI shard the status wins the race, so `pw` is `undefined` and `pw.run(...)` throws `reading 'run'`. The multi-tab hard failure is the same race on its first `pw.createSession` call (it passes 3/3 locally — consistent with a load-dependent flake).

### Fix

The robust specs (e.g. `insert-palette`) already avoid this by waiting on the API object itself rather than the status text. Added the same guard to the four reported specs — after the existing `text=Ready` wait:

```ts
await page.waitForFunction(
  () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
);
```

Kept scope to the four failing specs rather than rewriting the ~70 that share the `text=Ready` pattern but aren't flaking (most don't immediately touch `partwright`; the broad rewrite is a separate refactor).

## Test plan

- `npx playwright test tests/multi-tab-lock.spec.ts tests/paint-cancel.spec.ts tests/paint-coverage.spec.ts tests/paint-preview-shapes.spec.ts` → **8 passed / 0 failed**
- `tsc --noEmit` clean
- Test-only change; no source touched.

https://claude.ai/code/session_01VxYm3KUhkS4FDyUMrziDXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxYm3KUhkS4FDyUMrziDXF)_