### PR TITLE
fix: keep an open tool menu open when switching parts

### DIFF
--- a/prompts/20260620-163831-keep-tool-menu-open-across-part-switch.md
+++ b/prompts/20260620-163831-keep-tool-menu-open-across-part-switch.md
@@ -1,0 +1,47 @@
+---
+session: "hopeful-faraday"
+timestamp: "2026-06-20T16:38:31Z"
+model: claude-opus-4-8
+---
+
+## Human
+
+If I've opened a tool menu and switched parts, my tool menu closes. Possibly
+because the parts has a "customize" menu but once someone has a menu they've
+opened I don't want to close it and want to remember that as the current menu
+as they switch parts.
+
+(Clarified scope: ANY viewport tool panel the user has open — not just the
+Customize panel — should stay open across a part switch.)
+
+## Assistant
+
+## Key decisions
+
+**Root**: a part switch reloads the part (`loadVersionIntoEditor`) and re-runs
+`syncParamsPanel`. The part-load path itself does NOT close the floating tool
+panels (it only cancels voxel paint), so the *only* vector that closed an open
+menu was the Customize/params panel **auto-revealing** on a schema change:
+`paramsPanel.update()` reset `userClosed = false` whenever the schema changed,
+and the resulting `openViewportPanel(...)` — through the single-panel
+`viewportPanelRegistry` — closed whatever menu the user already had open.
+
+**Fix** (deferral, not a hard suppress):
+- Added `getActiveViewportPanel()` to `viewportPanelRegistry.ts` exposing the
+  current `active` panel ("the current menu").
+- In `paramsPanel.update()`, on a schema change Customize now auto-opens **only
+  when no other panel is active** (or Customize itself is the active one). If a
+  *different* menu is open, it sets `userClosed = true` and stays closed, so the
+  user's current menu survives the part switch. The part's knobs remain
+  reachable from the Customize pill (the count still updates).
+
+This preserves the original "first opening a parameterizable model auto-reveals
+its knobs" behavior (no panel active on initial load), while honoring an
+already-open menu during part switches.
+
+**Verification**: new e2e `tests/menu-persist-part-switch.spec.ts` (open Paint
+on a plain part → switch to a parametric part → Paint stays open, `#params-panel`
+stays hidden). Manually confirmed in-browser via a throwaway spec + screenshot.
+Existing `customizer.spec.ts` (12 tests, incl. auto-reveal) still green; added a
+`getActiveViewportPanel` case to the registry unit test. Full unit tier + madge
+cycle gate green.

--- a/src/ui/paramsPanel.ts
+++ b/src/ui/paramsPanel.ts
@@ -8,7 +8,7 @@
 // touches the engine or storage directly.
 
 import type { ParamSpec, ParamValue, ParamValues } from '../geometry/params';
-import { openViewportPanel, closeViewportPanel } from './viewportPanelRegistry';
+import { openViewportPanel, closeViewportPanel, getActiveViewportPanel } from './viewportPanelRegistry';
 import { attachViewportPanelDrag, setInitialPanelPosition } from './viewportPanelDrag';
 
 export interface ParamsPanelOptions {
@@ -177,8 +177,14 @@ export function createParamsPanel(opts: ParamsPanelOptions): ParamsPanelControll
     if (schemaChanged) {
       currentSig = sig;
       rebuild(schema);
-      // A new or changed parameter set re-opens the panel so its knobs are seen.
-      userClosed = false;
+      // A new or changed parameter set normally re-opens the panel so its knobs
+      // are seen (e.g. first opening a parameterizable model). But if the user
+      // already has a DIFFERENT viewport tool menu open — typically because they
+      // switched parts while using Surface/Paint/Resize/etc. — keep that menu as
+      // the current one and stay closed, rather than auto-popping over it. The
+      // user can still open Customize from its toolbar pill.
+      const other = getActiveViewportPanel();
+      userClosed = other !== null && other !== registryEntry;
     }
     paramCount = schema.length;
     updateValues(values);

--- a/src/ui/viewportPanelRegistry.ts
+++ b/src/ui/viewportPanelRegistry.ts
@@ -41,3 +41,11 @@ export function openViewportPanel(panel: ViewportPanel, opts?: { silent?: boolea
 export function closeViewportPanel(panel: ViewportPanel): void {
   if (active === panel) active = null;
 }
+
+/** The viewport tool panel currently open ("the current menu"), or `null` if
+ *  none. Lets a panel about to auto-open check whether the user already has a
+ *  *different* menu open and defer to it (see the Customizer's part-switch
+ *  auto-reveal). */
+export function getActiveViewportPanel(): ViewportPanel | null {
+  return active;
+}

--- a/tests/menu-persist-part-switch.spec.ts
+++ b/tests/menu-persist-part-switch.spec.ts
@@ -1,0 +1,66 @@
+// Regression: a viewport tool menu the user has open must survive a part
+// switch. Switching to a part that declares parameters used to auto-pop the
+// Customize panel, which — via the single-panel viewportPanelRegistry — stomped
+// whatever menu the user already had open (Paint/Surface/Resize/…). The fix
+// makes Customize defer to an already-open menu instead of auto-revealing over
+// it: the part's knobs stay reachable from the Customize pill, but the user's
+// current menu remains the current menu.
+
+import { test, expect, type Page } from 'playwright/test';
+
+const PLAIN = `const { Manifold } = api; return Manifold.cube([10,10,10], true);`;
+const PARAM = `const { Manifold } = api;
+const p = api.params({ width: { type:'number', default: 20, min:10, max:100, label:'Width' } });
+return Manifold.cube([p.width, p.width, p.width], true);`;
+
+interface API {
+  createSession: (n?: string) => Promise<{ id: string }>;
+  runAndSave: (c: string, l?: string) => Promise<unknown>;
+  createPart: (n?: string) => Promise<unknown>;
+  listParts: () => { id: string; name: string }[];
+}
+
+async function waitForEngine(page: Page) {
+  await page.waitForSelector('text=Ready', { timeout: 20_000 });
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { createPart?: unknown } }).partwright?.createPart,
+    { timeout: 20_000 },
+  );
+}
+async function clickPart(page: Page, id: string) {
+  await page.locator(`#parts-list [data-part-id="${id}"]`).click();
+  await page.waitForTimeout(1800); // switch + recompile + rehydrate settle
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+});
+
+test('an open tool menu survives a switch to a parametric part (no Customize stomp)', async ({ page }) => {
+  await page.goto('/editor');
+  await waitForEngine(page);
+
+  // Part 1: plain (no params). Part 2: parametric (declares api.params).
+  const { idPlain, idParam } = await page.evaluate(async ({ plain, param }) => {
+    const pw = (window as unknown as { partwright: API }).partwright;
+    await pw.createSession('menu-persist');
+    await pw.runAndSave(plain, 'plain');
+    const idPlain = pw.listParts()[0].id;
+    await pw.createPart('ParamPart');
+    await pw.runAndSave(param, 'param');
+    const idParam = pw.listParts().find((p) => p.name === 'ParamPart')!.id;
+    return { idPlain, idParam };
+  }, { plain: PLAIN, param: PARAM });
+
+  // On the plain part, open the Paint tool menu (it lives in the Tools popover).
+  await clickPart(page, idPlain);
+  await page.locator('#viewport-tools-group-btn').click();
+  await page.locator('#paint-toggle').click();
+  await expect(page.locator('#paint-picker-panel')).toBeVisible();
+  await expect(page.locator('#params-panel')).toBeHidden();
+
+  // Switch to the parametric part: Paint stays open, Customize does NOT pop over it.
+  await clickPart(page, idParam);
+  await expect(page.locator('#paint-picker-panel'), 'Paint menu stays open across the part switch').toBeVisible();
+  await expect(page.locator('#params-panel'), 'Customize must not stomp the open Paint menu').toBeHidden();
+});

