### PR TITLE
feat: paintImage AI tool with view-based decal placement

### DIFF
--- a/prompts/20260621-paint-image-ai-tool-and-view-placement.md
+++ b/prompts/20260621-paint-image-ai-tool-and-view-placement.md
@@ -1,0 +1,76 @@
+---
+session: "483euo"
+timestamp: "2026-06-21T01:50:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+---
+
+## Human
+
+An AI chat session struggled badly to paint a Garfield/"LASAGNA" shirt graphic
+onto a figure — it produced two formless orange blobs (screenshot attached). The
+user asked the AI for feedback; it diagnosed "no bridge between raster images and
+surface paint" and asked for a `paintDecal(image, {surface, point, size})` tool,
+an engrave "paint mode", region-scoped relief, and project-from-direction paint
+modes.
+
+## Assistant
+
+## Key decisions
+
+**The capability already existed — the gap was AI-tool parity, not geometry.**
+`window.partwright.paintImage` (→ `stampImageProgrammatic` → `stampImageOntoMesh`)
+already does orthographic image-projection onto the mesh as per-triangle paint:
+tangent frame, back-face skip, depth slab against thin walls, background removal,
+smooth-subdivided footprint. It was documented in ai.md/colors.md. But it was
+**never wired into `src/ai/tools.ts`** — not in ALL_TOOLS, no schema, no dispatch,
+not in PAINT_GATED — so the in-app chat agent literally had no tool to call it and
+fell back to `paintInBox`/`paintNear` (solid-colour regions) → blobs. This is the
+exact UI↔JS-API parity gap CLAUDE.md warns about.
+
+**Scope (confirmed with the user): tool wiring + a placement helper, named
+`paintImage`** (matches the existing console method — one name across surfaces —
+rather than the AI's suggested `paintDecal`). Skipped the engrave-paint-mode and
+region-relief asks as separate larger work.
+
+**The real pain point was placement, not the stamp.** The agent had to
+hand-compute `at` (a surface point) and `normal` (projection axis); that's where
+it gave up. So I added a `view` ('front'|'back'|'left'|'right'|'top'|'bottom')
+placement mode that auto-resolves both: the view fixes the projection normal
+(front=-Y, etc., per multiview's STANDARD_VIEWS) and a ray-cast toward the model
+centre finds the surface anchor. An optional `label` centres the projection on an
+`api.label` region and auto-sizes the decal to its footprint when `size` is
+omitted. Explicit `at`+`normal` still work unchanged (back-compat).
+
+**Kept the placement math in a new pure module** `src/color/imagePaintPlacement.ts`
+(`resolveImageStampPlacement`) — dependency-free (own Möller–Trumbore ray sweep,
+no THREE) so it unit-tests in the node tier and keeps the heavy logic out of the
+NUL-byte `main.ts`. `main.ts`'s `paintImage` just resolves the label→triangle set
+from `currentLabelMap`, calls the resolver, then the existing stamp path.
+
+**AI tool image source:** the tool takes `imageRef` (1-based index into the
+session reference images the user attached — same list `getReferenceImages`
+shows) or `imageUrl`; the dispatch resolves `imageRef` via `api.getImages()` →
+`src` data URL before calling `paintImage`. The schema description steers the
+model to use this for logos/graphics/text and explicitly warns off the
+solid-colour tools.
+
+## Verification
+
+- typecheck clean; 1566 unit tests pass (incl. 8 new placement tests); madge
+  no-cycles gate green.
+- Browser: ran a scratch spec that built a torso box, generated a transparent-bg
+  "LASAGNA" + disc graphic, called `paintImage({view:'front', size:34})`, and
+  screenshotted the front view — the disc and **legible** lettering projected
+  cleanly with the background dropped (17k triangles painted). Posted the PNG in
+  chat. Scratch spec deleted before commit.
+
+## Files
+
+- `src/color/imagePaintPlacement.ts` (new) — pure `resolveImageStampPlacement`.
+- `tests/unit/imagePaintPlacement.test.ts` (new).
+- `src/main.ts` — `paintImage` accepts `view`/`label`, optional `at`/`normal`/
+  `size`; resolves placement; help() table updated.
+- `src/ai/tools.ts` — `paintImage` schema + dispatch + PAINT_GATED +
+  PART_TARGETABLE_TOOLS.
+- `public/ai.md`, `public/ai/colors.md` — documented view/label placement.

--- a/prompts/20260621-paint-image-retro.md
+++ b/prompts/20260621-paint-image-retro.md
@@ -1,0 +1,18 @@
+---
+session: "483euo"
+timestamp: "2026-06-21T02:00:00Z"
+model: claude-opus-4-8
+tools: []
+---
+
+## Human
+
+(Stop-hook nudge.) Drop a /retro note for the paintImage work.
+
+## Assistant
+
+Added a 4-Ls retro entry (`retros/inbox/2026-06-21-paint-image-ai-tool.md`). Key
+"Longed for": a lint flagging `window.partwright` methods that have no matching
+AI tool in `ALL_TOOLS` — that's the parity-drift class this whole task came from
+(the projection engine + console `paintImage` existed; only the AI tool was
+missing). No code change; reflection only.

--- a/prompts/20260621-paint-image-review-fixes.md
+++ b/prompts/20260621-paint-image-review-fixes.md
@@ -1,0 +1,35 @@
+---
+session: "483euo"
+timestamp: "2026-06-21T01:57:00Z"
+model: claude-opus-4-8
+tools: [playwright]
+---
+
+## Human
+
+(Automated work-reviewer pass over PR #816.) Address the review findings.
+
+## Assistant
+
+## Key decisions
+
+Acted on the one should-fix and two nits from the branch review:
+
+- **`imageRef` index contract (should-fix).** `getReferenceImages` numbers its
+  list AFTER filtering to entries with a usable `src`, but the `paintImage`
+  dispatch indexed the unfiltered `getImages()` result — so a leading empty-src
+  attachment would skew the index and paint the wrong image. Fixed the dispatch
+  to filter to the same `usable` set before indexing, matching the contract the
+  tool advertises.
+- **View ordering consistency (nit).** Reordered `VIEW_NORMALS`/`STAMP_VIEWS` to
+  `front, back, left, right, top, bottom` so the resolver, schema enum, docs, and
+  error strings all agree; updated the unit assertion.
+- **Lazy bbox (nit).** Moved the bbox/diag/radius/center computation inside the
+  `if (!at)` branch — it's only needed for the auto-anchor ray, so an explicit
+  `at` with label-auto-size no longer pays for it.
+- **e2e golden path (nit).** Added `tests/paint-image-view.spec.ts`: builds a box,
+  projects a transparent-bg orange disc via `paintImage({view:'front'})`, asserts
+  triangles painted + orange avg colour, and that an unknown view errors. The
+  resolver math stays unit-covered; this proves the full console path.
+
+Verified: typecheck clean, placement unit tests pass, the new e2e spec passes.

--- a/public/ai.md
+++ b/public/ai.md
@@ -415,7 +415,7 @@ partwright.undoLastPaint() / redoLastPaint()                              // sin
 partwright.removeRegion(id) / setRegionVisibility(id, visible)            // per-region edits
 partwright.hideRegion(id) / showRegion(id) / clearColors()
 partwright.replaceColor({from:[r,g,b], to:[r,g,b], tolerance?})           // bulk-recolor matching regions (0..1 colors) -> {replaced}
-await partwright.paintImage({imageUrl, at:[x,y,z], normal:[nx,ny,nz], size, rotationDeg?, detail?, removeBackground?, name?}) // stamp an image onto the surface as a region -> {ok, name, triangles, avgColor}; get at/normal from probeRay; see /ai/colors.md
+await partwright.paintImage({imageUrl, view?:"front"|"back"|"left"|"right"|"top"|"bottom", label?, at?:[x,y,z], normal?:[nx,ny,nz], size?, rotationDeg?, detail?, removeBackground?, name?}) // project a raster image onto the surface as paint (logo/graphic/text/decal) -> {ok, name, triangles, avgColor}; use view (+ optional label) OR explicit at+normal (from probeRay); see /ai/colors.md
 // Filament palette — the print slots (AMS/MMU) regions map onto; see /ai/colors.md
 partwright.getPalette()                                                   // -> {id, name, capacity, constrained, slots:[{id,name,hex,td}]}
 partwright.listPalettes() / setActivePalette(id) / createPalette(name)

--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -630,24 +630,39 @@ This only changes region *colors*, not which triangles they cover — to repaint
 
 ## Stamping an image onto the surface
 
-`paintImage({imageUrl, at, normal, size, ...})` projects an image onto the model as a color region — the programmatic Image-paint tool. Use it for logos, decals, faces, or photo decals on a surface.
+`paintImage({imageUrl, view|at+normal, size, ...})` projects a **raster image** onto the model as paint — the right tool for a logo, sticker/decal, styled text or wordmark, a shirt graphic, or face/skin detail. It maps the image's actual pixels onto the triangles, so a logo stays a logo and lettering stays legible. **Do not reach for `paintNear`/`paintInBox` for a graphic** — those flood one flat colour and turn a picture into a blob.
+
+**Easiest — project from a named view:**
 
 ```js
-// stamp a logo on the +Z face of a 20mm cube, centred, 12mm across
+// put a graphic on the chest of a figure, projected from the front,
+// centred (and auto-sized) on the "shirt" label
 await partwright.paintImage({
-  imageUrl: logoDataUrl,     // a data: URL or a same-origin URL
-  at: [0, 0, 10],            // stamp centre, ON the surface (world coords)
-  normal: [0, 0, 1],         // the outward face direction there
-  size: 12,                  // stamp diameter in world units
-  rotationDeg: 0,            // spin around the normal (optional)
-  detail: 96,                // triangle rows across the stamp; higher = crisper. 0 = flat
-  removeBackground: true,    // drop the image's background (default true)
+  imageUrl: graphicDataUrl,  // a data: URL or a same-origin URL
+  view: 'front',             // front|back|left|right|top|bottom — projects flat along that axis
+  label: 'shirt',            // optional: centre on this api.label region; auto-sizes when size is omitted
+  // size: 30,               // decal width in model units (optional when `label` is given)
+  rotationDeg: 0,            // spin around the projection axis (optional)
+  removeBackground: true,    // drop the image's background so only the subject paints (default true)
 })
 // -> { ok, name, triangles, avgColor } or { error }
 ```
 
-- **Getting `at` / `normal`:** use `probeRay({origin, direction})` (returns the hit point + face normal), `measureAt([x,y])`, or a known face centre — `at` must lie on the surface and `normal` must face outward, or the footprint is empty and you get `{ error }`.
-- Only **forward-facing** triangles inside the stamp square are painted, so a stamp never bleeds onto the far side.
+**Precise — explicit anchor + direction** (when you need exact placement):
+
+```js
+await partwright.paintImage({
+  imageUrl: logoDataUrl,
+  at: [0, 0, 10],            // stamp centre, ON the surface (world coords)
+  normal: [0, 0, 1],         // the outward face direction there
+  size: 12,                  // decal width in world units
+  detail: 96,                // triangle rows across the stamp; higher = crisper. 0 = flat
+})
+```
+
+- **Placement:** pass `view` (auto-anchored at the model centre, optionally centred on a `label`) for the common case, OR explicit `at` + `normal` for precision — get those from `probeRay({origin, direction})` (returns hit point + face normal), `probePixel`, or a known face centre. With `view`, the projection direction is the view axis (front=-Y, back=+Y, right=+X, left=-X, top=+Z, bottom=-Z) and the surface anchor is found by ray-casting toward the model centre.
+- Only **forward-facing** triangles inside the footprint are painted, and a depth slab stops paint bleeding through to the far side.
+- After painting, **verify** with `renderView`/`renderViews` from the projection direction — confirm the graphic landed where you intended and is the right size before saving.
 - The stamp subdivides the footprint for crisp edges (smooth mode), so the model's triangle count rises locally — call `getGeometryData()` after if you care about the budget.
 - Call `saveVersion('stamped')` afterwards to persist it (paint isn't auto-saved).
 

--- a/retros/inbox/2026-06-21-paint-image-ai-tool.md
+++ b/retros/inbox/2026-06-21-paint-image-ai-tool.md
@@ -1,0 +1,22 @@
+---
+date: 2026-06-21
+author: claude (opus-4-8)
+task: paintImage AI tool + view-based decal placement (PR #816)
+---
+
+## Liked
+- The user handed me an AI's own post-mortem ("no bridge between raster images and surface paint"). Treating it as a *hypothesis to verify against the code* rather than a spec paid off: two parallel `explore` agents found the projection engine (`stampImageOntoMesh`) and console method (`paintImage`) already existed — the real gap was AI-tool parity, not geometry. Saved building a primitive that was already there.
+- `model:preview` wasn't the right tool here (this is paint, not a model), but the spec-driven browser screenshot was: one scratch spec projecting a transparent-bg "LASAGNA"+disc onto a box proved the whole path and produced a before/after the user could see at a glance.
+- The repo's own parity doctrine (CLAUDE.md "UI↔JS-API parity") named the exact bug class before I found it — the capability was reachable by clicking but not from chat.
+
+## Lacked
+- No typed link between a `window.partwright` method and its AI tool, so "console method exists but isn't an AI tool" is invisible until an agent fails in the field. A lint that flags `partwright.X` methods absent from `ALL_TOOLS` (with an allowlist for deliberate omissions) would have surfaced this gap proactively instead of via a user's bad experience.
+- Discovering how a chat-attached image reaches a tool took a few hops (`attachments.ts` → `getImages()` → `getReferenceImages` filtered list). A one-line "how attachments flow to tools" note in `docs/ai-internals.md` would shortcut that.
+
+## Learned
+- `getReferenceImages` numbers its list AFTER filtering to usable-`src` entries — so any tool taking a 1-based "image index from getReferenceImages" must filter identically or the index space diverges. The reviewer caught this; worth remembering for the next ref-image-consuming tool.
+- The promptlog PreToolUse guard blocks the *entire* bash command (incl. a leading `git add -A`) before it runs, so "`git add -A && git commit`" with an unstaged prompt log fails with nothing staged. Stage the prompt log in a separate call first.
+- `main.ts`'s NUL bytes are localized (template-literal cache keys); the `paintImage` block is plain text + em-dashes, so normal `Edit` worked. `cat -v` renders the em-dash's 0x80 byte as `M-^@`, which can be mistaken for a real NUL.
+
+## Longed for
+- The "method exists in UI/console but not as an AI tool" lint above is the biggest lever — it converts a whole class of silent parity drift into a CI signal. The capability-registry refactor CLAUDE.md mentions (one source both the command palette and API derive from) would subsume it.

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -541,6 +541,27 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'paintImage',
+    description: 'Project a RASTER IMAGE onto the surface as paint — the right tool for a logo, graphic, styled text/wordmark, or any picture-on-a-surface (a shirt graphic, a sticker/decal, a label, face/skin detail). It maps the actual image pixels onto the triangles, so a logo stays a logo and lettering stays legible — unlike the solid-colour region tools (paintNear/paintInBox), which can only flood one flat colour and turn a graphic into a blob. The image background is removed by default so only the subject paints. THE IMAGE: pass `imageRef` (1-based index of a session reference image — call getReferenceImages first to see what the user attached and its index) OR `imageUrl` (a data: or same-origin URL). PLACEMENT, two ways: (1) easiest — pass `view` (front/back/left/right/top/bottom) and it projects flat along that axis onto the surface facing the camera, auto-anchored at the model centre; add `label` to centre it on an api.label region (e.g. the shirt) and, if you omit `size`, to auto-size it to that region; (2) precise — pass explicit `at` (surface point) + `normal` (outward direction there) from probePixel/probeRay. `size` is the decal width in model units. `rotationDeg` twists it around the axis. Returns {ok, name, triangles, avgColor} or {error}. Verify with renderView/renderViews from the projection direction afterwards.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        imageRef: { type: 'number', description: '1-based index of a session reference image to paint (the order getReferenceImages lists them). Use this for an image the user attached.' },
+        imageUrl: { type: 'string', description: 'Alternative to imageRef: a data: URL or same-origin image URL.' },
+        view: { type: 'string', enum: ['front', 'back', 'left', 'right', 'top', 'bottom'], description: 'Project flat along this view axis onto the surface facing it, auto-anchored at the model centre. The simplest placement. front=-Y, back=+Y, right=+X, left=-X, top=+Z, bottom=-Z.' },
+        label: { type: 'string', description: 'Centre the projection on this api.label region (and auto-size to it when `size` is omitted). Combine with `view`, or with `at`+`normal` for explicit control.' },
+        at: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Explicit stamp centre on the surface (world coords), from probePixel/probeRay. Use with `normal` for precise placement instead of `view`.' },
+        normal: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Explicit outward projection direction at `at`. Pair with `at`.' },
+        size: { type: 'number', description: 'Decal width in model units. Optional when `label` is given (auto-sized to the label footprint).' },
+        rotationDeg: { type: 'number', description: 'Rotate the image around the projection axis, degrees. Default 0.' },
+        detail: { type: 'number', description: 'Triangle rows across the stamp; higher = crisper (default 96). 0 = flat stamp on the existing tessellation.' },
+        removeBackground: { type: 'boolean', description: 'Drop the image background so only the subject paints. Default true.' },
+        name: { type: 'string' },
+      },
+      required: [],
+    },
+  },
+  {
     name: 'paintInBox',
     description: 'Paint every triangle whose centroid is inside the axis-aligned box (optionally constrained by a normal cone). One call. Use for "paint the top half / the right rim / everything below z=0". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause. On fan-topology meshes (cylinder/revolve/linear_extrude surfaces), pass `coverageMode: "fully_inside"` and/or `maxTriangleArea` to avoid long radial triangles bleeding paint outside the box. On BREP-engine solids (replicad language, or a manifold-js session whose return value came through `BREP.toManifold`), OCCT booleans can leave interior intersection-seam triangles inside the bounding volume — the centroid test then catches them and you get patchy paint on a surface that looks solid. Default to `coverageMode: "fully_inside"` on BREP, or use `paintConnected` from a probePixel seed instead.',
     input_schema: {
@@ -1365,7 +1386,7 @@ export const PART_TARGETABLE_TOOLS = new Set<string>([
   'listVersions', 'loadVersion', 'saveVersion', 'forkVersion', 'copyColorsFromVersion',
   'modifyAndTest', 'query', 'findFaces', 'listComponents', 'listLabels', 'getModelColors',
   'listRegions', 'probePixel', 'probeRay', 'paintPreview', 'paintExplain',
-  'paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintInBox', 'paintInOrientedBox',
+  'paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintImage', 'paintInBox', 'paintInOrientedBox',
   'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels',
   'paintConnected', 'paintInCylinder', 'undoLastPaint', 'redoLastPaint', 'removeRegion',
   'clearColors', 'assertPaint', 'sliceAtZVisual', 'checkPrintability',
@@ -1480,7 +1501,7 @@ export const RETRY_SAFE_TOOLS = new Set([
 
 const RUN_GATED = new Set(['runCode', 'setParams']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion', 'saveVersion', 'applySurfaceTexture', 'applyVoronoiLamp', 'engraveModel', 'voxelizeModel', 'scaleModel', 'placeModel', 'rotateModel', 'layFlatModel']);
-const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintImage', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);
 /** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
  *  vision spend in one place — when off, the agent has to reason from
@@ -1946,6 +1967,36 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.paintNear(input);
     case 'paintStroke':
       return api.paintStroke(input);
+    case 'paintImage': {
+      // Resolve the image source: imageUrl wins; else imageRef indexes the
+      // session reference images (1-based, matching getReferenceImages).
+      let imageUrl = typeof input.imageUrl === 'string' ? input.imageUrl : undefined;
+      if (!imageUrl && input.imageRef != null) {
+        const imgs = typeof api.getImages === 'function' ? api.getImages() : [];
+        const list = (Array.isArray(imgs) ? imgs : []) as Array<{ src?: string }>;
+        const idx = Number(input.imageRef) - 1;
+        const entry = list[idx];
+        if (!entry || typeof entry.src !== 'string' || entry.src.length === 0) {
+          return { error: `paintImage: no reference image at index ${input.imageRef}. Call getReferenceImages to list attached images and their indices.` };
+        }
+        imageUrl = entry.src;
+      }
+      if (!imageUrl) {
+        return { error: 'paintImage: provide imageRef (1-based index from getReferenceImages) or imageUrl.' };
+      }
+      return api.paintImage({
+        imageUrl,
+        view: input.view,
+        label: input.label,
+        at: input.at,
+        normal: input.normal,
+        size: input.size,
+        rotationDeg: input.rotationDeg,
+        detail: input.detail,
+        removeBackground: input.removeBackground,
+        name: input.name,
+      });
+    }
     case 'paintInBox':
       return api.paintInBox(input);
     case 'paintInOrientedBox':

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1973,10 +1973,12 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       let imageUrl = typeof input.imageUrl === 'string' ? input.imageUrl : undefined;
       if (!imageUrl && input.imageRef != null) {
         const imgs = typeof api.getImages === 'function' ? api.getImages() : [];
-        const list = (Array.isArray(imgs) ? imgs : []) as Array<{ src?: string }>;
-        const idx = Number(input.imageRef) - 1;
-        const entry = list[idx];
-        if (!entry || typeof entry.src !== 'string' || entry.src.length === 0) {
+        // Index the SAME filtered list getReferenceImages numbers (entries with a
+        // usable src), so a 1-based imageRef the model read there resolves here.
+        const list = ((Array.isArray(imgs) ? imgs : []) as Array<{ src?: string }>)
+          .filter(im => typeof im.src === 'string' && im.src.length > 0);
+        const entry = list[Number(input.imageRef) - 1];
+        if (!entry) {
           return { error: `paintImage: no reference image at index ${input.imageRef}. Call getReferenceImages to list attached images and their indices.` };
         }
         imageUrl = entry.src;

--- a/src/color/imagePaintPlacement.ts
+++ b/src/color/imagePaintPlacement.ts
@@ -20,8 +20,8 @@ export type StampView = 'front' | 'back' | 'left' | 'right' | 'top' | 'bottom';
 const VIEW_NORMALS: Record<StampView, readonly [number, number, number]> = {
   front:  [0, -1, 0],
   back:   [0,  1, 0],
-  right:  [1,  0, 0],
   left:   [-1, 0, 0],
+  right:  [1,  0, 0],
   top:    [0,  0, 1],
   bottom: [0,  0, -1],
 };
@@ -174,26 +174,25 @@ export function resolveImageStampPlacement(
   // Fully explicit — no geometry analysis needed.
   if (at && size != null) return { at, normal, size };
 
-  const bbox = meshBBox(mesh);
-  if (!bbox) return { error: 'paintImage: the model has no geometry to project onto.' };
-  const diag = Math.hypot(bbox.max[0] - bbox.min[0], bbox.max[1] - bbox.min[1], bbox.max[2] - bbox.min[2]);
-  const radius = diag / 2 || 1;
-
   const label = (input.labelTriangles && input.labelTriangles.size > 0)
     ? labelGeometry(mesh, input.labelTriangles, normal)
     : null;
 
-  const center: [number, number, number] = label
-    ? label.center
-    : [
-        (bbox.min[0] + bbox.max[0]) / 2,
-        (bbox.min[1] + bbox.max[1]) / 2,
-        (bbox.min[2] + bbox.max[2]) / 2,
-      ];
-
   // Auto-anchor: cast from far on the camera side back toward the surface,
-  // through the lateral centre, and take the nearest forward hit.
+  // through the lateral centre, and take the nearest forward hit. Only the
+  // ray path needs the bbox, so compute it lazily here.
   if (!at) {
+    const bbox = meshBBox(mesh);
+    if (!bbox) return { error: 'paintImage: the model has no geometry to project onto.' };
+    const diag = Math.hypot(bbox.max[0] - bbox.min[0], bbox.max[1] - bbox.min[1], bbox.max[2] - bbox.min[2]);
+    const radius = diag / 2 || 1;
+    const center: [number, number, number] = label
+      ? label.center
+      : [
+          (bbox.min[0] + bbox.max[0]) / 2,
+          (bbox.min[1] + bbox.max[1]) / 2,
+          (bbox.min[2] + bbox.max[2]) / 2,
+        ];
     const margin = radius * 2 + 1;
     const origin: [number, number, number] = [
       center[0] + normal[0] * margin,

--- a/src/color/imagePaintPlacement.ts
+++ b/src/color/imagePaintPlacement.ts
@@ -1,0 +1,221 @@
+// Placement resolver for the image-stamp / decal flow. Turns a high-level
+// "project this graphic onto the FRONT of the model" request into the concrete
+// { at, normal, size } the stamp engine (stampImageOntoMesh) needs — so callers
+// (the window.partwright.paintImage console method and the AI paintImage tool)
+// don't have to hand-compute a surface anchor point and projection axis, which
+// is exactly where agents struggled (they fell back to solid-colour boxes).
+//
+// Pure + dependency-free (no THREE) so it unit-tests in the node tier. The ray
+// cast is a small Möller–Trumbore sweep over the mesh triangles — a one-shot
+// per stamp, so the O(numTri) cost is fine.
+
+import type { MeshData } from '../geometry/types';
+
+export type StampView = 'front' | 'back' | 'left' | 'right' | 'top' | 'bottom';
+
+/** Outward surface normal for each named view — the direction the painted face
+ *  points (toward the camera). Z-up, right-handed: the default "front" camera
+ *  looks toward +Y from -Y, so the front face points -Y. Mirrors
+ *  STANDARD_VIEWS in src/renderer/multiview.ts. */
+const VIEW_NORMALS: Record<StampView, readonly [number, number, number]> = {
+  front:  [0, -1, 0],
+  back:   [0,  1, 0],
+  right:  [1,  0, 0],
+  left:   [-1, 0, 0],
+  top:    [0,  0, 1],
+  bottom: [0,  0, -1],
+};
+
+export const STAMP_VIEWS = Object.keys(VIEW_NORMALS) as StampView[];
+
+export interface StampPlacementInput {
+  /** Named projection direction. Resolves both the projection axis and (with no
+   *  explicit `at`) the surface anchor. Ignored when `at` + `normal` are both given. */
+  view?: StampView;
+  /** Explicit surface anchor (world coords). Skips the auto ray-cast. */
+  at?: [number, number, number];
+  /** Explicit outward projection normal. Overrides the `view` normal. */
+  normal?: [number, number, number];
+  /** Decal width in model units. Auto-derived from the label's footprint when
+   *  omitted and `labelTriangles` is supplied. */
+  size?: number;
+  /** Triangle indices of a paint label region to centre the projection on (and
+   *  to auto-size against). Resolve a label name to this set before calling. */
+  labelTriangles?: Set<number> | null;
+}
+
+export interface ResolvedStampPlacement {
+  at: [number, number, number];
+  normal: [number, number, number];
+  size: number;
+}
+
+function normalize(v: readonly [number, number, number]): [number, number, number] | null {
+  const len = Math.hypot(v[0], v[1], v[2]);
+  if (!(len > 0)) return null;
+  return [v[0] / len, v[1] / len, v[2] / len];
+}
+
+/** Nearest forward ray-triangle hit distance (t), or null on a miss.
+ *  Möller–Trumbore, double-sided (a decal anchor doesn't care about winding). */
+function rayNearestHit(
+  mesh: MeshData,
+  origin: readonly [number, number, number],
+  dir: readonly [number, number, number],
+): number | null {
+  const { numTri, numProp, vertProperties: vp, triVerts: tv } = mesh;
+  const EPS = 1e-7;
+  let best = Infinity;
+  for (let t = 0; t < numTri; t++) {
+    const a = tv[t * 3] * numProp, b = tv[t * 3 + 1] * numProp, c = tv[t * 3 + 2] * numProp;
+    const ax = vp[a], ay = vp[a + 1], az = vp[a + 2];
+    const e1x = vp[b] - ax, e1y = vp[b + 1] - ay, e1z = vp[b + 2] - az;
+    const e2x = vp[c] - ax, e2y = vp[c + 1] - ay, e2z = vp[c + 2] - az;
+    // p = dir × e2
+    const px = dir[1] * e2z - dir[2] * e2y;
+    const py = dir[2] * e2x - dir[0] * e2z;
+    const pz = dir[0] * e2y - dir[1] * e2x;
+    const det = e1x * px + e1y * py + e1z * pz;
+    if (det > -EPS && det < EPS) continue; // ray parallel to triangle
+    const inv = 1 / det;
+    const tx = origin[0] - ax, ty = origin[1] - ay, tz = origin[2] - az;
+    const u = (tx * px + ty * py + tz * pz) * inv;
+    if (u < -EPS || u > 1 + EPS) continue;
+    // q = t × e1
+    const qx = ty * e1z - tz * e1y;
+    const qy = tz * e1x - tx * e1z;
+    const qz = tx * e1y - ty * e1x;
+    const v = (dir[0] * qx + dir[1] * qy + dir[2] * qz) * inv;
+    if (v < -EPS || u + v > 1 + EPS) continue;
+    const hit = (e2x * qx + e2y * qy + e2z * qz) * inv;
+    if (hit > EPS && hit < best) best = hit;
+  }
+  return best === Infinity ? null : best;
+}
+
+/** Average of the centroids of a triangle set, plus its extent in the plane
+ *  perpendicular to `n` (used to auto-size a decal to a label region). */
+function labelGeometry(
+  mesh: MeshData,
+  tris: Set<number>,
+  n: readonly [number, number, number],
+): { center: [number, number, number]; lateralExtent: number } | null {
+  if (tris.size === 0) return null;
+  const { numProp, vertProperties: vp, triVerts: tv } = mesh;
+  // In-plane tangent frame for measuring lateral spread.
+  const ref: [number, number, number] = Math.abs(n[2]) > 0.5 ? [0, 1, 0] : [0, 0, 1];
+  let tx = ref[1] * n[2] - ref[2] * n[1];
+  let ty = ref[2] * n[0] - ref[0] * n[2];
+  let tz = ref[0] * n[1] - ref[1] * n[0];
+  const tl = Math.hypot(tx, ty, tz) || 1; tx /= tl; ty /= tl; tz /= tl;
+  const bx = n[1] * tz - n[2] * ty, by = n[2] * tx - n[0] * tz, bz = n[0] * ty - n[1] * tx;
+
+  let cx = 0, cy = 0, cz = 0;
+  let minU = Infinity, maxU = -Infinity, minV = Infinity, maxV = -Infinity;
+  for (const t of tris) {
+    const a = tv[t * 3] * numProp, b = tv[t * 3 + 1] * numProp, c = tv[t * 3 + 2] * numProp;
+    const px = (vp[a] + vp[b] + vp[c]) / 3;
+    const py = (vp[a + 1] + vp[b + 1] + vp[c + 1]) / 3;
+    const pz = (vp[a + 2] + vp[b + 2] + vp[c + 2]) / 3;
+    cx += px; cy += py; cz += pz;
+    for (const off of [a, b, c]) {
+      const u = vp[off] * tx + vp[off + 1] * ty + vp[off + 2] * tz;
+      const v = vp[off] * bx + vp[off + 1] * by + vp[off + 2] * bz;
+      if (u < minU) minU = u; if (u > maxU) maxU = u;
+      if (v < minV) minV = v; if (v > maxV) maxV = v;
+    }
+  }
+  const inv = 1 / tris.size;
+  return {
+    center: [cx * inv, cy * inv, cz * inv],
+    lateralExtent: Math.max(maxU - minU, maxV - minV),
+  };
+}
+
+function meshBBox(mesh: MeshData): { min: [number, number, number]; max: [number, number, number] } | null {
+  const { numVert, numProp, vertProperties: vp } = mesh;
+  if (numVert === 0) return null;
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < numVert; i++) {
+    for (let k = 0; k < 3; k++) {
+      const c = vp[i * numProp + k];
+      if (c < min[k]) min[k] = c;
+      if (c > max[k]) max[k] = c;
+    }
+  }
+  return { min, max };
+}
+
+/** Resolve a high-level stamp request into { at, normal, size }. Returns
+ *  `{ error }` when it can't (no projection direction, empty mesh, the ray
+ *  misses the surface, or no size could be determined). */
+export function resolveImageStampPlacement(
+  mesh: MeshData,
+  input: StampPlacementInput,
+): ResolvedStampPlacement | { error: string } {
+  // Projection normal: explicit `normal` wins, else the named view.
+  let normal: [number, number, number] | null = null;
+  if (input.normal) {
+    normal = normalize(input.normal);
+    if (!normal) return { error: 'paintImage: `normal` must be a non-zero vector.' };
+  } else if (input.view) {
+    if (!VIEW_NORMALS[input.view]) {
+      return { error: `paintImage: unknown view "${input.view}". Use one of: ${STAMP_VIEWS.join(', ')}.` };
+    }
+    normal = [...VIEW_NORMALS[input.view]];
+  } else {
+    return { error: 'paintImage: provide a `view` (front/back/left/right/top/bottom) or both `at` and `normal`.' };
+  }
+
+  let at = input.at ? ([...input.at] as [number, number, number]) : null;
+  let size = (typeof input.size === 'number' && input.size > 0) ? input.size : null;
+
+  // Fully explicit — no geometry analysis needed.
+  if (at && size != null) return { at, normal, size };
+
+  const bbox = meshBBox(mesh);
+  if (!bbox) return { error: 'paintImage: the model has no geometry to project onto.' };
+  const diag = Math.hypot(bbox.max[0] - bbox.min[0], bbox.max[1] - bbox.min[1], bbox.max[2] - bbox.min[2]);
+  const radius = diag / 2 || 1;
+
+  const label = (input.labelTriangles && input.labelTriangles.size > 0)
+    ? labelGeometry(mesh, input.labelTriangles, normal)
+    : null;
+
+  const center: [number, number, number] = label
+    ? label.center
+    : [
+        (bbox.min[0] + bbox.max[0]) / 2,
+        (bbox.min[1] + bbox.max[1]) / 2,
+        (bbox.min[2] + bbox.max[2]) / 2,
+      ];
+
+  // Auto-anchor: cast from far on the camera side back toward the surface,
+  // through the lateral centre, and take the nearest forward hit.
+  if (!at) {
+    const margin = radius * 2 + 1;
+    const origin: [number, number, number] = [
+      center[0] + normal[0] * margin,
+      center[1] + normal[1] * margin,
+      center[2] + normal[2] * margin,
+    ];
+    const dir: [number, number, number] = [-normal[0], -normal[1], -normal[2]];
+    const t = rayNearestHit(mesh, origin, dir);
+    if (t == null) {
+      return { error: 'paintImage: no surface faces that view at the model centre — pass an explicit `at` point (e.g. from probePixel/probeRay).' };
+    }
+    at = [origin[0] + dir[0] * t, origin[1] + dir[1] * t, origin[2] + dir[2] * t];
+  }
+
+  // Auto-size to the label footprint (with a small margin) when no size given.
+  if (size == null) {
+    if (label && label.lateralExtent > 0) {
+      size = label.lateralExtent * 1.1;
+    } else {
+      return { error: 'paintImage: provide `size` (decal width in model units), or a `label` so it can be sized automatically.' };
+    }
+  }
+
+  return { at, normal, size };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -178,6 +178,7 @@ import type { Theme } from './ui/theme';
 import { initPaintUI, isPaintOpen, forceDeactivate as closePaintMenu } from './color/paintUI';
 import { initImagePaintUI, setSmoothStampCallback, setStampCommitHook, stampImageProgrammatic } from './color/imagePaintUI';
 import { stampImageOntoMesh, buildTangentFrame, entriesToPerTriColors, remapPerTriColors, loadImageDataFromUrl } from './color/imagePaint';
+import { resolveImageStampPlacement, STAMP_VIEWS, type StampView } from './color/imagePaintPlacement';
 import { initVoxelPaintUI, setVoxelPaintAvailable, syncActiveState as syncVoxelPaintUI } from './color/voxelPaintUI';
 import { initSimplifyUI, isSimplifyOpen, refreshSimplifyIfOpen, forceDeactivate as closeSimplifyMenu, notifyQualityLangChanged, setQualityRenderState, type SimplifyHandlers } from './ui/simplifyUI';
 import { initPrintToolsUI, isPrintToolsOpen, forceDeactivate as closePrintToolsMenu, type PrintToolsHandlers } from './ui/printToolsUI';
@@ -13692,24 +13693,45 @@ async function main() {
       return { replaced: count };
     },
 
-    /** Stamp an image onto the model surface as a color region — the
-     *  programmatic Image-paint tool. `imageUrl` is a `data:` URL or a
-     *  same-origin URL. `at` is the stamp centre on the surface (world coords)
-     *  and `normal` the outward face direction there — get them from probeRay /
-     *  measureAt / a face centroid. `size` is the stamp diameter in world units.
+    /** Stamp a raster image onto the model surface as paint — the programmatic
+     *  Image-paint tool, the right way to put a logo / graphic / text / decal on
+     *  a surface (a shirt graphic, a label, face/skin detail). `imageUrl` is a
+     *  `data:` URL or a same-origin URL.
+     *
+     *  PLACEMENT (two ways):
+     *   - Easiest: pass `view` ('front'|'back'|'left'|'right'|'top'|'bottom') and
+     *     the decal is projected flat along that axis onto the surface facing it,
+     *     auto-anchored at the model centre. Add `label` to centre (and, when
+     *     `size` is omitted, auto-size) the projection on an `api.label` region.
+     *   - Precise: pass explicit `at` (stamp centre on the surface, world coords)
+     *     and `normal` (outward face direction there) — from probeRay / probePixel
+     *     / a face centroid.
+     *
+     *  `size` is the decal width in world units (auto-derived from `label` when
+     *  omitted). `rotationDeg` twists the image around the projection axis.
      *  `detail` (default 96) is triangle rows across the stamp — higher = crisper
      *  (0 = flat stamp on the existing tessellation). `removeBackground` (default
-     *  true) drops the image's background. Only forward-facing triangles inside
-     *  the footprint are painted. Returns `{ ok, name, triangles, avgColor }` or
-     *  `{ error }`. Call saveVersion() afterwards to persist. */
-    async paintImage(opts: { imageUrl: string; at: [number, number, number]; normal: [number, number, number]; size: number; rotationDeg?: number; detail?: number; removeBackground?: boolean; name?: string }) {
+     *  true) drops the image's background so only the subject paints. Only
+     *  forward-facing triangles inside the footprint are painted; a depth slab
+     *  stops it bleeding through thin walls. Returns `{ ok, name, triangles,
+     *  avgColor }` or `{ error }`. Call saveVersion() afterwards to persist. */
+    async paintImage(opts: { imageUrl: string; view?: StampView; label?: string; at?: [number, number, number]; normal?: [number, number, number]; size?: number; rotationDeg?: number; detail?: number; removeBackground?: boolean; name?: string }) {
       const check = guard(() => {
         assertObject(opts, 'paintImage(opts)');
         assertString(opts?.imageUrl, 'paintImage(opts.imageUrl)', { allowEmpty: false });
-        assertNumberTuple(opts?.at, 3, 'paintImage(opts.at)').forEach((n, i) => assertNumber(n, `paintImage(opts.at[${i}])`, {}));
-        assertNumberTuple(opts?.normal, 3, 'paintImage(opts.normal)').forEach((n, i) => assertNumber(n, `paintImage(opts.normal[${i}])`, {}));
-        assertNumber(opts?.size, 'paintImage(opts.size)', { min: 0 });
-        if (opts.size <= 0) throw new ValidationError('paintImage(opts.size) must be greater than 0');
+        if (opts?.view !== undefined) {
+          assertString(opts.view, 'paintImage(opts.view)', { allowEmpty: false });
+          if (!(STAMP_VIEWS as string[]).includes(opts.view)) {
+            throw new ValidationError(`paintImage(opts.view) must be one of: ${STAMP_VIEWS.join(', ')}`);
+          }
+        }
+        if (opts?.label !== undefined) assertString(opts.label, 'paintImage(opts.label)', { allowEmpty: false });
+        if (opts?.at !== undefined) assertNumberTuple(opts.at, 3, 'paintImage(opts.at)').forEach((n, i) => assertNumber(n, `paintImage(opts.at[${i}])`, {}));
+        if (opts?.normal !== undefined) assertNumberTuple(opts.normal, 3, 'paintImage(opts.normal)').forEach((n, i) => assertNumber(n, `paintImage(opts.normal[${i}])`, {}));
+        if (opts?.size !== undefined) {
+          assertNumber(opts.size, 'paintImage(opts.size)', { min: 0 });
+          if (opts.size <= 0) throw new ValidationError('paintImage(opts.size) must be greater than 0');
+        }
         if (opts?.rotationDeg !== undefined) assertNumber(opts.rotationDeg, 'paintImage(opts.rotationDeg)', {});
         if (opts?.detail !== undefined) assertNumber(opts.detail, 'paintImage(opts.detail)', { min: 0, integer: true });
         if (opts?.removeBackground !== undefined) assertBoolean(opts.removeBackground, 'paintImage(opts.removeBackground)');
@@ -13717,6 +13739,27 @@ async function main() {
       });
       if (typeof check === 'object' && check !== null && 'error' in check) return check;
       if (!currentMeshData) return { error: 'No model loaded — run code first.' };
+
+      // Resolve a label name to its triangle set (used to centre/auto-size the
+      // projection). An unknown label is a clear user error, not a silent miss.
+      let labelTriangles: Set<number> | null = null;
+      if (opts.label) {
+        labelTriangles = currentLabelMap?.get(opts.label) ?? null;
+        if (!labelTriangles || labelTriangles.size === 0) {
+          const known = currentLabelMap ? Array.from(currentLabelMap.keys()) : [];
+          return { error: `paintImage: no label "${opts.label}" in the current model.${known.length ? ` Known labels: ${known.join(', ')}.` : ''}` };
+        }
+      }
+
+      const placement = resolveImageStampPlacement(currentMeshData, {
+        view: opts.view,
+        at: opts.at,
+        normal: opts.normal,
+        size: opts.size,
+        labelTriangles,
+      });
+      if ('error' in placement) return placement;
+
       let imageData: ImageData;
       try {
         imageData = await loadImageDataFromUrl(opts.imageUrl);
@@ -13724,9 +13767,9 @@ async function main() {
         return { error: `paintImage: could not load image — ${e instanceof Error ? e.message : String(e)}` };
       }
       const region = stampImageProgrammatic(imageData, {
-        hitPoint: opts.at,
-        hitNormal: opts.normal,
-        size: opts.size,
+        hitPoint: placement.at,
+        hitNormal: placement.normal,
+        size: placement.size,
         rotationDeg: opts.rotationDeg,
         detail: opts.detail,
         removeBackground: opts.removeBackground,
@@ -15281,7 +15324,7 @@ async function main() {
         'listRegions':     { signature: 'listRegions() -- List all color regions with bbox + centroid for each', docs: '/ai/colors.md' },
         'clearColors':     { signature: 'clearColors() -- Remove ALL color regions (use undoLastPaint to reverse just one)', docs: '/ai/colors.md' },
         'replaceColor':    { signature: 'replaceColor({from:[r,g,b], to:[r,g,b], tolerance?}) -- Recolor every USER paint region matching `from` (0..1 colors) -> {replaced, hint?}. Code-declared colors (api.paint.*/api.label) are edited in the code, not here.', docs: '/ai/colors.md' },
-        'paintImage':      { signature: 'await paintImage({imageUrl, at:[x,y,z], normal:[nx,ny,nz], size, rotationDeg?, detail?, removeBackground?, name?}) -- Stamp an image onto the surface as a color region -> {ok, name, triangles, avgColor} or {error}', docs: '/ai/colors.md' },
+        'paintImage':      { signature: 'await paintImage({imageUrl, view?:"front"|"back"|"left"|"right"|"top"|"bottom", label?, at?:[x,y,z], normal?:[nx,ny,nz], size?, rotationDeg?, detail?, removeBackground?, name?}) -- Project a raster image onto the surface as paint (logo/graphic/text/decal). Use view (auto-anchored, optionally centred on a label) OR explicit at+normal -> {ok, name, triangles, avgColor} or {error}', docs: '/ai/colors.md' },
         'getPalette':      { signature: 'getPalette() -- Active filament palette {id, name, capacity, constrained, slots:[{id,name,hex,td}]}', docs: '/ai/colors.md' },
         'listPalettes':    { signature: 'listPalettes() -- All saved palettes [{id, name, active}]', docs: '/ai/colors.md' },
         'createPalette':   { signature: 'createPalette(name) -- Create an empty palette -> {id} (call setActivePalette to switch)', docs: '/ai/colors.md' },

--- a/tests/paint-image-view.spec.ts
+++ b/tests/paint-image-view.spec.ts
@@ -1,0 +1,61 @@
+// Golden path for the view-based image-stamp placement (window.partwright.paintImage
+// with `view` instead of explicit at+normal). Covers the resolver added in
+// src/color/imagePaintPlacement.ts end-to-end against the real engine + mesh:
+// build a box, project a transparent-background graphic onto the FRONT face, and
+// assert the decal landed (triangles painted, the orange subject's avg colour).
+// The unit tier (tests/unit/imagePaintPlacement.test.ts) covers the math; this
+// proves the full console path wires up.
+
+import { test, expect } from 'playwright/test';
+import type { Page } from 'playwright/test';
+
+async function openEditor(page: Page) {
+  await page.goto('/editor');
+  await page.waitForSelector('text=Ready', { timeout: 15000 });
+  const skip = page.locator('button:has-text("Skip")');
+  if (await skip.count()) await skip.first().dispatchEvent('click').catch(() => {});
+}
+
+test('paintImage(view) projects a graphic onto the named view face', async ({ page }) => {
+  await openEditor(page);
+
+  // A 40×20×60 box: front face (the -Y side) is what `view: 'front'` projects onto.
+  await page.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    await pw.run(`const { Manifold } = api; return Manifold.cube([40, 20, 60], true);`);
+  });
+  await page.waitForTimeout(800);
+
+  // Transparent-background graphic: an orange disc (the only thing that should paint).
+  const imageUrl = await page.evaluate(() => {
+    const cv = document.createElement('canvas');
+    cv.width = 128; cv.height = 128;
+    const ctx = cv.getContext('2d')!;
+    ctx.clearRect(0, 0, 128, 128);
+    ctx.fillStyle = '#e08a1e';
+    ctx.beginPath(); ctx.arc(64, 64, 50, 0, Math.PI * 2); ctx.fill();
+    return cv.toDataURL('image/png');
+  });
+
+  const res = await page.evaluate(async (url) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    return await pw.paintImage({ imageUrl: url, view: 'front', size: 30 });
+  }, imageUrl) as { ok?: boolean; triangles?: number; avgColor?: [number, number, number]; error?: string };
+
+  expect(res.error).toBeUndefined();
+  expect(res.ok).toBe(true);
+  expect(res.triangles ?? 0).toBeGreaterThan(0);
+  // The painted subject is orange: red channel clearly dominates blue.
+  const [r, , b] = res.avgColor ?? [0, 0, 0];
+  expect(r).toBeGreaterThan(b);
+
+  // An unknown view is rejected with an actionable error (not a silent miss).
+  const bad = await page.evaluate(async (url) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (window as any).partwright;
+    return await pw.paintImage({ imageUrl: url, view: 'sideways', size: 30 });
+  }, imageUrl) as { error?: string };
+  expect(bad.error).toBeTruthy();
+});

--- a/tests/unit/imagePaintPlacement.test.ts
+++ b/tests/unit/imagePaintPlacement.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { resolveImageStampPlacement, STAMP_VIEWS } from '../../src/color/imagePaintPlacement';
+import type { MeshData } from '../../src/geometry/types';
+
+// A 10×10×10 cube centred at the origin (verts at ±5), 12 triangles.
+function makeCube(): MeshData {
+  const verts = [
+    -5, -5, -5,  // 0
+     5, -5, -5,  // 1
+     5,  5, -5,  // 2
+    -5,  5, -5,  // 3
+    -5, -5,  5,  // 4
+     5, -5,  5,  // 5
+     5,  5,  5,  // 6
+    -5,  5,  5,  // 7
+  ];
+  const tris = [
+    0, 5, 1, 0, 4, 5,   // front  (y = -5)
+    2, 3, 7, 2, 7, 6,   // back   (y = +5)
+    0, 3, 7, 0, 7, 4,   // left   (x = -5)
+    1, 5, 6, 1, 6, 2,   // right  (x = +5)
+    0, 2, 1, 0, 3, 2,   // bottom (z = -5)
+    4, 5, 6, 4, 6, 7,   // top    (z = +5)
+  ];
+  return {
+    vertProperties: new Float32Array(verts),
+    triVerts: new Uint32Array(tris),
+    numVert: 8,
+    numTri: tris.length / 3,
+    numProp: 3,
+  };
+}
+
+describe('resolveImageStampPlacement', () => {
+  it('passes explicit at+normal+size straight through', () => {
+    const r = resolveImageStampPlacement(makeCube(), {
+      at: [1, 2, 3], normal: [0, 0, 1], size: 4,
+    });
+    expect('error' in r).toBe(false);
+    if ('error' in r) return;
+    expect(r.at).toEqual([1, 2, 3]);
+    expect(r.normal).toEqual([0, 0, 1]);
+    expect(r.size).toBe(4);
+  });
+
+  it('resolves a front-view projection to the front face with the front normal', () => {
+    const r = resolveImageStampPlacement(makeCube(), { view: 'front', size: 6 });
+    expect('error' in r).toBe(false);
+    if ('error' in r) return;
+    // front faces -Y
+    expect(r.normal).toEqual([0, -1, 0]);
+    // anchored on the front face (y ≈ -5), centred laterally
+    expect(r.at[1]).toBeCloseTo(-5, 4);
+    expect(r.at[0]).toBeCloseTo(0, 4);
+    expect(r.at[2]).toBeCloseTo(0, 4);
+    expect(r.size).toBe(6);
+  });
+
+  it('resolves a top-view projection to the top face', () => {
+    const r = resolveImageStampPlacement(makeCube(), { view: 'top', size: 3 });
+    if ('error' in r) throw new Error(r.error);
+    expect(r.normal).toEqual([0, 0, 1]);
+    expect(r.at[2]).toBeCloseTo(5, 4);
+  });
+
+  it('auto-sizes to a label footprint when size is omitted', () => {
+    // front face triangle indices are 0 and 1
+    const label = new Set([0, 1]);
+    const r = resolveImageStampPlacement(makeCube(), { view: 'front', labelTriangles: label });
+    if ('error' in r) throw new Error(r.error);
+    // front face spans 10×10 → auto size = 10 * 1.1
+    expect(r.size).toBeCloseTo(11, 4);
+    expect(r.at[1]).toBeCloseTo(-5, 4);
+  });
+
+  it('errors when no view/normal is given', () => {
+    const r = resolveImageStampPlacement(makeCube(), { size: 5 });
+    expect('error' in r).toBe(true);
+  });
+
+  it('errors when size is omitted and there is no label to size against', () => {
+    const r = resolveImageStampPlacement(makeCube(), { view: 'front' });
+    expect('error' in r).toBe(true);
+  });
+
+  it('errors on a zero-length normal', () => {
+    const r = resolveImageStampPlacement(makeCube(), { normal: [0, 0, 0], at: [0, 0, 0], size: 2 });
+    expect('error' in r).toBe(true);
+  });
+
+  it('exposes all six named views', () => {
+    expect(STAMP_VIEWS).toEqual(['front', 'back', 'right', 'left', 'top', 'bottom']);
+  });
+});

--- a/tests/unit/imagePaintPlacement.test.ts
+++ b/tests/unit/imagePaintPlacement.test.ts
@@ -89,6 +89,6 @@ describe('resolveImageStampPlacement', () => {
   });
 
   it('exposes all six named views', () => {
-    expect(STAMP_VIEWS).toEqual(['front', 'back', 'right', 'left', 'top', 'bottom']);
+    expect(STAMP_VIEWS).toEqual(['front', 'back', 'left', 'right', 'top', 'bottom']);
   });
 });


### PR DESCRIPTION
## Summary

Lets the in-app AI chat **project a raster image onto a surface as paint** — a logo, sticker/decal, styled wordmark, shirt graphic, face/skin detail — instead of degrading a graphic to a solid-colour blob.

### Why
A user's AI session struggled to put a Garfield/"LASAGNA" shirt graphic on a figure and produced two formless orange blobs. Asked for feedback, the agent diagnosed "no bridge between raster images and surface paint."

The capability **already existed** — `window.partwright.paintImage` → `stampImageProgrammatic` → `stampImageOntoMesh` does orthographic image-projection onto the mesh as per-triangle paint (tangent frame, back-face skip, depth slab, background removal, smooth footprint), documented in `ai.md`/`colors.md`. But it was **never wired into `src/ai/tools.ts`**, so the chat agent had no tool to call it and fell back to `paintInBox`/`paintNear` (solid-colour regions) → blobs. This is exactly the UI↔JS-API parity gap `CLAUDE.md` warns about.

### What changed
- **`src/color/imagePaintPlacement.ts` (new)** — pure, dependency-free `resolveImageStampPlacement`. A `view` (`front`/`back`/`left`/`right`/`top`/`bottom`) fixes the projection normal and a Möller–Trumbore ray-cast toward the model centre finds the surface anchor; an optional `label` centres the projection on an `api.label` region and auto-sizes the decal to its footprint when `size` is omitted. Explicit `at`+`normal` still work (back-compat). No THREE dep → unit-testable in the node tier and keeps logic out of the NUL-byte `main.ts`.
- **`src/main.ts`** — `paintImage` accepts `view`/`label` and optional `at`/`normal`/`size`; resolves the label to its triangle set and runs the new resolver. `help()` table updated.
- **`src/ai/tools.ts`** — `paintImage` tool: schema (image via `imageRef` 1-based ref-image index or `imageUrl`) + dispatch (resolves `imageRef` → data URL via `getImages()`) + `PAINT_GATED` + `PART_TARGETABLE_TOOLS`. Description steers the model to use it for graphics/text and warns off the solid-colour tools.
- **Docs** — `public/ai.md`, `public/ai/colors.md` document the view/label placement modes.
- **Tests** — `tests/unit/imagePaintPlacement.test.ts` (8 cases).

### Decisions (confirmed with the user)
- **Scope:** tool wiring **+** placement helper (the agent's real blocker was computing `at`/`normal`, not the stamp). Deferred the engrave "paint mode" and region-scoped relief asks as separate larger work.
- **Name:** `paintImage` (matches the existing console method — one name across surfaces) rather than the suggested `paintDecal`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test:unit` — 1566 pass (incl. 8 new placement tests)
- [x] `npm run lint:deps` — no cycles
- [x] `npm run build` — clean
- [x] Browser: torso box + transparent-bg "LASAGNA"+disc graphic → `paintImage({view:'front', size:34})` → disc and **legible** lettering project cleanly, background dropped (17k tris painted). Screenshot posted in the session.
- [ ] PR-checks shards (build + unit + 3 e2e) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Zp8UgVFV9mnfK7LKtUosE

---
_Generated by [Claude Code](https://claude.ai/code/session_013Zp8UgVFV9mnfK7LKtUosE)_