### PR TITLE
feat: add a mobile Parts pane to the editor pane toggle

### DIFF
--- a/prompts/mobile-parts-pane.md
+++ b/prompts/mobile-parts-pane.md
@@ -1,0 +1,53 @@
+---
+date: 2026-06-20
+branch: claude/mobile-part-list-view-aqf2u7
+files_changed:
+  - src/ui/mobilePane.ts
+  - src/ui/layout.ts
+  - src/ui/partList.ts
+  - tests/mobile-parts-pane.spec.ts
+---
+
+## Human
+
+On mobile I don't see any way to view and change parts in the part list.
+
+## Assistant
+
+Root cause: on mobile the activity rail collapses from a vertical left sidebar
+to a horizontal top strip, so the parts list can't live inside it as it does on
+desktop. `placeParts()` instead nested the parts rail inside `editorGroup` (the
+code-pane container) as a cramped 144px column. But mobile shows exactly one of
+editor / viewport at a time, and `editorGroup` is hidden whenever the viewport
+is showing — and the default mobile pane is `viewport`, plus every rail tab tap
+forces the viewport pane. So a phone user almost never saw parts, and the only
+desktop "re-show" affordance (the floating » chip) also lived in the hidden
+`editorGroup`. Net effect: no reachable, discoverable way to view or switch
+parts on mobile.
+
+Fix: give the parts list its own mobile pane. The Code / Viewport toggle becomes
+a three-way Code / Parts / Viewport segmented control, and `MobilePane` gains a
+`'parts'` value. In the parts pane, `editorGroup` is shown but the code pane is
+hidden and the parts rail expands to full width (`flex-1` instead of the `w-36`
+column), giving touch-friendly full-width part rows with thumbnail, drag grip,
+rename, delete, and the add button. As a secondary win the Code pane now hides
+the parts column entirely, so the editor gets full width on a phone.
+
+Details:
+- `mobilePane.ts`: extend the union + the localStorage validation with `'parts'`.
+- `layout.ts`: add the third toggle button; `syncMobileToggleUI` and
+  `syncPaneVisibility` handle three panes (editorGroup shown for editor+parts,
+  with `editorPane`/`partsRail` toggled within it; rightPane for viewport).
+  `placeParts` mobile class is now full-width, and the desktop-only rail-collapse
+  early-return is scoped to the desktop branch. The desktop branch also force-
+  un-hides `editorPane` so a `'parts'`-pane hide can't bleed across the
+  breakpoint.
+- `partList.ts`: hide the « collapse button on mobile (`hidden md:flex`) — it's a
+  desktop width-reclaim affordance and would otherwise leave the pane empty.
+
+Verified at 375px in a real browser (screenshots of all three panes) and with a
+new golden-path e2e spec (`mobile-parts-pane.spec.ts`) asserting the three-way
+toggle, that the parts rail is hidden in viewport mode, and that tapping Parts
+reveals a full-width list with a part row + add button. Desktop layout snapshot
+confirmed unchanged (parts still in the activity rail with the collapse button).
+typecheck, full unit tier (1508), and `npm run build` all pass.

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,4 +1,4 @@
-import { getMobilePane, onMobilePaneChange, setMobilePane } from './mobilePane';
+import { getMobilePane, onMobilePaneChange, setMobilePane, type MobilePane } from './mobilePane';
 import { appPath } from '../deployment';
 import { showAdvancedSettingsModal } from './advancedSettingsModal';
 import { showAboutModal } from './aboutModal';
@@ -511,21 +511,29 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   const mobileEditorBtn = document.createElement('button');
   mobileEditorBtn.textContent = 'Code';
   mobileEditorBtn.title = 'Show code editor';
+  // Parts pane — gives the parts list its own full-width mobile view so it's
+  // reachable from anywhere (the rail isn't a usable left column on a phone).
+  const mobilePartsBtn = document.createElement('button');
+  mobilePartsBtn.textContent = 'Parts';
+  mobilePartsBtn.title = 'Show the parts list';
   const mobileViewportBtn = document.createElement('button');
   mobileViewportBtn.textContent = 'Viewport';
   mobileViewportBtn.title = 'Show 3D viewport';
   mobilePaneToggle.appendChild(mobileEditorBtn);
+  mobilePaneToggle.appendChild(mobilePartsBtn);
   mobilePaneToggle.appendChild(mobileViewportBtn);
 
   // py-3 (not py-2) keeps these mobile-only toggles ≥44px tall — the minimum
   // fingertip target. The toggle strip is `md:hidden`, so desktop never sees it.
   const MOBILE_TOGGLE_ACTIVE = 'flex-1 px-4 py-3 text-sm font-medium text-zinc-100 border-b-2 border-blue-500 bg-zinc-900';
   const MOBILE_TOGGLE_INACTIVE = 'flex-1 px-4 py-3 text-sm font-medium text-zinc-500 border-b-2 border-transparent';
