### PR TITLE
feat: let AI tools address parts by name/id/index, not just current selection

### DIFF
--- a/prompts/20260617-ai-part-target-addressing.md
+++ b/prompts/20260617-ai-part-target-addressing.md
@@ -1,0 +1,70 @@
+---
+date: 2026-06-17
+branch: claude/dazzling-franklin-ty7poh
+files_changed:
+  - src/ai/tools.ts
+  - src/main.ts
+  - public/ai.md
+  - tests/ai-part-target.spec.ts
+---
+
+## Human
+
+Saw an AI session working on a part; the user switched the viewed part from the
+part menu mid-turn. The AI was doing "select part → get current part" to read a
+part's info — fragile, because the human can move the current-part pointer while
+the AI works, so the AI ends up operating on the wrong part. Asked: it'd be
+better if the AI addressed parts directly by name/index instead of fetching the
+current part; keep changePart for when the user should watch the view change.
+Also flag any other cases of this class in the AI tool system.
+
+Chosen scope (via AskUserQuestion): the robust fix — give the mutating
+read/run/paint tools an explicit part target so addressing is decoupled from the
+shared "current part" focus.
+
+## Assistant
+
+Root problem: almost every AI tool acts on an *implicit* current-part pointer
+that is shared mutable state between the human and the agent — the same
+cross-actor bleed CLAUDE.md flags for tabs, but within one tab. The "changePart
+→ getCurrentPart" dance is a verification crutch for that shared pointer.
+
+Fix — separate *addressing* (which part an op targets) from *focus* (which part
+the human sees):
+
+- **`PART_TARGETABLE_TOOLS`** set in `tools.ts` lists the part-scoped tools
+  (reads, runs, paint, version ops, surface/transform). A post-array loop injects
+  a shared optional `part` property into each one's schema, so the description
+  lives in one place and can't drift. The prop is typeless on purpose: it accepts
+  a name/id string OR a 0-based index number. (Gemini's sanitizer defaults
+  typeless props to `string`, so Gemini callers get name/id addressing; the other
+  providers accept the full union including index.)
+- **Central switch in `executeTool`**: before running a part-scoped tool, if it
+  carries a `part` target, `focusTargetPart` resolves it (via the public
+  listParts/changePart API) and switches focus *first*, so the op acts on the
+  named part — not whatever the user last clicked. The key is stripped before the
+  per-tool API sees it (those reject unknown keys). It is a no-op when the target
+  is already current, which preserves any in-progress editor draft on that part.
+- **`resolvePartTarget` (main.ts)** gains 0-based index support, and a bare string
+  now resolves as id-OR-name (ids first). This gives the console/MCP API the same
+  flexible addressing: `changePart('Lid')`, `changePart(0)`, plus renamePart/
+  deletePart. Signatures + help() + ai.md updated.
+- **Reframed descriptions**: `changePart` is now "change what the USER sees" and
+  notes you rarely need it just to work on another part; `getCurrentPart` notes
+  it's rarely needed (prefer addressing by name/index); `listParts` documents the
+  `part` target.
+
+Decision: switch-then-act (focus follows the named part) rather than true
+headless operation on a non-focused part. The user explicitly accepted the view
+following ("the user can watch the view change"), and headless mutation would
+require rewriting the engine/viewport pipeline that paint/run/render depend on —
+a much larger, riskier change. Noted as a possible future follow-up.
+
+Other instances of the same class flagged to the user for follow-up (not fixed
+here): `runCode`/`runAndSave` defaulting to the live editor buffer (which the
+user may be typing into); current-session and current-version pointers; global
+toggles. These are tracked in the chat for separate issues.
+
+Tests: `tests/ai-part-target.spec.ts` covers console changePart by name/index,
+a part-scoped tool reaching a non-current part by name and index (and a clean
+error on a bad target), and runAndSave committing to the targeted part only.

