### PR TITLE
feat: progressive coarse→fine render for SDF figures

### DIFF
--- a/prompts/sdf-figure-progressive-preview.md
+++ b/prompts/sdf-figure-progressive-preview.md
@@ -1,0 +1,58 @@
+---
+date: 2026-06-19
+branch: claude/nifty-hamilton-cjwk3v
+files_changed:
+  - src/geometry/sdf.ts
+  - src/geometry/engineWorker.ts
+  - src/geometry/engine.ts
+  - src/config/appConfig.ts
+  - src/ui/advancedSettingsModal.tsx
+  - src/main.ts
+  - tests/unit/sdf.test.ts
+---
+
+## Human
+
+Catalog figures take a long time to render (sometimes >10s). Could we render them
+in low quality first and let a higher-quality render keep running in the background,
+or warn the user / gate mesh-altering actions behind a full-quality render?
+Investigate, report options, then (after picking a direction) implement.
+
+## Assistant
+
+Investigated where the 10+s goes: figures are SDF models (`api.sdf.figure(...).build(
+{ edgeLength, detail })`) lowered via `Manifold.levelSet` (marching cubes). The cost
+is the fine march over a large bbox PLUS per-detail-sphere refine passes — not
+Three.js, not paint. `edgeLength` is the only quality lever and it's hard-coded in
+each model's own code; the Settings "quality" preset (circularSegments) has zero
+effect on SDF.
+
+Weighed two real options with hard numbers. Baking meshes into the catalog (instant
+load, no recompute) was rejected: measured on real figures, even meshopt+16-bit-quant
+is ~1.2MB median / 1.8MB max per figure (~250MB+ repo bloat uncompressed), which the
+user explicitly didn't want. Went with **progressive coarse→fine** (zero download
+cost), mirroring the existing SCAD two-phase `onPreview`/`execute_preview` path which
+already runs end-to-end to the viewport.
+
+Implementation:
+- `sdf.ts`: module-level `setSdfPreviewScale(n)` — when set, `buildSdf` multiplies the
+  march `edgeLength` by it and drops every `detail` region (the two expensive parts).
+  Plus `sourceUsesSdfBuild(code)` so only SDF code pays for a second pass.
+- `engineWorker.ts`: for manifold-js code that does an SDF `.build()`, run a throwaway
+  coarse pass first → post `execute_preview` (reusing the SCAD message), then the full
+  pass → `execute_result`. Both runs are synchronous and back-to-back so no newer
+  execute can interleave; the preview's live Manifold is freed.
+- `engine.ts`: send `sdfPreviewScale` only when an `onPreview` consumer exists AND the
+  run is manifold-js (config-driven, `renderer.sdfPreviewScale`, default 2.5).
+- `main.ts`: extend the preview callback from SCAD-only to manifold-js, add a viewport
+  "⚡ Fast preview — rendering full quality…" pill (status indicator, not a toast) that
+  clears when the full mesh lands/errors/cancels, and gate `commitSurfaceModifier`
+  (the mesh-altering bake chokepoint) so it refuses while the preview is on screen —
+  the user's "force full quality before altering the mesh" ask.
+- `appConfig.ts` + `advancedSettingsModal.tsx`: typed `sdfPreviewScale` knob (1 = off).
+
+Why 2.5×: measured 24s→1.1s (ballerina), 42s→1.5s (chef), 13s→0.4s (grandpa) — 20-30×
+faster, coarse mesh stays watertight + single-component, and the silhouette/pose are
+fully recognizable (verified headlessly and in a real browser; the coarse ballerina
+shows the raised-O arms, arabesque leg, tutu, and base, with face/hand detail filling
+in on the full pass). Higher scales risk thin limbs vanishing in the preview.