--- a/tests/unit/viewportPanelRegistry.test.ts
+++ b/tests/unit/viewportPanelRegistry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   openViewportPanel,
   closeViewportPanel,
+  getActiveViewportPanel,
   onViewportPanelOpen,
   type ViewportPanel,
 } from '../../src/ui/viewportPanelRegistry';
@@ -54,6 +55,20 @@ describe('viewportPanelRegistry', () => {
     openViewportPanel(a); // same panel again
     expect(opens).toBe(after);
     expect(a.closed).toBe(0); // and it isn't closed against itself
+  });
+
+  it('getActiveViewportPanel reflects the open menu — so an auto-opening panel can defer to it', () => {
+    const a = panel();
+    const b = panel();
+    expect(getActiveViewportPanel()).toBeNull();
+    openViewportPanel(a);
+    expect(getActiveViewportPanel()).toBe(a);
+    // Opening b makes b current (a is closed) — switching parts while a tool is
+    // open keeps SOME panel as "the current menu".
+    openViewportPanel(b);
+    expect(getActiveViewportPanel()).toBe(b);
+    closeViewportPanel(b);
+    expect(getActiveViewportPanel()).toBeNull();
   });
 
   it('closeViewportPanel only clears when the given panel is active', () => {


### PR DESCRIPTION
## Summary

Switching to a part that declares parameters used to auto-pop the **Customize** panel, which — through the single-panel `viewportPanelRegistry` — closed whatever viewport tool menu (Paint / Surface / Resize / …) the user already had open. So opening a tool menu and then switching parts silently closed it.

The part-load path itself never closed those floating panels (it only cancels voxel paint); the **only** stomp vector was the Customize panel auto-revealing on a schema change. The fix makes Customize *defer* to an already-open menu:

- `viewportPanelRegistry.ts` — new `getActiveViewportPanel()` exposes the current open panel ("the current menu").
- `paramsPanel.update()` — on a schema change, Customize auto-reveals **only when no other panel is active** (or it is itself the active one). If a different menu is open, it stays closed (`userClosed = true`) so the user's current menu survives the part switch. The new part's knobs stay reachable from the Customize pill (its count still updates).

This keeps the original behavior intact — first opening a parameterizable model still auto-reveals its knobs, since no panel is active on a fresh load.

## Test plan

- **New e2e** `tests/menu-persist-part-switch.spec.ts`: open Paint on a plain part → switch to a parametric part → Paint stays open and `#params-panel` stays hidden. ✅
- Existing `customizer.spec.ts` (12 tests, incl. auto-reveal & toggle) still green. ✅
- Added a `getActiveViewportPanel` case to the registry unit test; full unit tier (1510) green; madge cycle gate green; typecheck clean. ✅
- Manually verified in-browser (throwaway spec + screenshot): Paint panel remained the current menu after switching to the parametric part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8L34JfFDBZMHzf9Zxjzvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8L34JfFDBZMHzf9Zxjzvn)_