### PR TITLE
feat: multi-part OBJ, STL, and GLB export

### DIFF
--- a/prompts/multipart-obj-stl-glb-export.md
+++ b/prompts/multipart-obj-stl-glb-export.md
@@ -1,0 +1,65 @@
+---
+date: 2026-06-19
+branch: claude/affectionate-feynman-547jlg
+files_changed:
+  - src/export/multiPart.ts
+  - src/export/gltf.ts
+  - src/export/stl.ts
+  - src/export/obj.ts
+  - src/renderer/viewport.ts
+  - src/ui/exportPartsModal.ts
+  - src/main.ts
+  - public/ai.md
+  - public/ai/file-io.md
+  - tests/multipart-export.spec.ts
+---
+
+## Human
+
+We recently merged multi-part 3MF export. Investigate the other export formats and
+implement multi-part OBJ, GLB, and STL exports too, doing it the "nicest" way each
+format natively supports rather than blindly copying 3MF's grid-of-objects.
+
+## Assistant
+
+The merged 3MF flow (`build3MFProject` + the part picker + `bakeColoredMeshForPart`)
+already had the format-agnostic half: pick parts, bake each part's latest version
+WITH its colours off-editor. So the work was per-format *bundling* + wiring, reusing
+that bake pipeline. Deliberately did NOT touch `threemfProject.ts` — another session
+owns the Bambu 3MF work there, so I kept the blast radius off that file.
+
+**Per-format bundling, matched to what each format natively supports** (the key
+decision — a grid-of-soup is the wrong model for the scene-graph formats):
+
+- **OBJ** — one `.obj` with a named `o <part>` object per part, grid-arranged so they
+  don't overlap. OBJ supports named objects natively, so parts stay distinct and
+  individually selectable. Vertex indices are cumulative (OBJ `f` indices are global).
+  Painted → shared `.mtl` (OBJ+MTL in a `.zip`), uncoloured parts bind to Default.
+- **GLB** — one glTF scene with a named node per part, grid-arranged. glTF is a scene
+  graph, so distinct named meshes is its natural form. Built a temporary `THREE.Scene`
+  from the baked meshes (NOT the live viewport, which only holds the active part),
+  reusing the viewport's `meshGLToBufferGeometry` (exported it) so colour semantics
+  match single-part GLB exactly. Disposed the temp geometries/materials.
+- **STL** — a `.zip` with one `.stl` per part. STL is a flat triangle soup with no
+  object names or colour, so separate files are the only faithful way to keep parts
+  distinct (a single merged soup would erase the boundaries). Refactored `buildSTL`
+  into a reusable `buildSTLBuffer` so the per-part files share the writer + header.
+
+**Shared layout helper** (`multiPart.ts`): `gridLayout` (the centred ⌈√N⌉-column grid,
+mirroring the generic 3MF layout) + `uniquePartStem` (sanitise/dedupe object/node/file
+names). Used by OBJ + GLB (STL needs no layout — separate files).
+
+**Wiring** (`main.ts`): generalised `showExportPartsModal` to take a format-specific
+title/description instead of the 3MF-only `bambu` flag. Added a format-agnostic
+`exportMultiPartFlow` (picker → bake → build → download) and routed the existing OBJ/
+STL/GLB toolbar actions to it when `parts.length > 1` (single-part unchanged) — exactly
+how the single "3MF" button already auto-routes. Added console/`window.partwright` API
+twins `export{OBJ,STL,GLB}Parts` + `*PartsData` (bytes-returning) via a shared
+`bakePartsForExport`/`exportPartsApi` core, registered in the `help()` table, and
+documented in `ai.md` + `ai/file-io.md` (the UI↔API parity rule). No in-app AI chat
+tool — matching the precedent that 3MF-parts is console-only.
+
+Verified with a new e2e spec (builders emit named objects / per-part files / named
+nodes; full bake pipeline via the API twins; the OBJ part picker) and a screenshot of
+the "Export parts to OBJ" modal. Existing 3MF multipart spec still green after the
+modal-signature change.

--- a/public/ai.md
+++ b/public/ai.md
@@ -288,6 +288,12 @@ await partwright.exportSTLData()
 await partwright.exportOBJData()        // text or base64 depending on whether colors are painted
 await partwright.export3MFData()
 await partwright.exportVOXData()        // -> {filename, mimeType, base64, sizeBytes} (voxel sessions only)
+// Multi-part: bundle several Session Parts into one file (default: all parts). See /ai/file-io.md.
+await partwright.export3MFParts(partIds?, filename?, {bambu?})  // 3MF: one part per Bambu/Orca plate (bambu:true, default) or generic grid (false)
+await partwright.exportOBJParts(partIds?, filename?)            // OBJ: named objects in one file, grid-arranged (+ .mtl .zip if painted)
+await partwright.exportSTLParts(partIds?, filename?)            // STL: a .zip of one .stl per part
+await partwright.exportGLBParts(partIds?, filename?)            // GLB: named nodes in one scene, grid-arranged
+// ...each has a *Data twin (export{3MF,OBJ,STL,GLB}PartsData) that RETURNS the bytes instead of downloading.
 await partwright.exportSessionData()    // -> {filename, mimeType, data, sizeBytes} (parsed JSON)
 partwright.exportCodeData()             // -> {filename, mimeType, language, text, sizeBytes}
 await partwright.importSessionData(parsedJson)         // -> {sessionId} or {error}

