### PR TITLE
fix: repair orphaned tool_results stranded by chat compaction

### DIFF
--- a/prompts/compaction-orphan-tool-result-repair.md
+++ b/prompts/compaction-orphan-tool-result-repair.md
@@ -1,0 +1,63 @@
+---
+date: 2026-06-17
+branch: claude/dreamy-mccarthy-ksv7wa
+files_changed:
+  - src/ai/historyRepair.ts
+  - src/ui/aiPanel.ts
+  - src/ai/anthropic.ts
+  - src/ai/openai.ts
+  - src/ai/local.ts
+  - tests/unit/historyRepair.test.ts
+  - tests/ai-providers.spec.ts
+---
+
+## Human
+
+After using the in-app `/compact` feature on a long session, the very next
+turn hit a provider 400 about a tool_call_id that didn't exist. Two
+hypotheses: (1) compaction isn't clearing out tool-call info, leaving a
+dangling reference; (2) the existing "repair corrupted tool history" recovery
+feature doesn't apply to this error category. Investigate, fix, open a PR.
+
+## Assistant
+
+Root cause: the whole tool-history-repair stack only ever handled ONE
+direction — an orphaned tool_**use** (assistant `tool_calls` with no matching
+result → inject a synthetic error result). The compaction failure is the
+mirror image: an orphaned tool_**result** — a kept `user.toolResults` entry
+whose originating `tool_use` was in the dropped/summarized slice. Every hosted
+provider 400s on a tool_result answering a tool_use it can't see ("unexpected
+`tool_use_id`" / "tool message must respond to a preceding tool_calls"). This
+explained both of the user's hypotheses at once:
+
+- `repairToolHistory`/`hasOrphanedToolCalls` only detected orphan tool_uses, so
+  the "🛠 Repair history" button never appeared for this case AND the repair
+  wouldn't have fixed it (hypothesis 2), and
+- compaction's `isOrphanToolResultHead` walk only guards the *head* of the kept
+  window, so a severed tool round elsewhere left a dangling result persisted
+  (hypothesis 1).
+
+Fix, defense-in-depth across all five providers:
+
+1. **`historyRepair.ts`** — `repairToolHistory` now also strips orphaned
+   tool_results (gather every known tool_use id; drop result blocks outside the
+   set; delete a carrier emptied by the strip via a new `toDelete` field).
+   This single canonical fix lights up the repair button (`hasOrphanedToolCalls`
+   is bidirectional now), powers `/repair`, the rewind guard, **and Gemini**
+   (which already routes through it).
+2. **`aiPanel.ts`** — extracted the rewind's inline repair into
+   `persistToolHistoryRepair()` and called it from BOTH compaction apply paths
+   (auto + manual) right after the drop+summary writes, so the persisted
+   post-compaction history can never carry a dangling reference (hypothesis 1).
+3. **Provider request builders** as a last line of defense (so the 400 never
+   fires even on a stale pre-fix history): `anthropic.ts` `stripOrphanToolResults`
+   in `buildApiMessages`; `openai.ts` orphan-output/orphan-tool-message strips in
+   both `sanitizeResponsesToolCalls` and `sanitizeChatToolMessages` (covers
+   `custom.ts`, which reuses them); `local.ts` now routes history through
+   `repairToolHistory` like Gemini.
+
+Verified: 1452 unit tests green (4 new orphan-tool_result cases in
+`historyRepair.test.ts`); 3 new browser e2e tests in `ai-providers.spec.ts`
+prove the orphaned tool_result is stripped from the real Anthropic / OpenAI
+Responses / OpenAI Chat request payloads; `tsc --noEmit` clean; `lint:deps`
+acyclic.

