### PR TITLE
refactor: conformal surface-marking/recess helpers; migrate nipples, navel, brows

### DIFF
--- a/examples/figure_expectant_mother.js
+++ b/examples/figure_expectant_mother.js
@@ -55,7 +55,6 @@ const eyes = F.face.eyes(rig, {
 // Flush, painted-on brows (labelled 'brows'). Kept OUT of the skin weld and
 // hard-unioned at the top level (like the eyes) so the dark brow colour isn't
 // flattened into skin. Soft 'natural' arch to match the serene expression.
-const brows = F.face.brows(rig, { shape: 'natural' });
 const lips = F.face.mouthAccents(rig, {
   style: 'lips',
   lipShape: 'natural',
@@ -74,6 +73,13 @@ const skin = F.weld(rig, [
   F.feet(rig, { toes: true }),
   face,
 ]).label('skin');
+
+// Flush, painted-on brows (labelled 'brows'). Kept OUT of the skin weld and
+// hard-unioned at the top level (like the eyes) so the dark brow colour isn't
+// flattened into skin. Seated CONFORMALLY on the real forehead via `on: skin`
+// (a thin proud strip of the actual surface — no curvature guess). Soft
+// 'natural' arch to match the serene expression.
+const brows = F.face.brows(rig, { shape: 'natural', on: skin });
 
 // 4. DRESS BODY — a SLEEVELESS maternity dress (its own region). F.clothing.top
 // with a hem below the pelvis and sleeve:'none' gives a bodice + flared cone

--- a/prompts/figure-conformal-brow-review-fixes.md
+++ b/prompts/figure-conformal-brow-review-fixes.md
@@ -1,0 +1,32 @@
+---
+date: 2026-06-18
+branch: claude/kind-cerf-dikkfm
+files_changed:
+  - src/geometry/sdfFigure.ts
+  - public/ai/figure.md
+  - tests/unit/sdfFigure.test.ts
+---
+
+## Human
+
+(work-reviewer findings on PR #741) Should-fix: (1) `assembleFace` now always
+passes `on: result`, silently switching ~50 in-assemble-brow figures from the
+legacy flush strip to a proud conformal brow — no escape hatch, no test guard;
+(2) the new brow `on` param is undocumented (API/doc parity); nit: a duplicated
+"Self-labelled" comment.
+
+## Assistant
+
+Addressed all three. The blast-radius finding was sharper than first read:
+in-assemble brows are flattened to skin by the `.label('skin')` weld, so they are
+deliberately FLUSH ("not a raised ridge") — forcing the proud conformal path
+would add an unwanted brow ridge to ~50 figures (a regression). So I scoped the
+conformal brow to OPT-IN: reverted `assembleFace` to the legacy in-assemble path
+(now byte-identical to main — zero blast radius), leaving the proud conformal
+brow for the top-level painted path via `F.face.brows(rig, { on: skin })` (what
+`expectant_mother` uses). Documented the `on` param in `public/ai/figure.md`'s
+Brows section (mirroring `F.nipples({ on })`). Added a unit test exercising the
+`on` path (label survives the offset+clip; non-degenerate geometry seated at the
+brow height) — the previously-unguarded branch. Removed the duplicated comment.
+typecheck clean; 242 figure unit tests pass; expectant_mother builds comp=1 with
+brows resolving.

--- a/prompts/figure-conformal-helpers-retro.md
+++ b/prompts/figure-conformal-helpers-retro.md
@@ -1,0 +1,22 @@
+---
+date: 2026-06-18
+branch: claude/kind-cerf-dikkfm
+files_changed:
+  - retros/inbox/20260618-conformal-marking-helpers.md
+---
+
+## Human
+
+(close-out of PR #741, now green + ready) Run /retro.
+
+## Assistant
+
+4-Ls retro for the surfaceMarking/surfaceRecess helper work. Durable lessons:
+(1) the design discussion clarified why proud and recessed can't be one helper
+(a carved void can't carry a paint label); (2) work-reviewer caught that
+defaulting `assembleFace` to the conformal brow would have added an unwanted
+ridge to ~50 in-assemble figures — the rule "check every call site of a shared
+builder before changing its default"; (3) "proud vs flush" is coupled to whether
+the marking is painted, which is exactly why blanket-applying proud was wrong.
+Reinforces the #732 stat-diff/catalog-freshness ask (would have answered the
+blast-radius question mechanically).

--- a/prompts/figure-conformal-marking-helpers.md
+++ b/prompts/figure-conformal-marking-helpers.md
@@ -1,0 +1,45 @@
+---
+date: 2026-06-18
+branch: claude/kind-cerf-dikkfm
+files_changed:
+  - src/geometry/sdfFigure.ts
+  - examples/figure_expectant_mother.js
+---
+
+## Human
+
+I like the idea of the two separate helpers. Build those helpers and use
+nipples, brows, and belly buttons (or mouths) as a test/experiment of how they
+are working. Produce several preview images with multiple angles for me to
+judge the quality.
+
+## Assistant
+
+Built the two engine helpers (issue #738) and migrated three features as the
+experiment:
+
+- `surfaceMarking(surface, region, relief, soften)` — a PROUD, paintable marking:
+  `surface.round(relief).smoothIntersect(region, soften)`. The areola recipe
+  generalized — conformal offset of the real surface, soft-clipped, label + union
+  at top level. Stands proud so the label owns its triangles (a coincident
+  marking dithers).
+- `surfaceRecess(body, cutter, soften)` — a carve (`smoothSubtract`). Kept
+  separate because the mechanism differs: a marking is added (union) and carries
+  a label; a recess is removed (subtract) and — being a void — can't (colour
+  rides positive unioned nodes), so a painted recess must pair it with a marking
+  shell inside (documented).
+
+Migrations: nipples → `surfaceMarking` (identical output, now via the helper);
+navel → `surfaceRecess`; brows → `surfaceMarking` + a new `on:` surface param so
+the brow is a thin proud strip of the ACTUAL forehead instead of a sagitta-guess
+capsule that floats/sinks. `assembleFace` passes `on: result`; top-level painted
+brows pass `on: skin` (updated `expectant_mother`). Legacy sunk-strip kept as the
+no-`on` fallback.
+
+Verified: typecheck clean, 240 figure unit tests pass, all three figures build
+componentCount=1 with labels resolving. Rendered multi-angle previews (brows
+colored face; swimmer nipples+navel colored front + profile) for the user to
+judge before opening the PR. Caveat noted: the brow's scoping arc is still
+coarsely positioned by the existing path (incl. sagDrop), but no longer DEFINES
+the surface — fully removing sagDrop (a depth-robust forward-curtain region) is a
+clean follow-up.

--- a/public/ai/figure.md
+++ b/public/ai/figure.md
@@ -813,10 +813,18 @@ the skin weld), exactly like the eyes — a brow welded into a `.label('skin')`
 mass loses its `'brows'` colour:
 
 ```js
-const brows = F.face.brows(rig, { shape: 'natural' });   // self-labelled 'brows'
+const skin  = F.weld(rig, [ … ]).label('skin');
+const brows = F.face.brows(rig, { shape: 'natural', on: skin }); // self-labelled 'brows'
 return sdf.union(skin, eyes, brows, lips, hair, base)
   .build({ edgeLength: 0.5, detail: F.faceDetail(rig) }); // detail keeps the strip crisp
 ```
+
+**Pass `on: skin`** (the body/face weld), exactly like `F.nipples(rig, { on: skin })`:
+each brow is then a thin **conformal offset of the real forehead** — a proud strip
+of the actual surface clipped to the brow arc — so it follows any skull with no
+curvature guess, and the `'brows'` label paints cleanly. (Omit `on` and it falls
+back to a sunk capsule strip positioned by an analytic skull approximation —
+fine for default heads, less robust on unusual proportions.)
 
 Pick a **`shape`** preset (individual knobs override it):
 
@@ -834,8 +842,9 @@ Pick a **`shape`** preset (individual knobs override it):
 Knobs (each overrides the preset): `width` (lateral span ×), `taper` (0–0.9, how
 much the tail thins), `relief` (0 = dead flush … up to a whisper-proud edge),
 `spacing` (multiplier on the **eye** spacing — default 1 sits each brow directly
-over its eyeball; >1 spreads the pair apart, <1 draws them in), plus the
-back-compat multipliers `thickness` (brow weight) and `lift` (arch). The
+over its eyeball; >1 spreads the pair apart, <1 draws them in), `on` (the body
+weld to seat the brow conformally on — see above), plus the back-compat
+multipliers `thickness` (brow weight) and `lift` (arch). The
 old `F.face.assemble(…, { brows: {} })` path still works but paints the brow
 **skin-coloured** (it's inside the skin weld) — use the top-level union above for
 dark brows. Always give `.build()` `detail: F.faceDetail(rig)` so the thin strip

--- a/retros/inbox/20260618-conformal-marking-helpers.md
+++ b/retros/inbox/20260618-conformal-marking-helpers.md
@@ -1,0 +1,19 @@
+# Retro — conformal surfaceMarking/surfaceRecess helpers (PR #741)
+
+4-Ls from generalizing the areola fix into reusable engine helpers + migrating nipples/navel/brows.
+
+## Liked
+- **The design discussion before coding paid off twice.** Articulating *why* one helper can't cleanly do both proud and recessed (a carved void can't carry a paint label — colour rides positive unioned nodes) surfaced the real boundary, and the user landed on two-helpers from that. Verifying the "void can't be labeled" claim in the code (the teeth-through-cavity pattern) before asserting it kept me honest.
+- **work-reviewer caught a regression I'd have shipped.** I migrated brows and tested *one* figure (expectant_mother, painted top-level brows) — but `assembleFace` passing `on: result` also flipped ~50 *in-assemble* brows to a proud strip. Those flatten to skin and are meant to be flush, so it'd have added an unwanted ridge everywhere. The review's blast-radius check turned a 1-figure experiment into a safe opt-in.
+
+## Lacked
+- **A habit of checking every call site of a shared path before changing its default.** I reasoned about the feature I was demoing, not the 50 other callers of `assembleFace`. The general rule: when you thread a new param into a shared builder and default it on, enumerate who already calls that builder and whether the new behavior is wanted there — *before* the reviewer does.
+- A fast way to tell "does this change alter the baked output of figure X?" without a full bake. The nipple/navel migrations were provably identical (pure refactor), but proving the brow blast radius meant reasoning about the label-weld flow by hand. A stat-diff harness (ties to #732) would make "did this geometry change?" a command, not an argument.
+
+## Learned
+- `.round(r)` (SDF `f − r`) is the engine's conformal-offset primitive and it's the right tool for any "thin layer hugging the real surface" feature — markings via `round(+) ∩ region`, and it's distinct from recess (`subtract`), which is a different mechanism, not a sign flip, because of labeling.
+- "Proud vs flush" for a marking isn't cosmetic — it's coupled to *whether it gets painted*. A painted marking must stand proud (own its triangles); an unpainted/flattened one should stay flush. The same helper serves both, but the call site has to choose relief by that criterion. That's exactly why blanket-applying the proud path to skin-flattened brows was wrong.
+
+## Longed for
+- The #732 catalog-freshness / stat-diff gate, again — it would have answered the blast-radius question mechanically.
+- A lightweight "call-site census" affordance (even just `npm run ag` patterns I keep handy) for "who calls this builder and with what" when changing a shared figure function's defaults.

--- a/src/geometry/sdfFigure.ts
+++ b/src/geometry/sdfFigure.ts
@@ -1052,9 +1052,43 @@ function buildTorso(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
     assertNoUnknownKeys(no, ['size', 'depth'], 'torso.navel');
     const size = num(no.size, r.chestX * 0.16, 'torso.navel.size', 1e-3);
     const depth = num(no.depth, 0.5, 'torso.navel.depth', 0, 1.5);
-    body = body.smoothSubtract(navelPit(sdf, rig.torso.navel, size, depth), size * 0.55);
+    body = surfaceRecess(body, navelPit(sdf, rig.torso.navel, size, depth), size * 0.55);
   }
   return body;
+}
+
+// ── Conformal surface features (issue #738) ────────────────────────────────
+// Two engine helpers for attaching a feature to a figure's REAL surface rather
+// than welding a separate primitive that APPROXIMATES it — the bug class behind
+// the areola/brow/eye fragility, where an analytic curvature guess jutted or
+// buried the feature and a coincident label dithered the paint. Both derive
+// their geometry from the actual body via `.round()` (SDF `f ∓ r`: an offset
+// along the TRUE normal everywhere), so they conform to whatever surface is
+// there with no guess. The two cases are deliberately separate ops because they
+// don't share a mechanism: a marking is ADDED (union) and carries a paint label;
+// a recess is REMOVED (subtract) and — being a void — cannot.
+
+/** A PROUD, paintable surface MARKING (areola, brow, …): `surface` grown outward
+ *  by `relief` along its true normal, clipped to `region`, with the rim softened
+ *  (`soften`) so it slopes back into the skin instead of ending in a hard wall.
+ *  Hard-union the result at the figure's TOP level and `.label()` it — standing
+ *  `relief` proud, the marking owns its own triangles so the label paints
+ *  cleanly (a flush/coincident marking dithers in the nearest-source label
+ *  transfer). `relief` must clear ~one local detail triangle, so the feature
+ *  also needs a matching `faceDetail` region; keep it small for a near-flush
+ *  look. The shape is fully conformal regardless of `relief`. */
+function surfaceMarking(surface: Node, region: Node, relief: number, soften: number): Node {
+  return surface.round(relief).smoothIntersect(region, soften);
+}
+
+/** A RECESS carved into `body` (navel, groove): subtracts `cutter` smoothly.
+ *  NOTE — a carved void CANNOT carry a paint label: colour rides positive,
+ *  unioned nodes (the nearest-source transfer has nothing to attach to on a
+ *  carved wall), so a recess paints as the surrounding skin. For a COLOURED
+ *  recess, pair this with a `surfaceMarking` shell seated inside the cavity (the
+ *  teeth-through-cavity pattern in `buildMouthAccents`). */
+function surfaceRecess(body: Node, cutter: Node, soften: number): Node {
+  return body.smoothSubtract(cutter, soften);
 }
 
 /** Flush, paintable areola discs + a tiny nipple nub, for hard-unioning at the
@@ -1110,16 +1144,15 @@ function buildNipples(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
       const cylCY = anchor[1] + (back - fwd) / 2;
       const col = (rad: number): Node =>
         sdf.cylinder(rad, fwd + back).rotate([90, 0, 0]).translate([anchor[0], cylCY, anchor[2]]);
-      // Disc: torso grown by `t`, clipped to `size`. A SMOOTH intersect rolls the
-      // rim off — instead of a hard cylinder wall (a `t`-tall step → a visible
-      // edge), the raised offset tapers gradually from its proud centre back down
-      // into the skin, so the areola reads as a gentle dome, not a stuck-on disc.
-      // The rim radius (≈ `size·0.7`) is large vs `t`, so it's mostly slope.
-      let patch = body.round(t).smoothIntersect(col(size), size * 0.7);
+      // Disc: torso grown by `t`, clipped to `size`. `surfaceMarking`'s soft clip
+      // rolls the rim off — instead of a hard cylinder wall (a `t`-tall step → a
+      // visible edge), the raised offset tapers gradually from its proud centre
+      // back into the skin, so the areola reads as a gentle dome, not a disc. The
+      // soften radius (≈ `size·0.7`) is large vs `t`, so it's mostly slope.
+      let patch = surfaceMarking(body, col(size), t, size * 0.7);
       if (nipR > 0) {
-        // Nipple: a narrower region grown a hair more, also softly clipped so it's
-        // a rounded rise, not a pin — a subtle central bump on the sloped disc.
-        patch = patch.union(body.round(t + nipR * 0.5).smoothIntersect(col(nipR), nipR));
+        // Nipple: a narrower region grown a hair more — a subtle central bump.
+        patch = patch.union(surfaceMarking(body, col(nipR), t + nipR * 0.5, nipR));
       }
       return patch;
     }
@@ -3044,7 +3077,7 @@ function buildBrows(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
   // slightly lifted medial head. (Replaces the old raised capsule-tube ridge that
   // frayed into spiky slivers at the figure grid.)
   const o = obj(opts, 'brows(opts)');
-  assertNoUnknownKeys(o, ['shape', 'thickness', 'lift', 'width', 'taper', 'relief', 'spacing'], 'brows(opts)');
+  assertNoUnknownKeys(o, ['shape', 'thickness', 'lift', 'width', 'taper', 'relief', 'spacing', 'on'], 'brows(opts)');
   const shape = o.shape === undefined ? 'natural'
     : assertEnum(o.shape, BROW_SHAPE_NAMES as unknown as readonly string[], 'brows.shape') as BrowShapeName;
   const P = BROW_SHAPE[shape];
@@ -3078,9 +3111,18 @@ function buildBrows(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
   const browCenter = (sideSign: number): Vec3 =>
     add3(browMid, scale3(right, sideSign * eyeHalfDist * spacing));
   const SEGS = 16;
-  // Sink the strip into the forehead so only a flush/whisper-proud cap reads:
-  // relief 0 → sunk by the full band (dead flush); relief 1 → barely sunk (proud).
-  const backSink = band * (1 - relief);
+  // `on` — the head/face surface to seat the brow CONFORMALLY on (the recommended
+  // path; pass the assembled face, or `skin` for top-level painted brows). With
+  // it, the swept arc below becomes a CLIP REGION and the brow itself is the real
+  // forehead offset outward a hair (`surfaceMarking`) — so it follows any skull
+  // with no sagitta curvature guess defining the geometry, and the 'brows' label
+  // paints cleanly. Without `on`, fall back to the legacy sunk-capsule strip
+  // (which IS the marking, positioned by the `sagDrop` guess).
+  const body = o.on as Node | undefined;
+  // Legacy sink (no `on`): sink the strip so only a flush/whisper-proud cap reads
+  // (relief 0 → dead flush, 1 → proud). Conformal (`on`): the arc straddles the
+  // surface as a clip region, so don't sink it — `surfaceMarking` sets the relief.
+  const backSink = body !== undefined ? 0 : band * (1 - relief);
   const browPt = (center: Vec3, sideSign: number, t: number): Vec3 => {
     const s = halfSpan * t;                                  // t<0 = medial (toward nose)
     const sagDrop = (s * s) / (2 * Math.max(rig.r.headX, 1e-3)); // follow skull curvature
@@ -3106,7 +3148,16 @@ function buildBrows(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
     return arc!;
   };
   // Self-labelled so a top-level hard-union carries the 'brows' paint region.
-  return browArc(+1).union(browArc(-1)).label('brows');
+  const arcs = browArc(+1).union(browArc(-1));
+  if (body !== undefined) {
+    // Conformal: the arc is the clip REGION; the brow is the real forehead grown
+    // a hair proud (near-flush, but enough to clear the brow detail triangle so
+    // the 'brows' label owns its surface). `relief` (0..1) nudges how proud.
+    const proud = Math.max(R * 0.02, band * 0.4) * (0.7 + 0.6 * relief);
+    return surfaceMarking(body, arcs, proud, band * 0.7).label('brows');
+  }
+  // Self-labelled so a top-level hard-union carries the 'brows' paint region.
+  return arcs.label('brows');
 }
 
 /** Weld nose/mouth/ears/brows onto a head with SHARP creases (small k), vs
@@ -3133,7 +3184,14 @@ function assembleFace(sdf: SdfApi, head: Node, rig: Rig, opts?: unknown): Node {
   if (o.nose !== false) result = result.smoothUnion(buildNose(sdf, rig, o.nose === true ? undefined : o.nose), crease);
   // Flush brows are hard-unioned (a smoothUnion would wipe the 'brows' label, #698,
   // and the sunk strip barely protrudes so the weld is near-invisible either way).
-  if (o.brows !== false && o.brows !== undefined) result = result.union(buildBrows(sdf, rig, o.brows === true ? undefined : o.brows));
+  if (o.brows !== false && o.brows !== undefined) {
+    // Seat the brow CONFORMALLY on the face built so far (`on: result`) — the
+    // real forehead, so no curvature guess. In-assemble brows still flatten to
+    // skin colour under a `.label('skin')` weld; for DARK painted brows, union
+    // `F.face.brows(rig, { on: skin })` at the top level instead.
+    const bo = o.brows === true ? {} : obj(o.brows, 'face.assemble.brows');
+    result = result.union(buildBrows(sdf, rig, { ...bo, on: result }));
+  }
   if (o.ears !== false) result = result.smoothUnion(buildEars(sdf, rig, o.ears === true ? undefined : o.ears), crease * 1.5);
   if (o.mouth !== false) {
     const mouth = buildMouthPart(sdf, rig, o.mouth === true ? undefined : o.mouth);

--- a/src/geometry/sdfFigure.ts
+++ b/src/geometry/sdfFigure.ts
@@ -3175,7 +3175,6 @@ function buildBrows(sdf: SdfApi, rig: Rig, opts?: unknown): Node {
     }
     return arc!;
   };
-  // Self-labelled so a top-level hard-union carries the 'brows' paint region.
   const arcs = browArc(+1).union(browArc(-1));
   if (body !== undefined) {
     // Conformal: the arc is the clip REGION; the brow is the real forehead grown
@@ -3212,14 +3211,12 @@ function assembleFace(sdf: SdfApi, head: Node, rig: Rig, opts?: unknown): Node {
   if (o.nose !== false) result = result.smoothUnion(buildNose(sdf, rig, o.nose === true ? undefined : o.nose), crease);
   // Flush brows are hard-unioned (a smoothUnion would wipe the 'brows' label, #698,
   // and the sunk strip barely protrudes so the weld is near-invisible either way).
-  if (o.brows !== false && o.brows !== undefined) {
-    // Seat the brow CONFORMALLY on the face built so far (`on: result`) — the
-    // real forehead, so no curvature guess. In-assemble brows still flatten to
-    // skin colour under a `.label('skin')` weld; for DARK painted brows, union
-    // `F.face.brows(rig, { on: skin })` at the top level instead.
-    const bo = o.brows === true ? {} : obj(o.brows, 'face.assemble.brows');
-    result = result.union(buildBrows(sdf, rig, { ...bo, on: result }));
-  }
+  // In-assemble brows stay on the legacy FLUSH path on purpose: the `.label('skin')`
+  // weld flattens them to skin, so they must read as flush skin, NOT a proud ridge.
+  // The conformal `surfaceMarking` brow (`buildBrows` with `on`) is a PROUD strip so
+  // its label can win the paint — wanted only for DARK painted brows, built at the
+  // top level via `F.face.brows(rig, { on: skin })` (see that function's `on` param).
+  if (o.brows !== false && o.brows !== undefined) result = result.union(buildBrows(sdf, rig, o.brows === true ? undefined : o.brows));
   if (o.ears !== false) result = result.smoothUnion(buildEars(sdf, rig, o.ears === true ? undefined : o.ears), crease * 1.5);
   if (o.mouth !== false) {
     const mouth = buildMouthPart(sdf, rig, o.mouth === true ? undefined : o.mouth);

--- a/tests/unit/sdfFigure.test.ts
+++ b/tests/unit/sdfFigure.test.ts
@@ -944,6 +944,23 @@ describe('figure brows — flush, labelled, preset-driven (#724)', () => {
     }
   });
 
+  it("conformal `on` path: still labels 'brows' and builds non-degenerate geometry", () => {
+    // `on` seats the brow as a conformal offset of the real surface (surfaceMarking)
+    // — surface.round(proud) ∩ arc — rather than the legacy sunk strip. A head-sized
+    // sphere stands in for the face surface; the offset must actually intersect the
+    // arc region (a zero proud or a missed region would yield an empty/degenerate
+    // patch), and the 'brows' label must survive the offset+clip.
+    const surf = api.sphere(rig.r.head * 1.4).translate(rig.joints.head as Vec3);
+    const brow = buildBrows(api, rig, { shape: 'natural', on: surf });
+    expect(labelsOf(brow)).toEqual(['brows']);
+    const b = brow.bounds();
+    expect(b.max[0] - b.min[0]).toBeGreaterThan(0);            // lateral span (the brow pair)
+    expect(b.max[2] - b.min[2]).toBeGreaterThan(0);            // vertical band
+    // Seated at the brow height, not adrift (within a head radius of the anchors).
+    const browZ = (rig.face.browL[2] + rig.face.browR[2]) / 2;
+    expect(Math.abs((b.max[2] + b.min[2]) / 2 - browZ)).toBeLessThan(rig.r.head);
+  });
+
   it("'bushy' is a thicker (taller) brow than 'thin'", () => {
     // Vertical extent of the strip ≈ its band thickness (+arch); bushy's wider
     // band dominates so the strip is clearly taller than the thin line.


### PR DESCRIPTION
## Summary

Extracts the areola fix's conformal-offset recipe into two reusable engine helpers so figure surface features stop reinventing the *"weld a separate primitive that approximates the body surface and hand-tune its protrusion"* anti-pattern (tracked in **#738**). That pattern fails three ways — paint dither (a coincident label dithers in the nearest-source transfer), surface mis-prediction (an analytic curvature guess juts on one figure and buries on another), and silent 0-triangle labels.

### Helpers (`src/geometry/sdfFigure.ts`)

```ts
surfaceMarking(surface, region, relief, soften)  // proud, paintable: surface.round(relief) ∩ region, soft rim
surfaceRecess(body, cutter, soften)              // carve: body.smoothSubtract(cutter)
```

- **`surfaceMarking`** — the generalized areola recipe: a conformal offset of the *real* surface (grown outward along the true normal via `.round()`), clipped to a region with a softened rim so it slopes into the skin. Label it and hard-union at the top level; standing proud, the label owns its triangles and paints cleanly.
- **`surfaceRecess`** — a carve. Deliberately a separate op because the mechanism differs: a marking is **added** (union) and carries a paint label; a recess is **removed** (subtract) and — being a void — *can't* (color rides positive unioned nodes). The doc-comment spells this out and points to the teeth-through-cavity pattern for colored recesses.

### Migrations (the experiment)

- **Nipples** → `surfaceMarking` (was inline; identical output, now via the helper).
- **Navel** → `surfaceRecess` (was a raw `smoothSubtract`; standardized — identical output).
- **Brows** → `surfaceMarking` + a new **opt-in `on:`** surface param. With `on` (the top-level painted-brow path, e.g. `F.face.brows(rig, { on: skin })`), the brow is a thin proud strip of the **actual forehead** clipped to the swept arc — no sagitta guess defining the geometry. **In-assemble brows are unchanged** (legacy flush strip): they're flattened to skin by the `.label('skin')` weld, so they must read flush, not a proud ridge — so `assembleFace` is byte-identical to `main` and the conformal path is strictly opt-in. `examples/figure_expectant_mother.js` adopts `on: skin`.

## Test plan

- `npm run typecheck` ✓; `tests/unit/sdfFigure.test.ts` (242, incl. a new brow `on`-path test) ✓.
- Test figures build `componentCount: 1` with labels resolving (`--require-labels areola,skin` / `brows,skin`).
- Visual QC (posted in-session): brows paint dark, soft-edged, conformal on the ridge — no slivers/float/sink; nipples soft sloped areolae with clean paint, near-flush in profile; navel a clean recessed dimple.
- `work-reviewer` pass: 0 blocking; the should-fix items (in-assemble blast radius, doc parity, unguarded `on`-path) are all addressed in this PR — in-assemble brows reverted to legacy, `on` documented in `figure.md`, `on`-path unit test added.

## Notes / follow-ups (part of #738)

- The brow's scoping arc is still coarsely positioned by the existing path (incl. `sagDrop`) but no longer *defines* the surface — a wrong guess shifts/narrows the strip slightly instead of floating/sinking it. Fully removing `sagDrop` (a depth-robust forward-curtain region) is a clean follow-up.
- Migrating **in-assemble** brows to conformal needs a proud-vs-flush decision (flush when flattened to skin) — deferred.
- Iris/pupil and the painted-mouth plate (Tier-2 in #738) are left as-is — fragile-but-working.
- No catalog re-bake: nipple/navel output is unchanged, and brow geometry changes only where a figure opts into `on:` (just `expectant_mother`). (Catalog freshness is its own gap — #732.)

Advances #738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESu7EtKZBKrQcJYcbTAJP1