### PR TITLE
fix: cancelling a catalog figure's initial render (dead button + colour loss)

### DIFF
--- a/prompts/cancel-during-initial-deeplink-render.md
+++ b/prompts/cancel-during-initial-deeplink-render.md
@@ -1,0 +1,47 @@
+---
+date: 2026-06-19
+branch: claude/bold-knuth-fhd0b9
+files_changed:
+  - src/main.ts
+  - tests/render-cancel-deeplink.spec.ts
+---
+
+## Human
+
+When opening a figure from the catalog, the recently-merged fast-preview feature
+shows the rough render plus the "Rendering…" message with a Cancel button — which
+I like. But clicking Cancel doesn't actually cancel the more complete, detailed
+render. Investigate, create a fix, and open a PR. Use the latest main.
+
+## Assistant
+
+Reproduced with a throwaway Playwright spec on `/editor?catalog=archer.partwright.json`
+(an SDF figure): the Cancel button appears at ~0.7s, but clicking it left the status
+ticking "Rendering… Xs" all the way to "Ready" at ~23s — the full render completed
+regardless. Instrumenting the click handler showed it never fired at all, even on a
+direct DOM `el.click()` with the button confirmed as the topmost element and only one
+in the DOM.
+
+Root cause is an ordering bug, *not* anything in the progressive-render feature
+itself. `main()` runs `await syncEditorFromURL()` partway through its setup, and the
+catalog deep-link path inside it `await`s the entire initial render
+(`loadCatalogFileIntoEditor → importSessionPayload → loadVersionIntoEditor →
+runCodeSync`). The `cancelInlineBtn` click handler was attached *much later* in
+`main()` — so during the first render of a deep-linked model, the button was visible
+(the run timer un-hid it) but had no listener yet. This affects any slow deep-linked
+load (`?session=`, `?idea=`, `?catalog=`), but it's most visible on catalog SDF
+figures because the new fast-preview path surfaces the Cancel button prominently for
+tens of seconds.
+
+Fix: attach the Cancel handler early — right after the layout is built and the
+fast-preview pill is set up, before `await syncEditorFromURL()`. The handler closes
+over `surfaceCarveCancel` (a surface-carve abort hook assigned far below in
+`buildSurfaceModifierProgress`), so I hoisted that `let` (and its sibling
+`surfaceCarveAbort`) to the early site to avoid a temporal-dead-zone read if Cancel
+is clicked during the first render; the original block now only assigns them. The
+handler body is byte-for-byte the same (carve cancel → surface-compute cancel →
+`cancelCurrentExecution`), so later-render behavior is unchanged.
+
+Verified the same repro now flips to "Cancelled" within ~0.5s and stays there (full
+render never lands). Added `tests/render-cancel-deeplink.spec.ts` as a regression
+guard. `npm run build` + `npm run test:unit` (1500) green.

--- a/prompts/cancel-initial-render-color-loss.md
+++ b/prompts/cancel-initial-render-color-loss.md
@@ -1,0 +1,52 @@
+---
+date: 2026-06-19
+branch: claude/bold-knuth-fhd0b9
+files_changed:
+  - src/main.ts
+  - tests/catalog-cancel-color-preserve.spec.ts
+---
+
+## Human
+
+I did a test where I clicked cancel as a long initial render was happening
+(opened a figure from the catalog). Then I clicked save after cancel. Then I
+edited the code to cause a rerender. The rerender took a while like it normally
+does and had a fast preview figure, but when the render completed the model had
+no color.
+
+## Assistant
+
+Reproduced with a scratch Playwright spec on the archer (a slow SDF figure whose
+14 colours are saved as `byLabel` colour regions): a normal load shows 14 regions;
+after cancelling the initial render the in-memory region count was **0**, and a
+Save then persisted **0** — destroying the figure's colours. A later edit→rerender
+re-resolves only the in-memory regions, so it rendered colourless.
+
+Root cause: `loadVersionIntoEditor` runs `runCodeSync` and, when it returns false,
+does `if (!applied) return` — which skips `rehydrateColorRegions`. Cancelling the
+initial render makes runCodeSync return false, so the version's colour regions
+never enter memory. `rehydrateColorRegions` can't simply be called on that path:
+it resolves `byLabel` regions against the finished mesh + labelMap, and a cancel
+leaves neither (only a throwaway coarse preview mesh, no labelMap), so every
+region would resolve to 0 triangles and be dropped.
+
+Notably this is only reachable *because* of the sibling fix in this PR (wiring the
+Cancel button to work during the initial render) — before that you couldn't cancel
+an initial figure render at all. So the two fixes ship together; merging the
+button fix alone would expose this colour-loss regression.
+
+Fix: added `stageUnresolvedColorRegions(geometryData)` — it loads the version's
+colour-region *descriptors* into the store with empty triangle sets (no mesh
+needed). Called on the cancel path in `loadVersionIntoEditor` (guarded by a
+`_runGeneration` check so a newer version-switch that superseded ours doesn't get
+clobbered). Because `serialize()` persists descriptors (not triangles), a Save now
+keeps the colours; and runCodeSync already re-resolves every in-memory region
+against the fresh mesh+labelMap on the next successful run, so the colours reappear
+on the rerender. Regions that genuinely no longer match just resolve to 0, exactly
+as the existing reconcile tolerates.
+
+Verified: after cancel → save the persisted session keeps all 14 colour regions
+(was 0), and the edit→rerender shows the fully-coloured archer. Added
+`tests/catalog-cancel-color-preserve.spec.ts` (asserts `exportSessionData()`'s
+latest version still has colour regions after cancel+save). build + 1508 unit
+tests + both cancel e2e specs green.

