### PR TITLE
feat: per-part colour swatches + a shared palette colour-picker modal

### DIFF
--- a/prompts/paint-whole-part-color-swatch.md
+++ b/prompts/paint-whole-part-color-swatch.md
@@ -1,0 +1,40 @@
+---
+title: Set the colour of a whole part from the paint menu
+date: 2026-06-20
+labels: [enhancement]
+---
+
+## Human
+
+We should have the ability to set the color for a whole part. Maybe part of
+the paint menu? Investigate and recommend, but go ahead and make a PR.
+
+## Assistant
+
+**Investigation.** The app's notion of a "part" is an `api.label(shape, name)`
+feature, already surfaced in the Paint menu's **Labels list**
+(`src/color/paintUI.ts`). Clicking a label row already painted the whole part —
+but only with whatever the *active* paint colour happened to be, and only via a
+passive colour dot that couldn't be edited. The persistent mechanism (`byLabel`
+region descriptor, re-resolved against the live label map on every run) was
+already in place and is exactly what `partwright.paintByLabel` emits, so
+UI↔API parity was already satisfied — the only gap was a direct UI affordance.
+
+**Decision.** Rather than add a new connected-component tool (the Bucket tool
+in colour mode at 100% tolerance already floods a whole mesh island, and the
+codebase's "part" concept is the label), I made each Labels-list row's colour
+indicator an interactive `<input type="color">` swatch. Picking a colour:
+
+- recolours the part's existing `byLabel` region **in place** when one exists
+  (no duplicate-region stacking), via `updateRegionColor`; otherwise
+- commits a fresh `byLabel` region over the label's triangle set (the same
+  descriptor `paintByLabel` produces, so it persists and re-resolves).
+
+The swatch defaults to the active paint colour (previewing "the part will become
+this") and stops click propagation so it doesn't also fire the row's
+paint-with-active-colour handler. The row click is unchanged, so existing
+behaviour and the existing e2e test still hold.
+
+No new `window.partwright` method was needed — `paintByLabel` already covers the
+capability for console/AI callers. Added an e2e case to
+`tests/paint-labels-panel.spec.ts` covering set + recolour-in-place.

--- a/prompts/shared-palette-color-picker-modal.md
+++ b/prompts/shared-palette-color-picker-modal.md
@@ -1,0 +1,51 @@
+---
+title: Shared palette colour-picker modal replacing native OS pickers
+date: 2026-06-21
+labels: [enhancement]
+---
+
+## Human
+
+I think all moments where we have a color picker from places like that, I
+think we should pop up a modal with a pallet color picker and within the pallet
+color picker is a complete freeform color picker that then adds that new color
+to the pallet when it's picked.
+
+(Follow-on to the per-part label swatch, which used the native OS picker.)
+
+## Assistant
+
+**Two clarifications resolved with the user first** (both change the build):
+1. *New freeform colour →* add to the **"Recent" history** (`recordColor`), not a
+   permanent filament slot. Slots map to real filaments, so promotion stays an
+   explicit action in the palette manager — auto-adding every ad-hoc colour
+   would balloon the slot list.
+2. *Scope →* **all** native `<input type="color">` pickers app-wide.
+
+**New shared component — `src/ui/colorPickerModal.ts`:**
+- `openColorPicker({ initialHex, title?, onPick, onClose? })` — a stacked overlay
+  (its own `z-[60]` overlay, **not** the singleton `createModalShell`, because it
+  is frequently opened from inside another modal/panel and modalShell would
+  force-close the parent). Shows the active palette's slots and the recent-colour
+  history as one-click commit swatches, plus a freeform native picker + hex input.
+  Palette/recent clicks commit immediately; the freeform pick commits via Apply
+  and is recorded to Recent.
+- `createColorSwatch({ initialHex, onPick, ... }) → { el, setHex }` — a swatch
+  button that opens the picker; the drop-in replacement for a native
+  `<input type="color">` styled as a swatch. Stops click propagation (so a swatch
+  inside a clickable row doesn't also trigger the row).
+
+**Wired every call site** to the shared picker: paint panel (custom colour,
+per-label part swatch, region-list swatch), surface modal custom colour, params
+panel `color` field, relief studio region swatch, annotation custom colour,
+voxel paint custom colour, image-paint background-colour picker, and the two
+image→voxel import modal pickers (TSX → button + `openColorPicker`). The palette
+manager's own slot editor stays a direct native picker on purpose (editing a
+slot's colour shouldn't reopen the palette).
+
+**Layering:** added a `ui → color/palette` import edge; `lint:deps` confirms the
+graph stays acyclic.
+
+**Tests:** new `tests/color-picker-modal.spec.ts` (palette-swatch commit +
+freeform→Recent). Updated `paint-labels-panel` and `paint-palette` specs that
+previously drove the native `<input type="color">` to go through the modal.

--- a/src/annotations/annotateUI.ts
+++ b/src/annotations/annotateUI.ts
@@ -294,6 +294,7 @@ function createPickerPanel(): HTMLElement {
       setPenColor(color);
       setTextColor(color);
       markActiveSwatch(grid, swatch);
+      custom.setHex(rgbToHex(color)); // keep the custom swatch a truthful preview
     });
     grid.appendChild(swatch);
   }

--- a/src/annotations/annotateUI.ts
+++ b/src/annotations/annotateUI.ts
@@ -44,6 +44,7 @@ import { openViewportPanel, closeViewportPanel } from '../ui/viewportPanelRegist
 import { attachViewportPanelDrag, setInitialPanelPosition } from '../ui/viewportPanelDrag';
 import { viewportToolsMount } from '../ui/popoverMenu';
 import { createToolPanelHeader, TOOL_TOGGLE_IDLE, TOOL_TOGGLE_ACTIVE } from '../ui/toolPanel';