--- a/public/ai.md
+++ b/public/ai.md
@@ -362,12 +362,14 @@ await partwright.clearAllSessions()      // Delete all sessions & versions
 // (run, save, paint, export, listVersions, ...) acts on. Versions are scoped
 // per part. Use parts for several distinct objects in one session (e.g. a box
 // and its lid); save them as separate STLs/parts, or model each in isolation.
+// Address a part by its name, its id, or its 0-based index (changePart/
+// renamePart/deletePart all accept any of the three).
 partwright.listParts()                   // -> [{id, name, order, isCurrent}]
 partwright.getCurrentPart()              // -> {id, name, order} or null
 await partwright.createPart(name?)       // New empty part + switch to it -> {id, name, order}
-await partwright.changePart(id)          // Switch active part (loads its latest version)
-await partwright.renamePart(id, name)    // Rename a part
-await partwright.deletePart(id)          // Delete a part + its versions (refuses the last one)
+await partwright.changePart(name|id|index)   // Switch active part (loads its latest version)
+await partwright.renamePart(name|id|index, newName)  // Rename a part
+await partwright.deletePart(name|id|index)   // Delete a part + its versions (refuses the last one)
 
 // Color regions -- tag face regions with a color. Full API in /ai/colors.md.
 // Quick reference (~30 methods total):