--- a/retros/inbox/20260617-153000-compaction-orphan-tool-result.md
+++ b/retros/inbox/20260617-153000-compaction-orphan-tool-result.md
@@ -1,0 +1,38 @@
+# Retro — repair orphaned tool_results stranded by compaction (PR #721)
+
+## Liked
+- The bug had a clean, single root cause once framed as a *direction*: the whole
+  repair stack (provider sanitizers + `repairToolHistory` + the repair button gate)
+  only handled orphaned tool_**use**, never the mirror orphaned tool_**result**.
+  Naming the symmetry turned a vague "400 after compact" into a precise, testable gap.
+- `tests/ai-providers.spec.ts` already had the exact pattern (stub `window.fetch`,
+  capture the request body, assert the wire payload) for the tool_use direction —
+  cloning it for the tool_result direction gave real-browser proof across Anthropic /
+  OpenAI Responses / OpenAI Chat in three short tests.
+
+## Lacked
+- No way to reproduce the actual provider 400 headlessly (needs a real key + a
+  corrupted persisted history), so verification leaned on the wire-format assertions
+  rather than an end-to-end "compact → next turn sends" flow. The 400 itself is only
+  provable against a live provider.
+- The repair invariant lives in FIVE places (3 provider sanitizers + the shared
+  `repairToolHistory` + compaction's own head-walk). Each handled the tool_use
+  direction independently, so the tool_result gap had to be closed in all of them.
+  A single canonical bidirectional `repairToolHistory` that every builder routes
+  through (gemini + local already do) would shrink that surface.
+
+## Learned
+- Compaction's `isOrphanToolResultHead` only guards the *head* of the kept window;
+  it silently assumes normal message ordering makes interior orphans impossible.
+  That holds for clean histories but not for ones already nicked by an earlier
+  partial repair / aborted turn / cross-tab edit — exactly when compaction runs.
+- The repair-button gate (`hasOrphanedToolCalls`) and the actual repair were the
+  same function, so a detection gap and a fix gap were one bug: the button never
+  appeared *because* the repair couldn't see the orphan. Worth checking, when a
+  "recovery doesn't fire" report comes in, whether detection and remedy share a path.
+
+## Longed for
+- A persisted-history invariant assertion (dev-only) that flags any tool_result whose
+  tool_use_id isn't present, fired on load/after every structural edit (compact,
+  rewind), so this class of corruption is caught at write time instead of as a
+  provider 400 on the next send.

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -349,7 +349,40 @@ export function buildApiMessages(
       if (content.length > 0) out.push({ role: 'assistant', content });
     }
   }
-  return sanitizeToolUse(out);
+  return stripOrphanToolResults(sanitizeToolUse(out));
+}
+
+/** Drop tool_result blocks whose `tool_use_id` has no matching `tool_use`
+ *  anywhere in the request — the mirror of sanitizeToolUse. Compaction (or any
+ *  edit that severs a tool round) can leave a kept tool_result whose call was
+ *  dropped, and the API 400s with "unexpected `tool_use_id`". A user message
+ *  emptied by the strip is removed so the request stays well-formed. Runs
+ *  after sanitizeToolUse, whose synthetic results reference real ids and so
+ *  are never stripped here. */
+function stripOrphanToolResults(messages: Anthropic.MessageParam[]): Anthropic.MessageParam[] {
+  const knownIds = new Set<string>();
+  for (const m of messages) {
+    if (m.role !== 'assistant' || !Array.isArray(m.content)) continue;
+    for (const b of m.content as Anthropic.ContentBlockParam[]) {
+      if (b.type === 'tool_use') knownIds.add((b as { type: 'tool_use'; id: string }).id);
+    }
+  }
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i];
+    if (m.role !== 'user' || !Array.isArray(m.content)) continue;
+    const content = m.content as Anthropic.ContentBlockParam[];
+    const filtered = content.filter(
+      b => b.type !== 'tool_result' || knownIds.has((b as { type: 'tool_result'; tool_use_id: string }).tool_use_id),
+    );
+    if (filtered.length === content.length) continue;
+    if (filtered.length === 0) {
+      messages.splice(i, 1);
+      i--;
+      continue;
+    }
+    m.content = filtered;
+  }
+  return messages;
 }
 
 /** Repair dangling tool_use/tool_result invariant violations before the

--- a/src/ai/historyRepair.ts
+++ b/src/ai/historyRepair.ts
@@ -25,6 +25,10 @@ export interface HistoryRepairResult {
   /** Messages that are new or were mutated and must be re-persisted
    *  (putMessages). */
   toPersist: ChatMessage[];
+  /** Messages that were removed entirely and must be deleted from storage
+   *  (deleteMessages). Currently only an empty carrier left behind after its
+   *  sole orphaned tool_result was stripped. */
+  toDelete: ChatMessage[];
   /** True when anything was changed (drives "nothing to repair" feedback). */
   changed: boolean;
 }
@@ -43,10 +47,20 @@ const INTERRUPTED_CONTENT =
  *      between them.
  *   3. assistant(tool_use) at the tail (no following message) — a synthetic
  *      tool_result user message is appended, leaving the chat in a normal
