### PR TITLE
feat: multi-part save modal + preserve part-list scroll on save

### DIFF
--- a/prompts/multi-part-save-modal-and-scroll.md
+++ b/prompts/multi-part-save-modal-and-scroll.md
@@ -67,3 +67,16 @@ decision left for the user.
 Verified in-browser with a Playwright spec (modal contents, "Save all" → every
 part gains v2, "Save current part only" → only the current part does) and the
 scroll fix (scrollTop preserved across a save with a 25-part rail).
+
+**Follow-up after user feedback.** The user clarified their real workflow: they
+build parts with the **"+" (Add part) button**, which — unlike the rail-switch
+path — does NOT auto-save the outgoing part. So that's the genuine source of
+"multiple unsaved parts", reached via normal manual use. Two refinements:
+- `onCreatePart` now stashes the current part's buffer as a draft before
+  switching (but deliberately does NOT auto-save it as a version — leaving it
+  unsaved is what surfaces it in the modal).
+- Dirty detection now covers **never-saved** parts: `partHasUnsavedDraft` treats
+  a part with no committed version as unsaved when it has a non-starter draft in
+  any language; `currentPartIsDirty` treats a never-saved current part as dirty
+  when its live buffer is non-starter. Added an e2e test reproducing the exact
+  "+ button, no save" flow → all three parts detected and committed by "Save all".

--- a/prompts/multi-part-save-modal-and-scroll.md
+++ b/prompts/multi-part-save-modal-and-scroll.md
@@ -80,3 +80,13 @@ path — does NOT auto-save the outgoing part. So that's the genuine source of
   any language; `currentPartIsDirty` treats a never-saved current part as dirty
   when its live buffer is non-starter. Added an e2e test reproducing the exact
   "+ button, no save" flow → all three parts detected and committed by "Save all".
+
+**Second follow-up.** User then created several parts via "+" WITHOUT editing
+them and wanted those offered too, with the modal noting which "have no changes
+yet". So: any part with NO committed version now counts as unsaved (even an
+untouched starter), and the detection returns a 3-way `PartSaveState`
+(`clean` / `empty` / `unsaved`) instead of a boolean — `partHasUnsavedDraft`
+became `partSaveState`. The modal renders an italic "no changes yet" note on
+`empty` rows (never-saved + still the starter) so the user can uncheck them; rows
+stay pre-checked by default. Added an e2e test: 5 never-edited parts created via
+"+" all show "no changes yet" and "Save all" commits a v1 for each.

