### PR TITLE
fix: give plantarflexed figure shoes a flat sole (no bubble foot)

### DIFF
--- a/prompts/figure-plantarflex-flat-sole.md
+++ b/prompts/figure-plantarflex-flat-sole.md
@@ -1,0 +1,42 @@
+---
+date: 2026-06-18
+component: figure footwear — plantarflexed (lifted) shoe sole
+---
+
+## Human
+
+rock climber and sprinter both have a bubble-foot problem that most other
+figures don't have. Can you investigate?
+
+## Assistant
+
+The "bubble foot" is the **plantarflexed (lifted) shoe**. `buildFootwear` builds
+the shoe body from a shared `last` ellipsoid centred on the sole plane (local
+z 0), so its lower half hangs ~1.5·r.foot below the foot. The **flat** (grounded)
+path slices that off at `groundZ`; the **plantarflexed** path (a foot lifted clear
+of the ground — rock-climber's foothold leg, sprinter's deeply-bent lead leg)
+deliberately skipped the floor clip ("the foot hangs in the air"), leaving that
+whole lower half of the ellipsoid as a round BALL under the shoe. The footwear
+resize (#737) shortened the shoe, which made the leftover blob read even more like
+a bubble than the old long club did. Standing figures never hit this branch, so
+"most other figures don't have it" — exactly the user's observation.
+
+Fix: give the airborne shoe a real flat sole *in its own pitched plane*. Build the
+foot-wrapping shell (body + coverage) in the LOCAL frame, clip it flat at
+`soleClipZ = -0.75·r.foot` — a hair below the deepest bare-foot mass (the instep
+dome bottoms ~0.65·r.foot under the sole plane), so the shoe still fully encloses
+the foot — THEN pivot. The contrasting sole band moves down to the same plane.
+The collar/boot-shaft stay world-anchored as before. The flat sole now tilts with
+the foot, so the lifted shoe reads as a shoe (defined sole + toe-spring) instead
+of a ball.
+
+Verified: the lifted shoe's dip below the bare foot drops from 2.31 (0.96·r.foot,
+the bubble) to 0.78 (0.33·r.foot, a normal sole). All 245 figure tests pass —
+including the lifted-foot grid enclosure probe, so coverage is still complete —
+plus a new regression test asserting the lifted shoe sits under the foot but
+doesn't bulge >0.6·r.foot below it. Change is entirely inside the `if (pf)`
+plantarflexed branch, so every standing/grounded shoe is byte-for-byte unchanged.
+Before/after full-figure renders for rock-climber and sprinter confirm the ball
+became a flat-soled shoe.
+
+Catalog re-bake of the affected shod entries rides on PR #739.

