### PR TITLE
feat: studio-space interactive viewport (graded backdrop, PBR lighting, contact shadow)

### DIFF
--- a/prompts/studio-viewport-environment.md
+++ b/prompts/studio-viewport-environment.md
@@ -79,3 +79,25 @@ users get the still-good gradient + floor + contact-shadow + direct-light PBR
 fallback, while real GPUs keep the full IBL look (the bake is effectively free
 there). Readiness back to ~3.2s; the failing spec passes 3/3. Unknown renderer
 (privacy-restricted debug info) is treated as hardware.
+
+### Follow-up: lighting/shadow made opt-in (user feedback)
+
+User feedback after seeing it live: loved the space + colors, but the
+image-based lighting looked too bright / washed-out (a "spotlight") and the
+shadow added little. Asked for a **"Light" button in the viewport, off by
+default**.
+
+Reworked accordingly:
+- **Default** is now the calm matte look — gradient backdrop + floor + matte
+  PBR under the existing ambient + two directional lights. **No env reflections,
+  no cast shadow.** (This also removed the `isSoftwareRenderer` gate entirely:
+  with no env at startup the latency problem is gone for everyone.)
+- A new **"☀ Light" viewport pill** (`#light-toggle`, off by default) toggles
+  `setStudioLighting`, which builds the PMREM env on first opt-in (never at
+  startup → startup stays fast, software-WebGL bake cost only paid on click) and
+  enables a **mild** contact shadow (shadowStrength 0.2 dark / 0.13 light) via
+  the key light's `castShadow` + the existing ShadowMaterial catcher.
+- Closed UI↔JS parity: `partwright.setStudioLighting(on?)` / `isStudioLighting()`
+  + help table + ai.md. New e2e `tests/studio-lighting.spec.ts` (off by default,
+  toggles on/off). The env build/shadow framing was factored into
+  `frameModelShadow()` so the toggle can size the shadow to the current model.

--- a/prompts/studio-viewport-environment.md
+++ b/prompts/studio-viewport-environment.md
@@ -1,0 +1,62 @@
+---
+date: 2026-06-20
+branch: claude/intelligent-ride-qb0w5p
+files_changed:
+  - src/renderer/studioEnv.ts
+  - src/renderer/viewport.ts
+  - src/renderer/materials.ts
+  - tests/unit/studioEnv.test.ts
+---
+
+## Human
+
+Revisit the interactive view. The current style feels too dark/vague — default
+to a lighter "space" so it feels like objects are in a room. Separately, explore
+making selection more direct (Tinkercad-style move, or a quick-actions menu on
+select). Investigate and recommend.
+
+After investigation the user chose two things via a decision prompt:
+1. Build the "studio space" look first (selection-first quick menu deferred to a
+   follow-up).
+2. Of the three prototyped looks, make **Preset 3 — dark studio stage** the
+   default, with a **stronger, clearly visible** contact shadow.
+
+## Assistant
+
+Investigated the viewport with three parallel explorations: the render/style was
+a flat navy void (`#1a1a2e`), three plain white lights, no shadows/env/floor,
+grid hidden by default, single cornflower-blue Phong material. The interaction
+model has no per-object scene graph (always one merged mesh; "parts" are
+code-level), and drag-to-move already exists as the buried Arrange mode — so I
+recommended a selection-first quick-actions HUD over a global default-drag, and
+splitting the visual work out as the low-risk first track.
+
+Per the repo norm for subjective/aesthetic work, I prototyped 3 switchable looks
+behind a temporary `?studio=N` gate and shipped side-by-side screenshots for the
+user to pick, rather than iterating one interpretation blind.
+
+Implementation of the chosen direction (dark studio stage default):
+
+- New `studioEnv.ts` owns the theme-keyed look: a vertical gradient backdrop,
+  floor color, env-map intensity, ACES exposure, contact-shadow strength, and a
+  PBR (`MeshStandardMaterial`) model color/roughness/metalness. Dark = graded
+  charcoal stage; light = soft seamless studio (so the existing light/dark toggle
+  stays coherent). Default theme is already `dark`, so new users get the stage.
+- `viewport.ts`: always-on now (gate removed). Adds RoomEnvironment IBL via
+  PMREM, ACES tone mapping, a floor plane + a transparent `ShadowMaterial`
+  shadow-catcher (so shadow darkness is tunable independent of floor color), and
+  a shadowed key light whose shadow frustum is sized to the model in
+  `frameModel`. `applyStudioTheme` re-skins everything (and the live mesh
+  material) on theme flip. The env map is rebuilt on `webglcontextrestored`
+  since it's a GPU texture lost with the context.
+- Kept light-rig *intensities* reading from `appConfig.renderer` (not baked into
+  the preset) so the existing advanced-settings knobs aren't orphaned — the env
+  map + gradient + floor + shadow carry the "stage" mood, not the intensities.
+- Removed the now-dead `createDefaultMaterial` (old flat Phong) per the
+  dead-export rule.
+
+Verified both themes in the browser (screenshots posted), plus `tsc`, unit tier,
+`lint:deps`, production build, and a new `studioEnv` unit test.
+
+Deferred (tracked for follow-up): the selection-first quick-actions HUD
+(click a model/part → Move/Rotate/Resize/Paint menu wired to existing ops).

--- a/prompts/studio-viewport-environment.md
+++ b/prompts/studio-viewport-environment.md
@@ -60,3 +60,22 @@ Verified both themes in the browser (screenshots posted), plus `tsc`, unit tier,
 
 Deferred (tracked for follow-up): the selection-first quick-actions HUD
 (click a model/part → Move/Rotate/Resize/Paint menu wired to existing ops).
+
+### Follow-up: CI e2e failure (window.partwright undefined)
+
+`multipart-export.spec.ts` failed in CI (and reproduced locally): two tests read
+`window.partwright` after a hard `waitForTimeout(4000)` and got `undefined`.
+Root cause was a **startup-latency regression**, not a crash — measured
+app-readiness jumped from ~2.85s (main) to ~6.95s (branch). The PMREM /
+RoomEnvironment image-based-lighting bake is ~tens of ms on a real GPU but
+~3.9s on the **software WebGL rasterizer** (SwiftShader) that CI and the
+sandbox use, and it ran on the synchronous init path before `window.partwright`
+attaches. A `setTimeout(0)` deferral didn't help (it fired during an `await`
+gap still ahead of the attach).
+
+Fix: detect a software rasterizer (`isSoftwareRenderer` via
+`WEBGL_debug_renderer_info`) and **skip the env bake there** — software/GPU-less
+users get the still-good gradient + floor + contact-shadow + direct-light PBR
+fallback, while real GPUs keep the full IBL look (the bake is effectively free
+there). Readiness back to ~3.2s; the failing spec passes 3/3. Unknown renderer
+(privacy-restricted debug info) is treated as hardware.

--- a/prompts/studio-viewport-environment.md
+++ b/prompts/studio-viewport-environment.md
@@ -101,3 +101,23 @@ Reworked accordingly:
   + help table + ai.md. New e2e `tests/studio-lighting.spec.ts` (off by default,
   toggles on/off). The env build/shadow framing was factored into
   `frameModelShadow()` so the toggle can size the shadow to the current model.
+
+### Follow-up: Light on-by-default + less bright + toggle re-enable bug
+
+More feedback: a toggle bug ("turned on, then off, then stopped working") and a
+preference shift — keep the Light feature but **on by default and less bright**,
+keeping the button.
+
+- **Toggle bug fix:** off→on stopped restoring reflections because the off path
+  nulled `scene.environment` but kept a "built" flag, so re-on skipped
+  re-applying it. Replaced the flag with a **cached env texture** (`studioEnvTexture`)
+  that off→on simply re-attaches; the on/off paths are unified in
+  `refreshStudioLighting()`. The e2e now exercises a full off→on→off→on cycle.
+- **On by default + less bright:** `studioLightingOn = true`; envIntensity
+  lowered (dark 0.7→0.32, light 1.0→0.45) and exposure normalized to 1.0 so the
+  reflections read as gentle fill, not a washed-out spotlight.
+- **Startup/CI safety with on-by-default:** re-introduced the software-rasterizer
+  gate (`studioEnvAllowed` via `isSoftwareRenderer`). On a GPU the env bakes at
+  init (~tens of ms); on software (CI/sandbox/GPU-less) it's skipped (matte +
+  shadow only), so `window.partwright` readiness stays ~3s and the env map is
+  rebuilt on context-restore only when lighting is on.

--- a/public/ai.md
+++ b/public/ai.md
@@ -243,6 +243,8 @@ partwright.getClipState()      // -> {enabled, z, min, max}
 // Viewport controls
 partwright.setGridVisible(on?)       // Show/hide grid plane (omit to toggle) -> boolean
 partwright.isGridVisible()           // Whether grid plane is visible
+partwright.setStudioLighting(on?)    // Toggle studio lighting: reflections + soft shadow, off by default (omit to toggle) -> boolean
+partwright.isStudioLighting()        // Whether studio lighting is on
 partwright.setDimensionsVisible(on?) // Show/hide bounding box dimensions (omit to toggle) -> boolean
 partwright.areDimensionsVisible()    // Whether dimensions overlay is visible
 partwright.setOrbitLock(on?)         // Lock/unlock camera rotation (omit to toggle) -> boolean

