### PR TITLE
feat: scale the ground grid to the studio room instead of a fixed patch

### DIFF
--- a/prompts/grid-scales-to-room.md
+++ b/prompts/grid-scales-to-room.md
@@ -1,0 +1,40 @@
+---
+date: 2026-06-21
+title: Grid scales to the studio room instead of a fixed 40-unit patch
+---
+
+## Human
+
+"the grid for models is often way too small. I think when the grid is enabled
+it should likely be the size of the room in the interactive view. It should be
+larger either way. make a PR way."
+
+## Assistant
+
+The ground grid was a fixed `THREE.GridHelper(40, 40)` parked at the model's
+base. Two problems compounded:
+
+- `makeGrid` **hardcoded** `40, 40`, silently ignoring the existing
+  `renderer.gridSize` / `renderer.gridDivisions` config — which even had an
+  Advanced Settings UI. The "Grid size" knob did nothing.
+- A fixed 40-unit footprint is tiny under a large model (e.g. a 120-unit cube
+  overhangs it) and oversized under a small one, while the studio floor (the
+  "room") already scales to `maxDim * 14`.
+
+Decision: make the grid **track the model/room size** like the floor does,
+rather than bumping a fixed size that would still be wrong at the other end of
+the scale range.
+
+- `makeGrid` now builds a unit-base grid at `gridDivisions` cells and applies
+  `lastGridScale`; `frameModel` re-derives that scale from the framed model as
+  `maxDim * gridRoomFactor / divisions`, so the world footprint is
+  `maxDim * gridRoomFactor` (divisions only set cell density, not extent). The
+  scale is re-applied on theme rebuilds via the stored `lastGridScale`.
+- Replaced the dead `renderer.gridSize` (absolute world units, never read) with
+  `renderer.gridRoomFactor` (default 8 — the grid spans 8× the model's largest
+  dimension, comfortably larger than before and clearly room-like). Updated the
+  Advanced Settings field/tooltips to match.
+
+Verified in-browser with a throwaway spec: a 120×120×40 cube now sits on a grid
+that extends well past it, and a radius-5 sphere gets a proportionally small
+grid — both "room-sized" rather than the old fixed patch.