--- a/retros/inbox/2026-06-19-cancel-button-deeplink-render.md
+++ b/retros/inbox/2026-06-19-cancel-button-deeplink-render.md
@@ -1,0 +1,39 @@
+# Retro — Cancel button dead during initial deep-link render (PR #772)
+
+## Liked
+- A throwaway Playwright spep on `/editor?catalog=archer.partwright.json` nailed
+  the repro in one run: snapshotting `status` + cancel-button visibility on a
+  timeline showed the render ticking to "Ready" at ~23s *despite* the click.
+- Instrumenting the click handler (and then a direct DOM `el.click()` with an
+  `elementFromPoint` + duplicate-id count check) was decisive: it proved the
+  handler *never fired* even though the button was the sole topmost element —
+  which redirected the hunt from "terminate() doesn't interrupt WASM" (wrong) to
+  "the listener isn't attached yet" (right).
+
+## Lacked
+- No structural guard against "visible-but-dead control": a button can be shown
+  by one code path (the run timer un-hides it) while its handler is wired by a
+  different, later code path. There's no lint or test that ties a control's
+  visibility to its listener being attached.
+- The initial-load ordering is implicit: `main()` is a ~13k-line async function
+  that `await`s the first render (`syncEditorFromURL`) partway through, so any
+  handler attached *below* that await is silently inert for the whole first
+  render. Nothing flags this; it's discoverable only by reading the await chain.
+
+## Learned
+- `worker.terminate()` *does* forcibly interrupt synchronous WASM mid-compute —
+  so when a "cancel" appears not to work, suspect the wiring (did the handler run
+  at all?) before suspecting the cancel mechanism. The console.debug already in
+  `restartEngineWorker` is a free tell: no `[EngineWorker] … cancelled` line ⇒
+  `cancelCurrentExecution` never ran.
+- Catalog figures load via `?catalog=` deep-link → `syncEditorFromURL` →
+  `loadCatalogFileIntoEditor` → `importSessionPayload` → `loadVersionIntoEditor`
+  → `runCodeSync`, and that whole chain is awaited inside `main()` before the
+  rest of `main()`'s event wiring runs.
+
+## Longed for
+- A cheap convention: attach interaction handlers for always-present chrome
+  (toolbar/status-row buttons) in a dedicated early "wire controls" pass that
+  runs *before* any awaited initial render, so a slow first load can never leave
+  a visible control inert. Hoisting the few forward-referenced `let`s (here
+  `surfaceCarveCancel`) is the only cost.

