### PR TITLE
test: widen catalog rolling-window slack to 30 days

### DIFF
--- a/prompts/20260617-022500-fix-catalog-rolling-window-timebomb.md
+++ b/prompts/20260617-022500-fix-catalog-rolling-window-timebomb.md
@@ -1,0 +1,38 @@
+---
+session: "eizk6n"
+timestamp: "2026-06-17T02:25:00Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+Reported a failing unit test:
+`tests/unit/catalog.test.ts > catalog snapshot shape > every model has a
+release_date inside the rolling year window` —
+`openai/o3-pro: 2025-06-10 is older than the rolling window`.
+
+## Assistant
+
+## Key decisions
+
+**Diagnosis**: This test asserts every model in the committed models.dev
+snapshot has a `release_date` within a rolling 365-day window (plus a slack
+margin). The reported `openai/o3-pro` failure was the symptom of a **wall-clock
+time bomb**, not a code bug — the model simply aged past the window. The weekly
+`refresh-models-catalog` trigger already regenerated the snapshot (dropping the
+aged-out `o3-pro`) and that commit is on `origin/main`, so the test passes on
+this branch as-is.
+
+**Why it recurs**: The snapshot is committed once, then the test runs on every
+PR until the *next* weekly refresh lands. The old `slack` was only 7 days, which
+exactly matches the refresh interval — so any delayed/skipped/soft-failed
+refresh (review lag, holiday week, upstream fetch failure) turns CI red on
+unrelated PRs. Three `google/gemini-2.5-*` models currently sit exactly at the
+365-day edge and would have tripped the same assertion within ~7 days.
+
+**Fix**: Widened the test's `slack` from 7 to 30 days. The test's real purpose
+is to flag a snapshot whose refresh pipeline has genuinely stalled (a month+),
+not to fail on normal weekly drift. 30 days gives the edge models comfortable
+runway while still catching an abandoned snapshot. Chose to relax the test
+rather than touch the refresh script, since the snapshot content is correct and
+the brittleness lived entirely in the assertion's margin.

--- a/tests/unit/catalog.test.ts
+++ b/tests/unit/catalog.test.ts
@@ -26,7 +26,14 @@ describe('catalog snapshot shape', () => {
 
   test('every model has a release_date inside the rolling year window', () => {
     const cutoff = Date.now() - 365 * 86_400_000;
-    const slack = 7 * 86_400_000; // tolerate week-of-day variance vs script run
+    // The snapshot is committed once and the test then runs on every PR for
+    // however long it takes the *next* weekly refresh to land. A model sitting
+    // right at the 365-day edge at refresh time ages out within days, so the
+    // slack must cover a realistically-delayed or skipped refresh (review lag,
+    // a holiday week, a soft-failed upstream fetch) — not just the day-of-week
+    // variance between the script run and this test. 30 days still flags a
+    // snapshot whose refresh pipeline has genuinely stalled for a month+.
+    const slack = 30 * 86_400_000;
     const cat = catalogJson as Record<string, { models: Record<string, { release_date: string }> }>;
     for (const [providerId, provider] of Object.entries(cat)) {
       for (const [modelId, model] of Object.entries(provider.models)) {


### PR DESCRIPTION
## Summary

The `catalog snapshot shape > every model has a release_date inside the rolling year window` unit test is a wall-clock time bomb. It asserts every model in the committed models.dev snapshot has a `release_date` within a rolling 365-day window plus a `slack` margin — but the snapshot is committed once and the test then runs on every PR until the *next* weekly `refresh-models-catalog` regeneration lands.

The old `slack` was **7 days**, which exactly matches the weekly refresh cadence. So any delayed, skipped, or soft-failed refresh (review lag, a holiday week, an upstream fetch failure) flips CI red on unrelated PRs:

- The reported failure was `openai/o3-pro: 2025-06-10 is older than the rolling window` — the model aged past the window before a refresh removed it.
- Three `google/gemini-2.5-*` models currently sit *exactly* at the 365-day edge (`2025-06-17`) and would have tripped the same assertion within ~7 days.

## Change

Widen the test's `slack` from 7 → **30 days**. The test's real purpose is to flag a snapshot whose refresh pipeline has genuinely stalled (a month+), not to fail on normal weekly drift. 30 days gives edge-of-window models comfortable runway while still catching an abandoned snapshot. The snapshot content itself is correct (the refresh already dropped `o3-pro`), so only the assertion's margin needed fixing.

## Test plan

- `npm run typecheck` — clean
- `npm run test:unit` — 1447 passed (91 files)
- `npx vitest run tests/unit/catalog.test.ts` — 20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUqYNeTmyUK9hcoJa5JTXT)_