### PR TITLE
feat: expand Bambu printer list to 14 models + fix process-preset compatibility

### DIFF
--- a/prompts/bambu-more-printers.md
+++ b/prompts/bambu-more-printers.md
@@ -1,0 +1,37 @@
+---
+date: 2026-06-19
+branch: claude/bambu-more-printers
+files_changed:
+  - src/export/threemfProject.ts
+  - tests/threemf-multipart.spec.ts
+  - public/ai/file-io.md
+---
+
+## Human
+
+I do want "More printer models" — you should be able to gather the exact strings
+from the bambu studio source code right?
+
+## Assistant
+
+Yes — resolved every Bambu machine profile (resources/profiles/BBL/machine, following
+`inherits`) for exact printer_model + bed + nozzle count, and every "0.20mm Standard"
+process preset's compatible_printers to map each printer to its process.
+
+This caught a bug in what shipped (#759): H2S is SINGLE-nozzle but I'd put it on the
+dual H2C base — Bambu would have converted it. Fixed (H2S/A2L → single P1S base; only
+H2C/H2D/H2D Pro/X2D are dual). Added H2D Pro, X2D, A2L, X1 Carbon ("Bambu Lab X1
+Carbon"), X1E, P2S — 14 printers total.
+
+Bigger latent bug surfaced via CLI: any printer whose model ≠ its base printer hit
+rc -17 "printer not compatible with the process preset" — because the base config's
+`print_settings_id` + `print_compatible_printers` still named the base printer. Only
+P1S (and X1/X1C/X1E, which share the P1S base's print_compatible_printers list) and
+H2C worked. Fix: per-printer `process` (the right "0.20mm Standard @BBL <suffix>";
+P1S/X1* share "@BBL X1C"), and override both `print_settings_id` and
+`print_compatible_printers` to the target printer in buildProjectSettings.
+
+Validated in the Bambu CLI: H2S, X2D, H2D, A1 mini, P1S all slice rc 0 (single +
+dual, base + non-base). e2e guards H2S=single-nozzle and the non-base process/compat
+stamping (H2S/H2D). The remaining models follow the identical override path; the user
+can GUI-confirm by loading the export.

--- a/public/ai/file-io.md
+++ b/public/ai/file-io.md
@@ -40,7 +40,7 @@ Each call also adds the export to the Recent Exports inbox so the user can re-do
 - **`{ bambu: false }`** — a **generic** multi-object 3MF: parts grid-arranged (no overlap), opens in any slicer, no Bambu metadata. The console/AI twin of the generic **"3MF"** export in a multi-part session.
 
 In Bambu mode you can pick the target machine (these match the export modal's dropdowns):
-- **`printer`** — `"h2c"` (default), `"h2d"`, `"h2s"` (dual-nozzle H2 family) or `"p1s"`, `"p1p"`, `"x1"`, `"a1"`, `"a1mini"` (single-nozzle). Sets the printer profile + bed so Bambu opens it natively without converting.
+- **`printer`** — dual-nozzle: `"h2c"` (default), `"h2d"`, `"h2dpro"`, `"x2d"`; single-nozzle: `"h2s"`, `"a2l"`, `"x1c"`, `"x1e"`, `"x1"`, `"p1s"`, `"p1p"`, `"p2s"`, `"a1"`, `"a1mini"`. Sets the printer profile + bed + process so Bambu opens it natively without converting.
 - **`nozzle`** — `"0.2"` | `"0.4"` (default) | `"0.6"` | `"0.8"`.
 - **`filament`** — `"pla"` (default) | `"petg"` | `"abs"` | `"asa"` | `"tpu"` | `"pc"`. One material for all colours; sets the filament type + temps.
 

--- a/retros/inbox/2026-06-20-bambu-more-printers.md
+++ b/retros/inbox/2026-06-20-bambu-more-printers.md
@@ -1,0 +1,15 @@
+# Retro — Bambu printer picker + "more models"
+
+**Liked**
+- BambuStudio's bundled profiles + the headless slicer CLI were a true source of truth: every "exact string" (printer_model, process-preset suffix, bed) and every structural fact (single vs dual nozzle, flush-matrix = nozzleCount×N²) came from real data, not guessing. The `--slice` loop caught load/compat errors I could never have reasoned out.
+
+**Lacked**
+- I validated the data layer only on the base==model case (P1S, H2C) and shipped #759 with a latent `rc -17` (process-preset incompatibility) for every NON-base printer (H2D/H2S). The base-printer case is the *least* representative one to test. Lesson: when a value is overridden onto a shared base, validate an entry where the override actually differs from the base — not the one that coincidentally matches.
+
+**Learned**
+- Bambu's printer↔process compatibility gate is `print_compatible_printers` (+ `print_settings_id`), not the printer label; overriding `printer_model` alone leaves the base's process, which Bambu rejects.
+- Process presets are SHARED across printers (P1S/X1/X1C/X1E all use `@BBL X1C`) — the mapping is per-preset `compatible_printers`, not a name transform.
+- A stale Vite dev server silently served old code to a Playwright `import()` mid-debug, making a correct fix look broken. `pkill -f vite` before re-validating a source change driven through the dev server.
+
+**Longed for**
+- A headless "does this 3mf open in the Bambu GUI" check. The CLI's `--slice` validates load+slice but NOT the GUI load_files path that caused the original crash — so GUI confirmation still falls to the user. A scriptable GUI-load smoke test would close the last validation gap.

--- a/src/export/threemfProject.ts
+++ b/src/export/threemfProject.ts
@@ -69,19 +69,37 @@ export interface BambuPrinterSpec {
   model: string;
   bed: [number, number];
   height: number;
+  /** print_settings_id (process preset) compatible with this printer. MUST match a
+   *  preset whose compatible_printers includes the model, or Bambu rejects the
+   *  project as "printer not compatible with the process preset" (rc -17). Sourced
+   *  from each BBL process preset's compatible_printers — note many printers SHARE a
+   *  preset (P1S/X1/X1E all use "@BBL X1C"). */
+  process: string;
 }
 
-// "Common models first" — verified model strings + public bed footprints. Dual-nozzle
-// (H2 family) reuse the H2C base; single-nozzle (P1/X1/A1) reuse the P1S base.
+// Model strings + bed footprints + nozzle class taken verbatim from BambuStudio's
+// bundled machine profiles (resources/profiles/BBL/machine, resolving `inherits`):
+// fdm_bbl_3dp_002_common = dual-nozzle (→ H2C base), fdm_bbl_3dp_001_common =
+// single-nozzle (→ P1S base). `model` MUST match Bambu's exact printer_model or
+// Bambu converts the project on open. Note H2S/A2L are SINGLE-nozzle despite their
+// large beds; X2D / H2D Pro are dual.
 export const BAMBU_PRINTERS: BambuPrinterSpec[] = [
-  { id: 'h2c', label: 'Bambu Lab H2C', base: 'h2c', model: 'Bambu Lab H2C', bed: [330, 320], height: 325 },
-  { id: 'h2d', label: 'Bambu Lab H2D', base: 'h2c', model: 'Bambu Lab H2D', bed: [350, 320], height: 325 },
-  { id: 'h2s', label: 'Bambu Lab H2S', base: 'h2c', model: 'Bambu Lab H2S', bed: [340, 320], height: 340 },
-  { id: 'p1s', label: 'Bambu Lab P1S', base: 'p1s', model: 'Bambu Lab P1S', bed: [256, 256], height: 256 },
-  { id: 'p1p', label: 'Bambu Lab P1P', base: 'p1s', model: 'Bambu Lab P1P', bed: [256, 256], height: 256 },
-  { id: 'x1', label: 'Bambu Lab X1', base: 'p1s', model: 'Bambu Lab X1', bed: [256, 256], height: 256 },
-  { id: 'a1', label: 'Bambu Lab A1', base: 'p1s', model: 'Bambu Lab A1', bed: [256, 256], height: 256 },
-  { id: 'a1mini', label: 'Bambu Lab A1 mini', base: 'p1s', model: 'Bambu Lab A1 mini', bed: [180, 180], height: 180 },
+  // Dual-nozzle (H2C structural base)
+  { id: 'h2c', label: 'Bambu Lab H2C', base: 'h2c', model: 'Bambu Lab H2C', bed: [330, 320], height: 325, process: '0.20mm Standard @BBL H2C' },
+  { id: 'h2d', label: 'Bambu Lab H2D', base: 'h2c', model: 'Bambu Lab H2D', bed: [350, 320], height: 325, process: '0.20mm Standard @BBL H2D' },
+  { id: 'h2dpro', label: 'Bambu Lab H2D Pro', base: 'h2c', model: 'Bambu Lab H2D Pro', bed: [350, 320], height: 325, process: '0.20mm Standard @BBL H2DP' },
+  { id: 'x2d', label: 'Bambu Lab X2D', base: 'h2c', model: 'Bambu Lab X2D', bed: [256, 256], height: 261, process: '0.20mm Standard @BBL X2D' },
+  // Single-nozzle (P1S structural base)
+  { id: 'h2s', label: 'Bambu Lab H2S', base: 'p1s', model: 'Bambu Lab H2S', bed: [340, 320], height: 340, process: '0.20mm Standard @BBL H2S' },
+  { id: 'a2l', label: 'Bambu Lab A2L', base: 'p1s', model: 'Bambu Lab A2L', bed: [330, 320], height: 325, process: '0.20mm Standard @BBL A2L' },
+  { id: 'x1c', label: 'Bambu Lab X1 Carbon', base: 'p1s', model: 'Bambu Lab X1 Carbon', bed: [256, 256], height: 250, process: '0.20mm Standard @BBL X1C' },
+  { id: 'x1e', label: 'Bambu Lab X1E', base: 'p1s', model: 'Bambu Lab X1E', bed: [256, 256], height: 250, process: '0.20mm Standard @BBL X1C' },
+  { id: 'x1', label: 'Bambu Lab X1', base: 'p1s', model: 'Bambu Lab X1', bed: [256, 256], height: 250, process: '0.20mm Standard @BBL X1C' },
+  { id: 'p1s', label: 'Bambu Lab P1S', base: 'p1s', model: 'Bambu Lab P1S', bed: [256, 256], height: 250, process: '0.20mm Standard @BBL X1C' },
+  { id: 'p1p', label: 'Bambu Lab P1P', base: 'p1s', model: 'Bambu Lab P1P', bed: [256, 256], height: 250, process: '0.20mm Standard @BBL P1P' },
+  { id: 'p2s', label: 'Bambu Lab P2S', base: 'p1s', model: 'Bambu Lab P2S', bed: [256, 256], height: 256, process: '0.20mm Standard @BBL P2S' },
+  { id: 'a1', label: 'Bambu Lab A1', base: 'p1s', model: 'Bambu Lab A1', bed: [256, 256], height: 256, process: '0.20mm Standard @BBL A1' },
+  { id: 'a1mini', label: 'Bambu Lab A1 mini', base: 'p1s', model: 'Bambu Lab A1 mini', bed: [180, 180], height: 180, process: '0.20mm Standard @BBL A1M' },
 ];
 export const DEFAULT_BAMBU_PRINTER = 'h2c';
 
@@ -739,6 +757,11 @@ function buildProjectSettings(filamentColors: string[], printer: BambuPrinterSpe
   // `model` must match Bambu's exact printer_model or Bambu converts on open.
   cfg.printer_model = printer.model;
   cfg.printer_settings_id = `${printer.model} ${nozzle} nozzle`;
+  // print_settings_id names the process; print_compatible_printers is the actual
+  // gate — if the selected printer isn't in it, Bambu rejects with rc -17 ("printer
+  // not compatible with the process preset"). Set both to the target printer.
+  cfg.print_settings_id = printer.process;
+  cfg.print_compatible_printers = [`${printer.model} ${nozzle} nozzle`];
   cfg.printer_variant = nozzle;
   cfg.printable_area = [`0x0`, `${printer.bed[0]}x0`, `${printer.bed[0]}x${printer.bed[1]}`, `0x${printer.bed[1]}`];
   cfg.printable_height = String(printer.height);

--- a/tests/threemf-multipart.spec.ts
+++ b/tests/threemf-multipart.spec.ts
@@ -291,17 +291,27 @@ test.describe('multi-part 3MF export', () => {
         const m = text.match(new RegExp(`"${key}":\\s*\\[([\\s\\S]*?)\\]`));
         return m ? (m[1].match(/"[^"]*"/g) ?? []).length : -1;
       };
+      const str = (text: string, key: string) => new RegExp(`"${key}":\\s*"([^"]*)"`).exec(text)?.[1];
       const parts = Array.from({ length: 4 }, (_, i) => makePart('p' + i));
       const h2c = await decode(build3MFProject(parts, { bambu: true })); // default
       const p1s = await decode(build3MFProject(parts, { bambu: true, printer: 'p1s', nozzle: '0.6' }));
+      // H2S is single-nozzle (regression guard: was wrongly mapped to the dual base);
+      // H2D is dual + a non-base printer (guards the print-process compatibility fix).
+      const h2s = await decode(build3MFProject(parts, { bambu: true, printer: 'h2s' }));
+      const h2d = await decode(build3MFProject(parts, { bambu: true, printer: 'h2d' }));
       return {
-        h2cModel: /"printer_model":\s*"([^"]*)"/.exec(h2c)?.[1],
+        h2cModel: str(h2c, 'printer_model'),
         h2cArea: /"printable_area":\s*\[([^\]]*)\]/.exec(h2c)?.[1].replace(/\s/g, ''),
         h2cNozzles: arrLen(h2c, 'nozzle_diameter'),
-        p1sModel: /"printer_model":\s*"([^"]*)"/.exec(p1s)?.[1],
-        p1sSettings: /"printer_settings_id":\s*"([^"]*)"/.exec(p1s)?.[1],
+        p1sModel: str(p1s, 'printer_model'),
+        p1sSettings: str(p1s, 'printer_settings_id'),
         p1sArea: /"printable_area":\s*\[([^\]]*)\]/.exec(p1s)?.[1].replace(/\s/g, ''),
         p1sNozzles: arrLen(p1s, 'nozzle_diameter'),
