### PR TITLE
fix: coi-serviceworker import.meta parse error breaking COI service-worker registration

### DIFF
--- a/prompts/20260619-203825-coi-serviceworker-import-meta.md
+++ b/prompts/20260619-203825-coi-serviceworker-import-meta.md
@@ -1,0 +1,45 @@
+---
+session: "fix-catalog-redirect"
+timestamp: "2026-06-19T20:38:25Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+When I click on a catalog image on the landing page or in the catalog, I get
+redirected back to the landing page. Maybe you just need to update to the latest
+main? There were some deployment/url/redirect changes.
+
+## Assistant
+
+## Investigation + decision
+
+Could NOT reproduce the catalog→landing bounce in any fresh context: local dev,
+production deep-link, and production tile-click all correctly load the editor
+(`/editor?catalog=…` → `/editor?session=…&v=1`). Server returns 200 for `/editor`
+everywhere (no server redirect). Both surfaces link tiles to `/editor?catalog=…`
+(`landingEntry.ts:163`, `content/build/render.ts:282`) — same working path.
+
+But every page load threw `Cannot use 'import.meta' outside a module`. Root
+cause: `public/coi-serviceworker.js:56` referenced `import.meta.url`, introduced
+10 days ago in #547 (`3bb99479`). The file is loaded as a CLASSIC `<script src>`,
+so `import.meta` is a PARSE-TIME SyntaxError — the whole script is discarded.
+Effect: the cross-origin-isolation service worker never registers/updates. On
+Cloudflare the page still works (COOP/COEP come from `_headers`), which is why it
+shipped invisibly — but a returning browser keeps an old, un-updatable SW
+controlling every navigation (and the `else` branch's `window.location.reload()`
+still fires when not yet isolated). That's the most likely source of the
+returning-browser navigation weirdness the user saw; a fresh context (my tests,
+incognito) never hits it.
+
+Fix: replace `new URL("coi-serviceworker.js", import.meta.url).href` with
+`document.currentScript.src` (standard coi-serviceworker v0.1.7 approach; still
+base-correct for `/vN/` deploys since Vite prefixes the `src`; mirrors
+`route-init.js`'s own currentScript pattern). Added `tests/coi-serviceworker.spec.ts`
+asserting `/editor` and `/catalog` load with zero uncaught page errors and a
+catalog tile opens the editor (not landing) — the cheap guard that would have
+caught this. Verified locally: import.meta error gone, catalog click → editor.
+
+Reported honestly that I could not reproduce the exact bounce in a fresh browser
+and that production lags main (different bundle hashes) — so a hard-refresh /
+SW-clear or a production promotion may also be part of the user's fix.

--- a/public/coi-serviceworker.js
+++ b/public/coi-serviceworker.js
@@ -53,7 +53,15 @@ if (typeof window === 'undefined') {
       window.sessionStorage.setItem("coiReloadedByCOI", "true");
       window.location.reload();
     } else if (n.serviceWorker) {
-      n.serviceWorker.register(new URL("coi-serviceworker.js", import.meta.url).href).then(
+      // Register this very file as the service worker. Must NOT use `import.meta`
+      // here: this script is loaded as a CLASSIC <script src> (not type=module),
+      // so `import.meta` is a *parse-time* SyntaxError that discards the whole
+      // file — silently breaking COI registration on every load. `currentScript`
+      // is reliable for a synchronous classic script and already carries the
+      // build's base prefix (e.g. /v1/coi-serviceworker.js), so it stays
+      // base-correct for versioned (/vN/) deploys. Mirrors route-init.js.
+      var swUrl = (document.currentScript && document.currentScript.src) || "coi-serviceworker.js";
+      n.serviceWorker.register(swUrl).then(
         (registration) => {
           registration.addEventListener("updatefound", () => {
             const newSW = registration.installing;

--- a/tests/coi-serviceworker.spec.ts
+++ b/tests/coi-serviceworker.spec.ts
@@ -1,0 +1,43 @@
+// Guards against the COI service-worker script silently breaking on load.
+//
+// `public/coi-serviceworker.js` is loaded as a CLASSIC <script src> (not a
+// module). A regression (#547) made it reference `import.meta.url`, which is a
+// PARSE-TIME SyntaxError in a classic script — discarding the whole file, so the
+// cross-origin-isolation service worker never registered/updated and every page
+// load threw "Cannot use 'import.meta' outside a module". That error is invisible
+// to the type checker and to a fresh app boot (the page still works when COOP/COEP
+// arrive via _headers), so it shipped. This test catches that class of regression
+// by asserting the content pages and the editor load with no uncaught page error.
+
+import { test, expect, type Page } from 'playwright/test';
+
+async function pageErrorsOnLoad(page: Page, route: string): Promise<string[]> {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await page.goto(route);
+  await page.waitForTimeout(2500);
+  return errors;
+}
+
+test.describe('COI service worker', () => {
+  test('the editor loads with no uncaught page error (coi-serviceworker parses)', async ({ page }) => {
+    const errors = await pageErrorsOnLoad(page, '/editor');
+    expect(errors, `unexpected page errors:\n${errors.join('\n')}`).toEqual([]);
+  });
+
+  test('the catalog page loads with no uncaught page error', async ({ page }) => {
+    const errors = await pageErrorsOnLoad(page, '/catalog');
+    expect(errors, `unexpected page errors:\n${errors.join('\n')}`).toEqual([]);
+  });
+
+  test('clicking a catalog tile opens the editor, not the landing page', async ({ page }) => {
+    await page.goto('/catalog');
+    await page.waitForTimeout(1500);
+    await page.locator('[data-catalog-tile]').first().click();
+    // The catalog deep-link imports the entry and rewrites to ?session=…; the
+    // editor must be present and the inline landing hero must NOT be showing.
+    await expect(page.locator('.cm-editor, #code-editor').first()).toBeVisible({ timeout: 20_000 });
+    await expect(page).toHaveURL(/\/editor\?/);
+    expect(await page.locator('#landing-inline').isVisible().catch(() => false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Investigating the reported "clicking a catalog image bounces back to the landing page," I found and fixed a **service-worker parse error** that's been throwing on every page load for 10 days.

`public/coi-serviceworker.js` is loaded as a **classic** `<script src>` (not `type="module"`). Line 56 referenced **`import.meta.url`** (introduced in #547, `3bb99479`). `import.meta` outside a module is a **parse-time `SyntaxError`**, so the *entire* script is discarded — every load threw `Cannot use 'import.meta' outside a module`, and the cross-origin-isolation service worker **never registered or updated**.

On Cloudflare the app still works because COOP/COEP arrive via `public/_headers`, which is why this shipped invisibly. But a **returning browser** is left with a stale, un-updatable SW controlling every navigation (and the `else` branch still fires `window.location.reload()` when the page isn't yet isolated) — the most plausible source of returning-browser navigation weirdness, which a fresh/incognito context never reproduces.

**Fix:** use `document.currentScript.src` (the standard coi-serviceworker v0.1.7 approach) instead of `import.meta.url`. It's reliable for a synchronous classic script, stays base-correct for `/vN/` versioned deploys (Vite prefixes the `src`), and mirrors how `public/route-init.js` already derives its own base.

### Honest caveat on the original symptom
I **could not reproduce the catalog→landing bounce** in any fresh context — local dev, production deep-link, and production tile-click all correctly load the editor (`/editor?catalog=…` → `/editor?session=…&v=1`), and the server returns `200` for `/editor` everywhere (no server redirect). The three environments also run different bundles (production lags `main`), so a **hard refresh / clearing the old service worker**, or a **production promotion of latest `main`**, may also be part of the fix on the user's end. This PR fixes the one concrete, confirmed defect in that area and removes a real confounder.

## Test plan
- New `tests/coi-serviceworker.spec.ts`: `/editor` and `/catalog` load with **zero** uncaught page errors (the cheap guard that would have caught this), and clicking a catalog tile opens the editor — not the landing page.
- Verified locally before/after: the `import.meta` page error is present on `main` and **gone** after the fix; catalog click → editor in both dev and against the live production site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGyRGhCFTap3MRD1SLyVnM)_