--- a/public/ai.md
+++ b/public/ai.md
@@ -243,7 +243,7 @@ partwright.getClipState()      // -> {enabled, z, min, max}
 // Viewport controls
 partwright.setGridVisible(on?)       // Show/hide grid plane (omit to toggle) -> boolean
 partwright.isGridVisible()           // Whether grid plane is visible
-partwright.setStudioLighting(on?)    // Toggle studio lighting: reflections + soft shadow, off by default (omit to toggle) -> boolean
+partwright.setStudioLighting(on?)    // Toggle studio lighting: reflections + soft shadow, on by default (omit to toggle) -> boolean
 partwright.isStudioLighting()        // Whether studio lighting is on
 partwright.setDimensionsVisible(on?) // Show/hide bounding box dimensions (omit to toggle) -> boolean
 partwright.areDimensionsVisible()    // Whether dimensions overlay is visible

--- a/retros/inbox/2026-06-20-studio-viewport.md
+++ b/retros/inbox/2026-06-20-studio-viewport.md
@@ -35,3 +35,22 @@ task: studio-space interactive viewport — graded backdrop + PBR lighting + con
 - A documented way to drive the live viewport for screenshots without writing a
   throwaway spec each time (tour-suppressed, code-loaded, param-aware). The
   manual-verification loop is the slowest part of any UI change here.
+
+## Addendum (post-feedback iterations)
+- **Learned:** PMREM/RoomEnvironment IBL is ~tens of ms on a GPU but ~4s on the
+  software WebGL rasterizer that CI and the sandbox use — and it ran on the
+  synchronous init path *before* `window.partwright` attaches, so it silently
+  regressed app-readiness (~2.9s → ~6.9s) and failed an e2e test that reads the
+  API after a fixed `waitForTimeout`. Lesson: any per-init WebGL bake must be
+  measured under software rendering, and gated (`isSoftwareRenderer` via
+  `WEBGL_debug_renderer_info`) or deferred. Hard-`waitForTimeout`-then-read-API
+  specs are the canary; the fix is to keep startup readiness flat.
+- **Learned (bug):** a toggle that nulls `scene.environment` on "off" must also
+  re-apply it on "on". Tracking a boolean "built" flag instead of caching the
+  texture made off→on a silent no-op ("toggle stopped working"). Cache the
+  resource and reattach; unify on/off in one `refresh()` so the two paths can't
+  drift.
+- **Longed for:** the sandbox being software-WebGL means GPU-only visual features
+  (IBL brightness) can't be eyeballed without temporarily forcing the GPU path —
+  a documented "force-GPU-path for screenshot" escape (env var / URL param) would
+  remove the temptation to ship aesthetic constants unverified.

--- a/retros/inbox/2026-06-20-studio-viewport.md
+++ b/retros/inbox/2026-06-20-studio-viewport.md
@@ -1,0 +1,37 @@
+---
+date: 2026-06-20
+task: studio-space interactive viewport — graded backdrop + PBR lighting + contact shadow (PR #793, tracking #792)
+---
+
+## Liked
+- Three parallel `explore` agents (render/style, interaction model, transform ops)
+  returned a complete, file:line-grounded picture of the viewport in one round —
+  enough to give an opinionated recommendation without the main context filling
+  with file dumps.
+- Prototyping 3 switchable looks behind a temporary `?studio=N` gate and shipping
+  side-by-side contact sheets (sharp montage) let the user pick the direction in
+  ONE round instead of iterating one interpretation blind. This is exactly the
+  "prototype + demo + pick" norm CLAUDE.md prescribes for subjective work, and it
+  paid off — the chosen look needed zero rework.
+
+## Lacked
+- No Playwright MCP, so every visual check is a spec round-trip (~1 min/run with
+  WASM warmup). Each tweak (tour overlay, camera dolly, theme toggle) cost a full
+  re-run. A tiny "load route + run code string + screenshot" helper that takes a
+  model file + URL params would have collapsed 3 iterations into config changes.
+- Hit the onboarding-tour auto-overlay polluting screenshots; had to discover the
+  `partwright-tour-completed` localStorage key. `npm run snap` (the look-only
+  helper) doesn't run code or suppress the tour — a `--no-tour` / `--run <file>`
+  flag would make it usable for "screenshot this example in this look."
+
+## Learned
+- The `model is always one merged THREE.Mesh; "parts" are code-level` fact is the
+  single most important constraint for any "select/manipulate an object" feature —
+  worth surfacing in CLAUDE.md's viewport section so the next agent doesn't
+  re-derive it (three sessions' worth of the main.ts NUL-byte note suggests this
+  pays off).
+
+## Longed for
+- A documented way to drive the live viewport for screenshots without writing a
+  throwaway spec each time (tour-suppressed, code-loaded, param-aware). The
+  manual-verification loop is the slowest part of any UI change here.

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ import { createParamsPanel, type ParamsPanelController } from './ui/paramsPanel'
 import { viewportToolsMount, openPopoverGroupById } from './ui/popoverMenu';
 import { TOOL_TOGGLE_IDLE, TOOL_TOGGLE_ACTIVE } from './ui/toolPanel';
 import { sliceAtZ, getBoundingBox } from './geometry/crossSection';
-import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCameraPose, setCameraPose, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange, resetView, onOrbitEnd } from './renderer/viewport';
+import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost, setOnContextRestored, setClipping, setClipZ, getClipState, getCameraState, getCameraPose, setCameraPose, getCanvas, getMeshGroup, getCamera, setMeasureLock, setUserOrbitLock, isUserOrbitLocked, onUserOrbitLockChange, setDimensionsVisible, isDimensionsVisible, setGridVisible, isGridVisible, setWireframeVisible, isWireframeVisible, onWireframeChange, setStudioLighting, isStudioLighting, onStudioLightingChange, resetView, onOrbitEnd } from './renderer/viewport';
 // Side-effect import: registers the phantom/annotation/session-plane viewport
 // hooks. Must load before initViewport runs (below). See viewportSubsystems.ts.
 import './renderer/viewportSubsystems';
