### PR TITLE
fix: serve /v1/editor (Cloudflare drops splat SPA fallbacks as loops)

### DIFF
--- a/prompts/fix-v1-spa-redirect.md
+++ b/prompts/fix-v1-spa-redirect.md
@@ -1,0 +1,40 @@
+---
+date: 2026-06-19
+branch: claude/fix-v1-spa-redirect
+files_changed:
+  - public/_redirects
+---
+
+## Human
+
+Production: https://main.partwright.pages.dev/v1/editor returns 404 (while /v1/
+shows the landing and the v1/ asset dir is uploaded). Cloudflare deploy log:
+`#19 /v1/* /v1/index.html 200 — Infinite loop detected in this rule and has been
+ignored` (and the same for `#32 /* /index.html 200`).
+
+## Assistant
+
+Root cause (from the deploy log, not timing): Cloudflare **rejects splat SPA
+fallbacks whose destination canonicalizes back into the splat source** — it
+strips `/index.html → /` and `.html`, so `/v1/* → /v1/index.html` becomes
+`/v1/* → /v1/` which re-matches `/v1/*` → "infinite loop" → the rule is dropped.
+With the rule gone, `/v1/editor` (no backing file) falls through and 404s. The
+build itself was correct (dist/v1/ deployed; `/v1/` works via directory-index).
+
+Fix: replace the splat with **exact per-route** SPA fallbacks, whose source can't
+canonicalize back into itself, so Cloudflare accepts them:
+- `/editor /index.html 200`
+- `/v1/editor /v1/index.html 200`
+
+The editor is the app's only no-file route (`/`, `/v1/` serve their index via
+directory-index; `/catalog`, `/help`, `/v1/catalog`, … are real pre-rendered
+.html; the editor's `?session=…` states share the `/editor` path). Also made the
+**root** `/editor` explicit (the original `/* /index.html 200` was loop-rejected
+too, so root SPA had been surviving only on Cloudflare's built-in fallback).
+Kept `/* /index.html 200` as a documented, harmless backstop (the vite dev/preview
+server still honors it). Verified both new rules are loop-safe (dest canonicalizes
+to `/` and `/v1/`, neither equal to its source).
+
+Per-major caveat: each new pinned major needs its own `/vN/editor /vN/index.html
+200` line, and any new top-level SPA route needs a line — documented in
+`_redirects`.

--- a/public/_redirects
+++ b/public/_redirects
@@ -12,11 +12,18 @@
 /current/* /:splat 302
 /current /editor 302
 
-# Pinned version mounts: each needs its OWN SPA fallback, listed BEFORE the root
-# one so a deep link like /v1/editor serves /v1/index.html (the pinned build),
-# not the root app. Real assets and the pre-rendered /v1/*.html content pages
-# resolve before this rule (same as the root fallback below).
-/v1/* /v1/index.html 200
+# SPA fallbacks for the app's only no-file route — the editor — at the root and
+# at each pinned mount. These MUST be explicit per-route rules, NOT splats:
+# Cloudflare REJECTS `/* /index.html 200` and `/v1/* /v1/index.html 200` as
+# infinite loops (the destination canonicalizes — /index.html → /, /v1/index.html
+# → /v1/ — and re-matches its own splat source), silently dropping them. An exact
+# source like `/editor` never canonicalizes back into itself, so it's accepted.
+# Everything else already has a file: /, /v1/ → their index via directory-index;
+# /catalog, /help, /v1/catalog, … → pre-rendered .html. The editor's ?session=…
+# states share the /editor path, so one rule each covers them. Add a line per new
+# top-level SPA route (and per pinned major).
+/editor /index.html 200
+/v1/editor /v1/index.html 200
 
 # Pre-rendered, app-free content pages (catalog.html / help.html / legal.html /
 # whats-new.html / ideas.html) are served by Cloudflare Pages at their CLEAN URLs
@@ -28,5 +35,8 @@
 # the prerenderContentPages middleware (src/content/build) instead.
 #
 # Specific assets (incl. the four content pages) resolve before this SPA
-# fallback, which only catches app routes like /editor.
+# fallback. NOTE: Cloudflare rejects this catch-all as an infinite loop
+# (/index.html → / → re-matches /*) and drops it — so the explicit `/editor` /
+# `/v1/editor` rules above are what actually serve the SPA. Kept as documented
+# intent + a harmless backstop (and the vite dev/preview server honors it).
 /* /index.html 200


### PR DESCRIPTION
## Summary

**Production hotfix:** `https://main.partwright.pages.dev/v1/editor` returns 404.

**Root cause (from the deploy log, confirmed — not timing):** Cloudflare rejects splat SPA fallbacks whose destination canonicalizes back into the splat source:
```
#19: /v1/* /v1/index.html 200
  Infinite loop detected in this rule and has been ignored.
#32: /* /index.html 200
  Infinite loop detected in this rule and has been ignored.
```
Cloudflare strips `/index.html → /` (and `.html`), so `/v1/* → /v1/index.html` effectively becomes `/v1/* → /v1/`, which re-matches `/v1/*` → it flags a loop and **drops the rule**. With it gone, `/v1/editor` (no backing file) falls through → 404. The build was fine — `dist/v1/` is deployed and `/v1/` renders (directory-index).

**Fix:** replace the splat with **exact per-route** SPA fallbacks, whose source can't canonicalize back into itself, so Cloudflare accepts them:
```
/editor    /index.html    200
/v1/editor /v1/index.html 200
```
The editor is the app's only no-file route (`/` and `/v1/` serve their index via directory-index; `/catalog`, `/help`, `/v1/catalog`, … are real pre-rendered `.html`; the editor's `?session=…` states share the `/editor` path). I also made the **root** `/editor` explicit — the original `/* /index.html 200` was loop-rejected too, so root SPA had been surviving only on Cloudflare's built-in fallback. Kept `/* /index.html 200` as a documented, harmless backstop (the vite dev/preview server still honors it).

> **Per-major caveat (documented in `_redirects`):** each new pinned major needs its own `/vN/editor /vN/index.html 200` line, and any new top-level SPA route needs a line. (A future cleanup could generate these in the build.)

## Test plan
- [x] Loop-safety verified: both new rules' destinations canonicalize to `/` and `/v1/` — neither equals its source, so Cloudflare won't drop them
- [x] `_redirects` lands in `dist/` (vite copies `public/` verbatim)
- [ ] PR-checks green
- [ ] **After merge + deploy:** confirm `/v1/editor` serves the pinned build (`/v1/assets/…`), `/editor` still works, `/v1/`, `/v1/catalog`, `/current/editor` unchanged — and the deploy log shows the two new rules under "valid redirect rules" (no longer "ignored")

Relates to #680.

https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6

---
_Generated by [Claude Code](https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6)_