### PR TITLE
feat: generalize reference images into typed session attachments

### DIFF
--- a/prompts/attachments-from-reference-images.md
+++ b/prompts/attachments-from-reference-images.md
@@ -1,0 +1,77 @@
+---
+session: "0ejjep"
+timestamp: "2026-06-20T19:40:00Z"
+---
+
+## Human
+
+If somebody attaches an image to an AI session in the rightmost pane, can I
+capture it into the project's image list? And does it even make sense to have
+"rough" reference images — I want past reference images to survive an AI history
+clear, but some refs age out of relevance. (After discussion:) Implement the
+reference-image list as a generalized "attachments" feature with enum kind
+types. Make sure in-app AI sessions have tools to fetch past attachments, and
+that AI-panel file uploads/attachments are saved as attachments on the
+project/session.
+
+## Assistant
+
+## Key decisions
+
+**Generalized the per-session "reference images" list into typed
+**attachments** rather than adding a parallel system.** The app already had a
+durable, exported, AI-readable image list (`Session.images` + the Images tab +
+the `getReferenceImages` tool). The right move was to widen that, not invent a
+second store. Renamed the persisted field `Session.images` → `Session.attachments`
+holding `SessionAttachment` = the old `{id, src, label}` plus
+`kind` (`image | model | document | text | other`), optional `mediaType`,
+`addedAt`, and `source` (`'user' | 'chat'`).
+
+**Put the types + classification in a dependency-free leaf
+(`src/storage/attachment.ts`).** `inferMediaType`/`inferAttachmentKind`/
+`normalizeAttachment` are pure and imported by both the storage layer (db.ts) and
+the renderer's in-memory holder (multiview.ts) without adding a module cycle
+(`lint:deps` stays acyclic). The renderer already imported `presetIndex` from
+storage, so the edge existed.
+
+**Back-compat was the main constraint — old IndexedDB sessions and exported
+`.partwright` files must still load.** Schema bumped 1.15 → 1.16. The existing
+read-time `migrateSessionImages` already normalized three legacy image shapes
+(`referenceImages`, object-map, `{angle}`); extended it to fold all of them —
+plus pre-1.16 `images` — into typed `kind:'image'` attachments via
+`normalizeAttachment`. Export writes `attachments`; import reads
+`attachments ?? images ?? referenceImages`. `updateSession` strips both legacy
+keys on write.
+
+**Kept the image-named API/UI as back-compat over the generalized store.**
+`getImages()` returns image-kind only; `setImages`/`clearImages` touch only
+image-kind attachments and preserve non-image ones; added
+`getAttachments`/`addAttachment`/`setAttachments`/`removeAttachment`/
+`clearAttachments`. All went into the `help()` table (and came off the
+apiParity `UNDOCUMENTED_BACKLOG`), closing the long-standing parity gap for the
+image methods at the same time.
+
+**AI parity (the two explicit asks):**
+- New `getAttachments` tool returns a text manifest of every attachment
+  (kind/mediaType/label/addedAt/source), inlines `text`-kind contents, and points
+  the model at `getReferenceImages` to actually *view* images. Added to
+  `ALWAYS_AVAILABLE` + `RETRY_SAFE_TOOLS`. `getReferenceImages` stays the
+  image-viewing path (now image-kind-filtered).
+- AI-panel image uploads (`attachImageSource`: paste / drag-drop / picker) now
+  also pin to the session as a `source:'chat'` image attachment (deduped by src,
+  no-op without a real session), so they survive `/clear`.
+
+**UI:** the tab is now "Attachments" (📎); non-image attachments render as a
+file card with a type icon + media type, and every tile carries a kind badge.
+File upload `accept` widened from `image/*` to any file.
+
+**Deliberately deferred to a follow-up (noted in PR):** attachment *bytes* still
+live inline as data URLs on the session (and thus in exports/share links), same
+as images always did. Phase 3 — moving binary payloads to a separate blob store
+and stripping large binaries from `trimForShare` — is a separate change.
+
+Verified: `npm run preflight` (1552 unit tests, no type errors, no cycles), a new
+`tests/unit/attachment.test.ts` for the pure helpers, a new
+`tests/attachments.spec.ts` golden-path e2e (mixed kinds, the tool manifest, the
+typed tiles), plus the existing getReferenceImages / share-link / import-export
+specs for back-compat, and an eyes-on screenshot of the Attachments tab.

--- a/public/ai.md
+++ b/public/ai.md
@@ -328,12 +328,16 @@ partwright.isRunning()                   // -> boolean (is code executing?)
 partwright.getSpendingMode()             // -> {mode, thinking, renderResolution, renderResolutionPx, verificationAngles, painting, sessionNotes, ...}
 partwright.setSpendingMode('balanced')   // 'cheap' | 'balanced' | 'expensive' (sets thinking, vision, paint, notes, caps at once)
 
-// Images -- attach photos to compare model against (see /ai/reference-images.md)
-partwright.setImages([{src, label?}, ...])  // replace all; src is data URL or http(s) URL; label is an optional caption
-partwright.addImage({src, label?})          // append one; returns {id, src, label?}
+// Attachments -- durable session files: reference photos, models, docs, notes
+//   (survive a chat clear; see /ai/reference-images.md#attachments)
+partwright.setImages([{src, label?}, ...])  // replace image attachments; src is data URL or http(s) URL; label optional
+partwright.addImage({src, label?})          // append one image; returns {id, src, label?}
 partwright.removeImage(id)                  // remove by id; returns true if removed
-partwright.clearImages()
-partwright.getImages()                      // -> [{id, src, label?}, ...]
+partwright.clearImages()                    // clear image attachments (non-image ones kept)
+partwright.getImages()                      // -> [{id, src, label?}, ...] (image-kind only)
+partwright.addAttachment({src, kind?, mediaType?, label?})  // pin ANY file; kind/mediaType inferred when omitted
+partwright.getAttachments()                 // -> [{id, kind, mediaType?, src, label?, addedAt?, source?}, ...]
+partwright.setAttachments([...]) / partwright.removeAttachment(id) / partwright.clearAttachments()
 
 // Color regions (~30 paint methods) — call readDoc("colors") for the full picker decision tree.
 partwright.paintRegion({point, normal, color, name?, tolerance?})  // coplanar flood-fill (flat faces)
@@ -834,9 +838,9 @@ The standard `exportGLB()` / `exportSTL()` / `exportOBJ()` / `export3MF()` metho
 
 ## Reference images & photo-to-model
 
-The user can attach reference photos via `partwright.setImages([...])`; they appear in the Images tab and Gallery. There's also an analyze-and-build workflow that takes a single photo and bootstraps a model from it.
+The user can attach reference photos via `partwright.setImages([...])`; they appear in the Attachments tab and Gallery. Photos are one **kind** of session attachment — the same panel also holds reference models, PDFs, and notes (`getAttachments`/`addAttachment`), all of which persist across a chat clear. There's also an analyze-and-build workflow that takes a single photo and bootstraps a model from it.
 
-**Call `readDoc({name: "reference-images"})`** when the user attaches a photo or asks you to model something from an image — covers `setImages` arguments, label conventions for elevation matching, and the five-step photo-to-model loop (major masses first, verify each elevation, iterate details).
+**Call `readDoc({name: "reference-images"})`** when the user attaches a photo or asks you to model something from an image — covers `setImages`/`getAttachments` arguments, label conventions for elevation matching, the durable-attachments model, and the five-step photo-to-model loop (major masses first, verify each elevation, iterate details).
 
 ## Iteration workflow
 

