### PR TITLE
test: deflake import-merge thumbnail spec by polling for async backfill

### DIFF
--- a/prompts/20260621-190000-fix-import-merge-thumbnail-flake.md
+++ b/prompts/20260621-190000-fix-import-merge-thumbnail-flake.md
@@ -1,0 +1,33 @@
+---
+title: Fix flaky import-merge thumbnail e2e test (staging gate failure)
+date: 2026-06-21
+---
+
+## Human
+
+A main → staging run failed. Can you figure out and fix?
+
+## Assistant
+
+Traced the failed `Gate main → staging` run (#450) to a single e2e failure in
+`tests/import-merge-url.spec.ts` — "merging an imported-mesh part regenerates
+its OWN thumbnail" — where `thumbs.imported` came back `undefined`. It failed on
+both the initial attempt and the retry.
+
+Reproduced locally: the test passes most of the time but fails intermittently
+(`--repeat-each=5` reliably reproduced one failure), confirming a flake rather
+than a real regression in product code.
+
+Root cause: the merge flow (`importValidatedSession` → `importSessionPartsIntoActive`
+in `src/main.ts`/`sessionManager.ts`) regenerates the merged part's thumbnail
+**asynchronously** — an inline capture on the freshly-selected part plus a
+fire-and-forget `void backfillThumbnailsForParts(...)`. The test waited only for
+`listParts().length === 2`, which resolves the moment the parts are copied in —
+*before* either thumbnail path completes — then immediately exported and read the
+thumbnail. The export occasionally raced ahead of the backfill and saw `undefined`.
+
+Decision: this is a test-timing bug, not a product defect (the thumbnail does get
+generated; the user briefly sees a placeholder, which is intended). Fixed by
+making the test `expect.poll` on the exported thumbnail itself (15s timeout)
+before asserting on it, instead of using part-count as a proxy for "thumbnail
+ready." Verified with `--repeat-each=8` (8/8 green) and the full spec file.

--- a/tests/import-merge-url.spec.ts
+++ b/tests/import-merge-url.spec.ts
@@ -169,6 +169,21 @@ test.describe('Import: merge + from-URL', () => {
       page.evaluate(() => (window as unknown as { partwright: PW }).partwright.listParts().length),
     ).toBe(2);
 
+    // The merged part's thumbnail is regenerated ASYNCHRONOUSLY after the part
+    // is copied in (an inline capture on the freshly-selected part, plus a
+    // fire-and-forget offscreen backfill). The part-count reaching 2 only
+    // signals the copy finished, NOT that the thumbnail has landed — so poll on
+    // the exported thumbnail itself before asserting, otherwise the export can
+    // race ahead of the backfill and read `undefined`.
+    await expect.poll(async () =>
+      page.evaluate(async () => {
+        const pw = (window as unknown as { partwright: PW }).partwright;
+        const { data } = await pw.exportSessionData(undefined, { includeThumbnails: true });
+        return data.versions.find((v) => (v.part ?? 0) === 1)?.thumbnail ?? null;
+      }),
+      { timeout: 15_000 },
+    ).toBeTruthy();
+
     // Export the host session (with thumbnails) and inspect the two parts'
     // thumbnails. The merged (imported) part is order 1; the host sphere is
     // order 0. `exportSession` omits the `part` field when the order is 0.


### PR DESCRIPTION
## Summary

The `Gate main → staging` run #450 (for the merge of PR #815) failed on a single e2e test: `tests/import-merge-url.spec.ts:85` — "merging an imported-mesh part regenerates its OWN thumbnail" — where `thumbs.imported` came back `undefined`. It failed on both the initial attempt and the retry, parking `staging` on the previous known-good commit.

**Root cause — a test-timing flake, not a product regression.** Reproduced locally with `--repeat-each=5` (one failure in five). The merge flow (`importValidatedSession` → `importSessionPartsIntoActive`) regenerates a merged part's thumbnail **asynchronously**: an inline capture on the freshly-selected part *plus* a fire-and-forget `void backfillThumbnailsForParts(...)`. The test only waited for `listParts().length === 2` — which resolves the moment the parts are copied in, **before** either thumbnail path completes — then immediately exported and read the thumbnail. The export occasionally raced ahead of the backfill and saw `undefined`.

The thumbnail *does* get generated (the user briefly sees a placeholder, which is intended), so this is a test-reliability bug, not a defect in the merge code.

## Fix

Make the test `expect.poll` on the exported thumbnail itself (15s timeout) before asserting on it, instead of using part-count as a proxy for "thumbnail ready."

## Test plan

- `npx playwright test import-merge-url --grep "regenerates its OWN thumbnail" --repeat-each=8` → **8/8 green** (and the test now resolves in ~3s instead of waiting blindly).
- Full `tests/import-merge-url.spec.ts` → 5/5 green.
- `npm run typecheck` → clean.
- Before the fix, `--repeat-each=5` reliably reproduced the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zpq7LUikkvTsyjWbCk4iH

---
_Generated by [Claude Code](https://claude.ai/code/session_016zpq7LUikkvTsyjWbCk4iH)_