- *      "ready for the model to respond" state (resumable, nothing dropped). */
+ *      "ready for the model to respond" state (resumable, nothing dropped).
+ *
+ *  It ALSO repairs the mirror-image corruption: an orphaned tool_RESULT — a
+ *  user message carrying a tool_result whose `tool_use_id` has no originating
+ *  assistant tool_use anywhere in the history. Compaction (and any edit that
+ *  drops the assistant turn that made the call) strands these, and every
+ *  hosted provider 400s on a tool_result that answers a tool_use it can't see
+ *  ("unexpected `tool_use_id`" / "messages with role 'tool' must be a response
+ *  to a preceding tool_calls"). The orphaned result blocks are stripped; if
+ *  that empties the carrier message it's removed (returned in `toDelete`). */
 export function repairToolHistory(history: ChatMessage[]): HistoryRepairResult {
   const messages = [...history];
   const toPersist: ChatMessage[] = [];
+  const toDelete: ChatMessage[] = [];
 
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
@@ -98,12 +112,52 @@ export function repairToolHistory(history: ChatMessage[]): HistoryRepairResult {
     }
   }
 
-  return { messages, toPersist, changed: toPersist.length > 0 };
+  // Second pass: strip orphaned tool_results. Gather every tool_use id known
+  // to the (already use-repaired) history; any tool_result answering an id
+  // outside that set has lost its originating call and must go. The synthetic
+  // results injected above reference real ids, so they're never stripped here.
+  const knownToolUseIds = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && msg.toolCalls) {
+      for (const tc of msg.toolCalls) knownToolUseIds.add(tc.id);
+    }
+  }
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role !== 'user' || !msg.toolResults || msg.toolResults.length === 0) continue;
+    const kept = msg.toolResults.filter(r => knownToolUseIds.has(r.toolUseId));
+    if (kept.length === msg.toolResults.length) continue; // nothing orphaned
+    if (kept.length === 0 && msg.blocks.length === 0) {
+      // The message was nothing but orphaned tool_result(s) — drop it.
+      messages.splice(i, 1);
+      toDelete.push(msg);
+      i--;
+      continue;
+    }
+    // Keep the message (it still has text or valid results) minus the orphans.
+    const repaired: ChatMessage = { ...msg, toolResults: kept };
+    messages[i] = repaired;
+    toPersist.push(repaired);
+  }
+
+  // Dedupe toPersist by id (a message touched by both passes appears once,
+  // latest wins) so callers don't write the same id twice.
+  const persistById = new Map<string, ChatMessage>();
+  for (const m of toPersist) persistById.set(m.id, m);
+
+  return {
+    messages,
+    toPersist: [...persistById.values()],
+    toDelete,
+    changed: persistById.size > 0 || toDelete.length > 0,
+  };
 }
 
-/** Cheap predicate: does this history contain an orphaned tool_use that would
- *  make the next provider request fail? Used to conditionally surface the
- *  "Repair tool history" affordance. */
+/** Cheap predicate: does this history contain a tool-history invariant
+ *  violation (an orphaned tool_use missing its result, OR an orphaned
+ *  tool_result whose tool_use was dropped) that would make the next provider
+ *  request fail? Used to conditionally surface the "Repair tool history"
+ *  affordance. */
 export function hasOrphanedToolCalls(history: ChatMessage[]): boolean {
   return repairToolHistory(history).changed;
 }

--- a/src/ai/local.ts
+++ b/src/ai/local.ts
@@ -29,6 +29,7 @@ import { loadSettings, type CustomLocalModel } from './settings';
 import { buildFallbackLadder, getCachedCeiling, getModelCeiling } from './modelMetadata';
 import { getConfig } from '../config/appConfig';
 import { registerWorker, markWorkerStarted } from '../diagnostics/workerStats';
+import { repairToolHistory } from './historyRepair';
 
 // We can't statically type-import from @mlc-ai/web-llm without forcing it
 // into the main bundle, so we keep the engine handle untyped here and rely
