### PR TITLE
feat: attachment descriptions + fix attachments lost on refresh

### DIFF
--- a/prompts/attachment-description-and-persist-fix.md
+++ b/prompts/attachment-description-and-persist-fix.md
@@ -1,0 +1,48 @@
+---
+session: "0ejjep"
+timestamp: "2026-06-21T00:40:00Z"
+---
+
+## Human
+
+(1) Rather than a single-line perspective label for attachments, add a generic
+free-form **description** so people can describe why the attachment is
+important. (2) Bug: attachments get cleared on page refresh — they should save
+in the session, not be forgotten. The user observed they survive *if* a version
+is saved, and suggested attachments are session-level / draft-like data that
+should load on open.
+
+## Assistant
+
+## Key decisions
+
+**Persistence bug — root cause was a restore gap, not a save gap.** Attachments
+were always persisted to the `Session` row (via `saveAttachments` →
+`dbUpdateSession`) the moment they were added. The bug: the *restore* on session
+open lived only inside `loadVersionIntoEditor`, so a session with attachments but
+**no saved version** reached the editor through `loadPartIntoEditor`'s no-version
+(`else`) branch, which never restored them — the in-memory mirror stayed empty
+on refresh. Fix: extracted `restoreAttachmentsForActiveSession()` and call it on
+every session-open path (the no-version branch, the version branch, the
+`partwright.openSession` API, and import), framing attachments as the
+session-level data they are. This matches the user's instinct exactly.
+
+**Description field — additive schema 1.16 → 1.17.** Added an optional
+`description` to `SessionAttachment` (a "why this matters" note, distinct from
+the short `label`/perspective caption). The label + Front/Right presets stay (per
+the user's "add, keep label" choice), so reference-photo ordering is preserved.
+The UI renders a description textarea under each tile's label;
+`addAttachment`/`setAttachments` accept `description`; the `getAttachments` AI
+tool surfaces it as a prominent "↳ …" line (it's the key intent signal). Docs +
+help table updated.
+
+**The e2e regression test caught a second drop.** `migrateSessionImages` in
+db.ts normalizes each attachment through an *explicit field list* — which didn't
+include `description`, so it was silently dropped on read. The
+reload-without-version-save e2e test failed on exactly that and pinned it. (The
+import path uses `normalizeAttachment(a)` with the whole object, so it was fine.)
+
+Both changes ship together as one attachments-improvement PR off the now-merged
+main (#807). Verified: `npm run preflight` (1558 unit tests, no type errors, no
+cycles), new unit case for `description`, two new e2e tests (reload-survives +
+description round-trip), and an eyes-on screenshot of the description field.

--- a/public/ai.md
+++ b/public/ai.md
@@ -335,8 +335,8 @@ partwright.addImage({src, label?})          // append one image; returns {id, sr
 partwright.removeImage(id)                  // remove by id; returns true if removed
 partwright.clearImages()                    // clear image attachments (non-image ones kept)
 partwright.getImages()                      // -> [{id, src, label?}, ...] (image-kind only)
-partwright.addAttachment({src, kind?, mediaType?, label?})  // pin ANY file; kind/mediaType inferred when omitted
-partwright.getAttachments()                 // -> [{id, kind, mediaType?, src, label?, addedAt?, source?}, ...]
+partwright.addAttachment({src, kind?, mediaType?, label?, description?})  // pin ANY file; kind/mediaType inferred; description = why it matters
+partwright.getAttachments()                 // -> [{id, kind, mediaType?, src, label?, description?, addedAt?, source?}, ...]
 partwright.setAttachments([...]) / partwright.removeAttachment(id) / partwright.clearAttachments()
 
 // Color regions (~30 paint methods) — call readDoc("colors") for the full picker decision tree.

--- a/public/ai/reference-images.md
+++ b/public/ai/reference-images.md
@@ -41,19 +41,21 @@ Attached images appear in the Attachments tab and the Gallery; render the model 
 
 Reference images are one **kind** of a more general session **attachment** — any file the user pins to the session as durable project context. An attachment carries a `kind` (`image` · `model` · `document` · `text` · `other`) plus an optional `mediaType`, so a session can hold reference photos *and* a reference STL/STEP, a spec-sheet PDF, or design notes. Attachments are **durable**: they survive clearing the AI chat and are saved in the exported `.partwright` file, so an agent resuming a session — or one whose chat history was cleared — can still find the material the work was based on.
 
+Each attachment has two text fields: a short **`label`** (a caption / perspective preset like "Front"), and a free-form **`description`** — *why* it matters (what to match, the constraint it captures, where it came from). **Read the descriptions** — they're the user's intent, the most important signal about what each file is for.
+
 The `setImages`/`addImage`/`getImages`/etc. helpers above still work (they operate on the `image`-kind attachments). The general API mirrors them across all kinds:
 
 ```js
 // Pin any file (kind + mediaType are inferred from the src/data URL or label
 // when omitted). source defaults to 'user'.
-partwright.addAttachment({ src: 'data:model/stl;base64,...', label: 'Reference bracket' })
-// -> { id, kind: 'model', mediaType: 'model/stl', src, label, addedAt, source: 'user' }
+partwright.addAttachment({ src: 'data:model/stl;base64,...', label: 'Reference bracket', description: 'Match the bolt-hole spacing on this part' })
+// -> { id, kind: 'model', mediaType: 'model/stl', src, label, description, addedAt, source: 'user' }
 
 // List everything pinned to the session
 partwright.getAttachments()
-// -> [{ id, kind, mediaType?, src, label?, addedAt?, source? }, ...]
+// -> [{ id, kind, mediaType?, src, label?, description?, addedAt?, source? }, ...]
 
-partwright.setAttachments([{ src, kind?, mediaType?, label? }, ...])  // replace the whole list
+partwright.setAttachments([{ src, kind?, mediaType?, label?, description? }, ...])  // replace the whole list
 partwright.removeAttachment(id)                                        // remove one by id
 partwright.clearAttachments()                                          // remove ALL (images included)
 ```

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -332,7 +332,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'getAttachments',
-    description: 'List ALL files the user pinned to this session (the "Attachments" panel): reference images, reference models (STL/STEP/3MF), documents (PDF), and text/notes. Returns a manifest — each entry\'s id, kind (image|model|document|text|other), media type, label, when it was added, and source (user vs captured from a chat upload). Text/notes attachments include their contents inline. These are DURABLE project context: they survive clearing the chat, so use this to recover reference material an earlier conversation was working from. To actually SEE image attachments, call getReferenceImages.',
+    description: 'List ALL files the user pinned to this session (the "Attachments" panel): reference images, reference models (STL/STEP/3MF), documents (PDF), and text/notes. Returns a manifest — each entry\'s id, kind (image|model|document|text|other), media type, label, the user\'s free-form DESCRIPTION of why it matters (shown as "↳ …" — read these, they\'re the key signal), when it was added, and source (user vs captured from a chat upload). Text/notes attachments include their contents inline. These are DURABLE project context: they survive clearing the chat, so use this to recover reference material an earlier conversation was working from. To actually SEE image attachments, call getReferenceImages.',
     input_schema: { type: 'object', properties: {} },
   },
   {
@@ -1720,6 +1720,7 @@ interface AttachmentEntry {
   mediaType?: string;
   src?: string;
   label?: string;
+  description?: string;
   addedAt?: number;
   source?: string;
 }
@@ -1771,6 +1772,10 @@ function executeGetAttachments(api: PartwrightAPI): ToolExecResult {
       a.id ? `id=${a.id}` : null,
     ].filter(Boolean);
     lines.push(parts.join(' · '));
+    // The description is the user's "why this matters" note — the most
+    // important signal for the model, so surface it prominently per entry.
+    const desc = a.description?.trim();
+    if (desc) lines.push(`   ↳ ${desc.replace(/\n/g, ' ')}`);
     if (a.kind === 'text') {
       const text = decodeTextAttachment(a.src);
       if (text) lines.push(`   ---\n${text.split('\n').map(l => `   ${l}`).join('\n')}\n   ---`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -356,16 +356,18 @@ function commitAttachments(next: SessionAttachment[]): void {
  *  src/label when omitted; an explicit `kind` is checked against the enum. */
 function buildAttachmentFromInput(input: unknown, ctx: string, source?: 'user' | 'chat'): SessionAttachment {
   const obj = assertObject(input, ctx)!;
-  assertNoUnknownKeys(obj, ['src', 'id', 'label', 'kind', 'mediaType'] as const, ctx);
+  assertNoUnknownKeys(obj, ['src', 'id', 'label', 'description', 'kind', 'mediaType'] as const, ctx);
   assertString(obj.src, `${ctx}.src`, { allowEmpty: false });
   if (obj.id !== undefined) assertString(obj.id, `${ctx}.id`, { allowEmpty: false });
   if (obj.label !== undefined) assertString(obj.label, `${ctx}.label`, { optional: true, allowEmpty: true });
+  if (obj.description !== undefined) assertString(obj.description, `${ctx}.description`, { optional: true, allowEmpty: true });
   if (obj.mediaType !== undefined) assertString(obj.mediaType, `${ctx}.mediaType`, { allowEmpty: false });
   if (obj.kind !== undefined) assertEnum(obj.kind, ATTACHMENT_KINDS, `${ctx}.kind`);
   return normalizeAttachment({
     id: obj.id as string | undefined,
     src: obj.src as string,
     label: obj.label as string | undefined,
+    description: obj.description as string | undefined,
     kind: obj.kind as AttachmentKind | undefined,
     mediaType: obj.mediaType as string | undefined,
     addedAt: Date.now(),
@@ -5321,6 +5323,25 @@ async function main() {
       // loop) reads the previous part's stale mesh, so freshly-created parts all
       // get one wrong, colorless thumbnail.
       await seedStarter(getActiveLanguage());
+      // Attachments are session-level, not version-level. The version-load path
+      // (loadVersionIntoEditor) restores them, but a session with attachments
+      // and NO saved version reaches the editor through this branch — so without
+      // this it would lose its attachments on refresh. See
+      // restoreAttachmentsForActiveSession.
+      await restoreAttachmentsForActiveSession();
+    }
+  }
+
+  /** Reload the active session's attachments (stored on the Session row) into
+   *  the in-memory mirror. Session-level data: restored on every session open,
+   *  independent of version/part loading, so attachments survive a refresh even
+   *  when the session has no saved version. */
+  async function restoreAttachmentsForActiveSession(): Promise<void> {
+    const sessionAttachments = await getAttachmentsFromSession();
+    if (sessionAttachments) {
+      _setAttachments(sessionAttachments);
+    } else {
+      _clearAttachments();
     }
   }
 
@@ -6122,12 +6143,7 @@ async function main() {
 
     await rehydrateColorRegions(version.geometryData);
     applyVersionAnnotations(version);
-    const sessionAttachments = await getAttachmentsFromSession();
-    if (sessionAttachments) {
-      _setAttachments(sessionAttachments);
-    } else {
-      _clearAttachments();
-    }
+    await restoreAttachmentsForActiveSession();
   }
 
   async function openEditorFromLanding() {
@@ -11297,13 +11313,8 @@ async function main() {
         setValue(version.code);
         await runCodeSync(version.code, { preserveCamera: true });
       }
-      // Restore attachments from session
-      const sessionAttachments = await getAttachmentsFromSession();
-      if (sessionAttachments) {
-        _setAttachments(sessionAttachments);
-      } else {
-        _clearAttachments();
-      }
+      // Attachments are session-level — restore regardless of whether a version loaded.
+      await restoreAttachmentsForActiveSession();
       return version ? { id: version.id, index: version.index, label: version.label } : null;
     },
 
@@ -12016,11 +12027,8 @@ async function main() {
         setValue(version.code);
         await runCodeSync(version.code, { preserveCamera: true });
       }
-      // Restore attachments from imported session
-      const sessionAttachments = await getAttachmentsFromSession();
-      if (sessionAttachments) {
-        _setAttachments(sessionAttachments);
-      }
+      // Restore attachments from imported session (session-level).
+      await restoreAttachmentsForActiveSession();
       return { id: session.id, name: session.name, ...(warning ? { warning } : {}) };
     },
 
@@ -15149,9 +15157,9 @@ async function main() {
         'addSessionNote':  { signature: 'await addSessionNote(text) -- Add note with [PREFIX] tag', docs: '/ai.md#session-notes----tracking-design-context' },
         'listSessionNotes': { signature: 'await listSessionNotes() -- List all session notes', docs: '/ai.md#session-notes----tracking-design-context' },
         // Attachments (durable project files: reference images, models, docs — survive a chat clear)
-        'getAttachments':  { signature: 'getAttachments() -- List session attachments -> [{id, kind, mediaType?, src, label?, addedAt?, source?}]. kind: image|model|document|text|other', docs: '/ai/reference-images.md#attachments' },
-        'addAttachment':   { signature: 'addAttachment({src, label?, kind?, mediaType?}) -- Pin a file to the session (kind/mediaType inferred when omitted) -> the stored item', docs: '/ai/reference-images.md#attachments' },
-        'setAttachments':  { signature: 'setAttachments([{src, label?, kind?, mediaType?}]) -- Replace the whole attachment list', docs: '/ai/reference-images.md#attachments' },
+        'getAttachments':  { signature: 'getAttachments() -- List session attachments -> [{id, kind, mediaType?, src, label?, description?, addedAt?, source?}]. kind: image|model|document|text|other; description = why it matters', docs: '/ai/reference-images.md#attachments' },
+        'addAttachment':   { signature: 'addAttachment({src, label?, description?, kind?, mediaType?}) -- Pin a file to the session (kind/mediaType inferred when omitted; description = why it matters) -> the stored item', docs: '/ai/reference-images.md#attachments' },
+        'setAttachments':  { signature: 'setAttachments([{src, label?, description?, kind?, mediaType?}]) -- Replace the whole attachment list', docs: '/ai/reference-images.md#attachments' },
         'removeAttachment': { signature: 'removeAttachment(id) -- Remove an attachment by id -> boolean', docs: '/ai/reference-images.md#attachments' },
         'clearAttachments': { signature: 'clearAttachments() -- Remove all attachments', docs: '/ai/reference-images.md#attachments' },
         'getImages':       { signature: 'getImages() -- Image-kind attachments only -> [{id, src, label?}]', docs: '/ai/reference-images.md#attachments' },

--- a/src/storage/attachment.ts
+++ b/src/storage/attachment.ts
@@ -39,6 +39,11 @@ export interface SessionAttachment extends AttachedImage {
   kind: AttachmentKind;
   /** MIME type when known (e.g. `image/png`, `model/stl`, `text/markdown`). */
   mediaType?: string;
+  /** Free-form note describing WHY this attachment matters — what to match, the
+   *  constraint it captures, the source it came from. Distinct from `label`
+   *  (a short caption / perspective preset): the description is the durable
+   *  context the AI reads back. */
+  description?: string;
   /** Epoch ms when the attachment was added — lets the UI/AI reason about
    *  staleness (a reference photo can age out of relevance). */
   addedAt?: number;
@@ -105,7 +110,7 @@ export function inferAttachmentKind(mediaType: string | undefined, src?: string,
  *  the read-time migration and by every construction site, so `kind`/`mediaType`
  *  are always populated consistently. */
 export function normalizeAttachment(
-  partial: { id?: string; src: string; label?: string; kind?: AttachmentKind; mediaType?: string; addedAt?: number; source?: 'user' | 'chat' },
+  partial: { id?: string; src: string; label?: string; description?: string; kind?: AttachmentKind; mediaType?: string; addedAt?: number; source?: 'user' | 'chat' },
   fallbackId: string,
 ): SessionAttachment {
   const mediaType = partial.mediaType || inferMediaType(partial.src, partial.label);
@@ -118,6 +123,8 @@ export function normalizeAttachment(
   if (mediaType) out.mediaType = mediaType;
   const label = partial.label?.trim();
   if (label) out.label = label;
+  const description = partial.description?.trim();
+  if (description) out.description = description;
   if (typeof partial.addedAt === 'number') out.addedAt = partial.addedAt;
   if (partial.source) out.source = partial.source;
   return out;

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -603,6 +603,7 @@ function migrateSessionImages(s: Session & { images?: LegacyImagesShape; referen
           src: typeof item.src === 'string' ? item.src : '',
           // Pre-unification rows tagged the angle; fold it into the label.
           label: collapseAngleIntoLabel(item),
+          description: typeof item.description === 'string' ? item.description : undefined,
           kind: typeof item.kind === 'string' ? (item.kind as AttachmentKind) : undefined,
           mediaType: typeof item.mediaType === 'string' ? item.mediaType : undefined,
           addedAt: typeof item.addedAt === 'number' ? item.addedAt : undefined,

--- a/src/storage/sessionManager.ts
+++ b/src/storage/sessionManager.ts
@@ -178,8 +178,12 @@ import { appPath } from '../deployment';
  *           context. Legacy `session.images` / `session.referenceImages`
  *           (and the object-map form) still read as image attachments. Older
  *           readers ignore the new field.
+ *  - `1.17` — attachments gain an optional free-form `description`
+ *           (`session.attachments[].description`) — a "why this matters" note
+ *           distinct from the short `label`/perspective caption. Additive;
+ *           older readers ignore it.
  */
-export const SCHEMA_VERSION = '1.16';
+export const SCHEMA_VERSION = '1.17';
 
 const CURRENT_MAJOR = 1;
 

--- a/src/ui/imagesView.ts
+++ b/src/ui/imagesView.ts
@@ -204,6 +204,34 @@ function createImageTile(item: SessionAttachment, allImages: SessionAttachment[]
   footer.appendChild(removeBtn);
 
   tile.appendChild(footer);
+
+  // Description: a free-form "why this matters" note, distinct from the short
+  // label. This is the durable context the AI reads back via getAttachments.
+  const descInput = document.createElement('textarea');
+  descInput.rows = 2;
+  descInput.placeholder = 'Describe why this matters (optional)…';
+  descInput.value = item.description ?? '';
+  descInput.className = 'mx-3 mb-2 bg-zinc-900 text-zinc-300 text-xs px-2 py-1 rounded border border-zinc-700 outline-none focus:border-blue-500 placeholder-zinc-600 resize-y';
+  const commitDescription = async () => {
+    const next = descInput.value.trim();
+    const current = item.description ?? '';
+    if (next === current) return;
+    const nextList = allImages.map(x => {
+      if (x.id !== item.id) return x;
+      const updated: SessionAttachment = { ...x, description: next };
+      if (!next) delete updated.description;
+      return updated;
+    });
+    await persistAndRefresh(nextList);
+  };
+  descInput.addEventListener('blur', commitDescription);
+  descInput.addEventListener('keydown', (e) => {
+    // Enter commits (Shift+Enter inserts a newline); Escape reverts.
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); descInput.blur(); }
+    if (e.key === 'Escape') { descInput.value = item.description ?? ''; descInput.blur(); }
+  });
+  tile.appendChild(descInput);
+
   return tile;
 }
 

--- a/tests/attachments.spec.ts
+++ b/tests/attachments.spec.ts
@@ -113,4 +113,55 @@ test.describe('session attachments', () => {
     await expect(panel.getByText('Model', { exact: true })).toBeVisible();
     await expect(panel.getByText('model/stl', { exact: true })).toBeVisible();
   });
+
+  test('attachments survive a page reload even with no saved version', async ({ page }) => {
+    await waitForEngine(page);
+    // Create a session and pin an attachment WITHOUT saving a version — the
+    // regression: attachments are session-level and must restore on open even
+    // when the version-load path never runs.
+    const sid = await page.evaluate(async ({ png }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const s = await pw.createSession('persist');
+      pw.addAttachment({ src: png, label: 'Front', description: 'why it matters' });
+      return s.id as string;
+    }, { png: PNG });
+    await page.waitForTimeout(1200);
+
+    await page.goto('/editor?session=' + sid);
+    await page.waitForFunction(
+      () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+      undefined,
+      { timeout: 30_000 },
+    );
+    await page.waitForTimeout(2500);
+
+    const after = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (window as any).partwright.getAttachments();
+    });
+    expect(after.length).toBe(1);
+    expect(after[0].label).toBe('Front');
+    expect(after[0].description).toBe('why it matters');
+  });
+
+  test('description round-trips through add + getAttachments tool', async ({ page }) => {
+    await waitForEngine(page);
+    await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (window as any).partwright.createSession('desc');
+    });
+    await page.waitForTimeout(1000);
+    const result = await page.evaluate(async ({ png }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pw = (window as any).partwright;
+      const stored = pw.addAttachment({ src: png, label: 'Front', description: 'match the chamfer angle' });
+      const { executeTool } = await import('/src/ai/tools.ts');
+      const tool = await executeTool('getAttachments', {});
+      return { storedDesc: stored.description, content: tool.content };
+    }, { png: PNG });
+    expect(result.storedDesc).toBe('match the chamfer angle');
+    // The manifest surfaces the description as a "↳ …" line.
+    expect(result.content).toMatch(/match the chamfer angle/);
+  });
 });

--- a/tests/chat-export.spec.ts
+++ b/tests/chat-export.spec.ts
@@ -107,7 +107,7 @@ test.describe('Chat export', () => {
         chat?: { id?: string; sessionId?: string; blocks: { type: string; text?: string }[] }[];
       };
     }, id);
-    expect(exported.partwright).toBe('1.16'); // tracks SCHEMA_VERSION (bumped to 1.16 for typed attachments)
+    expect(exported.partwright).toBe('1.17'); // tracks SCHEMA_VERSION (bumped to 1.17 for attachment descriptions)
     // App-version provenance (schema 1.15+): the dev build stamps package.json's semver.
     expect(exported.appVersion).toMatch(/^\d+\.\d+\.\d+$/);
     expect(exported.chat?.length).toBe(3);

--- a/tests/unit/attachment.test.ts
+++ b/tests/unit/attachment.test.ts
@@ -79,6 +79,16 @@ describe('normalizeAttachment', () => {
     expect(a.source).toBeUndefined();
   });
 
+  it('carries a trimmed description through, dropping an empty one', () => {
+    const a = normalizeAttachment(
+      { src: 'data:image/png;base64,AAAA', description: '  match the rounded corners  ' },
+      'id',
+    );
+    expect(a.description).toBe('match the rounded corners');
+    const b = normalizeAttachment({ src: 'data:image/png;base64,AAAA', description: '   ' }, 'id');
+    expect(b.description).toBeUndefined();
+  });
+
   it('keeps addedAt and source when provided', () => {
     const a = normalizeAttachment(
       { src: 'data:image/png;base64,AAAA', addedAt: 123, source: 'chat' },


### PR DESCRIPTION
Follow-up to #807 (typed session attachments). Two related improvements.

## 1. Fix: attachments cleared on page refresh

**Reported:** attachments disappear on refresh unless a version was saved first.

**Root cause** was a *restore* gap, not a save gap. Attachments are always persisted to the `Session` row (`saveAttachments` → `dbUpdateSession`) the moment they're added. But the restore-on-open lived only inside `loadVersionIntoEditor` — so a session with attachments and **no saved version** reaches the editor through `loadPartIntoEditor`'s no-version (`else`) branch, which never restored them, leaving the in-memory list empty after a reload.

**Fix:** extracted `restoreAttachmentsForActiveSession()` and call it on every session-open path (the no-version branch, version load, the `openSession` API, and import). Attachments are session-level data and now reload like it — matching the suggestion that they should load on open regardless of version.

## 2. Feature: free-form `description` per attachment

A "why this matters" note, distinct from the short `label`/perspective caption. Per the chosen direction, the **label and Front/Right presets are kept** (so reference-photo ordering is preserved) and the description is **added** alongside.

- Schema **1.16 → 1.17** (additive; read-time migration carries it through).
- Attachments panel shows a description textarea under each tile's label.
- `addAttachment`/`setAttachments` accept `description`; `getAttachments` AI tool surfaces it as a prominent `↳ …` line (it's the key intent signal for the model).
- Docs (`ai.md`, `reference-images.md`) + `help()` table updated.

## Test plan

- `npm run preflight` — 1558 unit tests, no type errors, no circular deps.
- New unit case for `description` normalization.
- New e2e: **reload-survives-without-version-save** (the regression) + **description round-trip** through `addAttachment`/`getAttachments`. The reload test caught a second dropped-field bug — `migrateSessionImages`' explicit normalizer list was missing `description` — now fixed.
- Eyes-on screenshot of the description field (posted in the session chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrTLwd9UVzMDsahTBM4iBK)_