--- a/prompts/sdf-preview-status-row-layout.md
+++ b/prompts/sdf-preview-status-row-layout.md
@@ -1,0 +1,37 @@
+---
+date: 2026-06-19
+branch: claude/nifty-hamilton-cjwk3v
+files_changed:
+  - src/main.ts
+---
+
+## Human
+
+(On PR #765's fast-preview pill) The "Fast Preview - Rendering full quality"
+message lays overtop of the "Rendering ..." message that has the timer and
+cancel button — it should be next to it or below it. Also, post-render the green
+"Ready" message is clipped / too-narrow and just shows "R...".
+
+## Assistant
+
+Two layout fixes in the viewport status row, verified in a real browser.
+
+1. The fast-preview pill was an independent overlay at `absolute top-2 left-2
+   z-20` — the exact coordinates of the status row (Rendering… + Cancel), so it
+   stacked on top. Moved it INTO the status row flex strip (appended next to the
+   Cancel button via `cancelInlineBtn.parentElement`) and dropped the absolute
+   positioning, so it flows inline: "Rendering… Xs · × Cancel · ⚡ Fast preview".
+   Shortened the label to "⚡ Fast preview" (full explanation stays in the title).
+
+2. The "R…" clip was a pre-existing bug surfaced by this feature. `setStatus`
+   overwrites the status span's class with `max-w-[60%] truncate` — but the
+   status row is an `absolute`, shrink-to-fit container, so a percentage max-width
+   resolves against the element's own content-sized parent and collapses to a
+   sliver once the Cancel button hides. Replaced `max-w-[60%]` with viewport-
+   relative `max-w-[55vw]` (resolves independently of the parent) and restored the
+   chip background/border that the className overwrite had also dropped. `truncate`
+   still ellipsizes long error messages.
+
+Verified: during preview the three chips sit inline with no overlap; after render
+`#status-indicator` shows full "Ready" with `scrollWidth === clientWidth` (not
+clipped).

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -149,6 +149,12 @@ export interface AppConfig {
      *  Caps how much IndexedDB space one save can take — a textured mesh costs
      *  roughly 18 bytes per triangle. */
     surfaceTexturePersistMaxTriangles: number;
+    /** Fast-preview coarsening factor for SDF models (figures). Before the
+     *  full-quality render, the Worker meshes a throwaway coarse pass at this
+     *  multiple of the model's march `edgeLength` (and skips detail regions) so
+     *  the viewport shows a rough shape in ~1-2s instead of waiting 10-50s.
+     *  Higher = faster/rougher preview; 1 (or below) disables the preview pass. */
+    sdfPreviewScale: number;
   };
   import: {
     /** Vertex-weld tolerance for STL imports (world units). */
@@ -313,6 +319,7 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     enhanceWarnTriangles: 1_000_000,
     enhanceMaxTriangles: 5_000_000,
     surfaceTexturePersistMaxTriangles: 1_000_000,
+    sdfPreviewScale: 2.5,
   },
   import: {
     stlWeldTolerance: 1e-5,

--- a/src/geometry/engine.ts
+++ b/src/geometry/engine.ts
@@ -584,7 +584,12 @@ export async function executeCodeAsync(
       meta: { startedAt: performance.now(), lang: l },
     });
     const companionFiles = getCompanionFiles();
-    engineWorker!.postMessage({ type: 'execute', callId, code: source, lang: l, imports, circularSegments: getDefaultCircularSegments(), params: paramOverrides ?? null, ...(Object.keys(companionFiles).length > 0 ? { companionFiles } : {}) });
+    // Progressive render: when the caller supplies an onPreview consumer and this
+    // is a manifold-js run, tell the Worker the coarse-preview factor so SDF
+    // figures rough out fast. The Worker further gates on the source actually
+    // doing an SDF `.build()`, so non-SDF code never pays for a second pass.
+    const sdfPreviewScale = (onPreview && l === 'manifold-js') ? getConfig().renderer.sdfPreviewScale : undefined;
+    engineWorker!.postMessage({ type: 'execute', callId, code: source, lang: l, imports, circularSegments: getDefaultCircularSegments(), params: paramOverrides ?? null, ...(sdfPreviewScale ? { sdfPreviewScale } : {}), ...(Object.keys(companionFiles).length > 0 ? { companionFiles } : {}) });
   });
 }
 

