### PR TITLE
feat: zoom the default model framing out a bit

### DIFF
--- a/prompts/20260620-151537-default-frame-zoom-out.md
+++ b/prompts/20260620-151537-default-frame-zoom-out.md
@@ -1,0 +1,33 @@
+---
+session: "cool-galileo"
+timestamp: "2026-06-20T15:15:37Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+After the import fix merged: the default view is too zoomed in on the new
+model — it should be more zoomed out by default. Make a new PR.
+
+## Assistant
+
+## Key decisions
+
+**Root**: `frameModel()` in `src/renderer/viewport.ts` hardcoded the auto-frame
+camera at `center ± maxDim * 1.2` on each axis (view distance ≈ 2.08·maxDim).
+That `1.2` is the framing tightness — too small, so the model nearly fills the
+viewport on every fresh render / Reset view.
+
+**Fix**: per the repo's "no hardcoded tuning constants" rule, promoted the factor
+to `renderer.defaultFrameFactor` in `appConfig.ts` and raised the default to
+**1.5** (view distance ≈ 2.6·maxDim — ~25% more margin). `frameModel` reads it
+via `getConfig()`. Exposed it in the Advanced Settings modal (Rendering section)
+as "Default zoom (framing)" so users can tune it live. Updated the adjacent
+maxDistance comment that referenced the old ~2.1·maxDim distance.
+
+Verified visually (scratch spec, throwaway): the same body+head figure that
+previously filled the frame now sits centered with comfortable margin. Full
+preflight green (the new config key didn't trip the config-shape unit tests).
+No new permanent test — the value is subjective and a hardcoded camera-distance
+assertion would be brittle; framing is already exercised indirectly by the e2e
+suite.

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -122,6 +122,11 @@ export interface AppConfig {
      *  far the camera can dolly back (OrbitControls maxDistance) so the model
      *  can't shrink to a speck. Re-derived from the model size on each frame. */
     maxZoomOutFactor: number;
+    /** Default framing tightness: when auto-framing (every fresh render and
+     *  "Reset view"), the camera sits at this multiple of the model's largest
+     *  dimension along each of X/Y/Z, i.e. a view distance of factor·√3·maxDim.
+     *  Higher = more zoomed out / more margin around the model. */
+    defaultFrameFactor: number;
     /** Ambient light intensity in the 3D viewport (0–2 range). */
     ambientLightIntensity: number;
     /** Primary directional light intensity (0–2 range). */
@@ -310,6 +315,7 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     orbitDampingFactor: 0.1,
     orbitDampingReferenceFps: 60,
     maxZoomOutFactor: 12,
+    defaultFrameFactor: 1.5,
     ambientLightIntensity: 0.6,
     primaryLightIntensity: 0.8,
     secondaryLightIntensity: 0.3,

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -464,10 +464,13 @@ function frameModel(): void {
   updateDimensionLines(box);
 
   controls.target.copy(center);
+  // How tightly the default view frames the model (factor·maxDim along each
+  // axis). Higher = more zoomed out. Tunable via renderer.defaultFrameFactor.
+  const frameFactor = getConfig().renderer.defaultFrameFactor;
   camera.position.set(
-    center.x + maxDim * 1.2,
-    center.y - maxDim * 1.2,
-    center.z + maxDim * 1.2,
+    center.x + maxDim * frameFactor,
+    center.y - maxDim * frameFactor,
+    center.z + maxDim * frameFactor,
   );
   // Adapt the clip planes to the model size. With a fixed far plane a large
   // model (e.g. scaled to ~890mm) auto-frames the camera far enough away that
@@ -479,7 +482,8 @@ function frameModel(): void {
     camera.updateProjectionMatrix();
     // Bound how far the user can dolly out so the model can't shrink to a
     // speck (and drift toward the far plane). The default framing distance is
-    // ~maxDim*2.1, so a multiple well above that still leaves generous room.
+    // frameFactor·√3·maxDim (~2.6·maxDim at the default), so maxZoomOutFactor
+    // (a larger multiple) still leaves generous room.
     controls.maxDistance = maxDim * getConfig().renderer.maxZoomOutFactor;
   }
   controls.update();

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -572,6 +572,14 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           onChange={v => set('renderer', 'maxZoomOutFactor', v)}
         />
         <Field
+          label="Default zoom (framing)"
+          tooltip="How zoomed-out the default view is, as a multiple of the model's largest dimension along each axis (view distance ≈ factor × 1.7 × that dimension). Higher leaves more margin around the model; lower fills more of the viewport. Applied on every fresh render and when you click Reset view."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.defaultFrameFactor}
+          value={c.renderer.defaultFrameFactor}
+          min={1} max={3} step={0.1}
+          onChange={v => set('renderer', 'defaultFrameFactor', v)}
+        />
+        <Field
           label="Orientation gizmo size"
           unit="px"
           tooltip="The canvas size in CSS pixels of the orientation gizmo (the XYZ cube in the viewport corner). Larger makes the axis labels easier to read; smaller keeps it out of the way. Takes effect after a page reload."


### PR DESCRIPTION
## Summary

Follow-up to #786: the default view was too zoomed in on a freshly rendered/imported model.

`frameModel()` positioned the auto-frame camera at `center ± maxDim * 1.2` along each axis (view distance ≈ 2.1 × the model's largest dimension), so the model nearly filled the viewport on every fresh render and on "Reset view".

This:
- Promotes that hardcoded `1.2` framing factor to **`renderer.defaultFrameFactor`** in `appConfig.ts` (per the repo's no-hardcoded-tuning-constants rule), read via `getConfig()`.
- Raises the default to **1.5** (view distance ≈ 2.6 × maxDim — ~25% more margin around the model).
- Exposes it in the Advanced Settings → Rendering panel as **"Default zoom (framing)"** so it's user-tunable live.

Applies to every auto-frame: fresh runs, version/part loads, imports, and the "Reset view" button.

## Test plan
- Manual browser verification (screenshot): the same body+head figure that previously filled the frame now sits centered with comfortable margin.
- `npm run preflight` green (typecheck + 1508 unit tests + lint:deps acyclic + lint:consistency) — the new config key doesn't trip the config-shape tests.
- No new permanent test: framing is exercised indirectly by the e2e suite, and a hardcoded camera-distance assertion for a subjective default would be brittle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEHeftHghYnTd8awLQbFA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEHeftHghYnTd8awLQbFA4)_