--- a/public/ai/file-io.md
+++ b/public/ai/file-io.md
@@ -57,6 +57,26 @@ const r = await partwright.export3MFPartsData(undefined, 'assembly', { bambu: tr
 // -> { filename, mimeType, base64: "...", sizeBytes, parts: 3 }
 ```
 
+## Multi-part OBJ / STL / GLB
+
+The same part-bake pipeline backs OBJ, STL, and GLB. Each takes `(partIds?, filename?)` (default: every part) and has a `*Data` twin that returns `{ filename, mimeType, base64, sizeBytes, parts }` instead of downloading. They're the console/AI twins of the **OBJ / STL / GLB** menu items in a multi-part session (the single button auto-routes to the part picker when the session has more than one part). Each format bundles parts the way its file format does best:
+
+- **`exportOBJParts` / `exportOBJPartsData`** — one `.obj` with a named `o <part>` object per part, **grid-arranged** so they don't overlap. Painted parts add a shared `.mtl` (OBJ + MTL bundled in a `.zip`); with no paint anywhere it's a plain `.obj`.
+- **`exportSTLParts` / `exportSTLPartsData`** — a `.zip` with **one `.stl` per part**. STL is a flat triangle soup with no object names or colour, so separate files are the only faithful way to keep parts distinct.
+- **`exportGLBParts` / `exportGLBPartsData`** — one `.glb` scene with a named node per part, **grid-arranged**. Painted parts export as vertex colours. glTF is a scene graph, so distinct named meshes is its natural multi-part form.
+
+```js
+// Every part as named objects in one OBJ:
+await partwright.exportOBJParts()
+// -> { ok: true, filename: "...zip", parts: 3 }
+
+// Specific parts, bytes returned (no download):
+const r = await partwright.exportGLBPartsData(["part_abc", "part_def"], "assembly")
+// -> { filename, mimeType, base64: "...", sizeBytes, parts: 2 }
+```
+
+Like 3MF, each part's **latest version** is re-baked with its colours (code-declared `api.label`/`api.paint.*` and saved manual paint) before bundling.
+
 ## Import — supply the payload directly
 ```js
 // Import a parsed .partwright.json (object or string) as a new active session

--- a/retros/inbox/20260619-multipart-obj-stl-glb-export.md
+++ b/retros/inbox/20260619-multipart-obj-stl-glb-export.md
@@ -1,0 +1,29 @@
+# Retro — multi-part OBJ / STL / GLB export (PR #761)
+
+**Liked.** The recently-merged 3MF multipart flow had already factored out the hard,
+format-agnostic half — pick parts → bake each part's latest version WITH colours
+off-editor (`bakeColoredMeshForPart`) + the part picker. So adding three more formats
+was mostly per-format *bundling* + wiring, not a rebuild. Routing the existing OBJ/STL/
+GLB toolbar buttons to the picker on `parts.length > 1` (mirroring the 3MF button)
+meant zero new UI surface to design.
+
+**Lacked.** The investigation subagent's report was thorough enough that I could
+design all three builders before reading a single exporter myself — but the GLB path
+still had a non-obvious trap: the existing GLB exporter serializes the *live viewport
+scene*, which only holds the active part. Nothing in the report flagged that it
+couldn't be reused for multipart; I had to discover that the scene had to be rebuilt
+from the baked meshes. A note like "GLB reads the live scene, not a MeshData" would
+have saved a read cycle.
+
+**Learned.** `GLTFExporter.parseAsync` defaults to `trs: false`, so node positions
+land in a baked `matrix`, NOT a `translation` — my first grid-layout assertion read
+`node.translation[0]` and saw `undefined` → all-zero → false "parts overlap" failure.
+The test now reads `translation ?? matrix[12]`. Worth remembering for any future glTF
+node-transform assertion.
+
+**Longed for.** A typed capability registry so "this format has a multipart export"
+is declared once and the toolbar + console API + docs all derive from it. Right now
+parity across the four export paths (menu button ⇄ `export*Parts` ⇄ `*PartsData` ⇄
+help table ⇄ ai.md) is hand-maintained in five places per format — the same drift
+risk CLAUDE.md's UI↔API parity section calls out. Adding a 5th format will touch all
+five again.

--- a/src/export/gltf.ts
+++ b/src/export/gltf.ts
@@ -1,7 +1,9 @@
 import * as THREE from 'three';
-import { getScene, withExportColors } from '../renderer/viewport';
+import { getScene, withExportColors, meshGLToBufferGeometry } from '../renderer/viewport';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
-import { downloadBlob, getExportFilename } from './download';
+import { downloadBlob, getExportFilename, getExportTitle } from './download';
+import { assertFiniteMesh, DEFAULT_COLOR_HEX } from './meshClean';
+import { gridLayout, uniquePartStem, type ExportPart } from './multiPart';
 import type { MeshData } from '../geometry/types';
 
 export interface BuiltExport {
@@ -108,4 +110,58 @@ export async function exportGLB(customName?: string, coloredMesh?: MeshData | nu
   const built = await buildGLB(customName, coloredMesh);
   downloadBlob(built.blob, built.filename, 'GLB');
   return built.filename;
+}
+
+const DEFAULT_RGB = Number('0x' + DEFAULT_COLOR_HEX.slice(1));
+
+/**
+ * Build a multi-part GLB: each Session Part becomes a separately-named node in one
+ * glTF scene, grid-arranged in XY so the parts don't overlap. glTF is a scene graph,
+ * so this — named distinct meshes — is the format's natural multi-part form (no
+ * triangle-soup merge). Painted parts (`mesh.triColors`) export as vertex colours;
+ * unpainted parts use the default fill colour. Built off-screen from the baked part
+ * meshes (NOT the live viewport), so it works for every part in the session, not just
+ * the active one.
+ */
+export async function buildGLBProject(
+  parts: ExportPart[],
+  opts: { customName?: string; gridGapMm?: number } = {},
+): Promise<BuiltExport> {
+  if (parts.length === 0) throw new Error('Cannot export: no parts selected.');
+  for (const p of parts) assertFiniteMesh(p.mesh);
+
+  const slots = gridLayout(parts.map(p => p.mesh), opts.gridGapMm);
+  const scene = new THREE.Scene();
+  scene.name = getExportTitle();
+  const used = new Set<string>();
+  parts.forEach((p, i) => {
+    const geometry = meshGLToBufferGeometry(p.mesh);
+    const material = p.mesh.triColors
+      ? new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.65, metalness: 0 })
+      : new THREE.MeshStandardMaterial({ color: DEFAULT_RGB, roughness: 0.65, metalness: 0 });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.name = uniquePartStem(p.name, used, `part_${i + 1}`);
+    const { dx, dy } = slots[i];
+    mesh.position.set(dx, dy, 0);
+    scene.add(mesh);
+  });
+
+  try {
+    const exporter = new GLTFExporter();
+    const result = await exporter.parseAsync(scene, { binary: true });
+    const mimeType = 'model/gltf-binary';
+    const blob = new Blob([result as ArrayBuffer], { type: mimeType });
+    return { blob, filename: getExportFilename('glb', opts.customName), mimeType };
+  } finally {
+    // Dispose the temporary scene's GPU-less geometries/materials (no WebGL upload
+    // happened, but BufferGeometry/Material still hold references — match the
+    // app-wide resource-lifecycle rule).
+    scene.traverse(obj => {
+      if (obj instanceof THREE.Mesh) {
+        obj.geometry.dispose();
+        const mat = obj.material;
+        (Array.isArray(mat) ? mat : [mat]).forEach(m => m.dispose());
+      }
+    });
+  }
 }

--- a/src/export/multiPart.ts
+++ b/src/export/multiPart.ts
@@ -1,0 +1,71 @@
+// Shared helpers for the multi-part OBJ / STL / GLB exporters — bundling several
+// Session Parts into one file. (3MF has its own richer `PartExport` + layout in
+// threemfProject.ts; these formats use the lighter primitives below.)
+
+import type { MeshData } from '../geometry/types';
+
+/** One Session Part with its baked (optionally coloured) mesh — the shared input
+ *  to the OBJ/STL/GLB multi-part builders. */
+export interface ExportPart {
+  /** Display name — becomes the object/node/file name in the export. */
+  name: string;
+  /** The part's mesh. `triColors` (if present) drives the per-triangle colour. */
+  mesh: MeshData;
+}
+
+interface PartXYBounds { cx: number; cy: number; width: number; depth: number; }
+
+function meshXYBounds(mesh: MeshData): PartXYBounds {
+  const { vertProperties, numProp, numVert } = mesh;
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (let i = 0; i < numVert; i++) {
+    const x = vertProperties[i * numProp], y = vertProperties[i * numProp + 1];
+    if (x < minX) minX = x; if (x > maxX) maxX = x;
+    if (y < minY) minY = y; if (y > maxY) maxY = y;
+  }
+  if (!Number.isFinite(minX)) return { cx: 0, cy: 0, width: 0, depth: 0 };
+  return { cx: (minX + maxX) / 2, cy: (minY + maxY) / 2, width: maxX - minX, depth: maxY - minY };
+}
+
+/** Per-part XY translation to apply so parts don't overlap. */
+export interface GridSlot { dx: number; dy: number; }
+
+/**
+ * Arrange parts in a centred ⌈√N⌉-column grid so they don't overlap — the same
+ * layout the generic multi-object 3MF uses. Returns, for each part, the XY
+ * translation to ADD to its geometry (move the part's XY bbox-centre onto its grid
+ * cell centre); Z is left untouched. The cell pitch is the largest part footprint
+ * plus `gapMm`, so no two parts touch.
+ */
+export function gridLayout(meshes: MeshData[], gapMm = 10): GridSlot[] {
+  const bounds = meshes.map(meshXYBounds);
+  const n = meshes.length;
+  const cols = Math.max(1, Math.ceil(Math.sqrt(n)));
+  const rows = Math.max(1, Math.ceil(n / cols));
+  const pitch = Math.max(1, ...bounds.map(b => Math.max(b.width, b.depth))) + gapMm;
+  return bounds.map((b, i) => {
+    const col = i % cols, row = Math.floor(i / cols);
+    const cellX = col * pitch - (cols - 1) * pitch / 2;
+    const cellY = row * pitch - (rows - 1) * pitch / 2;
+    return { dx: cellX - b.cx, dy: cellY - b.cy };
+  });
+}
+
+/**
+ * Sanitise a part name into a safe object/node/file stem and dedupe it against
+ * `used` (case-insensitive) by appending _2, _3, … An empty result falls back to
+ * `fallback`. Keeps OBJ `o` names, GLB node names, and STL file names collision-free.
+ */
+export function uniquePartStem(name: string, used: Set<string>, fallback: string): string {
+  let base = name
+    .replace(/[^a-zA-Z0-9 _-]/g, '')
+    .replace(/\s+/g, '_')
+    .replace(/[-_]{2,}/g, '_')
+    .replace(/^[-_]+|[-_]+$/g, '');
+  if (!base) base = fallback;
+  let stem = base;
+  let n = 2;
+  while (used.has(stem.toLowerCase())) stem = `${base}_${n++}`;
+  used.add(stem.toLowerCase());
+  return stem;
+}

--- a/src/export/obj.ts
+++ b/src/export/obj.ts
@@ -3,10 +3,30 @@ import { downloadBlob, getExportFilename, getExportTitle } from './download';
 import type { BuiltExport } from './gltf';
 import { buildZip } from './zip';
 import { assertFiniteMesh, assertExportableMesh, cleanMeshForExport, DEFAULT_COLOR_HEX, triColorHex, hasAnyPainted } from './meshClean';
+import { gridLayout, uniquePartStem, type ExportPart } from './multiPart';
 
 /** Round a float to 6 decimal places (float32 has ~7 significant digits). */
 function f6(v: number): string {
   return v.toFixed(6);
+}
+
+/** Build the `.mtl` text for a set of colour hexes (Kd diffuse + a flat ambient/
+ *  specular), shared by the single-part and multi-part OBJ exporters. */
+function buildMtl(hexes: Iterable<string>, title: string): string {
+  const lines: string[] = ['# Partwright — https://www.partwrightstudio.com', `# ${title} — Materials`];
+  for (const hex of hexes) {
+    const r = parseInt(hex.slice(1, 3), 16) / 255;
+    const g = parseInt(hex.slice(3, 5), 16) / 255;
+    const b = parseInt(hex.slice(5, 7), 16) / 255;
+    lines.push(`newmtl ${matName(hex)}`);
+    lines.push(`Kd ${r.toFixed(6)} ${g.toFixed(6)} ${b.toFixed(6)}`);
+    lines.push(`Ka 0.100000 0.100000 0.100000`);
+    lines.push(`Ks 0.300000 0.300000 0.300000`);
+    lines.push(`Ns 40.000000`);
+    lines.push(`d 1.000000`);
+    lines.push('');
+  }
+  return lines.join('\n') + '\n';
 }
 
 /**
@@ -53,26 +73,11 @@ export function buildOBJ(meshData: MeshData, customName?: string): BuiltExport {
       }
     }
 
-    // Generate MTL file with Kd diffuse colors
-    const mtlLines: string[] = ['# Partwright — https://www.partwrightstudio.com', `# ${title} — Materials`];
-    for (const hex of colorGroups.keys()) {
-      const r = parseInt(hex.slice(1, 3), 16) / 255;
-      const g = parseInt(hex.slice(3, 5), 16) / 255;
-      const b = parseInt(hex.slice(5, 7), 16) / 255;
-      mtlLines.push(`newmtl ${matName(hex)}`);
-      mtlLines.push(`Kd ${r.toFixed(6)} ${g.toFixed(6)} ${b.toFixed(6)}`);
-      mtlLines.push(`Ka 0.100000 0.100000 0.100000`);
-      mtlLines.push(`Ks 0.300000 0.300000 0.300000`);
-      mtlLines.push(`Ns 40.000000`);
-      mtlLines.push(`d 1.000000`);
-      mtlLines.push('');
-    }
-
     // Bundle OBJ + MTL in a ZIP
     const enc = new TextEncoder();
     const zip = buildZip([
       { name: `${baseName}.obj`, data: enc.encode(lines.join('\n') + '\n') },
-      { name: `${baseName}.mtl`, data: enc.encode(mtlLines.join('\n') + '\n') },
+      { name: `${baseName}.mtl`, data: enc.encode(buildMtl(colorGroups.keys(), title)) },
     ]);
 
     const mimeType = 'application/zip';
@@ -92,6 +97,85 @@ export function buildOBJ(meshData: MeshData, customName?: string): BuiltExport {
   const mimeType = 'text/plain';
   const blob = new Blob([lines.join('\n') + '\n'], { type: mimeType });
   return { blob, filename: getExportFilename('obj', customName), mimeType };
+}
+
+/**
+ * Build a multi-part OBJ: each Session Part becomes a named `o <part>` object in ONE
+ * `.obj` file, grid-arranged in XY so the parts don't overlap. OBJ natively supports
+ * named objects, so the parts stay distinct and individually selectable in any tool —
+ * no triangle-soup merge. Vertex indices are cumulative across parts (OBJ's `f`
+ * indices are global and 1-based). If any part is painted, the whole export bundles a
+ * shared `.mtl` (OBJ + MTL in a `.zip`) and unpainted parts use the Default material;
+ * with no colours anywhere it's a plain `.obj`.
+ */
+export function buildOBJProject(parts: ExportPart[], customName?: string, gridGapMm = 10): BuiltExport {
+  if (parts.length === 0) throw new Error('Cannot export: no parts selected.');
+  for (const p of parts) assertFiniteMesh(p.mesh);
+
+  const title = getExportTitle();
+  const slots = gridLayout(parts.map(p => p.mesh), gridGapMm);
+  const baseName = getExportFilename('obj', customName).replace(/\.obj$/, '');
+
+  // Clean each part once (drops degenerates + merges dup verts) — reused for the
+  // colour scan and the emit below.
+  const cleaned = parts.map(p => cleanMeshForExport(p.mesh));
+  const anyColors = parts.some((p, i) => p.mesh.triColors != null && hasAnyPainted(p.mesh.triColors, cleaned[i].validTris));
+
+  const lines: string[] = ['# Partwright — https://www.partwrightstudio.com', `# ${title}`];
+  if (anyColors) lines.push(`mtllib ${baseName}.mtl`);
+
+  const usedNames = new Set<string>();
+  const usedHexes = new Set<string>();
+  let vertOffset = 0; // cumulative unique-vertex count across emitted parts
+  parts.forEach((p, i) => {
+    const { remap, uniquePositions, validTris } = cleaned[i];
+    if (validTris.length === 0) return; // skip empty parts (keeps vertOffset correct)
+    const { triVerts, triColors } = p.mesh;
+    lines.push(`o ${uniquePartStem(p.name, usedNames, `part_${i + 1}`)}`);
+
+    const { dx, dy } = slots[i];
+    const numV = uniquePositions.length / 3;
+    for (let v = 0; v < numV; v++) {
+      lines.push(`v ${f6(uniquePositions[v * 3] + dx)} ${f6(uniquePositions[v * 3 + 1] + dy)} ${f6(uniquePositions[v * 3 + 2])}`);
+    }
+    const fv = (origVert: number) => remap[origVert] + 1 + vertOffset;
+
+    if (anyColors && triColors) {
+      // Group this part's faces by colour for usemtl runs (unpainted tris fall into
+      // the Default material via triColorHex).
+      const groups = new Map<string, number[]>();
+      for (const t of validTris) {
+        const hex = triColorHex(triColors, t);
+        let g = groups.get(hex);
+        if (!g) groups.set(hex, g = []);
+        g.push(t);
+      }
+      for (const [hex, tris] of groups) {
+        lines.push(`usemtl ${matName(hex)}`);
+        usedHexes.add(hex);
+        for (const t of tris) lines.push(`f ${fv(triVerts[t * 3])} ${fv(triVerts[t * 3 + 1])} ${fv(triVerts[t * 3 + 2])}`);
+      }
+    } else {
+      // Uncoloured part. When the export has an MTL (some other part is painted),
+      // bind it to the Default material so it isn't left material-less.
+      if (anyColors) { lines.push(`usemtl ${matName(DEFAULT_COLOR_HEX)}`); usedHexes.add(DEFAULT_COLOR_HEX); }
+      for (const t of validTris) lines.push(`f ${fv(triVerts[t * 3])} ${fv(triVerts[t * 3 + 1])} ${fv(triVerts[t * 3 + 2])}`);
+    }
+    vertOffset += numV;
+  });
+
+  if (anyColors) {
+    const enc = new TextEncoder();
+    const zip = buildZip([
+      { name: `${baseName}.obj`, data: enc.encode(lines.join('\n') + '\n') },
+      { name: `${baseName}.mtl`, data: enc.encode(buildMtl(usedHexes, title)) },
+    ]);
+    const mimeType = 'application/zip';
+    return { blob: new Blob([zip], { type: mimeType }), filename: `${baseName}.zip`, mimeType };
+  }
+
+  const mimeType = 'text/plain';
+  return { blob: new Blob([lines.join('\n') + '\n'], { type: mimeType }), filename: getExportFilename('obj', customName), mimeType };
 }
 
 export function exportOBJ(meshData: MeshData, customName?: string): string {

--- a/src/export/stl.ts
+++ b/src/export/stl.ts
@@ -1,10 +1,24 @@
 import type { MeshData } from '../geometry/types';
 import { downloadBlob, getExportFilename, getExportTitle } from './download';
 import { assertFiniteMesh, assertExportableMesh, cleanMeshForExport } from './meshClean';
+import { buildZip } from './zip';
+import { uniquePartStem, type ExportPart } from './multiPart';
 import type { BuiltExport } from './gltf';
 
-/** Build the binary STL blob for a mesh without triggering a download. */
-export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
+const ATTRIBUTION = 'Partwright partwrightstudio.com';
+
+/** Compose the (≤80-byte) ASCII header text for an STL file from a title, appending
+ *  the Partwright attribution when it still fits. The header must be plain ASCII:
+ *  setUint8 truncates each code unit to one byte, so a multi-byte char (e.g. the
+ *  em-dash getExportTitle puts between "name — label") would write garbage —
+ *  normalize dashes and drop other non-ASCII. */
+function stlHeaderText(title: string): string {
+  const t = title.replace(/[‒-―]/g, '-').replace(/[^\x20-\x7E]/g, '?');
+  return (t.length + 3 + ATTRIBUTION.length <= 80) ? `${t} - ${ATTRIBUTION}` : t;
+}
+
+/** Write the raw binary-STL bytes for a mesh, with `header` in the 80-byte header. */
+function buildSTLBuffer(meshData: MeshData, header: string): ArrayBuffer {
   assertFiniteMesh(meshData);
   const { numProp } = meshData;
 
@@ -26,23 +40,9 @@ export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
   const buffer = new ArrayBuffer(bufferSize);
   const view = new DataView(buffer);
 
-  // Header (80 bytes) — include session name if available, plus a Partwright
-  // attribution suffix when it fits. The header must be plain ASCII: setUint8
-  // truncates each code unit to one byte, so a multi-byte char (e.g. the
-  // em-dash getExportTitle puts between "name — label") would otherwise write
-  // garbage. Normalize dashes and drop other non-ASCII.
-  //
-  // CRITICAL: the header is fixed at 80 bytes and byte 80 holds the triangle
-  // count — the header must NEVER exceed 80 bytes or the count is corrupted.
-  // The attribution is only appended when the title + suffix still fits; the
-  // loop below caps at 80 as a final backstop regardless.
-  const title = getExportTitle()
-    .replace(/[‒-―]/g, '-')
-    .replace(/[^\x20-\x7E]/g, '?');
-  const ATTRIBUTION = 'Partwright partwrightstudio.com';
-  const header = (title.length + 3 + ATTRIBUTION.length <= 80)
-    ? `${title} - ${ATTRIBUTION}`
-    : title;
+  // Header (80 bytes). CRITICAL: the header is fixed at 80 bytes and byte 80
+  // holds the triangle count — the header must NEVER exceed 80 bytes or the count
+  // is corrupted, so the loop below caps at 80 as a final backstop regardless.
   for (let i = 0; i < Math.min(header.length, 80); i++) {
     view.setUint8(i, header.charCodeAt(i));
   }
@@ -100,9 +100,37 @@ export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
     view.setUint16(offset, 0, true); offset += 2;
   }
 
+  return buffer;
+}
+
+/** Build the binary STL blob for a mesh without triggering a download. */
+export function buildSTL(meshData: MeshData, customName?: string): BuiltExport {
+  const buffer = buildSTLBuffer(meshData, stlHeaderText(getExportTitle()));
   const mimeType = 'application/octet-stream';
   const blob = new Blob([buffer], { type: mimeType });
   return { blob, filename: getExportFilename('stl', customName), mimeType };
+}
+
+/**
+ * Build a multi-part STL: one `.stl` file per Session Part, bundled into a single
+ * `.zip`. STL is a flat triangle soup with no object names or boundaries, so the
+ * only faithful way to keep parts distinct is separate files (rather than merging
+ * them into one anonymous soup). Each part keeps its own coordinates; colours are
+ * dropped (STL has no colour). The part name drives both the file name and the STL
+ * header.
+ */
+export function buildSTLProject(parts: ExportPart[], customName?: string): BuiltExport {
+  if (parts.length === 0) throw new Error('Cannot export: no parts selected.');
+  const used = new Set<string>();
+  const files = parts.map((p, i) => {
+    const stem = uniquePartStem(p.name, used, `part_${i + 1}`);
+    const buffer = buildSTLBuffer(p.mesh, stlHeaderText(p.name || `part ${i + 1}`));
+    return { name: `${stem}.stl`, data: new Uint8Array(buffer) };
+  });
+  const zip = buildZip(files);
+  const mimeType = 'application/zip';
+  const base = getExportFilename('stl', customName).replace(/\.stl$/, '');
+  return { blob: new Blob([zip], { type: mimeType }), filename: `${base}.zip`, mimeType };
 }
 
 export function exportSTL(meshData: MeshData, customName?: string): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,9 +75,9 @@ import { createDiffView, refreshDiff } from './ui/diffView';
 import { createNotesView, refreshNotes } from './ui/notes';
 import { initDataExplorer, refreshDataExplorer } from './ui/dataExplorer';
 import { initSessionList, showSessionList } from './ui/sessionList';
-import { exportGLB, buildGLB } from './export/gltf';
-import { exportSTL, buildSTL } from './export/stl';
-import { exportOBJ, buildOBJ } from './export/obj';
+import { exportGLB, buildGLB, buildGLBProject } from './export/gltf';
+import { exportSTL, buildSTL, buildSTLProject } from './export/stl';
+import { exportOBJ, buildOBJ, buildOBJProject } from './export/obj';
 import { export3MF, build3MF } from './export/threemf';
 import { build3MFProject } from './export/threemfProject';
 import { showExportPartsModal, type ExportPartChoice } from './ui/exportPartsModal';
@@ -4137,6 +4137,8 @@ async function main() {
     if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('GLB'))) return;
     warnIfNotPrintable('GLB');
