### PR TITLE
fix: keep api.label underlay covering the mesh across incremental paint strokes

### DIFF
--- a/prompts/paint-model-region-underlay-coverage-collapse.md
+++ b/prompts/paint-model-region-underlay-coverage-collapse.md
@@ -1,0 +1,56 @@
+---
+session: "keen-wozniak"
+timestamp: "2026-06-21T18:55:00Z"
+---
+
+## Human
+
+While testing the buried-triangle fix, reported a second artifact via screenshots:
+purple "triangle junk" near the apex of a painted coarse square pyramid — the
+`api.label` color (`#a855f7`) showing through where the painted surface color
+should be. Said the original session was lost and couldn't be shared. Pointed at
+the purple upper triangles and asked to investigate the corruption.
+
+## Assistant
+
+## Key decisions
+
+**Separated this from the merged buried-triangle fix (#815).** The purple was the
+`api.label` *underlay* leaking through subdivided triangles — a color-propagation
+bug, distinct from #815's classification fix. Confirmed #815 worked (reporter no
+longer saw unpainted inner triangles).
+
+**Reproduced by direct measurement after visual repros failed.** Six visual
+repros (import-rebuild, import+stroke, byLabel-then-strokes, 5 apex strokes,
+strokes-then-byLabel) all rendered clean — because in each, the paint layer
+covered the whole mesh and hid the underlay. Instead of chasing pixels I measured
+`getModelRegions()[0].triangles.size` across successive incremental strokes on the
+coarse pyramid: **6 → 6033 → 2372 → 773** — the `api.label` underlay's coverage
+*collapsed* with each stroke instead of tracking the growing subdivided mesh.
+
+**Root cause.** `reresolveModelRegions` (`src/main.ts`) re-resolved each model
+region's `byLabel` descriptor via `resolveDescriptorTriangles`, which remaps
+`currentLabelMap` — and `currentLabelMap` indexes the **base** mesh (only set on a
+code run, lines 6028/16573, never updated as painting subdivides). In the
+incremental paint path the `parentToChildren` map indexes the **current** mesh, so
+after the 2nd stroke the stale base ids `{0..5}` were remapped through a
+current-mesh map and the underlay collapsed onto a shrinking, wrong cluster.
+Wherever the paint layer didn't cover (e.g. a geodesic-gated brush that can't
+cross a coarse pyramid's sharp apex), the mis-resolved underlay showed through as
+purple. It also broke live==reload determinism (a reload re-resolves to full
+coverage).
+
+**Fix.** In `reresolveModelRegions`, carry explicit/`byLabel` model regions
+forward via `remapTriangleIds(region.triangles, parentToChildren)` during an
+incremental subdivision — exactly what the paint regions a few lines up already
+do — and only re-resolve by descriptor on a full rebuild (`parentToChildren ===
+null`, where `currentLabelMap` matches the freshly built mesh). Coverage now grows
+6 → 6033 → 11975 → 17881 (tracks the mesh) instead of collapsing.
+
+**Verification.** New engine-backed e2e `tests/paint-model-region-coverage.spec.ts`
+asserts the underlay coverage never shrinks across incremental strokes — fails on
+the old code (773 < 6033), passes on the fix. Typecheck, all 1558 unit tests, and
+the paint-render-color / paint-in-code / save-after-paint / surface-paint-survival
+e2e specs all pass. Could not reproduce the exact visible purple (the reporter's
+specific paint mechanism + lost session), but the collapse is a confirmed
+coverage+determinism bug that directly explains the symptom domain.

