### PR TITLE
fix: per-part drafts carry unsaved paint so ＋/part-switch doesn't lose it (#736)

### DIFF
--- a/prompts/20260619-185844-part-unload-drafts-carry-paint.md
+++ b/prompts/20260619-185844-part-unload-drafts-carry-paint.md
@@ -1,0 +1,44 @@
+---
+session: "part-unload-preserve-paint"
+timestamp: "2026-06-19T18:58:44Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+If I paint and then click the "+" button to create a new part it still loses
+the paint operation I just completed. I imagined an "unload part" lifecycle that
+auto-saves/preserves properly, rather than save calls embedded ad-hoc in UI
+handlers. Confirm/deny + fix. [Chosen approach: drafts carry paint.]
+
+## Assistant
+
+## Key decisions
+
+Confirmed the diagnosis: preservation was hand-wired per UI handler. Rail-switch
+(`selectPart`) calls `preserveCurrentEditsIfNeeded()` (saves a version WITH
+paint), but ➕ (`onCreatePart`) only stashed the CODE draft (no paint) and then
+`startNewPartInEditor` → `dropPaintState()` wiped the regions. Per-part drafts
+never carried paint, so painting then ➕ lost it.
+
+Fix (drafts carry paint — keeps the part "unsaved"/listed in the save-all modal
+while preserving its paint):
+- `SessionDraft.colorRegions?: unknown[]` (IndexedDB-only, no schema bump);
+  threaded through `setDraft`/`writeDraft`/`readDraft` (typed
+  `SerializedColorRegion[]` at the sessionManager layer).
+- `partSaveState`: a draft whose paint differs from the saved version (or a
+  never-saved part whose draft has paint) is now `'unsaved'`, so the modal lists
+  it.
+- `main.ts`: `currentDraftRegions()` helper stashes `serializeRegions()` at all
+  5 `writeDraft` sites; `restoreDraftIfNewer` replays the draft's paint via
+  `rehydrateColorRegions` — re-running code only when it actually changed (no
+  double render) and rehydrating paint only when the draft carries it (so it
+  never wipes a loaded version's paint).
+- The ➕ stash guard became `(!isStarterCode(getValue()) || hasColorRegions())`
+  so a painted STARTER part also stashes (the original bug's exact case). The
+  API `createPart()` path still doesn't stash (intentional clean slate).
+
+Implemented via an `implementer` subagent in an isolated worktree; reviewed the
+diff and re-verified in the main checkout. New `tests/part-unload-paint.spec.ts`
+(paint→➕→switch-back restores paint; save-all captures it; survives reload);
+typecheck + unit (1508) + parts + save-all-parts all green. Fixes #736.

--- a/retros/inbox/20260619-190011-export-warning-and-part-lifecycle.md
+++ b/retros/inbox/20260619-190011-export-warning-and-part-lifecycle.md
@@ -1,0 +1,43 @@
+# Retro — export-unsaved warning, drafts-carry-paint, and the #764 scope saga
+
+**Context:** A long chat session off the part-color work: shipped the
+unsaved-export warning (#760) and the drafts-carry-paint part-unload fix (#778),
+and discovered the part-preservation logic is hand-wired per UI handler.
+
+## Liked
+- "Reproduce before coding" kept paying off: the multi-part 3MF export *bake*
+  path turned out NOT to be broken (it composes colour fine) — the real cause of
+  "parts lost colour on export" was unsaved work. The fix became a warning, not a
+  bake change. Verifying the claim first saved a phantom fix.
+- Delegating the drafts-carry-paint multi-file change to an `implementer` in a
+  worktree kept the heavy edits out of an already-huge context, and it caught a
+  real spec gap (the `onCreatePart` `isStarterCode` guard needed `|| hasColorRegions()`).
+
+## Lacked
+- A single "unload current part" lifecycle. Preservation is re-implemented in
+  each transition handler (`selectPart` saves a version incl. paint; `onCreatePart`
+  stashed code-only) — the exact inconsistency the user predicted, and the source
+  of the ➕-loses-paint bug. Drafts now carry paint, but the handlers still each
+  call preserve/stash by hand; a real `unloadCurrentPart()` chokepoint is still owed.
+- Cheap dirty-state instrumentation. `currentPartIsDirty`/`versionMatchesCurrent`
+  compare raw code, so `runAndSave` saving the unformatted arg made just-saved
+  parts read "unsaved" (#764) — invisible until the new warning surfaced it.
+
+## Learned
+- A "correct" fix can have a wide blast radius through bug-dependent code. The
+  #764 fix (save the formatted buffer) was right, but two separate features
+  (multi-part 3MF picker test, AND the thumbnail-camera pin→resave→new-thumbnail
+  path) silently *relied* on the raw-vs-formatted mismatch. Re-asking the user
+  with the new finding (instead of pushing through) avoided shipping a regression.
+- Cloudflare Pages 0-second "build failed" ≠ a code break: build-unit ran the
+  identical `npm run build` green. It was a deploy-config issue fixed on main
+  (versioned-deploy base-mount), not the account-quota I first guessed — I should
+  weight "what changed on main" higher before diagnosing infra.
+
+## Longed for
+- `unloadCurrentPart()` / `loadCurrentPart()` symmetry so per-version state
+  (code, paint, annotations, params, thumbnail-camera) can't drift between the
+  ~6 transition handlers.
+- A dirty-check that's format-insensitive (normalize before comparing) so save
+  state doesn't hinge on auto-format — would dissolve #764 and the thumbnail
+  dedup gap together.

--- a/src/main.ts
+++ b/src/main.ts
@@ -4920,7 +4920,7 @@ async function main() {
     // saving inside loadVersionIntoEditor would land under the wrong id.
     const { session, currentPart } = getState();
     if (session && currentPart) {
-      await writeDraft(session.id, getActiveLanguage(), getValue(), currentPart.id, getCompanionFiles());
+      await writeDraft(session.id, getActiveLanguage(), getValue(), currentPart.id, getCompanionFiles(), currentDraftRegions());
     }
     const version = await changePart(partId);
     // skipDraftSave: the outgoing draft was already saved above.
@@ -5023,8 +5023,8 @@ async function main() {
       // Unlike the rail-switch path we deliberately DON'T auto-save it as a
       // version — leaving it unsaved is exactly what surfaces it in that modal.
       const { session, currentPart } = getState();
-      if (session && currentPart && !isStarterCode(getValue())) {
-        await writeDraft(session.id, getActiveLanguage(), getValue(), currentPart.id, getCompanionFiles());
+      if (session && currentPart && (!isStarterCode(getValue()) || hasColorRegions())) {
+        await writeDraft(session.id, getActiveLanguage(), getValue(), currentPart.id, getCompanionFiles(), currentDraftRegions());
       }
       await createPart();
       startNewPartInEditor();
@@ -5527,7 +5527,7 @@ async function main() {
       if (!opts.skipDraftSave) {
         const sid = getState().session?.id;
         const pid = getState().currentPart?.id;
-        if (sid) await writeDraft(sid, getActiveLanguage(), getValue(), pid, getCompanionFiles());
+        if (sid) await writeDraft(sid, getActiveLanguage(), getValue(), pid, getCompanionFiles(), currentDraftRegions());
       }
       await switchLanguage(versionLang);
     } else {
@@ -6212,6 +6212,13 @@ async function main() {
   // reload / crash. It is deliberately skipped when we loaded an OLDER version
   // (explicit history navigation), so a stale draft never shadows a version
   // the user intentionally went back to.
+
+  /** Snapshot the current paint regions for stashing into a draft. Returns the
+   *  serialized regions array when there are any user-painted regions, or
+   *  undefined when the part is unpainted (so the draft omits the field). */
+  const currentDraftRegions = (): SerializedColorRegion[] | undefined =>
+    (hasColorRegions() ? serializeRegions() : undefined);
+
   async function restoreDraftIfNewer(): Promise<void> {
     const sid = getState().session?.id;
     if (!sid) return;
@@ -6230,10 +6237,24 @@ async function main() {
     const isScad = getActiveLanguage() === 'scad';
     const draftCompanions = isScad ? (draft.companionFiles ?? {}) : {};
     const companionsDiffer = isScad && !companionFilesEqual(getCompanionFiles(), draftCompanions);
-    if (draft.code === getValue() && !companionsDiffer) return;
-    if (isScad) setCompanionFiles(draftCompanions);
-    setValue(draft.code);
-    await runCodeSync(draft.code);
+    const hasDraftPaint = !!(draft.colorRegions && draft.colorRegions.length > 0);
+    // Skip only when code, companions, AND paint all match the loaded state.
+    if (draft.code === getValue() && !companionsDiffer && !hasDraftPaint) return;
+    if (draft.code !== getValue() || companionsDiffer) {
+      // Code or companions changed \u2014 re-run to produce the correct mesh before
+      // applying paint on top.
+      if (isScad) setCompanionFiles(draftCompanions);
+      setValue(draft.code);
+      await runCodeSync(draft.code);
+    }
+    // Re-apply the stashed paint onto the (now-current) mesh. rehydrateColorRegions
+    // clears existing user regions first, so it correctly supersedes whatever the
+    // saved version had. Only rehydrate when the draft actually carries paint \u2014
+    // if it doesn't, leave the existing paint state (loaded from the saved version)
+    // untouched so we don't accidentally clear paint that was already there.
+    if (hasDraftPaint) {
+      await rehydrateColorRegions({ colorRegions: draft.colorRegions });
+    }
   }
 
   async function syncEditorFromURL() {
@@ -6595,7 +6616,7 @@ async function main() {
     const pid = getState().currentPart?.id;
     const lang = getActiveLanguage();
     const code = getValue();
-    void writeDraft(sid, lang, code, pid, getCompanionFiles()).catch((e) => {
+    void writeDraft(sid, lang, code, pid, getCompanionFiles(), currentDraftRegions()).catch((e) => {
       if (isQuotaError(e)) {
         showToast('Storage full — could not autosave your draft. Free up space or export your work.', { variant: 'warn' });
       }
@@ -7817,7 +7838,7 @@ async function main() {
       // Persist the previous language's working buffer so flipping back
       // restores it exactly. Both languages stay live in IDB until the
       // part/session is deleted. Companions ride along for the SCAD buffer.
-      await writeDraft(sid, prevLang, currentCode, pid, getCompanionFiles());
+      await writeDraft(sid, prevLang, currentCode, pid, getCompanionFiles(), currentDraftRegions());
     }
     await applyEngineLanguage(lang);
     let nextCode: string | null = null;

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -175,6 +175,11 @@ export interface SessionDraft {
    *  recovers companion-file edits the same way it recovers main-code edits.
    *  Only written for SCAD drafts that have companions; absent otherwise. */
   companionFiles?: Record<string, string>;
+  /** Unsaved user paint regions (serialized) so a part that has been painted
+   *  but not yet saved keeps its paint across a part switch or reload. Stored
+   *  opaquely (unknown[]) to avoid importing color types into this low layer.
+   *  Only written when there are non-empty regions; absent otherwise. */
+  colorRegions?: unknown[];
   updatedAt: number;
 }
 
@@ -1071,7 +1076,7 @@ export async function getDraft(sessionId: string, language: 'manifold-js' | 'sca
   return reqToPromise(store.get(draftId(sessionId, language, partId))) as Promise<SessionDraft | null>;
 }
 
-export async function setDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', code: string, partId?: string, companionFiles?: Record<string, string>): Promise<void> {
+export async function setDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', code: string, partId?: string, companionFiles?: Record<string, string>, colorRegions?: unknown[]): Promise<void> {
   const store = await tx('drafts', 'readwrite');
   const row: SessionDraft = {
     id: draftId(sessionId, language, partId),
@@ -1079,6 +1084,7 @@ export async function setDraft(sessionId: string, language: 'manifold-js' | 'sca
     language,
     code,
     ...(companionFiles && Object.keys(companionFiles).length > 0 ? { companionFiles } : {}),
+    ...(colorRegions && colorRegions.length > 0 ? { colorRegions } : {}),
     updatedAt: Date.now(),
   };
   store.put(row);

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -706,10 +706,14 @@ export async function renameSession(id: string, newName: string): Promise<void> 
 // with the session (via sessionId index) and pruned when a part is deleted.
 
 /** The recoverable contents of an editor draft: the main buffer plus, for SCAD
- *  drafts, any unsaved companion files. */
+ *  drafts, any unsaved companion files, and unsaved user paint regions. */
 export interface DraftContents {
   code: string;
   companionFiles?: Record<string, string>;
+  /** Unsaved paint regions serialized from the draft slot. Absent when no paint
+   *  was stashed (e.g. the part was never painted or the draft predates this
+   *  field). */
+  colorRegions?: SerializedColorRegion[];
 }
 
 /** Read the working buffer for a (session, part, language) triple. Pass
@@ -718,15 +722,20 @@ export interface DraftContents {
 export async function readDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', partId?: string): Promise<DraftContents | null> {
   const row = await dbGetDraft(sessionId, language, partId);
   if (!row) return null;
-  return { code: row.code, companionFiles: row.companionFiles };
+  return {
+    code: row.code,
+    companionFiles: row.companionFiles,
+    colorRegions: row.colorRegions as SerializedColorRegion[] | undefined,
+  };
 }
 
 /** Write the working buffer for a (session, part, language) triple. Idempotent
  *  — the row is upserted by composite key. `companionFiles` is persisted for
  *  SCAD drafts so companion edits survive a reload; pass `{}` (or omit) for
- *  languages that don't use them. */
-export async function writeDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', code: string, partId?: string, companionFiles?: Record<string, string>): Promise<void> {
-  await dbSetDraft(sessionId, language, code, partId, companionFiles);
+ *  languages that don't use them. `colorRegions` carries unsaved paint so a
+ *  painted part keeps its paint across a switch or reload. */
+export async function writeDraft(sessionId: string, language: 'manifold-js' | 'scad' | 'replicad' | 'voxel', code: string, partId?: string, companionFiles?: Record<string, string>, colorRegions?: SerializedColorRegion[]): Promise<void> {
+  await dbSetDraft(sessionId, language, code, partId, companionFiles, colorRegions);
 }
 
 
@@ -936,10 +945,13 @@ export async function partSaveState(part: Part): Promise<PartSaveState> {
   const latest = await getLatestVersion(part.id);
   if (!latest) {
     // Never committed: "unsaved" if any stashed draft holds real (non-starter)
-    // content; otherwise it's an untouched new part ("no changes yet").
+    // content or unsaved paint; otherwise it's an untouched new part.
     const drafts = await dbListDrafts(part.sessionId);
     const prefix = `${part.sessionId}:${part.id}:`;
-    const hasContent = drafts.some(d => d.id.startsWith(prefix) && !isStarterCode(d.code));
+    const hasContent = drafts.some(d =>
+      d.id.startsWith(prefix) &&
+      (!isStarterCode(d.code) || (Array.isArray(d.colorRegions) && d.colorRegions.length > 0))
+    );
     return hasContent ? 'unsaved' : 'empty';
   }
   const lang = effectiveVersionLanguage(latest, currentState.session);
@@ -949,6 +961,13 @@ export async function partSaveState(part: Part): Promise<PartSaveState> {
   // SCAD drafts also stash unsaved companion-file edits; treat those as unsaved.
   if (lang === 'scad' && !companionFilesEqual(latest.companionFiles ?? {}, draft.companionFiles ?? {})) {
     return 'unsaved';
+  }
+  // A draft with paint regions that differ from the saved version's paint is unsaved.
+  if (draft.colorRegions && draft.colorRegions.length > 0) {
+    const savedGeoData = latest.geometryData as Record<string, unknown> | null;
+    if (!colorRegionsEqual({ colorRegions: draft.colorRegions }, savedGeoData)) {
+      return 'unsaved';
+    }
   }
   return 'clean';
 }

--- a/tests/part-unload-paint.spec.ts
+++ b/tests/part-unload-paint.spec.ts
@@ -1,0 +1,152 @@
+// E2E coverage for paint persistence across part switches (issue #736).
+// When a user paints a part and then switches away (via "+" add-part or the
+// part rail), the unsaved paint must survive in the per-part draft and be
+// restored when they switch back. The part should still appear as "unsaved"
+// in the multi-part save modal until the paint is committed.
+
+import { test, expect, type Page } from 'playwright/test';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+async function openEditor(page: Page) {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('partwright-tour-completed', '1');
+      localStorage.setItem('partwright-ai-settings-v1', JSON.stringify({ editorCollapsed: false }));
+    } catch { /* ignore */ }
+  });
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 30_000 });
+  await page.waitForFunction(() => !!(window as any).partwright?.runAndSave, { timeout: 30_000 });
+}
+
+const cube = `const { Manifold } = api; return Manifold.cube([10,10,10], true);`;
+
+test.describe('Part-unload paint persistence', () => {
+  test('paint survives clicking the + add-part button and switching back', async ({ page }) => {
+    await openEditor(page);
+
+    // Create a session, run+save part 1 to give it a mesh to paint.
+    await page.evaluate(async (code) => {
+      const pw = (window as any).partwright;
+      await pw.createSession('PaintPersist');
+      await pw.runAndSave(code, 'v1');
+    }, cube);
+
+    // Paint some triangles on part 1 via the console API.
+    await page.evaluate(() => {
+      (window as any).partwright.paintFaces({ triangleIds: [0, 1, 2, 3], color: [1, 0, 0], name: 'red' });
+    });
+
+    // Verify paint was applied.
+    const regionsBefore = await page.evaluate(() =>
+      (window as any).partwright.listRegions()
+    );
+    expect(regionsBefore.length).toBeGreaterThan(0);
+
+    // Note the id of Part 1 so we can navigate back to it.
+    const part1Id = await page.evaluate(() =>
+      (window as any).partwright.listParts().find((p: any) => p.isCurrent)?.id
+    );
+    expect(part1Id).toBeTruthy();
+
+    // Blur the editor to fire the autosave (stashes the draft including paint).
+    await page.locator('.cm-content').blur();
+    await page.waitForTimeout(600);
+
+    // Click the "+" add-part button — this is the action that previously lost paint.
+    // The button stashes the current part's draft (code + paint) before switching.
+    await page.locator('#btn-add-part').click();
+    await page.waitForTimeout(2000); // let the new part initialize (WASM)
+
+    // Switch back to Part 1 by clicking its row in the parts rail.
+    await page.locator(`#parts-list [data-part-id="${part1Id}"]`).click();
+    // Wait for the part switch + draft restore + rehydrate to complete.
+    await page.waitForTimeout(2500);
+
+    // The paint regions should be restored from the draft.
+    const regionsAfter = await page.evaluate(() =>
+      (window as any).partwright.listRegions()
+    );
+    expect(regionsAfter.length).toBeGreaterThan(0);
+  });
+
+  test('save-all captures stashed paint: painted+unswitched part appears in modal', async ({ page }) => {
+    await openEditor(page);
+
+    // Create session, run+save Part 1, paint it.
+    const part1Id = await page.evaluate(async (code) => {
+      const pw = (window as any).partwright;
+      await pw.createSession('PaintSaveAll');
+      await pw.runAndSave(code, 'v1');
+      pw.paintFaces({ triangleIds: [0, 1, 2, 3], color: [0, 1, 0], name: 'green' });
+      return pw.listParts().find((p: any) => p.isCurrent)?.id;
+    }, cube);
+
+    // Blur the editor so the autosave draft flush fires (captures paint too).
+    await page.locator('.cm-content').blur();
+    await page.waitForTimeout(600);
+
+    // Click "+" to add a new part — stashes the painted draft (code + paint).
+    await page.locator('#btn-add-part').click();
+    await page.waitForTimeout(1500);
+
+    // Trigger Cmd/Ctrl+S → should open the multi-part save modal listing Part 1 as unsaved.
+    await page.keyboard.press('ControlOrMeta+s');
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 7_000 });
+    // Part 1 must appear (the painted draft makes it unsaved even though code matches saved).
+    await expect(dialog.getByText('Part 1', { exact: true })).toBeVisible();
+
+    // "Save all" commits every listed part.
+    await dialog.getByRole('button', { name: 'Save all' }).click();
+    await page.waitForTimeout(3000);
+
+    // Switch back to Part 1 and verify its latest version has color regions.
+    await page.locator(`#parts-list [data-part-id="${part1Id}"]`).click();
+    await page.waitForTimeout(2500);
+
+    const regionsOnSaved = await page.evaluate(() =>
+      (window as any).partwright.listRegions()
+    );
+    expect(regionsOnSaved.length).toBeGreaterThan(0);
+  });
+
+  test('paint persists across a page reload when stashed in draft via the + button', async ({ page }) => {
+    await openEditor(page);
+
+    // Create session, run+save, paint.
+    const { sessionId, part1Id } = await page.evaluate(async (code) => {
+      const pw = (window as any).partwright;
+      const s = await pw.createSession('PaintReload');
+      await pw.runAndSave(code, 'v1');
+      pw.paintFaces({ triangleIds: [0, 1, 2, 3], color: [0, 0, 1], name: 'blue' });
+      const id = pw.listParts().find((p: any) => p.isCurrent)?.id;
+      return { sessionId: s.id, part1Id: id };
+    }, cube);
+
+    // Blur to trigger autosave so the draft is flushed before clicking "+".
+    await page.locator('.cm-content').blur();
+    await page.waitForTimeout(600);
+
+    // Click "+" — this stashes Part 1's draft (with paint) via the button path.
+    await page.locator('#btn-add-part').click();
+    await page.waitForTimeout(1500);
+
+    // Reload the page — the draft (including stashed paint) must survive in IDB.
+    await page.goto(`/editor?session=${sessionId}`);
+    await page.waitForSelector('text=Ready', { timeout: 30_000 });
+    await page.waitForFunction(() => !!(window as any).partwright?.listParts, { timeout: 30_000 });
+    await page.waitForTimeout(1500);
+
+    // The session should open on the last active part (Part 2). Switch to Part 1 —
+    // restoreDraftIfNewer should rehydrate its stashed paint from the draft.
+    await page.locator(`#parts-list [data-part-id="${part1Id}"]`).click();
+    await page.waitForTimeout(2500);
+
+    const regionsAfterReload = await page.evaluate(() =>
+      (window as any).partwright.listRegions()
+    );
+    expect(regionsAfterReload.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #736 — painting a part and then clicking **➕ Add part** (or otherwise leaving it) lost the unsaved paint.

**Root cause (confirmed):** part-transition preservation was hand-wired per UI handler, using two different mechanisms. The rail-switch path (`selectPart`) calls `preserveCurrentEditsIfNeeded()` → saves a version *including* paint. But the ➕ path (`onCreatePart`) only stashed a **code-only draft**, then `startNewPartInEditor` → `dropPaintState()` wiped the regions. Per-part drafts never carried paint, so the paint was gone.

**Fix (drafts carry paint):** instead of auto-saving, the per-part editor **draft now carries the unsaved paint regions** — so a painted-but-unsaved part stays "unsaved" (still listed in the multi-part save modal) while its paint survives a switch and a reload.

- `SessionDraft.colorRegions` — IndexedDB-only, optional, **no schema-version bump** (old drafts just lack it). Threaded through `setDraft` / `writeDraft` / `readDraft` (typed `SerializedColorRegion[]` at the sessionManager layer).
- `partSaveState`: a draft whose paint differs from the saved version (or a never-saved part whose draft has paint) is now `'unsaved'`, so the save-all modal still lists it.
- `main.ts`: a `currentDraftRegions()` helper stashes the serialized regions at all 5 `writeDraft` sites; `restoreDraftIfNewer` replays them via `rehydrateColorRegions` — re-running code **only when it actually changed** (no double-render) and rehydrating paint **only when the draft carries it** (so it never wipes a loaded version's paint). The ➕ stash guard now also fires when paint exists on starter code (the reported case).

This keeps the architecture's intent (the part stays unsaved for the modal) while closing the paint-loss gap. A fuller "single `unloadCurrentPart()` lifecycle" refactor is still possible later, but this makes the draft the consistent carrier of *all* unsaved state (code + companions + paint).

## Test plan
- New `tests/part-unload-paint.spec.ts`: paint → ➕ → switch back restores the paint; Save-all captures the stashed paint into the part's version; paint survives a page reload.
- `typecheck` clean; unit tier **1508** passed; `parts.spec` (incl. "adding a part after painting clears stale regions" — the API path still gets a clean slate) and `save-all-parts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGyRGhCFTap3MRD1SLyVnM)_