### PR TITLE
fix: cancel in-flight render on Character Creator preview changes

### DIFF
--- a/prompts/character-preview-cancel.md
+++ b/prompts/character-preview-cancel.md
@@ -1,0 +1,40 @@
+---
+date: 2026-06-20
+branch: claude/character-preview-cancel
+files_changed:
+  - src/main.ts
+  - src/ui/characterCreatorPanel.ts
+  - tests/character-creator.spec.ts
+---
+
+## Human
+
+After merging the Character Creator (#804): "when I make changes I'm not sure
+it's really cancelling. When I switch the presets at the top especially I don't
+see the fast preview update right away and the render time takes a long time like
+multiple renders stacked up or something."
+
+## Assistant
+
+Real bug. `partwright.buildCharacter`'s live-preview path called `runCodeSync`
+directly, bypassing the cancellation that the interactive `runCode` path does.
+A figure rebuild runs in the geometry Worker for ~20s, so switching presets
+mid-build started a second build while the first kept churning — they contended
+and stacked, exactly the symptom.
+
+Fix:
+- In `buildCharacter`'s non-save path, `cancelCurrentExecution()` (terminates +
+  respawns the geometry Worker, the same call the Cancel button and `runCode`
+  use) before the new `runCodeSync`, but only when `_running`, so an idle first
+  preview doesn't needlessly restart the worker. `runCodeSync` already catches
+  the resulting rejection and returns false, so no unhandled rejection.
+- Panel: `preview({ immediate })` — discrete jumps (a character preset or the
+  pose-preset dropdown) fire immediately instead of waiting out the slider
+  debounce, so a preset switch shows its coarse fast-preview right away. Slider
+  drags still debounce.
+
+Verified in a real browser: switching presets mid-build logs
+`[EngineWorker] Execution cancelled` once per switch (proof the prior build is
+terminated, not stacked), and three rapid preset switches settle in ~25s instead
+of ~60s+. Added a permanent regression test asserting a mid-build preset switch
+triggers a worker cancellation.

--- a/src/main.ts
+++ b/src/main.ts
@@ -11537,6 +11537,12 @@ async function main() {
         return { code, ...(r as Record<string, unknown>) };
       }
       // Live preview: swap the editor buffer and re-render without saving.
+      // Cancel any in-flight render first — a heavy SDF figure build runs in the
+      // geometry Worker, and without this a rapid preset/slider change would
+      // start a second build while the first keeps churning (they contend and
+      // stack, so the preview lags badly). Terminating the prior build mirrors
+      // what the interactive runCode path does for superseding auto-runs.
+      if (_running) cancelCurrentExecution();
       setValue(code);
       await runCodeSync(code);
       return { code };

--- a/src/ui/characterCreatorPanel.ts
+++ b/src/ui/characterCreatorPanel.ts
@@ -153,15 +153,19 @@ export function openCharacterCreatorPanel(api: CharacterCreatorApi): void {
     return ok;
   };
 
-  // Debounced live preview. The engine shows its own "Rendering…" status.
+  // Live preview. Slider drags debounce (one rebuild on settle); discrete jumps
+  // like a preset switch fire immediately (`immediate`). Either way buildCharacter
+  // cancels any in-flight render first, so changes never stack in the worker. The
+  // engine shows its own "Rendering…" status.
   let timer: number | undefined;