-  function syncMobileToggleUI(pane: 'editor' | 'viewport') {
+  function syncMobileToggleUI(pane: MobilePane) {
     mobileEditorBtn.className = pane === 'editor' ? MOBILE_TOGGLE_ACTIVE : MOBILE_TOGGLE_INACTIVE;
+    mobilePartsBtn.className = pane === 'parts' ? MOBILE_TOGGLE_ACTIVE : MOBILE_TOGGLE_INACTIVE;
     mobileViewportBtn.className = pane === 'viewport' ? MOBILE_TOGGLE_ACTIVE : MOBILE_TOGGLE_INACTIVE;
   }
   mobileEditorBtn.addEventListener('click', () => setMobilePane('editor'));
+  mobilePartsBtn.addEventListener('click', () => setMobilePane('parts'));
   mobileViewportBtn.addEventListener('click', () => setMobilePane('viewport'));
 
   // Tracks the most recently activated tab so breakpoint or mobile-pane
@@ -673,6 +681,10 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
       // Restore inline width if it was cleared on mobile, but not if collapsed.
       if (!editorCollapsed && !editorGroup.style.width) editorGroup.style.width = '40%';
       editorGroup.classList.toggle('hidden', tabHidesEditor);
+      // The parts rail + code pane are siblings only on mobile; on desktop the
+      // rail lives in the activity rail, so make sure neither was left hidden by
+      // a mobile pane choice when crossing the breakpoint.
+      editorPane.classList.remove('hidden');
       splitter.classList.toggle('hidden', tabHidesEditor || editorCollapsed);
       expandEditorBtn.classList.toggle('hidden', tabHidesEditor || !editorCollapsed);
       rightPane.classList.remove('hidden');
@@ -687,14 +699,23 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
       editorGroup.style.transition = '';
       splitter.classList.add('hidden');
       expandEditorBtn.classList.add('hidden');
+      // The desktop "collapse the rail" chip never applies on mobile — the pane
+      // toggle owns parts visibility here.
+      railExpandBtn.classList.add('hidden');
       if (tabHidesEditor) {
         editorGroup.classList.add('hidden');
+        partsRail.classList.add('hidden');
         rightPane.classList.remove('hidden');
         // No choice to make — hide the toggle on Diff.
         mobilePaneToggle.classList.add('hidden');
       } else {
         const pane = getMobilePane();
-        editorGroup.classList.toggle('hidden', pane !== 'editor');
+        // editorGroup hosts both the code pane and (on mobile) the parts rail,
+        // so it's shown for both the 'editor' and 'parts' panes; within it we
+        // reveal exactly one. 'parts' gives the list the full width.
+        editorGroup.classList.toggle('hidden', pane === 'viewport');
+        editorPane.classList.toggle('hidden', pane === 'parts');
+        partsRail.classList.toggle('hidden', pane !== 'parts');
         rightPane.classList.toggle('hidden', pane !== 'viewport');
         mobilePaneToggle.classList.remove('hidden');
         syncMobileToggleUI(pane);
@@ -797,10 +818,13 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   // rail is a horizontal strip, so Parts goes back to its column beside the
   // editor. moving a populated element preserves its children + listeners.
   const PARTS_CLASS_DESKTOP = 'flex flex-col flex-1 min-h-0 border-t border-zinc-800 overflow-hidden';
-  const PARTS_CLASS_MOBILE = 'flex flex-col shrink-0 w-36 min-h-0 border-r border-zinc-700 bg-zinc-900/60 overflow-hidden';
+  // On mobile the parts rail is its own full-width pane (selected via the pane
+  // toggle), so it grows to fill the editor group rather than sitting as a
+  // cramped fixed column. Visibility is owned by syncPaneVisibility.
+  const PARTS_CLASS_MOBILE = 'flex flex-col flex-1 min-w-0 min-h-0 bg-zinc-900/60 overflow-hidden';
   function placeParts(): void {
-    if (railCollapsed) return; // hidden either way; reposition when re-shown
     if (mqDesktop.matches) {
+      if (railCollapsed) return; // desktop-only collapse; reposition when re-shown
       partsRail.className = PARTS_CLASS_DESKTOP;
       rail.insertBefore(partsRail, catalogNavBtn);
     } else {

--- a/src/ui/mobilePane.ts
+++ b/src/ui/mobilePane.ts
@@ -7,7 +7,7 @@
 // "viewport-only" choice should not propagate to a desktop user opening the
 // same link.
 
-export type MobilePane = 'editor' | 'viewport';
+export type MobilePane = 'editor' | 'parts' | 'viewport';
 
 const STORAGE_KEY = 'partwright.mobilePane';
 const listeners = new Set<(pane: MobilePane) => void>();
@@ -17,7 +17,7 @@ let _current: MobilePane = readStored();
 function readStored(): MobilePane {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === 'editor' || stored === 'viewport') return stored;
+    if (stored === 'editor' || stored === 'parts' || stored === 'viewport') return stored;
   } catch {
     // localStorage may be unavailable (private mode, etc.)
   }

--- a/src/ui/partList.ts
+++ b/src/ui/partList.ts
@@ -90,7 +90,12 @@ function render(state: SessionState): void {
   addBtn.addEventListener('click', () => { if (state.session) void cb.onCreatePart(); });
   header.appendChild(addBtn);
 
+  // Collapsing the rail to reclaim horizontal width is a desktop affordance; on
+  // mobile the parts list is a full-width pane reached via the pane toggle, so
+  // hide the collapse button there (it would otherwise leave the pane empty).
   const collapseBtn = iconBtn('«', 'Hide parts panel'); // «
+  collapseBtn.classList.remove('flex');
+  collapseBtn.classList.add('hidden', 'md:flex');
   collapseBtn.addEventListener('click', () => cb.onToggleCollapse());
   header.appendChild(collapseBtn);
 

--- a/tests/mobile-parts-pane.spec.ts
+++ b/tests/mobile-parts-pane.spec.ts
@@ -1,0 +1,45 @@
+// The parts list is reachable on mobile via a dedicated "Parts" pane in the
+// Code / Parts / Viewport toggle. On a phone the activity rail collapses to a
+// horizontal strip, so the rail can't host the parts list as a left column —
+// without this pane there'd be no way to view or switch parts in viewport mode.
+
+import { test, expect } from 'playwright/test';
+
+test.describe('mobile parts pane', () => {
+  test.beforeEach(async ({ page }) => {
+    // Suppress the first-visit guided tour so its tooltip can't intercept taps.
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+    await page.setViewportSize({ width: 375, height: 800 });
+  });
+
+  test('Parts pane shows the full-width parts list and the toggle has three options', async ({ page }) => {
+    await page.goto('/editor');
+    // Wait for the editor engine to settle.
+    await page.waitForSelector('#parts-rail', { state: 'attached' });
+    await page.waitForTimeout(2000);
+
+    const toggle = page.locator('#mobile-pane-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle.getByRole('button', { name: 'Code', exact: true })).toBeVisible();
+    await expect(toggle.getByRole('button', { name: 'Parts', exact: true })).toBeVisible();
+    await expect(toggle.getByRole('button', { name: 'Viewport', exact: true })).toBeVisible();
+
+    // Default mobile pane is the viewport — the parts rail is hidden.
+    await expect(page.locator('#parts-rail')).toBeHidden();
+
+    // Tapping Parts reveals the parts list (with at least one part row).
+    await toggle.getByRole('button', { name: 'Parts', exact: true }).click();
+    const railEl = page.locator('#parts-rail');
+    await expect(railEl).toBeVisible();
+    await expect(page.locator('#parts-list [data-part-id]').first()).toBeVisible();
+    await expect(page.locator('#btn-add-part')).toBeVisible();
+    // It fills the width rather than sitting as a cramped fixed column.
+    const railWidth = (await railEl.boundingBox())!.width;
+    expect(railWidth).toBeGreaterThan(300);
+
+    // Switching to Code hides the parts rail again (full-width editor).
+    await toggle.getByRole('button', { name: 'Code', exact: true }).click();
+    await expect(page.locator('#parts-rail')).toBeHidden();
+    await expect(page.locator('#editor-container')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

On mobile there was no usable way to view or switch parts. On a phone the activity rail collapses from a vertical left sidebar to a horizontal top strip, so the parts list can't live in it the way it does on desktop. Instead it was nested inside the **code-pane container** (`editorGroup`) as a cramped 144 px column — and mobile shows exactly **one** of editor / viewport at a time, with `viewport` as the default pane (and every rail-tab tap forcing viewport). So the parts list was hidden almost all the time, and even the desktop "re-show" chip lived inside that same hidden container.

This gives the parts list **its own mobile pane**: the Code / Viewport toggle becomes a three-way **Code / Parts / Viewport** segmented control.

- In the **Parts** pane the parts rail expands to **full width** (instead of the `w-36` column), with touch-friendly full-width rows — thumbnail, drag-to-reorder grip, rename, delete, multi-select, and the add (`+`) button.
- Secondary win: the **Code** pane now hides the parts column entirely, so the editor gets the full phone width.
- Desktop is unchanged — parts still live in the activity rail, with the `«` collapse affordance (hidden on mobile, where the pane toggle replaces it).

## Changes

- `src/ui/mobilePane.ts` — `MobilePane` gains `'parts'` (+ localStorage validation).
- `src/ui/layout.ts` — third toggle segment; `syncMobileToggleUI` / `syncPaneVisibility` compose three panes; `placeParts` mobile class is full-width; the desktop-only rail-collapse early-return is scoped to the desktop branch; desktop branch force-un-hides the code pane so a `'parts'` hide can't bleed across the breakpoint.
- `src/ui/partList.ts` — `«` collapse button is `hidden md:flex` (desktop-only width-reclaim affordance).
- `tests/mobile-parts-pane.spec.ts` — golden-path e2e at 375 px.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:unit` (1508 pass)
- [x] `npm run build`
- [x] New e2e spec `mobile-parts-pane` passes
- [x] Manual browser verification at 375 px — all three panes screenshotted; desktop snapshot unchanged
- [ ] PR-checks shards green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bnKbnHyWS7N8oBsAVz8v5

---
_Generated by [Claude Code](https://claude.ai/code/session_019bnKbnHyWS7N8oBsAVz8v5)_