--- a/retros/inbox/grid-scales-to-room.md
+++ b/retros/inbox/grid-scales-to-room.md
@@ -1,0 +1,27 @@
+---
+date: 2026-06-21
+task: scale the ground grid to the studio room (PR #817)
+---
+
+## Liked
+- The headless verification loop was fast and decisive: a throwaway Playwright
+  spec driving `partwright.setGridVisible(true)` + `resetView()` over a large
+  cube and a small sphere proved the scaling behavior in one run, with PNGs to
+  show the user.
+
+## Lacked
+- No `gh` CLI and no `send_later` in this remote session, so watching CI to
+  green required a `Monitor` bash poll that just *wakes me to re-query the GitHub
+  MCP* — works, but it's an awkward indirection vs. a direct status poll.
+
+## Learned
+- The grid config (`renderer.gridSize`/`gridDivisions`) had a full Advanced
+  Settings UI but `makeGrid` hardcoded `40, 40` and never read it — a dead knob
+  hiding in plain sight. Worth grepping that a config field is actually *read*,
+  not just declared + surfaced in settings.
+
+## Longed for
+- A single "ground-plane sizing" source of truth: the studio floor's `maxDim*14`
+  factor is still an inline magic number in `frameModelShadow`, separate from the
+  new `gridRoomFactor`. A shared `studioRoomFactor` would keep floor + grid in
+  lockstep instead of two independent multipliers.

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -97,9 +97,12 @@ export interface AppConfig {
     maxPixelRatio: number;
     /** Render scale during camera orbit/zoom (0–1, lower = faster interaction). */
     interactionRenderScale: number;
-    /** Ground grid total size in world units. Takes effect on page reload. */
-    gridSize: number;
-    /** Number of grid divisions. Takes effect on page reload. */
+    /** Ground grid footprint as a multiple of the model's largest dimension, so
+     *  the grid scales with the model (spans the studio "room") instead of being
+     *  a fixed-size patch. Re-derived from the model size on each auto-frame. */
+    gridRoomFactor: number;
+    /** Number of grid divisions (cell count across the grid). Takes effect on
+     *  page reload. */
     gridDivisions: number;
     /** Orientation gizmo canvas size in CSS pixels. */
     gizmoSizePx: number;
@@ -310,7 +313,7 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
     fov: 50,
     maxPixelRatio: 2,
     interactionRenderScale: 0.6,
-    gridSize: 40,
+    gridRoomFactor: 8,
     gridDivisions: 40,
     gizmoSizePx: 128,
     gizmoMarginPx: 8,

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -17,8 +17,15 @@ const GRID_COLORS = { dark: { major: 0x444444, minor: 0x333333 }, light: { major
 
 function makeGrid(theme: Theme): THREE.GridHelper {
   const c = GRID_COLORS[theme];
-  const g = new THREE.GridHelper(40, 40, c.major, c.minor);
+  // Build the grid at a unit base size and scale it per-model in frameModel so
+  // it spans the studio "room" (tracks the model size) rather than a fixed
+  // 40-unit patch. `gridDivisions` sets the cell count; the base side length is
+  // the divisions count (1 unit per cell at scale 1) so the no-model default is
+  // still a sensible square. `lastGridScale` is re-applied on theme rebuilds.
+  const div = Math.max(2, Math.round(getConfig().renderer.gridDivisions));
+  const g = new THREE.GridHelper(div, div, c.major, c.minor);
   g.rotation.x = Math.PI / 2;
+  g.scale.setScalar(lastGridScale);
   g.visible = false;
   return g;
 }
@@ -115,6 +122,9 @@ let studioFloor: THREE.Mesh | null = null;
 let studioShadowCatcher: THREE.Mesh | null = null;
 let studioKeyLight: THREE.DirectionalLight | null = null;
 let lastFloorZ = 0;
+// Per-model scale applied to the unit-base grid so it spans the studio "room"
+// (re-derived from the model size in frameModel; re-applied on theme rebuilds).
+let lastGridScale = 1;
 // The "Light" toggle: gentle image-based reflections + a mild contact shadow.
 // On by default. The PMREM env is cached (built once, reused across off→on
 // cycles) and skipped entirely on a software rasterizer (studioEnvAllowed),
@@ -622,9 +632,17 @@ function frameModel(): void {
   // Update model bounds for clip slider
   modelBounds = { min: box.min.z, max: box.max.z };
 
-  // Position grid + studio floor at the bottom of the model.
+  // Position grid + studio floor at the bottom of the model, and size the grid
+  // to the studio "room" so it scales with the model instead of staying a fixed
+  // 40-unit patch (tiny under a large model, oversized under a small one). The
+  // footprint tracks maxDim · gridRoomFactor; dividing by the grid's unit-base
+  // side (its divisions) makes the world footprint independent of the divisions,
+  // which then only set cell density.
   lastFloorZ = box.min.z;
   grid.position.z = box.min.z;
+  const div = Math.max(2, Math.round(getConfig().renderer.gridDivisions));
+  lastGridScale = (maxDim * getConfig().renderer.gridRoomFactor) / div;
+  grid.scale.setScalar(lastGridScale);
 
   // Studio: park the floor under the model + size the shadow to its footprint.
   frameModelShadow();

--- a/src/ui/advancedSettingsModal.tsx
+++ b/src/ui/advancedSettingsModal.tsx
@@ -507,17 +507,17 @@ function AdvancedSettingsBody(props: { cfg: Signal<AppConfig>; onReset: () => vo
           onChange={v => set('renderer', 'interactionRenderScale', v)}
         />
         <Field
-          label="Grid size"
-          unit="units"
-          tooltip="The total side length of the ground-plane grid in model units. If your models are typically 200 units wide, set this to 400 or so to keep the grid visible around them. Takes effect after a page reload."
-          defaultValue={APP_CONFIG_DEFAULTS.renderer.gridSize}
-          value={c.renderer.gridSize}
-          min={4} max={1000} integer
-          onChange={v => set('renderer', 'gridSize', v)}
+          label="Grid room factor"
+          unit="× model"
+          tooltip="How far the ground grid extends, as a multiple of the model's largest dimension. The grid now scales with the model — spanning the studio 'room' around it — instead of being a fixed-size patch, so it stays useful from tiny parts to large models. Higher = a bigger grid around the model. Takes effect on the next render or 'Reset view'."
+          defaultValue={APP_CONFIG_DEFAULTS.renderer.gridRoomFactor}
+          value={c.renderer.gridRoomFactor}
+          min={1} max={40} step={0.5}
+          onChange={v => set('renderer', 'gridRoomFactor', v)}
         />
         <Field
           label="Grid divisions"
-          tooltip="The number of cells the grid is divided into. Combined with grid size this sets the cell size: a 40-unit grid with 40 divisions gives 1-unit cells. Takes effect after a page reload."
+          tooltip="The number of cells the grid is divided into across its full width. Since the grid scales to the model, this sets cell density (more divisions = finer cells). Takes effect after a page reload."
           defaultValue={APP_CONFIG_DEFAULTS.renderer.gridDivisions}
           value={c.renderer.gridDivisions}
           min={2} max={200} integer


### PR DESCRIPTION
## Summary

The ground grid was often way too small. It was a fixed `THREE.GridHelper(40, 40)` that never scaled with the model — tiny under a large model (a 120-unit cube overhangs it) and oversized under a small one — while the studio floor (the "room") already scales to the model size. On top of that, `makeGrid` **hardcoded** `40, 40`, silently ignoring the `renderer.gridSize` / `renderer.gridDivisions` config that even had an Advanced Settings UI, so the "Grid size" knob did nothing.

Now the grid **tracks the model/room size** like the studio floor does, so it's room-sized and larger in every case:

- `makeGrid` builds a unit-base grid (`gridDivisions` cells) and `frameModel` re-derives its scale from the framed model as `maxDim * gridRoomFactor / divisions` — making the world footprint `maxDim * gridRoomFactor` while divisions only set cell density. The scale is stored in `lastGridScale` and re-applied on theme rebuilds.
- Replaced the dead `renderer.gridSize` (absolute world units, never read) with `renderer.gridRoomFactor` (default **8** — the grid spans 8× the model's largest dimension). Updated the Advanced Settings field + tooltips to match.

## Before / after

| | Old | New |
|---|---|---|
| 120-unit cube | grid smaller than the cube | grid extends well past it |
| radius-5 sphere | giant 40-unit grid dwarfs it | proportionally small grid around it |

## Test plan

- `npm run typecheck` ✅
- `npm run test:unit` ✅ (1558 passed)
- Manual browser verification (throwaway Playwright spec): ran a large cube and a small sphere, enabled the grid via `partwright.setGridVisible(true)`, confirmed the grid scales to a sensible "room" in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dn2vm49jKDcqfntykRB9Ha)_