--- a/retros/inbox/20260617-130000-ai-part-target-addressing.md
+++ b/retros/inbox/20260617-130000-ai-part-target-addressing.md
@@ -1,0 +1,41 @@
+---
+date: 2026-06-17
+task: give AI tools an explicit part target instead of the implicit current-part pointer (PR #719, follow-ups #720)
+---
+
+## Liked
+- The dispatch in `tools.ts` was a single choke point: every tool routes through
+  `executeTool` → `dispatch`, so the part-switch concern dropped in as one
+  cross-cutting block instead of ~50 per-tool edits. Injecting the shared `part`
+  schema prop with a post-array loop (guarded by a `PART_TARGETABLE_TOOLS` set)
+  kept the description in one place and out of 50 hand-edits.
+- The e2e harness's `import('/src/ai/tools.ts')` + `executeTool(...)` pattern let
+  me test the *real* tool dispatch (not just the console API) headlessly — the
+  three-test spec exercised name/index/error/commit-isolation in ~25s.
+
+## Lacked
+- No typed link between a tool's schema and the API method it dispatches to, so
+  "which tools are part-scoped" is a hand-maintained set that can silently drift
+  as tools are added. Same root gap CLAUDE.md notes for UI↔API parity (no shared
+  capability registry).
+- The Gemini schema sanitizer quietly coerces typeless props to `string` — fine
+  here (Gemini loses only index addressing) but it's a non-obvious provider
+  asymmetry I only caught by reading `sanitizeSchemaForGemini`. Nothing surfaces
+  "this schema means different things to different providers."
+
+## Learned
+- The fragility the user spotted ("select part → get current part") was really a
+  symptom of *shared mutable state between two actors in one tab* — the same
+  bleed CLAUDE.md guards against across tabs, but the in-tab user↔agent case
+  isn't called out. Worth a sentence in the cross-tab-isolation section.
+- Switch-then-act has a hidden trap: reloading a part clobbers an in-progress
+  editor draft. The no-op-when-already-current guard is load-bearing, not an
+  optimization.
+
+## Longed for
+- A capability registry both the UI/command-palette and the AI tool layer derive
+  from, so part-scoping (and gating, and parity) is structural rather than three
+  hand-kept sets. That's the real fix for #720's whole class.
+- A lint that flags AI tools which pass `input` straight to an unknown-key-
+  rejecting API but aren't covered by a key-stripping step — I had to reason
+  manually that `delete input.part` was needed before the pass-through APIs.

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -847,12 +847,12 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'listParts',
-    description: 'List the parts in the active session: [{id, name, order, isCurrent}]. A session can hold multiple parts — independent objects, each with its own code and version history. The current part is what runCode / runAndSave / paint / export act on.',
+    description: 'List the parts in the active session: [{id, name, order, isCurrent}]. A session can hold multiple parts — independent objects, each with its own code and version history. The current part is the default target for runCode / runAndSave / paint / export, but those tools also take an optional `part` target (name, id, or index) so you can act on any part directly without switching focus first.',
     input_schema: { type: 'object', properties: {} },
   },
   {
     name: 'getCurrentPart',
-    description: 'Return the active part {id, name, order}, or null when no session is open.',
+    description: "Return the active part {id, name, order}, or null when no session is open. You rarely need this: changePart returns the part it switched to, listParts marks the current one (isCurrent), and every part-scoped tool takes a `part` target — so prefer addressing parts by name/index over reading the current selection (which the user can change while you work).",
     input_schema: { type: 'object', properties: {} },
   },
   {
@@ -867,36 +867,37 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'changePart',
-    description: "Switch the active part. Pass the part id from listParts(). Loads that part's latest version into the editor/viewport; all later code, paint, and version operations act on it.",
+    description: "Switch the active part — i.e. change what the USER sees in the editor/viewport. Address it by name, id (from listParts), or 0-based index. Loads that part's latest version. You usually do NOT need this just to work on a different part: every part-scoped tool (getCode, runCode, runAndSave, paint*, getGeometryData, …) takes an optional `part` target that addresses a part directly. Use changePart only when you want to move the user's focus, or to reset the editor to a part's latest saved version.",
     input_schema: {
       type: 'object',
       properties: {
-        id: { type: 'string', description: 'Part id from listParts().' },
+        part: { description: 'The part to switch to — its name, id (from listParts), or 0-based index.' },
+        id: { type: 'string', description: 'Deprecated alias for `part` — a part id from listParts().' },
       },
-      required: ['id'],
     },
   },
   {
     name: 'renamePart',
-    description: 'Rename a part. Pass its id (from listParts) and the new name.',
+    description: 'Rename a part. Address it by name, id (from listParts), or 0-based index, and give the new name.',
     input_schema: {
       type: 'object',
       properties: {
-        id: { type: 'string', description: 'Part id from listParts().' },
+        part: { description: 'The part to rename — its name, id (from listParts), or 0-based index.' },
+        id: { type: 'string', description: 'Deprecated alias for `part` — a part id from listParts().' },
         name: { type: 'string', description: 'New part name.' },
       },
-      required: ['id', 'name'],
+      required: ['name'],
     },
   },
   {
     name: 'deletePart',
-    description: "Delete a part and all its versions. Refuses to delete a session's last remaining part. If the active part is deleted, an adjacent part becomes active.",
+    description: "Delete a part and all its versions. Refuses to delete a session's last remaining part. If the active part is deleted, an adjacent part becomes active. Address it by name, id (from listParts), or 0-based index.",
     input_schema: {
       type: 'object',
       properties: {
-        id: { type: 'string', description: 'Part id from listParts().' },
+        part: { description: 'The part to delete — its name, id (from listParts), or 0-based index.' },
+        id: { type: 'string', description: 'Deprecated alias for `part` — a part id from listParts().' },
       },
-      required: ['id'],
     },
   },
   {
@@ -1342,6 +1343,44 @@ Plus preserveColor (default true — bake path only; on the code path paint re-r
   },
 ];
 