-  const preview = (): void => {
+  const preview = (opts?: { immediate?: boolean }): void => {
     window.clearTimeout(timer);
-    const delay = getConfig().ui.characterPreviewDebounceMs;
-    timer = window.setTimeout(async () => {
+    const fire = async () => {
       if (!(await confirmClobber())) return;
       void api.buildCharacter(spec, { save: false });
-    }, delay);
+    };
+    if (opts?.immediate) { void fire(); return; }
+    timer = window.setTimeout(fire, getConfig().ui.characterPreviewDebounceMs);
   };
 
   // A change handler that mutates the spec then re-previews.
@@ -174,7 +178,7 @@ export function openCharacterCreatorPanel(api: CharacterCreatorApi): void {
   for (const p of CHARACTER_PRESETS) {
     const b = el('button', BUTTON_SMALL_SECONDARY);
     b.textContent = p.label;
-    b.addEventListener('click', () => { spec = p.patch(); rebuild(); preview(); });
+    b.addEventListener('click', () => { spec = p.patch(); rebuild(); preview({ immediate: true }); });
     presetWrap.appendChild(b);
   }
   body.append(sectionTitle('Start from a preset'), presetWrap);
@@ -205,7 +209,7 @@ export function openCharacterCreatorPanel(api: CharacterCreatorApi): void {
     controls.append(selectRow('Preset', spec.pose.preset, posePresetOpts, v => {
       spec.pose = POSE_PRESETS[v]();
       rebuild();
-      preview();
+      preview({ immediate: true });
     }));
     const jointSlider = (label: string, get: () => number, set: (n: number) => void, min: number, max: number) =>
       controls.append(sliderRow(label, get(), min, max, 1, v => onEdit(() => set(v))));

--- a/tests/character-creator.spec.ts
+++ b/tests/character-creator.spec.ts
@@ -107,4 +107,35 @@ test.describe('Character Creator', () => {
     expect(code).toContain('@character v1');
     expect(code).toContain('headsTall');
   });
+
+  test('switching presets mid-build cancels the in-flight render (no stacking)', async ({ page }) => {
+    // A figure rebuild is heavy; without cancellation a second preset would start
+    // a build while the first kept churning in the worker. Switching mid-build
+    // must terminate the prior build (worker restart) so previews don't stack.
+    const restarts: string[] = [];
+    page.on('console', m => { if (m.text().includes('[EngineWorker]')) restarts.push(m.text()); });
+
+    await page.goto('/editor');
+    await waitForEngine(page);
+    await page.evaluate(async () => (window as unknown as { partwright: PW }).partwright.createSession('character-cancel'));
+
+    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur?.());
+    await page.keyboard.press('ControlOrMeta+k');
+    await page.locator('input[aria-label="Search commands"]').fill('Character Creator');
+    await page.keyboard.press('Enter');
+    const panel = page.getByRole('dialog', { name: 'Character Creator' });
+
+    await panel.getByRole('button', { name: 'Adult woman' }).click();
+    await page.getByRole('dialog', { name: 'Start a character' })
+      .getByRole('button', { name: 'Replace', exact: true }).click();
+    await page.waitForTimeout(1500);                       // let the build start
+    await panel.getByRole('button', { name: 'Chibi' }).click();   // switch mid-build
+
+    await page.waitForFunction(
+      () => (window as unknown as { partwright: PW }).partwright.getCode().includes('headsTall: 3.2'),
+      { timeout: 60_000 },
+    );
+    // The mid-build switch terminated the running build at least once.
+    expect(restarts.some(r => /cancel/i.test(r))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #804. Reported: *"when I switch the presets at the top especially I don't see the fast preview update right away and the render takes a long time, like multiple renders stacked up."*

That was exactly it. `partwright.buildCharacter`'s **live-preview path called `runCodeSync` directly**, bypassing the cancellation that the interactive `runCode` path performs. A figure rebuild runs in the geometry Worker for ~20s, so switching presets mid-build started a *second* build while the first kept churning — they contended and **stacked**.

### Fix
- **`buildCharacter` (preview path)** now calls `cancelCurrentExecution()` — the same terminate-and-respawn the Cancel button and `runCode` use — before the new `runCodeSync`, but only when a run is in flight (so an idle first preview doesn't needlessly restart the worker). `runCodeSync` already catches the resulting rejection and returns false, so there's no unhandled rejection.
- **Panel previews now fire immediately for discrete jumps** (a character preset or the pose-preset dropdown) instead of waiting out the slider debounce, so a preset switch shows its coarse fast-preview right away. Slider drags still debounce.

### Verification
In a real browser, switching presets mid-build logs `[EngineWorker] Execution cancelled` once per switch (proof the prior build is terminated, not stacked), and three rapid preset switches settle in **~25s instead of ~60s+**.

## Test plan
- ✅ `npm run preflight` (typecheck + 1538 unit tests + lint:deps + lint:consistency)
- ✅ New e2e: `switching presets mid-build cancels the in-flight render (no stacking)` — asserts a mid-build preset switch triggers a worker cancellation
- ✅ Existing Character Creator e2e suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRUDAYXiU7HUm7WytJoPs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRUDAYXiU7HUm7WytJoPs8)_