@@ -551,7 +552,12 @@ export async function streamLocalTurn(spec: LocalRequestSpec, callbacks: StreamC
   const systemSuffix = native
     ? spec.systemSuffix
     : appendPromptToolDocs(spec.systemSuffix, spec.tools);
-  const messages = buildLocalApiMessages(spec.systemPrompt, systemSuffix, spec.history, info, native);
+  // Repair any tool-history invariant violation (orphaned tool_use missing its
+  // result, or orphaned tool_result whose call was dropped by compaction)
+  // before building — the native function-calling path emits per-id `tool`
+  // messages WebLLM would otherwise reject. Mirrors gemini.ts.
+  const history = repairToolHistory(spec.history).messages;
+  const messages = buildLocalApiMessages(spec.systemPrompt, systemSuffix, history, info, native);
 
   const baseReq: Record<string, unknown> = {
     messages,

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -461,6 +461,16 @@ function buildResponsesInput(history: ChatMessage[]): ResponsesInputItem[] {
  *  tool-result — surfaced on a `user` message wedged between items — doesn't
  *  read as a gap. */
 function sanitizeResponsesToolCalls(items: ResponsesInputItem[]): ResponsesInputItem[] {
+  // Mirror the tool_use repair the other way: drop any function_call_output
+  // whose call_id has no function_call (e.g. compaction dropped the call). The
+  // Responses API 400s on an output for a call it can't see.
+  const calls = new Set<string>();
+  for (const it of items) if (it.type === 'function_call') calls.add(it.call_id);
+  for (let i = items.length - 1; i >= 0; i--) {
+    const it = items[i];
+    if (it.type === 'function_call_output' && !calls.has(it.call_id)) items.splice(i, 1);
+  }
+
   const answered = new Set<string>();
   for (const it of items) {
     if (it.type === 'function_call_output') answered.add(it.call_id);
@@ -746,6 +756,18 @@ function buildChatMessages(history: ChatMessage[]): OpenAIMessage[] {
  *  positional scan) so an image tool-result — which surfaces the image on a
  *  `user` message wedged between `tool` messages — doesn't read as a gap. */
 function sanitizeChatToolMessages(messages: OpenAIMessage[]): OpenAIMessage[] {
+  // Mirror the tool_calls repair the other way: drop any `tool` message whose
+  // tool_call_id has no assistant tool_calls entry (e.g. compaction dropped the
+  // call). OpenAI 400s on a tool message that responds to a call it can't see.
+  const calls = new Set<string>();
+  for (const m of messages) {
+    if (m.role === 'assistant' && m.tool_calls) for (const tc of m.tool_calls) calls.add(tc.id);
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.role === 'tool' && m.tool_call_id && !calls.has(m.tool_call_id)) messages.splice(i, 1);
+  }
+
   const answered = new Set<string>();
   for (const m of messages) {
     if (m.role === 'tool' && m.tool_call_id) answered.add(m.tool_call_id);

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -1900,7 +1900,8 @@ async function repairCurrentChat(): Promise<void> {
     return;
   }
   try {
-    await putMessages(result.toPersist);
+    if (result.toPersist.length > 0) await putMessages(result.toPersist);
+    if (result.toDelete.length > 0) await deleteMessages(result.toDelete.map(m => m.id));
   } catch (err) {
     setTransientStatus(`Couldn't repair chat: ${err instanceof Error ? err.message : String(err)}`);
     return;
@@ -1911,7 +1912,8 @@ async function repairCurrentChat(): Promise<void> {
   broadcastChatChanged();
   renderTranscript();
   updateRewindButtons();
-  showToast(`Repaired tool history — ${result.toPersist.length} message(s) fixed. You can continue now.`, { variant: 'success', source: 'ai' });
+  const fixed = result.toPersist.length + result.toDelete.length;
+  showToast(`Repaired tool history — ${fixed} message(s) fixed. You can continue now.`, { variant: 'success', source: 'ai' });
 }
 
 function formatDuration(ms: number): string {
@@ -2929,13 +2931,23 @@ async function rewindTurn(): Promise<void> {
   // just removed), which would 400 the very next send — so a rewind meant to
   // "step back and start over" wouldn't actually recover. Repair the exposed
   // history and persist it so the post-rewind state is always sendable.
-  const repair = repairToolHistory(state.history);
-  if (repair.changed) {
-    await putMessages(repair.toPersist);
-    state.history = repair.messages;
-  }
+  await persistToolHistoryRepair();
   renderTranscript();
   updateRewindButtons();
+}
+
+/** Persist any tool-history repair for the current `state.history` so the
+ *  post-edit conversation is always sendable: no orphaned tool_use (missing
+ *  result) and no orphaned tool_result (its tool_use was dropped — what a
+ *  compaction or rewind that severs a tool round leaves behind). Mirrors the
+ *  explicit "Repair history" action but runs silently after a structural edit.
+ *  No-op when the history is already clean. */
+async function persistToolHistoryRepair(): Promise<void> {
+  const repair = repairToolHistory(state.history);
+  if (!repair.changed) return;
+  if (repair.toPersist.length > 0) await putMessages(repair.toPersist);
+  if (repair.toDelete.length > 0) await deleteMessages(repair.toDelete.map(m => m.id));
+  state.history = repair.messages;
 }
 
 /** Restore the most recently rewound turn from the rewindStack back into
@@ -3970,8 +3982,12 @@ async function maybeAutoCompact(): Promise<void> {
   };
   await deleteMessages(proposal.drop.map(m => m.id));
   await putMessages([summaryMsg]);
-  broadcastChatChanged();
+  // Dropping the summarized tail can sever a tool round — leaving a kept
+  // tool_result whose originating tool_use is now gone. Clear that dangling
+  // reference so the very next turn doesn't 400 on an orphaned tool_use_id.
   await loadHistoryForCurrentSession();
+  await persistToolHistoryRepair();
+  broadcastChatChanged();
   renderTranscript();
   renderCostMeter();
 }
@@ -4048,8 +4064,12 @@ async function runCompact(): Promise<void> {
     };
     await deleteMessages(proposal.drop.map(m => m.id));
     await putMessages([summaryMsg]);
-    broadcastChatChanged();
+    // Dropping the summarized tail can sever a tool round — leaving a kept
+    // tool_result whose originating tool_use is now gone. Clear that dangling
+    // reference so the very next turn doesn't 400 on an orphaned tool_use_id.
     await loadHistoryForCurrentSession();
+    await persistToolHistoryRepair();
+    broadcastChatChanged();
     renderTranscript();
     renderCostMeter();
     setTransientStatus(`Compacted ${proposal.drop.length} turn(s); promoted ${notes.length} note(s).`);

--- a/tests/ai-providers.spec.ts
+++ b/tests/ai-providers.spec.ts
@@ -544,6 +544,104 @@ test.describe('Multi-provider AI', () => {
     expect(toolIdx).toBeLessThan(userIdx);
   });
 
+  test('Anthropic strips an orphaned tool_result left behind by compaction', async ({ page }) => {
+    // The mirror of the dangling-tool_use case: compaction (or any edit that
+    // drops the assistant turn that made a call) can leave a kept tool_result
+    // whose `tool_use_id` no longer has a matching tool_use. The API 400s with
+    // "unexpected `tool_use_id`" unless the builder strips it. buildApiMessages
+    // is pure, so assert directly.
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    const out = await page.evaluate(async () => {
+      const a = await import('/src/ai/anthropic.ts');
+      const history = [
+        // A compaction summary replaced the assistant(tool_use) that made the
+        // call — only the orphaned tool_result carrier survived.
+        { id: 's0', sessionId: 's', role: 'assistant', blocks: [{ type: 'text', text: '[compacted summary]' }], createdAt: 0, seq: 0 },
+        { id: 'u1', sessionId: 's', role: 'user', blocks: [], toolResults: [{ toolUseId: 'tu_GONE', content: '{"ok":true}' }], createdAt: 0, seq: 1 },
+        { id: 'u2', sessionId: 's', role: 'user', blocks: [{ type: 'text', text: 'now add a handle' }], createdAt: 0, seq: 2 },
+      ];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return a.buildApiMessages(history as any);
+    });
+    // The orphaned tool_result must not survive into the request.
+    const hasOrphan = out.some(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (m: any) => Array.isArray(m.content) && m.content.some((b: any) => b.type === 'tool_result' && b.tool_use_id === 'tu_GONE'),
+    );
+    expect(hasOrphan).toBe(false);
+    // The real user text is untouched.
+    const userText = out.some(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (m: any) => m.role === 'user' && Array.isArray(m.content) && m.content.some((b: any) => b.type === 'text' && b.text.includes('add a handle')),
+    );
+    expect(userText).toBe(true);
+  });
+
+  test('OpenAI (Responses) drops an orphaned function_call_output left behind by compaction', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    const sentBody = await page.evaluate(async () => {
+      const openai = await import('/src/ai/openai.ts');
+      let captured = '';
+      const origFetch = window.fetch;
+      // @ts-expect-error test stub
+      window.fetch = async (_input: unknown, init: { body?: string }) => {
+        captured = String(init?.body ?? '');
+        const body = 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"ok"}\n\nevent: response.completed\ndata: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}\n\n';
+        return new Response(new Blob([body]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+      };
+      try {
+        const history = [
+          { id: 's0', sessionId: 's', role: 'assistant', blocks: [{ type: 'text', text: '[compacted summary]' }], createdAt: 0, seq: 0 },
+          { id: 'u1', sessionId: 's', role: 'user', blocks: [], toolResults: [{ toolUseId: 'call_GONE', content: 'ok' }], createdAt: 0, seq: 1 },
+          { id: 'u2', sessionId: 's', role: 'user', blocks: [{ type: 'text', text: 'now add a handle' }], createdAt: 0, seq: 2 },
+        ];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await openai.streamTurn({ apiKey: 'k', model: 'gpt-5.5', systemPrompt: 'sys', systemSuffix: '', history: history as any, tools: [] });
+      } finally {
+        window.fetch = origFetch;
+      }
+      return captured;
+    });
+    const sent = JSON.parse(sentBody);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const items = sent.input as any[];
+    expect(items.some(it => it.type === 'function_call_output' && it.call_id === 'call_GONE')).toBe(false);
+  });
+
+  test('OpenAI (Chat Completions) drops an orphaned tool message left behind by compaction', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForSelector('#ai-panel', { state: 'attached' });
+    const sentBody = await page.evaluate(async () => {
+      const openai = await import('/src/ai/openai.ts');
+      let captured = '';
+      const origFetch = window.fetch;
+      // @ts-expect-error test stub
+      window.fetch = async (_input: unknown, init: { body?: string }) => {
+        captured = String(init?.body ?? '');
+        const body = 'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n';
+        return new Response(new Blob([body]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+      };
+      try {
+        const history = [
+          { id: 's0', sessionId: 's', role: 'assistant', blocks: [{ type: 'text', text: '[compacted summary]' }], createdAt: 0, seq: 0 },
+          { id: 'u1', sessionId: 's', role: 'user', blocks: [], toolResults: [{ toolUseId: 'call_GONE', content: 'ok' }], createdAt: 0, seq: 1 },
+          { id: 'u2', sessionId: 's', role: 'user', blocks: [{ type: 'text', text: 'now add a handle' }], createdAt: 0, seq: 2 },
+        ];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await openai.streamTurn({ apiKey: 'k', model: 'gpt-4o', systemPrompt: 'sys', systemSuffix: '', history: history as any, tools: [] });
+      } finally {
+        window.fetch = origFetch;
+      }
+      return captured;
+    });
+    const sent = JSON.parse(sentBody);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const msgs = sent.messages as any[];
+    expect(msgs.some(m => m.role === 'tool' && m.tool_call_id === 'call_GONE')).toBe(false);
+  });
+
   test('OpenAI (Chat Completions) keeps tool calls distinct when an OpenAI-compatible server omits tool_calls[].index', async ({ page }) => {
     // llama.cpp/vLLM/Ollama OpenAI-compat shims frequently stream tool calls
     // without the numeric `index`. Keying buffers on `index ?? 0` collapsed

--- a/tests/unit/historyRepair.test.ts
+++ b/tests/unit/historyRepair.test.ts
@@ -104,4 +104,54 @@ describe('repairToolHistory', () => {
     const history = [userText(0, 'hi'), assistant(1, ['t1']), toolResults(2, ['t1'])];
     expect(hasOrphanedToolCalls(history)).toBe(false);
   });
+
+  describe('orphaned tool_results (the compaction case)', () => {
+    it('removes a tool_result whose tool_use was dropped, deleting the empty carrier', () => {
+      // What compaction strands: a summary turn replaced the assistant(tool_use)
+      // but the tool_result carrier survived in the kept tail.
+      const history = [assistant(0, [], '[compacted summary]'), toolResults(1, ['gone']), userText(2, 'continue')];
+      expect(hasOrphanedToolCalls(history)).toBe(true);
+      const r = repairToolHistory(history);
+      expect(r.changed).toBe(true);
+      expect(r.toDelete).toHaveLength(1);
+      expect(r.toDelete[0].id).toBe('r1');
+      // The orphan is gone; nothing else disturbed.
+      expect(r.messages.map(m => m.id)).toEqual(['a0', 'u2']);
+      expect(hasOrphanedToolCalls(r.messages)).toBe(false);
+    });
+
+    it('strips only the orphaned ids from a carrier that also has a valid result', () => {
+      // A multi-call turn split by compaction: t1's call was dropped, t2's kept.
+      const history = [assistant(0, ['t2']), toolResults(1, ['t1', 't2'])];
+      const r = repairToolHistory(history);
+      expect(r.changed).toBe(true);
+      expect(r.toDelete).toHaveLength(0);
+      const carrier = r.messages[1];
+      const ids = carrier.toolResults!.map(x => x.toolUseId);
+      expect(ids).toEqual(['t2']);
+      expect(r.toPersist.map(m => m.id)).toContain('r1');
+    });
+
+    it('keeps a carrier that has text alongside the orphaned result', () => {
+      const carrier: ChatMessage = {
+        id: 'm1', sessionId: 's', role: 'user',
+        blocks: [{ type: 'text', text: 'thanks' }],
+        toolResults: [{ toolUseId: 'gone', content: 'ok', isError: false }],
+        createdAt: 1000, seq: 1,
+      };
+      const r = repairToolHistory([userText(0, 'hi'), carrier]);
+      expect(r.changed).toBe(true);
+      expect(r.toDelete).toHaveLength(0);
+      const repaired = r.messages.find(m => m.id === 'm1')!;
+      expect(repaired.toolResults).toHaveLength(0);
+      expect(repaired.blocks[0]).toEqual({ type: 'text', text: 'thanks' });
+    });
+
+    it('does not flag a valid result whose tool_use lives anywhere in history', () => {
+      const history = [assistant(0, ['t1']), toolResults(1, ['t1']), userText(2, 'ok')];
+      const r = repairToolHistory(history);
+      expect(r.changed).toBe(false);
+      expect(r.toDelete).toHaveLength(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the provider 400 hit on the first turn **after `/compact`** ("a tool_call_id that didn't exist"), and makes the existing tool-history recovery actually cover that error category.

**Root cause:** the entire tool-history-repair stack only ever handled *one* direction — an orphaned tool_**use** (an assistant `tool_calls` message with no matching result → inject a synthetic error result). The compaction failure is the mirror image: an orphaned tool_**result** — a kept `user.toolResults` entry whose originating `tool_use` was in the dropped/summarized slice. Every hosted provider 400s on a tool_result that answers a tool_use it can't see (`unexpected tool_use_id` / "tool message must respond to a preceding tool_calls").

This explained both halves of the report at once:
- `repairToolHistory` / `hasOrphanedToolCalls` only detected orphan tool_**uses**, so the "🛠 Repair history" button never appeared for this case *and* the repair wouldn't have fixed it.
- compaction's `isOrphanToolResultHead` walk only guards the **head** of the kept window, so a severed tool round elsewhere left a dangling result *persisted*.

## Changes (defense-in-depth, all five providers)

1. **`src/ai/historyRepair.ts`** — `repairToolHistory` now also strips orphaned tool_results (gather every known tool_use id; drop result blocks outside the set; delete a carrier emptied by the strip via a new `toDelete` field). One canonical fix that lights up the repair button (`hasOrphanedToolCalls` is bidirectional now), powers `/repair`, the rewind guard, **and Gemini** (already routes through it).
2. **`src/ui/aiPanel.ts`** — extracted the rewind's inline repair into `persistToolHistoryRepair()` and call it from **both** compaction apply paths (auto + manual) right after the drop+summary writes, so the persisted post-compaction history can never carry a dangling reference.
3. **Provider request builders** as a last line of defense (so the 400 never fires even on a stale pre-fix history): `anthropic.ts` `stripOrphanToolResults`; `openai.ts` orphan strips in both `sanitizeResponsesToolCalls` and `sanitizeChatToolMessages` (also covers `custom.ts`, which reuses them); `local.ts` now routes history through `repairToolHistory` like Gemini.

## Test plan

- ✅ `npm run typecheck` clean
- ✅ `npm run test:unit` — 1452 pass, incl. 4 new orphan-tool_result cases in `tests/unit/historyRepair.test.ts`
- ✅ `npm run lint:deps` — acyclic
- ✅ 3 new browser e2e in `tests/ai-providers.spec.ts` prove the orphaned tool_result is stripped from the real Anthropic / OpenAI Responses / OpenAI Chat request payloads (run locally, green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRb8pt4GMej3Xcpi8PHG1s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRb8pt4GMej3Xcpi8PHG1s)_