--- a/src/geometry/sdfFigure.ts
+++ b/src/geometry/sdfFigure.ts
@@ -1790,8 +1790,8 @@ function buildFootwear(sdf: SdfApi, rig: Rig, opts: unknown, kind: 'shoes' | 'bo
         .rotate([0, 0, yawL])
         .translate([A[0], A[1], A[2]]);
 
-      // Body (last + heel) pivoted onto the pointed foot.
-      let pUpper = place(local);
+      const bigP = Math.max(footLen, r.lowerLeg) * 8;
+
       // Collar welds the opening to the shank, and (boots) the shaft runs up the
       // lower leg — both in WORLD, anchored at the ankle/shank like the flat path.
       const collar = sdf.capsule(
@@ -1799,11 +1799,6 @@ function buildFootwear(sdf: SdfApi, rig: Rig, opts: unknown, kind: 'shoes' | 'bo
         [A[0], A[1], sz - r.foot * 0.1],
         r.lowerLeg * 0.92 + wallT,
       );
-      pUpper = pUpper.smoothUnion(collar, r.foot * 0.55);
-      if (kind === 'boots') {
-        const shaft = sdf.capsule(A, shaftTop(A, K), r.lowerLeg + wallT);
-        pUpper = pUpper.smoothUnion(shaft, r.lowerLeg * 0.9);
-      }
 
       // Guaranteed-coverage underlayer, built in the LOCAL frame then pivoted with
       // the foot (its ankle column tracks the pivot; the boot shaft stays world).
@@ -1823,26 +1818,44 @@ function buildFootwear(sdf: SdfApi, rig: Rig, opts: unknown, kind: 'shoes' | 'bo
       const instE = sdf.ellipsoid(r.foot * 0.8 * size, footLen * 0.33, r.foot * 0.8)
         .translate([0, ankleLY + footLen * 0.2, szL + r.foot * 0.15]);
       const colC = sdf.capsule([0, ankleLY, A[2] - groundZ], [0, ankleLY, szL + r.foot * 0.2], r.lowerLeg * 0.8);
-      let footMassP = place(sCap.smoothUnion(instE, r.foot * 0.6).smoothUnion(colC, r.foot * 0.6));
-      if (kind === 'boots') footMassP = footMassP.union(sdf.capsule(A, shaftTop(A, K), r.lowerLeg));
-      footMassP = footMassP.round(t);
-      // No ground floor clip — the pointed foot hangs in the air.
-      const pShoe = pUpper.union(footMassP);
+      const coverageLocal = sCap.smoothUnion(instE, r.foot * 0.6).smoothUnion(colC, r.foot * 0.6).round(t);
+
+      // FLAT SOLE in the PITCHED frame. The shared `last` ellipsoid is centred on
+      // the sole plane (local z 0), so its lower half hangs ~1.5·r.foot below the
+      // foot. The flat path slices that off at groundZ; the plantarflexed path used
+      // to skip the clip ("the foot hangs in the air") — leaving that lower half as
+      // a round BUBBLE under lifted shoes (rock-climber / sprinter). Instead clip
+      // the foot-wrapping shell flat at `soleClipZ` (a hair below the bare foot's
+      // own underside, so it still fully encloses the foot) BEFORE pivoting, so the
+      // airborne shoe carries a real flat sole + toe-spring that tilts with the
+      // foot — a shoe, not a ball. `soleClipZ` is below the deepest bare-foot mass
+      // (the instep dome bottoms ~0.65·r.foot under the sole plane).
+      const soleClipZ = -r.foot * 0.75;
+      const localFloor = sdf.box([bigP, bigP, bigP]).translate([0, 0, bigP / 2 + soleClipZ]); // z ≥ soleClipZ
+      const shellLocal = local.union(coverageLocal).intersect(localFloor);
+      let pUpper = place(shellLocal);
+      pUpper = pUpper.smoothUnion(collar, r.foot * 0.55);
+      if (kind === 'boots') {
+        const shaft = sdf.capsule(A, shaftTop(A, K), r.lowerLeg + wallT);
+        // shaft both shapes (outer) and guarantees coverage (inner, world).
+        pUpper = pUpper.smoothUnion(shaft, r.lowerLeg * 0.9).union(sdf.capsule(A, shaftTop(A, K), r.lowerLeg));
+      }
+      const pShoe = pUpper;
 
       if (!soleOn) return { upper: pShoe, sole: null };
 
       // Contrasting sole region: a thin footprint slab at the shoe's underside,
-      // built local and pivoted with the shoe (same shaping as the flat sole).
-      const bigP = Math.max(footLen, r.lowerLeg) * 8;
+      // sitting on the SAME pitched sole plane (`soleClipZ`) the shell is clipped
+      // to, built local and pivoted with the shoe (same shaping as the flat sole).
       const hwP = hw;
       const lipCapP = Math.min(lip, hwP * 0.45);
       const soleRP = hwP + lipCapP;
       const soleHeelYP = shoeHeelY + soleRP;
       const soleToeYP = shoeToeY - soleRP;
-      const soleBandLocal = sdf.box([bigP, bigP, soleThick]).translate([0, 0, soleThick / 2]);
+      const soleBandLocal = sdf.box([bigP, bigP, soleThick]).translate([0, 0, soleClipZ + soleThick / 2]);
       const footprintLocal = sdf.capsule(
-        [0, soleHeelYP, soleThick / 2],
-        [0, Math.max(soleToeYP, soleHeelYP + soleRP * 0.2), soleThick / 2],
+        [0, soleHeelYP, soleClipZ + soleThick / 2],
+        [0, Math.max(soleToeYP, soleHeelYP + soleRP * 0.2), soleClipZ + soleThick / 2],
         soleRP,
       ).intersect(soleBandLocal);
       const soleBoundsP = lipCapP > 0 ? pShoe.round(lipCapP) : pShoe;

--- a/tests/unit/sdfFigure.test.ts
+++ b/tests/unit/sdfFigure.test.ts
@@ -1352,6 +1352,21 @@ describe('figure footwear — shoes & boots', () => {
     expect(pokesThrough).toBe(0);          // …and the shoe encloses every bit of it
   });
 
+  it('a lifted shoe has a flat sole, not a bubble — it does not bulge far below the foot', () => {
+    // The shared `last` ellipsoid is centred on the sole plane, so its lower half
+    // hangs ~1.5·r.foot below the foot. The flat path slices it off at groundZ; the
+    // plantarflexed path must clip it too (in its pitched plane) or that lower half
+    // shows as a round BUBBLE under lifted shoes (rock-climber / sprinter). Guard it:
+    // the lifted shoe's lowest point must sit only a sole's-thickness below the bare
+    // foot's lowest point — not the ~1·r.foot bulge the unclipped ellipsoid gave.
+    const rig = buildRig({ pose: { legR: { raiseSide: 30, raiseFwd: 25, bend: 80 }, legL: { raiseSide: 12, bend: 25 } } });
+    const feet = buildFeet(api, rig) as SdfNode;
+    const shoes = buildShoes(api, rig) as SdfNode;
+    const dip = feet.bounds().min[2] - shoes.bounds().min[2];   // how far the shoe hangs below the foot
+    expect(dip).toBeGreaterThan(0);                  // the shoe is still UNDER the foot (sole present)
+    expect(dip).toBeLessThan(rig.r.foot * 0.6);      // …but no ~1·r.foot bubble (was 0.96·r.foot)
+  });
+
   it('the base descends to contain a posed/shod sole (no poke-through)', () => {
     const rig = buildRig({ pose: { legR: { raiseFwd: 12, bend: 28 }, legL: { raiseSide: 6 } } });
     const base = buildBase(api, rig) as SdfNode;


### PR DESCRIPTION
## Summary

Follow-up to #737. The **rock climber** and **sprinter** (and any figure with a strongly **lifted** foot) showed a "bubble foot" — the lifted shoe rendered as a round ball instead of a shoe. Most figures (standing) were unaffected, exactly as reported.

**Root cause:** `buildFootwear`'s shoe body is a `last` ellipsoid centred on the sole plane, so its lower half hangs ~1.5·r.foot below the foot. The **grounded** path slices that off at `groundZ`; the **plantarflexed** (airborne-foot) path deliberately skipped the floor clip ("the foot hangs in the air"), leaving the ellipsoid's lower half as a ball. The #737 resize shortened the shoe, which made the leftover blob read even more like a bubble.

## Fix

Give the airborne shoe a real flat sole **in its own pitched plane**: build the foot-wrapping shell (body + coverage) in the local frame, clip it flat at `soleClipZ = -0.75·r.foot` — a hair below the deepest bare-foot mass so the shoe still fully encloses the foot — **then** pivot. The contrasting sole band moves to the same plane; collar/boot-shaft stay world-anchored. The sole now tilts with the foot, so the lifted shoe reads as a shoe (defined sole + toe-spring), not a ball.

## Verification

- Lifted shoe's dip below the bare foot drops **2.31 → 0.78** (0.96·r.foot bubble → 0.33·r.foot sole).
- All 245 figure unit tests pass — including the lifted-foot grid enclosure probe, so coverage stays complete.
- New regression test bounds the dip `< 0.6·r.foot`.
- The change is confined to the `if (pf)` plantarflexed branch, so **every grounded/standing shoe is byte-for-byte unchanged**.
- Before/after full-figure renders (rock climber, sprinter) confirm the ball became a flat-soled shoe.

The catalog re-bake of the affected entries rides on **#739** (which will pick up this fix).

## Test plan
- [x] `npm run typecheck` + figure unit tests (245) green
- [x] before/after renders reviewed
- [ ] PR-checks shards green


---
_Generated by [Claude Code](https://claude.ai/code/session_016YhW8TRqj9MhTuwm8euyBK)_