+        h2sNozzles: arrLen(h2s, 'nozzle_diameter'),
+        h2sProcess: str(h2s, 'print_settings_id'),
+        h2sCompat: /"print_compatible_printers":\s*\[([^\]]*)\]/.exec(h2s)?.[1],
+        h2dProcess: str(h2d, 'print_settings_id'),
+        h2dCompat: /"print_compatible_printers":\s*\[([^\]]*)\]/.exec(h2d)?.[1],
       };
     });
 
@@ -314,5 +324,14 @@ test.describe('multi-part 3MF export', () => {
     expect(out.p1sSettings).toBe('Bambu Lab P1S 0.6 nozzle');
     expect(out.p1sNozzles).toBe(1);
     expect(out.p1sArea).toContain('256x256');
+    // H2S is SINGLE-nozzle (not the dual H2C base) — regression guard.
+    expect(out.h2sNozzles).toBe(1);
+    // Process + compatibility stamped to the target printer (the rc -17 fix): a
+    // non-base printer must carry its own process + print_compatible_printers, else
+    // Bambu rejects "printer not compatible with the process preset".
+    expect(out.h2sProcess).toBe('0.20mm Standard @BBL H2S');
+    expect(out.h2sCompat).toContain('Bambu Lab H2S');
+    expect(out.h2dProcess).toBe('0.20mm Standard @BBL H2D');
+    expect(out.h2dCompat).toContain('Bambu Lab H2D');
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #759 (printer picker, merged): expand the Bambu printer dropdown from 8 to **14 models**, with strings/beds/nozzle-class taken **verbatim from BambuStudio's bundled profiles** (no guessing). Tracking: **#757**.

Added: **H2D Pro, X2D, A2L, X1 Carbon, X1E, P2S** (alongside H2C, H2D, H2S, P1S, P1P, X1, A1, A1 mini).

## Two bugs this surfaced (both fixed)
1. **H2S was wrongly dual-nozzle.** The source shows H2S (and A2L) are *single*-nozzle; I'd put H2S on the dual H2C base, so Bambu would have converted it. Now only **H2C / H2D / H2D Pro / X2D** are dual; everything else is single.
2. **`rc -17` "printer not compatible with the process preset"** — *latent in #759*. Any printer whose `model` differs from its structural base carried the **base** printer's `print_settings_id` + `print_compatible_printers`, so Bambu rejected it. Only P1S (and X1/X1C/X1E, which share the P1S base's compat list) and H2C happened to work. Fix: each printer carries its compatible **process** (from each BBL process preset's `compatible_printers` — e.g. P1S/X1/X1C/X1E all share `@BBL X1C`), and `buildProjectSettings` overrides `print_settings_id` + `print_compatible_printers` to the target printer.

## Validation
- ✅ Bambu CLI: **H2S, X2D, H2D, A1 mini, P1S** all slice `rc 0` (single + dual, base + non-base printers).
- ✅ e2e guards: H2S = single-nozzle (regression), and the non-base process/compat stamping (H2S/H2D process = `0.20mm Standard @BBL H2S/H2D`, compat lists the target).
- ✅ Typecheck + build clean; 5 multipart e2e green.
- The remaining models (H2D Pro, A2L, X1C, X1E, X1, P1P, P2S, A1) follow the identical override path; loadable in Bambu Studio's GUI for spot-checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FH4ezzKM3KavfP9L1BPgLz

---
_Generated by [Claude Code](https://claude.ai/code/session_01FH4ezzKM3KavfP9L1BPgLz)_