--- a/public/ai/reference-images.md
+++ b/public/ai/reference-images.md
@@ -33,9 +33,36 @@ partwright.clearImages()
 partwright.getImages()  // -> [{id, src, label?}, ...]
 ```
 
-Attached images appear in the Images tab and the Gallery; render the model with `renderViews` to compare it against them at matching angles.
+Attached images appear in the Attachments tab and the Gallery; render the model with `renderViews` to compare it against them at matching angles.
 
-**Seeing the references as the AI:** in the in-app AI chat, call the **`getReferenceImages`** tool — it returns every attached reference as one labeled grid image (plus a text list of the labels), so the model can actually look at what the user attached on any turn rather than guess.
+**Seeing the references as the AI:** in the in-app AI chat, call the **`getReferenceImages`** tool — it returns every attached reference *image* as one labeled grid image (plus a text list of the labels), so the model can actually look at what the user attached on any turn rather than guess.
+
+## Attachments
+
+Reference images are one **kind** of a more general session **attachment** — any file the user pins to the session as durable project context. An attachment carries a `kind` (`image` · `model` · `document` · `text` · `other`) plus an optional `mediaType`, so a session can hold reference photos *and* a reference STL/STEP, a spec-sheet PDF, or design notes. Attachments are **durable**: they survive clearing the AI chat and are saved in the exported `.partwright` file, so an agent resuming a session — or one whose chat history was cleared — can still find the material the work was based on.
+
+The `setImages`/`addImage`/`getImages`/etc. helpers above still work (they operate on the `image`-kind attachments). The general API mirrors them across all kinds:
+
+```js
+// Pin any file (kind + mediaType are inferred from the src/data URL or label
+// when omitted). source defaults to 'user'.
+partwright.addAttachment({ src: 'data:model/stl;base64,...', label: 'Reference bracket' })
+// -> { id, kind: 'model', mediaType: 'model/stl', src, label, addedAt, source: 'user' }
+
+// List everything pinned to the session
+partwright.getAttachments()
+// -> [{ id, kind, mediaType?, src, label?, addedAt?, source? }, ...]
+
+partwright.setAttachments([{ src, kind?, mediaType?, label? }, ...])  // replace the whole list
+partwright.removeAttachment(id)                                        // remove one by id
+partwright.clearAttachments()                                          // remove ALL (images included)
+```
+
+`clearImages()` / `setImages()` touch only the image-kind attachments and leave non-image ones intact; `clearAttachments()` removes everything.
+
+**Captured chat uploads.** When the user uploads or pastes an image into the AI chat drawer, it is automatically pinned to the session as an `image` attachment with `source: 'chat'` (deduped by content). So even if the chat is later cleared, those references remain available.
+
+**Seeing all attachments as the AI:** call the **`getAttachments`** tool to get a manifest of every attachment — id, kind, media type, label, when it was added, and whether it came from the user or a chat upload. `text`-kind attachments include their contents inline. Use it to recover reference material an earlier conversation worked from; to actually *view* image attachments, call `getReferenceImages`.
 
 ## Photo-to-model workflow
 

--- a/retros/inbox/2026-06-20-reference-images-to-attachments.md
+++ b/retros/inbox/2026-06-20-reference-images-to-attachments.md
@@ -1,0 +1,63 @@
+# Retro — reference images → typed session attachments
+
+**Task:** Generalized the per-session "reference images" list into typed
+**attachments** (`image | model | document | text | other`), so a session can
+pin reference models/PDFs/notes alongside photos. Durable across an AI chat
+clear; AI-panel uploads auto-captured; new `getAttachments` tool. Schema
+1.15→1.16. PR #807, follow-up #809.
+
+## Liked
+- The discovery agent (`explore`) up front paid off hugely: it mapped the full
+  three-store picture (chat-transcript blocks vs the global `aiAttachments`
+  recent cache vs the per-session `Session.images` list) in one shot, which is
+  exactly what made the design conversation with the user concrete instead of
+  hand-wavy.
+- The existing `migrateSessionImages` read-time migration was the perfect
+  template — the `referenceImages`→`images` precedent meant the rename to
+  `attachments` had a proven back-compat pattern to extend rather than invent.
+- Putting the types + classification in a dependency-free leaf
+  (`storage/attachment.ts`) kept `lint:deps` acyclic with zero fuss and gave the
+  pure helpers a fast unit-test home.
+
+## Lacked
+- I missed a reader: `src/ui/importSummary.ts` still read `session.images` only,
+  so the import-preview showed zero references for 1.16 exports. The schema-sync
+  ladder in CLAUDE.md lists 7 locations but a field *rename* (not add) has a
+  different blast radius — every *reader* of the old field name, not just the
+  serialize/deserialize path. A `grep` for the old field name across `src/`
+  would have caught it; I leaned on typecheck, which passed because the legacy
+  field still exists in the type for back-compat.
+- I designed `addedAt`/`source` metadata for the user's "aging" concern but
+  initially never stamped `addedAt` at the construction sites — the field was
+  advertised in docs/the tool but always "date unknown". Designing a field and
+  wiring its population are two steps; I did the first and the reviewer caught
+  the second.
+
+## Learned
+- **A field rename needs a "find every reader" sweep, distinct from the
+  schema-add ladder.** The add-a-field checklist assumes the field name is new;
+  a rename leaves old readers silently pointing at a now-unwritten key, and
+  typecheck won't flag it when the old name is retained for back-compat. Grep the
+  old name.
+- The `work-reviewer` earned its keep here — both its findings (the import-preview
+  reader, the unstamped `addedAt`) were real and neither was caught by
+  typecheck/preflight/the e2e suite I'd written. Running it before marking ready
+  is the right gate.
+- Two CI failures were both mine and both deterministic: a hardcoded
+  `SCHEMA_VERSION` assertion (the exact drift CLAUDE.md rule #6 warns about) and
+  a command-palette keyword collision (I added "notes" as a keyword to the
+  Attachments command, hijacking "Go to Notes"). New command-palette keywords
+  need a glance at sibling commands for collisions.
+
+## Longed for
+- The no-`gh`/no-token shell in the remote env meant I couldn't poll CI from a
+  Monitor loop — I had to re-arm a dumb sleep-timer that wakes me to query the
+  GitHub MCP. A first-class "notify on check-run completion" wake (the inverse of
+  the failure webhook, which *does* fire) would replace ~10 manual re-polls per
+  PR. CI success not being a webhook is the single biggest friction in the
+  watch-the-PR loop.
+- The recurring UI↔API parity gap bit again: the image methods existed but were
+  never in the `help()` table (sitting in the apiParity backlog). A single
+  capability registry that both the command palette and the API derive from
+  (noted in CLAUDE.md as a deferred refactor) would have made "is this method
+  discoverable?" structural instead of a per-PR manual check.

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -327,7 +327,12 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'getReferenceImages',
-    description: 'See the reference images the user attached to this session (the "Images" / reference panel — e.g. photos or alternate-angle views to model from or match). Returns ALL of them as ONE labeled grid image (each tile captioned with its label) plus a text list of the labels. Call this at the START of any task that refers to attached photos/views, and again whenever you need to re-check them — do NOT guess at a subject you have not actually seen. If nothing is attached, it says so.',
+    description: 'See the reference IMAGES the user attached to this session (the "Attachments" panel — e.g. photos or alternate-angle views to model from or match). Returns ALL image attachments as ONE labeled grid image (each tile captioned with its label) plus a text list of the labels. Call this at the START of any task that refers to attached photos/views, and again whenever you need to re-check them — do NOT guess at a subject you have not actually seen. For non-image attachments (reference models, PDFs, notes) use getAttachments. If nothing is attached, it says so.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'getAttachments',
+    description: 'List ALL files the user pinned to this session (the "Attachments" panel): reference images, reference models (STL/STEP/3MF), documents (PDF), and text/notes. Returns a manifest — each entry\'s id, kind (image|model|document|text|other), media type, label, when it was added, and source (user vs captured from a chat upload). Text/notes attachments include their contents inline. These are DURABLE project context: they survive clearing the chat, so use this to recover reference material an earlier conversation was working from. To actually SEE image attachments, call getReferenceImages.',
     input_schema: { type: 'object', properties: {} },
   },
   {
@@ -1391,6 +1396,7 @@ const ALWAYS_AVAILABLE = new Set([
   'getMeshSummary',
   'getFeatureCentroids',
   'getReferenceImages',
+  'getAttachments',
   'getSessionContext',
   'listVersions',
   // loadVersion is intentionally NOT here — it's listed in SAVE_GATED so
@@ -1460,7 +1466,7 @@ export const CONFIRM_REQUIRED_TOOLS = new Set([
 export const RETRY_SAFE_TOOLS = new Set([
   // Pure reads / queries
   'getActiveLanguage', 'getCode', 'getParams', 'getGeometryData', 'getMeshSummary',
-  'getFeatureCentroids', 'getReferenceImages', 'getSessionContext', 'listVersions',
+  'getFeatureCentroids', 'getReferenceImages', 'getAttachments', 'getSessionContext', 'listVersions',
   'listSessionNotes', 'readDoc', 'findFaces', 'listComponents', 'listLabels',
   'getModelColors',
   'listRegions', 'probePixel', 'paintPreview', 'paintExplain', 'query', 'probeRay',
@@ -1595,6 +1601,7 @@ export async function executeTool(name: string, input: Record<string, unknown>):
     if (name === 'runIsolated') return await executeRunIsolated(api, input);
     if (name === 'sliceAtZVisual') return await executeSliceAtZVisual(api, input);
     if (name === 'getReferenceImages') return await executeGetReferenceImages(api);
+    if (name === 'getAttachments') return executeGetAttachments(api);
 
     const result = await dispatch(api, name, input);
     if (result === undefined) return { content: '(ok)', isError: false };
@@ -1690,7 +1697,7 @@ async function executeGetReferenceImages(api: PartwrightAPI): Promise<ToolExecRe
     .map(im => ({ src: im.src as string, label: im.label }));
   if (usable.length === 0) {
     return {
-      content: 'No reference images are attached to this session. If the task refers to photos or views, ask the user to attach them in the Images panel (or via the Self-Modeling Studio) — do not invent a subject.',
+      content: 'No reference images are attached to this session. If the task refers to photos or views, ask the user to attach them in the Attachments panel (or via the Self-Modeling Studio) — do not invent a subject. (Non-image attachments, if any, are listed by getAttachments.)',
       isError: false,
     };
   }
@@ -1703,6 +1710,77 @@ async function executeGetReferenceImages(api: PartwrightAPI): Promise<ToolExecRe
   return {
     content: `${usable.length} reference image(s), tiled left-to-right, top-to-bottom in the attached grid:\n${labels}`,
     image: grid,
+    isError: false,
+  };
+}
+
+interface AttachmentEntry {
+  id?: string;
+  kind?: string;
+  mediaType?: string;
+  src?: string;
+  label?: string;
+  addedAt?: number;
+  source?: string;
+}
+
+/** Decode a text attachment's `data:` URL to its string contents, capped so a
+ *  large file can't blow the tool result. Returns null when it isn't decodable
+ *  inline (remote URL, non-text payload). */
+function decodeTextAttachment(src: string | undefined): string | null {
+  if (!src || !src.startsWith('data:')) return null;
+  const comma = src.indexOf(',');
+  if (comma < 0) return null;
+  const meta = src.slice(5, comma);
+  const payload = src.slice(comma + 1);
+  const CAP = 4000;
+  try {
+    let text: string;
+    if (/;base64/i.test(meta)) {
+      const bin = atob(payload);
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      text = new TextDecoder().decode(bytes);
+    } else {
+      text = decodeURIComponent(payload);
+    }
+    return text.length > CAP ? `${text.slice(0, CAP)}\n…(truncated, ${text.length} chars total)` : text;
+  } catch {
+    return null;
+  }
+}
+
+function executeGetAttachments(api: PartwrightAPI): ToolExecResult {
+  const raw = typeof api.getAttachments === 'function' ? api.getAttachments() : [];
+  const items = (Array.isArray(raw) ? raw : []) as AttachmentEntry[];
+  if (items.length === 0) {
+    return {
+      content: 'No attachments are pinned to this session. Reference files (images, models, PDFs, notes) added in the Attachments panel — or images uploaded in this chat — would appear here. If the task needs reference material, ask the user to attach it.',
+      isError: false,
+    };
+  }
+  const imageCount = items.filter(a => a.kind === 'image').length;
+  const lines: string[] = [];
+  items.forEach((a, i) => {
+    const when = typeof a.addedAt === 'number' ? new Date(a.addedAt).toISOString().slice(0, 10) : 'date unknown';
+    const parts = [
+      `${i + 1}. [${a.kind ?? 'other'}] ${a.label?.trim() || '(no label)'}`,
+      a.mediaType ? `type=${a.mediaType}` : null,
+      `added ${when}`,
+      a.source ? `via ${a.source}` : null,
+      a.id ? `id=${a.id}` : null,
+    ].filter(Boolean);
+    lines.push(parts.join(' · '));
+    if (a.kind === 'text') {
+      const text = decodeTextAttachment(a.src);
+      if (text) lines.push(`   ---\n${text.split('\n').map(l => `   ${l}`).join('\n')}\n   ---`);
+    }
+  });
+  const hint = imageCount > 0
+    ? `\n\n${imageCount} image attachment(s) above — call getReferenceImages to view them.`
+    : '';
+  return {
+    content: `${items.length} attachment(s) pinned to this session:\n${lines.join('\n')}${hint}`,
     isError: false,
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -367,6 +367,7 @@ function buildAttachmentFromInput(input: unknown, ctx: string, source?: 'user' |
     label: obj.label as string | undefined,
     kind: obj.kind as AttachmentKind | undefined,
     mediaType: obj.mediaType as string | undefined,
+    addedAt: Date.now(),
     source,
   }, generateId());
 }
@@ -11087,6 +11088,7 @@ async function main() {
           src: item.src as string,
           label: item.label as string | undefined,
           kind: 'image',
+          addedAt: Date.now(),
           source: 'user',
         }, generateId()));
       }
@@ -11107,6 +11109,7 @@ async function main() {
         src: obj.src as string,
         label: obj.label as string | undefined,
         kind: 'image',
+        addedAt: Date.now(),
         source: 'user',
       }, generateId());
       commitAttachments([..._getAttachments(), item]);

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,8 @@ import { initViewport, updateMesh, clearMesh, setOnMeshUpdate, setOnContextLost,
 // Side-effect import: registers the phantom/annotation/session-plane viewport
 // hooks. Must load before initViewport runs (below). See viewportSubsystems.ts.
 import './renderer/viewportSubsystems';
-import { renderCompositeCanvas, renderSingleView, renderSingleViewCanvas, renderSliceSVG, setImages as _setImages, clearImages as _clearImages, getImages as _getImages, buildViewCamera, RENDER_VIEW_MODES, EDGE_MODES, STANDARD_VIEWS, type AttachedImage, type RenderViewMode, type EdgeMode } from './renderer/multiview';
+import { renderCompositeCanvas, renderSingleView, renderSingleViewCanvas, renderSliceSVG, setAttachments as _setAttachments, clearAttachments as _clearAttachments, getAttachments as _getAttachments, getImageAttachments as _getImageAttachments, buildViewCamera, RENDER_VIEW_MODES, EDGE_MODES, STANDARD_VIEWS, type AttachedImage, type SessionAttachment, type AttachmentKind, type RenderViewMode, type EdgeMode } from './renderer/multiview';
+import { normalizeAttachment, ATTACHMENT_KINDS } from './storage/attachment';
 import { generateId, getLatestVersion, listVersions, listParts, updateVersionThumbnail } from './storage/db';
 import { setPhantom, clearPhantom, hasPhantom, type PhantomOptions } from './renderer/phantomGeometry';
 import { initEditor, setValue, getValue, getSelection, setLanguage as setEditorLanguage, setEditorDiagnostics, clearEditorDiagnostics, revealFirstDiagnostic, formatCode, openFindReplace, getAutoFormat, setAutoFormat, getLineWrap, setLineWrap, getLineNumbers, setLineNumbers, getFontSize, setFontSize, getFontSizeBounds, editorContentDiffersFrom, createCompanionEditor, setCompanionEditorContent } from './editor/codeEditor';
@@ -289,8 +290,8 @@ import {
   importSession,
   importSessionPartsIntoActive,
   clearAllSessions,
-  saveImages as persistImages,
-  getImagesFromSession,
+  saveAttachments as persistAttachments,
+  getAttachmentsFromSession,
   addSessionNote,
   listSessionNotes,
   deleteIfEmpty,
@@ -338,6 +339,37 @@ import { getConfig, saveAppConfig } from './config/appConfig';
 import { nextStarter, isStarterCode } from './editor/starters';
 import { parseLabelColor } from './color/labelColor';
 import { extractPositions, maxEdgeLength, minEdgeLength, estimateRefineTriangles } from './surface/meshSubdivide';
+
+// === Attachment helpers (shared by the setImages/addImage + setAttachments/
+// addAttachment API methods) ===
+
+/** Push the new attachment list into the in-memory mirror AND persist it to
+ *  the active session. Mirrors the old `_setImages + persistImages` pairing. */
+function commitAttachments(next: SessionAttachment[]): void {
+  _setAttachments(next);
+  void persistAttachments(next);
+}
+
+/** Validate a loose `{src, id?, label?, kind?, mediaType?}` input and normalize
+ *  it into a typed SessionAttachment. `kind`/`mediaType` are inferred from the
+ *  src/label when omitted; an explicit `kind` is checked against the enum. */
+function buildAttachmentFromInput(input: unknown, ctx: string, source?: 'user' | 'chat'): SessionAttachment {
+  const obj = assertObject(input, ctx)!;
+  assertNoUnknownKeys(obj, ['src', 'id', 'label', 'kind', 'mediaType'] as const, ctx);
+  assertString(obj.src, `${ctx}.src`, { allowEmpty: false });
+  if (obj.id !== undefined) assertString(obj.id, `${ctx}.id`, { allowEmpty: false });
+  if (obj.label !== undefined) assertString(obj.label, `${ctx}.label`, { optional: true, allowEmpty: true });
+  if (obj.mediaType !== undefined) assertString(obj.mediaType, `${ctx}.mediaType`, { allowEmpty: false });
+  if (obj.kind !== undefined) assertEnum(obj.kind, ATTACHMENT_KINDS, `${ctx}.kind`);
+  return normalizeAttachment({
+    id: obj.id as string | undefined,
+    src: obj.src as string,
+    label: obj.label as string | undefined,
+    kind: obj.kind as AttachmentKind | undefined,
+    mediaType: obj.mediaType as string | undefined,
+    source,
+  }, generateId());
+}
 
 // Editor starters — one simple, labelled, self-coloured primitive per engine,
 // rotated so a fresh session/part/language opens on a different cube / sphere /
@@ -5194,11 +5226,11 @@ async function main() {
 
   function startNewSessionInEditor() {
     resetEditorToStarter();
-    _clearImages();
+    _clearAttachments();
   }
 
   // Reset the editor for a freshly created part. Unlike a new session, parts
-  // share the session's reference images, so those are left intact.
+  // share the session's attachments, so those are left intact.
   function startNewPartInEditor() {
     resetEditorToStarter();
   }
@@ -5639,7 +5671,7 @@ async function main() {
     { id: 'tab-interactive', title: 'Go to 3D view', hint: 'Tab', keywords: 'interactive viewport model', run: () => switchTab('interactive'), enabled: isEditorActive },
     { id: 'tab-gallery', title: 'Go to Gallery (read-only)', hint: 'Tab', keywords: 'thumbnails versions visual grid', run: () => switchTab('gallery'), enabled: isEditorActive },
     { id: 'tab-versions', title: 'Go to Versions', hint: 'Tab', keywords: 'history rename delete', run: () => switchTab('versions'), enabled: isEditorActive },
-    { id: 'tab-images', title: 'Go to Reference images', hint: 'Tab', keywords: 'photos reference', run: () => switchTab('images'), enabled: isEditorActive },
+    { id: 'tab-images', title: 'Go to Attachments', hint: 'Tab', keywords: 'photos reference images attachments files model document pdf notes', run: () => switchTab('images'), enabled: isEditorActive },
     { id: 'tab-diff', title: 'Go to Diff', hint: 'Tab', keywords: 'compare changes', run: () => switchTab('diff'), enabled: isEditorActive },
     { id: 'tab-notes', title: 'Go to Notes', hint: 'Tab', keywords: 'session notes', run: () => switchTab('notes'), enabled: isEditorActive },
     { id: 'tab-data', title: 'Go to Data', hint: 'Tab', keywords: 'storage browser indexeddb inventory', run: () => switchTab('data'), enabled: isEditorActive },
@@ -5701,8 +5733,8 @@ async function main() {
   // Init images view
   createImagesView(imagesContainer, {
     onChange: async (next) => {
-      _setImages(next);
-      await persistImages(next);
+      _setAttachments(next);
+      await persistAttachments(next);
     },
   });
 
@@ -6017,11 +6049,11 @@ async function main() {
 
     await rehydrateColorRegions(version.geometryData);
     applyVersionAnnotations(version);
-    const sessionImages = await getImagesFromSession();
-    if (sessionImages) {
-      _setImages(sessionImages);
+    const sessionAttachments = await getAttachmentsFromSession();
+    if (sessionAttachments) {
+      _setAttachments(sessionAttachments);
     } else {
-      _clearImages();
+      _clearAttachments();
     }
   }
 
@@ -11043,23 +11075,25 @@ async function main() {
     },
     setImages(images: Array<{ src: string; id?: string; label?: string }>): AttachedImage[] {
       const arr = assertArray(images, 'setImages(images)') as Array<Record<string, unknown>>;
-      const items: AttachedImage[] = [];
+      const items: SessionAttachment[] = [];
       for (let i = 0; i < arr.length; i++) {
         const item = assertObject(arr[i], `setImages(images)[${i}]`)!;
         assertNoUnknownKeys(item, ['src', 'id', 'label'] as const, `setImages(images)[${i}]`);
         assertString(item.src, `setImages(images)[${i}].src`, { allowEmpty: false });
         if (item.id !== undefined) assertString(item.id, `setImages(images)[${i}].id`, { allowEmpty: false });
         if (item.label !== undefined) assertString(item.label, `setImages(images)[${i}].label`, { optional: true, allowEmpty: true });
-        const built: AttachedImage = {
-          id: (item.id as string | undefined) ?? generateId(),
+        items.push(normalizeAttachment({
+          id: item.id as string | undefined,
           src: item.src as string,
-        };
-        const lbl = (item.label as string | undefined)?.trim();
-        if (lbl) built.label = lbl;
-        items.push(built);
+          label: item.label as string | undefined,
+          kind: 'image',
+          source: 'user',
+        }, generateId()));
       }
-      _setImages(items);
-      persistImages(items);
+      // Replace the image-kind attachments, preserving any non-image ones
+      // (models, docs) the user/AI may have pinned.
+      const nonImages = _getAttachments().filter(a => a.kind !== 'image');
+      commitAttachments([...items, ...nonImages]);
       return items;
     },
 
@@ -11069,35 +11103,78 @@ async function main() {
       assertNoUnknownKeys(obj, ['src', 'label'] as const, 'addImage(image)');
       assertString(obj.src, 'addImage(image).src', { allowEmpty: false });
       if (obj.label !== undefined) assertString(obj.label, 'addImage(image).label', { optional: true, allowEmpty: true });
-      const item: AttachedImage = { id: generateId(), src: obj.src as string };
-      const lbl = (obj.label as string | undefined)?.trim();
-      if (lbl) item.label = lbl;
-      const next = [..._getImages(), item];
-      _setImages(next);
-      persistImages(next);
+      const item = normalizeAttachment({
+        src: obj.src as string,
+        label: obj.label as string | undefined,
+        kind: 'image',
+        source: 'user',
+      }, generateId());
+      commitAttachments([..._getAttachments(), item]);
       return item;
     },
 
-    /** Remove an image by id. Returns true if an image was removed. */
+    /** Remove an image (or any attachment) by id. Returns true if one was removed. */
     removeImage(id: string): boolean {
       assertString(id, 'removeImage(id)', { allowEmpty: false });
-      const current = _getImages();
-      const next = current.filter(img => img.id !== id);
+      const current = _getAttachments();
+      const next = current.filter(a => a.id !== id);
       if (next.length === current.length) return false;
-      _setImages(next);
-      persistImages(next);
+      commitAttachments(next);
       return true;
     },
 
-    /** Clear all images */
+    /** Clear the image attachments (non-image attachments are preserved). */
     clearImages(): void {
-      _clearImages();
-      persistImages(null);
+      const nonImages = _getAttachments().filter(a => a.kind !== 'image');
+      commitAttachments(nonImages);
     },
 
-    /** Get the currently attached images as an array of `{id, angle, src}`. */
+    /** Get the image-kind attachments as `{id, src, label}`. */
     getImages(): AttachedImage[] {
-      return _getImages();
+      return _getImageAttachments();
+    },
+
+    // === Attachments (generalization of reference images) ===
+
+    /** Replace the whole attachment list. Each item: `{src, kind?, mediaType?, id?, label?}`
+     *  — `kind`/`mediaType` are inferred from the src/label when omitted. */
+    setAttachments(attachments: Array<{ src: string; id?: string; label?: string; kind?: AttachmentKind; mediaType?: string }>): SessionAttachment[] {
+      const arr = assertArray(attachments, 'setAttachments(attachments)') as Array<Record<string, unknown>>;
+      const items: SessionAttachment[] = [];
+      for (let i = 0; i < arr.length; i++) {
+        items.push(buildAttachmentFromInput(arr[i], `setAttachments(attachments)[${i}]`));
+      }
+      commitAttachments(items);
+      return items;
+    },
+
+    /** Append one attachment. `{src, kind?, mediaType?, label?}` — kind/mediaType
+     *  inferred when omitted. Returns the stored item with its assigned id. */
+    addAttachment(attachment: { src: string; label?: string; kind?: AttachmentKind; mediaType?: string }): SessionAttachment {
+      const obj = assertObject(attachment, 'addAttachment(attachment)')!;
+      const item = buildAttachmentFromInput(obj, 'addAttachment(attachment)', 'user');
+      commitAttachments([..._getAttachments(), item]);
+      return item;
+    },
+
+    /** Remove an attachment by id. Returns true if one was removed. */
+    removeAttachment(id: string): boolean {
+      assertString(id, 'removeAttachment(id)', { allowEmpty: false });
+      const current = _getAttachments();
+      const next = current.filter(a => a.id !== id);
+      if (next.length === current.length) return false;
+      commitAttachments(next);
+      return true;
+    },
+
+    /** Clear ALL attachments (images and non-images). */
+    clearAttachments(): void {
+      commitAttachments([]);
+    },
+
+    /** Get all attachments: `{id, kind, mediaType?, src, label?, addedAt?, source?}`. */
+    getAttachments(): SessionAttachment[] {
+      return _getAttachments();
     },
 
     // === Session API ===
@@ -11137,12 +11214,12 @@ async function main() {
         setValue(version.code);
         await runCodeSync(version.code, { preserveCamera: true });
       }
-      // Restore images from session
-      const sessionImages = await getImagesFromSession();
-      if (sessionImages) {
-        _setImages(sessionImages);
+      // Restore attachments from session
+      const sessionAttachments = await getAttachmentsFromSession();
+      if (sessionAttachments) {
+        _setAttachments(sessionAttachments);
       } else {
-        _clearImages();
+        _clearAttachments();
       }
       return version ? { id: version.id, index: version.index, label: version.label } : null;
     },
@@ -11856,10 +11933,10 @@ async function main() {
         setValue(version.code);
         await runCodeSync(version.code, { preserveCamera: true });
       }
-      // Restore images from imported session
-      const sessionImages = await getImagesFromSession();
-      if (sessionImages) {
-        _setImages(sessionImages);
+      // Restore attachments from imported session
+      const sessionAttachments = await getAttachmentsFromSession();
+      if (sessionAttachments) {
+        _setAttachments(sessionAttachments);
       }
       return { id: session.id, name: session.name, ...(warning ? { warning } : {}) };
     },
@@ -14988,6 +15065,17 @@ async function main() {
         // Notes
         'addSessionNote':  { signature: 'await addSessionNote(text) -- Add note with [PREFIX] tag', docs: '/ai.md#session-notes----tracking-design-context' },
         'listSessionNotes': { signature: 'await listSessionNotes() -- List all session notes', docs: '/ai.md#session-notes----tracking-design-context' },
+        // Attachments (durable project files: reference images, models, docs — survive a chat clear)
+        'getAttachments':  { signature: 'getAttachments() -- List session attachments -> [{id, kind, mediaType?, src, label?, addedAt?, source?}]. kind: image|model|document|text|other', docs: '/ai/reference-images.md#attachments' },
+        'addAttachment':   { signature: 'addAttachment({src, label?, kind?, mediaType?}) -- Pin a file to the session (kind/mediaType inferred when omitted) -> the stored item', docs: '/ai/reference-images.md#attachments' },
+        'setAttachments':  { signature: 'setAttachments([{src, label?, kind?, mediaType?}]) -- Replace the whole attachment list', docs: '/ai/reference-images.md#attachments' },
+        'removeAttachment': { signature: 'removeAttachment(id) -- Remove an attachment by id -> boolean', docs: '/ai/reference-images.md#attachments' },
+        'clearAttachments': { signature: 'clearAttachments() -- Remove all attachments', docs: '/ai/reference-images.md#attachments' },
+        'getImages':       { signature: 'getImages() -- Image-kind attachments only -> [{id, src, label?}]', docs: '/ai/reference-images.md#attachments' },
+        'addImage':        { signature: 'addImage({src, label?}) -- Pin a reference image (shorthand for addAttachment with kind:image)', docs: '/ai/reference-images.md#attachments' },
+        'setImages':       { signature: 'setImages([{src, label?, id?}]) -- Replace the image attachments (non-image attachments preserved)', docs: '/ai/reference-images.md#attachments' },
+        'removeImage':     { signature: 'removeImage(id) -- Remove an attachment by id -> boolean', docs: '/ai/reference-images.md#attachments' },
+        'clearImages':     { signature: 'clearImages() -- Remove the image attachments (non-image attachments preserved)', docs: '/ai/reference-images.md#attachments' },
         // Inspection
         'sliceAtZ':        { signature: 'sliceAtZ(z) -- Cross-section at height -> {polygons, svg, area}', docs: '/ai.md#console-api--windowpartwright' },
         'getBoundingBox':  { signature: 'getBoundingBox() -- -> {min, max}', docs: '/ai.md#console-api--windowpartwright' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -5671,7 +5671,7 @@ async function main() {
     { id: 'tab-interactive', title: 'Go to 3D view', hint: 'Tab', keywords: 'interactive viewport model', run: () => switchTab('interactive'), enabled: isEditorActive },
     { id: 'tab-gallery', title: 'Go to Gallery (read-only)', hint: 'Tab', keywords: 'thumbnails versions visual grid', run: () => switchTab('gallery'), enabled: isEditorActive },
     { id: 'tab-versions', title: 'Go to Versions', hint: 'Tab', keywords: 'history rename delete', run: () => switchTab('versions'), enabled: isEditorActive },
-    { id: 'tab-images', title: 'Go to Attachments', hint: 'Tab', keywords: 'photos reference images attachments files model document pdf notes', run: () => switchTab('images'), enabled: isEditorActive },
+    { id: 'tab-images', title: 'Go to Attachments', hint: 'Tab', keywords: 'photos reference images attachments files model document pdf', run: () => switchTab('images'), enabled: isEditorActive },
     { id: 'tab-diff', title: 'Go to Diff', hint: 'Tab', keywords: 'compare changes', run: () => switchTab('diff'), enabled: isEditorActive },
     { id: 'tab-notes', title: 'Go to Notes', hint: 'Tab', keywords: 'session notes', run: () => switchTab('notes'), enabled: isEditorActive },
     { id: 'tab-data', title: 'Go to Data', hint: 'Tab', keywords: 'storage browser indexeddb inventory', run: () => switchTab('data'), enabled: isEditorActive },

--- a/src/renderer/multiview.ts
+++ b/src/renderer/multiview.ts
@@ -3,6 +3,7 @@ import { createWhiteMaterial, createBlackWireframeMaterial, createCreaseEdgeMate
 import type { MeshData } from '../geometry/types';
 import { buildOffscreenOverlay, disposeOffscreenOverlay } from './viewportRegistry';
 import { presetIndex } from '../storage/db';
+import type { SessionAttachment, AttachedImage } from '../storage/attachment';
 import { CREASE_ANGLE_DEG, resolveEdgeMode, type EdgeMode } from './edgeMode';
 import { getConfig } from '../config/appConfig';
 export { EDGE_MODES, type EdgeMode } from './edgeMode';
@@ -250,34 +251,38 @@ export function renderCompositeCanvas(meshData: MeshData): HTMLCanvasElement {
   return compositeCanvas;
 }
 
-// === Attached images for elevation comparison ===
+// === Attached session attachments (reference images, models, docs…) ===
 
-export interface AttachedImage {
-  id: string;
-  src: string;
-  /** Optional user-facing caption. Drives ordering via preset matching. */
-  label?: string;
-}
+export type { SessionAttachment, AttachedImage, AttachmentKind } from '../storage/attachment';
 
-let _images: AttachedImage[] = [];
+// In-memory mirror of the active session's attachment list. The session
+// manager seeds it on open and persists mutations back to IndexedDB; the UI
+// reads it synchronously here.
+let _attachments: SessionAttachment[] = [];
 
-export function setImages(images: AttachedImage[]): void {
-  _images = images;
+export function setAttachments(attachments: SessionAttachment[]): void {
+  _attachments = attachments;
   window.dispatchEvent(new Event('images-changed'));
 }
 
-export function clearImages(): void {
-  _images = [];
+export function clearAttachments(): void {
+  _attachments = [];
   window.dispatchEvent(new Event('images-changed'));
 }
 
-export function getImages(): AttachedImage[] {
-  return _images;
+export function getAttachments(): SessionAttachment[] {
+  return _attachments;
+}
+
+/** Image-kind attachments only — what the Gallery strip and the AI's
+ *  `getReferenceImages` tool render. */
+export function getImageAttachments(): SessionAttachment[] {
+  return _attachments.filter(a => a.kind === 'image');
 }
 
 /** Stable sort: preset-matching labels first in preset order, others keep
  *  their insertion order at the end. */
-export function sortImagesByPreset(images: readonly AttachedImage[]): AttachedImage[] {
+export function sortImagesByPreset<T extends AttachedImage>(images: readonly T[]): T[] {
   return images
     .map((item, idx) => ({ item, idx, p: presetIndex(item.label) }))
     .sort((a, b) => {

--- a/src/storage/attachment.ts
+++ b/src/storage/attachment.ts
@@ -1,0 +1,135 @@
+// Shared, dependency-free types + classification helpers for session
+// attachments — the generalization of the old "reference images" list.
+//
+// An attachment is any file the user pins to a session as durable project
+// context: a reference photo, a spec-sheet PDF, a reference STL/STEP, a notes
+// markdown, etc. It outlives the AI chat transcript (clearing the chat does
+// NOT remove it) and is exported with the session, so an agent resuming a
+// session — or one whose chat history was cleared — can still find the
+// material the work was based on.
+//
+// This module is a LEAF (imported by both the storage layer and the renderer's
+// in-memory holder): it must stay free of any app imports so the dependency
+// graph keeps its direction. Pure data + pure functions only.
+
+/** The coarse category of an attachment. Drives how the UI previews it and how
+ *  the AI is allowed to consume it: an `image` can be *seen* by a vision model,
+ *  a `text` document can be *read* inline, while `model`/`document`/`other`
+ *  binaries can generally only be referenced by name + type. */
+export type AttachmentKind = 'image' | 'model' | 'document' | 'text' | 'other';
+
+export const ATTACHMENT_KINDS: readonly AttachmentKind[] = ['image', 'model', 'document', 'text', 'other'];
+
+/** Legacy display shape — every reference image was historically `{id, src, label?}`.
+ *  Retained as the *read* shape used by display/sort helpers; the persisted and
+ *  in-memory shape is the richer {@link SessionAttachment} below, which extends
+ *  it with the `kind`/`mediaType` metadata. */
+export interface AttachedImage {
+  id: string;
+  /** data URL or remote URL — the payload. */
+  src: string;
+  /** User-facing caption. */
+  label?: string;
+}
+
+/** A typed session attachment. Superset of {@link AttachedImage}: old image
+ *  rows migrate forward by gaining `kind: 'image'`. */
+export interface SessionAttachment extends AttachedImage {
+  /** Coarse category. */
+  kind: AttachmentKind;
+  /** MIME type when known (e.g. `image/png`, `model/stl`, `text/markdown`). */
+  mediaType?: string;
+  /** Epoch ms when the attachment was added — lets the UI/AI reason about
+   *  staleness (a reference photo can age out of relevance). */
+  addedAt?: number;
+  /** Provenance: `'user'` = added in the Attachments panel; `'chat'` =
+   *  captured from a file uploaded in the AI chat drawer. */
+  source?: 'user' | 'chat';
+}
+
+/** Map a file extension (no dot, lowercased) to a MIME type, for the cases the
+ *  browser doesn't hand us one (remote URLs, some drag-drops). */
+const EXT_MEDIA_TYPE: Record<string, string> = {
+  png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
+  webp: 'image/webp', svg: 'image/svg+xml', bmp: 'image/bmp', avif: 'image/avif',
+  stl: 'model/stl', step: 'model/step', stp: 'model/step', '3mf': 'model/3mf',
+  obj: 'model/obj', gltf: 'model/gltf+json', glb: 'model/gltf-binary',
+  pdf: 'application/pdf',
+  md: 'text/markdown', markdown: 'text/markdown', txt: 'text/plain',
+  csv: 'text/csv', json: 'application/json', scad: 'text/plain', svgz: 'image/svg+xml',
+};
+
+/** Extract a lowercased extension from a filename, URL path, or label. */
+function extOf(s: string | undefined): string {
+  if (!s) return '';
+  // Strip query/hash, then take the final path segment's extension.
+  const path = s.split(/[?#]/)[0];
+  const seg = path.split('/').pop() ?? '';
+  const dot = seg.lastIndexOf('.');
+  return dot >= 0 ? seg.slice(dot + 1).toLowerCase() : '';
+}
+
+/** Best-effort MIME type from a data URL prefix, a URL/filename extension, or a
+ *  label. Returns undefined when nothing can be determined. */
+export function inferMediaType(src: string | undefined, label?: string): string | undefined {
+  if (src && src.startsWith('data:')) {
+    const semi = src.indexOf(';');
+    const comma = src.indexOf(',');
+    const end = semi >= 0 ? semi : comma;
+    const mt = end > 5 ? src.slice(5, end) : '';
+    if (mt) return mt;
+  }
+  const ext = extOf(label) || extOf(src);
+  return ext ? EXT_MEDIA_TYPE[ext] : undefined;
+}
+
+/** Classify into one of the coarse {@link AttachmentKind} buckets from whatever
+ *  is known (MIME type, src/data URL, and/or label). */
+export function inferAttachmentKind(mediaType: string | undefined, src?: string, label?: string): AttachmentKind {
+  const mt = (mediaType || inferMediaType(src, label) || '').toLowerCase();
+  if (mt.startsWith('image/')) return 'image';
+  if (mt.startsWith('model/')) return 'model';
+  if (mt === 'application/pdf') return 'document';
+  if (mt.startsWith('text/') || mt === 'application/json') return 'text';
+  // Fall back to extension for binaries the MIME table didn't cover.
+  const ext = extOf(label) || extOf(src);
+  if (['stl', 'step', 'stp', '3mf', 'obj', 'gltf', 'glb'].includes(ext)) return 'model';
+  if (ext === 'pdf') return 'document';
+  if (['md', 'markdown', 'txt', 'csv', 'json', 'scad'].includes(ext)) return 'text';
+  if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'avif'].includes(ext)) return 'image';
+  return 'other';
+}
+
+/** Fill in the typed fields of an attachment from a loose/legacy partial. Pure:
+ *  the caller supplies a fallback id (and may pass `addedAt`/`source`). Used by
+ *  the read-time migration and by every construction site, so `kind`/`mediaType`
+ *  are always populated consistently. */
+export function normalizeAttachment(
+  partial: { id?: string; src: string; label?: string; kind?: AttachmentKind; mediaType?: string; addedAt?: number; source?: 'user' | 'chat' },
+  fallbackId: string,
+): SessionAttachment {
+  const mediaType = partial.mediaType || inferMediaType(partial.src, partial.label);
+  const kind = partial.kind || inferAttachmentKind(mediaType, partial.src, partial.label);
+  const out: SessionAttachment = {
+    id: partial.id || fallbackId,
+    src: partial.src,
+    kind,
+  };
+  if (mediaType) out.mediaType = mediaType;
+  const label = partial.label?.trim();
+  if (label) out.label = label;
+  if (typeof partial.addedAt === 'number') out.addedAt = partial.addedAt;
+  if (partial.source) out.source = partial.source;
+  return out;
+}
+
+/** Short human-readable noun for a kind, for UI badges and AI manifests. */
+export function attachmentKindLabel(kind: AttachmentKind): string {
+  switch (kind) {
+    case 'image': return 'Image';
+    case 'model': return 'Model';
+    case 'document': return 'Document';
+    case 'text': return 'Text';
+    default: return 'File';
+  }
+}

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1,11 +1,25 @@
 // IndexedDB storage for sessions and versions
 
+import {
+  type AttachedImage,
+  type SessionAttachment,
+  type AttachmentKind,
+  normalizeAttachment,
+} from './attachment';
+
+export type { AttachedImage, SessionAttachment, AttachmentKind } from './attachment';
+
 export interface Session {
   id: string;
   name: string;
   created: number;
   updated: number;
-  images?: AttachedImage[] | null;
+  /** Typed project attachments (reference photos, spec PDFs, reference models,
+   *  notes…) — the generalization of the old `images` list. Survives an AI
+   *  chat clear and is exported with the session. Legacy `images` /
+   *  `referenceImages` shapes migrate into this field on read
+   *  ({@link migrateSessionImages}). */
+  attachments?: SessionAttachment[] | null;
   /** Modeling language for this session. Missing = 'manifold-js'. */
   language?: 'manifold-js' | 'scad' | 'replicad' | 'voxel';
   /** Id of the part that is active when the session is (re)opened. Missing =
@@ -53,18 +67,6 @@ export interface Part {
   order: number;
   created: number;
   updated: number;
-}
-
-export interface AttachedImage {
-  id: string;
-  /** data URL or remote URL */
-  src: string;
-  /** User-facing caption. Shown in the Gallery, lightbox, and tooltips.
-   *  May match one of the preset labels (Front, Right, Back, Left, Top,
-   *  Perspective) — those drive ordering of the image strip — or be
-   *  a free-form custom string. Empty string and undefined both mean
-   *  "no caption". */
-  label?: string;
 }
 
 /** Suggested labels offered as quick picks in the UI. Items whose label
@@ -561,67 +563,83 @@ export async function createSession(name?: string, language?: 'manifold-js' | 's
 // stored before the array migration may still be in this form.
 type LegacyImagesObject = Partial<Record<LegacyImageAngle, string>>;
 
+type LegacyImagesShape = LegacyImagesObject | AttachedImage[] | null;
+
 export async function getSession(id: string): Promise<Session | null> {
   const store = await tx('sessions', 'readonly');
-  const raw = await reqToPromise(store.get(id)) as (Session & { referenceImages?: LegacyImagesObject | AttachedImage[] | null }) | null;
+  const raw = await reqToPromise(store.get(id)) as (Session & { images?: LegacyImagesShape; referenceImages?: LegacyImagesShape }) | null;
   return raw ? migrateSessionImages(raw) : null;
 }
 
 export async function listSessions(): Promise<Session[]> {
   const store = await tx('sessions', 'readonly');
-  const sessions = await reqToPromise(store.getAll()) as (Session & { referenceImages?: LegacyImagesObject | AttachedImage[] | null })[];
+  const sessions = await reqToPromise(store.getAll()) as (Session & { images?: LegacyImagesShape; referenceImages?: LegacyImagesShape })[];
   return sessions.map(migrateSessionImages).sort((a, b) => b.updated - a.updated);
 }
 
-// Read-time migration for three legacy shapes:
-//  1. Pre-rename sessions stored data under `referenceImages` instead of `images`.
+// Read-time migration for legacy shapes, collapsing them all into the typed
+// `attachments` array:
+//  1. Pre-rename sessions stored data under `referenceImages`, then `images`.
 //  2. Pre-array sessions stored an object map ({front: 'url', ...}) rather than an array.
 //  3. Pre-unification sessions stored items as {id, angle, src, label?}; we collapse
-//     `angle` into `label` here so callers see a single user-facing field.
-function migrateSessionImages(s: Session & { referenceImages?: LegacyImagesObject | AttachedImage[] | null }): Session {
+//     `angle` into `label`.
+//  4. Pre-attachments sessions stored `{id, src, label}` images with no `kind` —
+//     we normalize each into a typed `kind: 'image'` attachment.
+function migrateSessionImages(s: Session & { images?: LegacyImagesShape; referenceImages?: LegacyImagesShape }): Session {
   // Operate on an untyped view so we can hold both legacy and new shapes during migration.
-  const raw = s as unknown as { images?: unknown; referenceImages?: unknown };
-  if (raw.images == null && raw.referenceImages != null) {
-    raw.images = raw.referenceImages;
-  }
+  const raw = s as unknown as { attachments?: unknown; images?: unknown; referenceImages?: unknown };
+  // Pick the first present source, newest field name first.
+  let src: unknown = raw.attachments ?? raw.images ?? raw.referenceImages ?? null;
+  delete raw.images;
   delete raw.referenceImages;
-  if (raw.images && !Array.isArray(raw.images) && typeof raw.images === 'object') {
-    raw.images = legacyImagesObjectToArray(raw.images as LegacyImagesObject);
+  if (src && !Array.isArray(src) && typeof src === 'object') {
+    src = legacyImagesObjectToArray(src as LegacyImagesObject);
   }
-  if (Array.isArray(raw.images)) {
-    raw.images = (raw.images as Array<Record<string, unknown>>).map(collapseAngleIntoLabel);
+  if (Array.isArray(src)) {
+    raw.attachments = (src as Array<Record<string, unknown>>).map(item =>
+      normalizeAttachment(
+        {
+          id: typeof item.id === 'string' ? item.id : undefined,
+          src: typeof item.src === 'string' ? item.src : '',
+          // Pre-unification rows tagged the angle; fold it into the label.
+          label: collapseAngleIntoLabel(item),
+          kind: typeof item.kind === 'string' ? (item.kind as AttachmentKind) : undefined,
+          mediaType: typeof item.mediaType === 'string' ? item.mediaType : undefined,
+          addedAt: typeof item.addedAt === 'number' ? item.addedAt : undefined,
+          source: item.source === 'chat' || item.source === 'user' ? item.source : undefined,
+        },
+        generateId(),
+      ),
+    );
+  } else {
+    raw.attachments = null;
   }
   return s;
 }
 
-/** Drop the legacy `angle` field, copying it into `label` (capitalized) when
- *  a label isn't already present. After this, `label` is the single source of
- *  truth for how the image is named in the UI. */
-function collapseAngleIntoLabel(item: Record<string, unknown>): AttachedImage {
-  const id = typeof item.id === 'string' ? item.id : generateId();
-  const src = typeof item.src === 'string' ? item.src : '';
+/** Compute the effective label: explicit label wins, else the legacy
+ *  `angle` field capitalized, else empty. */
+function collapseAngleIntoLabel(item: Record<string, unknown>): string {
   const existingLabel = typeof item.label === 'string' ? item.label.trim() : '';
+  if (existingLabel) return existingLabel;
   const angle = typeof item.angle === 'string' ? item.angle : '';
-  const out: AttachedImage = { id, src };
-  const label = existingLabel || (angle ? capitalize(angle) : '');
-  if (label) out.label = label;
-  return out;
+  return angle ? capitalize(angle) : '';
 }
 
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-export function legacyImagesObjectToArray(obj: LegacyImagesObject): AttachedImage[] {
-  const result: AttachedImage[] = [];
+export function legacyImagesObjectToArray(obj: LegacyImagesObject): SessionAttachment[] {
+  const result: SessionAttachment[] = [];
   for (const angle of LEGACY_ANGLES) {
     const src = obj[angle];
-    if (src) result.push({ id: generateId(), src, label: capitalize(angle) });
+    if (src) result.push(normalizeAttachment({ src, label: capitalize(angle), kind: 'image' }, generateId()));
   }
   return result;
 }
 
-export async function updateSession(id: string, updates: Partial<Pick<Session, 'name' | 'created' | 'updated' | 'images' | 'language' | 'currentPartId' | 'aiPreference' | 'thumbCamera' | 'workCamera'>>): Promise<void> {
+export async function updateSession(id: string, updates: Partial<Pick<Session, 'name' | 'created' | 'updated' | 'attachments' | 'language' | 'currentPartId' | 'aiPreference' | 'thumbCamera' | 'workCamera'>>): Promise<void> {
   const store = await tx('sessions', 'readwrite');
   // Read-modify-write inside one transaction: queue the put from the get's
   // callback (awaiting between them risks auto-commit), then await oncomplete.
@@ -630,8 +648,9 @@ export async function updateSession(id: string, updates: Partial<Pick<Session, '
     const session = getReq.result as Session | null;
     if (!session) return;
     Object.assign(session, updates);
-    // Strip legacy field if present so it doesn't shadow the new one on re-read
+    // Strip legacy fields if present so they don't shadow the new one on re-read
     delete (session as { referenceImages?: unknown }).referenceImages;
+    delete (session as { images?: unknown }).images;
     store.put(session);
   };
   await txComplete(store.transaction);

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -42,7 +42,9 @@ import {
   type VersionOperation,
   type SessionNote,
   type AttachedImage,
+  type SessionAttachment,
 } from './db';
+import { normalizeAttachment } from './attachment';
 import { publishTabSync, onTabSync } from './tabSync';
 import { clearReliefSettings } from '../relief/reliefSettings';
 import { listMessages as dbListMessages, putMessages as dbPutMessages } from '../ai/db';
@@ -168,8 +170,16 @@ import { appPath } from '../deployment';
  *           schema number; it's the signal the cross-major migration flow keys
  *           off (see appVersionCompat.ts). Absent on pre-1.15 files and on
  *           dev/test builds (version 'unknown'); older readers ignore it.
+ *  - `1.16` — reference images generalized to typed **attachments**
+ *           (`session.attachments`). Each item carries a `kind`
+ *           (`image | model | document | text | other`) plus optional
+ *           `mediaType`/`addedAt`/`source`, so a session can pin non-image
+ *           files (spec PDFs, reference models, notes) as durable project
+ *           context. Legacy `session.images` / `session.referenceImages`
+ *           (and the object-map form) still read as image attachments. Older
+ *           readers ignore the new field.
  */
-export const SCHEMA_VERSION = '1.15';
+export const SCHEMA_VERSION = '1.16';
 
 const CURRENT_MAJOR = 1;
 
@@ -204,9 +214,10 @@ export interface ExportedSession {
    * @since 1.15
    */
   appVersion?: string;
-  /** Images may be the array form or the legacy object map ({front, right, ...}).
-   * Both also exist under `referenceImages` for pre-rename exports. */
-  session: { name: string; created: number; updated: number; images?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; referenceImages?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; language?: 'manifold-js' | 'scad' | 'replicad' | 'voxel'; thumbCamera?: { azimuth: number; elevation: number }; workCamera?: { position: [number, number, number]; target: [number, number, number] } };
+  /** Attachments (schema 1.16+) are the array of typed `SessionAttachment`s.
+   * Legacy `images` / `referenceImages` (array form or the object map
+   * {front, right, ...}) still read as image attachments for older exports. */
+  session: { name: string; created: number; updated: number; attachments?: SessionAttachment[] | null; images?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; referenceImages?: AttachedImage[] | Partial<Record<LegacyImageAngle, string>> | null; language?: 'manifold-js' | 'scad' | 'replicad' | 'voxel'; thumbCamera?: { azimuth: number; elevation: number }; workCamera?: { position: [number, number, number]; target: [number, number, number] } };
   /**
    * The session's parts, ordered by `order`. Present from schema 1.7. Pre-1.7
    * files omit this; on import they collapse into a single default part.
@@ -479,7 +490,7 @@ export function getSchemaCompatibilityWarning(data: ExportedSession): string | n
   return null;
 }
 
-export type { Session, Part, Version, VersionOperation, SessionNote, AttachedImage, SessionDraft } from './db';
+export type { Session, Part, Version, VersionOperation, SessionNote, AttachedImage, SessionAttachment, AttachmentKind, SessionDraft } from './db';
 
 // Pure resolver for a version's effective modeling language — re-exported from
 // its own tiny module so unit tests can import it without dragging in the
@@ -1461,29 +1472,29 @@ export function getGalleryUrl(): string {
   return `${base}?session=${currentState.session.id}&gallery`;
 }
 
-// === Images ===
+// === Attachments (formerly "reference images") ===
 
-export async function saveImages(images: AttachedImage[] | null): Promise<void> {
+export async function saveAttachments(attachments: SessionAttachment[] | null): Promise<void> {
   if (!currentState.session) return;
   const id = currentState.session.id;
   await dbUpdateSession(id, {
-    images,
+    attachments,
     updated: Date.now(),
   });
   // Update local state so getState() reflects the change
   currentState = {
     ...currentState,
-    session: { ...currentState.session, images },
+    session: { ...currentState.session, attachments },
   };
   notify();
   publishTabSync({ kind: 'session-meta', sessionId: id });
 }
 
-export async function getImagesFromSession(): Promise<AttachedImage[] | null> {
+export async function getAttachmentsFromSession(): Promise<SessionAttachment[] | null> {
   if (!currentState.session) return null;
   // Refresh from DB in case it was updated externally
   const session = await getSession(currentState.session.id);
-  return session?.images ?? null;
+  return session?.attachments ?? null;
 }
 
 // === Notes ===
@@ -1890,7 +1901,7 @@ export async function exportSession(
   return {
     partwright: SCHEMA_VERSION,
     ...(stampedAppVersion ? { appVersion: stampedAppVersion } : {}),
-    session: { name: session.name, created: session.created, updated: session.updated, images: session.images ?? null, ...(session.language ? { language: session.language } : {}), ...(session.thumbCamera ? { thumbCamera: session.thumbCamera } : {}), ...(session.workCamera ? { workCamera: session.workCamera } : {}) },
+    session: { name: session.name, created: session.created, updated: session.updated, attachments: session.attachments ?? null, ...(session.language ? { language: session.language } : {}), ...(session.thumbCamera ? { thumbCamera: session.thumbCamera } : {}), ...(session.workCamera ? { workCamera: session.workCamera } : {}) },
     parts: parts.map(p => ({ name: p.name, order: p.order })),
     versions: flat.map(({ v, partOrder }, i) => {
       const colorRegions = opts.includeColorRegions ? extractColorRegions(v.geometryData) : undefined;
@@ -1961,15 +1972,19 @@ export async function importSession(
   // version-language fallback chain).
   const session = await dbCreateSession(data.session.name, asLanguage(data.session.language));
 
-  // Restore images if present in the exported data. Handle two legacy shapes:
+  // Restore attachments if present. Handle the new field plus legacy shapes:
+  //   - 1.16+: `attachments` (typed SessionAttachment[])
+  //   - pre-1.16: `images` (typed-less array of {id, src, label})
   //   - pre-rename: `referenceImages` instead of `images`
-  //   - pre-array: object map `{front: 'url', ...}` instead of `[{id, angle, src}]`
-  const rawImages = data.session.images ?? data.session.referenceImages ?? null;
-  if (rawImages) {
-    const imagesArr = Array.isArray(rawImages)
-      ? rawImages
-      : legacyImagesObjectToArray(rawImages);
-    await dbUpdateSession(session.id, { images: imagesArr });
+  //   - pre-array: object map `{front: 'url', ...}`
+  // Everything is normalized into typed attachments (image-kind for the legacy
+  // shapes, which only ever held images).
+  const rawAttachments = data.session.attachments ?? data.session.images ?? data.session.referenceImages ?? null;
+  if (rawAttachments) {
+    const arr = Array.isArray(rawAttachments)
+      ? rawAttachments.map(a => normalizeAttachment(a, generateId()))
+      : legacyImagesObjectToArray(rawAttachments);
+    await dbUpdateSession(session.id, { attachments: arr });
   }
 
   // Restore the pinned thumbnail camera (schema 1.12+). Validate both angles

--- a/src/ui/aiPanel.ts
+++ b/src/ui/aiPanel.ts
@@ -2788,6 +2788,31 @@ function attachImageSource(img: ImageSource): void {
   // Fire-and-forget — IDB write failures shouldn't block the UI; the
   // image is already attached to this turn either way.
   void putAttachment(img).catch(err => console.warn('Recent attachments: write failed', err));
+  // Also pin it to the session's durable attachments, so it survives a chat
+  // clear and the AI can fetch it back via getReferenceImages/getAttachments.
+  captureChatImageAsAttachment(img);
+}
+
+/** Pin an AI-panel image upload onto the current session as a durable,
+ *  chat-sourced attachment. No-op when there's no real session (the global
+ *  chat bucket) or the same image is already attached (dedup by src). */
+function captureChatImageAsAttachment(img: ImageSource): void {
+  if (!state.sessionId || state.sessionId === GLOBAL_CHAT_BUCKET) return;
+  const pw = (window as unknown as {
+    partwright?: {
+      getAttachments?: () => Array<{ src?: string }>;
+      addAttachment?: (a: { src: string; label?: string; kind?: string; mediaType?: string }) => unknown;
+    };
+  }).partwright;
+  if (!pw?.addAttachment || !pw.getAttachments) return;
+  const src = `data:${img.mediaType};base64,${img.data}`;
+  try {
+    const existing = pw.getAttachments();
+    if (Array.isArray(existing) && existing.some(a => a.src === src)) return;
+    pw.addAttachment({ src, label: img.label, kind: 'image', mediaType: img.mediaType });
+  } catch (err) {
+    console.warn('Session attachments: capture failed', err);
+  }
 }
 
 function renderPendingImages(): void {

--- a/src/ui/gallery.ts
+++ b/src/ui/gallery.ts
@@ -2,7 +2,7 @@
 // plus a read-only strip of attached reference images at the top.
 
 import { listCurrentVersions, loadVersion, getState } from '../storage/sessionManager';
-import { getImages, sortImagesByPreset, type AttachedImage } from '../renderer/multiview';
+import { getImageAttachments, sortImagesByPreset, type SessionAttachment } from '../renderer/multiview';
 import { createVersionTile } from './versionTile';
 
 let galleryEl: HTMLElement | null = null;
@@ -25,7 +25,7 @@ export async function refreshGallery(): Promise<void> {
   if (!galleryEl) return;
 
   const versions = await listCurrentVersions();
-  const images = getImages();
+  const images = getImageAttachments();
   galleryEl.innerHTML = '';
 
   if (images.length > 0) {
@@ -58,7 +58,7 @@ export async function refreshGallery(): Promise<void> {
   galleryEl.appendChild(grid);
 }
 
-function createImagesSection(images: AttachedImage[]): HTMLElement {
+function createImagesSection(images: SessionAttachment[]): HTMLElement {
   const section = document.createElement('div');
   section.className = 'mb-4 pb-4 border-b border-zinc-700';
 

--- a/src/ui/imagesView.ts
+++ b/src/ui/imagesView.ts
@@ -257,7 +257,7 @@ export function showAttachImageModal(
       const name = file.name.toLowerCase();
       const dataUrl = await readFileAsDataURL(file);
       const att = normalizeAttachment(
-        { src: dataUrl, label: file.name, mediaType: file.type || undefined, source: 'user' },
+        { src: dataUrl, label: file.name, mediaType: file.type || undefined, addedAt: Date.now(), source: 'user' },
         generateId(),
       );
       // For reference photos, snap the label to a matching preset angle.
@@ -321,7 +321,7 @@ export function showAttachImageModal(
       const dataUrl = await fetchImageAsDataURL(url);
       const matched = PRESET_LABELS.find(p => url.toLowerCase().includes(p.toLowerCase()));
       const item = normalizeAttachment(
-        { src: dataUrl, label: matched ?? 'Perspective', kind: 'image', source: 'user' },
+        { src: dataUrl, label: matched ?? 'Perspective', kind: 'image', addedAt: Date.now(), source: 'user' },
         generateId(),
       );
       await onSave([...current, item]);

--- a/src/ui/imagesView.ts
+++ b/src/ui/imagesView.ts
@@ -1,18 +1,21 @@
-// Images panel — list, attach, relabel, and remove session images.
-// Each image has a single `label` field (a free-form caption with preset
-// suggestions like Front/Right/Back/Left/Top/Perspective). The label is
-// what shows in the Gallery; presets just make common values one click
-// away rather than always typing.
+// Attachments panel — list, attach, relabel, and remove session attachments.
+// Attachments are durable project files (reference images, reference models,
+// spec PDFs, notes…) pinned to the session — they survive an AI chat clear and
+// are exported with the session. Each carries a `kind`
+// (image|model|document|text|other) plus a free-form `label` caption with
+// preset suggestions like Front/Right/Back/Left/Top/Perspective (mainly useful
+// for reference photos). The label shows in the Gallery for image attachments.
 
-import { getState, type AttachedImage } from '../storage/sessionManager';
+import { getState, type SessionAttachment } from '../storage/sessionManager';
 import { generateId, PRESET_LABELS } from '../storage/db';
-import { getImages, sortImagesByPreset } from '../renderer/multiview';
+import { normalizeAttachment, attachmentKindLabel } from '../storage/attachment';
+import { getAttachments, sortImagesByPreset } from '../renderer/multiview';
 
 const DATALIST_ID = 'image-label-presets';
 
 export interface ImagesViewCallbacks {
-  /** Persist the new images list. The view re-renders after this resolves. */
-  onChange: (images: AttachedImage[]) => Promise<void> | void;
+  /** Persist the new attachment list. The view re-renders after this resolves. */
+  onChange: (attachments: SessionAttachment[]) => Promise<void> | void;
 }
 
 let containerEl: HTMLElement | null = null;
@@ -50,19 +53,19 @@ export function refreshImages(): void {
   if (!state.session) {
     const empty = document.createElement('div');
     empty.className = 'flex items-center justify-center flex-1 text-zinc-500 text-sm';
-    empty.textContent = 'Open a session to attach images.';
+    empty.textContent = 'Open a session to attach files.';
     containerEl.appendChild(empty);
     return;
   }
 
   containerEl.appendChild(createHeader());
 
-  const images = sortImagesByPreset(getImages());
+  const items = sortImagesByPreset(getAttachments());
 
-  if (images.length === 0) {
+  if (items.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'flex items-center justify-center flex-1 text-zinc-500 text-sm mt-8';
-    empty.textContent = 'No images yet. Click "Attach image…" to add one.';
+    empty.textContent = 'No attachments yet. Click "Attach…" to add a reference image, model, or document.';
     containerEl.appendChild(empty);
     return;
   }
@@ -71,8 +74,8 @@ export function refreshImages(): void {
   grid.className = 'grid gap-3 mt-3';
   grid.style.gridTemplateColumns = 'repeat(auto-fill, minmax(220px, 1fr))';
 
-  for (const item of images) {
-    grid.appendChild(createImageTile(item, images));
+  for (const item of items) {
+    grid.appendChild(createImageTile(item, items));
   }
 
   containerEl.appendChild(grid);
@@ -87,12 +90,12 @@ function createHeader(): HTMLElement {
 
   const titleText = document.createElement('div');
   titleText.className = 'text-sm font-semibold text-zinc-200';
-  titleText.textContent = 'Reference images';
+  titleText.textContent = 'Attachments';
   title.appendChild(titleText);
 
   const desc = document.createElement('div');
   desc.className = 'text-xs text-zinc-500 leading-relaxed mt-0.5';
-  desc.textContent = 'Photos or renderings the model should match. Each image has a label — pick a preset like "Front" or type your own caption — that shows in the Gallery and orders the image strip.';
+  desc.textContent = 'Reference files pinned to this session — photos to match, reference models, spec sheets, notes. They stay with the session (an AI chat clear won\'t remove them) and the assistant can read them back. Each has a label; presets like "Front" order reference photos in the Gallery.';
   title.appendChild(desc);
 
   header.appendChild(title);
@@ -100,28 +103,59 @@ function createHeader(): HTMLElement {
   const addBtn = document.createElement('button');
   addBtn.id = 'btn-attach-image';
   addBtn.className = 'shrink-0 px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors';
-  addBtn.textContent = '+ Attach image…';
-  addBtn.addEventListener('click', () => showAttachImageModal(getImages(), persistAndRefresh));
+  addBtn.textContent = '+ Attach…';
+  addBtn.addEventListener('click', () => showAttachImageModal(getAttachments(), persistAndRefresh));
   header.appendChild(addBtn);
 
   return header;
 }
 
-function createImageTile(item: AttachedImage, allImages: AttachedImage[]): HTMLElement {
+/** Emoji icon for a non-image attachment kind, shown on the file-card tile. */
+function kindIcon(kind: SessionAttachment['kind']): string {
+  switch (kind) {
+    case 'model': return '\u{1F9CA}';      // ice cube — stands in for a 3D model
+    case 'document': return '\u{1F4C4}';    // page
+    case 'text': return '\u{1F4DD}';        // memo
+    default: return '\u{1F4CE}';            // paperclip
+  }
+}
+
+function createImageTile(item: SessionAttachment, allImages: SessionAttachment[]): HTMLElement {
   const tile = document.createElement('div');
-  tile.className = 'bg-zinc-800 rounded-lg overflow-hidden flex flex-col';
+  tile.className = 'bg-zinc-800 rounded-lg overflow-hidden flex flex-col relative';
 
-  // Thumbnail
-  const thumbContainer = document.createElement('div');
-  thumbContainer.className = 'aspect-square bg-zinc-900 flex items-center justify-center overflow-hidden cursor-pointer';
-  thumbContainer.title = 'Click to enlarge';
+  // Kind badge (top-right) for quick scanning, esp. with mixed attachment types.
+  const badge = document.createElement('div');
+  badge.className = 'absolute top-1.5 right-1.5 z-10 px-1.5 py-0.5 rounded text-[10px] font-medium bg-black/60 text-zinc-200 pointer-events-none';
+  badge.textContent = attachmentKindLabel(item.kind);
+  tile.appendChild(badge);
 
-  const img = document.createElement('img');
-  img.className = 'w-full h-full object-contain';
-  applyImageSrc(img, item.src);
-  thumbContainer.appendChild(img);
-  thumbContainer.addEventListener('click', () => showLightbox(item.src, item.label || ''));
-  tile.appendChild(thumbContainer);
+  if (item.kind === 'image') {
+    // Thumbnail
+    const thumbContainer = document.createElement('div');
+    thumbContainer.className = 'aspect-square bg-zinc-900 flex items-center justify-center overflow-hidden cursor-pointer';
+    thumbContainer.title = 'Click to enlarge';
+
+    const img = document.createElement('img');
+    img.className = 'w-full h-full object-contain';
+    applyImageSrc(img, item.src);
+    thumbContainer.appendChild(img);
+    thumbContainer.addEventListener('click', () => showLightbox(item.src, item.label || ''));
+    tile.appendChild(thumbContainer);
+  } else {
+    // Non-image: a file card with a type icon + media type.
+    const card = document.createElement('div');
+    card.className = 'aspect-square bg-zinc-900 flex flex-col items-center justify-center gap-1 text-zinc-400';
+    const icon = document.createElement('div');
+    icon.className = 'text-4xl';
+    icon.textContent = kindIcon(item.kind);
+    card.appendChild(icon);
+    const mt = document.createElement('div');
+    mt.className = 'text-[10px] text-zinc-500 px-2 text-center break-all';
+    mt.textContent = item.mediaType || attachmentKindLabel(item.kind);
+    card.appendChild(mt);
+    tile.appendChild(card);
+  }
 
   // Footer: label input (with preset suggestions) and remove button
   const footer = document.createElement('div');
@@ -139,8 +173,9 @@ function createImageTile(item: AttachedImage, allImages: AttachedImage[]): HTMLE
     if (next === current) return;
     const nextList = allImages.map(x => {
       if (x.id !== item.id) return x;
-      const updated: AttachedImage = { id: x.id, src: x.src };
-      if (next) updated.label = next;
+      // Preserve kind/mediaType/addedAt/source; only the label changes.
+      const updated: SessionAttachment = { ...x, label: next };
+      if (!next) delete updated.label;
       return updated;
     });
     await persistAndRefresh(nextList);
@@ -172,7 +207,7 @@ function createImageTile(item: AttachedImage, allImages: AttachedImage[]): HTMLE
   return tile;
 }
 
-async function persistAndRefresh(next: AttachedImage[]): Promise<void> {
+async function persistAndRefresh(next: SessionAttachment[]): Promise<void> {
   await cb.onChange(next);
   refreshImages();
 }
@@ -180,8 +215,8 @@ async function persistAndRefresh(next: AttachedImage[]): Promise<void> {
 // === Attach modal (file upload + URL paste) ===
 
 export function showAttachImageModal(
-  current: AttachedImage[],
-  onSave: (next: AttachedImage[]) => Promise<void> | void,
+  current: SessionAttachment[],
+  onSave: (next: SessionAttachment[]) => Promise<void> | void,
 ): void {
   const backdrop = document.createElement('div');
   backdrop.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm';
@@ -191,11 +226,11 @@ export function showAttachImageModal(
 
   const title = document.createElement('h2');
   title.className = 'text-base font-semibold text-zinc-100 mb-2';
-  title.textContent = 'Attach an image';
+  title.textContent = 'Attach a file';
 
   const explanation = document.createElement('p');
   explanation.className = 'text-sm text-zinc-400 mb-4 leading-relaxed';
-  explanation.textContent = 'Add a photo or rendering you want your model to match. Each image is auto-labeled from its filename or URL — rename it from the tile after attaching. The label appears in the Gallery and orders the image strip.';
+  explanation.textContent = 'Pin a reference file to this session — a photo to match, a reference model, a spec sheet, or notes. The type is detected automatically. Each item is auto-labeled from its filename or URL; rename it from the tile after attaching.';
 
   // File upload section
   const fileSection = document.createElement('div');
@@ -207,23 +242,30 @@ export function showAttachImageModal(
 
   const fileHint = document.createElement('div');
   fileHint.className = 'text-xs text-zinc-500 mb-2 leading-relaxed';
-  fileHint.textContent = 'Select one or more images. Filenames containing front/right/back/left/top/perspective auto-set the label to the matching preset; anything else uses "Perspective".';
+  fileHint.textContent = 'Select one or more files (images, STL/STEP/3MF models, PDFs, text). For reference photos, filenames containing front/right/back/left/top/perspective auto-set the matching preset label.';
 
   const fileInput = document.createElement('input');
   fileInput.type = 'file';
-  fileInput.accept = 'image/*';
   fileInput.multiple = true;
   fileInput.className = 'hidden';
   fileInput.addEventListener('change', async () => {
     const files = Array.from(fileInput.files || []);
     if (!files.length) return;
 
-    const additions: AttachedImage[] = [];
+    const additions: SessionAttachment[] = [];
     for (const file of files) {
       const name = file.name.toLowerCase();
       const dataUrl = await readFileAsDataURL(file);
-      const matched = PRESET_LABELS.find(p => name.includes(p.toLowerCase()));
-      additions.push({ id: generateId(), src: dataUrl, label: matched ?? 'Perspective' });
+      const att = normalizeAttachment(
+        { src: dataUrl, label: file.name, mediaType: file.type || undefined, source: 'user' },
+        generateId(),
+      );
+      // For reference photos, snap the label to a matching preset angle.
+      if (att.kind === 'image') {
+        const matched = PRESET_LABELS.find(p => name.includes(p.toLowerCase()));
+        att.label = matched ?? 'Perspective';
+      }
+      additions.push(att);
     }
 
     await onSave([...current, ...additions]);
@@ -278,7 +320,10 @@ export function showAttachImageModal(
     try {
       const dataUrl = await fetchImageAsDataURL(url);
       const matched = PRESET_LABELS.find(p => url.toLowerCase().includes(p.toLowerCase()));
-      const item: AttachedImage = { id: generateId(), src: dataUrl, label: matched ?? 'Perspective' };
+      const item = normalizeAttachment(
+        { src: dataUrl, label: matched ?? 'Perspective', kind: 'image', source: 'user' },
+        generateId(),
+      );
       await onSave([...current, item]);
       backdrop.remove();
     } catch (err) {

--- a/src/ui/importSummary.ts
+++ b/src/ui/importSummary.ts
@@ -31,16 +31,20 @@ export interface SessionImportSummary {
 
 /** Build a SessionImportSummary from a parsed .partwright.json payload. */
 export function summarizeSessionImport(data: ExportedSession): SessionImportSummary {
-  // Build a list of image labels for the import preview. Handle three shapes:
-  //   - current: array of {id, src, label?}
+  // Build a list of image labels for the import preview. Handle the shapes:
+  //   - 1.16+: array of typed attachments {id, kind, src, label?} — image-kind only
+  //   - pre-1.16: array of {id, src, label?} (all images)
   //   - pre-unification: array of {id, angle, src, label?} — fall back to angle
   //   - pre-array: object map {front: 'url', ...} — use the keys
-  // Items with no label and no angle are listed as "(unlabeled)".
-  const imgs = data.session.images ?? data.session.referenceImages ?? null;
+  // Non-image attachments (models/docs/text) are excluded — this list is the
+  // reference-photo preview. Items with no label and no angle are "(unlabeled)".
+  const imgs = data.session.attachments ?? data.session.images ?? data.session.referenceImages ?? null;
   const referenceSides: string[] = [];
   if (Array.isArray(imgs)) {
     for (const item of imgs) {
-      const it = item as { label?: string; angle?: string };
+      const it = item as { label?: string; angle?: string; kind?: string };
+      // Legacy rows carry no `kind` (all were images); 1.16 rows may be non-image.
+      if (it.kind !== undefined && it.kind !== 'image') continue;
       const label = (it.label ?? '').trim() || (it.angle ? it.angle : '');
       referenceSides.push(label || '(unlabeled)');
     }

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -334,8 +334,8 @@ export function createLayout(appContainer: HTMLElement, opts: CreateLayoutOption
   // needs a separate rail item.
   const tabVersions = createRailItem('Versions', 'Versions', '🕒', false);
   tabVersions.title = 'Saved versions — thumbnails, rename, delete';
-  const tabImages = createRailItem('Images', 'Images', '📷', false);
-  tabImages.title = 'Reference images attached to this session';
+  const tabImages = createRailItem('Images', 'Attachments', '📎', false);
+  tabImages.title = 'Attachments: reference images, models, docs & notes pinned to this session';
   const tabDiff = createRailItem('Diff', 'Diff', '🔀', false);
   tabDiff.title = 'Compare code between two versions';
   const tabNotes = createRailItem('Notes', 'Notes', '📝', false);

--- a/tests/attachments.spec.ts
+++ b/tests/attachments.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect, type Page } from 'playwright/test';
+
+// Session attachments: the generalization of "reference images" into typed
+// project files (image | model | document | text | other). They persist with
+// the session, survive a chat clear, and the AI can list them via the
+// getAttachments tool (images are viewed via getReferenceImages).
+
+const PNG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+async function waitForEngine(page: Page) {
+  await page.goto('/editor');
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    undefined,
+    { timeout: 30_000 },
+  );
+}
+
+test.describe('session attachments', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('classifies mixed attachment kinds and clearImages preserves non-images', async ({ page }) => {
+    await waitForEngine(page);
+    await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      await pw.createSession('attachments');
+    });
+    await page.waitForTimeout(1000);
+
+    const kinds = await page.evaluate(async ({ png }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      pw.addAttachment({ src: png, label: 'Front' });
+      pw.addAttachment({ src: 'data:model/stl;base64,AAAA', label: 'Reference bracket' });
+      pw.addAttachment({ src: 'data:application/pdf;base64,AAAA', label: 'Spec sheet' });
+      // kind inferred from a filename-bearing label when no media type is in the src
+      pw.addAttachment({ src: 'https://example.com/notes.md', label: 'notes.md' });
+      return pw.getAttachments().map((a: { kind: string }) => a.kind).sort();
+    }, { png: PNG });
+    expect(kinds).toEqual(['document', 'image', 'model', 'text']);
+
+    // clearImages drops only the image-kind attachment; the rest remain.
+    const afterClear = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      pw.clearImages();
+      return pw.getAttachments().map((a: { kind: string }) => a.kind).sort();
+    });
+    expect(afterClear).toEqual(['document', 'model', 'text']);
+    expect(await page.evaluate(() => (window as unknown as { partwright: { getImages: () => unknown[] } }).partwright.getImages().length)).toBe(0);
+  });
+
+  test('getAttachments tool returns a manifest with inline text and an image hint', async ({ page }) => {
+    await waitForEngine(page);
+    await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (window as any).partwright.createSession('attachments-tool');
+    });
+    await page.waitForTimeout(1000);
+
+    const result = await page.evaluate(async ({ png }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      pw.addAttachment({ src: png, label: 'Front' });
+      pw.addAttachment({ src: 'data:text/markdown;base64,' + btoa('# Notes\nrounded corners'), label: 'Design notes' });
+      const { executeTool } = await import('/src/ai/tools.ts');
+      return executeTool('getAttachments', {});
+    }, { png: PNG });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toMatch(/2 attachment/);
+    expect(result.content).toMatch(/\[image\]/);
+    expect(result.content).toMatch(/\[text\]/);
+    // text attachment contents are inlined
+    expect(result.content).toMatch(/rounded corners/);
+    // points the model at getReferenceImages to actually view the image
+    expect(result.content).toMatch(/getReferenceImages/);
+    // it's a text manifest, not an image block
+    expect(result.image).toBeFalsy();
+  });
+
+  test('renders a typed tile (kind badge) per attachment in the Attachments tab', async ({ page }) => {
+    await waitForEngine(page);
+    await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (window as any).partwright.createSession('attachments-ui');
+    });
+    await page.waitForTimeout(1000);
+    await page.evaluate(async ({ png }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      pw.addAttachment({ src: png, label: 'Front' });
+      pw.addAttachment({ src: 'data:model/stl;base64,AAAA', label: 'Reference bracket' });
+    }, { png: PNG });
+
+    await page.locator('[data-tab="Images"]').click();
+    const panel = page.locator('#images-container');
+    await expect(panel.getByText('Attachments', { exact: true })).toBeVisible();
+    await expect(panel.getByText('Image', { exact: true })).toBeVisible();
+    await expect(panel.getByText('Model', { exact: true })).toBeVisible();
+    await expect(panel.getByText('model/stl', { exact: true })).toBeVisible();
+  });
+});

--- a/tests/attachments.spec.ts
+++ b/tests/attachments.spec.ts
@@ -42,6 +42,16 @@ test.describe('session attachments', () => {
     }, { png: PNG });
     expect(kinds).toEqual(['document', 'image', 'model', 'text']);
 
+    // Newly-pinned attachments are stamped with addedAt + source (the metadata
+    // the "aging"/provenance story relies on).
+    const meta = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const a = (window as any).partwright.getAttachments()[0];
+      return { addedAt: typeof a.addedAt, source: a.source };
+    });
+    expect(meta.addedAt).toBe('number');
+    expect(meta.source).toBe('user');
+
     // clearImages drops only the image-kind attachment; the rest remain.
     const afterClear = await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/chat-export.spec.ts
+++ b/tests/chat-export.spec.ts
@@ -107,8 +107,8 @@ test.describe('Chat export', () => {
         chat?: { id?: string; sessionId?: string; blocks: { type: string; text?: string }[] }[];
       };
     }, id);
-    expect(exported.partwright).toBe('1.15'); // tracks SCHEMA_VERSION (bumped to 1.15 for appVersion provenance)
-    // App-version provenance (schema 1.15): the dev build stamps package.json's semver.
+    expect(exported.partwright).toBe('1.16'); // tracks SCHEMA_VERSION (bumped to 1.16 for typed attachments)
+    // App-version provenance (schema 1.15+): the dev build stamps package.json's semver.
     expect(exported.appVersion).toMatch(/^\d+\.\d+\.\d+$/);
     expect(exported.chat?.length).toBe(3);
     expect(exported.chat?.[0].blocks[0].text).toBe('Design a widget bracket');

--- a/tests/unit/apiParity.test.ts
+++ b/tests/unit/apiParity.test.ts
@@ -45,8 +45,7 @@ const INTENTIONALLY_UNDOCUMENTED = new Set([
 // asserted to actually exist (no stale entries), so the list can't rot.
 const UNDOCUMENTED_BACKLOG = new Set([
   'getThumbnailCamera', 'sliceAtZVisual', 'importImageAsRelief', 'importSvgAsRelief',
-  'getReliefSwapGuide', 'setReliefPreviewMode', 'setImages', 'addImage', 'removeImage',
-  'clearImages', 'getImages', 'closeSession', 'deleteSession', 'commitWithColors',
+  'getReliefSwapGuide', 'setReliefPreviewMode', 'closeSession', 'deleteSession', 'commitWithColors',
   'navigateVersion', 'getSessionUrl', 'getSessionState', 'deleteSessionNote',
   'updateSessionNote', 'exportSession', 'importSession', 'clearAllSessions', 'isRunning',
   'getPrinterSettings', 'setPrinterSettings', 'checkPrintability', 'createSessionWithVersions',

--- a/tests/unit/attachment.test.ts
+++ b/tests/unit/attachment.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  inferMediaType,
+  inferAttachmentKind,
+  normalizeAttachment,
+  attachmentKindLabel,
+  ATTACHMENT_KINDS,
+} from '../../src/storage/attachment';
+
+describe('inferMediaType', () => {
+  it('reads the MIME from a data URL prefix', () => {
+    expect(inferMediaType('data:image/png;base64,AAAA')).toBe('image/png');
+    expect(inferMediaType('data:application/pdf;base64,AAAA')).toBe('application/pdf');
+    expect(inferMediaType('data:text/markdown,hello')).toBe('text/markdown');
+  });
+
+  it('falls back to a filename/URL extension', () => {
+    expect(inferMediaType('https://x.com/model.stl')).toBe('model/stl');
+    expect(inferMediaType('https://x.com/a/b/photo.JPG')).toBe('image/jpeg');
+    expect(inferMediaType(undefined, 'spec.pdf')).toBe('application/pdf');
+  });
+
+  it('ignores query/hash when reading the extension', () => {
+    expect(inferMediaType('https://x.com/p.png?w=10#frag')).toBe('image/png');
+  });
+
+  it('returns undefined when nothing is determinable', () => {
+    expect(inferMediaType('https://x.com/noext')).toBeUndefined();
+    expect(inferMediaType(undefined)).toBeUndefined();
+  });
+});
+
+describe('inferAttachmentKind', () => {
+  it('classifies images', () => {
+    expect(inferAttachmentKind('image/png')).toBe('image');
+    expect(inferAttachmentKind(undefined, 'a.webp')).toBe('image');
+  });
+  it('classifies models', () => {
+    expect(inferAttachmentKind('model/stl')).toBe('model');
+    expect(inferAttachmentKind(undefined, 'part.step')).toBe('model');
+    expect(inferAttachmentKind(undefined, 'part.3mf')).toBe('model');
+    // octet-stream STL: MIME is unhelpful, extension wins.
+    expect(inferAttachmentKind('application/octet-stream', 'part.stl')).toBe('model');
+  });
+  it('classifies documents and text', () => {
+    expect(inferAttachmentKind('application/pdf')).toBe('document');
+    expect(inferAttachmentKind('text/markdown')).toBe('text');
+    expect(inferAttachmentKind('application/json')).toBe('text');
+    expect(inferAttachmentKind(undefined, 'notes.md')).toBe('text');
+  });
+  it('falls back to other', () => {
+    expect(inferAttachmentKind('application/zip')).toBe('other');
+    expect(inferAttachmentKind(undefined, 'mystery.xyz')).toBe('other');
+  });
+});
+
+describe('normalizeAttachment', () => {
+  it('fills kind + mediaType from the src and assigns a fallback id', () => {
+    const a = normalizeAttachment({ src: 'data:image/png;base64,AAAA' }, 'fallback-id');
+    expect(a.id).toBe('fallback-id');
+    expect(a.kind).toBe('image');
+    expect(a.mediaType).toBe('image/png');
+  });
+
+  it('preserves an explicit id, kind, and trims the label', () => {
+    const a = normalizeAttachment(
+      { id: 'x1', src: 'https://x.com/p.bin', kind: 'model', label: '  Reference  ' },
+      'unused',
+    );
+    expect(a.id).toBe('x1');
+    expect(a.kind).toBe('model');
+    expect(a.label).toBe('Reference');
+  });
+
+  it('drops an empty label and omits addedAt/source when absent', () => {
+    const a = normalizeAttachment({ src: 'data:image/png;base64,AAAA', label: '   ' }, 'id');
+    expect(a.label).toBeUndefined();
+    expect(a.addedAt).toBeUndefined();
+    expect(a.source).toBeUndefined();
+  });
+
+  it('keeps addedAt and source when provided', () => {
+    const a = normalizeAttachment(
+      { src: 'data:image/png;base64,AAAA', addedAt: 123, source: 'chat' },
+      'id',
+    );
+    expect(a.addedAt).toBe(123);
+    expect(a.source).toBe('chat');
+  });
+
+  it('migrates a legacy image row (no kind) to a typed image attachment', () => {
+    // The shape old sessions stored: {id, src, label} with no kind/mediaType.
+    const a = normalizeAttachment(
+      { id: 'old', src: 'data:image/jpeg;base64,AAAA', label: 'Front' },
+      'gen',
+    );
+    expect(a.kind).toBe('image');
+    expect(a.mediaType).toBe('image/jpeg');
+    expect(a.id).toBe('old');
+  });
+});
+
+describe('attachmentKindLabel', () => {
+  it('has a noun for every kind', () => {
+    for (const k of ATTACHMENT_KINDS) {
+      expect(attachmentKindLabel(k).length).toBeGreaterThan(0);
+    }
+    expect(attachmentKindLabel('image')).toBe('Image');
+    expect(attachmentKindLabel('other')).toBe('File');
+  });
+});

--- a/tests/unit/import-summary.test.ts
+++ b/tests/unit/import-summary.test.ts
@@ -78,6 +78,27 @@ describe('summarizeSessionImport — language resolution', () => {
     expect(summary.languages).toEqual(['manifold-js']);
   });
 
+  it('lists image-kind labels from a 1.16 attachments array, excluding non-image attachments', () => {
+    const summary = summarizeSessionImport(payload({
+      session: {
+        attachments: [
+          { id: 'a', kind: 'image', src: 'data:image/png;base64,AAAA', label: 'Front' },
+          { id: 'b', kind: 'model', src: 'data:model/stl;base64,AAAA', label: 'Reference bracket' },
+          { id: 'c', kind: 'image', src: 'data:image/png;base64,AAAA' },
+        ],
+      } as Partial<ExportedSession['session']>,
+    }));
+    // The model is excluded; the unlabeled image becomes "(unlabeled)".
+    expect(summary.referenceSides).toEqual(['Front', '(unlabeled)']);
+  });
+
+  it('still reads legacy session.images (pre-1.16, no kind) as reference sides', () => {
+    const summary = summarizeSessionImport(payload({
+      session: { images: [{ id: 'a', src: 'x', label: 'Right' }] } as Partial<ExportedSession['session']>,
+    }));
+    expect(summary.referenceSides).toEqual(['Right']);
+  });
+
   it('sanitizes a junk on-disk language, falling through to the session level', () => {
     const summary = summarizeSessionImport(
       payload({ session: { language: 'voxel' }, versions: [version('python')] }),


### PR DESCRIPTION
## Summary

Reference images become one **kind** of a general per-session **attachments** list. An attachment carries a `kind` (`image | model | document | text | other`) plus optional `mediaType`, `addedAt`, and `source`, so a session can pin reference photos *and* a reference STL/STEP, a spec PDF, or design notes.

Attachments are **durable project context**: they survive clearing the AI chat and are saved in the exported `.partwright` file — so an agent resuming a session (or one whose chat history was cleared) can still find the material the work was based on. This directly addresses the original ask: capture AI-panel uploads into the project, and let them outlive an AI history clear.

### What changed

- **Data model** — new dependency-free leaf `src/storage/attachment.ts`: `SessionAttachment` + pure classification (`normalizeAttachment`, `inferAttachmentKind`, `inferMediaType`). No new module cycle (`lint:deps` stays acyclic).
- **Schema 1.15 → 1.16** — `Session.images` → `Session.attachments`. Read-time migration and the import path fold legacy `images` / `referenceImages` / object-map shapes into typed `kind:'image'` attachments, so **old IndexedDB sessions and exported files still load**. `updateSession` strips both legacy keys on write.
- **`window.partwright` API** — added `getAttachments` / `addAttachment` / `setAttachments` / `removeAttachment` / `clearAttachments`. The image-named methods (`setImages`/`getImages`/…) are kept as back-compat over the image-kind subset and were added to the `help()` table (closing the pre-existing parity gap; removed from the apiParity backlog).
- **In-app AI** — new `getAttachments` tool returns a manifest of every attachment (kind/mediaType/label/addedAt/source), inlines `text`-kind contents, and points the model at `getReferenceImages` to actually view images. `getReferenceImages` is now image-kind-filtered. **AI-panel image uploads (paste / drag-drop / picker) are auto-pinned to the session as `source:'chat'` attachments** (deduped, no-op without a real session) so they survive `/clear`.
- **UI** — the tab is now **"Attachments"** (📎). Non-image attachments render as a file card with a type icon + media type; every tile shows a kind badge. Upload `accept` widened from `image/*` to any file.
- **Docs** — `public/ai.md` + `public/ai/reference-images.md#attachments`.

### Screenshot

Attachments tab with mixed kinds — image (thumbnail), model (`model/stl`), text, and document tiles, each with a kind badge:

![attachments tab](https://github.com/kemper/partwright/assets/placeholder) <!-- posted in session chat -->

### Test plan

- `npm run preflight` — 1552 unit tests, no type errors, no circular deps.
- New `tests/unit/attachment.test.ts` (classification + normalization + legacy-row migration).
- New `tests/attachments.spec.ts` golden path (mixed kinds, `getAttachments` tool manifest with inlined text, typed tiles).
- Back-compat e2e: `getReferenceImages`, `share-link`, `import-merge*`, `import-target`, `multipart-export`, `session-modal`, `export-safety` — all green.
- Eyes-on browser screenshot of the Attachments tab.

### Deliberately deferred (follow-up)

Attachment **bytes** still live inline as data URLs on the session (and thus in exports/share links) — exactly as reference images always did. Moving binary payloads to a separate blob store and stripping large binaries from `trimForShare` is a separate Phase-3 change; I'll file a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrTLwd9UVzMDsahTBM4iBK)_