+/** Tools whose effect is scoped to a single part — they read or mutate the
+ *  active part's code, geometry, paint, or version history. Each gains an
+ *  optional `part` target (injected below) so the model can address a part
+ *  directly instead of leaning on the shared "current part" pointer, which the
+ *  human can move from the part menu mid-turn. When `part` is supplied,
+ *  executeTool switches focus to it *before* running the op (see
+ *  `focusTargetPart`), so the op always acts on the part the model named — not
+ *  on whatever the user last clicked. The part-management tools (listParts /
+ *  changePart / createPart / …) are deliberately excluded: they already take an
+ *  explicit target or operate at the session level. */
+export const PART_TARGETABLE_TOOLS = new Set<string>([
+  'getActiveLanguage', 'setActiveLanguage',
+  'getCode', 'setCode', 'runCode', 'runAndSave', 'runAndAssert', 'runAndExplain',
+  'getParams', 'setParams', 'getGeometryData', 'getMeshSummary', 'getFeatureCentroids',
+  'listVersions', 'loadVersion', 'saveVersion', 'forkVersion', 'copyColorsFromVersion',
+  'modifyAndTest', 'query', 'findFaces', 'listComponents', 'listLabels', 'getModelColors',
+  'listRegions', 'probePixel', 'probeRay', 'paintPreview', 'paintExplain',
+  'paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintInBox', 'paintInOrientedBox',
+  'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels',
+  'paintConnected', 'paintInCylinder', 'undoLastPaint', 'redoLastPaint', 'removeRegion',
+  'clearColors', 'assertPaint', 'sliceAtZVisual', 'checkPrintability',
+  'renderView', 'renderViews',
+  'applySurfaceTexture', 'applyVoronoiLamp', 'engraveModel', 'voxelizeModel',
+  'scaleModel', 'placeModel', 'rotateModel', 'layFlatModel',
+]);
+
+// The shared `part` target schema, injected into every targetable tool so the
+// description stays in one place. Typeless on purpose — it accepts a name/id
+// string OR a 0-based index number (resolvePartTarget in main.ts handles both).
+const PART_TARGET_PROP = {
+  description: 'Optional. The part to act on — addressed by its name, its id (from listParts), or its 0-based index. Defaults to the current part. Pass this to target a specific part directly instead of relying on the current selection; it also makes a separate changePart call unnecessary. Switching focus to the part is visible to the user.',
+};
+for (const tool of ALL_TOOLS) {
+  if (PART_TARGETABLE_TOOLS.has(tool.name) && !('part' in tool.input_schema.properties)) {
+    tool.input_schema.properties.part = PART_TARGET_PROP;
+  }
+}
+
 const ALWAYS_AVAILABLE = new Set([
   'getActiveLanguage',
   'setActiveLanguage',
@@ -1485,6 +1524,33 @@ function getApi(): PartwrightAPI {
   return w.partwright;
 }
 
+/** Switch focus to the part a part-scoped tool named via its `part` target, so
+ *  the op runs against that part rather than whatever the user last selected in
+ *  the part menu. `target` is a part name, id, or 0-based index (mirrors
+ *  resolvePartTarget on the API side). No-op when the target is already current
+ *  — which avoids reloading the part and clobbering any in-progress editor draft
+ *  on it. Returns an error string on a bad target, or null on success. */
+async function focusTargetPart(api: PartwrightAPI, target: string | number): Promise<string | null> {
+  const parts = api.listParts() as Array<{ id: string; name: string; order: number; isCurrent: boolean }> | undefined;
+  if (!Array.isArray(parts) || parts.length === 0) {
+    return `Cannot target part ${JSON.stringify(target)}: no active session with parts. Open a session first.`;
+  }
+  let match: { id: string; isCurrent: boolean } | undefined;
+  if (typeof target === 'number') {
+    if (!Number.isInteger(target) || target < 0) return `Cannot target part: index must be a non-negative integer (got ${JSON.stringify(target)}).`;
+    match = [...parts].sort((a, b) => a.order - b.order)[target];
+  } else {
+    match = parts.find(p => p.id === target) ?? parts.find(p => p.name === target);
+  }
+  if (!match) return `Cannot target part ${JSON.stringify(target)}: no matching part (by name, id, or index). Call listParts() to see what's available.`;
+  if (match.isCurrent) return null; // already focused — don't reload and clobber an in-progress edit
+  const switched = await api.changePart(match.id) as { error?: string } | undefined;
+  if (switched && typeof switched === 'object' && 'error' in switched && switched.error) {
+    return `Cannot target part ${JSON.stringify(target)}: ${switched.error}`;
+  }
+  return null;
+}
+
 /** Dispatches a tool call to window.partwright and stringifies the result.
  *  Errors are caught and returned with isError: true so the loop can feed
  *  them back to the model for self-correction. Tools that return an
@@ -1510,6 +1576,18 @@ export async function executeTool(name: string, input: Record<string, unknown>):
       }
     }
     const api = getApi();
+    // Part addressing: a part-scoped tool may name a `part` target (name, id, or
+    // 0-based index). Switch focus to it before running so the op acts on the
+    // addressed part — not whatever the user last clicked. Strip the key first so
+    // the per-tool APIs (which reject unknown keys) never see it.
+    if (PART_TARGETABLE_TOOLS.has(name)) {
+      const target = input.part as string | number | undefined;
+      delete input.part;
+      if (target != null) {
+        const focusErr = await focusTargetPart(api, target);
+        if (focusErr) return { content: focusErr, isError: true };
+      }
+    }
     // Tools that ship images back to the model bypass the generic JSON
     // dispatch — they need the data-URL → multimodal-image wrapping.
     if (name === 'renderView') return executeRenderView(api, input);
@@ -1903,11 +1981,11 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
     case 'createPart':
       return api.createPart(input.name as string | undefined);
     case 'changePart':
-      return api.changePart(input.id as string);
+      return api.changePart((input.part ?? input.id) as string | number);
     case 'renamePart':
-      return api.renamePart(input.id as string, input.name as string);
+      return api.renamePart((input.part ?? input.id) as string | number, input.name as string);
     case 'deletePart':
-      return api.deletePart(input.id as string);
+      return api.deletePart((input.part ?? input.id) as string | number);
     case 'assertPaint':
       return api.assertPaint(input);
     case 'paintInCylinder':

--- a/src/main.ts
+++ b/src/main.ts
@@ -1857,14 +1857,31 @@ function resolvePartTarget(target: unknown, caller: string): Part | { error: str
     return { error: `${caller}: no active session. Call createSession() or openSession(id) first.` };
   }
   const parts = listCurrentParts();
+  // 0-based index into the parts as listParts() returns them (sorted by order).
+  // Lets a caller address "the second part" without first looking up its id.
+  if (typeof target === 'number') {
+    if (!Number.isInteger(target) || target < 0) {
+      return { error: `${caller}: index must be a non-negative integer.` };
+    }
+    const ordered = [...parts].sort((a, b) => a.order - b.order);
+    const part = ordered[target];
+    if (!part) return { error: `${caller}: no part at index ${target}. Use listParts() to see available parts.` };
+    return part;
+  }
+  // A bare string is ambiguous between an id and a human-facing name, so try
+  // both (id first — ids are unique). Object form keeps the field explicit.
+  if (typeof target === 'string') {
+    if (target.length === 0) return { error: `${caller}: part must be a non-empty string.` };
+    const part = parts.find(p => p.id === target) ?? parts.find(p => p.name === target);
+    if (!part) return { error: `${caller}: no part matching ${JSON.stringify(target)} (by id or name). Use listParts() to see available parts.` };
+    return part;
+  }
   let id: string | undefined;
   let name: string | undefined;
-  if (typeof target === 'string') {
-    id = target;
-  } else if (target && typeof target === 'object') {
+  if (target && typeof target === 'object') {
     ({ id, name } = target as { id?: string; name?: string });
   } else {
-    return { error: `${caller}(target): pass a part id string, or { id } / { name } from listParts().` };
+    return { error: `${caller}(target): pass a part name, id string, or 0-based index — or { id } / { name } from listParts().` };
   }
   let part: Part | undefined;
   if (id !== undefined) {
@@ -10047,9 +10064,10 @@ async function main() {
       return { id: part.id, name: part.name, order: part.order };
     },
 
-    /** Switch the active part. Pass a part id string, or { id } / { name } from
-     *  listParts(). Loads that part's latest version into the editor. */
-    async changePart(target: string | { id?: string; name?: string }) {
+    /** Switch the active part. Pass a part name, id string, or 0-based index —
+     *  or { id } / { name } from listParts(). Loads that part's latest version
+     *  into the editor. */
+    async changePart(target: string | number | { id?: string; name?: string }) {
       const part = resolvePartTarget(target, 'changePart');
       if ('error' in part) return part;
       const version = await changePart(part.id);
@@ -10061,8 +10079,8 @@ async function main() {
       };
     },
 
-    /** Rename a part. Pass a part id string, or { id } / { name }. */
-    async renamePart(target: string | { id?: string; name?: string }, newName: string) {
+    /** Rename a part. Pass a part name, id string, 0-based index, or { id } / { name }. */
+    async renamePart(target: string | number | { id?: string; name?: string }, newName: string) {
       const check = guard(() => assertString(newName, 'renamePart(newName)', { allowEmpty: false }));
       if (typeof check === 'object' && check !== null && 'error' in check) return check;
       const part = resolvePartTarget(target, 'renamePart');
@@ -10072,8 +10090,9 @@ async function main() {
     },
 
     /** Delete a part and its versions. Refuses to delete a session's last part.
-     *  Deleting the active part activates and loads an adjacent one. */
-    async deletePart(target: string | { id?: string; name?: string }) {
+     *  Deleting the active part activates and loads an adjacent one. Pass a part
+     *  name, id string, 0-based index, or { id } / { name }. */
+    async deletePart(target: string | number | { id?: string; name?: string }) {
       const part = resolvePartTarget(target, 'deletePart');
       if ('error' in part) return part;
       const wasCurrent = getCurrentPart()?.id === part.id;
@@ -13795,9 +13814,9 @@ async function main() {
         'listParts':       { signature: 'listParts() -- List parts in the session -> [{id, name, order, isCurrent}]', docs: '/ai.md#console-api--windowpartwright' },
         'getCurrentPart':  { signature: 'getCurrentPart() -- Active part -> {id, name, order} or null', docs: '/ai.md#console-api--windowpartwright' },
         'createPart':      { signature: 'await createPart(name?) -- New empty part + switch to it -> {id, name, order}', docs: '/ai.md#console-api--windowpartwright' },
-        'changePart':      { signature: 'await changePart(id) -- Switch active part (loads its latest version)', docs: '/ai.md#console-api--windowpartwright' },
-        'renamePart':      { signature: 'await renamePart(id, name) -- Rename a part', docs: '/ai.md#console-api--windowpartwright' },
-        'deletePart':      { signature: 'await deletePart(id) -- Delete a part and its versions', docs: '/ai.md#console-api--windowpartwright' },
+        'changePart':      { signature: 'await changePart(name|id|index) -- Switch active part (loads its latest version)', docs: '/ai.md#console-api--windowpartwright' },
+        'renamePart':      { signature: 'await renamePart(name|id|index, newName) -- Rename a part', docs: '/ai.md#console-api--windowpartwright' },
+        'deletePart':      { signature: 'await deletePart(name|id|index) -- Delete a part and its versions', docs: '/ai.md#console-api--windowpartwright' },
         'getShareLink':    { signature: 'await getShareLink() -- Read-only share link for the current version -> {url, encodedBytes} or {error}; the link to hand the user when done', docs: '/ai.md#console-api--windowpartwright' },
         'getGalleryUrl':   { signature: 'getGalleryUrl() -- URL for gallery view (local browser only)', docs: '/ai.md#console-api--windowpartwright' },
         // Notes

--- a/tests/ai-part-target.spec.ts
+++ b/tests/ai-part-target.spec.ts
@@ -1,0 +1,135 @@
+// E2E coverage for AI part addressing: part-scoped tools accept an optional
+// `part` target (name / id / 0-based index) so the model acts on the part it
+// names rather than the shared "current part" pointer the user can move from the
+// part menu mid-turn. Exercised through the real executeTool dispatch and the
+// window.partwright console API. Network-free — geometry is produced locally.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { createPart?: unknown } }).partwright?.createPart,
+    { timeout: 20_000 },
+  );
+}
+
+const cube = (s: number, marker: string) =>
+  `// ${marker}\nconst { Manifold } = api; return Manifold.cube([${s}, ${s}, ${s}], true);`;
+
+// Build a two-part session: "Part 1" (code A) + "Lid" (code B), leaving Part 1
+// focused so a `part` target has to do real work to reach Lid.
+async function setupTwoParts(page: Page) {
+  return page.evaluate(async ({ codeA, codeB }) => {
+    interface PartsAPI {
+      createSession: (name?: string) => Promise<{ id: string }>;
+      runAndSave: (code: string, label?: string) => Promise<unknown>;
+      createPart: (name?: string) => Promise<{ id: string; name: string }>;
+      changePart: (t: string | number) => Promise<unknown>;
+      listParts: () => { id: string; name: string; order: number; isCurrent: boolean }[];
+    }
+    const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+    await pw.createSession('targets');
+    await pw.runAndSave(codeA, 'a1');          // Part 1
+    const lid = await pw.createPart('Lid');
+    await pw.runAndSave(codeB, 'b1');          // Lid (now current)
+    await pw.changePart('Part 1');             // refocus Part 1 by NAME
+    const parts = pw.listParts();
+    return { lidId: lid.id, current: parts.find(p => p.isCurrent)?.name, names: parts.map(p => p.name) };
+  }, { codeA: cube(10, 'PARTONE'), codeB: cube(6, 'LIDCODE') });
+}
+
+test.describe('AI part addressing', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('partwright-tour-completed', '1');
+      try { localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({ editorCollapsed: false })); } catch { /* ignore */ }
+    });
+  });
+
+  test('console changePart accepts name and 0-based index', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    const setup = await setupTwoParts(page);
+    expect(setup.current).toBe('Part 1');          // refocus-by-name worked
+
+    const out = await page.evaluate(async () => {
+      interface PartsAPI {
+        changePart: (t: string | number) => Promise<unknown>;
+        listParts: () => { name: string; isCurrent: boolean }[];
+        getCode: () => string;
+      }
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      await pw.changePart('Lid');                   // by name
+      const afterName = pw.listParts().find(p => p.isCurrent)?.name;
+      const nameCode = pw.getCode();
+      await pw.changePart(0);                       // by 0-based index → first part
+      const afterIndex = pw.listParts().find(p => p.isCurrent)?.name;
+      return { afterName, nameCode, afterIndex };
+    });
+    expect(out.afterName).toBe('Lid');
+    expect(out.nameCode).toContain('LIDCODE');
+    expect(out.afterIndex).toBe('Part 1');
+  });
+
+  test('a part-scoped tool acts on the named part, not the current one', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    await setupTwoParts(page);                       // Part 1 is current
+
+    const out = await page.evaluate(async () => {
+      const { executeTool } = await import('/src/ai/tools.ts');
+      // Read Lid's code WITHOUT a prior changePart — target it by name.
+      const byName = await executeTool('getCode', { part: 'Lid' });
+      // Read Part 1's code by index.
+      const byIndex = await executeTool('getCode', { part: 0 });
+      // Bad target → a clean error, not a wrong-part action.
+      const bad = await executeTool('getCode', { part: 'Nope' });
+      return {
+        byName: byName.content, byNameErr: byName.isError,
+        byIndex: byIndex.content, byIndexErr: byIndex.isError,
+        badErr: bad.isError, badMsg: bad.content,
+      };
+    });
+
+    expect(out.byNameErr).toBe(false);
+    expect(out.byName).toContain('LIDCODE');         // reached Lid though Part 1 was current
+    expect(out.byIndexErr).toBe(false);
+    expect(out.byIndex).toContain('PARTONE');        // index 0 = Part 1
+    expect(out.badErr).toBe(true);
+    expect(out.badMsg).toMatch(/no matching part/i);
+  });
+
+  test('runAndSave with a part target commits to that part only', async ({ page }) => {
+    await page.goto('/editor');
+    await waitForEngine(page);
+    await setupTwoParts(page);                       // Part 1 current, each part has 1 version
+
+    const out = await page.evaluate(async ({ newLid }) => {
+      interface PartsAPI {
+        changePart: (t: string | number) => Promise<unknown>;
+        listVersions: () => Promise<{ index: number }[]>;
+        getCode: () => string;
+      }
+      const pw = (window as unknown as { partwright: PartsAPI }).partwright;
+      const { executeTool } = await import('/src/ai/tools.ts');
+      // Commit a new version to Lid while Part 1 is the current selection.
+      const exec = await executeTool('runAndSave', { part: 'Lid', code: newLid, label: 'b2' });
+      // Lid gained a version...
+      await pw.changePart('Lid');
+      const lidVersions = (await pw.listVersions()).length;
+      const lidCode = pw.getCode();
+      // ...and Part 1 did not.
+      await pw.changePart('Part 1');
+      const part1Versions = (await pw.listVersions()).length;
+      const part1Code = pw.getCode();
+      return { execErr: exec.isError, lidVersions, lidCode, part1Versions, part1Code };
+    }, { newLid: cube(7, 'LIDV2') });
+
+    expect(out.execErr).toBe(false);
+    expect(out.lidVersions).toBe(2);                 // Lid: a1-equivalent + new
+    expect(out.lidCode).toContain('LIDV2');
+    expect(out.part1Versions).toBe(1);              // Part 1 untouched
+    expect(out.part1Code).toContain('PARTONE');
+  });
+});


