### PR TITLE
fix: serve the editor as a real editor.html (Cloudflare clean-URL, not a redirect)

### DIFF
--- a/prompts/fix-editor-html-alias.md
+++ b/prompts/fix-editor-html-alias.md
@@ -1,0 +1,44 @@
+---
+date: 2026-06-19
+branch: claude/fix-editor-html-alias
+files_changed:
+  - vite.config.ts
+  - public/_redirects
+---
+
+## Human
+
+After #774: branch deploy /v1/editor 302-redirects to /v1/ (not the editor), and
+/current/editor redirects all the way to / — meaning /editor itself redirects to
+/ too.
+
+## Assistant
+
+Root cause: Cloudflare Pages canonicalizes `.html`/`/index.html` URLs
+(`/index.html → /`, `/foo.html → /foo`) with a 308 — and it applies this to the
+DESTINATION of a `_redirects` 200-rewrite. So #774's `/editor /index.html 200`
+and `/v1/editor /v1/index.html 200` rules rewrote to `…/index.html`, which
+Cloudflare then 308-redirected to `/` and `/v1/`. (And the earlier `/v1/* …`
+splat was rejected outright as an infinite loop for the same canonicalization
+reason.) Net: every form of `_redirects` SPA-fallback-to-index.html either loops
+or redirects the user off the route. `/current/editor → /editor → /` confirmed
+the root editor was hit too.
+
+Fix: stop using `_redirects` for the editor and serve it as a **real static
+file**, the one mechanism that demonstrably works on this project — the content
+pages (`/catalog → catalog.html`). Added an `editorHtmlAlias()` Vite plugin that
+copies the SPA shell `index.html` → `editor.html` in each build's outDir (so
+`dist/editor.html` and `dist/v1/editor.html`), and removed the two canonicalizing
+`_redirects` rules. Cloudflare now serves `/editor → /editor.html` and
+`/v1/editor → /v1/editor.html` at their clean URLs — no rewrite, no
+canonicalization, no loop. `/` and `/v1/` still serve their index via
+directory-index; `/current/editor → /editor` (302) then lands on `/editor.html`.
+
+Verified: `npm run build` emits `dist/editor.html` (refs `/assets/…`) and
+`dist/v1/editor.html` (refs `/v1/assets/…`), each byte-identical to its
+sibling `index.html`. `_redirects` now carries only the alias/redirect rules +
+the harmless `/*` backstop. (Note: this was a main/staging-preview regression;
+production is unaffected until the next promotion.)
+
+Per-major note: the plugin runs for every build outDir, so a future `/v2/`
+automatically gets `dist/v2/editor.html` — no per-major `_redirects` line needed.

--- a/prompts/fix-redirects-stale-comment.md
+++ b/prompts/fix-redirects-stale-comment.md
@@ -1,0 +1,25 @@
+---
+date: 2026-06-19
+branch: claude/fix-editor-html-alias
+files_changed:
+  - public/_redirects
+---
+
+## Human
+
+Follow-up on PR #775 (serve the editor as a real editor.html instead of a
+`_redirects` index.html rewrite). The CI/Cloudflare deploy is green; clean up
+before merge.
+
+## Assistant
+
+Spotted a stale comment in `public/_redirects`: the block above the `/*`
+catch-all still claimed "the explicit `/editor` / `/v1/editor` rules above are
+what actually serve the SPA" — but #775 *removed* those rules. The SPA editor
+route is now served by the real `editor.html` files the `editorHtmlAlias()`
+plugin emits at the root and in each pinned mount (`/editor` → `editor.html`,
+`/v1/editor` → `/v1/editor.html`), exactly like the content pages.
+
+Rewrote the comment to describe the real-static-file mechanism and dropped the
+dangling reference to the deleted rules. Comment-only change — no routing
+behavior changes.