--- a/prompts/multi-part-save-modal-and-scroll.md
+++ b/prompts/multi-part-save-modal-and-scroll.md
@@ -1,0 +1,69 @@
+---
+date: 2026-06-18
+branch: claude/sweet-pasteur-bz2gl4
+files_changed:
+  - src/ui/saveAllModal.ts
+  - src/ui/partList.ts
+  - src/ui/sessionBar.ts
+  - src/storage/sessionManager.ts
+  - src/main.ts
+  - public/ai.md
+  - tests/save-all-parts.spec.ts
+---
+
+## Human
+
+When I save and I have multiple parts with unsaved changes, I have to click each
+part and hit Cmd/Ctrl+S separately. We should: (1) if a save shortcut fires while
+multiple parts have unsaved changes, pop a modal listing all the unsaved parts,
+pre-checked, in the same order as the left rail, with the current part called out
+as "current", and let me save just the current part or all of them; the Save
+button should do the same thing. (2) Also: when I scroll down the part list and
+hit Cmd+S, the list jumps back to the top — the scroll position should be
+preserved.
+
+## Assistant
+
+Two parts, one PR.
+
+**Scroll preservation.** `partList.render()` rebuilt the whole rail via
+`railEl.innerHTML = ''`, which destroys the `#parts-list` scroll container and
+creates a fresh one at scrollTop 0. Every save calls `saveVersion → notify →
+render`, so any save reset the scroll. Fix: capture the existing `#parts-list`
+scrollTop before the rebuild and restore it onto the new list after the rows are
+appended (the browser clamps it to the new scrollHeight). Mirrors the AI
+transcript's existing measure-then-restore pattern.
+
+**Multi-part save modal.** New `saveAllModal.ts` (built on `modalShell`) lists
+each unsaved part as a pre-checked checkbox row in rail order, badges the current
+part, and offers Cancel / "Save current part only" / "Save all" (the primary
+button's label reflects the checked count). Detection:
+- Current part — judged from the LIVE editor buffer via a new
+  `currentPartIsDirty()` in sessionManager, which reuses saveVersion's dedup
+  predicate (extracted as `versionMatchesCurrent`) so it accounts for code,
+  annotations, paint, params, and companion files.
+- Other parts — judged from their stashed per-part draft via a new
+  `partHasUnsavedDraft()` (draft code/companions ≠ that part's latest version).
+
+`saveVersionWithToast` (Cmd/Ctrl+S) and the 💾 button (routed through a new
+optional `onSave` callback on the session bar) both go through the modal-aware
+path: when ≥2 parts are unsaved it opens the modal; otherwise it's the plain
+single-part save with identical toasts. "Save all/selected" visits each
+non-current part via the existing rail-switch flow (extracted as `selectPart`,
+which restores the part's draft and re-runs its code so the saved version carries
+the right geometry + thumbnail), saves it, then returns to the originally-active
+part. UI↔API parity: added `window.partwright.saveAllParts()` + a `help()` entry
++ an `ai.md` line.
+
+**Key finding surfaced to the user (not yet acted on):** switching parts via the
+rail already auto-saves the outgoing part (`preserveCurrentEditsIfNeeded` commits
+a version on switch), so multiple parts only stay unsaved when the active part is
+changed *without* that auto-save — e.g. the programmatic `changePart` API that
+AI-driven multi-part editing uses. The modal therefore mainly helps AI/
+programmatic flows today; whether manual rail-switching should ALSO stop
+auto-saving (so manual editing accumulates unsaved parts) is a separate product
+decision left for the user.
+
+Verified in-browser with a Playwright spec (modal contents, "Save all" → every
+part gains v2, "Save current part only" → only the current part does) and the
+scroll fix (scrollTop preserved across a save with a 25-part rail).

--- a/public/ai.md
+++ b/public/ai.md
@@ -343,6 +343,7 @@ await partwright.createSession(name?)    // -> {id, url, galleryUrl}
 await partwright.runAndSave(code, label?, assertions?) // Assert+save in one call -> {passed?, geometry, printability, version, diff, galleryUrl, colorRegions?}. `colorRegions` (also on saveVersion) lists each paint region's {name, kind, label?, triangleCount} — confirm `kind: 'byLabel'` for small files and a non-zero triangleCount. Voxel runs add `geometry.voxelCount`.
 await partwright.createSessionWithVersions(name, [{code, label},...]) // Batch create
 await partwright.saveVersion(label?)     // Save current state as version
+await partwright.saveAllParts()          // Save every part with unsaved changes (visits each, restores the active part) -> {saved, failed} or {error}
 await partwright.listVersions()          // -> [{id, index, label, timestamp, status}]
 await partwright.loadVersion({index} | {id})  // Load version into editor -> {id, index, label, code, geometryData, labelsAvailable, labelCount} or {error}
 await partwright.renameVersion({index} | {id}, label) // Relabel a version (index is immutable) -> {ok, id, index, label} or {error}

--- a/retros/inbox/20260618-123000-multi-part-save-modal.md
+++ b/retros/inbox/20260618-123000-multi-part-save-modal.md
@@ -1,0 +1,39 @@
+# Retro — multi-part save modal + part-list scroll fix (PR #734)
+
+## Liked
+- The detection refactor stayed clean: extracting `saveVersion`'s dedup into
+  `versionMatchesCurrent` let `currentPartIsDirty` reuse the exact same
+  five-axis comparison instead of drifting a second copy.
+- Reusing the rail-switch flow (`selectPart`) for "Save all" meant each
+  non-current part is saved through the *real* load+run path, so saved versions
+  carry correct geometry/thumbnails — no special-case save plumbing.
+
+## Lacked
+- A way to construct "multiple unsaved parts" in a test without fighting the
+  autosave machinery. Two traps cost real cycles:
+  1. **Rail-switching auto-saves the outgoing part** (`preserveCurrentEditsIfNeeded`),
+     so editing-then-switching never leaves a part dirty. My first repro showed
+     0 dirty parts and looked like a feature bug.
+  2. **Programmatic `setCode`/`setValue` CANCELS the pending autosave** (by
+     design — see codeEditor.setValue), so it never writes a draft. Tests that
+     set code via the API silently produce no draft → no dirty non-current part.
+     Real typing + blur (or the visibilitychange hook) is required.
+
+## Learned
+- The genuine source of "multiple unsaved parts" is the **"+" (Add part) button**:
+  unlike the rail click, `onCreatePart` does NOT auto-save (or even stash) the
+  outgoing part. That asymmetry — rail-switch saves, "+" doesn't — is the whole
+  reason the user accumulated unsaved parts. The user knew their workflow; I had
+  to reconcile it against the code before the feature made sense.
+- "Unsaved part" detection must handle **never-saved** parts (no version to diff
+  against), not just parts that diverge from a committed version — a part built
+  via "+" and not yet saved has no version at all.
+
+## Longed for
+- A single helper to set up "a session with N parts in known dirty/clean states"
+  for tests — every multi-part test re-derives the type-real-code + blur +
+  API-changePart dance. A `tests/helpers/parts.ts` fixture would remove ~40
+  lines of fragile setup per spec.
+- Documented somewhere discoverable (CLAUDE.md?) that **rail-switch auto-saves
+  but "+" does not**, and that **setCode cancels autosave** — both are
+  non-obvious and each has cost multiple sessions a debugging detour.

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ import { showAdvancedSettingsModal } from './ui/advancedSettingsModal';
 import { combo, MOD_LABEL, SHIFT_LABEL, ALT_LABEL } from './ui/shortcutDefs';
 import { showToast } from './ui/toast';
 import { confirmDialog, promptDialog } from './ui/dialogs';
+import { showSaveAllModal, type UnsavedPartRow } from './ui/saveAllModal';
 import { updateAppHistory } from './ui/appHistory';
 import { initAiPanel, setActiveSession as setAiActiveSession, toggleAiPanel, toggleAiPanelFromToolbar, prefillAiInput, setAiPanelRouteActive, closeAiPanel, isAiTurnInFlight, onAiTurnEnd } from './ui/aiPanel';
 import { onViewportPanelOpen } from './ui/viewportPanelRegistry';
@@ -268,6 +269,8 @@ import {
   deletePart,
   deleteParts,
   reorderParts,
+  partHasUnsavedDraft,
+  currentPartIsDirty,
   getState,
   setSessionThumbCamera,
   setSessionWorkCamera,
@@ -4394,8 +4397,42 @@ async function main() {
     }
   }
 
-  // Create session bar
+  /** Switch the active part and load it (plus any stashed unsaved draft) into
+   *  the editor — the shared body behind the parts-rail click AND the
+   *  multi-part save flow's "visit each part to save it" loop. Stashes the
+   *  outgoing part's buffer as a draft first so nothing is lost on the switch. */
+  async function selectPart(partId: string): Promise<void> {
+    // Cancel any in-flight render so stale previews can't land on the viewport
+    // after we've switched away to a different part.
+    cancelCurrentExecution();
+    // Save any unsaved non-starter edits as a version (imported SCAD with
+    // errors, etc.) so they survive the switch and are loadable on return.
+    await preserveCurrentEditsIfNeeded();
+    // Also stash the raw editor buffer as a per-part draft BEFORE changePart
+    // runs — after that call currentPart is already the incoming part, so
+    // saving inside loadVersionIntoEditor would land under the wrong id.
+    const { session, currentPart } = getState();
+    if (session && currentPart) {
+      await writeDraft(session.id, getActiveLanguage(), getValue(), currentPart.id, getCompanionFiles());
+    }
+    const version = await changePart(partId);
+    // skipDraftSave: the outgoing draft was already saved above.
+    await loadPartIntoEditor(version, { skipDraftSave: true });
+    // Restore the incoming part's unsaved work (if any) on top of the saved
+    // version that loadPartIntoEditor just loaded.
+    await restoreDraftIfNewer();
+  }
+
+  // Assigned to the modal-aware save once it's defined below; the session bar's
+  // Save button reads it through this mutable handle so a click and Cmd/Ctrl+S
+  // run identical logic (including the multi-part save modal).
+  let saveVersionFromUI: (() => void | Promise<void>) | undefined;
+
+  // Create session bar. The 💾 Save button defers to `saveVersionFromUI` (the
+  // modal-aware save assigned below, once it's defined) so clicking Save and
+  // pressing Cmd/Ctrl+S share the exact same multi-part flow.
   createSessionBar(editorUI, {
+    onSave: () => { void saveVersionFromUI?.(); },
     onSaveVersion: async () => ({
       code: getValue(),
       geometryData: enrichGeometryDataWithColors(getGeometryDataObj()),
@@ -4454,27 +4491,7 @@ async function main() {
 
   // Parts rail — IDE-style list of the session's parts.
   createPartList(partsRail, {
-    onSelectPart: async (partId: string) => {
-      // Cancel any in-flight render so stale Part N previews can't land on
-      // the viewport after we've switched away to a different part.
-      cancelCurrentExecution();
-      // Save any unsaved non-starter edits as a version (imported SCAD with
-      // errors, etc.) so they survive the switch and are loadable on return.
-      await preserveCurrentEditsIfNeeded();
-      // Also stash the raw editor buffer as a per-part draft BEFORE changePart
-      // runs — after that call currentPart is already the incoming part, so
-      // saving inside loadVersionIntoEditor would land under the wrong id.
-      const { session, currentPart } = getState();
-      if (session && currentPart) {
-        await writeDraft(session.id, getActiveLanguage(), getValue(), currentPart.id, getCompanionFiles());
-      }
-      const version = await changePart(partId);
-      // skipDraftSave: the outgoing draft was already saved above.
-      await loadPartIntoEditor(version, { skipDraftSave: true });
-      // Restore the incoming part's unsaved work (if any) on top of the
-      // saved version that loadPartIntoEditor just loaded.
-      await restoreDraftIfNewer();
-    },
+    onSelectPart: (partId: string) => selectPart(partId),
     onCreatePart: async () => {
       // Structural part edits are leader-only — a read-only viewer must not
       // write to the shared session (mirrors the run/save guard).
@@ -4592,7 +4609,9 @@ async function main() {
   });
 
   // Global undo / redo / save shortcuts (OS-aware, focus/tool-routed).
-  const saveVersionWithToast = async () => {
+
+  // Save the CURRENT part and toast the outcome — the single-part save path.
+  const saveCurrentPartWithToast = async () => {
     let result;
     try {
       result = await saveCurrentVersion();
@@ -4621,6 +4640,94 @@ async function main() {
       showToast(`Saved v${result.index}${result.label ? ` — ${result.label}` : ''}`, { variant: 'success' });
     }
   };
+
+  /** Parts in the active session with unsaved changes, in left-panel order.
+   *  The current part is judged from the live editor buffer; the others from
+   *  their stashed per-part drafts. */
+  const gatherUnsavedParts = async (): Promise<UnsavedPartRow[]> => {
+    const { session, parts, currentPart } = getState();
+    if (!session) return [];
+    const rows: UnsavedPartRow[] = [];
+    for (const part of parts) {
+      const isCurrent = part.id === currentPart?.id;
+      const dirty = isCurrent
+        ? currentPartIsDirty(
+            getValue(),
+            enrichGeometryDataWithColors(getGeometryDataObj()),
+            { paramValues: currentParamValues, companionFiles: getCompanionFiles() },
+          )
+        : await partHasUnsavedDraft(part);
+      if (dirty) rows.push({ id: part.id, name: part.name, isCurrent });
+    }
+    return rows;
+  };
+
+  /** Save several parts in one action: each non-current part is loaded into the
+   *  editor (which restores its stashed draft and re-runs its code, so the saved
+   *  version carries the right geometry + thumbnail), saved, then the original
+   *  part is restored. The current part is saved in place first to avoid an
+   *  unnecessary round-trip. */
+  const saveSelectedParts = async (partIds: string[]): Promise<{ saved: number; failed: number }> => {
+    const wanted = new Set(partIds);
+    const originalPartId = getState().currentPart?.id ?? null;
+    // Preserve the rail's order; only touch parts the user kept checked.
+    const ordered = getState().parts.filter(p => wanted.has(p.id));
+    let saved = 0;
+    let failed = 0;
+    const tally = async () => {
+      try {
+        const result = await saveCurrentVersion();
+        if ('error' in result) failed++;
+        else if (!('skipped' in result)) saved++;
+        // 'skipped' = nothing actually changed (a race or already-saved); no-op.
+      } catch {
+        failed++;
+      }
+    };
+    try {
+      // Current part first, in place — no part switch needed.
+      if (originalPartId && wanted.has(originalPartId)) await tally();
+      for (const part of ordered) {
+        if (part.id === originalPartId) continue;
+        await selectPart(part.id);
+        await tally();
+      }
+    } finally {
+      // Always return to where the user was, even if a save threw.
+      if (originalPartId && getState().currentPart?.id !== originalPartId) {
+        await selectPart(originalPartId);
+      }
+    }
+    if (failed > 0) {
+      showToast(`Saved ${saved} part${saved === 1 ? '' : 's'}, ${failed} failed`, { variant: 'warn' });
+    } else {
+      showToast(`Saved ${saved} part${saved === 1 ? '' : 's'}`, { variant: 'success' });
+    }
+    return { saved, failed };
+  };
+
+  // Modal-aware save: when ≥2 parts have unsaved changes, let the user choose
+  // whether to save just the current part or a selected subset; otherwise this
+  // is the plain single-part save. Drives both Cmd/Ctrl+S and the 💾 button.
+  const saveVersionWithToast = async () => {
+    const unsaved = await gatherUnsavedParts();
+    if (unsaved.length >= 2) {
+      const choice = await showSaveAllModal(unsaved);
+      if (choice.action === 'cancel') return;
+      if (choice.action === 'selected') {
+        const onlyCurrent = choice.partIds.length === 1 && choice.partIds[0] === getState().currentPart?.id;
+        if (!onlyCurrent) {
+          await saveSelectedParts(choice.partIds);
+          return;
+        }
+      }
+      // 'current', or a "selected" set that's just the current part → fall
+      // through to the single-part save below (same toasts as a normal save).
+    }
+    await saveCurrentPartWithToast();
+  };
+  // Exposed so the session-bar 💾 button routes through the same modal flow.
+  saveVersionFromUI = saveVersionWithToast;
   installKeyboardShortcuts({ onSave: saveVersionWithToast });
 
   // Viewport tools need the editor active and a model on screen to act on.
@@ -10116,6 +10223,19 @@ async function main() {
       return saveCurrentVersion(label);
     },
 
+    /** Save every part in the active session that has unsaved changes, in one
+     *  call — the non-interactive twin of the 💾 button's multi-part save
+     *  modal. Each part is loaded, saved, and the originally-active part is
+     *  restored. Returns how many parts were saved (and how many failed). */
+    async saveAllParts() {
+      if (!getState().session) {
+        return { error: 'No active session. Call createSession() or openSession(id) first.' };
+      }
+      const unsaved = await gatherUnsavedParts();
+      if (unsaved.length === 0) return { saved: 0, failed: 0 };
+      return saveSelectedParts(unsaved.map(p => p.id));
+    },
+
     /** Commit the current state, routing between `runAndSave` and
      *  `saveVersion` automatically based on whether the code changed:
      *
@@ -13800,6 +13920,7 @@ async function main() {
         'createSession':   { signature: 'await createSession(name?) -- Create session -> {id, url, galleryUrl}', docs: '/ai.md#console-api--windowpartwright' },
         'runAndSave':      { signature: 'await runAndSave(code, label?, assertions?) -- Assert + save version in one call', docs: '/ai.md#assert--save-in-one-call' },
         'saveVersion':     { signature: 'await saveVersion(label?) -- Save current state as version', docs: '/ai.md#console-api--windowpartwright' },
+        'saveAllParts':    { signature: 'await saveAllParts() -- Save every part with unsaved changes', docs: '/ai.md#console-api--windowpartwright' },
         'listVersions':    { signature: 'await listVersions() -- List all versions in session', docs: '/ai.md#console-api--windowpartwright' },
         'loadVersion':     { signature: 'await loadVersion({index} | {id}) -- Load version into editor -> {id, index, label, code, geometryData} or {error}', docs: '/ai.md#console-api--windowpartwright' },
         'renameVersion':   { signature: 'await renameVersion({index} | {id}, label) -- Relabel a version -> {ok, id, index, label} or {error}', docs: '/ai.md#console-api--windowpartwright' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -269,7 +269,7 @@ import {
   deletePart,
   deleteParts,
   reorderParts,
-  partHasUnsavedDraft,
+  partSaveState,
   currentPartIsDirty,
   getState,
   setSessionThumbCamera,
@@ -4658,14 +4658,20 @@ async function main() {
     const rows: UnsavedPartRow[] = [];
     for (const part of parts) {
       const isCurrent = part.id === currentPart?.id;
-      const dirty = isCurrent
-        ? currentPartIsDirty(
-            getValue(),
-            enrichGeometryDataWithColors(getGeometryDataObj()),
-            { paramValues: currentParamValues, companionFiles: getCompanionFiles() },
-          )
-        : await partHasUnsavedDraft(part);
-      if (dirty) rows.push({ id: part.id, name: part.name, isCurrent });
+      if (isCurrent) {
+        if (!currentPartIsDirty(
+          getValue(),
+          enrichGeometryDataWithColors(getGeometryDataObj()),
+          { paramValues: currentParamValues, companionFiles: getCompanionFiles() },
+        )) continue;
+        // No committed version + untouched starter buffer = "no changes yet".
+        const empty = !getState().currentVersion && isStarterCode(getValue());
+        rows.push({ id: part.id, name: part.name, isCurrent, status: empty ? 'empty' : 'unsaved' });
+      } else {
+        const state = await partSaveState(part);
+        if (state === 'clean') continue;
+        rows.push({ id: part.id, name: part.name, isCurrent, status: state });
+      }
     }
     return rows;
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -4496,6 +4496,14 @@ async function main() {
       // Structural part edits are leader-only — a read-only viewer must not
       // write to the shared session (mirrors the run/save guard).
       if (isReadOnlyViewer()) return;
+      // Stash the current part's buffer as a draft before switching away so its
+      // unsaved work survives and is detectable by the multi-part save modal.
+      // Unlike the rail-switch path we deliberately DON'T auto-save it as a
+      // version — leaving it unsaved is exactly what surfaces it in that modal.
+      const { session, currentPart } = getState();
+      if (session && currentPart && !isStarterCode(getValue())) {
+        await writeDraft(session.id, getActiveLanguage(), getValue(), currentPart.id, getCompanionFiles());
+      }
       await createPart();
       startNewPartInEditor();
     },

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -921,34 +921,36 @@ export async function changePart(partId: string, versionIndex?: number): Promise
   return version;
 }
 
-/** True when a *non-current* part has unsaved edits — a stored per-part draft
- *  whose code (or, for SCAD, companion files) diverges from that part's latest
- *  saved version. This is how the multi-part save flow discovers parts the user
- *  edited and then switched away from (their draft is stashed on switch). The
- *  CURRENT part is NOT judged here — its live editor buffer (which also carries
- *  paint/param/annotation changes the draft doesn't) is the source of truth, so
- *  the caller checks it directly. Returns false for a part that has never been
- *  saved (no versions yet) — its starter buffer isn't "unsaved work" to surface.
+/** Save state of a NON-current part for the multi-part save flow:
+ *   - `'clean'`   — committed and its draft matches (nothing to save).
+ *   - `'empty'`   — never committed AND still the untouched starter ("no changes
+ *                   yet"): savable, but the modal notes it so the user can skip.
+ *   - `'unsaved'` — real work to save: either never committed but edited, or
+ *                   committed with a diverging draft (code / SCAD companions).
+ *  The CURRENT part is judged from the live editor buffer instead (its draft
+ *  doesn't carry paint/param/annotation changes) — see {@link currentPartIsDirty}.
  */
-export async function partHasUnsavedDraft(part: Part): Promise<boolean> {
+export type PartSaveState = 'clean' | 'empty' | 'unsaved';
+
+export async function partSaveState(part: Part): Promise<PartSaveState> {
   const latest = await getLatestVersion(part.id);
   if (!latest) {
-    // Never saved (e.g. built via the "+" button and not yet committed): it's
-    // unsaved if it has a non-starter draft in ANY language. (The "+" path
-    // stashes the outgoing buffer as a draft, so real work lands here.)
+    // Never committed: "unsaved" if any stashed draft holds real (non-starter)
+    // content; otherwise it's an untouched new part ("no changes yet").
     const drafts = await dbListDrafts(part.sessionId);
     const prefix = `${part.sessionId}:${part.id}:`;
-    return drafts.some(d => d.id.startsWith(prefix) && !isStarterCode(d.code));
+    const hasContent = drafts.some(d => d.id.startsWith(prefix) && !isStarterCode(d.code));
+    return hasContent ? 'unsaved' : 'empty';
   }
   const lang = effectiveVersionLanguage(latest, currentState.session);
   const draft = await readDraft(part.sessionId, lang, part.id);
-  if (!draft) return false;
-  if (draft.code !== latest.code) return true;
-  // SCAD drafts also stash unsaved companion-file edits; treat those as dirty.
-  if (lang === 'scad') {
-    return !companionFilesEqual(latest.companionFiles ?? {}, draft.companionFiles ?? {});
+  if (!draft) return 'clean';
+  if (draft.code !== latest.code) return 'unsaved';
+  // SCAD drafts also stash unsaved companion-file edits; treat those as unsaved.
+  if (lang === 'scad' && !companionFilesEqual(latest.companionFiles ?? {}, draft.companionFiles ?? {})) {
+    return 'unsaved';
   }
-  return false;
+  return 'clean';
 }
 
 export async function renamePart(partId: string, newName: string): Promise<void> {
@@ -1166,11 +1168,9 @@ export function currentPartIsDirty(
   },
 ): boolean {
   if (!currentState.session || !currentState.currentPart) return false;
-  if (!currentState.currentVersion) {
-    // Never-saved current part: dirty when the live buffer holds real (non-
-    // starter) content the user would lose if it weren't saved.
-    return !isStarterCode(code);
-  }
+  // Never committed → unsaved, even if the buffer is still the starter: a part
+  // the user created and hasn't saved should be offered in the multi-part save.
+  if (!currentState.currentVersion) return true;
   const nextCompanions = opts?.companionFiles ?? currentState.currentVersion.companionFiles ?? {};
   return !versionMatchesCurrent(code, serializeAnnotations(), geometryData, opts?.paramValues, nextCompanions);
 }

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -32,6 +32,7 @@ import {
   getDraft as dbGetDraft,
   setDraft as dbSetDraft,
   deleteDraft as dbDeleteDraft,
+  listDrafts as dbListDrafts,
   deletePartDrafts as dbDeletePartDrafts,
   legacyImagesObjectToArray,
   generateId,
@@ -61,6 +62,7 @@ import { setActiveImports, type ImportedMesh } from '../import/importedMesh';
 import type { PersistedSurfaceTexture } from '../surface/surfaceOpSpec';
 import { setCompanionFiles, companionFilesEqual } from '../import/companionFiles';
 import { getActiveLanguage } from '../geometry/engine';
+import { isStarterCode } from '../editor/starters';
 import { effectiveVersionLanguage, asLanguage } from './languageFallback';
 import { buildInfo } from '../buildInfo';
 import { appVersionCompatibility } from './appVersionCompat';
@@ -930,7 +932,14 @@ export async function changePart(partId: string, versionIndex?: number): Promise
  */
 export async function partHasUnsavedDraft(part: Part): Promise<boolean> {
   const latest = await getLatestVersion(part.id);
-  if (!latest) return false;
+  if (!latest) {
+    // Never saved (e.g. built via the "+" button and not yet committed): it's
+    // unsaved if it has a non-starter draft in ANY language. (The "+" path
+    // stashes the outgoing buffer as a draft, so real work lands here.)
+    const drafts = await dbListDrafts(part.sessionId);
+    const prefix = `${part.sessionId}:${part.id}:`;
+    return drafts.some(d => d.id.startsWith(prefix) && !isStarterCode(d.code));
+  }
   const lang = effectiveVersionLanguage(latest, currentState.session);
   const draft = await readDraft(part.sessionId, lang, part.id);
   if (!draft) return false;
@@ -1156,8 +1165,11 @@ export function currentPartIsDirty(
     companionFiles?: Record<string, string>;
   },
 ): boolean {
-  if (!currentState.session || !currentState.currentPart || !currentState.currentVersion) {
-    return false;
+  if (!currentState.session || !currentState.currentPart) return false;
+  if (!currentState.currentVersion) {
+    // Never-saved current part: dirty when the live buffer holds real (non-
+    // starter) content the user would lose if it weren't saved.
+    return !isStarterCode(code);
   }
   const nextCompanions = opts?.companionFiles ?? currentState.currentVersion.companionFiles ?? {};
   return !versionMatchesCurrent(code, serializeAnnotations(), geometryData, opts?.paramValues, nextCompanions);

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -919,6 +919,29 @@ export async function changePart(partId: string, versionIndex?: number): Promise
   return version;
 }
 
+/** True when a *non-current* part has unsaved edits — a stored per-part draft
+ *  whose code (or, for SCAD, companion files) diverges from that part's latest
+ *  saved version. This is how the multi-part save flow discovers parts the user
+ *  edited and then switched away from (their draft is stashed on switch). The
+ *  CURRENT part is NOT judged here — its live editor buffer (which also carries
+ *  paint/param/annotation changes the draft doesn't) is the source of truth, so
+ *  the caller checks it directly. Returns false for a part that has never been
+ *  saved (no versions yet) — its starter buffer isn't "unsaved work" to surface.
+ */
+export async function partHasUnsavedDraft(part: Part): Promise<boolean> {
+  const latest = await getLatestVersion(part.id);
+  if (!latest) return false;
+  const lang = effectiveVersionLanguage(latest, currentState.session);
+  const draft = await readDraft(part.sessionId, lang, part.id);
+  if (!draft) return false;
+  if (draft.code !== latest.code) return true;
+  // SCAD drafts also stash unsaved companion-file edits; treat those as dirty.
+  if (lang === 'scad') {
+    return !companionFilesEqual(latest.companionFiles ?? {}, draft.companionFiles ?? {});
+  }
+  return false;
+}
+
 export async function renamePart(partId: string, newName: string): Promise<void> {
   await dbUpdatePart(partId, { name: newName, updated: Date.now() });
   const idx = currentState.parts.findIndex(p => p.id === partId);
@@ -1095,6 +1118,51 @@ function colorRegionsEqual(prev: Record<string, unknown> | null | undefined, nex
   return JSON.stringify(prevRegions) === JSON.stringify(nextRegions);
 }
 
+/** Shared dedup predicate: true when the given editor state is byte-identical
+ *  to the loaded version (code, annotations, color regions, params, companion
+ *  files), so saving it would be a no-op. `annotationSnapshot` is passed in so
+ *  callers don't re-serialize annotations twice. Used by both saveVersion (to
+ *  skip a redundant save) and {@link currentPartIsDirty} (to detect a dirty
+ *  current part for the multi-part save flow). */
+function versionMatchesCurrent(
+  code: string,
+  annotationSnapshot: ReturnType<typeof serializeAnnotations>,
+  geometryData: Record<string, unknown> | null,
+  paramValues: Record<string, number | boolean | string> | undefined,
+  nextCompanions: Record<string, string>,
+): boolean {
+  return (
+    !!currentState.currentVersion &&
+    currentState.currentVersion.code === code &&
+    annotationsEqual(currentState.currentVersion.annotations, annotationSnapshot) &&
+    colorRegionsEqual(currentState.currentVersion.geometryData as Record<string, unknown> | null, geometryData) &&
+    paramValuesEqual(currentState.currentVersion.paramValues, paramValues) &&
+    companionFilesEqual(currentState.currentVersion.companionFiles, nextCompanions)
+  );
+}
+
+/** Whether the CURRENT part has unsaved edits relative to its loaded version —
+ *  the live-editor counterpart to {@link partHasUnsavedDraft} (which judges the
+ *  other parts from their stashed drafts). Mirrors saveVersion's dedup so the
+ *  multi-part save flow can decide whether the current part belongs in the
+ *  unsaved set before committing anything. A part with no loaded version yet
+ *  (freshly created, never saved) is NOT reported dirty here — an untouched
+ *  starter buffer isn't unsaved work to nag about. */
+export function currentPartIsDirty(
+  code: string,
+  geometryData: Record<string, unknown> | null,
+  opts?: {
+    paramValues?: Record<string, number | boolean | string>;
+    companionFiles?: Record<string, string>;
+  },
+): boolean {
+  if (!currentState.session || !currentState.currentPart || !currentState.currentVersion) {
+    return false;
+  }
+  const nextCompanions = opts?.companionFiles ?? currentState.currentVersion.companionFiles ?? {};
+  return !versionMatchesCurrent(code, serializeAnnotations(), geometryData, opts?.paramValues, nextCompanions);
+}
+
 export async function saveVersion(
   code: string,
   geometryData: Record<string, unknown> | null,
@@ -1140,12 +1208,7 @@ export async function saveVersion(
   // identical to the current version (unless forced).
   if (
     !options?.force &&
-    currentState.currentVersion &&
-    currentState.currentVersion.code === code &&
-    annotationsEqual(currentState.currentVersion.annotations, annotationSnapshot) &&
-    colorRegionsEqual(currentState.currentVersion.geometryData as Record<string, unknown> | null, geometryData) &&
-    paramValuesEqual(currentState.currentVersion.paramValues, paramValues) &&
-    companionFilesEqual(currentState.currentVersion.companionFiles, nextCompanions)
+    versionMatchesCurrent(code, annotationSnapshot, geometryData, paramValues, nextCompanions)
   ) {
     return null;
   }

--- a/src/ui/partList.ts
+++ b/src/ui/partList.ts
@@ -66,6 +66,12 @@ function render(state: SessionState): void {
     clearSelection();
   }
 
+  // Preserve the list's scroll position across the full rebuild below. The
+  // scrollable `#parts-list` div is recreated from scratch on every render
+  // (e.g. on each save, which calls notify() → render), so without this the
+  // list jumps back to the top whenever a re-render fires while scrolled down.
+  const prevScrollTop = railEl.querySelector('#parts-list')?.scrollTop ?? 0;
+
   railEl.innerHTML = '';
 
   // Header: title + collapse + add.
@@ -122,6 +128,11 @@ function render(state: SessionState): void {
   if (selected.size > 0) {
     railEl.appendChild(buildActionBar(state));
   }
+
+  // Restore the pre-rebuild scroll position now that the rows exist (clamped by
+  // the browser to the new scrollHeight). Keeps Cmd+S from scrolling the list
+  // to the top when the user had scrolled down through a long part list.
+  if (prevScrollTop > 0) list.scrollTop = prevScrollTop;
 }
 
 function buildRow(part: Part, isCurrent: boolean, partCount: number, list: HTMLElement, currentVersion: Version | null): HTMLElement {

--- a/src/ui/saveAllModal.ts
+++ b/src/ui/saveAllModal.ts
@@ -1,0 +1,127 @@
+// Multi-part save modal — shown when a save action (Cmd/Ctrl+S or the 💾 Save
+// button) fires while two or more parts in the session have unsaved changes.
+// Lists every unsaved part in left-panel order, each pre-checked, with the
+// current part called out, and lets the user save just the current part or any
+// subset. Returns the user's choice; the caller (main.ts) does the saving.
+
+import { createModalShell } from './modalShell';
+import { BUTTON_PRIMARY, BUTTON_CANCEL } from './styleConstants';
+
+/** A filled secondary action button, sized to match {@link BUTTON_PRIMARY}.
+ *  Used for "Save current part only" so it reads as a real action alongside the
+ *  primary "Save selected", not as a cancel link. */
+const BUTTON_SECONDARY =
+  'px-4 py-1.5 rounded-lg text-sm font-medium bg-zinc-700 text-zinc-100 hover:bg-zinc-600 transition-colors';
+
+export interface UnsavedPartRow {
+  id: string;
+  name: string;
+  /** The part currently loaded in the editor — called out in the list. */
+  isCurrent: boolean;
+}
+
+export type SaveAllChoice =
+  | { action: 'cancel' }
+  | { action: 'current' }
+  | { action: 'selected'; partIds: string[] };
+
+/** Open the multi-part save modal. `parts` must already be in the left-panel
+ *  display order. Resolves with the user's choice (cancel / save current only /
+ *  save the checked subset). */
+export function showSaveAllModal(parts: UnsavedPartRow[]): Promise<SaveAllChoice> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (choice: SaveAllChoice) => {
+      if (settled) return;
+      settled = true;
+      resolve(choice);
+      shell.close();
+    };
+
+    const shell = createModalShell({
+      title: 'Save unsaved parts',
+      maxWidth: 'md',
+      scrollable: true,
+      // Escape / click-outside / ✕ all count as cancel.
+      onClose: () => { if (!settled) { settled = true; resolve({ action: 'cancel' }); } },
+    });
+
+    const intro = document.createElement('p');
+    intro.className = 'text-zinc-300';
+    intro.textContent =
+      `${parts.length} parts have unsaved changes. Choose which to save — all are selected by default.`;
+    shell.body.appendChild(intro);
+
+    const listEl = document.createElement('div');
+    listEl.className = 'flex flex-col gap-0.5 max-h-64 overflow-auto -mx-1';
+    shell.body.appendChild(listEl);
+
+    const checkboxes = new Map<string, HTMLInputElement>();
+    const currentId = parts.find(p => p.isCurrent)?.id ?? null;
+
+    for (const part of parts) {
+      const row = document.createElement('label');
+      row.className =
+        'flex items-center gap-2.5 py-1.5 px-2 mx-1 rounded cursor-pointer hover:bg-zinc-700/40';
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.checked = true;
+      input.className = 'w-4 h-4 accent-blue-500 cursor-pointer shrink-0';
+      input.addEventListener('change', updateSelectedButton);
+      checkboxes.set(part.id, input);
+      row.appendChild(input);
+
+      const name = document.createElement('span');
+      name.className = 'text-zinc-100 truncate flex-1 min-w-0';
+      name.textContent = part.name;
+      row.appendChild(name);
+
+      if (part.isCurrent) {
+        const badge = document.createElement('span');
+        badge.className =
+          'shrink-0 text-[10px] uppercase tracking-wide font-semibold text-blue-300 bg-blue-500/15 border border-blue-500/30 rounded px-1.5 py-0.5';
+        badge.textContent = 'Current part';
+        row.appendChild(badge);
+      }
+
+      listEl.appendChild(row);
+    }
+
+    // Footer: Cancel | Save current part only | Save selected (N)
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = BUTTON_CANCEL;
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => finish({ action: 'cancel' }));
+    shell.footer.appendChild(cancelBtn);
+
+    if (currentId) {
+      const currentBtn = document.createElement('button');
+      currentBtn.className = BUTTON_SECONDARY;
+      currentBtn.textContent = 'Save current part only';
+      currentBtn.addEventListener('click', () => finish({ action: 'current' }));
+      shell.footer.appendChild(currentBtn);
+    }
+
+    const selectedBtn = document.createElement('button');
+    selectedBtn.className = BUTTON_PRIMARY;
+    shell.footer.appendChild(selectedBtn);
+    selectedBtn.addEventListener('click', () => {
+      const ids = parts.map(p => p.id).filter(id => checkboxes.get(id)?.checked);
+      if (ids.length === 0) return;
+      finish({ action: 'selected', partIds: ids });
+    });
+
+    function updateSelectedButton(): void {
+      const count = parts.filter(p => checkboxes.get(p.id)?.checked).length;
+      selectedBtn.textContent = count === parts.length ? 'Save all' : `Save selected (${count})`;
+      selectedBtn.disabled = count === 0;
+      selectedBtn.classList.toggle('opacity-50', count === 0);
+      selectedBtn.classList.toggle('cursor-default', count === 0);
+    }
+    updateSelectedButton();
+
+    // Focus the primary action so Enter saves all by default.
+    requestAnimationFrame(() => selectedBtn.focus());
+  });
+}

--- a/src/ui/saveAllModal.ts
+++ b/src/ui/saveAllModal.ts
@@ -18,6 +18,9 @@ export interface UnsavedPartRow {
   name: string;
   /** The part currently loaded in the editor — called out in the list. */
   isCurrent: boolean;
+  /** `'empty'` = a never-saved part still on the starter ("no changes yet");
+   *  `'unsaved'` = has real unsaved work. Drives the per-row status note. */
+  status: 'empty' | 'unsaved';
 }
 
 export type SaveAllChoice =
@@ -76,6 +79,14 @@ export function showSaveAllModal(parts: UnsavedPartRow[]): Promise<SaveAllChoice
       name.className = 'text-zinc-100 truncate flex-1 min-w-0';
       name.textContent = part.name;
       row.appendChild(name);
+
+      // "no changes yet" note for freshly-created parts the user hasn't edited.
+      if (part.status === 'empty') {
+        const note = document.createElement('span');
+        note.className = 'shrink-0 text-[11px] italic text-zinc-500';
+        note.textContent = 'no changes yet';
+        row.appendChild(note);
+      }
 
       if (part.isCurrent) {
         const badge = document.createElement('span');

--- a/src/ui/sessionBar.ts
+++ b/src/ui/sessionBar.ts
@@ -19,6 +19,11 @@ import { isQuotaError } from '../storage/quota';
 import { languageBadge } from './languageBadge';
 
 export interface SessionBarCallbacks {
+  /** When provided, the 💾 Save button delegates entirely to this handler
+   *  (which owns its own toasts + the multi-part save modal) instead of the
+   *  bar's built-in single-version save. Lets a click and Cmd/Ctrl+S share one
+   *  flow. */
+  onSave?: () => void | Promise<void>;
   onSaveVersion: () => Promise<{ code: string; geometryData: Record<string, unknown> | null; thumbnail: Blob | null }>;
   onLoadVersion: (code: string) => void;
   onNewSession: () => void;
@@ -175,6 +180,22 @@ function render(state: SessionState) {
   let saving = false;
   const saveBtn = btn('\uD83D\uDCBE Save', async () => {
     if (saving) return;
+    // When the host supplies a save handler, delegate to it \u2014 it owns the
+    // multi-part save modal and its own toasts/guards \u2014 and skip the bar's
+    // built-in single-version path entirely.
+    if (callbacks.onSave) {
+      saving = true;
+      saveBtn.disabled = true;
+      saveBtn.classList.add('opacity-50');
+      try {
+        await callbacks.onSave();
+      } finally {
+        saving = false;
+        saveBtn.disabled = false;
+        saveBtn.classList.remove('opacity-50');
+      }
+      return;
+    }
     saving = true;
     saveBtn.disabled = true;
     saveBtn.classList.add('opacity-50');

--- a/tests/save-all-parts.spec.ts
+++ b/tests/save-all-parts.spec.ts
@@ -164,6 +164,37 @@ test.describe('Multi-part save', () => {
     expect(counts).toEqual([1, 1, 1]);
   });
 
+  test('parts created via "+" with no edits show "no changes yet" and are saveable', async ({ page }) => {
+    await openEditor(page);
+    await page.evaluate(() => (window as any).partwright.createSession('EmptyParts'));
+    // Create 4 more parts via the "+" button without editing anything.
+    for (let i = 0; i < 4; i++) {
+      await page.locator('#btn-add-part').click();
+      await page.waitForTimeout(400);
+    }
+
+    await page.keyboard.press('ControlOrMeta+s');
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    // 5 parts (initial + 4), none ever committed → all offered.
+    await expect(dialog.locator('input[type="checkbox"]')).toHaveCount(5);
+    // …and every one is flagged "no changes yet".
+    await expect(dialog.getByText('no changes yet')).toHaveCount(5);
+
+    await dialog.getByRole('button', { name: 'Save all' }).click();
+    await page.waitForTimeout(3000);
+    const counts = await page.evaluate(async () => {
+      const pw = (window as any).partwright;
+      const out: number[] = [];
+      for (const p of pw.listParts()) {
+        await pw.changePart(p.id);
+        out.push((await pw.listVersions()).length);
+      }
+      return out;
+    });
+    expect(counts).toEqual([1, 1, 1, 1, 1]);
+  });
+
   test('"Save current part only" saves just the current part', async ({ page }) => {
     await openEditor(page);
     await setupThreeUnsavedParts(page);

--- a/tests/save-all-parts.spec.ts
+++ b/tests/save-all-parts.spec.ts
@@ -1,0 +1,156 @@
+// E2E for the multi-part save flow. When two or more parts in a session carry
+// unsaved changes, the save action (Cmd/Ctrl+S or the 💾 button) opens a modal
+// listing every unsaved part — pre-checked, in rail order, current part called
+// out — and lets the user save just the current part or a selected subset.
+//
+// Unsaved-on-a-non-current-part arises when a part is edited and the active
+// part is then changed WITHOUT the rail's auto-save-on-switch — i.e. the
+// programmatic `changePart` API (how AI-driven multi-part editing switches
+// parts). We use that here to set up several genuinely-unsaved parts.
+
+import { test, expect, type Page } from 'playwright/test';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function openEditor(page: Page) {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('partwright-tour-completed', '1');
+      localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({ editorCollapsed: false }));
+    } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 30_000 });
+  await page.waitForFunction(() => !!(window as any).partwright?.runAndSave, { timeout: 30_000 });
+}
+
+async function typeCode(page: Page, text: string) {
+  await page.locator('.cm-content').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('Delete');
+  await page.keyboard.type(text, { delay: 3 });
+}
+
+// Blur the editor to fire its onBlur autosave (persists the per-part draft).
+async function flushDraft(page: Page) {
+  await page.locator('.cm-content').blur();
+  await page.waitForTimeout(500);
+}
+
+async function saveShortcut(page: Page) {
+  await page.keyboard.press('ControlOrMeta+s');
+  await page.waitForTimeout(700);
+}
+
+/** Build a session with three parts, each saved at v1, then leave all three
+ *  with unsaved edits (two via stashed drafts, one live on the current part).
+ *  Returns the part ids in rail order. */
+async function setupThreeUnsavedParts(page: Page) {
+  await page.evaluate(() => (window as any).partwright.createSession('SaveAllSpec'));
+  await typeCode(page, 'const {Manifold}=api; return Manifold.cube([10,10,10],true);');
+  await flushDraft(page);
+  await saveShortcut(page);
+
+  await page.evaluate(() => (window as any).partwright.createPart('Bracket'));
+  await typeCode(page, 'const {Manifold}=api; return Manifold.sphere(6,32);');
+  await flushDraft(page);
+  await saveShortcut(page);
+
+  await page.evaluate(() => (window as any).partwright.createPart('Spacer'));
+  await typeCode(page, 'const {Manifold}=api; return Manifold.cylinder(8,4);');
+  await flushDraft(page);
+  await saveShortcut(page);
+
+  const ids = await page.evaluate(() =>
+    (window as any).partwright.listParts().map((p: any) => ({ id: p.id, name: p.name })));
+  const [p1, p2] = ids;
+
+  // Dirty Spacer (current), persist its draft, then programmatically switch
+  // (no auto-save) → Spacer stays unsaved.
+  await typeCode(page, 'const {Manifold}=api; return Manifold.cylinder(9,5); // edit');
+  await flushDraft(page);
+  await page.evaluate((id) => (window as any).partwright.changePart(id), p2.id);
+  await page.waitForTimeout(500);
+
+  // Dirty Bracket, persist, switch to Part 1 → Bracket stays unsaved.
+  await typeCode(page, 'const {Manifold}=api; return Manifold.sphere(7,32); // edit');
+  await flushDraft(page);
+  await page.evaluate((id) => (window as any).partwright.changePart(id), p1.id);
+  await page.waitForTimeout(500);
+
+  // Dirty Part 1 (now current) — left live, unsaved.
+  await typeCode(page, 'const {Manifold}=api; return Manifold.cube([12,12,12],true); // edit');
+  await page.waitForTimeout(300);
+
+  return ids;
+}
+
+test.describe('Multi-part save', () => {
+  test('Cmd+S with several unsaved parts opens the save modal, current part called out', async ({ page }) => {
+    await openEditor(page);
+    await setupThreeUnsavedParts(page);
+
+    await page.keyboard.press('ControlOrMeta+s');
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await expect(dialog).toContainText('3 parts have unsaved changes');
+    await expect(dialog).toContainText('Current part');
+    // All three unsaved parts are listed.
+    for (const name of ['Part 1', 'Bracket', 'Spacer']) {
+      await expect(dialog.getByText(name, { exact: true })).toBeVisible();
+    }
+    // Every checkbox starts checked.
+    const boxes = dialog.locator('input[type="checkbox"]');
+    await expect(boxes).toHaveCount(3);
+    for (let i = 0; i < 3; i++) await expect(boxes.nth(i)).toBeChecked();
+  });
+
+  test('"Save all" commits a new version for every unsaved part', async ({ page }) => {
+    await openEditor(page);
+    await setupThreeUnsavedParts(page);
+
+    await page.keyboard.press('ControlOrMeta+s');
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.getByRole('button', { name: 'Save all' }).click();
+    await page.waitForTimeout(2500);
+
+    const counts = await page.evaluate(async () => {
+      const pw = (window as any).partwright;
+      const out: Record<string, number> = {};
+      for (const p of pw.listParts()) {
+        await pw.changePart(p.id);
+        out[p.name] = (await pw.listVersions()).length;
+      }
+      return out;
+    });
+    expect(counts['Part 1']).toBe(2);
+    expect(counts['Bracket']).toBe(2);
+    expect(counts['Spacer']).toBe(2);
+  });
+
+  test('"Save current part only" saves just the current part', async ({ page }) => {
+    await openEditor(page);
+    await setupThreeUnsavedParts(page);
+
+    await page.keyboard.press('ControlOrMeta+s');
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.getByRole('button', { name: 'Save current part only' }).click();
+    await page.waitForTimeout(1500);
+
+    const counts = await page.evaluate(async () => {
+      const pw = (window as any).partwright;
+      const out: Record<string, number> = {};
+      for (const p of pw.listParts()) {
+        await pw.changePart(p.id);
+        out[p.name] = (await pw.listVersions()).length;
+      }
+      return out;
+    });
+    // Only Part 1 (the current part) gained a version; the others stay at v1.
+    expect(counts['Part 1']).toBe(2);
+    expect(counts['Bracket']).toBe(1);
+    expect(counts['Spacer']).toBe(1);
+  });
+});

--- a/tests/save-all-parts.spec.ts
+++ b/tests/save-all-parts.spec.ts
@@ -129,6 +129,41 @@ test.describe('Multi-part save', () => {
     expect(counts['Spacer']).toBe(2);
   });
 
+  test('parts built via the "+" button without saving are detected as unsaved', async ({ page }) => {
+    await openEditor(page);
+    // Mirror the real workflow: type a part, click "+", type the next, etc.
+    // The "+" path does not auto-save, so each prior part stays unsaved.
+    await page.evaluate(() => (window as any).partwright.createSession('PlusFlow'));
+    await typeCode(page, 'const {Manifold}=api; return Manifold.cube([10,10,10],true); // one');
+    await page.locator('#btn-add-part').click();
+    await page.waitForTimeout(500);
+    await typeCode(page, 'const {Manifold}=api; return Manifold.sphere(6,32); // two');
+    await page.locator('#btn-add-part').click();
+    await page.waitForTimeout(500);
+    await typeCode(page, 'const {Manifold}=api; return Manifold.cylinder(8,4); // three');
+    await page.waitForTimeout(300);
+
+    await page.keyboard.press('ControlOrMeta+s');
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    // All three never-saved-but-edited parts should be offered.
+    await expect(dialog.locator('input[type="checkbox"]')).toHaveCount(3);
+
+    await dialog.getByRole('button', { name: 'Save all' }).click();
+    await page.waitForTimeout(2500);
+    const counts = await page.evaluate(async () => {
+      const pw = (window as any).partwright;
+      const out: number[] = [];
+      for (const p of pw.listParts()) {
+        await pw.changePart(p.id);
+        out.push((await pw.listVersions()).length);
+      }
+      return out;
+    });
+    // Every part now has its first committed version.
+    expect(counts).toEqual([1, 1, 1]);
+  });
+
   test('"Save current part only" saves just the current part', async ({ page }) => {
     await openEditor(page);
     await setupThreeUnsavedParts(page);


### PR DESCRIPTION
## Summary

Two save-flow papercuts hit while working across many parts:

### 1. Multi-part save modal
When a save action fires (Cmd/Ctrl+S **or** the 💾 Save button) and **two or more parts have unsaved changes**, a modal lists every unsaved part:
- pre-checked, in the same order as the left rail,
- the **current part is badged "Current part"**,
- footer offers **Cancel** / **Save current part only** / **Save all** (the primary button's label reflects the checked count).

Single-part saves are unchanged (no modal; same toasts).

**Dirty detection** covers both committed and never-saved parts:
- Current part — live editor buffer via new `currentPartIsDirty()` (reuses `saveVersion`'s dedup predicate, extracted as `versionMatchesCurrent`, so it accounts for code, annotations, paint, params, companion files); a never-saved current part counts as dirty when its buffer is non-starter.
- Other parts — new `partHasUnsavedDraft()` (draft ≠ latest version); a part with no committed version counts as unsaved when it has a non-starter draft.

"Save all/selected" visits each non-current part through the existing rail-switch flow (extracted as `selectPart` — restores the part's draft + re-runs its code so the saved version carries the right geometry/thumbnail), saves it, then returns to the originally-active part.

**The "+" (Add part) button** now stashes the current part's buffer as a draft before switching (it doesn't auto-save it — staying unsaved is what surfaces it in the modal). This is the real workflow that accumulates unsaved parts: building part after part via "+" never committed the prior ones.

**UI↔API parity:** `window.partwright.saveAllParts()` + `help()` entry + `ai.md` line.

### 2. Part-list scroll preserved on save
`partList.render()` rebuilt the rail with `railEl.innerHTML = ''`, destroying the `#parts-list` scroll container — so every save (`saveVersion → notify → render`) reset the list to the top. Now scrollTop is captured before the rebuild and restored after.

## Context
Unlike the "+" button, switching parts via the **rail** already auto-saves the outgoing part (`preserveCurrentEditsIfNeeded`). The "+" path does not — confirmed as the source of the user's "multiple unsaved parts". Left the auto-save asymmetry as-is on purpose: the "+" leaving parts unsaved is exactly what the modal is for.

## Verification
Modal contents verified in-browser (screenshot in session chat): rows `Part 1` `[CURRENT PART]` / `Bracket` / `Spacer`, all checked, "3 parts have unsaved changes…", buttons `Cancel` / `Save current part only` / `Save all`.

## Test plan
- [x] `npm run typecheck`, `npm run test:unit` (1476 pass), `npm run lint:deps`, `npm run build`
- [x] `tests/save-all-parts.spec.ts` (4 tests): modal contents + current-part badge + all-checked; "Save all" → every part gains a version; **parts built via "+" without saving are detected**; "Save current part only" → only the current part
- [x] Scroll fix verified in-browser (scrollTop preserved across a save with a 25-part rail)
- [ ] PR-checks e2e shards green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqwQ7xpeCDaVsm6Y2hFxbp