+    // Multi-part session → pick parts and bundle them as named nodes in one scene.
+    if (getState().parts.length > 1) { await exportMultiPartFlow('GLB', GLB_PARTS_DESC, buildGLBPartsBlob); return; }
     try {
       assertFiniteMesh(currentMeshData);
       notifyMultiPartExport();
@@ -4151,6 +4153,8 @@ async function main() {
     if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('STL'))) return;
     warnIfNotPrintable('STL');
+    // Multi-part session → pick parts and bundle a .stl per part in one .zip.
+    if (getState().parts.length > 1) { await exportMultiPartFlow('STL', STL_PARTS_DESC, buildSTLPartsBlob); return; }
     notifyMultiPartExport();
     try { showToast(`Exported ${exportSTL(fileExportMesh(false)!)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : 'STL export failed', { variant: 'warn' }); }
@@ -4160,6 +4164,8 @@ async function main() {
     if (!currentMeshData) { noGeometryToast(); return; }
     if (!(await confirmExportOrProceed('OBJ'))) return;
     warnIfNotPrintable('OBJ');
+    // Multi-part session → pick parts and emit named objects in one .obj.
+    if (getState().parts.length > 1) { await exportMultiPartFlow('OBJ', OBJ_PARTS_DESC, buildOBJPartsBlob); return; }
     notifyMultiPartExport();
     try { showToast(`Exported ${exportOBJ(fileExportMesh(true)!)}`, { variant: 'success' }); }
     catch (e) { showToast(e instanceof Error ? e.message : 'OBJ export failed', { variant: 'warn' }); }
@@ -4176,7 +4182,13 @@ async function main() {
       const v = await getLatestVersion(p.id);
       choices.push({ id: p.id, name: p.name, thumbnail: v?.thumbnail ?? null });
     }
-    const selected = await showExportPartsModal(choices, activeId, bambu);
+    const selected = await showExportPartsModal(choices, {
+      activePartId: activeId,
+      title: bambu ? 'Export parts to 3MF (Bambu/Orca)' : 'Export parts to 3MF',
+      description: bambu
+        ? 'Choose which parts to include. Each selected part is placed on its own build plate, and painted colours are bound to filaments for Bambu Studio / OrcaSlicer.'
+        : 'Choose which parts to include. Each selected part is added as a separate object, arranged in a grid so they don’t overlap. Standard 3MF — opens in any slicer.',
+    });
     if (!selected || selected.length === 0) return;
 
     const byId = new Map(parts.map(p => [p.id, p]));
@@ -4205,6 +4217,130 @@ async function main() {
       endProgress(job);
     }
   }
+
+  /** Format-agnostic multi-part export flow for OBJ / STL / GLB: pick parts (with
+   *  previews), bake each selected part's coloured mesh off-editor, hand the baked
+   *  set to `build`, and download the result. Mirrors {@link export3MFMultiPartFlow}
+   *  but for the scene-graph / soup formats (3MF keeps its own bed-aware flow). */
+  async function exportMultiPartFlow(
+    formatTag: string,
+    description: string,
+    build: (parts: { name: string; mesh: MeshData }[]) => BuiltExport | Promise<BuiltExport>,
+  ): Promise<void> {
+    const parts = getState().parts;
+    const activeId = getState().currentPart?.id ?? null;
+    const choices: ExportPartChoice[] = [];
+    for (const p of parts) {
+      const v = await getLatestVersion(p.id);
+      choices.push({ id: p.id, name: p.name, thumbnail: v?.thumbnail ?? null });
+    }
+    const selected = await showExportPartsModal(choices, {
+      activePartId: activeId,
+      title: `Export parts to ${formatTag}`,
+      description,
+    });
+    if (!selected || selected.length === 0) return;
+
+    const byId = new Map(parts.map(p => [p.id, p]));
+    const job = startProgress({ title: `Preparing ${formatTag}`, indeterminate: false, message: 'Baking parts…' });
+    try {
+      const baked: { name: string; mesh: MeshData }[] = [];
+      for (let i = 0; i < selected.length; i++) {
+        const part = byId.get(selected[i]);
+        if (!part) continue;
+        updateProgress(job, i / selected.length, `Baking "${part.name}" (${i + 1}/${selected.length})…`);
+        const result = await bakeColoredMeshForPart(part.id, part.name);
+        if (result) baked.push(result);
+      }
+      updateProgress(job, 1, `Writing ${formatTag}…`);
+      if (baked.length === 0) { showToast('None of the selected parts produced geometry to export.', { variant: 'warn' }); return; }
+
+      const built = await build(baked);
+      downloadBlob(built.blob, built.filename, formatTag);
+      const skipped = selected.length - baked.length;
+      const note = skipped > 0 ? ` (${skipped} skipped — no geometry)` : '';
+      showToast(`Exported ${built.filename} — ${baked.length} part${baked.length === 1 ? '' : 's'}${note}`, { variant: 'success' });
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : `${formatTag} export failed`, { variant: 'warn' });
+    } finally {
+      endProgress(job);
+    }
+  }
+
+  /** Console/AI core for the multi-part OBJ/STL/GLB exports: validate the part ids
+   *  (default: all), bake each part's coloured mesh off-editor, and return the baked
+   *  set. Mirrors the validation of {@link build3MFPartsExport} without the 3MF
+   *  builder, so the per-format API twins just supply the builder. */
+  async function bakePartsForExport(partIds?: string[]): Promise<{ baked: { name: string; mesh: MeshData }[] } | { error: string }> {
+    const allParts = getState().parts;
+    if (allParts.length === 0) return { error: 'No parts in this session.' };
+    let ids = partIds;
+    if (ids !== undefined) {
+      if (!Array.isArray(ids) || !ids.every(id => typeof id === 'string')) {
+        return { error: 'partIds must be an array of part-id strings.' };
+      }
+    } else {
+      ids = allParts.map(p => p.id);
+    }
+    const byId = new Map(allParts.map(p => [p.id, p]));
+    const baked: { name: string; mesh: MeshData }[] = [];
+    for (const id of ids) {
+      const part = byId.get(id);
+      if (!part) return { error: `Unknown part id "${id}".` };
+      const result = await bakeColoredMeshForPart(part.id, part.name);
+      if (result) baked.push(result);
+    }
+    if (baked.length === 0) return { error: 'None of the selected parts produced geometry to export.' };
+    return { baked };
+  }
+
+  /** Console/AI twin of a multi-part OBJ/STL/GLB export — bakes the requested parts
+   *  (default: all) and DOWNLOADS the bundled file. */
+  async function exportPartsApi(
+    formatTag: string,
+    build: (parts: { name: string; mesh: MeshData }[]) => BuiltExport | Promise<BuiltExport>,
+    partIds?: string[],
+    filename?: string,
+  ): Promise<{ ok: true; filename: string; parts: number } | { error: string }> {
+    assertString(filename, `export${formatTag}Parts(partIds, filename)`, { optional: true });
+    const r = await bakePartsForExport(partIds);
+    if ('error' in r) return r;
+    let built: BuiltExport;
+    try { built = await build(r.baked); } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
+    downloadBlob(built.blob, built.filename, formatTag);
+    return { ok: true as const, filename: built.filename, parts: r.baked.length };
+  }
+
+  /** Like {@link exportPartsApi} but RETURNS the bytes (base64) instead of
+   *  downloading — the agent/test-friendly twin. */
+  async function exportPartsDataApi(
+    formatTag: string,
+    build: (parts: { name: string; mesh: MeshData }[]) => BuiltExport | Promise<BuiltExport>,
+    partIds?: string[],
+    filename?: string,
+  ): Promise<{ filename: string; mimeType: string; sizeBytes: number; base64: string; parts: number } | { error: string }> {
+    assertString(filename, `export${formatTag}PartsData(partIds, filename)`, { optional: true });
+    const r = await bakePartsForExport(partIds);
+    if ('error' in r) return r;
+    let built: BuiltExport;
+    try { built = await build(r.baked); } catch (e) { return { error: e instanceof Error ? e.message : String(e) }; }
+    return {
+      filename: built.filename,
+      mimeType: built.mimeType,
+      sizeBytes: built.blob.size,
+      base64: await blobToBase64(built.blob),
+      parts: r.baked.length,
+    };
+  }
+
+  // Per-format builder bound to a custom filename, shared by the menu flow + API.
+  const buildOBJPartsBlob = (baked: { name: string; mesh: MeshData }[], filename?: string) => buildOBJProject(baked, filename);
+  const buildSTLPartsBlob = (baked: { name: string; mesh: MeshData }[], filename?: string) => buildSTLProject(baked, filename);
+  const buildGLBPartsBlob = (baked: { name: string; mesh: MeshData }[], filename?: string) => buildGLBProject(baked, { customName: filename });
+
+  const OBJ_PARTS_DESC = 'Choose which parts to include. Each part becomes a named object in one .obj file, arranged in a grid so they don’t overlap. Painted colours export as materials (.mtl, bundled in a .zip).';
+  const STL_PARTS_DESC = 'Choose which parts to include. Each part is saved as its own .stl file, bundled in a .zip. STL has no colour or part names, so separate files keep the parts distinct.';
+  const GLB_PARTS_DESC = 'Choose which parts to include. Each part becomes a named node in one .glb scene, arranged in a grid. Painted colours export as vertex colours.';
 
   /** Shared core for the multi-part 3MF exports: validate the part ids, bake each
    *  selected part's coloured mesh off-editor, and build the 3MF. Returns the
@@ -9146,6 +9282,46 @@ async function main() {
      *  export3MFParts (default true). */
     export3MFPartsData(partIds?: string[], filename?: string, opts?: { bambu?: boolean }) {
       return export3MFPartsDataApi(partIds, filename, opts);
+    },
+
+    /** Bundle several Session Parts into ONE OBJ — each part a named `o <part>`
+     *  object in one .obj, grid-arranged so they don't overlap; painted parts add a
+     *  shared .mtl (OBJ + MTL in a .zip). The UI equivalent is the "OBJ" export in a
+     *  multi-part session. Pass an array of part ids (default: every part); each
+     *  part's latest version is baked WITH its colours. `{ ok, filename, parts }` or
+     *  `{ error }`. */
+    exportOBJParts(partIds?: string[], filename?: string) {
+      return exportPartsApi('OBJ', baked => buildOBJPartsBlob(baked, filename), partIds, filename);
+    },
+    /** Bytes-returning twin of {@link exportOBJParts} — RETURNS
+     *  `{ filename, mimeType, base64, sizeBytes, parts }` (or `{ error }`). */
+    exportOBJPartsData(partIds?: string[], filename?: string) {
+      return exportPartsDataApi('OBJ', baked => buildOBJPartsBlob(baked, filename), partIds, filename);
+    },
+
+    /** Bundle several Session Parts into ONE STL download — a `.zip` with one `.stl`
+     *  per part (STL has no part names or colour, so separate files keep them
+     *  distinct). The UI equivalent is the "STL" export in a multi-part session. Pass
+     *  an array of part ids (default: every part). `{ ok, filename, parts }` or
+     *  `{ error }`. */
+    exportSTLParts(partIds?: string[], filename?: string) {
+      return exportPartsApi('STL', baked => buildSTLPartsBlob(baked, filename), partIds, filename);
+    },
+    /** Bytes-returning twin of {@link exportSTLParts}. */
+    exportSTLPartsData(partIds?: string[], filename?: string) {
+      return exportPartsDataApi('STL', baked => buildSTLPartsBlob(baked, filename), partIds, filename);
+    },
+
+    /** Bundle several Session Parts into ONE GLB — each part a named node in one glTF
+     *  scene, grid-arranged; painted parts export as vertex colours. The UI
+     *  equivalent is the "GLB" export in a multi-part session. Pass an array of part
+     *  ids (default: every part). `{ ok, filename, parts }` or `{ error }`. */
+    exportGLBParts(partIds?: string[], filename?: string) {
+      return exportPartsApi('GLB', baked => buildGLBPartsBlob(baked, filename), partIds, filename);
+    },
+    /** Bytes-returning twin of {@link exportGLBParts}. */
+    exportGLBPartsData(partIds?: string[], filename?: string) {
+      return exportPartsDataApi('GLB', baked => buildGLBPartsBlob(baked, filename), partIds, filename);
     },
 
     /** Export the current voxel grid as a MagicaVoxel `.vox` download. Voxel
@@ -14236,6 +14412,12 @@ async function main() {
         'export3MF':       { signature: 'export3MF() -- Download 3MF file', docs: '/ai.md#console-api--windowpartwright' },
         'export3MFParts':  { signature: 'await export3MFParts(partIds?, filename?, {bambu?}) -- Bundle parts into one 3MF; bambu:true (default) = one part per Bambu/Orca plate, false = generic multi-object grid -> {ok, filename, parts}', docs: '/ai/file-io.md' },
         'export3MFPartsData': { signature: 'await export3MFPartsData(partIds?, filename?, {bambu?}) -- Same as export3MFParts but RETURNS {filename, mimeType, base64, sizeBytes, parts} instead of downloading', docs: '/ai/file-io.md' },
+        'exportOBJParts':  { signature: 'await exportOBJParts(partIds?, filename?) -- Bundle parts into one OBJ (named objects, grid-arranged; .mtl in a .zip if painted) -> {ok, filename, parts}', docs: '/ai/file-io.md' },
+        'exportOBJPartsData': { signature: 'await exportOBJPartsData(partIds?, filename?) -- Same as exportOBJParts but RETURNS {filename, mimeType, base64, sizeBytes, parts} instead of downloading', docs: '/ai/file-io.md' },
+        'exportSTLParts':  { signature: 'await exportSTLParts(partIds?, filename?) -- Bundle parts into a .zip of one .stl per part -> {ok, filename, parts}', docs: '/ai/file-io.md' },
+        'exportSTLPartsData': { signature: 'await exportSTLPartsData(partIds?, filename?) -- Same as exportSTLParts but RETURNS {filename, mimeType, base64, sizeBytes, parts} instead of downloading', docs: '/ai/file-io.md' },
+        'exportGLBParts':  { signature: 'await exportGLBParts(partIds?, filename?) -- Bundle parts into one GLB (named nodes, grid-arranged; vertex colours) -> {ok, filename, parts}', docs: '/ai/file-io.md' },
+        'exportGLBPartsData': { signature: 'await exportGLBPartsData(partIds?, filename?) -- Same as exportGLBParts but RETURNS {filename, mimeType, base64, sizeBytes, parts} instead of downloading', docs: '/ai/file-io.md' },
         'exportVOX':       { signature: 'exportVOX() -- Download MagicaVoxel .vox (voxel sessions)', docs: '/ai/voxel.md' },
         // AI-friendly export — return bytes over the API instead of triggering a download
         'exportGLBData':   { signature: 'await exportGLBData() -- Return GLB as {filename, mimeType, base64, sizeBytes}', docs: '/ai/file-io.md' },

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -585,7 +585,12 @@ function removeClipPlaneVisual() {
   }
 }
 
-function meshGLToBufferGeometry(mesh: MeshData): THREE.BufferGeometry {
+/** Convert a MeshData to a THREE.BufferGeometry. With per-triangle `triColors`
+ *  the geometry is unindexed (each triangle's 3 verts carry that triangle's
+ *  colour, unpainted → default blue) and gets a `color` attribute; without
+ *  colours it stays indexed. Exported so the multi-part GLB builder
+ *  (`buildGLBProject`) can reuse the exact same conversion the viewport uses. */
+export function meshGLToBufferGeometry(mesh: MeshData): THREE.BufferGeometry {
   const geometry = new THREE.BufferGeometry();
 
   if (mesh.triColors) {

--- a/src/ui/exportPartsModal.ts
+++ b/src/ui/exportPartsModal.ts
@@ -1,11 +1,12 @@
-// Part-selection modal for multi-part 3MF export. Lets the user pick which
-// Session Parts to bundle into one 3MF (one part per build plate), with a
-// thumbnail preview of each. The currently-viewed part is preselected; a
-// Select-all / Select-none toggle handles assemblies with many parts.
+// Part-selection modal for multi-part exports (3MF / OBJ / STL / GLB). Lets the
+// user pick which Session Parts to bundle into one file, with a thumbnail preview
+// of each. The currently-viewed part is preselected; a Select-all / Select-none
+// toggle handles assemblies with many parts.
 //
 // Resolves with the chosen part ids (in list order) when the user confirms, or
 // null if they cancel / dismiss. Only the export caller decides what to do with
-// the selection — this modal is pure UI.
+// the selection — this modal is pure UI; the format-specific title/description
+// are passed in by the caller.
 
 import { createModalShell } from './modalShell';
 import { BUTTON_PRIMARY, BUTTON_CANCEL } from './styleConstants';
@@ -17,23 +18,32 @@ export interface ExportPartChoice {
   thumbnail: Blob | null;
 }
 
+export interface ExportPartsModalOptions {
+  /** Part preselected on open (typically the currently-viewed part). */
+  activePartId: string | null;
+  /** Modal title, e.g. "Export parts to OBJ". */
+  title: string;
+  /** One-line explanation of how this format bundles the parts. */
+  description: string;
+}
+
 /**
- * Show the multi-part 3MF part picker. `activePartId` is preselected. `bambu`
- * tailors the title/help text (per-plate Bambu project vs generic multi-object).
- * Returns the selected part ids, or null on cancel.
+ * Show the multi-part export part picker. Returns the selected part ids (in list
+ * order), or null on cancel. The caller supplies the format-specific title +
+ * description via `opts`.
  */
 export function showExportPartsModal(
   parts: ExportPartChoice[],
-  activePartId: string | null,
-  bambu = true,
+  opts: ExportPartsModalOptions,
 ): Promise<string[] | null> {
+  const { activePartId, title, description } = opts;
   return new Promise((resolve) => {
     let result: string[] | null = null;
     // Track object URLs so we can revoke them on teardown (no GPU/blob leak).
     const objectUrls: string[] = [];
 
     const shell = createModalShell({
-      title: bambu ? 'Export parts to 3MF (Bambu/Orca)' : 'Export parts to 3MF',
+      title,
       scrollable: true,
       onClose: () => {
         document.removeEventListener('keydown', onEnter);
@@ -44,9 +54,7 @@ export function showExportPartsModal(
 
     const sub = document.createElement('p');
     sub.className = 'text-[11px] text-zinc-400 leading-relaxed';
-    sub.textContent = bambu
-      ? 'Choose which parts to include. Each selected part is placed on its own build plate, and painted colours are bound to filaments for Bambu Studio / OrcaSlicer.'
-      : 'Choose which parts to include. Each selected part is added as a separate object, arranged in a grid so they don’t overlap. Standard 3MF — opens in any slicer.';
+    sub.textContent = description;
     shell.body.appendChild(sub);
 
     // Header row with the count + select-all toggle.

--- a/tests/multipart-export.spec.ts
+++ b/tests/multipart-export.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from 'playwright/test';
+
+// Multi-part OBJ / STL / GLB export: validates the format-specific multi-part
+// builders (named objects in one OBJ, a .zip of per-part STLs, named nodes in one
+// GLB) and the full part-bake pipeline driven through the console API.
+
+test.describe('multi-part OBJ / STL / GLB export', () => {
+  test.beforeEach(async ({ page }) => {
+    // Suppress the first-run guided tour — its backdrop intercepts clicks.
+    await page.addInitScript(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ } });
+  });
+
+  test('builders emit named objects / per-part files / named nodes', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForTimeout(4000); // let the module graph + engine settle
+
+    const report = await page.evaluate(async () => {
+      const { buildOBJProject } = await import('/src/export/obj.ts');
+      const { buildSTLProject } = await import('/src/export/stl.ts');
+      const { buildGLBProject } = await import('/src/export/gltf.ts');
+
+      // A part built from a flat list of per-triangle colours (mirrors the 3MF
+      // multipart test): each triangle gets 3 fresh verts so colours are valid.
+      const makePart = (name: string, triRgb: [number, number, number][]) => {
+        const verts: number[] = [];
+        const tris: number[] = [];
+        const colors: number[] = [];
+        triRgb.forEach((rgb, i) => {
+          const base = i * 3;
+          verts.push(0, 0, i, 10, 0, i, 0, 10, i);
+          tris.push(base, base + 1, base + 2);
+          colors.push(rgb[0], rgb[1], rgb[2]);
+        });
+        const triColors = new Uint8Array(colors);
+        (triColors as Uint8Array & { _painted?: Uint8Array })._painted = new Uint8Array(triRgb.length).fill(1);
+        return {
+          name,
+          mesh: {
+            vertProperties: new Float32Array(verts), triVerts: new Uint32Array(tris),
+            numVert: triRgb.length * 3, numTri: triRgb.length, numProp: 3, triColors,
+          },
+        };
+      };
+
+      const parts = [
+        makePart('Body', [[255, 0, 0], [0, 0, 255]]),
+        makePart('Lid', [[0, 0, 255]]),
+      ];
+
+      const bytes = (b: Blob) => b.arrayBuffer().then(a => new Uint8Array(a));
+      const text = (b: Blob) => b.arrayBuffer().then(a => new TextDecoder('latin1').decode(new Uint8Array(a)));
+
+      const obj = buildOBJProject(parts);
+      const stl = buildSTLProject(parts);
+      const glb = buildGLBProject(parts);
+
+      // Pull the JSON chunk out of the GLB to inspect the scene graph. GLB layout:
+      // 12-byte header, then a JSON chunk (length @12, type @16, data @20).
+      const glbBuilt = await glb;
+      const glbBytes = await bytes(glbBuilt.blob);
+      const dv = new DataView(glbBytes.buffer);
+      const jsonLen = dv.getUint32(12, true);
+      const glbJson = JSON.parse(new TextDecoder().decode(glbBytes.subarray(20, 20 + jsonLen)));
+
+      return {
+        obj: { filename: obj.filename, mime: obj.mimeType, text: await text(obj.blob) },
+        stl: { filename: stl.filename, mime: stl.mimeType, text: await text(stl.blob) },
+        glb: { filename: glbBuilt.filename, mime: glbBuilt.mimeType, json: glbJson },
+      };
+    });
+
+    // ── OBJ: named objects in one file, grid-arranged, colours → .mtl in a .zip ──
+    expect(report.obj.mime).toBe('application/zip'); // painted → OBJ+MTL bundle
+    expect(report.obj.filename).toMatch(/\.zip$/);
+    const o = report.obj.text;
+    // One `o <part>` per part — the named, separable objects OBJ supports natively.
+    expect((o.match(/^o Body/m) ?? []).length).toBe(1);
+    expect((o.match(/^o Lid/m) ?? []).length).toBe(1);
+    // Shared material library + per-colour groups (red + blue from Body).
+    expect(o).toContain('mtllib');
+    expect(o).toContain('newmtl');
+    expect((o.match(/^usemtl /gm) ?? []).length).toBeGreaterThanOrEqual(2);
+    // Cumulative vertex indexing: the Lid's faces must reference verts past the
+    // Body's 6 unique verts (a face index > 6 proves the offset was applied).
+    const faceIdx = [...o.matchAll(/^f (\d+) (\d+) (\d+)/gm)].flatMap(m => [Number(m[1]), Number(m[2]), Number(m[3])]);
+    expect(Math.max(...faceIdx)).toBeGreaterThan(6);
+    // Grid layout: the two parts occupy distinct X columns, so some vertices carry
+    // a negative X (left cell) and some a positive X (right cell) — no overlap.
+    const xs = [...o.matchAll(/^v (-?[\d.]+) /gm)].map(m => Number(m[1]));
+    expect(Math.min(...xs)).toBeLessThan(0);
+    expect(Math.max(...xs)).toBeGreaterThan(0);
+
+    // ── STL: a .zip with one .stl per part (no soup merge) ──
+    expect(report.stl.mime).toBe('application/zip');
+    expect(report.stl.filename).toMatch(/\.zip$/);
+    // Both part filenames appear in the ZIP (central directory / local headers).
+    expect(report.stl.text).toContain('Body.stl');
+    expect(report.stl.text).toContain('Lid.stl');
+
+    // ── GLB: each part a named node/mesh in one scene ──
+    expect(report.glb.mime).toBe('model/gltf-binary');
+    expect(report.glb.filename).toMatch(/\.glb$/);
+    const names = (report.glb.json.nodes ?? []).map((n: { name?: string }) => n.name);
+    expect(names).toContain('Body');
+    expect(names).toContain('Lid');
+    expect(report.glb.json.meshes.length).toBe(2);
+    // Grid layout: the two nodes sit at different X positions (no overlap). The
+    // exporter may write the position as `translation` (TRS) or baked into a
+    // `matrix` (element 12 = translation X) — accept either form.
+    const xPos = (report.glb.json.nodes ?? []).map((n: { translation?: number[]; matrix?: number[] }) =>
+      n.translation ? n.translation[0] : (n.matrix ? n.matrix[12] : 0));
+    expect(new Set(xPos).size).toBeGreaterThan(1);
+  });
+
+  test('exportOBJ/STL/GLBPartsData bundle real parts through the full bake pipeline', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForTimeout(4000);
+
+    const out = await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: any }).partwright;
+      (await import('/src/geometry/units.ts')).setUnits('mm');
+      // Three real coloured parts.
+      await pw.runAndSave('return api.label(api.Manifold.cube([20,20,20], true), "red", { color: [1,0,0] });', 'red');
+      await pw.createPart('Green');
+      await pw.runAndSave('return api.label(api.Manifold.sphere(12, 48), "green", { color: [0,1,0] });', 'green');
+      await pw.createPart('Blue');
+      await pw.runAndSave('return api.label(api.Manifold.cylinder(24, 10, 10, 48), "blue", { color: [0,0,1] });', 'blue');
+
+      const obj = await pw.exportOBJPartsData(undefined, 'probe');
+      const stl = await pw.exportSTLPartsData(undefined, 'probe');
+      const glb = await pw.exportGLBPartsData(undefined, 'probe');
+      return { obj, stl, glb };
+    });
+
+    // Each API twin baked all 3 parts and returned bytes (no download).
+    for (const r of [out.obj, out.stl, out.glb]) {
+      expect((r as { error?: string }).error).toBeUndefined();
+      expect((r as { parts: number }).parts).toBe(3);
+      expect((r as { base64: string }).base64.length).toBeGreaterThan(0);
+    }
+    expect(out.obj.mimeType).toBe('application/zip');   // painted → OBJ+MTL .zip
+    expect(out.stl.mimeType).toBe('application/zip');   // .zip of 3 .stl
+    expect(out.glb.mimeType).toBe('model/gltf-binary');
+  });
+
+  test('OBJ part picker exports a multi-object file from a multi-part session', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForTimeout(4000);
+
+    // Build a 2-part session through the console API (mm so the unitless confirm
+    // modal doesn't precede the part picker).
+    await page.evaluate(async () => {
+      const pw = (window as unknown as { partwright: any }).partwright;
+      (await import('/src/geometry/units.ts')).setUnits('mm');
+      await pw.runAndSave('return api.Manifold.cube([10,10,10], true);', 'box');
+      await pw.createPart('Pyramid');
+      await pw.runAndSave('return api.Manifold.cube([8,8,8], true);', 'pyramid');
+    });
+    await page.waitForTimeout(1500);
+
+    await page.locator('#btn-export').click();
+    await page.locator('#export-dropdown').getByText('OBJ', { exact: true }).click();
+
+    // The part picker should appear, titled for OBJ.
+    const modal = page.getByRole('dialog');
+    await expect(modal.getByText(/Export parts to OBJ/i)).toBeVisible({ timeout: 10000 });
+    await page.screenshot({ path: 'test-results/multipart-obj-modal.png' });
+
+    await modal.getByRole('button', { name: /select all/i }).click();
+    const downloadPromise = page.waitForEvent('download', { timeout: 30000 }).catch(() => null);
+    await modal.getByRole('button', { name: /export/i }).click();
+    const download = await downloadPromise;
+    expect(download).not.toBeNull();
+    // Painted? No — plain cubes → plain .obj. Either way the multi-part OBJ path ran.
+    expect(download!.suggestedFilename()).toMatch(/\.(obj|zip)$/);
+  });
+});


### PR DESCRIPTION
## Summary

Extends the recently-merged **multi-part 3MF export** to **OBJ, STL, and GLB** — bundling several Session Parts into one file. Rather than blindly copying 3MF's grid-of-objects, each format bundles parts the way its file format natively supports:

| Format | How parts are bundled | Why |
|---|---|---|
| **OBJ** | Named `o <part>` objects in **one .obj**, grid-arranged; painted parts add a shared `.mtl` (OBJ+MTL in a `.zip`) | OBJ supports named objects natively — parts stay distinct & selectable |
| **STL** | A **`.zip` of one `.stl` per part** | STL is a flat triangle soup with no object names or colour — separate files are the only faithful way to keep parts distinct |
| **GLB** | A named **node per part in one glTF scene**, grid-arranged; vertex colours | glTF is a scene graph — distinct named meshes is its natural multi-part form |

The existing **OBJ / STL / GLB toolbar buttons auto-route** to the part picker when the session has more than one part (single-part export unchanged) — exactly how the single "3MF" button already behaves. Console/`window.partwright` API twins are added too.

## What's reused

- The part-bake pipeline (`bakeColoredMeshForPart`) and the part picker — only the per-format *bundling* + wiring is new.
- A shared `multiPart.ts` helper: `gridLayout` (centred ⌈√N⌉-column grid, mirroring the generic 3MF layout) + `uniquePartStem` (sanitise/dedupe object/node/file names).
- The viewport's `meshGLToBufferGeometry` (now exported) for the GLB scene, so colour semantics match single-part GLB exactly.

## Does NOT touch `threemfProject.ts`

A parallel session owns the Bambu 3MF work in that file, so this PR stays clear of it. The only 3MF-adjacent change is generalising the shared part-picker modal's signature (3MF-only `bambu` flag → format-specific title/description).

## API

New console methods (the agent surface — no in-app AI chat tool, matching the precedent that `export3MFParts` is console-only):

- `exportOBJParts(partIds?, filename?)` / `exportOBJPartsData(...)`
- `exportSTLParts(partIds?, filename?)` / `exportSTLPartsData(...)`
- `exportGLBParts(partIds?, filename?)` / `exportGLBPartsData(...)`

Registered in `help()`, documented in `public/ai.md` + `public/ai/file-io.md`.

## Test plan

- New `tests/multipart-export.spec.ts`:
  - builders emit named objects (OBJ `o` lines + cumulative vertex indices + grid offset), a `.zip` of per-part `.stl` files, and named nodes in one GLB scene;
  - the full bake pipeline via the `*PartsData` API twins (3 real coloured parts);
  - the OBJ part picker opens & exports from a multi-part session (screenshot below).
- Existing `tests/threemf-multipart.spec.ts` still green after the modal-signature change.
- `npm run preflight` (typecheck + 1490 unit tests + lint:deps + lint:consistency) and `npm run build` both green.

### Screenshot — "Export parts to OBJ" picker

The OBJ button opens the same part picker as 3MF, titled & described for OBJ:

![OBJ part picker](https://github.com/kemper/partwright/assets/multipart-obj-modal.png)

*(Screenshot captured in the e2e run: `test-results/multipart-obj-modal.png`.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJi3ZZfXLH7jnF844Ph2PH)_