--- a/public/_redirects
+++ b/public/_redirects
@@ -31,9 +31,10 @@
 # redirect loop. The dev/preview server reproduces the clean-URL serving via
 # the prerenderContentPages middleware (src/content/build) instead.
 #
-# Specific assets (incl. the four content pages) resolve before this SPA
-# fallback. NOTE: Cloudflare rejects this catch-all as an infinite loop
-# (/index.html → / → re-matches /*) and drops it — so the explicit `/editor` /
-# `/v1/editor` rules above are what actually serve the SPA. Kept as documented
-# intent + a harmless backstop (and the vite dev/preview server honors it).
+# Specific assets (incl. the content pages and editor.html) resolve before this
+# SPA fallback. NOTE: Cloudflare rejects this catch-all as an infinite loop
+# (/index.html → / → re-matches /*) and drops it — so the real static files
+# (/editor → editor.html, /v1/editor → /v1/editor.html, the content pages) are
+# what actually serve. Kept as documented intent + a harmless backstop (and the
+# vite dev/preview server honors it).
 /* /index.html 200

--- a/public/_redirects
+++ b/public/_redirects
@@ -12,18 +12,15 @@
 /current/* /:splat 302
 /current /editor 302
 
-# SPA fallbacks for the app's only no-file route — the editor — at the root and
-# at each pinned mount. These MUST be explicit per-route rules, NOT splats:
-# Cloudflare REJECTS `/* /index.html 200` and `/v1/* /v1/index.html 200` as
-# infinite loops (the destination canonicalizes — /index.html → /, /v1/index.html
-# → /v1/ — and re-matches its own splat source), silently dropping them. An exact
-# source like `/editor` never canonicalizes back into itself, so it's accepted.
-# Everything else already has a file: /, /v1/ → their index via directory-index;
-# /catalog, /help, /v1/catalog, … → pre-rendered .html. The editor's ?session=…
-# states share the /editor path, so one rule each covers them. Add a line per new
-# top-level SPA route (and per pinned major).
-/editor /index.html 200
-/v1/editor /v1/index.html 200
+# The editor (the app's only no-file route) is served as a REAL static file:
+# the build emits `editor.html` (a copy of the SPA shell index.html) at the root
+# AND in each pinned mount, so Cloudflare serves /editor → /editor.html and
+# /v1/editor → /v1/editor.html at their clean URLs — exactly like /catalog →
+# /catalog.html. See the editorHtmlAlias() plugin in vite.config.ts. (A
+# `_redirects` 200-rewrite to …/index.html does NOT work: Cloudflare canonicalizes
+# the destination — /index.html → /, /foo.html → /foo — and 308-redirects the user
+# off the route; a /*-style splat to index.html is rejected as an infinite loop.)
+# / and /v1/ still serve their index.html via directory-index.
 
 # Pre-rendered, app-free content pages (catalog.html / help.html / legal.html /
 # whats-new.html / ideas.html) are served by Cloudflare Pages at their CLEAN URLs

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -161,6 +161,35 @@ function baseAwareManifest(): Plugin {
   };
 }
 
+// Emit `editor.html` as a copy of the SPA shell `index.html` so the editor's
+// no-file route is served as a REAL static file at its clean URL (Cloudflare
+// maps `/editor` → `/editor.html`, exactly like `/catalog` → `/catalog.html`).
+// This is the only reliable SPA-fallback on Cloudflare Pages: a `_redirects`
+// `200`-rewrite to `…/index.html` gets the destination canonicalized
+// (`/index.html` → `/`, `/foo.html` → `/foo`) and 308-redirects the user away
+// (and a `/*`/`/v1/*` splat to index.html is rejected as an infinite loop).
+// Runs per build via config.build.outDir, so it covers both `dist/` and the
+// nested `dist/v1/`. The copy keeps index.html's own (already base-correct)
+// asset refs. `/` and `/v1/` still serve their index via directory-index.
+function editorHtmlAlias(): Plugin {
+  let outDir = 'dist';
+  return {
+    name: 'partwright-editor-html-alias',
+    apply: 'build',
+    configResolved(config) {
+      outDir = config.build.outDir;
+    },
+    closeBundle() {
+      try {
+        const html = readFileSync(resolve(outDir, 'index.html'), 'utf8');
+        writeFileSync(resolve(outDir, 'editor.html'), html, 'utf8');
+      } catch {
+        /* no index.html emitted — nothing to alias */
+      }
+    },
+  };
+}
+
 // Build/version metadata surfaced by the in-app About dialog so a given deploy
 // can be traced back to an exact commit/branch — handy for Cloudflare branch &
 // PR preview deploys, which otherwise look identical. Cloudflare sets CF_PAGES_*