--- a/src/geometry/engineWorker.ts
+++ b/src/geometry/engineWorker.ts
@@ -46,6 +46,7 @@ import { ensureBrepLoaded, sourceUsesBrep, parseStepBlob, pushPendingBrepImport,
 import { sourceUsesManifoldText, preloadTextFonts } from './textGlyphs';
 import { setActiveImports, type ImportedMesh } from '../import/importedMesh';
 import { setCircularSegmentsOverride } from './qualitySettings';
+import { setSdfPreviewScale, sourceUsesSdfBuild } from './sdf';
 import type { Language } from './engines/types';
 import { simplifyToTriangleBudget, enhanceToTriangleBudget, simplifyToTolerance, refineToEdgeLength, isEnhanceExceeded, type SimplifyResult, type EnhanceResult, type EnhanceExceeded } from './simplify';
 import type { MeshData } from './types';
@@ -105,7 +106,7 @@ self.onmessage = async (event: MessageEvent) => {
 
   // ── execute ────────────────────────────────────────────────────────────
   if (msg.type === 'execute') {
-    const { callId, code, lang, imports, circularSegments, params, companionFiles } = msg as unknown as {
+    const { callId, code, lang, imports, circularSegments, params, companionFiles, sdfPreviewScale } = msg as unknown as {
       callId: string;
       code: string;
       lang?: Language;
@@ -113,6 +114,7 @@ self.onmessage = async (event: MessageEvent) => {
       circularSegments?: number;
       params?: Record<string, unknown> | null;
       companionFiles?: Record<string, string>;
+      sdfPreviewScale?: number | null;
     };
     // Worker-side compute timer. Reported back on execute_result so the
     // worker-health panel can separate real evaluation time from the
@@ -195,6 +197,32 @@ self.onmessage = async (event: MessageEvent) => {
           await preloadTextFonts();
         }
         setActiveImports(runImports);
+        // Progressive render for SDF models (figures): a throwaway coarse pass
+        // first, posted as `execute_preview` so the viewport shows a rough shape
+        // in ~1-2s, then the full-quality pass below. Gated on the source doing
+        // an SDF `.build()` so plain Manifold code never pays for a second pass.
+        // Both runs are synchronous and back-to-back (no await between them), so
+        // no newer execute can interleave; cancellation terminates the Worker.
+        if (typeof sdfPreviewScale === 'number' && sdfPreviewScale > 1 && sourceUsesSdfBuild(code as string)) {
+          try {
+            setSdfPreviewScale(sdfPreviewScale);
+            const preview = manifoldJsEngine.run(code as string, params ?? undefined);
+            if (preview.mesh) {
+              const pm = preview.mesh;
+              const ptransfer: Transferable[] = [pm.vertProperties.buffer, pm.triVerts.buffer];
+              if (pm.mergeFromVert) ptransfer.push(pm.mergeFromVert.buffer);
+              if (pm.mergeToVert)   ptransfer.push(pm.mergeToVert.buffer);
+              if (pm.runIndex)      ptransfer.push(pm.runIndex.buffer);
+              if (pm.runOriginalID) ptransfer.push(pm.runOriginalID.buffer);
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              (self as any).postMessage({ type: 'execute_preview', callId, mesh: pm }, ptransfer);
+            }
+            // Free the preview's live Manifold — only the mesh was transferred.
+            const plive = (preview as { manifold?: { delete?: () => void } } | undefined)?.manifold;
+            if (plive && typeof plive.delete === 'function') { try { plive.delete(); } catch { /* freed */ } }
+          } catch { /* preview is best-effort; fall through to the full render */ }
+          finally { setSdfPreviewScale(null); }
+        }
         result = manifoldJsEngine.run(code as string, params ?? undefined);
       }
 

--- a/src/geometry/sdf.ts
+++ b/src/geometry/sdf.ts
@@ -49,6 +49,30 @@ type LabelFn = (shape: ManifoldInstance, name: string) => ManifoldInstance;
  *  undefined — only `.build()` requires it. */
 interface BuildContext { Manifold: ManifoldClass; label: LabelFn }
 
+// --- Fast-preview coarsening -------------------------------------------------
+// SDF builds (figures especially) spend ~all their time in Manifold.levelSet —
+// marching a fine grid plus per-detail-sphere refine passes. For a progressive
+// "show something now, refine in the background" render, the Worker sets a
+// preview scale before a throwaway first pass: `buildSdf` then multiplies the
+// march edgeLength by it and drops every `detail` region. A scale of ~2.5 cuts
+// the cell count ~15× AND skips the fine face/hand passes, so a 20s figure
+// roughs out in a second or two. null = normal (full-quality) build.
+let sdfPreviewScale: number | null = null;
+
+/** Worker-only: set the coarsening factor for the next preview pass, or null to
+ *  build at full quality. Read once at the top of every `buildSdf`. */
+export function setSdfPreviewScale(scale: number | null): void {
+  sdfPreviewScale = scale !== null && Number.isFinite(scale) && scale > 1 ? scale : null;
+}
+
+/** Cheap source heuristic: does this code lower an SDF through `.build()`? Only
+ *  such runs benefit from the coarse-preview pass (they're the slow ones —
+ *  everything else returns a Manifold directly and is already fast). Gates the
+ *  Worker's two-phase render so non-SDF code never pays for a throwaway pass. */
+export function sourceUsesSdfBuild(code: string): boolean {
+  return /\bsdf\b/.test(code) && /\.build\s*\(/.test(code);
+}
+
 export type Vec3 = [number, number, number];
 export interface Box { min: Vec3; max: Vec3 }
 
@@ -490,10 +514,15 @@ function buildSdf(
       + 'Intersect with a finite shape, or pass an explicit { bounds: { min:[x,y,z], max:[x,y,z] } }.',
     );
   }
-  const edgeLength = opts.edgeLength ?? defaultEdgeLength(bounds);
+  const baseEdgeLength = opts.edgeLength ?? defaultEdgeLength(bounds);
   const level = opts.level ?? 0;
   const tolerance = opts.tolerance;
-  const detail = opts.detail ?? [];
+  // Fast preview: coarsen the march and skip the fine detail passes. The result
+  // is a throwaway rough mesh shown while the full-quality pass runs (the Worker
+  // clears the scale and re-builds immediately after).
+  const previewScale = sdfPreviewScale;
+  const edgeLength = previewScale !== null ? baseEdgeLength * previewScale : baseEdgeLength;
+  const detail = previewScale !== null ? [] : (opts.detail ?? []);
 
   // Partition the tree into labelled regions. If there are no labels,
   // returns a single anonymous region covering the whole root.

--- a/src/main.ts
+++ b/src/main.ts
@@ -522,6 +522,11 @@ const partMeshCache = new Map<string, PartMeshCacheEntry>();
 let geometryDataEl: HTMLElement;
 // Viewport overlay pill — shows printability issues after each successful run.
 let printabilityIndicatorEl: HTMLElement | null = null;
+let fastPreviewPillEl: HTMLElement | null = null;
+/** True while the viewport shows the coarse fast-preview pass of an SDF model
+ *  and the full-quality render is still in flight. Used to gate mesh-altering
+ *  actions (paint, surface modifiers) so they don't bind to the throwaway mesh. */
+let _showingFastPreview = false;
 // Viewport overlay pill — shown when a run's `api.surface.*` texture chain is
 // NOT in the memo cache (a "sticky" miss): we render the base mesh and let the
 // user press this to recompute the (potentially slow) texture on demand. See
@@ -4849,6 +4854,19 @@ async function main() {
   printabilityIndicatorEl.style.display = 'none';
   viewportPane.appendChild(printabilityIndicatorEl);
 
+  // Fast-preview pill — shown while the viewport is displaying the rough coarse
+  // pass of a slow SDF model (figures) and the full-quality render is still
+  // running in the Worker. A status indicator, not a toast: it clears the moment
+  // the full mesh lands (or the run errors/cancels). See runCodeSync's preview
+  // callback. Title explains the swap so the rough→sharp transition isn't a
+  // surprise.
+  fastPreviewPillEl = document.createElement('span');
+  fastPreviewPillEl.className = 'absolute top-2 left-2 z-20 text-xs text-sky-300 font-mono bg-zinc-900/80 px-2 py-0.5 rounded border border-sky-700/60 cursor-help';
+  fastPreviewPillEl.textContent = '⚡ Fast preview — rendering full quality…';
+  fastPreviewPillEl.title = 'Showing a quick rough version of this model. The full-detail render is still computing and will replace it automatically. Wait for it before painting or editing the mesh.';
+  fastPreviewPillEl.style.display = 'none';
+  viewportPane.appendChild(fastPreviewPillEl);
+
   // Surface "Re-apply" pill — a persistent status indicator (not a transient
   // toast) shown when the model declares `api.surface.*` textures whose result
   // isn't cached for the current code/params. Until pressed, the viewport shows
@@ -8040,6 +8058,14 @@ async function main() {
   }
 
   async function commitSurfaceModifier(result: ModifierResult, preserveColor: boolean, opts?: { warnOnBake?: boolean }): Promise<Record<string, unknown>> {
+    // Refuse to bake while a coarse fast-preview is on screen: the modifier would
+    // bind to the throwaway low-res mesh, which the full-quality render is about
+    // to replace. Tell the user to let it finish (it auto-completes in seconds).
+    if (_showingFastPreview) {
+      const msg = 'Full-quality render still in progress — wait for it to finish before altering the mesh.';
+      showToast(msg, { variant: 'warn' });
+      return { error: msg };
+    }
     // Capture the language *before* the commit switches it, so we can warn when a
     // SCAD/BREP session is silently baked to a mesh. The transform path
     // (commitTransform) emits its own, more specific warning and passes
@@ -15579,6 +15605,15 @@ async function main() {
     cancelInlineBtn.classList.add('hidden');
   }
 
+  function showFastPreviewPill(): void {
+    _showingFastPreview = true;
+    if (fastPreviewPillEl) fastPreviewPillEl.style.display = '';
+  }
+  function hideFastPreviewPill(): void {
+    _showingFastPreview = false;
+    if (fastPreviewPillEl) fastPreviewPillEl.style.display = 'none';
+  }
+
   async function runCodeSync(src: string, opts: { surfaceErrors?: boolean; preserveCamera?: boolean; skipSurface?: boolean } = {}): Promise<boolean> {
     // Hard refusal in shared-preview mode: this is the single execution
     // chokepoint that the console API (partwright.run / runAndSave) also routes
@@ -15609,22 +15644,27 @@ async function main() {
     // on a session's first render, so a genuinely new model still auto-frames.
     const preservedCameraPose = opts.preserveCamera ? captureCameraToPreserve() : null;
 
-    // SCAD preview callback: receives the fast Phase 1 mesh and updates the
-    // viewport immediately so the user sees geometry while Phase 2 renders. Skip
-    // its auto-frame while preserving the camera, so the mid-run preview doesn't
-    // momentarily snap to the default view before the final restore lands.
-    const onScadPreview = getActiveLanguage() === 'scad'
+    // Progressive-render preview callback: receives the fast coarse-pass mesh and
+    // updates the viewport immediately so the user sees geometry while the full
+    // render finishes. Used by two engines: SCAD's two-phase compile, and the
+    // manifold-js SDF coarse pass (figures). Skip its auto-frame while preserving
+    // the camera, so the mid-run preview doesn't momentarily snap to the default
+    // view before the final restore lands. For SDF, raise the "⚡ Fast preview"
+    // pill so the user knows the rough mesh will be replaced.
+    const previewLang = getActiveLanguage();
+    const onEnginePreview = (previewLang === 'scad' || previewLang === 'manifold-js')
       ? (previewResult: MeshResult) => {
           if (myGen !== _runGeneration || !previewResult.mesh) return;
           currentMeshData = previewResult.mesh;
           updateMesh(previewResult.mesh, { skipAutoFrame: preservedCameraPose !== null });
+          if (previewLang === 'manifold-js') showFastPreviewPill();
         }
       : undefined;
 
     // Feed the Customizer's current overrides into the model's api.params(...).
     let result: Awaited<ReturnType<typeof executeCodeAsync>>;
     try {
-      result = await executeCodeAsync(src, undefined, currentParamValues, onScadPreview);
+      result = await executeCodeAsync(src, undefined, currentParamValues, onEnginePreview);
     } catch (err) {
       // Worker was terminated (cancelled by user, cancelled for a newer run,
       // timeout, or crash). Only clean up if we're still the active run —
@@ -15632,6 +15672,7 @@ async function main() {
       if (myGen !== _runGeneration) return false;
       _running = false;
       stopRunTimer();
+      hideFastPreviewPill();
       const msg = err instanceof Error ? err.message : String(err);
       const wasCancelled = /cancell?ed/i.test(msg);
       setStatus(statusBar, wasCancelled ? 'ready' : 'error', wasCancelled ? 'Cancelled' : msg);
@@ -15646,6 +15687,9 @@ async function main() {
     const elapsed = Math.round(performance.now() - t0);
     _running = false;
     stopRunTimer();
+    // The full-quality mesh is in hand — the coarse preview (if any) is about to
+    // be replaced, so drop the pill.
+    hideFastPreviewPill();
 
     // Record the engine WASM heap high-water for this run (undefined for non
     // manifold-js engines, which own separate heaps). Surfaced in the Data panel

--- a/src/main.ts
+++ b/src/main.ts
@@ -4861,11 +4861,13 @@ async function main() {
   // callback. Title explains the swap so the rough→sharp transition isn't a
   // surprise.
   fastPreviewPillEl = document.createElement('span');
-  fastPreviewPillEl.className = 'absolute top-2 left-2 z-20 text-xs text-sky-300 font-mono bg-zinc-900/80 px-2 py-0.5 rounded border border-sky-700/60 cursor-help';
-  fastPreviewPillEl.textContent = '⚡ Fast preview — rendering full quality…';
+  fastPreviewPillEl.className = 'text-xs text-sky-300 font-mono bg-zinc-900/80 px-2 py-0.5 rounded border border-sky-700/60 cursor-help whitespace-nowrap';
+  fastPreviewPillEl.textContent = '⚡ Fast preview';
   fastPreviewPillEl.title = 'Showing a quick rough version of this model. The full-detail render is still computing and will replace it automatically. Wait for it before painting or editing the mesh.';
   fastPreviewPillEl.style.display = 'none';
-  viewportPane.appendChild(fastPreviewPillEl);
+  // Live inside the status row (next to the "Rendering… Xs" text + Cancel button)
+  // rather than as its own absolute overlay, so it never stacks on top of them.
+  (cancelInlineBtn.parentElement ?? viewportPane).appendChild(fastPreviewPillEl);
 
   // Surface "Re-apply" pill — a persistent status indicator (not a transient
   // toast) shown when the model declares `api.surface.*` textures whose result
@@ -16133,8 +16135,13 @@ function setStatus(el: HTMLElement, state: 'ready' | 'running' | 'error' | 'load
   el.title = text;
   // Keep the indicator click-transparent — `setStatus` overwrites the className
   // so the original `pointer-events-none` from layout.ts would otherwise be
-  // lost, letting it intercept clicks on the Insert button it overlaps.
-  el.className = 'text-xs font-mono max-w-[60%] truncate text-right pointer-events-none ';
+  // lost, letting it intercept clicks on what it overlaps. Restore the chip
+  // background/border too (also dropped on overwrite). The status row is an
+  // absolute, shrink-to-fit flex strip, so cap the width with a viewport-
+  // relative `max-w` (a percentage would resolve against this very element's
+  // shrink-to-fit parent and collapse "Ready" to "R…"); `truncate` still
+  // ellipsizes long error messages.
+  el.className = 'text-xs font-mono max-w-[55vw] truncate pointer-events-none bg-zinc-900/70 px-2 py-0.5 rounded border border-zinc-700 ';
   switch (state) {
     case 'ready':
       el.className += 'text-emerald-400';

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -660,6 +660,16 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           min={0} max={20_000_000} integer
           onChange={v => set('renderer', 'surfaceTexturePersistMaxTriangles', v)}
         />
+        <Field
+          label="SDF fast-preview coarsening"
+          unit="×"
+          hint="Higher = faster but rougher preview. Set to 1 to disable the preview pass."
+          tooltip="SDF models (figures) render in two passes: a fast, coarse preview shown immediately, then the full-quality mesh that replaces it. This is how much coarser the preview march is than the model's real edgeLength — at 2.5× a figure that takes 20-40s roughs out in ~1-2s. The preview also skips fine detail regions (faces, hands). Set to 1 or below to turn the preview off and always render at full quality directly."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.sdfPreviewScale}
+          value={c.renderer.sdfPreviewScale}
+          min={1} max={6} step={0.5}
+          onChange={v => set('renderer', 'sdfPreviewScale', v)}
+        />
       </Section>
 
       <Section title="Import">

--- a/tests/unit/sdf.test.ts
+++ b/tests/unit/sdf.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from 'vitest';
 import {
   SdfNode,
   partitionByLabel,
+  sourceUsesSdfBuild,
   __testables__,
 } from '../../src/geometry/sdf';
 
@@ -1091,5 +1092,19 @@ describe('sdf build options — detail regions', () => {
   it('caps the region count', () => {
     const many = Array.from({ length: 25 }, () => ({ center: [0, 0, 0], radius: 1, edgeLength: 0.1 }));
     expect(() => assertBuildOpts({ detail: many })).toThrow(/at most/);
+  });
+});
+
+describe('sourceUsesSdfBuild — fast-preview gate', () => {
+  it('matches code that lowers an SDF through .build()', () => {
+    expect(sourceUsesSdfBuild('const { sdf } = api;\nreturn sdf.sphere(10).build({ edgeLength: 0.5 });')).toBe(true);
+    expect(sourceUsesSdfBuild('return api.sdf.figure.rig({}).build({ edgeLength: 0.52 });')).toBe(true);
+    expect(sourceUsesSdfBuild('return foo.build ( { edgeLength: 1 } ); // sdf model')).toBe(true);
+  });
+
+  it('skips plain Manifold code so it never pays for a second pass', () => {
+    expect(sourceUsesSdfBuild('return Manifold.cube([10, 10, 10]);')).toBe(false);
+    expect(sourceUsesSdfBuild('return api.imports[0].build();')).toBe(false); // .build() but no sdf
+    expect(sourceUsesSdfBuild('const { sdf } = api;\nreturn sdf.sphere(10);')).toBe(false); // sdf but no .build()
   });
 });


### PR DESCRIPTION
## Summary

Catalog **figures** are SDF models (`api.sdf.figure(...).build({ edgeLength, detail })`) lowered through `Manifold.levelSet` (marching cubes). The fine march over a large bounding box, plus the per-detail-sphere refine passes for faces/hands, is what makes them take **10–50 s** to appear — not Three.js, not painting. `edgeLength` is the only quality lever and it's hard-coded in each model's code; the Settings quality preset (circularSegments) has **zero** effect on SDF.

This adds a **progressive render**: a fast coarse pass shows a recognizable figure in ~1–2 s, then the full-quality mesh swaps in behind it. It reuses the existing SCAD two-phase `onPreview` → `execute_preview` → viewport path, so it adds **no** download/storage cost (baking meshes into the catalog was measured at ~1.2–1.8 MB/figure even with meshopt+quantization, and rejected).

### Measured (real catalog figures)

| Figure | Full | Coarse preview (×2.5) | Speedup |
|---|---|---|---|
| ballerina | 24.2 s | **1.1 s** | 21× |
| chef | 41.9 s | **1.5 s** | 27× |
| grandpa | 13.2 s | **0.4 s** | 32× |

The coarse mesh stays watertight and single-component, and the silhouette/pose are fully recognizable (verified headlessly and in a real browser).

## What changed

- **`sdf.ts`** — `setSdfPreviewScale(n)`: `buildSdf` multiplies the march `edgeLength` by it and drops all `detail` regions (the two expensive parts). `sourceUsesSdfBuild(code)` gates the second pass so plain Manifold code never pays for it.
- **`engineWorker.ts`** — manifold-js SDF runs post an `execute_preview` (coarse) before the full `execute_result`. Both passes are synchronous and back-to-back (no interleave); the preview's live Manifold is freed.
- **`engine.ts` / `appConfig.ts`** — config-driven `renderer.sdfPreviewScale` (default `2.5`, `1` = off), sent only for manifold-js runs that have an `onPreview` consumer.
- **`main.ts`** — the preview callback now covers manifold-js (not just SCAD); a "⚡ Fast preview — rendering full quality…" viewport pill (a status indicator, not a toast) shows while the coarse mesh is up and clears when the full mesh lands/errors/cancels; `commitSurfaceModifier` refuses to bake while the preview is on screen (the "force full quality before altering the mesh" gate).
- **`advancedSettingsModal.tsx`** — exposes the coarsening knob.
- **`tests/unit/sdf.test.ts`** — unit coverage for `sourceUsesSdfBuild`.

## Test plan

- [x] `npm run preflight` (typecheck + 1492 unit tests + lint:deps + lint:consistency) — green
- [x] Headless timing across ballerina/chef/grandpa (20–30× faster; coarse mesh manifold + 1 component)
- [x] Browser: ran a figure via the console API, confirmed the coarse preview + pill appears at ~3 s and the full 290k-tri mesh swaps in with the pill cleared (screenshots in chat)
- [ ] PR-checks e2e shards green

## Notes / follow-ups

- The coarse preview is intentionally **colorless** (paint resolution is main-side and tied to the full mesh); the full pass brings color. Carrying figure label colors into the preview is a possible enhancement.
- Only manifold-js SDF builds are progressive; SCAD already had its own two-phase path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWL7ZhLsWXNVxieMaKMTdw)_