### PR TITLE
docs: changelog + help for the v1.0 release

### DIFF
--- a/prompts/changelog-v1-release.md
+++ b/prompts/changelog-v1-release.md
@@ -1,0 +1,51 @@
+---
+date: 2026-06-20
+branch: claude/changelog-v1-release
+files_changed:
+  - src/content/data/whatsNew.ts
+  - src/content/data/help.ts
+---
+
+## Human
+
+After cutting the v1.0.0 release, the user asked for a PR that updates the
+public-facing changelog and any other documentation that was missed while the
+recent work was being done.
+
+## Assistant
+
+The changelog (`src/content/data/whatsNew.ts`, a hand-curated weekly log) stopped
+at "June 12 – 13, 2026" — but a full week of user-visible work had merged to
+`main` since then. Enumerated it from the `feat:`/`fix:` commit subjects on
+`origin/main` since June 14 and clustered the user-facing themes into a new
+"June 14 – 20, 2026" week entry, headlined "Partwright 1.0":
+
+- **Releases** — first tagged 1.0 release (version in the About dialog, semver
+  going forward); pinned version URLs (`/v1/…` frozen mounts, versionless root,
+  `/current/` alias).
+- **Export & printing** — export every part at once; multi-plate Bambu/Orca 3MF
+  with filament colours; lift the 3-filament cap (every distinct + hand-painted
+  color to its own filament); export warns on unsaved/never-saved parts and
+  surfaces printability issues.
+- **Figures** — 20+ full-body catalog figures + ear busts; richer noses, lip /
+  eyebrow / elf-ear refinements; belly + maternity bodies; flush areolae;
+  progressive coarse→fine render.
+- **Garments & footwear** — conforming/draping apron/bib/tabard/cape panels and
+  skirt coverage; footwear derived from the bare foot via SDF offset, flat sole
+  for plantarflexed feet.
+- **Editor, paint & AI** — cancel a deep-link render; smoother painting (no
+  needless re-subdivision, edge-smoothing tip); AI can target parts by
+  name/id/index; 500k triangle budget.
+
+Doc gap also fixed: the help page's export section listed the formats but never
+mentioned the new **multi-part / multi-plate / multi-filament** export. Added a
+"Multi-part & multi-color export" paragraph to `help.ts` covering all-parts
+export, plate layout, the lifted color cap, and the unsaved/printability warning.
+
+Checked `public/llms.txt` — it's intentionally concise and already links
+`/whats-new` and `/ai.md`, so no change needed there.
+
+Per the deployment pipeline, changelog/help edits must flow through `main`
+(a `docs:` PR), never onto the release branch — so this is a fresh branch off
+`origin/main`. Verified: `npm run typecheck` clean; screenshotted `/whats-new`
+to confirm the new entry renders.