--- a/retros/inbox/measure-state-when-visual-repro-fails.md
+++ b/retros/inbox/measure-state-when-visual-repro-fails.md
@@ -1,0 +1,33 @@
+# Retro — paint underlay leak (#836/#838), buried triangle (#815)
+
+## Liked
+- Asking the user for the real `.partwright.json` cracked #815 fast — four synthetic
+  repros all looked correct; the actual session reproduced the bug in one run. The
+  `manifoldJsEngine.run()` + `refineMeshPipeline()` vite-node harness made it a
+  ~2s loop with no browser.
+- The before/after colored `renderViews` shots gave the user (and me) immediate
+  visual proof.
+
+## Lacked
+- A way to reproduce the #836 "purple junk" *visually* — the reporter's session was
+  lost, and in every reproduction I built the paint layer covered the whole mesh and
+  hid the underlay. Six visual repros all looked clean.
+
+## Learned
+- **When a visual bug won't reproduce on screen, measure the underlying STATE
+  directly.** Instead of chasing pixels, I queried `getModelRegions()[0].triangles.size`
+  across successive incremental strokes and saw it collapse 6033→2372→773 — the bug
+  was obvious and deterministic in the number even though no render showed it. The
+  pixel is a lagging, lossy indicator; the data structure is ground truth.
+- Two layers that resolve the *same* predicate by *different* mechanisms (paint
+  byLabel carries `region.triangles` forward; model byLabel re-resolved from
+  `currentLabelMap`) will silently diverge — and `currentLabelMap` indexing the base
+  mesh while `parentToChildren` indexes the current mesh is a trap. A shared helper
+  for "carry a label region across subdivision" would have prevented both.
+
+## Longed for
+- A tiny in-app debug hook to dump per-region triangle coverage vs mesh `numTri`
+  (live), so this class of "region lost coverage after subdivision" bug is a glance,
+  not a scripted measurement. Could be a `partwright.__regionCoverage()` diagnostic.
+- A "session autosave / crash-recovery" so a lost session (the reason #836 couldn't
+  be reproduced from the source) is recoverable.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1426,8 +1426,22 @@ function rebuildPaintedGeometry(): void {
  *  `parentToChildren` from the run's labelMap. No-op when no underlay exists. */
 function reresolveModelRegions(mesh: MeshData, adjacency: AdjacencyGraph | null, parentToChildren: Map<number, number[]> | null): void {
   for (const region of getModelRegions()) {
-    const { triangles } = resolveDescriptorTriangles(region.descriptor, mesh, adjacency, parentToChildren, region.id);
-    setModelRegionTriangles(region.id, triangles);
+    const d = region.descriptor;
+    // Across an *incremental* subdivision (parentToChildren present), explicit and
+    // byLabel model regions must carry their current triangle set forward via the
+    // parent→children map — exactly like the paint regions above. Re-resolving a
+    // byLabel descriptor here would remap `currentLabelMap` (which indexes the
+    // BASE mesh) through a CURRENT-mesh parent map, so its coverage collapses onto
+    // a shrinking, wrong cluster with each stroke (the api.label underlay then
+    // leaks through wherever paint doesn't cover). On a full rebuild
+    // (parentToChildren === null) currentLabelMap matches the freshly-built mesh,
+    // so re-resolving by descriptor is correct.
+    if (parentToChildren && (d.kind === 'byLabel' || d.kind === 'triangles')) {
+      setModelRegionTriangles(region.id, remapTriangleIds(region.triangles, parentToChildren));
+    } else {
+      const { triangles } = resolveDescriptorTriangles(d, mesh, adjacency, parentToChildren, region.id);
+      setModelRegionTriangles(region.id, triangles);
+    }
   }
 }
 

--- a/tests/paint-model-region-coverage.spec.ts
+++ b/tests/paint-model-region-coverage.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from 'playwright/test';
+
+// Regression for the model-region (api.label underlay) coverage collapse.
+//
+// `api.label(shape, name, { color })` creates a *model region* — the colored
+// underlay beneath the paint layer — carrying a `byLabel` descriptor. Each smooth
+// (edge-smoothing) brush stroke incrementally subdivides the working mesh, and
+// `reresolveModelRegions` must carry the underlay's coverage across that split.
+//
+// The bug: it re-resolved the `byLabel` descriptor from `currentLabelMap`, which
+// indexes the BASE mesh, but remapped those ids through the CURRENT-mesh
+// parent→children map. After the 2nd incremental stroke the stale base ids no
+// longer line up, so the underlay's coverage collapsed onto a shrinking, wrong
+// cluster of triangles (observed 6033 → 2372 → 773 on a coarse pyramid). Wherever
+// paint didn't cover, the label underlay then leaked through (e.g. purple
+// triangles near a coarse pyramid's apex). It also broke live==reload determinism
+// (a reload re-resolves to full coverage).
+//
+// The fix carries explicit/byLabel model regions forward via parent→children like
+// the paint regions already do, so coverage tracks the mesh instead of collapsing.
+
+test('api.label underlay coverage does not collapse across incremental strokes', async ({ page }) => {
+  test.setTimeout(120000);
+  const code =
+    "const { Manifold } = api;\n" +
+    "return api.label(Manifold.cylinder(22, 14, 0, 4), 'pyramid', { color: '#a855f7' });\n";
+
+  await page.goto('/editor');
+  await page.waitForFunction(() => !!(window as unknown as { partwright?: unknown }).partwright, null, {
+    timeout: 60000,
+  });
+  await page.evaluate(async (c) => { await (window as unknown as { partwright: { run: (s: string) => Promise<unknown> } }).partwright.run(c); }, code);
+  await page.waitForTimeout(4000);
+
+  // A smooth brush stroke on the +X+Y face climbing toward the apex (0,0,22).
+  function faceStroke(zLo: number, zHi: number, j: number): [number, number, number][] {
+    const s: [number, number, number][] = [];
+    for (let i = 0; i < 12; i++) {
+      const t = i / 11;
+      const z = zLo + (zHi - zLo) * t;
+      const k = z / 22;
+      s.push([7 * (1 - k) + j * Math.sin(i), 7 * (1 - k) - j * Math.cos(i), z]);
+    }
+    return s;
+  }
+
+  const coverage = async (): Promise<number> =>
+    page.evaluate(async () => {
+      const { getModelRegions } = await import('/src/color/regions.ts');
+      return getModelRegions().reduce((n, r) => n + r.triangles.size, 0);
+    });
+
+  const series: number[] = [];
+  for (let i = 0; i < 3; i++) {
+    const samples = faceStroke(4 + i * 4, 9 + i * 4, 0.9);
+    await page.evaluate(async (s) => {
+      const { addRegion } = await import('/src/color/regions.ts');
+      addRegion('S', [0.85, 0.8, 0.3], 'paintbrush',
+        { kind: 'brushStroke', samples: s, radius: 1, shape: 'circle', maxEdge: 0.0625, surface: 'slab', depth: 0, wrapAngleDeg: 90 } as never,
+        new Set<number>(), true);
+    }, samples);
+    await page.waitForTimeout(7000);
+    series.push(await coverage());
+  }
+
+  // The label covers the whole shape, so its underlay must track the (growing)
+  // subdivided mesh — never shrink. Pre-fix this collapsed (e.g. 6033→2372→773).
+  expect(series.length).toBe(3);
+  expect(series[0]).toBeGreaterThan(100);
+  for (let i = 1; i < series.length; i++) {
+    expect(series[i]).toBeGreaterThanOrEqual(series[i - 1]);
+  }
+});


### PR DESCRIPTION
## Summary

Fixes the **"purple triangle junk"** a user hit while painting a coarse model (follow-up to #815, which fixed a *different* artifact — unpainted buried triangles). Those purple triangles are the `api.label` color underlay (`#a855f7`) showing through where the painted surface color should be.

**Root cause.** `reresolveModelRegions` (`src/main.ts`) re-resolved each model region's `byLabel` descriptor from `currentLabelMap` — which indexes the **base** mesh and is set only on a code run, never updated as painting subdivides. In the *incremental* paint path, `parentToChildren` indexes the **current** mesh, so after the 2nd stroke the stale base ids `{0..5}` were remapped through a current-mesh map and the underlay's coverage **collapsed onto a shrinking, wrong cluster** of triangles. Wherever the paint layer didn't cover (e.g. a geodesic-gated brush that can't cross a coarse pyramid's sharp apex), the mis-resolved underlay leaked through. It also broke **live==reload determinism** (a reload re-resolves to full coverage).

Confirmed by direct measurement — model-region coverage on a coarse pyramid across successive incremental strokes:

| | after stroke 1 | stroke 2 | stroke 3 |
|---|---|---|---|
| **before** | 6033 | 2372 ↓ | 773 ↓↓ |
| **after** | 6033 | 11975 | 17881 (tracks the mesh) |

**Fix.** Carry explicit/`byLabel` model regions forward via `remapTriangleIds(region.triangles, parentToChildren)` during an incremental subdivision — exactly what the paint regions a few lines up already do — and only re-resolve by descriptor on a full rebuild (`parentToChildren === null`, where `currentLabelMap` matches the freshly built mesh).

## Test plan

- New `tests/paint-model-region-coverage.spec.ts` — engine-backed e2e asserting the `api.label` underlay coverage never shrinks across incremental strokes. **Fails pre-fix (773 < 6033), passes post-fix.**
- Typecheck + all 1558 unit tests pass.
- `paint-render-color`, `paint-in-code`, `save-after-paint`, `surface-paint-survival` e2e specs pass locally.

## Notes

I could **not** reproduce the exact *visible* purple from the reporter's session (it was lost, and in every reproduction I built the paint layer covered the whole mesh and hid the underlay). But the coverage collapse is a confirmed correctness + determinism bug that directly explains the reported symptom, and it's fixed here. Tracked context in the related issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012QUBh8cE2evTcBuFJCFYWc)_