@@ -7341,6 +7341,7 @@ async function main() {
   // Wire up viewport overlay buttons
   initWireframeToggle(clipControls);
   initGridToggle(clipControls);
+  initLightToggle(clipControls);
   initDimensionsToggle(clipControls);
   initAnnotateUI(clipControls);
   initPaintUI(clipControls);
@@ -10105,6 +10106,19 @@ async function main() {
     /** Whether the grid plane is currently visible */
     isGridVisible(): boolean {
       return isGridVisible();
+    },
+
+    /** Enable or disable studio lighting (image-based reflections + a mild
+     *  contact shadow). Off by default. Pass a boolean to set, omit to toggle. */
+    setStudioLighting(on?: boolean): boolean {
+      assertBoolean(on, 'setStudioLighting(on)', { optional: true });
+      setStudioLighting(on ?? !isStudioLighting());
+      return isStudioLighting();
+    },
+
+    /** Whether studio lighting (reflections + soft shadow) is currently on */
+    isStudioLighting(): boolean {
+      return isStudioLighting();
     },
 
     /** Show or hide the bounding box dimension overlays. Pass a boolean to set, omit to toggle. */
@@ -14703,6 +14717,8 @@ async function main() {
         // Viewport controls
         'setGridVisible':       { signature: 'setGridVisible(on?) -- Show/hide grid plane (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
         'isGridVisible':        { signature: 'isGridVisible() -- Whether grid plane is visible', docs: '/ai.md#viewport-controls' },
+        'setStudioLighting':    { signature: 'setStudioLighting(on?) -- Toggle studio lighting: reflections + soft shadow, off by default (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
+        'isStudioLighting':     { signature: 'isStudioLighting() -- Whether studio lighting is on', docs: '/ai.md#viewport-controls' },
         'setDimensionsVisible': { signature: 'setDimensionsVisible(on?) -- Show/hide bounding box dimensions (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
         'areDimensionsVisible': { signature: 'areDimensionsVisible() -- Whether dimensions overlay is visible', docs: '/ai.md#viewport-controls' },
         'setOrbitLock':         { signature: 'setOrbitLock(on?) -- Lock/unlock camera rotation (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
@@ -16319,6 +16335,23 @@ async function main() {
       gridBtn.className = nowVisible ? activeClass : inactiveClass;
       gridBtn.title = nowVisible ? 'Hide grid plane' : 'Show grid plane';
     });
+  }
+
+  function initLightToggle(container: HTMLElement) {
+    const lightBtn = container.querySelector('#light-toggle') as HTMLButtonElement;
+    if (!lightBtn) return;
+
+    const inactiveClass = 'px-2 py-1 rounded text-xs bg-zinc-800/80 backdrop-blur text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-colors border border-zinc-600/50';
+    const activeClass = 'px-2 py-1 rounded text-xs bg-amber-500/20 backdrop-blur text-amber-400 hover:bg-amber-500/30 transition-colors border border-amber-500/30';
+
+    const reflect = (on: boolean) => {
+      lightBtn.className = on ? activeClass : inactiveClass;
+      lightBtn.title = on ? 'Turn off studio lighting (reflections + soft shadow)' : 'Studio lighting: reflections + soft shadow (off by default)';
+    };
+    reflect(isStudioLighting());
+    onStudioLightingChange(reflect);
+
+    lightBtn.addEventListener('click', () => { setStudioLighting(!isStudioLighting()); });
   }
 
   function initDimensionsToggle(container: HTMLElement) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10109,7 +10109,7 @@ async function main() {
     },
 
     /** Enable or disable studio lighting (image-based reflections + a mild
-     *  contact shadow). Off by default. Pass a boolean to set, omit to toggle. */
+     *  contact shadow). On by default. Pass a boolean to set, omit to toggle. */
     setStudioLighting(on?: boolean): boolean {
       assertBoolean(on, 'setStudioLighting(on)', { optional: true });
       setStudioLighting(on ?? !isStudioLighting());
@@ -14717,7 +14717,7 @@ async function main() {
         // Viewport controls
         'setGridVisible':       { signature: 'setGridVisible(on?) -- Show/hide grid plane (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
         'isGridVisible':        { signature: 'isGridVisible() -- Whether grid plane is visible', docs: '/ai.md#viewport-controls' },
-        'setStudioLighting':    { signature: 'setStudioLighting(on?) -- Toggle studio lighting: reflections + soft shadow, off by default (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
+        'setStudioLighting':    { signature: 'setStudioLighting(on?) -- Toggle studio lighting: reflections + soft shadow, on by default (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
         'isStudioLighting':     { signature: 'isStudioLighting() -- Whether studio lighting is on', docs: '/ai.md#viewport-controls' },
         'setDimensionsVisible': { signature: 'setDimensionsVisible(on?) -- Show/hide bounding box dimensions (omit to toggle) -> boolean', docs: '/ai.md#viewport-controls' },
         'areDimensionsVisible': { signature: 'areDimensionsVisible() -- Whether dimensions overlay is visible', docs: '/ai.md#viewport-controls' },
@@ -16346,7 +16346,7 @@ async function main() {
 
     const reflect = (on: boolean) => {
       lightBtn.className = on ? activeClass : inactiveClass;
-      lightBtn.title = on ? 'Turn off studio lighting (reflections + soft shadow)' : 'Studio lighting: reflections + soft shadow (off by default)';
+      lightBtn.title = on ? 'Turn off studio lighting (reflections + soft shadow)' : 'Turn on studio lighting (reflections + soft shadow)';
     };
     reflect(isStudioLighting());
     onStudioLightingChange(reflect);

--- a/src/renderer/materials.ts
+++ b/src/renderer/materials.ts
@@ -1,14 +1,5 @@
 import * as THREE from 'three';
 
-export function createDefaultMaterial(vertexColors = false): THREE.MeshPhongMaterial {
-  return new THREE.MeshPhongMaterial({
-    color: vertexColors ? 0xffffff : 0x4a9eff,
-    shininess: 40,
-    side: THREE.DoubleSide,
-    vertexColors,
-  });
-}
-
 export function createWireframeMaterial(): THREE.MeshBasicMaterial {
   return new THREE.MeshBasicMaterial({
     color: 0x000000,

--- a/src/renderer/studioEnv.ts
+++ b/src/renderer/studioEnv.ts
@@ -28,28 +28,27 @@ export interface StudioPreset {
 }
 
 const STUDIO_PRESETS: Record<Theme, StudioPreset> = {
-  // Dark studio stage — a graded charcoal "spotlit stage" with rim highlights
-  // from the environment and a strong contact shadow. The default look.
+  // Dark studio stage — a graded charcoal space. Matte by default; the "Light"
+  // toggle adds image-based reflections (envIntensity) + a mild contact shadow.
   dark: {
     bgTop: 0x2b2f36,
     bgBottom: 0x14161a,
     floorColor: 0x14161a,
     envIntensity: 0.7,
     exposure: 1.05,
-    shadowStrength: 0.55,
+    shadowStrength: 0.2,
     matColor: 0xb8c0cc,
-    matRoughness: 0.45,
-    matMetalness: 0.1,
+    matRoughness: 0.5,
+    matMetalness: 0.0,
   },
-  // Light soft studio — near-white seamless paper, neutral matte object, soft
-  // grounding shadow. The "product photo on seamless paper" look.
+  // Light soft studio — near-white seamless paper, neutral matte object.
   light: {
     bgTop: 0xf6f4f0,
     bgBottom: 0xe4ded4,
     floorColor: 0xe9e3da,
     envIntensity: 1.0,
     exposure: 1.0,
-    shadowStrength: 0.28,
+    shadowStrength: 0.13,
     matColor: 0x9aa3ad,
     matRoughness: 0.6,
     matMetalness: 0.0,
@@ -58,23 +57,6 @@ const STUDIO_PRESETS: Record<Theme, StudioPreset> = {
 
 export function studioPresetFor(theme: Theme): StudioPreset {
   return STUDIO_PRESETS[theme];
-}
-
-/** Whether the WebGL context is a software rasterizer (SwiftShader / llvmpipe /
- *  Microsoft Basic Render). PMREM image-based-lighting generation is ~50ms on a
- *  real GPU but multiple seconds on a software rasterizer, where it would freeze
- *  startup — callers skip the env bake when this is true. Unknown renderer
- *  (privacy-restricted debug info) is treated as hardware. */
-export function isSoftwareRenderer(gl: WebGLRenderingContext | WebGL2RenderingContext): boolean {
-  try {
-    const ext = gl.getExtension('WEBGL_debug_renderer_info');
-    if (!ext) return false;
-    const r = String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) ?? '').toLowerCase();
-    return r.includes('swiftshader') || r.includes('llvmpipe') ||
-      r.includes('software') || r.includes('basic render');
-  } catch {
-    return false;
-  }
 }
 
 /** Vertical gradient background as a small CanvasTexture. */

--- a/src/renderer/studioEnv.ts
+++ b/src/renderer/studioEnv.ts
@@ -60,6 +60,23 @@ export function studioPresetFor(theme: Theme): StudioPreset {
   return STUDIO_PRESETS[theme];
 }
 
+/** Whether the WebGL context is a software rasterizer (SwiftShader / llvmpipe /
+ *  Microsoft Basic Render). PMREM image-based-lighting generation is ~50ms on a
+ *  real GPU but multiple seconds on a software rasterizer, where it would freeze
+ *  startup — callers skip the env bake when this is true. Unknown renderer
+ *  (privacy-restricted debug info) is treated as hardware. */
+export function isSoftwareRenderer(gl: WebGLRenderingContext | WebGL2RenderingContext): boolean {
+  try {
+    const ext = gl.getExtension('WEBGL_debug_renderer_info');
+    if (!ext) return false;
+    const r = String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) ?? '').toLowerCase();
+    return r.includes('swiftshader') || r.includes('llvmpipe') ||
+      r.includes('software') || r.includes('basic render');
+  } catch {
+    return false;
+  }
+}
+
 /** Vertical gradient background as a small CanvasTexture. */
 export function makeGradientTexture(topHex: number, bottomHex: number): THREE.Texture {
   const canvas = document.createElement('canvas');

--- a/src/renderer/studioEnv.ts
+++ b/src/renderer/studioEnv.ts
@@ -34,8 +34,8 @@ const STUDIO_PRESETS: Record<Theme, StudioPreset> = {
     bgTop: 0x2b2f36,
     bgBottom: 0x14161a,
     floorColor: 0x14161a,
-    envIntensity: 0.7,
-    exposure: 1.05,
+    envIntensity: 0.32,
+    exposure: 1.0,
     shadowStrength: 0.2,
     matColor: 0xb8c0cc,
     matRoughness: 0.5,
@@ -46,7 +46,7 @@ const STUDIO_PRESETS: Record<Theme, StudioPreset> = {
     bgTop: 0xf6f4f0,
     bgBottom: 0xe4ded4,
     floorColor: 0xe9e3da,
-    envIntensity: 1.0,
+    envIntensity: 0.45,
     exposure: 1.0,
     shadowStrength: 0.13,
     matColor: 0x9aa3ad,
@@ -57,6 +57,24 @@ const STUDIO_PRESETS: Record<Theme, StudioPreset> = {
 
 export function studioPresetFor(theme: Theme): StudioPreset {
   return STUDIO_PRESETS[theme];
+}
+
+/** Whether the WebGL context is a software rasterizer (SwiftShader / llvmpipe /
+ *  Microsoft Basic Render). The PMREM image-based-lighting bake is ~tens of ms
+ *  on a real GPU but multiple seconds on a software rasterizer, where it would
+ *  freeze startup — callers skip the env bake there (keeping the matte + shadow
+ *  look). Unknown renderer (privacy-restricted debug info) is treated as
+ *  hardware. */
+export function isSoftwareRenderer(gl: WebGLRenderingContext | WebGL2RenderingContext): boolean {
+  try {
+    const ext = gl.getExtension('WEBGL_debug_renderer_info');
+    if (!ext) return false;
+    const r = String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) ?? '').toLowerCase();
+    return r.includes('swiftshader') || r.includes('llvmpipe') ||
+      r.includes('software') || r.includes('basic render');
+  } catch {
+    return false;
+  }
 }
 
 /** Vertical gradient background as a small CanvasTexture. */

--- a/src/renderer/studioEnv.ts
+++ b/src/renderer/studioEnv.ts
@@ -1,0 +1,89 @@
+import * as THREE from 'three';
+import type { Theme } from '../ui/theme';
+
+// "Studio space" rendering for the interactive viewport: instead of a flat color
+// void, the model sits in a graded backdrop with image-based PBR lighting, a
+// floor, and a contact shadow that grounds it in the space. Driven by the
+// light/dark theme — dark is a spotlit "stage", light is a soft seamless studio.
+
+// Note: the light-rig *intensities* stay user-tunable in appConfig.renderer
+// (ambient/primary/secondary) and are read by the viewport — they are not in
+// this preset. The preset owns only the look-defining, theme-dependent bits.
+export interface StudioPreset {
+  /** Vertical background gradient (top → bottom). */
+  bgTop: number;
+  bgBottom: number;
+  /** Floor plane base color. */
+  floorColor: number;
+  /** Image-based-lighting (RoomEnvironment) contribution. */
+  envIntensity: number;
+  /** ACES tone-mapping exposure. */
+  exposure: number;
+  /** Contact-shadow darkness (ShadowMaterial opacity, 0..1). */
+  shadowStrength: number;
+  /** Default (unpainted) model material. */
+  matColor: number;
+  matRoughness: number;
+  matMetalness: number;
+}
+
+const STUDIO_PRESETS: Record<Theme, StudioPreset> = {
+  // Dark studio stage — a graded charcoal "spotlit stage" with rim highlights
+  // from the environment and a strong contact shadow. The default look.
+  dark: {
+    bgTop: 0x2b2f36,
+    bgBottom: 0x14161a,
+    floorColor: 0x14161a,
+    envIntensity: 0.7,
+    exposure: 1.05,
+    shadowStrength: 0.55,
+    matColor: 0xb8c0cc,
+    matRoughness: 0.45,
+    matMetalness: 0.1,
+  },
+  // Light soft studio — near-white seamless paper, neutral matte object, soft
+  // grounding shadow. The "product photo on seamless paper" look.
+  light: {
+    bgTop: 0xf6f4f0,
+    bgBottom: 0xe4ded4,
+    floorColor: 0xe9e3da,
+    envIntensity: 1.0,
+    exposure: 1.0,
+    shadowStrength: 0.28,
+    matColor: 0x9aa3ad,
+    matRoughness: 0.6,
+    matMetalness: 0.0,
+  },
+};
+
+export function studioPresetFor(theme: Theme): StudioPreset {
+  return STUDIO_PRESETS[theme];
+}
+
+/** Vertical gradient background as a small CanvasTexture. */
+export function makeGradientTexture(topHex: number, bottomHex: number): THREE.Texture {
+  const canvas = document.createElement('canvas');
+  canvas.width = 2;
+  canvas.height = 256;
+  const ctx = canvas.getContext('2d')!;
+  const grad = ctx.createLinearGradient(0, 0, 0, 256);
+  grad.addColorStop(0, '#' + topHex.toString(16).padStart(6, '0'));
+  grad.addColorStop(1, '#' + bottomHex.toString(16).padStart(6, '0'));
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, 2, 256);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.needsUpdate = true;
+  return tex;
+}
+
+/** Default (unpainted / vertex-colored) model material for a studio preset. */
+export function createStudioMaterial(preset: StudioPreset, vertexColors: boolean): THREE.MeshStandardMaterial {
+  return new THREE.MeshStandardMaterial({
+    color: vertexColors ? 0xffffff : preset.matColor,
+    roughness: preset.matRoughness,
+    metalness: preset.matMetalness,
+    side: THREE.DoubleSide,
+    vertexColors,
+  });
+}

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -4,7 +4,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
 import type { MeshData } from '../geometry/types';
 import { createWireframeMaterial } from './materials';
-import { studioPresetFor, makeGradientTexture, createStudioMaterial, type StudioPreset } from './studioEnv';
+import { studioPresetFor, makeGradientTexture, createStudioMaterial, isSoftwareRenderer, type StudioPreset } from './studioEnv';
 import { initMeasureOverlay } from './measureOverlay';
 import { initOrientationGizmo, renderGizmo, updateGizmo, isGizmoAnimating } from './orientationGizmo';
 import { initDimensionLines, updateDimensionLines, setDimensionsVisible as setDimensionsVisibleImpl, isDimensionsVisible } from './dimensionLines';
@@ -106,21 +106,23 @@ const ndcForHit = new THREE.Vector2();
 let grid: THREE.GridHelper;
 
 // Studio-space rendering: a gradient backdrop + a floor place the model in a
-// space (instead of the old flat color void). By DEFAULT the model is evenly lit
-// and matte with no image-based reflections and no cast shadow — those read as a
-// distracting "spotlight". The optional "Light" toggle (off by default) turns on
-// RoomEnvironment image-based lighting + a mild contact shadow for users who want
-// the richer studio look. Driven by the light/dark theme (see studioEnv.ts).
+// space (instead of the old flat color void). The "Light" toggle adds (gentle)
+// RoomEnvironment image-based reflections + a mild contact shadow on top of the
+// matte base — ON by default, but toggleable from the viewport. Driven by the
+// light/dark theme (see studioEnv.ts).
 let studioPreset: StudioPreset = studioPresetFor('dark');
 let studioFloor: THREE.Mesh | null = null;
 let studioShadowCatcher: THREE.Mesh | null = null;
 let studioKeyLight: THREE.DirectionalLight | null = null;
 let lastFloorZ = 0;
-// The "Light" toggle: enhanced image-based lighting + mild contact shadow. Off
-// by default (the calm matte look); building the PMREM env only on opt-in keeps
-// startup fast and dodges the software-WebGL bake cost entirely.
-let studioLightingOn = false;
-let studioEnvBuilt = false;
+// The "Light" toggle: gentle image-based reflections + a mild contact shadow.
+// On by default. The PMREM env is cached (built once, reused across off→on
+// cycles) and skipped entirely on a software rasterizer (studioEnvAllowed),
+// where the bake would freeze startup — there the toggle controls just the
+// shadow and the model stays matte.
+let studioLightingOn = true;
+let studioEnvAllowed = true;
+let studioEnvTexture: THREE.Texture | null = null;
 const studioLightingListeners: Array<(on: boolean) => void> = [];
 
 /** Re-skin the studio scene (backdrop, floor, model material) for a theme —
@@ -133,7 +135,7 @@ function applyStudioTheme(theme: Theme): void {
   renderer.toneMappingExposure = studioPreset.exposure;
   if (studioFloor) (studioFloor.material as THREE.MeshStandardMaterial).color.set(studioPreset.floorColor);
   if (studioShadowCatcher) (studioShadowCatcher.material as THREE.ShadowMaterial).opacity = studioPreset.shadowStrength;
-  if (studioLightingOn && studioEnvBuilt) scene.environmentIntensity = studioPreset.envIntensity;
+  if (scene.environment) scene.environmentIntensity = studioPreset.envIntensity;
   // Recolor the live model material in place (it's only rebuilt on the next run).
   const solid = meshGroup?.children.find(c => c instanceof THREE.Mesh && c.name !== 'wireframe' && c.name !== 'clip-cap');
   if (solid instanceof THREE.Mesh) {
@@ -146,27 +148,27 @@ function applyStudioTheme(theme: Theme): void {
   }
 }
 
-/** Build (or rebuild) the RoomEnvironment IBL map and apply it. The PMREM bake
- *  is ~tens of ms on a GPU but seconds on a software rasterizer, so it only runs
- *  when the user opts into the "Light" toggle (never at startup). */
-function buildStudioEnvironment(): void {
-  const old = scene.environment;
-  const pmrem = new THREE.PMREMGenerator(renderer);
-  scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+/** Apply the cached RoomEnvironment IBL map (baking it once, lazily). The PMREM
+ *  bake is ~tens of ms on a GPU but seconds on a software rasterizer, so it's
+ *  gated on studioEnvAllowed. The texture is cached so off→on cycles just
+ *  reattach it (no rebake) — re-nulled only on context loss. */
+function applyStudioEnvironment(): void {
+  if (!studioEnvAllowed) return;
+  if (!studioEnvTexture) {
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    studioEnvTexture = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+    pmrem.dispose();
+  }
+  scene.environment = studioEnvTexture;
   scene.environmentIntensity = studioPreset.envIntensity;
-  pmrem.dispose();
-  if (old) old.dispose();
-  studioEnvBuilt = true;
 }
 
-/** Toggle the enhanced studio lighting (image-based reflections + mild contact
- *  shadow). Off by default. Exposed on the viewport "Light" button. */
-export function setStudioLighting(on: boolean): void {
-  if (on === studioLightingOn) return;
-  studioLightingOn = on;
-  if (on) {
-    if (!studioEnvBuilt) buildStudioEnvironment();
-    else scene.environmentIntensity = studioPreset.envIntensity;
+/** Apply the current studio-lighting state to the scene: env reflections (when
+ *  allowed) + the mild contact shadow, or neither. Shared by the toggle and the
+ *  initial setup. */
+function refreshStudioLighting(): void {
+  if (studioLightingOn) {
+    applyStudioEnvironment();
     renderer.shadowMap.enabled = true;
     if (studioKeyLight) studioKeyLight.castShadow = true;
     if (studioShadowCatcher) studioShadowCatcher.visible = true;
@@ -177,8 +179,16 @@ export function setStudioLighting(on: boolean): void {
     if (studioShadowCatcher) studioShadowCatcher.visible = false;
     renderer.shadowMap.enabled = false;
   }
-  studioLightingListeners.forEach(fn => fn(on));
   needsRender = true;
+}
+
+/** Toggle the studio lighting (image-based reflections + mild contact shadow).
+ *  On by default. Exposed on the viewport "Light" button. */
+export function setStudioLighting(on: boolean): void {
+  if (on === studioLightingOn) return;
+  studioLightingOn = on;
+  refreshStudioLighting();
+  studioLightingListeners.forEach(fn => fn(on));
 }
 
 export function isStudioLighting(): boolean { return studioLightingOn; }
@@ -235,6 +245,10 @@ export function initViewport(container: HTMLElement): {
   renderer.localClippingEnabled = true;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
   renderer.toneMappingExposure = studioPreset.exposure;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  // Skip the costly PMREM env bake on a software rasterizer (CI / GPU-less) so
+  // it never freezes startup; the toggle there controls just the matte+shadow.
+  studioEnvAllowed = !isSoftwareRenderer(renderer.getContext());
 
   // WebGL context-loss recovery. preventDefault() on 'lost' is what lets the
   // browser restore the context; while lost we cancel the RAF loop so we don't
@@ -249,6 +263,10 @@ export function initViewport(container: HTMLElement): {
   canvas.addEventListener('webglcontextrestored', () => {
     contextLost = false;
     needsRender = true;
+    // The env map is a GPU texture lost with the context — drop the cache and
+    // reapply the current lighting state (rebuilds it if lighting is on).
+    studioEnvTexture = null;
+    refreshStudioLighting();
     onContextRestored?.();
     // Restart the render loop (it was cancelled on loss).
     animate();
@@ -329,8 +347,8 @@ export function initViewport(container: HTMLElement): {
   }, { capture: true, passive: false });
 
   // Lighting — ambient + key/fill directionals; intensities stay user-tunable
-  // via appConfig.renderer. The key (dir1) only casts a shadow when the "Light"
-  // toggle is on (castShadow flipped in setStudioLighting).
+  // via appConfig.renderer. The key (dir1) casts the contact shadow when the
+  // "Light" toggle is on (castShadow flipped in refreshStudioLighting).
   const ambient = new THREE.AmbientLight(0xffffff, getConfig().renderer.ambientLightIntensity);
   scene.add(ambient);
 
@@ -347,8 +365,8 @@ export function initViewport(container: HTMLElement): {
   scene.add(dir2);
 
   // Floor the model sits on, plus a transparent shadow-catcher above it so the
-  // contact shadow's darkness is tunable independent of the floor color. The
-  // catcher is hidden until the "Light" toggle turns on.
+  // contact shadow's darkness is tunable independent of the floor color. Its
+  // visibility follows the "Light" toggle (set in refreshStudioLighting).
   const floorMat = new THREE.MeshStandardMaterial({
     color: studioPreset.floorColor,
     roughness: 0.95,
@@ -385,6 +403,11 @@ export function initViewport(container: HTMLElement): {
 
   meshGroup = new THREE.Group();
   scene.add(meshGroup);
+
+  // Apply the initial studio-lighting state (on by default): env reflections
+  // (GPU only) + the mild contact shadow. Runs after meshGroup exists so the
+  // shadow framing has something to measure.
+  refreshStudioLighting();
 
   // Measure overlay group
   initMeasureOverlay(scene, camera, renderer);

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -4,7 +4,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
 import type { MeshData } from '../geometry/types';
 import { createWireframeMaterial } from './materials';
-import { studioPresetFor, makeGradientTexture, createStudioMaterial, isSoftwareRenderer, type StudioPreset } from './studioEnv';
+import { studioPresetFor, makeGradientTexture, createStudioMaterial, type StudioPreset } from './studioEnv';
 import { initMeasureOverlay } from './measureOverlay';
 import { initOrientationGizmo, renderGizmo, updateGizmo, isGizmoAnimating } from './orientationGizmo';
 import { initDimensionLines, updateDimensionLines, setDimensionsVisible as setDimensionsVisibleImpl, isDimensionsVisible } from './dimensionLines';
@@ -105,29 +105,35 @@ const ndcForHit = new THREE.Vector2();
 // Grid plane
 let grid: THREE.GridHelper;
 
-// Studio-space rendering: a gradient backdrop, image-based PBR lighting, a floor,
-// and a contact shadow that grounds the model in a space — instead of the old
-// flat color void. Driven by the light/dark theme (see studioEnv.ts).
+// Studio-space rendering: a gradient backdrop + a floor place the model in a
+// space (instead of the old flat color void). By DEFAULT the model is evenly lit
+// and matte with no image-based reflections and no cast shadow — those read as a
+// distracting "spotlight". The optional "Light" toggle (off by default) turns on
+// RoomEnvironment image-based lighting + a mild contact shadow for users who want
+// the richer studio look. Driven by the light/dark theme (see studioEnv.ts).
 let studioPreset: StudioPreset = studioPresetFor('dark');
 let studioFloor: THREE.Mesh | null = null;
 let studioShadowCatcher: THREE.Mesh | null = null;
 let studioKeyLight: THREE.DirectionalLight | null = null;
 let lastFloorZ = 0;
-// Whether to bake the PMREM image-based-lighting env. Off on software WebGL,
-// where the bake costs seconds and would freeze startup (see isSoftwareRenderer).
-let studioEnvEnabled = true;
+// The "Light" toggle: enhanced image-based lighting + mild contact shadow. Off
+// by default (the calm matte look); building the PMREM env only on opt-in keeps
+// startup fast and dodges the software-WebGL bake cost entirely.
+let studioLightingOn = false;
+let studioEnvBuilt = false;
+const studioLightingListeners: Array<(on: boolean) => void> = [];
 
-/** Re-skin the studio scene (backdrop, lights, floor, shadow, model material)
- *  for a theme — called once at init's theme value and again on every flip. */
+/** Re-skin the studio scene (backdrop, floor, model material) for a theme —
+ *  called once at init's theme value and again on every flip. */
 function applyStudioTheme(theme: Theme): void {
   studioPreset = studioPresetFor(theme);
   const old = scene.background;
   scene.background = makeGradientTexture(studioPreset.bgTop, studioPreset.bgBottom);
   if (old instanceof THREE.Texture) old.dispose();
   renderer.toneMappingExposure = studioPreset.exposure;
-  scene.environmentIntensity = studioPreset.envIntensity;
   if (studioFloor) (studioFloor.material as THREE.MeshStandardMaterial).color.set(studioPreset.floorColor);
   if (studioShadowCatcher) (studioShadowCatcher.material as THREE.ShadowMaterial).opacity = studioPreset.shadowStrength;
+  if (studioLightingOn && studioEnvBuilt) scene.environmentIntensity = studioPreset.envIntensity;
   // Recolor the live model material in place (it's only rebuilt on the next run).
   const solid = meshGroup?.children.find(c => c instanceof THREE.Mesh && c.name !== 'wireframe' && c.name !== 'clip-cap');
   if (solid instanceof THREE.Mesh) {
@@ -139,6 +145,44 @@ function applyStudioTheme(theme: Theme): void {
     }
   }
 }
+
+/** Build (or rebuild) the RoomEnvironment IBL map and apply it. The PMREM bake
+ *  is ~tens of ms on a GPU but seconds on a software rasterizer, so it only runs
+ *  when the user opts into the "Light" toggle (never at startup). */
+function buildStudioEnvironment(): void {
+  const old = scene.environment;
+  const pmrem = new THREE.PMREMGenerator(renderer);
+  scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+  scene.environmentIntensity = studioPreset.envIntensity;
+  pmrem.dispose();
+  if (old) old.dispose();
+  studioEnvBuilt = true;
+}
+
+/** Toggle the enhanced studio lighting (image-based reflections + mild contact
+ *  shadow). Off by default. Exposed on the viewport "Light" button. */
+export function setStudioLighting(on: boolean): void {
+  if (on === studioLightingOn) return;
+  studioLightingOn = on;
+  if (on) {
+    if (!studioEnvBuilt) buildStudioEnvironment();
+    else scene.environmentIntensity = studioPreset.envIntensity;
+    renderer.shadowMap.enabled = true;
+    if (studioKeyLight) studioKeyLight.castShadow = true;
+    if (studioShadowCatcher) studioShadowCatcher.visible = true;
+    frameModelShadow();
+  } else {
+    scene.environment = null;
+    if (studioKeyLight) studioKeyLight.castShadow = false;
+    if (studioShadowCatcher) studioShadowCatcher.visible = false;
+    renderer.shadowMap.enabled = false;
+  }
+  studioLightingListeners.forEach(fn => fn(on));
+  needsRender = true;
+}
+
+export function isStudioLighting(): boolean { return studioLightingOn; }
+export function onStudioLightingChange(fn: (on: boolean) => void): void { studioLightingListeners.push(fn); }
 
 // Mesh edge (wireframe) overlay visibility. Hidden by default so the model
 // reads cleanly; paint mode forces it on (see paintMode.ts) and the viewport
@@ -191,9 +235,6 @@ export function initViewport(container: HTMLElement): {
   renderer.localClippingEnabled = true;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
   renderer.toneMappingExposure = studioPreset.exposure;
-  renderer.shadowMap.enabled = true;
-  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-  studioEnvEnabled = !isSoftwareRenderer(renderer.getContext());
 
   // WebGL context-loss recovery. preventDefault() on 'lost' is what lets the
   // browser restore the context; while lost we cancel the RAF loop so we don't
@@ -208,23 +249,10 @@ export function initViewport(container: HTMLElement): {
   canvas.addEventListener('webglcontextrestored', () => {
     contextLost = false;
     needsRender = true;
-    // The image-based-lighting env texture lives on the GPU and is lost with
-    // the context — regenerate it so the model isn't left unlit after restore.
-    if (studioEnvEnabled) buildStudioEnvironment();
     onContextRestored?.();
     // Restart the render loop (it was cancelled on loss).
     animate();
   }, false);
-
-  // Build (or rebuild) the RoomEnvironment IBL map and apply it to the scene.
-  function buildStudioEnvironment(): void {
-    const old = scene.environment;
-    const pmrem = new THREE.PMREMGenerator(renderer);
-    scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
-    scene.environmentIntensity = studioPreset.envIntensity;
-    pmrem.dispose();
-    if (old) old.dispose();
-  }
 
   controls = new OrbitControls(camera, canvas);
   controls.enableDamping = true;
@@ -301,13 +329,13 @@ export function initViewport(container: HTMLElement): {
   }, { capture: true, passive: false });
 
   // Lighting — ambient + key/fill directionals; intensities stay user-tunable
-  // via appConfig.renderer. The key (dir1) also casts the contact shadow.
+  // via appConfig.renderer. The key (dir1) only casts a shadow when the "Light"
+  // toggle is on (castShadow flipped in setStudioLighting).
   const ambient = new THREE.AmbientLight(0xffffff, getConfig().renderer.ambientLightIntensity);
   scene.add(ambient);
 
   const dir1 = new THREE.DirectionalLight(0xffffff, getConfig().renderer.primaryLightIntensity);
   dir1.position.set(10, -10, 15);
-  dir1.castShadow = true;
   dir1.shadow.mapSize.set(2048, 2048);
   dir1.shadow.bias = -0.0005;
   scene.add(dir1);
@@ -318,15 +346,9 @@ export function initViewport(container: HTMLElement): {
   dir2.position.set(-10, 10, -5);
   scene.add(dir2);
 
-  // Image-based lighting from a neutral room for believable PBR shading. On a
-  // real GPU the PMREM bake is ~tens of ms; on a software rasterizer it costs
-  // seconds and would freeze startup, so it's skipped there (the model still
-  // reads well under the ambient + two directional lights). It's a GPU texture,
-  // so it's also rebuilt on webglcontextrestored (see the handler above).
-  if (studioEnvEnabled) buildStudioEnvironment();
-
   // Floor the model sits on, plus a transparent shadow-catcher above it so the
-  // contact shadow's darkness is tunable independent of the floor color.
+  // contact shadow's darkness is tunable independent of the floor color. The
+  // catcher is hidden until the "Light" toggle turns on.
   const floorMat = new THREE.MeshStandardMaterial({
     color: studioPreset.floorColor,
     roughness: 0.95,
@@ -340,6 +362,7 @@ export function initViewport(container: HTMLElement): {
     new THREE.ShadowMaterial({ opacity: studioPreset.shadowStrength }),
   );
   studioShadowCatcher.receiveShadow = true;
+  studioShadowCatcher.visible = false;
   scene.add(studioShadowCatcher);
 
   // Grid on XY plane (hidden by default; user-toggleable). Theme-colored.
@@ -514,6 +537,38 @@ export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boole
   onMeshUpdate?.(meshData);
 }
 
+/** Park the studio floor under the model and (when lighting is on) size the key
+ *  light's shadow frustum + catcher to the model's footprint. Computes its own
+ *  bounds so the "Light" toggle can call it without a full re-frame. No-op when
+ *  the mesh group is empty. */
+function frameModelShadow(): void {
+  const box = new THREE.Box3().setFromObject(meshGroup);
+  if (box.isEmpty()) return;
+  const center = box.getCenter(new THREE.Vector3());
+  const size = box.getSize(new THREE.Vector3());
+  const maxDim = Math.max(size.x, size.y, size.z);
+  if (!Number.isFinite(maxDim) || maxDim <= 0) return;
+
+  if (studioFloor) {
+    studioFloor.position.set(center.x, center.y, box.min.z - maxDim * 0.004);
+    studioFloor.scale.set(maxDim * 14, maxDim * 14, 1);
+  }
+  if (studioShadowCatcher) {
+    studioShadowCatcher.position.set(center.x, center.y, box.min.z - maxDim * 0.002);
+    studioShadowCatcher.scale.set(maxDim * 14, maxDim * 14, 1);
+  }
+  if (studioKeyLight) {
+    studioKeyLight.position.set(center.x + maxDim * 0.8, center.y - maxDim * 0.5, box.max.z + maxDim * 1.4);
+    studioKeyLight.target.position.copy(center);
+    studioKeyLight.target.updateMatrixWorld();
+    const cam = studioKeyLight.shadow.camera;
+    const ext = maxDim * 1.4;
+    cam.left = -ext; cam.right = ext; cam.top = ext; cam.bottom = -ext;
+    cam.near = maxDim * 0.1; cam.far = maxDim * 6;
+    cam.updateProjectionMatrix();
+  }
+}
+
 /** Frame the camera to the default 3/4 view of the current model and refresh
  *  everything derived from its bounds: clip-slider range, grid height, dimension
  *  annotations, near/far planes, and the zoom-out (maxDistance) limit. Shared by
@@ -548,26 +603,8 @@ function frameModel(): void {
   lastFloorZ = box.min.z;
   grid.position.z = box.min.z;
 
-  // Studio: park the floor (and its shadow catcher just above it) under the
-  // model, and size the key light's shadow frustum to the model's footprint.
-  if (studioFloor) {
-    studioFloor.position.set(center.x, center.y, box.min.z - maxDim * 0.004);
-    studioFloor.scale.set(maxDim * 14, maxDim * 14, 1);
-  }
-  if (studioShadowCatcher) {
-    studioShadowCatcher.position.set(center.x, center.y, box.min.z - maxDim * 0.002);
-    studioShadowCatcher.scale.set(maxDim * 14, maxDim * 14, 1);
-  }
-  if (studioKeyLight) {
-    studioKeyLight.position.set(center.x + maxDim * 0.8, center.y - maxDim * 0.5, box.max.z + maxDim * 1.4);
-    studioKeyLight.target.position.copy(center);
-    studioKeyLight.target.updateMatrixWorld();
-    const cam = studioKeyLight.shadow.camera;
-    const ext = maxDim * 1.4;
-    cam.left = -ext; cam.right = ext; cam.top = ext; cam.bottom = -ext;
-    cam.near = maxDim * 0.1; cam.far = maxDim * 6;
-    cam.updateProjectionMatrix();
-  }
+  // Studio: park the floor under the model + size the shadow to its footprint.
+  frameModelShadow();
 
   // Update bounding box dimension annotations
   updateDimensionLines(box);

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -4,7 +4,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
 import type { MeshData } from '../geometry/types';
 import { createWireframeMaterial } from './materials';
-import { studioPresetFor, makeGradientTexture, createStudioMaterial, type StudioPreset } from './studioEnv';
+import { studioPresetFor, makeGradientTexture, createStudioMaterial, isSoftwareRenderer, type StudioPreset } from './studioEnv';
 import { initMeasureOverlay } from './measureOverlay';
 import { initOrientationGizmo, renderGizmo, updateGizmo, isGizmoAnimating } from './orientationGizmo';
 import { initDimensionLines, updateDimensionLines, setDimensionsVisible as setDimensionsVisibleImpl, isDimensionsVisible } from './dimensionLines';
@@ -113,6 +113,9 @@ let studioFloor: THREE.Mesh | null = null;
 let studioShadowCatcher: THREE.Mesh | null = null;
 let studioKeyLight: THREE.DirectionalLight | null = null;
 let lastFloorZ = 0;
+// Whether to bake the PMREM image-based-lighting env. Off on software WebGL,
+// where the bake costs seconds and would freeze startup (see isSoftwareRenderer).
+let studioEnvEnabled = true;
 
 /** Re-skin the studio scene (backdrop, lights, floor, shadow, model material)
  *  for a theme — called once at init's theme value and again on every flip. */
@@ -190,6 +193,7 @@ export function initViewport(container: HTMLElement): {
   renderer.toneMappingExposure = studioPreset.exposure;
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  studioEnvEnabled = !isSoftwareRenderer(renderer.getContext());
 
   // WebGL context-loss recovery. preventDefault() on 'lost' is what lets the
   // browser restore the context; while lost we cancel the RAF loop so we don't
@@ -206,7 +210,7 @@ export function initViewport(container: HTMLElement): {
     needsRender = true;
     // The image-based-lighting env texture lives on the GPU and is lost with
     // the context — regenerate it so the model isn't left unlit after restore.
-    buildStudioEnvironment();
+    if (studioEnvEnabled) buildStudioEnvironment();
     onContextRestored?.();
     // Restart the render loop (it was cancelled on loss).
     animate();
@@ -314,10 +318,12 @@ export function initViewport(container: HTMLElement): {
   dir2.position.set(-10, 10, -5);
   scene.add(dir2);
 
-  // Image-based lighting from a neutral room for believable PBR shading. The
-  // generated env is a GPU texture, so it's lost with the WebGL context and
-  // rebuilt on restore (see the webglcontextrestored handler above).
-  buildStudioEnvironment();
+  // Image-based lighting from a neutral room for believable PBR shading. On a
+  // real GPU the PMREM bake is ~tens of ms; on a software rasterizer it costs
+  // seconds and would freeze startup, so it's skipped there (the model still
+  // reads well under the ambient + two directional lights). It's a GPU texture,
+  // so it's also rebuilt on webglcontextrestored (see the handler above).
+  if (studioEnvEnabled) buildStudioEnvironment();
 
   // Floor the model sits on, plus a transparent shadow-catcher above it so the
   // contact shadow's darkness is tunable independent of the floor color.

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -1,8 +1,10 @@
 import * as THREE from 'three';
 import { Timer } from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
 import type { MeshData } from '../geometry/types';
-import { createDefaultMaterial, createWireframeMaterial } from './materials';
+import { createWireframeMaterial } from './materials';
+import { studioPresetFor, makeGradientTexture, createStudioMaterial, type StudioPreset } from './studioEnv';
 import { initMeasureOverlay } from './measureOverlay';
 import { initOrientationGizmo, renderGizmo, updateGizmo, isGizmoAnimating } from './orientationGizmo';
 import { initDimensionLines, updateDimensionLines, setDimensionsVisible as setDimensionsVisibleImpl, isDimensionsVisible } from './dimensionLines';
@@ -11,9 +13,7 @@ import { frameRateAdjustedDamping } from './orbitDamping';
 import { getTheme, onThemeChange, type Theme } from '../ui/theme';
 import { getConfig } from '../config/appConfig';
 
-const VIEWPORT_BG = { dark: 0x1a1a2e, light: 0xededed } as const;
 const GRID_COLORS = { dark: { major: 0x444444, minor: 0x333333 }, light: { major: 0xb0b0b0, minor: 0xc8c8c8 } } as const;
-function bgFor(theme: Theme): number { return VIEWPORT_BG[theme]; }
 
 function makeGrid(theme: Theme): THREE.GridHelper {
   const c = GRID_COLORS[theme];
@@ -105,6 +105,38 @@ const ndcForHit = new THREE.Vector2();
 // Grid plane
 let grid: THREE.GridHelper;
 
+// Studio-space rendering: a gradient backdrop, image-based PBR lighting, a floor,
+// and a contact shadow that grounds the model in a space — instead of the old
+// flat color void. Driven by the light/dark theme (see studioEnv.ts).
+let studioPreset: StudioPreset = studioPresetFor('dark');
+let studioFloor: THREE.Mesh | null = null;
+let studioShadowCatcher: THREE.Mesh | null = null;
+let studioKeyLight: THREE.DirectionalLight | null = null;
+let lastFloorZ = 0;
+
+/** Re-skin the studio scene (backdrop, lights, floor, shadow, model material)
+ *  for a theme — called once at init's theme value and again on every flip. */
+function applyStudioTheme(theme: Theme): void {
+  studioPreset = studioPresetFor(theme);
+  const old = scene.background;
+  scene.background = makeGradientTexture(studioPreset.bgTop, studioPreset.bgBottom);
+  if (old instanceof THREE.Texture) old.dispose();
+  renderer.toneMappingExposure = studioPreset.exposure;
+  scene.environmentIntensity = studioPreset.envIntensity;
+  if (studioFloor) (studioFloor.material as THREE.MeshStandardMaterial).color.set(studioPreset.floorColor);
+  if (studioShadowCatcher) (studioShadowCatcher.material as THREE.ShadowMaterial).opacity = studioPreset.shadowStrength;
+  // Recolor the live model material in place (it's only rebuilt on the next run).
+  const solid = meshGroup?.children.find(c => c instanceof THREE.Mesh && c.name !== 'wireframe' && c.name !== 'clip-cap');
+  if (solid instanceof THREE.Mesh) {
+    const mat = solid.material;
+    if (mat instanceof THREE.MeshStandardMaterial && !mat.vertexColors) {
+      mat.color.set(studioPreset.matColor);
+      mat.roughness = studioPreset.matRoughness;
+      mat.metalness = studioPreset.matMetalness;
+    }
+  }
+}
+
 // Mesh edge (wireframe) overlay visibility. Hidden by default so the model
 // reads cleanly; paint mode forces it on (see paintMode.ts) and the viewport
 // toggle button lets the user override either way.
@@ -137,8 +169,10 @@ export function initViewport(container: HTMLElement): {
   camera: THREE.PerspectiveCamera;
   renderer: THREE.WebGLRenderer;
 } {
+  studioPreset = studioPresetFor(getTheme());
+
   scene = new THREE.Scene();
-  scene.background = new THREE.Color(bgFor(getTheme()));
+  scene.background = makeGradientTexture(studioPreset.bgTop, studioPreset.bgBottom);
 
   camera = new THREE.PerspectiveCamera(50, 1, 0.1, 1000);
   camera.position.set(15, -15, 15);
@@ -152,6 +186,10 @@ export function initViewport(container: HTMLElement): {
   renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
   renderer.setPixelRatio(baseDpr());
   renderer.localClippingEnabled = true;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = studioPreset.exposure;
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
   // WebGL context-loss recovery. preventDefault() on 'lost' is what lets the
   // browser restore the context; while lost we cancel the RAF loop so we don't
@@ -166,10 +204,23 @@ export function initViewport(container: HTMLElement): {
   canvas.addEventListener('webglcontextrestored', () => {
     contextLost = false;
     needsRender = true;
+    // The image-based-lighting env texture lives on the GPU and is lost with
+    // the context — regenerate it so the model isn't left unlit after restore.
+    buildStudioEnvironment();
     onContextRestored?.();
     // Restart the render loop (it was cancelled on loss).
     animate();
   }, false);
+
+  // Build (or rebuild) the RoomEnvironment IBL map and apply it to the scene.
+  function buildStudioEnvironment(): void {
+    const old = scene.environment;
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+    scene.environmentIntensity = studioPreset.envIntensity;
+    pmrem.dispose();
+    if (old) old.dispose();
+  }
 
   controls = new OrbitControls(camera, canvas);
   controls.enableDamping = true;
@@ -245,31 +296,60 @@ export function initViewport(container: HTMLElement): {
     }));
   }, { capture: true, passive: false });
 
-  // Lighting
+  // Lighting — ambient + key/fill directionals; intensities stay user-tunable
+  // via appConfig.renderer. The key (dir1) also casts the contact shadow.
   const ambient = new THREE.AmbientLight(0xffffff, getConfig().renderer.ambientLightIntensity);
   scene.add(ambient);
 
   const dir1 = new THREE.DirectionalLight(0xffffff, getConfig().renderer.primaryLightIntensity);
   dir1.position.set(10, -10, 15);
+  dir1.castShadow = true;
+  dir1.shadow.mapSize.set(2048, 2048);
+  dir1.shadow.bias = -0.0005;
   scene.add(dir1);
+  scene.add(dir1.target);
+  studioKeyLight = dir1;
 
   const dir2 = new THREE.DirectionalLight(0xffffff, getConfig().renderer.secondaryLightIntensity);
   dir2.position.set(-10, 10, -5);
   scene.add(dir2);
 
-  // Grid on XY plane (hidden by default)
+  // Image-based lighting from a neutral room for believable PBR shading. The
+  // generated env is a GPU texture, so it's lost with the WebGL context and
+  // rebuilt on restore (see the webglcontextrestored handler above).
+  buildStudioEnvironment();
+
+  // Floor the model sits on, plus a transparent shadow-catcher above it so the
+  // contact shadow's darkness is tunable independent of the floor color.
+  const floorMat = new THREE.MeshStandardMaterial({
+    color: studioPreset.floorColor,
+    roughness: 0.95,
+    metalness: 0.0,
+  });
+  studioFloor = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), floorMat);
+  scene.add(studioFloor);
+
+  studioShadowCatcher = new THREE.Mesh(
+    new THREE.PlaneGeometry(1, 1),
+    new THREE.ShadowMaterial({ opacity: studioPreset.shadowStrength }),
+  );
+  studioShadowCatcher.receiveShadow = true;
+  scene.add(studioShadowCatcher);
+
+  // Grid on XY plane (hidden by default; user-toggleable). Theme-colored.
   grid = makeGrid(getTheme());
   scene.add(grid);
 
-  // Re-tint scene + grid when theme flips
+  // Re-skin the whole studio when the theme flips.
   onThemeChange((theme) => {
-    (scene.background as THREE.Color).set(bgFor(theme));
+    applyStudioTheme(theme);
     const wasVisible = grid.visible;
     scene.remove(grid);
     grid.geometry.dispose();
     (grid.material as THREE.Material).dispose();
     grid = makeGrid(theme);
     grid.visible = wasVisible;
+    grid.position.z = lastFloorZ;
     scene.add(grid);
     needsRender = true;
   });
@@ -388,7 +468,7 @@ export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boole
   const geometry = meshGLToBufferGeometry(meshData);
   const hasColors = geometry.hasAttribute('color');
 
-  const solidMat = createDefaultMaterial(hasColors);
+  const solidMat = createStudioMaterial(studioPreset, hasColors);
   const wireMat = createWireframeMaterial();
 
   // Apply clipping planes to materials
@@ -398,6 +478,7 @@ export function updateMesh(meshData: MeshData, options?: { skipAutoFrame?: boole
   }
 
   const solidMesh = new THREE.Mesh(geometry, solidMat);
+  solidMesh.castShadow = true;
   const wireMesh = new THREE.Mesh(geometry, wireMat);
   wireMesh.name = 'wireframe';
   wireMesh.visible = wireframeVisible;
@@ -457,8 +538,30 @@ function frameModel(): void {
   // Update model bounds for clip slider
   modelBounds = { min: box.min.z, max: box.max.z };
 
-  // Position grid at the bottom of the model
+  // Position grid + studio floor at the bottom of the model.
+  lastFloorZ = box.min.z;
   grid.position.z = box.min.z;
+
+  // Studio: park the floor (and its shadow catcher just above it) under the
+  // model, and size the key light's shadow frustum to the model's footprint.
+  if (studioFloor) {
+    studioFloor.position.set(center.x, center.y, box.min.z - maxDim * 0.004);
+    studioFloor.scale.set(maxDim * 14, maxDim * 14, 1);
+  }
+  if (studioShadowCatcher) {
+    studioShadowCatcher.position.set(center.x, center.y, box.min.z - maxDim * 0.002);
+    studioShadowCatcher.scale.set(maxDim * 14, maxDim * 14, 1);
+  }
+  if (studioKeyLight) {
+    studioKeyLight.position.set(center.x + maxDim * 0.8, center.y - maxDim * 0.5, box.max.z + maxDim * 1.4);
+    studioKeyLight.target.position.copy(center);
+    studioKeyLight.target.updateMatrixWorld();
+    const cam = studioKeyLight.shadow.camera;
+    const ext = maxDim * 1.4;
+    cam.left = -ext; cam.right = ext; cam.top = ext; cam.bottom = -ext;
+    cam.near = maxDim * 0.1; cam.far = maxDim * 6;
+    cam.updateProjectionMatrix();
+  }
 
   // Update bounding box dimension annotations
   updateDimensionLines(box);

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -936,6 +936,7 @@ function createClipControls(): HTMLElement {
   // independent flips, and a menu round-trip per toggle was pure friction.
   container.appendChild(makeViewportPill('wireframe-toggle', '△ Edges', 'Show mesh edges'));
   container.appendChild(makeViewportPill('grid-toggle', '▦ Grid', 'Show grid plane'));
+  container.appendChild(makeViewportPill('light-toggle', '☀ Light', 'Studio lighting: reflections + soft shadow (off by default)'));
   // Dimensions defaults on — give it the active blue styling to match its state.
   container.appendChild(makeViewportPill(
     'dimensions-toggle', '⬚ Dims', 'Toggle bounding box dimensions',

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -936,7 +936,7 @@ function createClipControls(): HTMLElement {
   // independent flips, and a menu round-trip per toggle was pure friction.
   container.appendChild(makeViewportPill('wireframe-toggle', '△ Edges', 'Show mesh edges'));
   container.appendChild(makeViewportPill('grid-toggle', '▦ Grid', 'Show grid plane'));
-  container.appendChild(makeViewportPill('light-toggle', '☀ Light', 'Studio lighting: reflections + soft shadow (off by default)'));
+  container.appendChild(makeViewportPill('light-toggle', '☀ Light', 'Studio lighting: reflections + soft shadow (on by default)'));
   // Dimensions defaults on — give it the active blue styling to match its state.
   container.appendChild(makeViewportPill(
     'dimensions-toggle', '⬚ Dims', 'Toggle bounding box dimensions',

--- a/tests/studio-lighting.spec.ts
+++ b/tests/studio-lighting.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from 'playwright/test';
+
+// The viewport "Light" toggle: studio image-based lighting + a mild contact
+// shadow, off by default (opt-in so the default view stays calm/matte).
+test.describe('studio lighting toggle', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ } });
+  });
+
+  test('Light pill is off by default and toggles studio lighting on/off', async ({ page }) => {
+    await page.goto('/editor');
+    await page.waitForFunction(() => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run, null, { timeout: 30000 });
+
+    const lightBtn = page.locator('#light-toggle');
+    await expect(lightBtn).toBeVisible();
+
+    const isOn = () => page.evaluate(() => (window as unknown as { partwright: { isStudioLighting(): boolean } }).partwright.isStudioLighting());
+
+    // Off by default.
+    expect(await isOn()).toBe(false);
+
+    // Click turns it on (the PMREM env bake can take a moment on software WebGL).
+    await lightBtn.click();
+    await expect.poll(isOn, { timeout: 20000 }).toBe(true);
+
+    // Click again turns it back off.
+    await lightBtn.click();
+    await expect.poll(isOn, { timeout: 10000 }).toBe(false);
+  });
+});

--- a/tests/studio-lighting.spec.ts
+++ b/tests/studio-lighting.spec.ts
@@ -1,13 +1,15 @@
 import { test, expect } from 'playwright/test';
 
 // The viewport "Light" toggle: studio image-based lighting + a mild contact
-// shadow, off by default (opt-in so the default view stays calm/matte).
+// shadow, on by default, toggleable from the viewport. Re-toggling must keep
+// working across off→on→off cycles (regression: a stale env-cache flag once
+// broke re-enabling).
 test.describe('studio lighting toggle', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => { try { localStorage.setItem('partwright-tour-completed', '1'); } catch { /* ignore */ } });
   });
 
-  test('Light pill is off by default and toggles studio lighting on/off', async ({ page }) => {
+  test('Light pill is on by default and toggles cleanly across cycles', async ({ page }) => {
     await page.goto('/editor');
     await page.waitForFunction(() => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run, null, { timeout: 30000 });
 
@@ -16,15 +18,17 @@ test.describe('studio lighting toggle', () => {
 
     const isOn = () => page.evaluate(() => (window as unknown as { partwright: { isStudioLighting(): boolean } }).partwright.isStudioLighting());
 
-    // Off by default.
-    expect(await isOn()).toBe(false);
+    // On by default.
+    expect(await isOn()).toBe(true);
 
-    // Click turns it on (the PMREM env bake can take a moment on software WebGL).
-    await lightBtn.click();
-    await expect.poll(isOn, { timeout: 20000 }).toBe(true);
-
-    // Click again turns it back off.
+    // Off → on → off → on must all register (not just the first cycle).
     await lightBtn.click();
     await expect.poll(isOn, { timeout: 10000 }).toBe(false);
+    await lightBtn.click();
+    await expect.poll(isOn, { timeout: 20000 }).toBe(true);
+    await lightBtn.click();
+    await expect.poll(isOn, { timeout: 10000 }).toBe(false);
+    await lightBtn.click();
+    await expect.poll(isOn, { timeout: 10000 }).toBe(true);
   });
 });

--- a/tests/unit/studioEnv.test.ts
+++ b/tests/unit/studioEnv.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { studioPresetFor, createStudioMaterial } from '../../src/renderer/studioEnv';
+
+describe('studioEnv', () => {
+  it('gives distinct dark and light presets', () => {
+    const dark = studioPresetFor('dark');
+    const light = studioPresetFor('light');
+    // Dark stage is darker than the light seamless studio.
+    expect(dark.bgBottom).toBeLessThan(light.bgBottom);
+    expect(dark.floorColor).toBeLessThan(light.floorColor);
+    // Both define a tunable contact-shadow strength in range.
+    for (const p of [dark, light]) {
+      expect(p.shadowStrength).toBeGreaterThan(0);
+      expect(p.shadowStrength).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('builds a PBR material honoring the preset for the unpainted case', () => {
+    const preset = studioPresetFor('dark');
+    const mat = createStudioMaterial(preset, false);
+    expect(mat).toBeInstanceOf(THREE.MeshStandardMaterial);
+    expect(mat.vertexColors).toBe(false);
+    expect(mat.color.getHex()).toBe(preset.matColor);
+    expect(mat.roughness).toBe(preset.matRoughness);
+    expect(mat.metalness).toBe(preset.matMetalness);
+    expect(mat.side).toBe(THREE.DoubleSide);
+  });
+
+  it('uses a white base when vertex colors drive the look (painted models)', () => {
+    const mat = createStudioMaterial(studioPresetFor('light'), true);
+    expect(mat.vertexColors).toBe(true);
+    expect(mat.color.getHex()).toBe(0xffffff);
+  });
+});


### PR DESCRIPTION
## Summary

Revisits the interactive view so the model sits **in a space** instead of a flat dark void.

**Always on:**
- **Vertical gradient backdrop** + **a floor** the model rests on
- **PBR model** (`MeshStandardMaterial`) lit by ambient + two directional lights (intensities from `appConfig.renderer`)
- **Theme-driven**: dark = graded charcoal space, light = soft seamless studio

**"☀ Light" viewport pill — on by default, toggleable:**
- Adds **gentle** RoomEnvironment image-based reflections (envIntensity 0.32 dark / 0.45 light — tuned down so it's soft fill, not a washed-out spotlight) + a **mild contact shadow**
- The PMREM env bake runs on GPUs only; on software WebGL (CI / GPU-less) it's skipped (matte + shadow), so startup stays fast and the env is rebuilt on context-restore
- The env texture is cached so off→on→off cycles stay correct (fixed a regression where re-enabling didn't restore reflections)
- Parity API: `partwright.setStudioLighting(on?)` / `isStudioLighting()`

## Test plan
- `tsc`, `npm run test:unit` (incl. `studioEnv.test.ts`), `npm run lint:deps`, `npm run build` — all green
- e2e `tests/studio-lighting.spec.ts` (on by default; full off→on→off→on cycle); re-confirmed `multipart-export.spec.ts` passes (startup readiness unaffected)
- Manual browser verification (screenshots in the session): default look + Light on/off, both themes

## Scope manifest
Part 1 of 2 of "revisit the interactive view" (tracking: #792):
- [x] this PR — studio-space rendering (gradient backdrop + floor + PBR; "Light" toggle, on by default, for gentle reflections + mild shadow)
- [ ] selection-first quick-actions HUD (click a model/part → Move/Rotate/Resize/Paint menu) — tracked: #792, not yet started

🤖 Generated with [Claude Code](https://claude.com/claude-code)