@@ -219,7 +248,7 @@ export default defineConfig({
   define: {
     __BUILD_INFO__: JSON.stringify(resolveBuildInfo()),
   },
-  plugins: [tailwindcss(), prerenderContentPages(), absoluteUrls(), basePaths(), markdownCharset(), dynamicSitemap(), baseAwareManifest()],
+  plugins: [tailwindcss(), prerenderContentPages(), absoluteUrls(), basePaths(), markdownCharset(), dynamicSitemap(), baseAwareManifest(), editorHtmlAlias()],
   esbuild: {
     // .tsx files compile JSX via preact/jsx-runtime — keeps the bundle on
     // Preact without pulling in React. Vanilla .ts files in the rest of


### PR DESCRIPTION
## Summary

Follow-up hotfix to #774. After #774, the branch deploy showed `/v1/editor` 302-redirecting to `/v1/`, and `/current/editor` redirecting all the way to `/` — i.e. **`/editor` itself redirects to `/`** too.

**Root cause:** Cloudflare Pages canonicalizes `.html`/`/index.html` URLs (`/index.html → /`, `/foo.html → /foo`) with a 308 — **and it applies this to the *destination* of a `_redirects` 200-rewrite.** So #774's `/editor /index.html 200` and `/v1/editor /v1/index.html 200` rewrote to `…/index.html`, which Cloudflare then 308-redirected to `/` and `/v1/`. (The earlier `/v1/* …` splat was rejected as an infinite loop for the same canonicalization reason.) Every `_redirects`-to-`index.html` form either loops or redirects the user off the route.

**Fix:** stop using `_redirects` for the editor; serve it as a **real static file** — the mechanism the content pages already use reliably on this project (`/catalog → catalog.html`):
- **`editorHtmlAlias()` Vite plugin** copies the SPA shell `index.html` → `editor.html` in each build's outDir → `dist/editor.html` **and** `dist/v1/editor.html` (runs for every `/vN/` automatically).
- **Removed** the canonicalizing `/editor` + `/v1/editor` `_redirects` rules.

Cloudflare now serves `/editor → /editor.html` and `/v1/editor → /v1/editor.html` at their clean URLs — no rewrite, no canonicalization, no loop. `/` and `/v1/` keep serving their index via directory-index; `/current/editor → /editor` (302) then lands on `/editor.html`.

> Scope note: this was a **main/staging-preview** regression — production is unaffected until the next promotion. This must merge before promoting `/v1/` to production.

## Test plan
- [x] `npm run build` emits `dist/editor.html` (refs `/assets/…`) and `dist/v1/editor.html` (refs `/v1/assets/…`), each byte-identical to its sibling `index.html`
- [x] `_redirects` now carries only the `/ai|/agent|/api`, `/current` rules + the harmless `/*` backstop — no `…/index.html` rewrites
- [ ] PR-checks green
- [ ] **On this PR's preview, verify:** `/editor` (versionless), `/v1/editor` (pinned `/v1/assets/…`), `/current/editor` → `/editor`, `/v1/` (landing) — all serve, none redirect off-route
- [ ] After merge → confirm on `main`, then staging, then promote

Relates to #680.

https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6

---
_Generated by [Claude Code](https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6)_