### PR TITLE
fix: prevent duplicate catalog panes on rapid re-navigation

### DIFF
--- a/prompts/catalog-split-view-bug.md
+++ b/prompts/catalog-split-view-bug.md
@@ -1,0 +1,39 @@
+---
+date: 2026-06-20
+branch: claude/catalog-split-view-bug-kbgw1q
+files_changed:
+  - src/main.ts
+  - tests/catalog.spec.ts
+---
+
+## Human
+
+Sometimes when I click a link to the catalog multiple times really quickly,
+the catalog opens up with a kind of split view — two catalogs in two different
+internal panes, or three.
+
+## Assistant
+
+Root cause: a re-entrancy race in `showCatalogPage` (`src/main.ts`). The pane
+is built lazily behind an `if (!catalogEl)` guard, but `createCatalogPage`
+*awaits a manifest `fetch`* before returning, so `catalogEl` stays `null`
+across the whole async gap. Any second call that lands during that window — a
+rapid second click, or the `popstate` that the first click's `history.pushState`
+synchronously fires — sees `catalogEl` still `null`, passes the guard again,
+and calls `createCatalogPage` a second time. Each call does
+`container.appendChild(page)` with a fresh `<div id="catalog-page">`, so two or
+three clicks stack two or three catalog panes. Only the last assignment to
+`catalogEl` sticks, but all the DOM nodes are already appended and visible.
+
+Fix: guard the async span with an in-flight promise. Store the pending
+`createCatalogPage(...)` promise in `catalogElPromise`; concurrent entries
+reuse that one promise (`catalogEl = await catalogElPromise`) instead of
+kicking off another build. This is the standard idempotent-lazy-init pattern;
+the sibling page constructors (`createWhatsNewPage`, etc.) are synchronous, so
+they don't share this race and were left untouched.
+
+Verified with a Playwright repro that fires four rapid pushState+popstate route
+syncs (the same concurrency a triple-click produces) and asserts exactly one
+`#catalog-page` exists. Confirmed it fails on the pre-fix code (multiple stacked
+panes) and passes after — promoted into `tests/catalog.spec.ts` as a permanent
+regression test.

--- a/retros/inbox/catalog-split-view-race.md
+++ b/retros/inbox/catalog-split-view-race.md
@@ -1,0 +1,33 @@
+# Retro — catalog split-view bug (rapid clicks stack panes) (#811)
+
+## Liked
+- The `explore` subagent nailed the root cause in one pass: it traced the full
+  router path (`syncRouteFromURL` → `showCatalogPage`), spotted that the
+  `if (!catalogEl)` guard straddles an `await createCatalogPage(...)` that does a
+  manifest fetch, and named the exact race window — all returned as file:line
+  conclusions, no file dumps in my context. A clean delegation win.
+- `git stash` → re-run test → `git stash pop` to prove the regression test
+  actually fails on the pre-fix code took ~30s and turned "I think this is the
+  bug" into "this is the bug." Cheap, high-confidence.
+
+## Lacked
+- No shared helper for "lazy-init an async-built singleton page." This same
+  `if (!x) x = await build()` shape is repeated for each overlay page in
+  `main.ts`; the others happen to be synchronous today, but the next async one
+  will reintroduce this exact race. A tiny `lazyOnce(build)` util that caches
+  the in-flight promise would make the safe pattern the default.
+
+## Learned
+- **`history.pushState` fires `popstate` synchronously**, so a single click into
+  `showCatalogPage` can re-enter itself via the router *before* its own `await`
+  resolves — re-entrancy isn't only from a literal double-click. Any lazy guard
+  on an awaited build must use an in-flight-promise lock, not a post-await flag.
+- The screenshot path is reused across runs, so a `git stash` re-run overwrites
+  it — the on-disk PNG after a stash/pop dance is the *last* run's, not the one
+  you think. Copy to `-BEFORE`/`-AFTER` names when capturing both states.
+
+## Longed for
+- A way to self-wake on CI *success* / mergeability in this remote env: no
+  `send_later`, no `gh` CLI, and Monitor can't query GitHub from bash without a
+  token — so I fell back to a blind `sleep` timer Monitor to re-poll via MCP.
+  A first-class "notify me when PR checks settle" hook would replace the timer.

--- a/src/main.ts
+++ b/src/main.ts
@@ -6151,6 +6151,7 @@ async function main() {
   }
 
   let catalogEl: HTMLElement | null = null;
