### PR TITLE
fix: eliminate streak slivers when painting with smoothed edges

### DIFF
--- a/prompts/paint-smooth-edge-streak-slivers.md
+++ b/prompts/paint-smooth-edge-streak-slivers.md
@@ -1,0 +1,52 @@
+---
+session: "pxo3mn"
+timestamp: "2026-06-21T20:00:00Z"
+---
+
+## Human
+
+"On occasion when I paint with smoothed edges I see a triangle aberration. It's
+not consistent but here is a screenshot of what it looks like." Screenshot: a
+painted blob on a tessellated cone with thin razor-like "streaks" radiating
+downward from the painted region, aligned with the cone's vertical mesh edges.
+Follow-up: "Noticed the downward streaks close to the center."
+
+## Assistant
+
+## Key decisions
+
+**Root cause: the boundary-conforming clip emitted degenerate slivers when the
+paint outline grazed a triangle corner.** `clipByField` (src/color/subdivide.ts)
+splits every triangle the `field = 0` contour crosses into three sub-triangles
+along the crossing. When the contour grazes a corner — both edge crossings from
+one vertex land near it — the `(P1, C, Q)` sub-triangle becomes a long,
+razor-thin sliver spanning the whole triangle. The old `1e-6` parameter clamp
+was meant to prevent zero-area slivers but did the opposite: it *kept* the thin
+wedge instead of collapsing it.
+
+**Why the streaks are long and aligned with mesh edges.** `selectByClassify`
+skips refining a straddling triangle when the field is "provably straight" across
+it (a straight painted edge needs no curve refinement). So a straight outline
+grazing a *coarse, un-refined* triangle goes straight to the clip and emits a
+full-triangle-length sliver. Where the outline runs nearly parallel to a chain of
+mesh edges (the cone's vertical radial edges), each grazed triangle contributes
+one sliver → a vertical "downward streak." Intermittent because it needs the
+outline to graze near a vertex.
+
+**Fix (clip robustness, crack-free).** In `clipByField`:
+1. `crossOf` now *snaps* a crossing that lands within `CLIP_SNAP_EPS` (1% of an
+   edge) onto the existing endpoint vertex instead of minting a near-coincident
+   one. The snap is a pure function of the shared (undirected) edge, so both
+   triangles across it snap identically — no T-junction / crack.
+2. A new `emitClip` drops any sub-triangle snapping has collapsed to a point
+   (coincident indices) or a line (collinear vertices). These carry zero surface
+   area, so dropping them removes no coverage; the sibling sub-triangles already
+   tile the parent's real area.
+
+**Verification.** Headless geometry repro (build a coarse grid + a square outline
+grazing a grid column): long thin slivers went **72 → 0**, worst-triangle extent
+2.83 → 0.088 (sub-cell, invisible). Added a regression test in
+`tests/unit/subdivide.test.ts`. Full unit tier (1588 tests) green, typecheck
+clean, `lint:deps` acyclic. Browser check: painted a grazing squiggle on a
+tessellated cone via `partwright.paintStroke` — the painted edge renders smooth
+with no streaks.

--- a/retros/inbox/2026-06-21-paint-smooth-edge-streak-slivers.md
+++ b/retros/inbox/2026-06-21-paint-smooth-edge-streak-slivers.md
@@ -1,0 +1,21 @@
+---
+date: 2026-06-21
+author: claude (opus-4-8)
+task: Fix triangle "streak" slivers when painting with smoothed edges (PR #843)
+---
+
+## Liked
+- A photo of the defect + one follow-up clue ("downward streaks close to the center") was enough to localize a subtle marching-triangles bug. The clue that the streaks aligned with the cone's *vertical mesh edges* was the key that turned "intermittent sliver" into "contour grazing a corner of a coarse, un-refined triangle."
+- Delegating the first codebase sweep to the `explore` agent returned the whole smooth-paint pipeline (paintMode → refinePipeline → subdivide.clipByField) with the exact suspect function and code, so the main context stayed clean for analysis.
+- Reproducing the bug **headlessly with vite-node** before touching code: a 40-line script driving the real `buildStrokeMesh` over a coarse grid, measuring per-triangle min-altitude, gave a hard number (72 long slivers → 0) that proved both the bug and the fix without a browser round-trip.
+
+## Lacked
+- `clipByField`, `buildRefinedMesh`, and `subdivideSelected` aren't exported, so the headless repro had to go through `buildStrokeMesh` (the only exported entry). A thin `__testables__` for the clip internals would have let me assert directly on the clip output.
+- No existing "mesh-quality" assertion helper (degenerate/sliver detection by aspect ratio or min-altitude). I hand-rolled the cross-product altitude math twice (repro + unit test). A shared `triAspect`/`isSliver` test util would be reusable for any future tessellation work.
+
+## Learned
+- The `1e-6` crossing clamp in `clipByField` was an *anti-fix*: clamping a grazing crossing to 1e-6 off the vertex preserves the razor-thin wedge instead of collapsing it. The robust pattern is **snap-to-vertex on the shared edge** (pure function of the undirected edge → crack-free) then **drop the resulting zero-area sub-triangles** (zero coverage → no hole). Area-based dropping of *non-degenerate* slivers would crack; only snapped/collinear (exactly-zero-area) drops are safe.
+- The visible-long-streak (vs invisible-tiny-sliver) distinction came from `selectByClassify`'s straight-boundary refinement skip: a straight outline grazing a *coarse* triangle reaches the clip un-refined, so the sliver spans a whole coarse cell. Tiny fine-rim slivers were always present but sub-pixel.
+
+## Longed for
+- A headless way to render the *painted* mesh (not just geometry stats) — `model:preview` renders model code, but paint regions live in the app/session layer, so the visual check still needed a Playwright screenshot. A `partwright render --paint` path would close that loop.

--- a/src/color/subdivide.ts
+++ b/src/color/subdivide.ts
@@ -114,6 +114,18 @@ const MAX_PASSES = 16;
  *  rather than freeze. */
 const MAX_REFINED_TRIANGLES = 5_000_000;
 
+/** Boundary-clip snap tolerance (fraction of an edge). When the `field = 0`
+ *  contour crosses an edge within this fraction of an endpoint, the crossing is
+ *  snapped exactly onto that vertex instead of spawning a near-coincident new
+ *  one. This kills the "streak" artifact: a contour grazing a triangle corner
+ *  would otherwise emit a razor-thin sliver spanning the whole (possibly coarse,
+ *  un-refined) triangle — most visible where a straight painted edge runs nearly
+ *  parallel to a chain of mesh edges (e.g. the vertical edges down a cone). The
+ *  snap decision is a pure function of the shared edge, so neighbouring triangles
+ *  stay crack-free; the collapsed sliver becomes degenerate and is dropped. At
+ *  1% of an edge the boundary shift is sub-pixel (and zero on a refined rim). */
+const CLIP_SNAP_EPS = 1e-2;
+
 /** Whether the `slab` surface constraint is active for a stroke (mode not
  *  geodesic, a finite depth, and per-sample normals to measure offset against). */
 function slabActive(stroke: BrushStroke): boolean {
@@ -943,16 +955,26 @@ function clipByField(
     const existing = crossIndex.get(k);
     if (existing !== undefined) return existing;
     const fa = fieldAt(a), fb = fieldAt(b);
-    // Crossing parameter, clamped just off the endpoints so a contour grazing a
-    // vertex can't spawn a zero-area sliver.
-    let t = fa / (fa - fb);
-    if (!(t > 1e-6)) t = 1e-6;
-    if (!(t < 1 - 1e-6)) t = 1 - 1e-6;
-    const m = nextV++;
-    crossIndex.set(k, m);
-    for (let p = 0; p < P; p++) {
-      newVertProps.push(vertProperties[a * P + p] + t * (vertProperties[b * P + p] - vertProperties[a * P + p]));
+    const t = fa / (fa - fb);
+    // Snap a crossing that lands within CLIP_SNAP_EPS of an endpoint ONTO that
+    // existing vertex rather than minting a near-coincident one. A contour
+    // grazing a corner (both of a vertex's edges crossing near it) would
+    // otherwise spawn a long razor-thin sliver; snapping collapses it to a
+    // degenerate triangle the emit loop drops. Pure function of the (shared)
+    // edge → neighbours snap identically, so no T-junction / crack. `!(t > …)`
+    // also routes a NaN field ratio to the `a` endpoint.
+    let m: number;
+    if (!(t > CLIP_SNAP_EPS)) {
+      m = a;
+    } else if (!(t < 1 - CLIP_SNAP_EPS)) {
+      m = b;
+    } else {
+      m = nextV++;
+      for (let p = 0; p < P; p++) {
+        newVertProps.push(vertProperties[a * P + p] + t * (vertProperties[b * P + p] - vertProperties[a * P + p]));
+      }
     }
+    crossIndex.set(k, m);
     return m;
   };
 
@@ -961,6 +983,25 @@ function clipByField(
   const emit = (a: number, b: number, c: number, parent: number): void => {
     outTris.push(a, b, c);
     childParent.push(parent);
+  };
+  // Emit a clipped sub-triangle, skipping any that snapping has collapsed to a
+  // line or point (two coincident indices, or three collinear vertices). These
+  // carry zero surface area, so dropping them removes no coverage and can't open
+  // a crack — it just keeps the streak slivers out of the output. The untouched
+  // sibling sub-triangles already tile the parent's real area.
+  // Position of a vertex by index — original verts live in `vertProperties`,
+  // freshly-minted crossings in `newVertProps` (indices ≥ numVert).
+  const posOf = (v: number, axis: number): number =>
+    v < numVert ? vertProperties[v * P + axis] : newVertProps[(v - numVert) * P + axis];
+  const emitClip = (a: number, b: number, c: number, parent: number): void => {
+    if (a === b || b === c || a === c) return;
+    const e1x = posOf(b, 0) - posOf(a, 0), e1y = posOf(b, 1) - posOf(a, 1), e1z = posOf(b, 2) - posOf(a, 2);
+    const e2x = posOf(c, 0) - posOf(a, 0), e2y = posOf(c, 1) - posOf(a, 1), e2z = posOf(c, 2) - posOf(a, 2);
+    const nx = e1y * e2z - e1z * e2y;
+    const ny = e1z * e2x - e1x * e2z;
+    const nz = e1x * e2y - e1y * e2x;
+    if (nx * nx + ny * ny + nz * nz <= 1e-20) return; // collinear → zero area
+    emit(a, b, c, parent);
   };
 
   for (let t = 0; t < numTri; t++) {
@@ -982,9 +1023,9 @@ function clipByField(
     else if (in1 !== in0 && in1 !== in2) { A = v1; B = v2; C = v0; }
     else { A = v2; B = v0; C = v1; }
     const P1 = crossOf(A, B), Q = crossOf(A, C);
-    emit(A, P1, Q, t);
-    emit(P1, B, C, t);
-    emit(P1, C, Q, t);
+    emitClip(A, P1, Q, t);
+    emitClip(P1, B, C, t);
+    emitClip(P1, C, Q, t);
   }
 
   const totalVert = numVert + newVertProps.length / P;

--- a/tests/unit/subdivide.test.ts
+++ b/tests/unit/subdivide.test.ts
@@ -2,7 +2,7 @@
 // in/out test and the boundary-conforming clip). Pure geometry — no browser.
 
 import { describe, test, expect } from 'vitest';
-import { strokeSignedDist, sprayCoverage, airbrushDither, strokeFootprintTriangles, buildGeodesicField, deriveSampleNormals, wrapAngleGate, type BrushStroke } from '../../src/color/subdivide';
+import { strokeSignedDist, sprayCoverage, airbrushDither, strokeFootprintTriangles, buildGeodesicField, deriveSampleNormals, wrapAngleGate, buildStrokeMesh, type BrushStroke } from '../../src/color/subdivide';
 import { closestPointOnTriangle } from '../../src/color/adjacency';
 import type { MeshData } from '../../src/geometry/types';
 
@@ -456,5 +456,62 @@ describe('airbrush spray coverage', () => {
   test('coverage is monotonic in strength (the dither superset → non-flaky tests)', () => {
     const lo = stroke({ strength: 0.5 }), hi = stroke({ strength: 0.9 });
     for (const sd of [-10, -6, -3, -1]) expect(sprayCoverage(sd, hi)).toBeGreaterThanOrEqual(sprayCoverage(sd, lo));
+  });
+});
+
+/** Build a flat NxN coarse quad grid in the XY plane (big triangles), centered
+ *  at the origin with cell size `S`. */
+function flatGrid(N: number, S: number): MeshData {
+  const verts: number[] = [], tris: number[] = [];
+  const idx = (i: number, j: number) => i * (N + 1) + j;
+  for (let i = 0; i <= N; i++) for (let j = 0; j <= N; j++) verts.push(j * S - (N * S) / 2, i * S - (N * S) / 2, 0);
+  for (let i = 0; i < N; i++) for (let j = 0; j < N; j++) {
+    const a = idx(i, j), b = idx(i, j + 1), c = idx(i + 1, j), d = idx(i + 1, j + 1);
+    tris.push(a, b, d, a, d, c);
+  }
+  return { vertProperties: new Float32Array(verts), triVerts: new Uint32Array(tris), numVert: verts.length / 3, numTri: tris.length / 3, numProp: 3 };
+}
+
+/** Longest edge and minimum altitude (sliver width) of a triangle. */
+function triShape(m: MeshData, t: number): { longest: number; width: number } {
+  const p = (v: number) => [m.vertProperties[v * 3], m.vertProperties[v * 3 + 1], m.vertProperties[v * 3 + 2]] as const;
+  const A = p(m.triVerts[t * 3]), B = p(m.triVerts[t * 3 + 1]), C = p(m.triVerts[t * 3 + 2]);
+  const sub = (u: readonly number[], v: readonly number[]) => [u[0] - v[0], u[1] - v[1], u[2] - v[2]];
+  const len = (u: number[]) => Math.hypot(u[0], u[1], u[2]);
+  const cr = (u: number[], v: number[]) => [u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2], u[0] * v[1] - u[1] * v[0]];
+  const area = 0.5 * len(cr(sub(B, A), sub(C, A)));
+  const longest = Math.max(len(sub(B, A)), len(sub(C, B)), len(sub(A, C)));
+  return { longest, width: longest > 0 ? (2 * area) / longest : 0 };
+}
+
+describe('clipByField — no streak slivers when the boundary grazes a corner', () => {
+  // Regression for the "downward streak" paint artifact: a straight painted edge
+  // running nearly parallel to a chain of coarse mesh edges used to emit a long,
+  // razor-thin sliver spanning each grazed triangle. The snap-to-vertex clip must
+  // not produce any triangle that is both long (a meaningful fraction of a coarse
+  // cell) and razor-thin.
+  test('a square edge grazing a grid column produces no long thin slivers', () => {
+    const mesh = flatGrid(20, 2.0);
+    // Right edge of the square footprint lands at x ≈ 8.001, grazing the grid
+    // column at x = 8 (cells span x ∈ {…, 8, 10, …}).
+    const stroke: BrushStroke = { samples: [[-0.999, 0.0007, 0]], radius: 9.0, shape: 'square', maxEdge: 9.0 / 64 };
+    const { mesh: out } = buildStrokeMesh(mesh, [stroke]);
+
+    let longThinSlivers = 0;
+    for (let t = 0; t < out.numTri; t++) {
+      const { longest, width } = triShape(out, t);
+      // A streak: spans a sizeable fraction of the 2-unit cell yet is hair-thin.
+      if (longest > 0.5 && width < 0.02) longThinSlivers++;
+    }
+    expect(longThinSlivers).toBe(0);
+  });
+
+  test('the painted region is preserved (the clip still covers the footprint)', () => {
+    const mesh = flatGrid(20, 2.0);
+    const stroke: BrushStroke = { samples: [[-0.999, 0.0007, 0]], radius: 9.0, shape: 'square', maxEdge: 9.0 / 64 };
+    const { mesh: out } = buildStrokeMesh(mesh, [stroke]);
+    // Centroids well inside the footprint must still resolve as painted.
+    const painted = strokeFootprintTriangles(out, stroke);
+    expect(painted.size).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the intermittent **triangle "streak" aberration** users see when painting with smoothed edges — thin razor-like slivers radiating across the painted region, most visible on a coarse mesh whose edges run parallel to the painted outline (the reported case: vertical "downward streaks" on a tessellated cone).

**Root cause.** `clipByField` (`src/color/subdivide.ts`) is the boundary-conforming clip: every triangle the `field = 0` paint outline crosses is split into three sub-triangles along the crossing. When the contour **grazes a triangle corner** — both edge crossings from one vertex land near it — the `(P1, C, Q)` sub-triangle degenerates into a long, razor-thin sliver spanning the whole triangle. The old `1e-6` crossing clamp, intended to prevent zero-area slivers, actually *preserved* the thin wedge instead of collapsing it.

Why long & mesh-aligned: `selectByClassify` deliberately skips refining triangles where the outline is straight (no curvature to resolve), so a straight outline grazing a **coarse, un-refined** triangle reaches the clip and emits a full-triangle-length sliver. Where the outline runs nearly parallel to a chain of mesh edges (a cone's vertical radial edges), each grazed triangle contributes one sliver → a vertical streak. Intermittent because it requires the outline to graze near a vertex.

## The fix (crack-free clip robustness)

In `clipByField`:
1. **Snap-to-vertex** — `crossOf` snaps a crossing landing within `CLIP_SNAP_EPS` (1% of an edge) onto the existing endpoint vertex rather than minting a near-coincident one. The decision is a pure function of the shared (undirected) edge, so both triangles across it snap identically → no T-junction / crack. At 1% the boundary shift is sub-pixel (and zero on a refined rim).
2. **Drop degenerates** — a new `emitClip` skips sub-triangles snapping has collapsed to a point (coincident indices) or a line (collinear vertices). They carry zero surface area, so dropping them removes no coverage and can't open a crack; the sibling sub-triangles already tile the parent's real area. The painted footprint is unchanged.

## Test plan

- **Headless geometry repro** (coarse grid + square outline grazing a grid column): long thin slivers **72 → 0**; worst-triangle extent **2.83 → 0.088** (sub-cell, invisible).
- **Regression test** added to `tests/unit/subdivide.test.ts` (asserts no long thin slivers + footprint preserved).
- `npm run typecheck` clean; full unit tier **1588 passed**; `npm run lint:deps` acyclic.
- **Browser check**: painted a grazing squiggle on a tessellated cone via `partwright.paintStroke` — the painted edge renders smooth, no streaks.

| Before (reported) | After |
|---|---|
| thin vertical streaks radiating from the painted blob | clean, smooth painted edge |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXFjmmPBgroCxSfXtLnJp7)_