### PR DESCRIPTION
## Summary

The AI's part-scoped tools all act on an **implicit "current part" pointer** — shared mutable state the human also controls. When a user clicks a different part in the part menu mid-turn, the agent's notion of "the part I'm working on" silently desyncs, so it operates on the wrong part. The "select part → get current part" pattern the agent fell into is really a fragile verification crutch for that shared pointer.

This separates **addressing** (which part an op targets) from **focus** (which part the human sees): part-scoped tools now take an optional `part` target so the agent names its part directly instead of relying on whatever the user last clicked.

## What changed

- **`src/ai/tools.ts`**
  - `PART_TARGETABLE_TOOLS` set + a post-array loop that injects a shared optional `part` schema prop into every part-scoped tool (reads, runs, paint, version ops, surface/transform). Typeless on purpose: accepts a name/id **string** or a 0-based **index** number. (Gemini's sanitizer defaults typeless props to `string`, so Gemini gets name/id addressing; other providers get the full union.)
  - `focusTargetPart` in `executeTool` resolves the `part` target and switches focus **before** running the op, then strips the key before the per-tool API sees it (those reject unknown keys). No-op when the target is already current, so an in-progress editor draft on that part survives.
  - Reframed descriptions: `changePart` = "change what the USER sees" (rarely needed just to work on another part); `getCurrentPart` notes it's rarely needed; `listParts` documents the `part` target.
- **`src/main.ts`** — `resolvePartTarget` gains 0-based index support and a bare string now resolves as **id-or-name** (ids first). Console `changePart`/`renamePart`/`deletePart` accept `name | id | index`. `help()` signatures updated.
- **`public/ai.md`** — console part-API docs updated for name/id/index addressing.

## Design note

Switch-then-act (focus follows the named part) rather than true headless operation on a non-focused part. The user explicitly accepted the view following ("the user can watch the view change"); headless mutation would mean rewriting the engine/viewport pipeline paint/run/render depend on — a much larger, riskier change, flagged as a possible future follow-up.

## Test plan

- `npm run typecheck` ✅ · `npm run build` ✅ · `npm run test:unit` (1448) ✅ · `npm run lint:deps` (acyclic) ✅
- New `tests/ai-part-target.spec.ts` (3 tests) ✅ — console changePart by name/index; a part-scoped tool reaching a non-current part by name and index (+ clean error on a bad target); runAndSave committing to the targeted part only.
- `tests/parts.spec.ts` (10) ✅ — no regressions.

## Follow-ups (same class, not in this PR)

Other implicit-shared-state hazards surfaced in discussion, to be filed separately: `runCode`/`runAndSave` defaulting to the live editor buffer the user may be typing into; the current-session and current-version pointers; global toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoGpGzEK15vJdvXuhQ5axo)_