--- a/src/main.ts
+++ b/src/main.ts
@@ -4999,6 +4999,29 @@ async function main() {
   // rather than as its own absolute overlay, so it never stacks on top of them.
   (cancelInlineBtn.parentElement ?? viewportPane).appendChild(fastPreviewPillEl);
 
+  // Owners of the inline Cancel button when an SDF surface carve (engrave /
+  // voronoi lamp) is running. Declared here — early, before the initial
+  // syncEditorFromURL render — so the click handler attached just below can
+  // close over them without a temporal-dead-zone error. They're assigned in
+  // buildSurfaceModifierProgress far below.
+  let surfaceCarveAbort: AbortController | null = null;
+  let surfaceCarveCancel: (() => void) | null = null;
+
+  // Wire the Cancel button NOW, before the first deep-link render. main() awaits
+  // the initial render inside syncEditorFromURL(), so attaching this handler at
+  // its natural spot far below left the button visible-but-dead for the whole
+  // first render of a slow model — exactly the catalog-figure case where the
+  // fast-preview pill + "Rendering… Xs" timer + Cancel button all appear but the
+  // click did nothing. Precedence: a running surface carve owns it (aborts the
+  // SDF sweep); then an in-flight surface-texture chain (terminates the surface
+  // Worker — the base mesh stays + the Re-apply pill appears); otherwise it
+  // cancels the current engine execution (terminates the geometry Worker).
+  cancelInlineBtn.addEventListener('click', () => {
+    if (surfaceCarveCancel) { surfaceCarveCancel(); return; }
+    if (cancelSurfaceCompute()) return;
+    cancelCurrentExecution();
+  });
+
   // Surface "Re-apply" pill — a persistent status indicator (not a transient
   // toast) shown when the model declares `api.surface.*` textures whose result
   // isn't cached for the current code/params. Until pressed, the viewport shows
@@ -8693,10 +8716,9 @@ async function main() {
   // the Cancel aborts the sweep (see surfaceCarveCancel, wired into
   // cancelInlineBtn). Supersede any in-flight carve when a newer one starts
   // (rapid slider edits). Lighter modifiers run inline with no indicator.
-  let surfaceCarveAbort: AbortController | null = null;
-  // While a carve is running, the toolbar Cancel button aborts it instead of
-  // cancelling a worker run. Cleared when the carve settles.
-  let surfaceCarveCancel: (() => void) | null = null;
+  // surfaceCarveAbort / surfaceCarveCancel are declared early (near the
+  // fast-preview pill setup) so the Cancel handler can be wired before the
+  // initial render; this block only assigns them.
   const SDF_HEAVY = new Set(['engrave', 'voronoiLamp']);
   async function buildSurfaceModifierProgress(
     id: Parameters<typeof buildSurfaceModifier>[0],
@@ -15703,15 +15725,12 @@ async function main() {
   // Start the elapsed-time display for a render. The cancel button and timer
   // are delayed 400 ms so fast runs (manifold-js is typically < 100 ms) never
   // flash them. stopRunTimer() always cancels the pending show before it fires.
-  cancelInlineBtn.addEventListener('click', () => {
-    // A running surface carve owns the Cancel button (it aborts the SDF sweep);
-    // an in-flight surface-texture chain owns it next (terminates the surface
-    // Worker — the run already finished, so the base mesh stays + the Re-apply
-    // pill appears); otherwise this cancels the current engine execution.
-    if (surfaceCarveCancel) { surfaceCarveCancel(); return; }
-    if (cancelSurfaceCompute()) return;
-    cancelCurrentExecution();
-  });
+  // NOTE: the Cancel button's click handler is attached *early* (right after the
+  // layout is built, before the initial syncEditorFromURL render) — see the
+  // `cancelInlineBtn.addEventListener` near the fast-preview pill setup. Attaching
+  // it here instead left the button dead for the entire first render of a slow
+  // deep-linked model (catalog SDF figures especially), because main() awaits
+  // that render before ever reaching this line.
 
   function startRunTimer(t0: number): void {
     _runTimerStart = t0;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1284,6 +1284,36 @@ async function rehydrateColorRegions(geometryData: Record<string, unknown> | nul
   return report;
 }
 
+/** Load a version's saved colour-region *descriptors* into the store WITHOUT
+ *  resolving them against a mesh (empty triangle sets). Used when a version
+ *  load can't finish its render — most importantly when the user cancels the
+ *  slow initial render of a catalog figure. Without this, the cancel skips
+ *  rehydrateColorRegions entirely (it needs a finished mesh + labelMap to
+ *  resolve `byLabel` regions), so the figure's colours never enter memory: a
+ *  subsequent Save then serialises the empty store over the version's colours
+ *  (permanent loss), and the next edit→rerender shows a colourless model.
+ *
+ *  Staging the descriptors fixes both: `serialize()` persists descriptors (not
+ *  triangles), so a Save keeps the colours, and runCodeSync re-resolves every
+ *  in-memory region against the freshly-rendered mesh+labelMap on the next run,
+ *  so the colours reappear. Regions that genuinely no longer match just resolve
+ *  to 0 triangles, exactly as the normal reconcile path already tolerates. */
+function stageUnresolvedColorRegions(geometryData: Record<string, unknown> | null): void {
+  resetPaintWorkerState();
+  clearRegions();
+  const regions = geometryData?.colorRegions as SerializedColorRegion[] | undefined;
+  if (!regions || regions.length === 0) {
+    syncLockState();
+    return;
+  }
+  suspendReconcile = true;
+  for (const region of regions) {
+    addRegion(region.name, region.color, region.source, region.descriptor, new Set<number>(), region.visible !== false, region.slotId);
+  }
+  suspendReconcile = false;
+  syncLockState();
+}
+
 /** Draw `currentMeshData` with the model-declared colour underlay (api.label /
  *  api.paint) applied — or the plain mesh when the model declares no colours.
  *  The shared "show model colours" step for restore paths: a no-op for an
@@ -5643,10 +5673,23 @@ async function main() {
         seedSurfaceCache(persistedTexture.key, persistedTexture.mesh as MeshData);
       }
       const meshBeforeRun = currentMeshData;
+      const genBeforeRun = _runGeneration;
       const applied = await runCodeSync(version.code, { preserveCamera: true, skipSurface: opts.skipSurface });
       // If a newer version-switch arrived while we were compiling, our result
       // was discarded — don't rehydrate colours or annotations for the wrong version.
-      if (!applied) return;
+      if (!applied) {
+        // The render didn't complete (most commonly: the user cancelled the slow
+        // initial render of a catalog figure). rehydrateColorRegions needs a
+        // finished mesh + labelMap to resolve regions, so it's skipped here — but
+        // we must still stage the version's colour-region descriptors into memory,
+        // or a Save would persist an empty store over the figure's colours and the
+        // next edit→rerender would render colourless. They re-resolve on the next
+        // successful run. Skip when a NEWER run superseded ours (runCodeSync bumped
+        // _runGeneration past the one our call started): that newer run owns the
+        // store and must not be clobbered with this version's descriptors.
+        if (_runGeneration === genBeforeRun + 1) stageUnresolvedColorRegions(version.geometryData);
+        return;
+      }
       // Store the freshly compiled result so the next switch back is instant.
       // Only cache on a successful mesh-producing run (compile errors leave
       // currentMeshData as the previous part's mesh, i.e. unchanged).

--- a/tests/catalog-cancel-color-preserve.spec.ts
+++ b/tests/catalog-cancel-color-preserve.spec.ts
@@ -1,0 +1,54 @@
+// Regression: cancelling the slow initial render of a catalog figure, then
+// saving, must NOT lose the figure's colours.
+//
+// Catalog figures (e.g. the archer) carry their colours as `byLabel` colour
+// regions in the saved version, resolved against the rendered mesh + labelMap.
+// When the user cancels the initial render, that render never produces a mesh,
+// so rehydrateColorRegions (which needs one) is skipped. Previously the colour
+// regions then never entered memory at all — so a subsequent Save serialised an
+// empty store over the figure's 14 colours (permanent loss) and the next
+// edit→rerender showed a colourless model. The fix stages the version's colour
+// descriptors into memory on the cancel path, so a Save preserves them and they
+// re-resolve on the next successful run.
+//
+// This bug is only reachable because the Cancel button now works during the
+// initial render (the sibling fix in this PR) — so the two ship together.
+
+import { test, expect } from 'playwright/test';
+
+test.describe('catalog figure cancel + save preserves colours', () => {
+  test('cancelling the initial render then saving keeps the colour regions', async ({ page }) => {
+    test.setTimeout(90_000);
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+
+    // The archer is a slow SDF figure with 14 byLabel colour regions.
+    await page.goto('/editor?catalog=archer.partwright.json');
+
+    const cancelBtn = page.locator('#btn-cancel-inline');
+    const status = page.locator('#status-indicator');
+
+    // Cancel the initial render the moment the button appears.
+    await expect(cancelBtn).toBeVisible({ timeout: 30_000 });
+    await cancelBtn.click();
+    await expect(status).toHaveText('Cancelled', { timeout: 5_000 });
+
+    // Save the (un-rendered) figure.
+    await page.getByText('💾 Save', { exact: false }).first().click();
+    // Let the save commit.
+    await page.waitForTimeout(1_500);
+
+    // The persisted session must still carry the figure's colour regions —
+    // before the fix this came back as 0 (the colours were destroyed).
+    const colourCount = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const res = await pw.exportSessionData();
+      const versions = res?.data?.versions ?? [];
+      // The latest version carries the saved colour regions.
+      const last = versions[versions.length - 1] ?? {};
+      return Array.isArray(last.colorRegions) ? last.colorRegions.length : -1;
+    });
+
+    expect(colourCount).toBeGreaterThan(0);
+  });
+});

--- a/tests/render-cancel-deeplink.spec.ts
+++ b/tests/render-cancel-deeplink.spec.ts
@@ -1,0 +1,41 @@
+// Regression: the inline "× Cancel" button must work during the *initial*
+// deep-link render, not just on later edits. main() awaits the first render
+// inside syncEditorFromURL() before finishing its setup, so the Cancel button's
+// click handler used to be wired up only AFTER that render completed — leaving
+// the button visible-but-dead for the whole first render of a slow model. The
+// catalog SDF figures are the worst case: their two-phase progressive render
+// shows the "Rendering… Xs" timer + Cancel button (and a "⚡ Fast preview" pill)
+// for tens of seconds, but clicking Cancel did nothing and the full-detail
+// render landed anyway. The handler is now attached early; this guards it.
+
+import { test, expect } from 'playwright/test';
+
+test.describe('initial deep-link render cancel', () => {
+  test('cancelling a catalog figure load stops the full render', async ({ page }) => {
+    test.setTimeout(60_000);
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+
+    // An SDF figure (archer) — slow enough that the inline Cancel button shows
+    // during the initial render.
+    await page.goto('/editor?catalog=archer.partwright.json');
+
+    const cancelBtn = page.locator('#btn-cancel-inline');
+    const status = page.locator('#status-indicator');
+
+    // The Cancel button appears once the render passes the short delay gate.
+    await expect(cancelBtn).toBeVisible({ timeout: 25_000 });
+    await expect(status).toHaveText(/Rendering/, { timeout: 25_000 });
+
+    await cancelBtn.click();
+
+    // Cancel terminates the geometry Worker: the status flips to "Cancelled" and
+    // the button hides almost immediately — the full-detail render never lands.
+    await expect(status).toHaveText('Cancelled', { timeout: 5_000 });
+    await expect(cancelBtn).toBeHidden();
+
+    // And it STAYS cancelled — prove the heavy full render didn't quietly finish
+    // and overwrite the status a few seconds later (the original bug's tell).
+    await page.waitForTimeout(4_000);
+    await expect(status).toHaveText('Cancelled');
+  });
+});


### PR DESCRIPTION
## Summary

Two related fixes for **cancelling the slow initial render of a catalog figure**. They ship together because the second bug is only *reachable* once the first is fixed.

### 1. The inline "× Cancel" button did nothing during the initial render

Ordering bug in `main()`: it `await`s the first deep-link render inside `syncEditorFromURL()`, but the `cancelInlineBtn` click handler was attached much later in `main()`. So for the whole first render of a deep-linked model — catalog SDF figures especially, where the new progressive fast-preview shows the "⚡ Fast preview" pill + "Rendering… Xs" timer + Cancel button for tens of seconds — the button was **visible but had no listener**. Clicking it did nothing and the full render finished anyway. (Confirmed with instrumentation: the handler never fired, even on a direct DOM click.)

**Fix:** attach the handler early, right after the layout + fast-preview pill are built, before `await syncEditorFromURL()`. Hoist the `surfaceCarveAbort` / `surfaceCarveCancel` `let`s to that early site so the closure has no temporal-dead-zone read; the original block only assigns them now. Handler body unchanged.

### 2. Cancelling then saving destroyed the figure's colours

Once the Cancel button works (fix #1), a new path opens: cancel the initial render → Save → edit → rerender showed a **colourless** model. Catalog figures carry their colours as `byLabel` colour regions in the saved version, resolved against the rendered mesh + labelMap. `loadVersionIntoEditor` skips `rehydrateColorRegions` when the render doesn't finish (no mesh/labelMap to resolve against), so the colour regions never entered memory — then a Save serialised the **empty** store over the figure's 14 colours (permanent loss), and the rerender re-resolved only the in-memory regions (none).

**Fix:** `stageUnresolvedColorRegions()` loads the version's colour-region *descriptors* into the store with empty triangle sets on the cancel path (guarded by a `_runGeneration` check so a superseding version-switch isn't clobbered). `serialize()` persists descriptors, so a Save keeps the colours; `runCodeSync` already re-resolves every in-memory region against the fresh mesh + labelMap on the next run, so they reappear on the rerender.

## Test plan

- **Fix #1:** repro on `/editor?catalog=archer...` — before: status ran "Rendering…" to "Ready" at ~23s despite the click; after: flips to "Cancelled" in ~0.5s and stays. Spec: `tests/render-cancel-deeplink.spec.ts`.
- **Fix #2:** repro on the archer — before: cancel → 0 colour regions, save persists 0; after: cancel → 14 staged, save keeps 14, edit→rerender renders the fully-coloured figure. Spec: `tests/catalog-cancel-color-preserve.spec.ts`.
- `npm run build` ✅ · `npm run test:unit` (1508) ✅ · both new e2e specs ✅ · clean `work-reviewer` pass on fix #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)