### PR TITLE
fix: fold the /v1/ dual build into npm run build (deploy robustness)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,10 +95,14 @@ How it's wired:
   content nav (`rebaseHtmlPaths`), the pre-paint pair (`entry.ts` +
   `public/route-init.js`, which derives its base from its own `<script src>`),
   and `manifest.json` all follow it. Every piece is a **no-op at base `/`**.
-- **`npm run build:deploy`** produces the combined deploy: the versionless root
-  build in `dist/` plus a `DEPLOY_BASE=/v1/` build nested in `dist/v1/`. To go
-  live, point the **Cloudflare build command** at `npm run build:deploy` (the
-  default `npm run build` only emits the versionless root).
+- **`npm run build` produces the combined deploy**: the versionless root build
+  in `dist/` plus a `DEPLOY_BASE=/v1/` build nested in `dist/v1/`. The Cloudflare
+  build command stays the **default `npm run build`** — no per-deploy command
+  change, so a branch that predates this still builds (its own `build` just emits
+  the versionless root). `build:deploy` remains as a back-compat alias of
+  `build`. *(History: the dual build was briefly a separate `build:deploy` script;
+  pointing the project-wide Cloudflare command at it broke every branch that
+  lacked the script — so it was folded into `build`.)*
 - **`public/_redirects`** carries the per-mount SPA fallback (`/v1/* /v1/index.html 200`
   before the root `/* /index.html 200` — first-match wins) and the `/current/`
   alias. **Verify `/v1/editor` on a real Cloudflare preview** before flipping

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
-    "build:deploy": "npm run build && DEPLOY_BASE=/v1/ vite build --outDir dist/v1 --emptyOutDir",
+    "build": "tsc && vite build && DEPLOY_BASE=/v1/ vite build --outDir dist/v1 --emptyOutDir",
+    "build:deploy": "npm run build",
     "typecheck": "tsc --noEmit",
     "preflight": "npm run typecheck && npm run test:unit && npm run lint:deps && npm run lint:consistency",
     "snap": "node scripts/snap.mjs",

--- a/prompts/versioned-deploy-build-fold.md
+++ b/prompts/versioned-deploy-build-fold.md
@@ -1,0 +1,46 @@
+---
+date: 2026-06-19
+branch: claude/versioned-deploy-build-fold
+files_changed:
+  - package.json
+  - CLAUDE.md
+---
+
+## Human
+
+Production incident during the versioned-deploy cutover go-live: after merging
+#688 to main and pointing the Cloudflare build command at `npm run build:deploy`,
+Cloudflare builds failed (`Missing script: "build:deploy"`) on every branch that
+predated the merge; and once reverted to `npm run build`, `/v1/editor` 404s
+(while `/current/editor` correctly redirects) — i.e. the new `_redirects` is live
+but `dist/v1/` wasn't built.
+
+## Assistant
+
+Root cause: the dual build lived in a **separate `build:deploy` script**, but the
+Cloudflare build command is **project-wide**. So:
+- Setting the command to `build:deploy` broke every branch lacking the script
+  (all open PRs predating the merge) — and `main` itself until #688 landed.
+- Reverting to `npm run build` un-broke builds but emitted only the versionless
+  root (no `dist/v1/`), so `/v1/editor` → `/v1/*` redirect → missing
+  `/v1/index.html` → 404. (`/current/editor` working confirmed the new
+  `_redirects` was deployed — it's a missing-artifact problem, not a routing bug.)
+
+Fix: **fold the dual build into the default `npm run build`** so the Cloudflare
+command never needs changing and no branch can break:
+- `build` = `tsc && vite build && DEPLOY_BASE=/v1/ vite build --outDir dist/v1 --emptyOutDir`.
+- `build:deploy` kept as a back-compat alias (`npm run build`) so a command still
+  set to `build:deploy` also works.
+- A branch that predates this runs *its own* single `build` (versionless) → its
+  Cloudflare preview passes; `main`/staging/prod run the new dual `build` → ship
+  `/v1/`. Trade-off: ~25 s added to every `npm run build` (CI included) — accepted
+  given the split caused a production-build outage.
+
+Verified locally: `npm run build` now emits `dist/index.html` (→ `/assets/…`,
+versionless) **and** `dist/v1/index.html` (→ `/v1/assets/…`, pinned), with the
+`/v1/*` + `/current/` `_redirects`. Updated the CLAUDE.md deployment section
+(the command is the default `npm run build` again; documented the history).
+
+Go-live after merge: with the Cloudflare command on the default `npm run build`,
+the next staging/prod build produces `/v1/` automatically — verify `/v1/editor`
+serves the pinned build (`/v1/assets/…`) on staging, then promote.


### PR DESCRIPTION
## Summary

Fixes the deploy-topology fragility that caused the cutover go-live incident: the `/v1/` dual build was a **separate `build:deploy` script**, but the Cloudflare build command is **project-wide**, so:

- Pointing the command at `build:deploy` failed (`Missing script`) on every branch that lacked the script — all open PRs predating the cutover, and `main` itself until #688 landed.
- Reverting to `npm run build` un-broke builds but emitted only the versionless root → `dist/v1/` missing → `https://main.partwright.pages.dev/v1/editor` **404** (while `/current/editor` correctly redirected — confirming the new `_redirects` was live; it was a missing-artifact problem, not a routing bug).

**Fix: fold the dual build into the default `npm run build`** so the Cloudflare command never needs changing and no branch can break:
- `build` = `tsc && vite build && DEPLOY_BASE=/v1/ vite build --outDir dist/v1 --emptyOutDir`
- `build:deploy` kept as a **back-compat alias** of `build` (so a command still set to `build:deploy` also works)

A branch that predates this runs *its own* single (versionless) `build` → its preview passes; `main`/staging/prod run the new dual `build` → ship `/v1/`. **Trade-off:** ~25 s added to every `npm run build` (CI included) — accepted, since the split caused a production-build outage.

## Test plan
- [x] `npm run build` now emits **both** `dist/index.html` (→ `/assets/…`, versionless) and `dist/v1/index.html` (→ `/v1/assets/…`, pinned), with the `/v1/*` + `/current/` `_redirects`
- [x] CLAUDE.md deployment docs updated (command is the default `npm run build` again; history noted)
- [ ] PR-checks shards green
- [ ] After merge: with the Cloudflare command on the default `npm run build`, verify `/v1/editor` serves the pinned build on **staging**, then promote

### Go-live (after merge)
1. Set the Cloudflare build command to the **default `npm run build`** (if it isn't already).
2. Let the staging gate advance staging → verify `/v1/editor` (pinned) + `/editor` (versionless) + `/current/editor` (→ `/editor`).
3. Promote to production.

Relates to #680.

https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6

---
_Generated by [Claude Code](https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6)_