--- a/src/content/data/help.ts
+++ b/src/content/data/help.ts
@@ -170,6 +170,7 @@ export const HELP_STATIC_SECTIONS: ContentSection[] = [
       '<li><strong class="text-zinc-300">GLB</strong> — Web/preview format with vertex colors. Good for embedding online, not read by slicers.</li>' +
       '<li><strong class="text-zinc-300">STEP</strong> — Exact BREP solids, available from BREP-language sessions. The CAD interchange format for downstream engineering tools.</li>' +
       '</ul><br>' +
+      '<strong class="text-zinc-300">Multi-part &amp; multi-color export:</strong> A session with several parts exports them all at once — 3MF, STL, OBJ, and GLB all carry every part. Multi-part 3MF lays the parts out across printer plates with their filament colours preserved and arranged to fit the bed, ready for Bambu Studio or OrcaSlicer. Color export is not capped at three filaments — every distinct color, including hand-painted per-triangle color, maps to its own filament. Before exporting, the confirm dialog warns when any part (even one you’re not currently viewing) has unsaved or never-saved changes and surfaces printability issues, so nothing ships stale.<br><br>' +
       '<strong class="text-zinc-300">Export — Project formats:</strong>' +
       '<ul class="list-disc list-inside mt-2 space-y-1 text-zinc-400">' +
       '<li><strong class="text-zinc-300">Session (.partwright.json)</strong> — All versions, notes, annotations, color regions, and attached images. Another Partwright user can import this and pick up where you left off. A dialog lets you choose whether to embed the thumbnail, notes, annotations, and color regions.</li>' +

--- a/src/content/data/whatsNew.ts
+++ b/src/content/data/whatsNew.ts
@@ -26,6 +26,97 @@ export const WHATS_NEW_INTRO =
 // Most recent first. Each entry is a calendar week (Mon–Sun) of shipped work.
 export const WHATS_NEW_WEEKS: WeekEntry[] = [
   {
+    range: 'June 14 – 20, 2026',
+    headline: 'Partwright 1.0 — multi-part & multi-color export, a big figure expansion, and pinned version URLs',
+    groups: [
+      {
+        label: 'Releases',
+        items: [
+          {
+            title: 'Partwright 1.0',
+            body: 'Partwright reached its first tagged release. The running version is shown in the About dialog, and every release from here on is semantically versioned (vX.Y.Z) so you can tell at a glance whether an update is a routine fix or a bigger change.',
+          },
+          {
+            title: 'Pinned version URLs',
+            body: 'The site root always serves the latest version (the usual /, /editor, /catalog…). Each major version is now also reachable at its own path — e.g. /v1/editor — which stays frozen even after a newer version takes over the root, so a link you pin keeps working. /current/ is a stable alias that always points at the newest.',
+          },
+        ],
+      },
+      {
+        label: 'Export & printing',
+        items: [
+          {
+            title: 'Export every part at once',
+            body: 'A session with several parts now exports them all together — to 3MF, STL, OBJ, or GLB — instead of one part at a time.',
+          },
+          {
+            title: 'Multi-plate Bambu / Orca layout',
+            body: 'Multi-part 3MF export lays your parts out across printer plates with their filament colours preserved, arranged to fit the bed, ready to open in Bambu Studio or OrcaSlicer.',
+          },
+          {
+            title: 'More than three colors',
+            body: 'Color export is no longer capped at three filaments — every distinct color in a model is exported to its own filament, and hand-painted per-triangle color carries through to the slicer.',
+          },
+          {
+            title: 'Don’t lose unsaved work on export',
+            body: 'The export dialog now warns when any part — including parts you’re not currently looking at — has unsaved or never-saved changes, surfaces printability issues right in the confirm step, and can jump you straight to a save chooser so nothing ships stale.',
+          },
+        ],
+      },
+      {
+        label: 'Figures',
+        items: [
+          {
+            title: 'Many more ready-made figures',
+            body: 'The catalog gained 20+ full-body figures showcasing the figure builder, plus ear-showcase busts — all baking as clean, single printable pieces.',
+          },
+          {
+            title: 'More expressive faces',
+            body: 'Figure faces got richer noses with a properly sculpted, projecting form (and a cleaner nostril carve), named lip-shape presets, preset-driven eyebrows that track the eyes, and an elf-ear option with an adjustable point and tilt.',
+          },
+          {
+            title: 'More varied bodies',
+            body: 'New body controls include a native belly knob, a maternity build with a cradle pose and dress for expectant figures, and areolae/nipples that seat flush and paint cleanly across slim, muscled, and fuller chests.',
+          },
+          {
+            title: 'Smoother, faster figure preview',
+            body: 'Figures now render progressively — a coarse pass appears almost immediately and refines to full detail — so posing and tweaking feel responsive instead of waiting on a single slow render.',
+          },
+        ],
+      },
+      {
+        label: 'Garments & footwear',
+        items: [
+          {
+            title: 'Conforming and draping garments',
+            body: 'Figures can wear front/back-panel garments — apron, bib, tabard, cape — that either conform to the torso or drape from it (with apron ties and adjustable thickness), and dress/robe skirts now reliably cover the legs and chest instead of leaving gaps.',
+          },
+          {
+            title: 'Footwear that fits the foot',
+            body: 'Shoes and boots are now derived from each figure’s bare foot via an SDF offset rather than a generic last, so they fit without heel jut or club toe, and a lifted (plantarflexed) foot gets a flat sole instead of a bubble.',
+          },
+        ],
+      },
+      {
+        label: 'Editor, paint & AI',
+        items: [
+          {
+            title: 'Cancel a slow render',
+            body: 'The render Cancel button is now wired up from the moment a deep-linked model starts rendering, so a heavy model opened from a link can be interrupted instead of locking the view.',
+          },
+          {
+            title: 'Smoother painting',
+            body: 'After a smooth stroke the mesh no longer needlessly re-subdivides on every subsequent paint, and the paint refine modal offers a one-click “turn off edge smoothing” tip when it would give cleaner results.',
+          },
+          {
+            title: 'AI can target any part',
+            body: 'The in-app AI can now address parts by name, id, or index — not just whichever part is selected — and the advisory triangle budget was raised to 500k for more detailed models.',
+          },
+        ],
+      },
+    ],
+  },
+  {
     range: 'June 12 – 13, 2026',
     headline: 'Diverse figures, footwear and expressive faces, plus editor and viewport polish',
     groups: [


### PR DESCRIPTION
## What

Updates the public-facing **changelog** and the **help page** to cover the work that shipped for the v1.0 release but hadn't been documented yet.

### `src/content/data/whatsNew.ts` — new "June 14 – 20, 2026" entry
The changelog had stopped at *June 12 – 13*, but a full week of user-visible work merged to `main` since. New entry, headlined **"Partwright 1.0"**, with groups:
- **Releases** — first tagged 1.0 release (version shown in About; semver going forward); pinned version URLs (`/v1/…` frozen mounts, versionless root, `/current/` alias).
- **Export & printing** — export every part at once; multi-plate Bambu/Orca 3MF with filament colours; lift the 3-filament cap; export warns on unsaved/never-saved parts + surfaces printability.
- **Figures** — 20+ full-body catalog figures + ear busts; richer faces (nose/lips/eyebrows/elf ears); belly + maternity bodies; flush areolae; progressive coarse→fine render.
- **Garments & footwear** — conforming/draping apron/bib/tabard/cape + skirt coverage; footwear from the bare foot via SDF offset, flat plantarflex sole.
- **Editor, paint & AI** — cancel a deep-link render; smoother painting; AI targets parts by name/id/index; 500k triangle budget.

### `src/content/data/help.ts` — export-section gap
The export section listed the formats but never mentioned the new **multi-part / multi-plate / multi-filament** export. Added a "Multi-part & multi-color export" paragraph (all-parts export, plate layout, lifted color cap, unsaved/printability warning).

Checked `public/llms.txt` — intentionally concise and already links `/whats-new` + `/ai.md`, so no change needed.

## Why through `main`

Per the deployment pipeline, changelog/help/docs edits must flow **main → gate → staging → promotion**, never onto the release branch — so this is a `docs:` PR off the latest `origin/main`. It will reach production via the normal promotion, not the in-flight #779.

## Test plan

- ✅ `npm run typecheck` clean
- ✅ Screenshotted `/whats-new` — the new v1.0 entry renders at the top in the established style (posted in chat)
- PR-checks runs build + unit + e2e shards on this draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6

---
_Generated by [Claude Code](https://claude.ai/code/session_019jMWW5CUnuGD5fxTmP49r6)_