+  let catalogElPromise: Promise<HTMLElement> | null = null;
   let catalogHasAppBackTarget = false;
   async function showCatalogPage(options: { history?: 'push' | 'replace' | 'none' } = {}) {
     const historyMode = options.history ?? 'push';
@@ -6159,18 +6160,25 @@ async function main() {
       updateAppHistory(appPath('/catalog'), historyMode);
     }
     if (!catalogEl) {
-      catalogEl = await createCatalogPage(overlayContainer, {
-        onBack: () => {
-          if (catalogHasAppBackTarget) {
-            window.history.back();
-          } else {
-            updateAppHistory(appPath('/'), 'replace');
-            void syncRouteFromURL();
-          }
-        },
-        onLoadEntry: handleCatalogEntryLoad,
-        onOpenIdeas: () => { showIdeasPage(); },
-      });
+      // createCatalogPage awaits a manifest fetch before returning, so guard the
+      // async gap with an in-flight promise: rapid re-entry (a second click, or
+      // the popstate the first click's pushState fires) must reuse the pending
+      // build, not start a second one that appends another #catalog-page pane.
+      if (!catalogElPromise) {
+        catalogElPromise = createCatalogPage(overlayContainer, {
+          onBack: () => {
+            if (catalogHasAppBackTarget) {
+              window.history.back();
+            } else {
+              updateAppHistory(appPath('/'), 'replace');
+              void syncRouteFromURL();
+            }
+          },
+          onLoadEntry: handleCatalogEntryLoad,
+          onOpenIdeas: () => { showIdeasPage(); },
+        });
+      }
+      catalogEl = await catalogElPromise;
     }
     overlayContainer.classList.remove('hidden');
     editorUI.classList.add('hidden');

--- a/tests/catalog.spec.ts
+++ b/tests/catalog.spec.ts
@@ -192,4 +192,26 @@ test.describe('Catalog page (static)', () => {
     await expect(page.locator('#catalog-page [data-catalog-empty]')).toBeVisible();
     await expect(page.locator('#catalog-page a[data-catalog-tile]:not(.hidden)')).toHaveCount(0);
   });
+
+  test('rapid re-navigation to the catalog renders a single pane (no split view)', async ({ page }) => {
+    // Regression: createCatalogPage awaits a manifest fetch before returning, so
+    // the `if (!catalogEl)` guard stayed null across the await. Rapid re-entry
+    // (a double-click, or the popstate a pushState fires) bypassed it and
+    // appended a second/third #catalog-page, stacking duplicate catalog panes.
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+    await page.goto('/editor');
+    await page.waitForFunction(() => !!(window as unknown as { partwright?: unknown }).partwright, null, { timeout: 30_000 });
+
+    // Fire several route syncs back-to-back, faster than the manifest fetch
+    // resolves — the same concurrency a rapid double/triple click produces.
+    await page.evaluate(() => {
+      for (let i = 0; i < 4; i++) {
+        window.history.pushState({}, '', '/catalog');
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      }
+    });
+
+    await expect(page.locator('#catalog-page')).toBeVisible({ timeout: 20_000 });
+    await expect(page.locator('#catalog-page')).toHaveCount(1);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the "split view" bug: clicking a catalog link two or three times quickly opened the catalog with two or three catalog panes stacked in the same overlay.

**Root cause** — a re-entrancy race in `showCatalogPage` (`src/main.ts`). The pane is built lazily behind an `if (!catalogEl)` guard, but `createCatalogPage` *awaits a manifest `fetch`* before returning, so `catalogEl` stays `null` across the whole async gap. A second call landing in that window — a rapid second click, or the `popstate` that the first click's `history.pushState` synchronously fires — passes the guard again and calls `createCatalogPage` a second time. Each call `appendChild`s a fresh `<div id="catalog-page">`, so N clicks stack N panes. Only the last `catalogEl` assignment sticks, but every appended node is already visible.

**Fix** — guard the async span with an in-flight promise (`catalogElPromise`). Concurrent entries reuse the pending build (`catalogEl = await catalogElPromise`) instead of starting another. Standard idempotent-lazy-init pattern. Sibling page constructors (`createWhatsNewPage`, etc.) are synchronous and don't share this race, so they're untouched.

## Test plan

- New regression test in `tests/catalog.spec.ts`: fires four rapid `pushState`+`popstate` route syncs (the concurrency a triple-click produces) and asserts exactly one `#catalog-page`. **Verified it fails on the pre-fix code** (multiple stacked panes) and passes after.
- Manual browser repro before/after: pre-fix screenshot showed 3 stacked "Catalog" headers; post-fix shows a single, correctly-rendered catalog.
- `npm run build` ✅ · `npm run test:unit` (1541 passed) ✅ · `npm run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WyK3UseqgKZqRmw7G9vJB

---
_Generated by [Claude Code](https://claude.ai/code/session_011WyK3UseqgKZqRmw7G9vJB)_