+import { createColorSwatch } from '../ui/colorPickerModal';
 
 const PRESET_COLORS: [number, number, number][] = [
   [0.95, 0.20, 0.45], // hot pink (default)
@@ -303,22 +304,23 @@ function createPickerPanel(): HTMLElement {
   // Custom color
   const customRow = document.createElement('div');
   customRow.className = 'flex items-center gap-1.5 mb-2';
-  const colorInput = document.createElement('input');
-  colorInput.type = 'color';
-  colorInput.value = rgbToHex(PRESET_COLORS[0]);
-  colorInput.className = 'w-6 h-6 rounded cursor-pointer border-0 p-0 bg-transparent';
-  colorInput.title = 'Custom color';
-  colorInput.addEventListener('input', () => {
-    const hex = colorInput.value;
-    const r = parseInt(hex.slice(1, 3), 16) / 255;
-    const g = parseInt(hex.slice(3, 5), 16) / 255;
-    const b = parseInt(hex.slice(5, 7), 16) / 255;
-    setPenColor([r, g, b]);
-    setTextColor([r, g, b]);
-    for (const child of Array.from(grid.children)) {
-      (child as HTMLElement).classList.remove('border-white/80', 'ring-1', 'ring-white/30');
-    }
+  const custom = createColorSwatch({
+    initialHex: rgbToHex(PRESET_COLORS[0]),
+    title: 'Custom color',
+    modalTitle: 'Annotation colour',
+    className: 'w-6 h-6 shrink-0 rounded cursor-pointer border border-zinc-500 hover:border-white/70 transition-colors',
+    onPick: (hex) => {
+      const r = parseInt(hex.slice(1, 3), 16) / 255;
+      const g = parseInt(hex.slice(3, 5), 16) / 255;
+      const b = parseInt(hex.slice(5, 7), 16) / 255;
+      setPenColor([r, g, b]);
+      setTextColor([r, g, b]);
+      for (const child of Array.from(grid.children)) {
+        (child as HTMLElement).classList.remove('border-white/80', 'ring-1', 'ring-white/30');
+      }
+    },
   });
+  const colorInput = custom.el;
   const customLabel = document.createElement('span');
   customLabel.className = 'text-[10px] text-zinc-500';
   customLabel.textContent = 'Custom';

--- a/src/color/imagePaintUI.ts
+++ b/src/color/imagePaintUI.ts
@@ -37,6 +37,7 @@ import { getCurrentMesh as getPaintMesh } from './paintAccessors';
 import { deactivateMode, registerExclusiveMode } from '../ui/modeExclusion';
 import { forceDeactivate as closeSimplifyMenu } from '../ui/simplifyUI';
 import { viewportToolsMount } from '../ui/popoverMenu';
+import { createColorSwatch } from '../ui/colorPickerModal';
 import { setInitialPanelPosition, attachViewportPanelDrag } from '../ui/viewportPanelDrag';
 import { createToolPanelHeader } from '../ui/toolPanel';
 import { openViewportPanel, closeViewportPanel } from '../ui/viewportPanelRegistry';
@@ -775,28 +776,28 @@ function buildBackgroundSection(): HTMLElement {
   pickerLabel.className = 'text-[11px] text-zinc-400 shrink-0';
   pickerLabel.textContent = 'Or pick color:';
 
-  const colorInput = document.createElement('input');
-  colorInput.type = 'color';
-  colorInput.value = '#ffffff';
-  colorInput.className = 'w-7 h-7 rounded cursor-pointer border border-zinc-600/40 bg-transparent p-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded [&::-webkit-color-swatch]:border-0';
-  colorInput.title = 'Manually specify the background colour to remove';
+  const colorSwatch = createColorSwatch({
+    initialHex: '#ffffff',
+    title: 'Manually specify the background colour to remove',
+    modalTitle: 'Background colour to remove',
+    className: 'w-7 h-7 shrink-0 rounded cursor-pointer border border-zinc-600/40 hover:border-white/70 transition-colors',
+    onPick: (hex) => {
+      opts.manualBgColor = [
+        parseInt(hex.slice(1, 3), 16),
+        parseInt(hex.slice(3, 5), 16),
+        parseInt(hex.slice(5, 7), 16),
+      ];
+      opts.removeBackground = true;
+      autoCheck.checked = true;
+      renderPreview();
+    },
+  });
+  const colorInput = colorSwatch.el;
 
   const colorClear = document.createElement('button');
   colorClear.className = 'text-[10px] text-zinc-500 hover:text-zinc-200 underline-offset-2 hover:underline transition-colors';
   colorClear.textContent = 'clear';
   colorClear.title = 'Revert to auto background detection';
-
-  colorInput.addEventListener('input', () => {
-    const hex = colorInput.value;
-    opts.manualBgColor = [
-      parseInt(hex.slice(1, 3), 16),
-      parseInt(hex.slice(3, 5), 16),
-      parseInt(hex.slice(5, 7), 16),
-    ];
-    opts.removeBackground = true;
-    autoCheck.checked = true;
-    renderPreview();
-  });
 
   colorClear.addEventListener('click', () => {
     opts.manualBgColor = undefined;

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -1670,14 +1670,52 @@ function createLabelRow(label: LabelInfo, alreadyPainted: boolean): HTMLElement 
     );
   });
 
-  const dot = document.createElement('span');
-  dot.className = 'w-3 h-3 rounded-sm shrink-0 border border-zinc-600/60';
-  if (alreadyPainted) {
-    // Show the most recently-applied color for this label so the user can
-    // distinguish "blue eye" from "red eye" at a glance.
-    const last = [...getRegions()].reverse().find(r => r.descriptor.kind === 'byLabel' && r.descriptor.label === label.name);
-    if (last) dot.style.backgroundColor = rgbToCSS(last.color);
-  }
+  // Inline colour swatch — set the colour of this whole part directly, without
+  // first selecting the active paint colour. It doubles as the "already
+  // painted" indicator: when a byLabel region exists for this label the swatch
+  // shows its colour (the most recent one wins in compositing), so the user can
+  // tell a "blue eye" from a "red eye" at a glance. Editing it recolours that
+  // region in place instead of stacking a duplicate; for an unpainted label it
+  // commits a fresh byLabel region (the same descriptor partwright.paintByLabel
+  // emits, so it persists and re-resolves across runs). Defaults to the active
+  // paint colour so the swatch previews "the part will become this".
+  const lastPainted = alreadyPainted
+    ? [...getRegions()].reverse().find(r => r.descriptor.kind === 'byLabel' && r.descriptor.label === label.name) ?? null
+    : null;
+  const dot = document.createElement('input');
+  dot.type = 'color';
+  dot.value = rgbToHex(lastPainted ? lastPainted.color : getColor());
+  dot.className = 'w-3.5 h-3.5 shrink-0 rounded-sm border border-zinc-500 hover:border-white/60 cursor-pointer bg-transparent p-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-sm [&::-webkit-color-swatch]:border-0 [&::-moz-color-swatch]:rounded-sm [&::-moz-color-swatch]:border-0';
+  dot.dataset.action = 'set-label-color';
+  dot.title = lastPainted
+    ? `Recolour the whole "${label.name}" part`
+    : `Set the colour of the whole "${label.name}" part`;
+  // Don't let the swatch click bubble to the row (which paints with the active
+  // colour); the swatch is the "pick a specific colour" path.
+  dot.addEventListener('click', (e) => e.stopPropagation());
+  dot.addEventListener('change', () => {
+    if (label.triangles.size === 0) return;
+    const hex = dot.value;
+    const rgb: [number, number, number] = [
+      parseInt(hex.slice(1, 3), 16) / 255,
+      parseInt(hex.slice(3, 5), 16) / 255,
+      parseInt(hex.slice(5, 7), 16) / 255,
+    ];
+    const existing = [...getRegions()].reverse().find(r => r.descriptor.kind === 'byLabel' && r.descriptor.label === label.name);
+    if (existing) {
+      updateRegionColor(existing.id, rgb);
+    } else {
+      addRegion(
+        label.name,
+        rgb,
+        'paintbrush',
+        { kind: 'byLabel', label: label.name },
+        new Set(label.triangles),
+        true,
+        getSlotId() ?? undefined,
+      );
+    }
+  });
 
   const nameEl = document.createElement('span');
   nameEl.className = 'text-[11px] truncate flex-1 text-zinc-300';

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -98,6 +98,7 @@ import { attachViewportPanelDrag, setInitialPanelPosition } from '../ui/viewport
 import { registerExclusiveMode, deactivateMode } from '../ui/modeExclusion';
 import { viewportToolsMount } from '../ui/popoverMenu';
 import { createToolPanelHeader, TOOL_TOGGLE_IDLE, TOOL_TOGGLE_ACTIVE } from '../ui/toolPanel';
+import { createColorSwatch } from '../ui/colorPickerModal';
 
 let paintBtn: HTMLButtonElement | null = null;
 let pickerPanel: HTMLElement | null = null;
@@ -242,19 +243,21 @@ function createPaletteSection(): HTMLElement {
   // Custom (ad-hoc, unslotted) colour — hidden when the palette is constrained.
   const customRow = document.createElement('div');
   customRow.className = 'flex items-center gap-1.5';
-  const colorInput = document.createElement('input');
-  colorInput.type = 'color';
-  colorInput.className = 'w-6 h-6 rounded cursor-pointer border-0 p-0 bg-transparent';
-  colorInput.title = 'Custom color (unslotted)';
-  colorInput.addEventListener('input', () => {
-    const hex = colorInput.value;
-    setColor([
-      parseInt(hex.slice(1, 3), 16) / 255,
-      parseInt(hex.slice(3, 5), 16) / 255,
-      parseInt(hex.slice(5, 7), 16) / 255,
-    ]);
-    renderSwatches(); // drop the active-slot ring — we're now on an ad-hoc colour
+  const custom = createColorSwatch({
+    initialHex: rgbToHex(getColor()),
+    title: 'Custom color (unslotted)',
+    modalTitle: 'Custom paint colour',
+    className: 'w-6 h-6 shrink-0 rounded cursor-pointer border border-zinc-500 hover:border-white/70 transition-colors',
+    onPick: (hex) => {
+      setColor([
+        parseInt(hex.slice(1, 3), 16) / 255,
+        parseInt(hex.slice(3, 5), 16) / 255,
+        parseInt(hex.slice(5, 7), 16) / 255,
+      ]);
+      renderSwatches(); // drop the active-slot ring — we're now on an ad-hoc colour
+    },
   });
+  const colorInput = custom.el;
   const customLabel = document.createElement('span');
   customLabel.className = 'text-[10px] text-zinc-500';
   customLabel.textContent = 'Custom';
@@ -1682,40 +1685,40 @@ function createLabelRow(label: LabelInfo, alreadyPainted: boolean): HTMLElement 
   const lastPainted = alreadyPainted
     ? [...getRegions()].reverse().find(r => r.descriptor.kind === 'byLabel' && r.descriptor.label === label.name) ?? null
     : null;
-  const dot = document.createElement('input');
-  dot.type = 'color';
-  dot.value = rgbToHex(lastPainted ? lastPainted.color : getColor());
-  dot.className = 'w-3.5 h-3.5 shrink-0 rounded-sm border border-zinc-500 hover:border-white/60 cursor-pointer bg-transparent p-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-sm [&::-webkit-color-swatch]:border-0 [&::-moz-color-swatch]:rounded-sm [&::-moz-color-swatch]:border-0';
-  dot.dataset.action = 'set-label-color';
-  dot.title = lastPainted
-    ? `Recolour the whole "${label.name}" part`
-    : `Set the colour of the whole "${label.name}" part`;
-  // Don't let the swatch click bubble to the row (which paints with the active
-  // colour); the swatch is the "pick a specific colour" path.
-  dot.addEventListener('click', (e) => e.stopPropagation());
-  dot.addEventListener('change', () => {
-    if (label.triangles.size === 0) return;
-    const hex = dot.value;
-    const rgb: [number, number, number] = [
-      parseInt(hex.slice(1, 3), 16) / 255,
-      parseInt(hex.slice(3, 5), 16) / 255,
-      parseInt(hex.slice(5, 7), 16) / 255,
-    ];
-    const existing = [...getRegions()].reverse().find(r => r.descriptor.kind === 'byLabel' && r.descriptor.label === label.name);
-    if (existing) {
-      updateRegionColor(existing.id, rgb);
-    } else {
-      addRegion(
-        label.name,
-        rgb,
-        'paintbrush',
-        { kind: 'byLabel', label: label.name },
-        new Set(label.triangles),
-        true,
-        getSlotId() ?? undefined,
-      );
-    }
+  // The swatch opens the shared palette picker (createColorSwatch stops the
+  // click from bubbling to the row's paint-with-active-colour handler). Picking
+  // a colour recolours this part's existing byLabel region in place, or commits
+  // a fresh one — the same descriptor partwright.paintByLabel emits.
+  const swatch = createColorSwatch({
+    initialHex: rgbToHex(lastPainted ? lastPainted.color : getColor()),
+    title: lastPainted ? `Recolour the whole "${label.name}" part` : `Set the colour of the whole "${label.name}" part`,
+    modalTitle: `Colour for "${label.name}"`,
+    className: 'w-3.5 h-3.5 shrink-0 rounded-sm border border-zinc-500 hover:border-white/60 cursor-pointer',
+    dataAction: 'set-label-color',
+    onPick: (hex) => {
+      if (label.triangles.size === 0) return;
+      const rgb: [number, number, number] = [
+        parseInt(hex.slice(1, 3), 16) / 255,
+        parseInt(hex.slice(3, 5), 16) / 255,
+        parseInt(hex.slice(5, 7), 16) / 255,
+      ];
+      const existing = [...getRegions()].reverse().find(r => r.descriptor.kind === 'byLabel' && r.descriptor.label === label.name);
+      if (existing) {
+        updateRegionColor(existing.id, rgb);
+      } else {
+        addRegion(
+          label.name,
+          rgb,
+          'paintbrush',
+          { kind: 'byLabel', label: label.name },
+          new Set(label.triangles),
+          true,
+          getSlotId() ?? undefined,
+        );
+      }
+    },
   });
+  const dot = swatch.el;
 
   const nameEl = document.createElement('span');
   nameEl.className = 'text-[11px] truncate flex-1 text-zinc-300';
@@ -1765,26 +1768,24 @@ function updateRegionList(container: HTMLElement): void {
       if (releaseHover) { releaseHover(); releaseHover = null; }
     });
 
-    // Color swatch doubles as an edit affordance: the dot IS the native
-    // <input type="color">, styled to read as a swatch. The OS picker pops up
-    // anchored to the swatch (no hidden offscreen input → no "picker closes
-    // when I move the mouse" surprise). `change` commits a single
-    // updateRegionColor on release, so the mesh reconciler only fires once
-    // per pick instead of on every channel drag.
-    const dot = document.createElement('input');
-    dot.type = 'color';
-    dot.value = rgbToHex(region.color);
-    dot.className = 'w-3.5 h-3.5 shrink-0 rounded-sm border border-zinc-500 hover:border-white/60 cursor-pointer bg-transparent p-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-sm [&::-webkit-color-swatch]:border-0 [&::-moz-color-swatch]:rounded-sm [&::-moz-color-swatch]:border-0';
-    dot.title = `Click to change colour (${rgbToHex(region.color)})`;
-    if (!region.visible) dot.classList.add('opacity-30');
-    dot.addEventListener('change', () => {
-      const hex = dot.value;
-      const r = parseInt(hex.slice(1, 3), 16) / 255;
-      const g = parseInt(hex.slice(3, 5), 16) / 255;
-      const b = parseInt(hex.slice(5, 7), 16) / 255;
-      updateRegionColor(region.id, [r, g, b]);
+    // Colour swatch doubles as an edit affordance: clicking it opens the shared
+    // palette picker (createColorSwatch stops the click bubbling to the row).
+    // Picking commits a single updateRegionColor, so the mesh reconciler fires
+    // once per pick. The row is rebuilt on regions change, so no setHex needed.
+    const swatch = createColorSwatch({
+      initialHex: rgbToHex(region.color),
+      title: `Click to change colour (${rgbToHex(region.color)})`,
+      modalTitle: `Recolour "${region.name}"`,
+      className: `w-3.5 h-3.5 shrink-0 rounded-sm border border-zinc-500 hover:border-white/60 cursor-pointer${region.visible ? '' : ' opacity-30'}`,
+      onPick: (hex) => {
+        updateRegionColor(region.id, [
+          parseInt(hex.slice(1, 3), 16) / 255,
+          parseInt(hex.slice(3, 5), 16) / 255,
+          parseInt(hex.slice(5, 7), 16) / 255,
+        ]);
+      },
     });
-    dot.addEventListener('click', (e) => e.stopPropagation());
+    const dot = swatch.el;
 
     const label = document.createElement('span');
     label.className = `text-[11px] truncate flex-1 ${region.visible ? 'text-zinc-400' : 'text-zinc-600 line-through'}`;

--- a/src/color/paintUI.ts
+++ b/src/color/paintUI.ts
@@ -289,6 +289,9 @@ function createPaletteSection(): HTMLElement {
       });
       grid.appendChild(swatch);
     });
+    // Keep the custom swatch a truthful preview of the active paint colour
+    // (it changes when a slot is selected, not just on a custom pick).
+    custom.setHex(rgbToHex(getColor()));
   }
 
   function renderBudget(): void {

--- a/src/color/voxelPaintUI.ts
+++ b/src/color/voxelPaintUI.ts
@@ -10,6 +10,7 @@ import { viewportToolsMount } from '../ui/popoverMenu';
 import { attachViewportPanelDrag, setInitialPanelPosition } from '../ui/viewportPanelDrag';
 import { createToolPanelHeader, TOOL_TOGGLE_IDLE, TOOL_TOGGLE_ACTIVE } from '../ui/toolPanel';
 import { openViewportPanel, closeViewportPanel } from '../ui/viewportPanelRegistry';
+import { createColorSwatch } from '../ui/colorPickerModal';
 
 const SWATCHES: string[] = [
   '#ff3b30', '#ff8c42', '#ffd60a', '#34c759', '#5ac8fa',
@@ -371,12 +372,14 @@ function buildColorRow(): HTMLElement {
 
   const customRow = document.createElement('label');
   customRow.className = 'flex items-center gap-2 text-[11px] text-zinc-400';
-  const customInput = document.createElement('input');
-  customInput.type = 'color';
-  customInput.value = '#ffaa00';
-  customInput.className = 'w-6 h-6 rounded border border-zinc-600/60 bg-transparent cursor-pointer';
-  customInput.title = 'Custom color';
-  customInput.addEventListener('input', () => selectColor(customInput.value, null));
+  const custom = createColorSwatch({
+    initialHex: '#ffaa00',
+    title: 'Custom color',
+    modalTitle: 'Custom voxel colour',
+    className: 'w-6 h-6 shrink-0 rounded border border-zinc-600/60 cursor-pointer hover:border-white/70 transition-colors',
+    onPick: (hex) => selectColor(hex, null),
+  });
+  const customInput = custom.el;
   customRow.appendChild(customInput);
   const customLabel = document.createElement('span');
   customLabel.textContent = 'Custom color';

--- a/src/ui/colorPickerModal.ts
+++ b/src/ui/colorPickerModal.ts
@@ -1,0 +1,272 @@
+// Shared palette colour picker — the modal that replaces the native OS
+// `<input type="color">` across the app. It shows the active filament palette
+// and the recent-colour history as one-click swatches, plus a freeform picker
+// for any colour. A freeform pick is remembered in "Recent" (`recordColor`) so
+// it's one click away next time, but it does NOT become a permanent filament
+// slot — slots map to real filaments, so promotion to a slot stays an explicit
+// action in the palette manager.
+//
+// It is built as its own stacked overlay rather than via `createModalShell`,
+// because it is frequently opened from *inside* another modal/panel (surface,
+// params, image-import, the paint panel) and the singleton modalShell would
+// force-close that parent. It sits at z-[60] so it floats above modalShell
+// (z-50) and the viewport tool panels.
+
+import {
+  getActivePalette,
+  getColorHistory,
+  recordColor,
+  onPaletteChange,
+} from '../color/palette';
+
+export interface ColorPickerOptions {
+  /** Colour shown as selected when the picker opens (`#rrggbb`). */
+  initialHex: string;
+  /** Modal heading. Defaults to "Pick a colour". */
+  title?: string;
+  /** Called once with the committed `#rrggbb` when the user chooses a colour. */
+  onPick: (hex: string) => void;
+  /** Called when the picker closes for any reason (after `onPick` on commit,
+   *  or on cancel). */
+  onClose?: () => void;
+}
+
+function normalizeHex(hex: string): string {
+  const h = hex.trim().toLowerCase();
+  const m = /^#?([0-9a-f]{6})$/.exec(h);
+  if (m) return `#${m[1]}`;
+  const short = /^#?([0-9a-f]{3})$/.exec(h);
+  if (short) {
+    const [r, g, b] = short[1].split('');
+    return `#${r}${r}${g}${g}${b}${b}`;
+  }
+  return '#000000';
+}
+
+let openOverlay: HTMLElement | null = null;
+
+/** Open the shared palette colour picker. Idempotent per call — opening a new
+ *  one closes any picker already showing. */
+export function openColorPicker(opts: ColorPickerOptions): void {
+  // Only one picker at a time; closing the old one fires its onClose.
+  if (openOverlay) openOverlay.dispatchEvent(new CustomEvent('picker:force-close'));
+
+  let selected = normalizeHex(opts.initialHex);
+  let closed = false;
+
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'fixed inset-0 bg-black/60 flex items-center justify-center z-[60] p-4';
+  overlay.dataset.testid = 'color-picker';
+
+  const panel = document.createElement('div');
+  panel.className = 'bg-zinc-800 rounded-xl shadow-2xl border border-zinc-700 w-full max-w-xs flex flex-col max-h-[calc(100vh-2rem)]';
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'true');
+  panel.setAttribute('aria-label', opts.title ?? 'Pick a colour');
+  panel.tabIndex = -1;
+
+  // Header
+  const header = document.createElement('div');
+  header.className = 'px-4 py-2.5 border-b border-zinc-700 flex items-center justify-between';
+  const titleEl = document.createElement('h2');
+  titleEl.className = 'text-sm font-semibold text-zinc-100';
+  titleEl.textContent = opts.title ?? 'Pick a colour';
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'px-2 py-1 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 text-sm';
+  closeBtn.textContent = '✕';
+  closeBtn.setAttribute('aria-label', 'Dismiss');
+  closeBtn.title = 'Close';
+  header.append(titleEl, closeBtn);
+  panel.appendChild(header);
+
+  // Body (scrollable)
+  const body = document.createElement('div');
+  body.className = 'px-4 py-3 flex flex-col gap-3 overflow-y-auto flex-1 min-h-0';
+  panel.appendChild(body);
+
+  // Selected-colour preview row.
+  const previewRow = document.createElement('div');
+  previewRow.className = 'flex items-center gap-2';
+  const previewSwatch = document.createElement('div');
+  previewSwatch.className = 'w-8 h-8 rounded-md border border-zinc-600 shrink-0';
+  previewSwatch.style.backgroundColor = selected;
+  const previewHex = document.createElement('span');
+  previewHex.className = 'text-xs font-mono text-zinc-300';
+  previewHex.textContent = selected;
+  previewRow.append(previewSwatch, previewHex);
+  body.appendChild(previewRow);
+
+  function setSelected(hex: string): void {
+    selected = normalizeHex(hex);
+    previewSwatch.style.backgroundColor = selected;
+    previewHex.textContent = selected;
+    if (customInput.value.toLowerCase() !== selected) customInput.value = selected;
+    if (hexText.value.toLowerCase() !== selected) hexText.value = selected;
+  }
+
+  function commit(hex: string, { record }: { record: boolean }): void {
+    const norm = normalizeHex(hex);
+    if (record) recordColor(norm);
+    opts.onPick(norm);
+    close();
+  }
+
+  // ── Palette swatches ──────────────────────────────────────────────────────
+  const paletteLabel = document.createElement('div');
+  paletteLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider font-medium';
+  paletteLabel.textContent = 'Palette';
+  const paletteGrid = document.createElement('div');
+  paletteGrid.className = 'grid grid-cols-8 gap-1.5';
+  body.append(paletteLabel, paletteGrid);
+
+  // ── Recent colours ────────────────────────────────────────────────────────
+  const recentLabel = document.createElement('div');
+  recentLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider font-medium';
+  recentLabel.textContent = 'Recent';
+  const recentGrid = document.createElement('div');
+  recentGrid.className = 'grid grid-cols-8 gap-1.5';
+  body.append(recentLabel, recentGrid);
+
+  function swatchButton(hex: string, name: string, record: boolean): HTMLButtonElement {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'w-7 h-7 rounded border border-zinc-600/60 hover:border-white/70 transition-colors';
+    b.style.backgroundColor = hex;
+    b.title = name;
+    b.dataset.hex = hex.toLowerCase();
+    // One click on a known colour commits immediately — that's the fast path.
+    b.addEventListener('click', () => commit(hex, { record }));
+    return b;
+  }
+
+  function renderSwatches(): void {
+    paletteGrid.replaceChildren();
+    for (const slot of getActivePalette().slots) {
+      paletteGrid.appendChild(swatchButton(slot.hex, `${slot.name} (${slot.hex})`, false));
+    }
+    const hist = getColorHistory();
+    recentLabel.classList.toggle('hidden', hist.length === 0);
+    recentGrid.classList.toggle('hidden', hist.length === 0);
+    recentGrid.replaceChildren();
+    for (const hex of hist) recentGrid.appendChild(swatchButton(hex, hex, false));
+  }
+
+  // ── Custom / freeform picker ──────────────────────────────────────────────
+  const customLabel = document.createElement('div');
+  customLabel.className = 'text-[10px] text-zinc-500 uppercase tracking-wider font-medium';
+  customLabel.textContent = 'Custom';
+  const customRow = document.createElement('div');
+  customRow.className = 'flex items-center gap-2';
+  const customInput = document.createElement('input');
+  customInput.type = 'color';
+  customInput.value = selected;
+  customInput.className = 'w-9 h-9 rounded cursor-pointer border-0 p-0 bg-transparent shrink-0';
+  customInput.title = 'Pick any colour';
+  customInput.dataset.action = 'custom-color';
+  customInput.addEventListener('input', () => setSelected(customInput.value));
+  const hexText = document.createElement('input');
+  hexText.type = 'text';
+  hexText.value = selected;
+  hexText.spellcheck = false;
+  hexText.className = 'flex-1 min-w-0 px-2 py-1 rounded text-xs font-mono bg-zinc-900/60 text-zinc-200 border border-zinc-700 uppercase';
+  hexText.setAttribute('aria-label', 'Hex colour');
+  hexText.addEventListener('input', () => {
+    if (/^#?[0-9a-fA-F]{6}$/.test(hexText.value.trim())) setSelected(hexText.value);
+  });
+  hexText.addEventListener('keydown', (e) => { if (e.key === 'Enter') commit(selected, { record: true }); });
+  customRow.append(customInput, hexText);
+  body.append(customLabel, customRow);
+
+  // Footer
+  const footer = document.createElement('div');
+  footer.className = 'px-4 py-2.5 border-t border-zinc-700 flex items-center justify-end gap-2';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'px-3 py-1.5 rounded text-xs bg-zinc-700/60 text-zinc-200 hover:bg-zinc-600/60 transition-colors';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => close());
+  const applyBtn = document.createElement('button');
+  applyBtn.className = 'px-3 py-1.5 rounded text-xs bg-blue-600/80 text-white hover:bg-blue-500 transition-colors';
+  applyBtn.textContent = 'Apply';
+  applyBtn.title = 'Use the custom colour (also saved to Recent)';
+  // Apply commits the freeform selection and records it to history. Palette /
+  // recent swatch clicks commit on their own (already-known colours).
+  applyBtn.addEventListener('click', () => commit(selected, { record: true }));
+  footer.append(cancelBtn, applyBtn);
+  panel.appendChild(footer);
+
+  overlay.appendChild(panel);
+  document.body.appendChild(overlay);
+  openOverlay = overlay;
+
+  const offPalette = onPaletteChange(renderSwatches);
+  renderSwatches();
+
+  const escHandler = (e: KeyboardEvent): void => { if (e.key === 'Escape') { e.stopPropagation(); close(); } };
+  document.addEventListener('keydown', escHandler, true);
+  overlay.addEventListener('picker:force-close', () => close());
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+  closeBtn.addEventListener('click', () => close());
+
+  requestAnimationFrame(() => { if (!closed) hexText.focus(); });
+
+  function close(): void {
+    if (closed) return;
+    closed = true;
+    document.removeEventListener('keydown', escHandler, true);
+    offPalette();
+    overlay.remove();
+    if (openOverlay === overlay) openOverlay = null;
+    if (previouslyFocused && previouslyFocused.isConnected) previouslyFocused.focus();
+    opts.onClose?.();
+  }
+}
+
+export interface ColorSwatchOptions {
+  /** Initial colour shown on the swatch (`#rrggbb`). */
+  initialHex: string;
+  /** Called with the committed `#rrggbb` when the user picks a colour. */
+  onPick: (hex: string) => void;
+  /** Swatch button tooltip / accessible name. */
+  title?: string;
+  /** Modal heading shown when the picker opens. Defaults to `title`. */
+  modalTitle?: string;
+  /** Override the swatch button classes (omit to use the default swatch look). */
+  className?: string;
+  /** Optional `data-action` attribute for tests / hooks. */
+  dataAction?: string;
+}
+
+const DEFAULT_SWATCH_CLASS =
+  'w-6 h-6 shrink-0 rounded border border-zinc-500 hover:border-white/70 cursor-pointer transition-colors';
+
+/** Build a swatch button that opens {@link openColorPicker} on click. Returns
+ *  the element plus a `setHex` to update its displayed colour from the caller
+ *  (e.g. when an external edit changes the bound value). The drop-in replacement
+ *  for a native `<input type="color">` styled as a swatch. */
+export function createColorSwatch(opts: ColorSwatchOptions): { el: HTMLButtonElement; setHex: (hex: string) => void } {
+  let hex = normalizeHex(opts.initialHex);
+  const el = document.createElement('button');
+  el.type = 'button';
+  el.className = opts.className ?? DEFAULT_SWATCH_CLASS;
+  el.style.backgroundColor = hex;
+  if (opts.title) { el.title = opts.title; el.setAttribute('aria-label', opts.title); }
+  if (opts.dataAction) el.dataset.action = opts.dataAction;
+
+  const setHex = (next: string): void => {
+    hex = normalizeHex(next);
+    el.style.backgroundColor = hex;
+  };
+
+  el.addEventListener('click', (e) => {
+    e.stopPropagation();
+    openColorPicker({
+      initialHex: hex,
+      title: opts.modalTitle ?? opts.title,
+      onPick: (picked) => { setHex(picked); opts.onPick(picked); },
+    });
+  });
+
+  return { el, setHex };
+}

--- a/src/ui/colorPickerModal.ts
+++ b/src/ui/colorPickerModal.ts
@@ -48,13 +48,16 @@ let openOverlay: HTMLElement | null = null;
 /** Open the shared palette colour picker. Idempotent per call — opening a new
  *  one closes any picker already showing. */
 export function openColorPicker(opts: ColorPickerOptions): void {
+  // Capture the trigger BEFORE force-closing any open picker — the old one's
+  // close() restores focus to its own origin, which would otherwise overwrite
+  // what we read here.
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+
   // Only one picker at a time; closing the old one fires its onClose.
   if (openOverlay) openOverlay.dispatchEvent(new CustomEvent('picker:force-close'));
 
   let selected = normalizeHex(opts.initialHex);
   let closed = false;
-
-  const previouslyFocused = document.activeElement as HTMLElement | null;
 
   const overlay = document.createElement('div');
   overlay.className = 'fixed inset-0 bg-black/60 flex items-center justify-center z-[60] p-4';
@@ -205,6 +208,21 @@ export function openColorPicker(opts: ColorPickerOptions): void {
 
   const escHandler = (e: KeyboardEvent): void => { if (e.key === 'Escape') { e.stopPropagation(); close(); } };
   document.addEventListener('keydown', escHandler, true);
+
+  // Keep Tab focus inside the picker while it's open — it's a hand-rolled
+  // overlay (not modalShell), so it must provide its own focus trap.
+  const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  panel.addEventListener('keydown', (e: KeyboardEvent) => {
+    if (e.key !== 'Tab') return;
+    const f = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(el => el.offsetParent !== null || el === document.activeElement);
+    if (f.length === 0) { e.preventDefault(); return; }
+    const first = f[0];
+    const last = f[f.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    const idx = active ? f.indexOf(active) : -1;
+    if (e.shiftKey && (active === first || idx === -1)) { e.preventDefault(); last.focus(); }
+    else if (!e.shiftKey && (active === last || idx === -1)) { e.preventDefault(); first.focus(); }
+  });
   overlay.addEventListener('picker:force-close', () => close());
   overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
   closeBtn.addEventListener('click', () => close());

--- a/src/ui/imageVoxelImportModal.tsx
+++ b/src/ui/imageVoxelImportModal.tsx
@@ -22,6 +22,7 @@ import {
   type ImageVoxelColorMode,
 } from '../import/imageToVoxel';
 import { listSlotRgb255 } from '../color/palette';
+import { openColorPicker } from './colorPickerModal';
 
 export interface ImageVoxelModalOptions {
   filename?: string;
@@ -260,11 +261,12 @@ function PaletteEditor(props: {
       <div class="flex flex-wrap items-center gap-1.5">
         {palette.map((c, i) => (
           <div class="relative">
-            <input
-              type="color"
-              class="w-7 h-7 rounded border border-zinc-700 bg-transparent cursor-pointer"
-              value={toHex(c)}
-              onInput={e => setSwatch(i, (e.target as HTMLInputElement).value)}
+            <button
+              type="button"
+              title={`Edit colour (${toHex(c)})`}
+              class="w-7 h-7 rounded border border-zinc-700 cursor-pointer hover:border-white/70 transition-colors"
+              style={`background-color:${toHex(c)}`}
+              onClick={() => openColorPicker({ initialHex: toHex(c), title: 'Palette colour', onPick: hex => setSwatch(i, hex) })}
             />
             <button
               type="button"
@@ -584,11 +586,12 @@ function ImageVoxelBody(props: {
                 Flat
               </SegButton>
               {opts.colorMode === 'flat' && (
-                <input
-                  type="color"
-                  class="w-7 h-7 rounded border border-zinc-700 bg-transparent cursor-pointer shrink-0"
-                  value={toHex(opts.flatColor)}
-                  onInput={e => set('flatColor', fromHex((e.target as HTMLInputElement).value))}
+                <button
+                  type="button"
+                  title={`Flat colour (${toHex(opts.flatColor)})`}
+                  class="w-7 h-7 rounded border border-zinc-700 cursor-pointer shrink-0 hover:border-white/70 transition-colors"
+                  style={`background-color:${toHex(opts.flatColor)}`}
+                  onClick={() => openColorPicker({ initialHex: toHex(opts.flatColor), title: 'Flat colour', onPick: hex => set('flatColor', fromHex(hex)) })}
                 />
               )}
             </div>

--- a/src/ui/paramsPanel.ts
+++ b/src/ui/paramsPanel.ts
@@ -10,6 +10,7 @@
 import type { ParamSpec, ParamValue, ParamValues } from '../geometry/params';
 import { openViewportPanel, closeViewportPanel } from './viewportPanelRegistry';
 import { attachViewportPanelDrag, setInitialPanelPosition } from './viewportPanelDrag';
+import { createColorSwatch } from './colorPickerModal';
 
 export interface ParamsPanelOptions {
   /** Fired when a single widget changes — main.ts updates the override, re-runs,
@@ -336,12 +337,15 @@ function buildWidget(spec: ParamSpec, onChange: (key: string, value: ParamValue)
     setValue = (v) => { sel.value = String(v); };
   } else if (spec.type === 'color') {
     row.appendChild(labelRow);
-    const color = document.createElement('input');
-    color.type = 'color';
-    color.className = 'w-full h-7 bg-zinc-800 border border-zinc-600 rounded cursor-pointer';
-    color.addEventListener('change', () => onChange(spec.key, color.value));
-    row.appendChild(color);
-    setValue = (v) => { color.value = String(v); };
+    const sw = createColorSwatch({
+      initialHex: '#000000',
+      title: 'Pick a colour',
+      modalTitle: spec.label ?? 'Pick a colour',
+      className: 'w-full h-7 rounded border border-zinc-600 cursor-pointer',
+      onPick: (hex) => onChange(spec.key, hex),
+    });
+    row.appendChild(sw.el);
+    setValue = (v) => { sw.setHex(String(v)); };
   } else {
     // text
     row.appendChild(labelRow);

--- a/src/ui/reliefStudio.ts
+++ b/src/ui/reliefStudio.ts
@@ -19,6 +19,7 @@ import {
 } from '../color/regions';
 import { openViewportPanel, closeViewportPanel } from './viewportPanelRegistry';
 import { setInitialPanelPosition, attachViewportPanelDrag } from './viewportPanelDrag';
+import { createColorSwatch } from './colorPickerModal';
 
 export interface ReliefStudioDeps {
   getLayerHeight(): number;
@@ -258,15 +259,14 @@ export function mountReliefStudio(host: HTMLElement, deps: ReliefStudioDeps): Re
       // fires once when the picker is committed, so we reconcile the model
       // mesh just once per pick instead of on every channel drag.
       const hex = rgbToHex(r.color);
-      const swatchPicker = document.createElement('input');
-      swatchPicker.type = 'color';
-      swatchPicker.value = hex;
-      swatchPicker.className = 'w-5 h-5 shrink-0 rounded-sm border border-black/30 cursor-pointer bg-transparent p-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-sm [&::-webkit-color-swatch]:border-0 [&::-moz-color-swatch]:rounded-sm [&::-moz-color-swatch]:border-0';
-      swatchPicker.title = `Click to change colour (${hex})`;
-      swatchPicker.addEventListener('change', () => {
-        updateRegionColor(r.id, hexToRgb(swatchPicker.value));
+      const swatchPicker = createColorSwatch({
+        initialHex: hex,
+        title: `Click to change colour (${hex})`,
+        modalTitle: `Recolour "${r.name}"`,
+        className: 'w-5 h-5 shrink-0 rounded-sm border border-black/30 cursor-pointer',
+        onPick: (picked) => updateRegionColor(r.id, hexToRgb(picked)),
       });
-      row.appendChild(swatchPicker);
+      row.appendChild(swatchPicker.el);
 
       // Click-to-rename: name span swaps to an input on click; commits on
       // blur/Enter and reverts on Escape.

--- a/src/ui/reliefStudio.ts
+++ b/src/ui/reliefStudio.ts
@@ -252,12 +252,9 @@ export function mountReliefStudio(host: HTMLElement, deps: ReliefStudioDeps): Re
       const row = document.createElement('div');
       row.className = 'flex items-center gap-1.5 py-1 px-1 -mx-1 rounded hover:bg-zinc-700/40 transition-colors';
 
-      // Click-to-edit swatch. The native `<input type="color">` IS the swatch
-      // (styled to look like one), so the OS picker pops up anchored to the
-      // swatch — not at the corner of a separately-sized hidden input, which
-      // was the root of the "picker closes too easily" complaint. `change`
-      // fires once when the picker is committed, so we reconcile the model
-      // mesh just once per pick instead of on every channel drag.
+      // Click-to-edit swatch — opens the shared palette colour picker, which
+      // commits once when the colour is chosen, so we reconcile the model mesh
+      // just once per pick instead of on every channel drag.
       const hex = rgbToHex(r.color);
       const swatchPicker = createColorSwatch({
         initialHex: hex,

--- a/src/ui/surfaceModal.ts
+++ b/src/ui/surfaceModal.ts
@@ -24,6 +24,7 @@ import { buildTriColors } from '../color/regions';
 import type { StampMask, EngraveProjection } from '../surface/modifiers';
 import { engravePlanarFootprint, engraveFreeFootprint } from '../surface/engraveStamp';
 import { listFilaments } from '../color/palette';
+import { createColorSwatch } from './colorPickerModal';
 
 type ApplyResult = { error?: string; label?: string } | Record<string, unknown>;
 type ModId = 'fuzzy' | 'knit' | 'cable' | 'waffle' | 'fur' | 'woven' | 'knurl' | 'voronoi' | 'voronoiLamp' | 'engrave' | 'smooth' | 'voxelize';
@@ -268,6 +269,16 @@ function colorField(initial: string, onChange: () => void) {
     }
   };
 
+  // Off-palette custom colour — opens the shared palette picker. Declared before
+  // the quick-pick grid so the grid's click handlers can sync the swatch.
+  const pickerSwatch = createColorSwatch({
+    initialHex: value,
+    title: 'Custom colour',
+    modalTitle: 'Custom colour',
+    className: 'w-6 h-6 shrink-0 rounded cursor-pointer border border-zinc-500 hover:border-white/70 transition-colors',
+    onPick: (hex) => { value = toColorInputHex(hex); pickerSwatch.setHex(value); syncRings(); onChange(); },
+  });
+
   for (const f of listFilaments()) {
     const btn = el('button', 'w-6 h-6 rounded border-2 border-transparent hover:border-white/50 transition-colors');
     btn.type = 'button';
@@ -275,7 +286,7 @@ function colorField(initial: string, onChange: () => void) {
     btn.title = `${f.name} (${f.hex})`;
     btn.addEventListener('click', () => {
       value = toColorInputHex(f.hex);
-      picker.value = value;
+      pickerSwatch.setHex(value);
       syncRings();
       onChange();
     });
@@ -283,14 +294,8 @@ function colorField(initial: string, onChange: () => void) {
     grid.append(btn);
   }
 
-  // Off-palette custom colour. 'change' (not 'input') — re-running the SDF carve
-  // on every drag tick of the native picker would queue a carve per hover.
-  const customRow = el('label', 'flex items-center gap-1.5 cursor-pointer');
-  const picker = el('input', 'w-6 h-6 rounded cursor-pointer border-0 p-0 bg-transparent');
-  picker.type = 'color';
-  picker.value = value;
-  picker.addEventListener('change', () => { value = picker.value; syncRings(); onChange(); });
-  customRow.append(picker, el('span', 'text-[10px] text-zinc-500', 'Custom colour'));
+  const customRow = el('label', 'flex items-center gap-1.5');
+  customRow.append(pickerSwatch.el, el('span', 'text-[10px] text-zinc-500', 'Custom colour'));
 
   wrap.append(grid, customRow);
   syncRings();

--- a/src/ui/surfaceModal.ts
+++ b/src/ui/surfaceModal.ts
@@ -249,8 +249,8 @@ function toColorInputHex(hex: string): string {
 }
 
 /** A colour control that mirrors the paint tools: the shared filament palette as
- *  a swatch grid (click to pick a slot) plus a native picker for an off-palette
- *  colour. Returns the current hex via `get()`. `onChange` fires on every pick.
+ *  a swatch grid (click to pick a slot) plus the shared palette picker for an
+ *  off-palette colour. Returns the current hex via `get()`. `onChange` fires on every pick.
  *  Snapshots the palette at creation — the panel is short-lived, so it doesn't
  *  subscribe to live palette edits the way the persistent paint drawer does. */
 function colorField(initial: string, onChange: () => void) {

--- a/tests/color-picker-modal.spec.ts
+++ b/tests/color-picker-modal.spec.ts
@@ -1,0 +1,73 @@
+// The shared palette colour-picker modal (src/ui/colorPickerModal.ts) that
+// replaces the native OS <input type="color"> across the app. Golden path:
+//   1. Opening a swatch shows the palette + a freeform "Custom" picker.
+//   2. Clicking a palette slot swatch commits that colour immediately.
+//   3. A freeform pick + Apply commits the colour AND records it to "Recent",
+//      so it's a one-click swatch the next time the picker opens.
+
+import { test, expect } from 'playwright/test';
+
+async function openEditorWithLabels(page: import('playwright/test').Page) {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (window as any).partwright.run(`
+      const { Manifold } = api;
+      const body = api.label(Manifold.sphere(20, 32), 'body');
+      const nose = api.label(Manifold.sphere(3, 16).translate([0, 19, 0]), 'nose');
+      return body.add(nose);
+    `);
+  });
+  await page.locator('#paint-toggle').dispatchEvent('click');
+  await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+}
+
+test.describe('palette colour picker modal', () => {
+  test('palette swatch commits, freeform pick records to Recent', async ({ page }) => {
+    await openEditorWithLabels(page);
+
+    const noseSwatch = page.locator('#paint-label-list [data-label-name="nose"] button[data-action="set-label-color"]');
+
+    // Opening shows the palette grid + the freeform custom input.
+    await noseSwatch.dispatchEvent('click');
+    const modal = page.locator('[data-testid="color-picker"]');
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('input[data-action="custom-color"]')).toBeVisible();
+    const paletteSwatches = modal.locator('.grid button[data-hex]');
+    expect(await paletteSwatches.count()).toBeGreaterThan(0);
+
+    // Clicking the first palette slot commits its colour immediately (modal closes).
+    const firstHex = await paletteSwatches.first().getAttribute('data-hex');
+    await paletteSwatches.first().dispatchEvent('click');
+    await expect(modal).toBeHidden();
+
+    const noseColor = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const regions = (window as any).partwright.listRegions() as { name: string; color: [number, number, number] }[];
+      const r = regions.find(x => x.name === 'nose');
+      if (!r) return null;
+      const [a, b, c] = r.color;
+      const h = (n: number) => Math.round(n * 255).toString(16).padStart(2, '0');
+      return `#${h(a)}${h(b)}${h(c)}`;
+    });
+    expect(noseColor).toBe(firstHex);
+
+    // Now a freeform pick → Apply records the colour to Recent.
+    await noseSwatch.dispatchEvent('click');
+    await expect(modal).toBeVisible();
+    await page.evaluate(() => {
+      const ov = document.querySelector('[data-testid="color-picker"]')!;
+      const ci = ov.querySelector('input[data-action="custom-color"]') as HTMLInputElement;
+      ci.value = '#12ab56';
+      ci.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await modal.locator('button:has-text("Apply")').dispatchEvent('click');
+    await expect(modal).toBeHidden();
+
+    // Reopen — the freeform colour is now a Recent swatch.
+    await noseSwatch.dispatchEvent('click');
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('button[data-hex="#12ab56"]')).toHaveCount(1);
+  });
+});

--- a/tests/paint-labels-panel.spec.ts
+++ b/tests/paint-labels-panel.spec.ts
@@ -90,16 +90,26 @@ test.describe('paint labels panel', () => {
     await page.waitForSelector('#paint-picker-panel:not(.hidden)');
 
     const labelList = page.locator('#paint-label-list');
-    const swatch = labelList.locator('[data-label-name="eye"] input[data-action="set-label-color"]');
+    const swatch = labelList.locator('[data-label-name="eye"] button[data-action="set-label-color"]');
     await expect(swatch).toHaveCount(1);
 
-    // Picking a colour on the unpainted "eye" part commits a byLabel region
-    // with that exact colour — no need to select the active colour first.
-    await swatch.evaluate((el) => {
-      const input = el as HTMLInputElement;
-      input.value = '#00ff00';
-      input.dispatchEvent(new Event('change', { bubbles: true }));
-    });
+    // The swatch opens the shared palette picker; choose a freeform colour and
+    // Apply. Picking on the unpainted "eye" part commits a byLabel region with
+    // that exact colour — no need to select the active colour first.
+    const pickColor = async (hex: string) => {
+      await swatch.dispatchEvent('click');
+      await page.waitForSelector('[data-testid="color-picker"]');
+      await page.evaluate((h) => {
+        const ov = document.querySelector('[data-testid="color-picker"]')!;
+        const ci = ov.querySelector('input[data-action="custom-color"]') as HTMLInputElement;
+        ci.value = h;
+        ci.dispatchEvent(new Event('input', { bubbles: true }));
+      }, hex);
+      await page.locator('[data-testid="color-picker"] button:has-text("Apply")').dispatchEvent('click');
+      await page.waitForSelector('[data-testid="color-picker"]', { state: 'detached' });
+    };
+
+    await pickColor('#00ff00');
 
     let region = await page.evaluate(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -111,12 +121,7 @@ test.describe('paint labels panel', () => {
 
     // Only one region for the part — re-picking recolours in place rather than
     // stacking a duplicate byLabel region.
-    const swatch2 = labelList.locator('[data-label-name="eye"] input[data-action="set-label-color"]');
-    await swatch2.evaluate((el) => {
-      const input = el as HTMLInputElement;
-      input.value = '#0000ff';
-      input.dispatchEvent(new Event('change', { bubbles: true }));
-    });
+    await pickColor('#0000ff');
 
     const eyeRegions = await page.evaluate(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/paint-labels-panel.spec.ts
+++ b/tests/paint-labels-panel.spec.ts
@@ -78,6 +78,55 @@ test.describe('paint labels panel', () => {
     await expect(labelList.locator('[data-label-name="eye"]')).toContainText('✓');
   });
 
+  test('per-part colour swatch sets a whole label colour and recolours in place', async ({ page }) => {
+    await openEditorWithCode(page, `
+      const { Manifold } = api;
+      const head = api.label(Manifold.sphere(20, 32), 'head');
+      const eye = api.label(Manifold.sphere(5, 16).translate([-8, 14, 5]), 'eye');
+      return head.add(eye);
+    `);
+
+    await page.locator('#paint-toggle').dispatchEvent('click');
+    await page.waitForSelector('#paint-picker-panel:not(.hidden)');
+
+    const labelList = page.locator('#paint-label-list');
+    const swatch = labelList.locator('[data-label-name="eye"] input[data-action="set-label-color"]');
+    await expect(swatch).toHaveCount(1);
+
+    // Picking a colour on the unpainted "eye" part commits a byLabel region
+    // with that exact colour — no need to select the active colour first.
+    await swatch.evaluate((el) => {
+      const input = el as HTMLInputElement;
+      input.value = '#00ff00';
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    let region = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const regions = (window as any).partwright.listRegions() as { name: string; color: [number, number, number] }[];
+      return regions.find(r => r.name === 'eye');
+    });
+    expect(region).toBeTruthy();
+    expect(region!.color.map(c => Math.round(c * 255))).toEqual([0, 255, 0]);
+
+    // Only one region for the part — re-picking recolours in place rather than
+    // stacking a duplicate byLabel region.
+    const swatch2 = labelList.locator('[data-label-name="eye"] input[data-action="set-label-color"]');
+    await swatch2.evaluate((el) => {
+      const input = el as HTMLInputElement;
+      input.value = '#0000ff';
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const eyeRegions = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const regions = (window as any).partwright.listRegions() as { name: string; color: [number, number, number] }[];
+      return regions.filter(r => r.name === 'eye');
+    });
+    expect(eyeRegions).toHaveLength(1);
+    expect(eyeRegions[0].color.map(c => Math.round(c * 255))).toEqual([0, 0, 255]);
+  });
+
   test('empty state hints at api.label when no labels in the run', async ({ page }) => {
     await openEditorWithCode(page, `return api.Manifold.cube([10, 10, 10], true);`);
 

--- a/tests/paint-palette.spec.ts
+++ b/tests/paint-palette.spec.ts
@@ -87,11 +87,18 @@ test.describe('filament palette + slot painting', () => {
     await openEditorWithSlab(page);
 
     // Pick an off-palette ad-hoc colour via the custom picker (pure green).
+    // The custom swatch opens the shared palette picker modal; set its freeform
+    // input and Apply.
+    await page.locator('#paint-picker-panel button[title="Custom color (unslotted)"]').dispatchEvent('click');
+    await page.waitForSelector('[data-testid="color-picker"]');
     await page.evaluate(() => {
-      const input = document.querySelector('#paint-picker-panel input[type="color"][title="Custom color (unslotted)"]') as HTMLInputElement;
-      input.value = '#00ff00';
-      input.dispatchEvent(new Event('input', { bubbles: true }));
+      const ov = document.querySelector('[data-testid="color-picker"]')!;
+      const ci = ov.querySelector('input[data-action="custom-color"]') as HTMLInputElement;
+      ci.value = '#00ff00';
+      ci.dispatchEvent(new Event('input', { bubbles: true }));
     });
+    await page.locator('[data-testid="color-picker"] button:has-text("Apply")').dispatchEvent('click');
+    await page.waitForSelector('[data-testid="color-picker"]', { state: 'detached' });
 
     // Turn on constrain mode via the palette manager (opening it closes Paint).
     await page.locator('#palette-manager-toggle').dispatchEvent('click');
@@ -227,10 +234,16 @@ test.describe('filament palette + slot painting', () => {
     // Paint an in-palette slot colour, then an off-palette custom colour.
     await page.locator('#paint-picker-panel button[title^="Slot 3:"]').dispatchEvent('click');
     await bucketPaintCentre(page);
-    await page.locator('#paint-picker-panel input[title*="Custom color"]').evaluate((el) => {
-      (el as HTMLInputElement).value = '#aa33cc';
-      el.dispatchEvent(new Event('input', { bubbles: true }));
+    await page.locator('#paint-picker-panel button[title*="Custom color"]').dispatchEvent('click');
+    await page.waitForSelector('[data-testid="color-picker"]');
+    await page.evaluate(() => {
+      const ov = document.querySelector('[data-testid="color-picker"]')!;
+      const ci = ov.querySelector('input[data-action="custom-color"]') as HTMLInputElement;
+      ci.value = '#aa33cc';
+      ci.dispatchEvent(new Event('input', { bubbles: true }));
     });
+    await page.locator('[data-testid="color-picker"] button:has-text("Apply")').dispatchEvent('click');
+    await page.waitForSelector('[data-testid="color-picker"]', { state: 'detached' });
     await bucketPaintCentre(page);
 
     // The manager's reconciliation section flags the off-palette colour.


### PR DESCRIPTION
## Summary

Two related improvements to colour picking, building on each other:

### 1. Set a whole part's colour from the Paint menu
Each label row in the Paint panel's **Labels list** gets a colour swatch. Picking a colour sets that whole labelled part's colour — recolouring its existing `byLabel` region in place, or committing a fresh one. Reuses the persistent `byLabel` descriptor (same as `partwright.paintByLabel`), so it survives re-runs and UI↔API parity already holds.

### 2. Shared palette colour-picker modal (replaces the native OS pickers)
New `src/ui/colorPickerModal.ts`:
- **`openColorPicker({ initialHex, title?, onPick })`** — a stacked overlay showing the active **filament palette** + **recent-colour history** as one-click swatches, plus a **freeform** picker (native input + hex field). Palette/recent clicks commit immediately; a freeform pick commits via **Apply** and is saved to **Recent**.
- **`createColorSwatch({ initialHex, onPick }) → { el, setHex }`** — a swatch button that opens the picker; a drop-in replacement for `<input type="color">` styled as a swatch.

**Design decisions (confirmed with the user):**
- A freeform colour is added to **Recent**, *not* promoted to a permanent filament slot (slots map to real filaments; promotion stays explicit in the palette manager).
- Built as its **own overlay** (`z-[60]`), not the singleton `createModalShell`, because it's often opened from *inside* another modal/panel — modalShell would force-close the parent.

**Every native colour picker now uses it:** paint panel (custom / per-part / region swatches), surface modal, params panel, relief studio, annotations, voxel paint, image paint, and the image→voxel import modal. The palette manager's **own slot editor stays a direct picker** by design (editing a slot shouldn't reopen the palette).

## Screenshots
Per-part swatches in the Labels list, and the new palette picker modal — both posted in the session chat.

## Test plan
- `npm run typecheck` · `npm run build` — clean
- `npm run test:unit` — 1508 passing
- `npm run lint:deps` — acyclic (new `ui → color/palette` edge is fine)
- New e2e: `tests/color-picker-modal.spec.ts` (palette-swatch commit + freeform→Recent) and the per-part swatch case in `tests/paint-labels-panel.spec.ts`
- Updated `paint-labels-panel` / `paint-palette` specs that previously drove the native picker to go through the modal — passing
- Manual browser verification (screenshots) of both the Labels-list swatches and the picker modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NTRsWniugNz4g6bjLDeoB