### PR TITLE
feat: chibi dog to cat parity + tuxedo/points colorway patterns

### DIFF
--- a/evals/cases/chibi-cat/model.js
+++ b/evals/cases/chibi-cat/model.js
@@ -23,6 +23,9 @@ const p = api.params({
   face:  { type: 'select', default: 'round',
            options: ['round', 'pointed'],
            label: 'Face' },
+  pattern: { type: 'select', default: 'solid',
+           options: ['solid', 'tuxedo', 'points'],
+           label: 'Pattern' },
 });
 
 // ============================================================
@@ -454,6 +457,65 @@ const detailRegions = [
 ];
 
 // ============================================================
+// PATTERN MARKINGS (colorway patterns: tuxedo, points)
+// Markings are PROUD labeled blobs blended into the body surface (the muzzle
+// recipe) so the nearest-centroid color remap paints them cleanly flush — an
+// `intersect`'d coincident patch would tie with `body` and salt-and-pepper.
+// `solid` adds none, so the default render is unchanged (baseline-safe).
+// ============================================================
+function markAnchorsFor() {
+  if (p.pose === 'sitting') {
+    return {
+      pawPts: [[2.7, -5.0, 2.3], [-2.7, -5.0, 2.3]],
+      chest: [0, -4.6, 9.2], chestR: [3.3, 4.7, 5.0],
+      faceCenter: [0, fc.muzzleY + 2.7, fc.muzzleZ + 0.6], faceR: [4.3, 2.5, 3.7],
+      tailPts: [[5.2, -2.5, 3.2], [3.0, -6.0, 2.2]],
+      earPts: [ears.innerEarLPos, ears.innerEarRPos],
+    };
+  }
+  const br = bodyResult;
+  return {
+    pawPts: [
+      [br.frontLegX, br.frontLegY, br.legBottom], [-br.frontLegX, br.frontLegY, br.legBottom],
+      [br.backLegX, br.backLegY, br.legBottom], [-br.backLegX, br.backLegY, br.legBottom],
+    ],
+    chest: [0, br.frontLegY - 1.2, br.legBottom + 3.5], chestR: [3.2, 3.0, 4.0],
+    faceCenter: [0, br.headY - 4.6, br.headZ - 1.6], faceR: [4.4, 3.2, 4.0],
+    tailPts: [[0, br.rearY + 0.5, br.rearZ + 6.0]],
+    earPts: [ears.innerEarLPos, ears.innerEarRPos],
+  };
+}
+
+function buildMarkings() {
+  if (p.pattern === 'solid') return [];
+  const a = markAnchorsFor();
+  const out = [];
+  if (p.pattern === 'tuxedo') {
+    // White bib (chest) + white socks (paws)
+    out.push(sdf.ellipsoid(a.chestR[0], a.chestR[1], a.chestR[2])
+      .translate(a.chest[0], a.chest[1], a.chest[2]).label('bib'));
+    for (const [x, y, z] of a.pawPts) {
+      out.push(sdf.ellipsoid(2.7, 2.3, 2.5).translate(x, y, z).label('socks'));
+    }
+  } else if (p.pattern === 'points') {
+    // Siamese-style darker extremities: ears, face mask, paws, tail tip
+    for (const [x, y, z] of a.earPts) {
+      out.push(sdf.ellipsoid(2.4, 1.4, 3.0).translate(x, y, z + 0.5).label('points'));
+    }
+    out.push(sdf.ellipsoid(a.faceR[0], a.faceR[1], a.faceR[2])
+      .translate(a.faceCenter[0], a.faceCenter[1], a.faceCenter[2]).label('points'));
+    for (const [x, y, z] of a.pawPts) {
+      out.push(sdf.ellipsoid(2.5, 2.5, 1.9).translate(x, y, z).label('points'));
+    }
+    for (const [x, y, z] of a.tailPts) {
+      out.push(sdf.ellipsoid(2.2, 2.4, 2.2).translate(x, y, z).label('points'));
+    }
+  }
+  return out;
+}
+const markings = buildMarkings();
+
+// ============================================================
 // ASSEMBLE & LIFT TO z≥0
 // ============================================================
 const cat = sdf.union(
@@ -465,7 +527,8 @@ const cat = sdf.union(
   lidsL, lidsR,
   noseFull,
   mouth,
-  innerEarL, innerEarR
+  innerEarL, innerEarR,
+  ...markings
 );
 
 // Lift to ensure min-z ≈ 0.

--- a/evals/cases/chibi-cat/palettes/points.json
+++ b/evals/cases/chibi-cat/palettes/points.json
@@ -1,0 +1,12 @@
+{
+  "body": "#EDE2CE",
+  "lids": "#DCCFB6",
+  "muzzle": "#F3ECDC",
+  "eye": "#FAFAFA",
+  "iris": "#4F8FD0",
+  "pupil": "#141414",
+  "nose": "#9A6A60",
+  "mouth": "#4A352F",
+  "innerEar": "#C99C86",
+  "points": "#4A3329"
+}

--- a/evals/cases/chibi-cat/palettes/tuxedo.json
+++ b/evals/cases/chibi-cat/palettes/tuxedo.json
@@ -1,0 +1,13 @@
+{
+  "body": "#26272D",
+  "lids": "#1F2025",
+  "muzzle": "#F4F4EE",
+  "eye": "#FAFAFA",
+  "iris": "#5BA86F",
+  "pupil": "#141414",
+  "nose": "#E79AA6",
+  "mouth": "#3A2E2E",
+  "innerEar": "#E9A6AD",
+  "bib": "#F4F4EE",
+  "socks": "#F4F4EE"
+}

--- a/evals/cases/chibi-dog/model.js
+++ b/evals/cases/chibi-dog/model.js
@@ -1,125 +1,490 @@
-// Dog A — "Floppy Ears Chibi" — cocker spaniel feel: long drooping ears, snout, gentle look
-// Sitting pose, face points -Y, Z up.
-// v4: ear Y-radius 0.8→1.5 (printable), eyeR 1.05→1.35 + spacing ±2.9, nose Y −12.5→−11.5,
-//     tail X 2.0→3.5 (visible 3/4), neck radius 2.8→3.1, flat base disc (print-safe)
+// Dog — Parametric chibi dog with pose, build, ears, tail, face, pattern variants
+// Face points -Y, Z up.  Brought to cat-parity: figure-API eyelids, colored
+// muzzle/nose/mouth/inner-ear labels, parametric builder + paramsSchema, and the
+// shared proud-blob pattern markings (tuxedo, tan-points).
+// v5: parity rewrite (was a single hand-tuned spaniel).
+
 const { sdf } = api;
 
 // ============================================================
-// Eye geometry constants
-// eyeR enlarged for soulful-puppy look
+// PARAMS
 // ============================================================
-const eyeR = 1.35;
-const eyeAnchorLx = -2.9;
-const eyeAnchorRx =  2.9;
-const eyeAnchorY  = -9.0; // pushed back into head for overlap
-const eyeAnchorZ  = 25.5;
+const p = api.params({
+  pose:  { type: 'select', default: 'sitting',
+           options: ['sitting', 'standing'],
+           label: 'Pose' },
+  build: { type: 'select', default: 'average',
+           options: ['puppy', 'slim', 'average', 'chonky'],
+           label: 'Build' },
+  ears:  { type: 'select', default: 'floppy',
+           options: ['floppy', 'perky', 'long'],
+           label: 'Ears' },
+  tail:  { type: 'select', default: 'curl',
+           options: ['curl', 'short', 'fluffy'],
+           label: 'Tail' },
+  face:  { type: 'select', default: 'snouty',
+           options: ['snouty', 'round'],
+           label: 'Face' },
+  pattern: { type: 'select', default: 'solid',
+           options: ['solid', 'tuxedo', 'tan-points'],
+           label: 'Pattern' },
+});
 
 // ============================================================
-// BODY MASSES
+// BUILD SCALE TABLE
 // ============================================================
+const BUILD = {
+  puppy:   { bodyRx: 6.0, bodyRy: 4.8, bodyRz: 4.4, headScale: 1.18, legThick: 1.8, legLength: 3.0 },
+  slim:    { bodyRx: 5.6, bodyRy: 4.4, bodyRz: 4.8, headScale: 0.95, legThick: 1.8, legLength: 5.0 },
+  average: { bodyRx: 6.6, bodyRy: 5.2, bodyRz: 5.0, headScale: 1.00, legThick: 2.1, legLength: 4.2 },
+  chonky:  { bodyRx: 8.0, bodyRy: 6.6, bodyRz: 5.8, headScale: 1.06, legThick: 2.6, legLength: 3.4 },
+};
+const bld = BUILD[p.build];
 
-const haunches = sdf.ellipsoid(8.5, 6.0, 4.5).translate(0, 0, 4.5);
-const torso = sdf.ellipsoid(7.0, 5.5, 5.5).translate(0, -0.5, 10.0);
-let bodyMass = haunches.smoothUnion(torso, 2.2);
+// ============================================================
+// EYE GEOMETRY CONSTANTS  (big soulful puppy eyes, recessed for lids)
+// ============================================================
+const eyeR        = 2.6;   // chibi-sized eyes
+const eyeAnchorLx = -3.5;
+const eyeAnchorRx =  3.5;
+const eyeAnchorY  = -7.0;  // slightly recessed in head for natural look (head front ≈ -8.2)
+const eyeAnchorZ  = 24.0;
+const halfBoxY    = 50;
+const eyeClipBox  = sdf.box([eyeR * 2 + 2, halfBoxY * 2, eyeR * 2 + 2]);
 
-// Flat stable base disc — thick enough to guarantee z=0 flat floor
-const baseDisc = sdf.ellipsoid(8.5, 5.8, 2.5).translate(0, 0, 2.5);
-bodyMass = bodyMass.smoothUnion(baseDisc, 2.0);
+// ============================================================
+// FACE / SNOUT GEOMETRY (face = snouty vs round)
+// A real projecting dog snout (ellipsoid long in -Y) with nose at the tip.
+// snoutRy controls how far the muzzle projects forward — key for dog vs cat.
+// ============================================================
+const FACE = {
+  snouty: { headRx: 8.4, headRy: 7.2, headRz: 7.8, headY: -1.0, headZ: 22.5,
+            snoutRx: 3.6, snoutRy: 5.5, snoutRz: 3.2, snoutY: -9.8, snoutZ: 19.8,
+            muzzleRx: 3.2, muzzleRy: 1.4, muzzleRz: 2.2, muzzleY: -14.0, muzzleZ: 19.6,
+            noseY: -15.0, noseZ: 20.2 },
+  round:  { headRx: 8.6, headRy: 7.8, headRz: 8.0, headY: -1.0, headZ: 22.5,
+            snoutRx: 3.6, snoutRy: 3.8, snoutRz: 3.0, snoutY: -8.4, snoutZ: 19.2,
+            muzzleRx: 3.0, muzzleRy: 1.1, muzzleRz: 2.1, muzzleY: -11.4, muzzleZ: 19.0,
+            noseY: -12.4, noseZ: 19.8 },
+};
+const fc = FACE[p.face];
 
-// Front legs — forward-placed sitting pose
-const pawFront = sdf.capsule([4.0, -3.0, 8.5], [4.0, -3.5, 1.5], 2.0).mirrorPair('x');
-bodyMass = bodyMass.smoothUnion(pawFront, 2.2);
+// ============================================================
+// BODY GEOMETRY (pose-dependent)
+// ============================================================
+function buildSittingBody() {
+  const haunches = sdf.ellipsoid(8.0, 6.0, 4.6).translate(0, 0, 4.4);
+  const torso = sdf.ellipsoid(bld.bodyRx, bld.bodyRy, bld.bodyRz).translate(0, -0.5, 9.5);
+  let bodyMass = haunches.smoothUnion(torso, 2.5);
 
-// Neck — softened cinch (radius 2.8→3.1)
-const neck = sdf.capsule([0, -1, 14.5], [0, -1.5, 16.5], 3.1);
-bodyMass = bodyMass.smoothUnion(neck, 2.0);
+  const baseDisc = sdf.ellipsoid(8.2, 5.6, 2.5).translate(0, 0, 2.5);
+  bodyMass = bodyMass.smoothUnion(baseDisc, 2.2);
 
-// Head — big round chibi head
-const head = sdf.ellipsoid(8.0, 7.0, 7.5).translate(0, -1.5, 23.0);
-bodyMass = bodyMass.smoothUnion(head, 2.2);
+  // Front legs/paws — forward-placed sitting pose
+  const pawFront = sdf.capsule([3.2, -4.0, 8.0], [3.4, -4.4, 1.2], 2.1).mirrorPair('x');
+  bodyMass = bodyMass.smoothUnion(pawFront, 2.0);
 
-// Floppy ears: Y-radius 0.8→1.5 for printable thickness
-const flopEarR = sdf.ellipsoid(2.0, 1.5, 6.5).translate(8.5, -0.5, 21.0);
-const flopEarL = sdf.ellipsoid(2.0, 1.5, 6.5).translate(-8.5, -0.5, 21.0);
-bodyMass = bodyMass.smoothUnion(flopEarR, 1.8).smoothUnion(flopEarL, 1.8);
+  const neck = sdf.capsule([0, -1.0, 13.5], [0, -1.0, 15.5], 2.9);
+  bodyMass = bodyMass.smoothUnion(neck, 2.4);
 
-// Spaniel snout
-const muzzlePad = sdf.ellipsoid(2.5, 1.4, 1.2).translate(0, -10.0, 21.5);
-bodyMass = bodyMass.smoothUnion(muzzlePad, 1.8);
+  const headSdf = sdf.ellipsoid(fc.headRx * bld.headScale, fc.headRy * bld.headScale, fc.headRz * bld.headScale)
+    .translate(0, fc.headY, fc.headZ);
+  bodyMass = bodyMass.smoothUnion(headSdf, 3.0);
 
-const snout = sdf.ellipsoid(4.5, 2.8, 3.2).translate(0, -10.0, 22.0);
-bodyMass = bodyMass.smoothUnion(snout, 2.2);
+  // Projecting snout
+  const snout = sdf.ellipsoid(fc.snoutRx, fc.snoutRy, fc.snoutRz).translate(0, fc.snoutY, fc.snoutZ);
+  bodyMass = bodyMass.smoothUnion(snout, 2.0);
 
-// Stubby happy tail: X shifted 2.0→3.5 so it peeks into 3/4 view
-const tailBase = sdf.capsule([0, 5.5, 11.0], [3.5, 7.0, 15.5], 1.8);
-const tailTip  = sdf.capsule([3.5, 7.0, 15.5], [3.0, 7.5, 16.8], 2.0);
-let tail = tailBase.smoothUnion(tailTip, 1.5);
-bodyMass = bodyMass.smoothUnion(tail, 2.0);
+  return { bodyMass, headCenter: [0, fc.headY, fc.headZ] };
+}
+
+function buildStandingBody() {
+  const lt = bld.legThick;
+  const ll = bld.legLength;
+  const pawZ   = lt;
+  const legTopZ = pawZ + ll;
+
+  const bodyRx = bld.bodyRx * 0.72;
+  const bodyRY = bld.bodyRx * 1.50;
+  const bodyRz = bld.bodyRz * 0.82;
+  const bodyCenterZ = legTopZ + bodyRz;
+
+  const legX  = bodyRx  * 0.74;
+  const legFY = -bodyRY * 0.50;
+  const legBY =  bodyRY * 0.52;
+
+  const legFL = sdf.capsule([ legX, legFY, pawZ], [ legX, legFY, legTopZ], lt);
+  const legFR = sdf.capsule([-legX, legFY, pawZ], [-legX, legFY, legTopZ], lt);
+  const legBL = sdf.capsule([ legX, legBY, pawZ], [ legX, legBY, legTopZ], lt);
+  const legBR = sdf.capsule([-legX, legBY, pawZ], [-legX, legBY, legTopZ], lt);
+
+  const pawFL = sdf.ellipsoid(lt * 1.25, lt * 1.10, lt * 0.75).translate( legX, legFY, pawZ);
+  const pawFR = sdf.ellipsoid(lt * 1.25, lt * 1.10, lt * 0.75).translate(-legX, legFY, pawZ);
+  const pawBL = sdf.ellipsoid(lt * 1.15, lt * 1.25, lt * 0.75).translate( legX, legBY, pawZ);
+  const pawBR = sdf.ellipsoid(lt * 1.15, lt * 1.25, lt * 0.75).translate(-legX, legBY, pawZ);
+
+  const torso    = sdf.ellipsoid(bodyRx, bodyRY, bodyRz).translate(0, 0, bodyCenterZ);
+  const haunchY  = bodyRY * 0.55;
+  const haunches = sdf.ellipsoid(bodyRx * 0.92, bodyRY * 0.55, bodyRz * 0.94)
+    .translate(0, haunchY, bodyCenterZ + bodyRz * 0.08);
+  const chestY  = -bodyRY * 0.55;
+  const chest   = sdf.ellipsoid(bodyRx * 0.78, bodyRY * 0.45, bodyRz * 0.84)
+    .translate(0, chestY, bodyCenterZ + bodyRz * 0.10);
+
+  let bodyMass = torso
+    .smoothUnion(haunches, 2.8)
+    .smoothUnion(chest,    2.4)
+    .smoothUnion(legFL, 2.2).smoothUnion(legFR, 2.2)
+    .smoothUnion(legBL, 2.2).smoothUnion(legBR, 2.2)
+    .smoothUnion(pawFL, 1.6).smoothUnion(pawFR, 1.6)
+    .smoothUnion(pawBL, 1.6).smoothUnion(pawBR, 1.6);
+
+  const neckRootZ = bodyCenterZ + bodyRz * 0.60;
+  const neckRootY = -bodyRY * 0.60;
+  const neckTipZ  = neckRootZ + 3.5;
+  const neckTipY  = neckRootY - 2.0;
+  const neck = sdf.capsule([0, neckRootY, neckRootZ], [0, neckTipY, neckTipZ], 2.8);
+  bodyMass = bodyMass.smoothUnion(neck, 2.8);
+
+  const headRxS = fc.headRx * bld.headScale;
+  const headRyS = fc.headRy * bld.headScale;
+  const headRzS = fc.headRz * bld.headScale;
+  const headY  = neckTipY - headRyS * 0.55;
+  const headZ  = neckTipZ + headRzS * 0.28;
+  const headSdf = sdf.ellipsoid(headRxS, headRyS, headRzS).translate(0, headY, headZ);
+  bodyMass = bodyMass.smoothUnion(headSdf, 3.2);
+
+  const snout = sdf.ellipsoid(fc.snoutRx, fc.snoutRy, fc.snoutRz)
+    .translate(0, headY + (fc.snoutY - fc.headY), headZ + (fc.snoutZ - fc.headZ));
+  bodyMass = bodyMass.smoothUnion(snout, 2.0);
+
+  return {
+    bodyMass,
+    headCenter: [0, headY, headZ],
+    legBottom: pawZ,
+    frontLegX: legX, frontLegY: legFY,
+    backLegX:  legX, backLegY:  legBY,
+    headY, headZ,
+    headDeltaY: headY - fc.headY,
+    headDeltaZ: headZ - fc.headZ,
+    rearY: bodyRY * 0.86,
+    rearZ: bodyCenterZ,
+  };
+}
+
+// ============================================================
+// BUILD THE BODY + face-feature offsets
+// ============================================================
+let bodyResult, eyeZ, eyeY, faceDY, faceDZ;
+
+if (p.pose === 'sitting') {
+  bodyResult = buildSittingBody();
+  eyeZ = eyeAnchorZ;  eyeY = eyeAnchorY;  faceDY = 0;  faceDZ = 0;
+} else {
+  bodyResult = buildStandingBody();
+  faceDY = bodyResult.headDeltaY;  faceDZ = bodyResult.headDeltaZ;
+  eyeZ = eyeAnchorZ + faceDZ;  eyeY = eyeAnchorY + faceDY;
+}
+
+// ============================================================
+// EARS
+// ============================================================
+function buildEars(headCenter) {
+  const hx = fc.headRx * bld.headScale;
+  const hz = fc.headRz * bld.headScale;
+  const [hcx, hcy, hcz] = headCenter;
+  const sideX = hx * 0.86;
+  const topZ  = hcz + hz * 0.45;
+
+  if (p.ears === 'floppy') {
+    // Spaniel floppy ears: root at the temple/side of the head, drape downward.
+    // Three-point capsule chain for a gentle outward-then-down hang.
+    const earRootZ  = hcz + hz * 0.15;   // attach mid-height on head side
+    const earMidZ   = earRootZ - 3.0;    // swings outward as it drops
+    const earTipZ   = earRootZ - 8.5;    // hangs well below chin
+    const earOutX   = hx * 0.92;         // just at the head side
+    const earMidX   = hx * 1.08;         // swings slightly wider at mid
+    const earCY     = hcy - 0.5;         // at the face center plane
+
+    const earTopL = sdf.capsule([-earOutX, earCY, earRootZ], [-earMidX, earCY + 0.4, earMidZ], 2.1);
+    const earBotL = sdf.capsule([-earMidX, earCY + 0.4, earMidZ], [-earMidX * 0.9, earCY + 0.8, earTipZ], 1.6);
+    const earL = earTopL.smoothUnion(earBotL, 1.5);
+
+    const earTopR = sdf.capsule([ earOutX, earCY, earRootZ], [ earMidX, earCY + 0.4, earMidZ], 2.1);
+    const earBotR = sdf.capsule([ earMidX, earCY + 0.4, earMidZ], [ earMidX * 0.9, earCY + 0.8, earTipZ], 1.6);
+    const earR = earTopR.smoothUnion(earBotR, 1.5);
+
+    return { earL, earR, blend: 1.8,
+             innerEarLPos: [-earOutX, earCY - 0.5, earRootZ - 1.0],
+             innerEarRPos: [ earOutX, earCY - 0.5, earRootZ - 1.0] };
+  } else if (p.ears === 'perky') {
+    // Upright triangular ears
+    const earL = sdf.ellipsoid(2.4, 0.9, 3.6).rotate(0, -18, 0).translate(-hx * 0.55, hcy - 0.3, topZ + 3.0);
+    const earR = sdf.ellipsoid(2.4, 0.9, 3.6).rotate(0,  18, 0).translate( hx * 0.55, hcy - 0.3, topZ + 3.0);
+    return { earL, earR, blend: 2.4,
+             innerEarLPos: [-hx * 0.55, hcy - 1.0, topZ + 3.0],
+             innerEarRPos: [ hx * 0.55, hcy - 1.0, topZ + 3.0] };
+  } else {
+    // long: basset hound — very long floppy ears, hanging well below the chin.
+    // Keep ears at sides (don't pull inward at the tip) to avoid topology tunnels.
+    const earRootZ  = hcz + hz * 0.10;
+    const earMidZ   = earRootZ - 4.5;
+    const earTipZ   = earRootZ - 10.0;   // long but not so long they encircle the body
+    const earOutX   = hx * 0.90;
+    const earMidX   = hx * 1.05;         // swings out slightly at mid
+    const earCY     = hcy - 0.3;
+
+    const earTopL = sdf.capsule([-earOutX, earCY, earRootZ], [-earMidX, earCY + 0.5, earMidZ], 2.2);
+    const earBotL = sdf.capsule([-earMidX, earCY + 0.5, earMidZ], [-earMidX, earCY + 0.8, earTipZ], 1.7);
+    const earL = earTopL.smoothUnion(earBotL, 1.6);
+
+    const earTopR = sdf.capsule([ earOutX, earCY, earRootZ], [ earMidX, earCY + 0.5, earMidZ], 2.2);
+    const earBotR = sdf.capsule([ earMidX, earCY + 0.5, earMidZ], [ earMidX, earCY + 0.8, earTipZ], 1.7);
+    const earR = earTopR.smoothUnion(earBotR, 1.6);
+
+    return { earL, earR, blend: 1.8,
+             innerEarLPos: [-earOutX, earCY - 0.6, earRootZ - 1.5],
+             innerEarRPos: [ earOutX, earCY - 0.6, earRootZ - 1.5] };
+  }
+}
+
+// ============================================================
+// TAIL
+// ============================================================
+function buildTail(rootX, rootY, rootZ) {
+  if (p.tail === 'curl') {
+    const t0 = sdf.capsule([rootX, rootY + 1.5, rootZ],      [rootX + 2.5, rootY + 2.0, rootZ + 3.0], 1.9);
+    const t1 = sdf.capsule([rootX + 2.5, rootY + 2.0, rootZ + 3.0], [rootX + 1.5, rootY + 1.0, rootZ + 5.5], 1.6);
+    const t2 = sdf.capsule([rootX + 1.5, rootY + 1.0, rootZ + 5.5], [rootX - 0.5, rootY + 1.5, rootZ + 6.0], 1.4);
+    return t0.smoothUnion(t1, 1.5).smoothUnion(t2, 1.3);
+  } else if (p.tail === 'short') {
+    const stub = sdf.capsule([rootX, rootY + 1.0, rootZ], [rootX + 1.5, rootY + 2.5, rootZ + 2.0], 1.9);
+    const tip  = sdf.sphere(1.8).translate(rootX + 1.8, rootY + 3.2, rootZ + 3.0);
+    return stub.smoothUnion(tip, 1.3);
+  } else {
+    // fluffy: thick plumed tail
+    const t0 = sdf.capsule([rootX, rootY + 1.5, rootZ],      [rootX + 3.0, rootY + 2.5, rootZ + 3.5], 2.6);
+    const t1 = sdf.capsule([rootX + 3.0, rootY + 2.5, rootZ + 3.5], [rootX + 2.0, rootY + 1.0, rootZ + 6.5], 2.3);
+    const t2 = sdf.sphere(2.1).translate(rootX + 0.5, rootY + 1.5, rootZ + 7.0);
+    return t0.smoothUnion(t1, 2.0).smoothUnion(t2, 1.8);
+  }
+}
+
+// ============================================================
+// ASSEMBLE BODY + EARS + TAIL
+// ============================================================
+let { bodyMass } = bodyResult;
+const headCenter = bodyResult.headCenter;
+
+const ears = buildEars(headCenter);
+bodyMass = bodyMass.smoothUnion(ears.earL, ears.blend).smoothUnion(ears.earR, ears.blend);
+
+let tail;
+if (p.pose === 'sitting') {
+  tail = buildTail(4.5, 4.5, 6.0);
+} else {
+  const rY = bodyResult.rearY || 8.0;
+  const rZ = bodyResult.rearZ || 10.0;
+  if (p.tail === 'short') {
+    const t0 = sdf.capsule([0, rY, rZ + 0.5], [0, rY + 2.5, rZ + 3.0], 1.8);
+    const t1 = sdf.sphere(1.7).translate(0, rY + 3.0, rZ + 4.5);
+    tail = t0.smoothUnion(t1, 1.3);
+  } else if (p.tail === 'fluffy') {
+    const t0 = sdf.capsule([0, rY,       rZ + 0.5], [0, rY + 2.5, rZ + 4.5], 2.6);
+    const t1 = sdf.capsule([0, rY + 2.5, rZ + 4.5], [0, rY + 2.0, rZ + 8.5], 2.3);
+    const t2 = sdf.sphere(2.0).translate(0, rY + 1.0, rZ + 9.5);
+    tail = t0.smoothUnion(t1, 1.9).smoothUnion(t2, 1.7);
+  } else {
+    // curl up
+    const t0 = sdf.capsule([0, rY,       rZ + 0.5], [0, rY + 2.0, rZ + 4.0], 1.9);
+    const t1 = sdf.capsule([0, rY + 2.0, rZ + 4.0], [0, rY + 1.0, rZ + 7.5], 1.6);
+    const t2 = sdf.capsule([0, rY + 1.0, rZ + 7.5], [0, rY - 1.5, rZ + 8.5], 1.4);
+    tail = t0.smoothUnion(t1, 1.6).smoothUnion(t2, 1.4);
+  }
+}
+bodyMass = bodyMass.smoothUnion(tail, 1.8);
 
 const bodyLabeled = bodyMass.label('body');
 
 // ============================================================
-// EYES — ball-in-ball (eyeR = 1.35)
+// MUZZLE PAD (lighter snout underside / mouth area)
 // ============================================================
+const muzzleY = fc.muzzleY + faceDY;
+const muzzleZ = fc.muzzleZ + faceDZ;
+const muzzlePad = sdf.ellipsoid(fc.muzzleRx, fc.muzzleRy, fc.muzzleRz)
+  .translate(0, muzzleY, muzzleZ).label('muzzle');
 
-const eyeballL = sdf.sphere(eyeR).translate(eyeAnchorLx, eyeAnchorY, eyeAnchorZ).label('eye');
-const eyeballR = sdf.sphere(eyeR).translate(eyeAnchorRx, eyeAnchorY, eyeAnchorZ).label('eye');
+// ============================================================
+// INNER-EAR PADS
+// ============================================================
+const [ielx, iely, ielz] = ears.innerEarLPos;
+const [ierx, iery, ierz] = ears.innerEarRPos;
+// Inner ear pads: must be placed on the INNER face of the ear (facing the head / -Y)
+// and protrude slightly outward from the ear surface so the nearest-centroid remap
+// correctly assigns them the innerEar color.
+// For floppy ears the ear face points somewhat forward (-Y), so we offset slightly in -Y.
+let innerEarL, innerEarR;
+if (p.ears === 'floppy' || p.ears === 'long') {
+  // Place on the face of the ear that looks toward the viewer (-Y side of the ear capsule).
+  // The ear capsule has radius ~2.1-2.2, so we need to protrude past that in -Y.
+  // Use a larger Y protrusion to reliably sit on the outside surface of the ear.
+  const ieOffY = -1.8;
+  innerEarL = sdf.ellipsoid(1.3, 0.4, 2.6).translate(ielx, iely + ieOffY, ielz).label('innerEar');
+  innerEarR = sdf.ellipsoid(1.3, 0.4, 2.6).translate(ierx, iery + ieOffY, ierz).label('innerEar');
+} else {
+  innerEarL = sdf.ellipsoid(1.3, 0.7, 2.6).rotate(0, -18, 0).translate(ielx, iely - 0.5, ielz).label('innerEar');
+  innerEarR = sdf.ellipsoid(1.3, 0.7, 2.6).rotate(0,  18, 0).translate(ierx, iery - 0.5, ierz).label('innerEar');
+}
 
-// Iris cap
-const irisDiscR    = eyeR * 0.55;
-const irisProtrude = eyeR * 0.15;
+// ============================================================
+// EYES — ball-in-ball iris/pupil caps (cat recipe)
+// ============================================================
+const eyeSphereL = sdf.sphere(eyeR).translate(eyeAnchorLx, eyeY, eyeZ);
+const eyeSphereR = sdf.sphere(eyeR).translate(eyeAnchorRx, eyeY, eyeZ);
+const eyeClipL   = eyeClipBox.translate(eyeAnchorLx, eyeY - halfBoxY, eyeZ);
+const eyeClipR   = eyeClipBox.translate(eyeAnchorRx, eyeY - halfBoxY, eyeZ);
+const eyeballL   = eyeSphereL.intersect(eyeClipL).label('eye');
+const eyeballR   = eyeSphereR.intersect(eyeClipR).label('eye');
+
+const eyeFrontY_actual = eyeY - eyeR;
+
+const irisDiscR     = eyeR * 0.80;   // big iris fills the eye (soft, not startled)
+const irisProtrude  = eyeR * 0.18;   // more dome = looks glossy
 const irisBallRadius = (irisDiscR * irisDiscR + irisProtrude * irisProtrude) / (2 * irisProtrude);
-const eyeFrontY    = eyeAnchorY - eyeR;
-const irisBallCY   = eyeFrontY + irisBallRadius - irisProtrude;
-
-const irisBallL = sdf.sphere(irisBallRadius).translate(eyeAnchorLx, irisBallCY, eyeAnchorZ);
-const irisBallR = sdf.sphere(irisBallRadius).translate(eyeAnchorRx, irisBallCY, eyeAnchorZ);
-const irisClipL = sdf.cylinder(irisDiscR, irisBallRadius * 3.0)
-  .rotate(90, 0, 0).translate(eyeAnchorLx, irisBallCY, eyeAnchorZ);
-const irisClipR = sdf.cylinder(irisDiscR, irisBallRadius * 3.0)
-  .rotate(90, 0, 0).translate(eyeAnchorRx, irisBallCY, eyeAnchorZ);
+const irisBallCY    = eyeFrontY_actual + irisBallRadius - irisProtrude;
+const irisBallL = sdf.sphere(irisBallRadius).translate(eyeAnchorLx, irisBallCY, eyeZ);
+const irisBallR = sdf.sphere(irisBallRadius).translate(eyeAnchorRx, irisBallCY, eyeZ);
+const irisClipL = sdf.cylinder(irisDiscR, irisBallRadius * 3.0).rotate(90, 0, 0).translate(eyeAnchorLx, irisBallCY, eyeZ);
+const irisClipR = sdf.cylinder(irisDiscR, irisBallRadius * 3.0).rotate(90, 0, 0).translate(eyeAnchorRx, irisBallCY, eyeZ);
 const irisCapL = irisBallL.intersect(irisClipL).label('iris');
 const irisCapR = irisBallR.intersect(irisClipR).label('iris');
 
-// Pupil cap — protrudes past iris
-const irisCapFrontY  = eyeFrontY - irisProtrude;
-const pupilDiscR     = eyeR * 0.27;
-const pupilExtraProtrude = eyeR * 0.10;
-const pupilBallRadius = (pupilDiscR * pupilDiscR + pupilExtraProtrude * pupilExtraProtrude) / (2 * pupilExtraProtrude);
-const pupilBallCY    = irisCapFrontY + pupilBallRadius - pupilExtraProtrude;
-
-const pupilBallL  = sdf.sphere(pupilBallRadius).translate(eyeAnchorLx, pupilBallCY, eyeAnchorZ);
-const pupilBallRn = sdf.sphere(pupilBallRadius).translate(eyeAnchorRx, pupilBallCY, eyeAnchorZ);
-const pupilClipL  = sdf.cylinder(pupilDiscR, pupilBallRadius * 3.0)
-  .rotate(90, 0, 0).translate(eyeAnchorLx, pupilBallCY, eyeAnchorZ);
-const pupilClipR  = sdf.cylinder(pupilDiscR, pupilBallRadius * 3.0)
-  .rotate(90, 0, 0).translate(eyeAnchorRx, pupilBallCY, eyeAnchorZ);
+const irisCapFrontY      = eyeFrontY_actual - irisProtrude;
+const pupilDiscR         = eyeR * 0.44;
+const pupilExtraProtrude = eyeR * 0.20;
+const pupilBallRadius    = (pupilDiscR * pupilDiscR + pupilExtraProtrude * pupilExtraProtrude) / (2 * pupilExtraProtrude);
+const pupilBallCY        = irisCapFrontY + pupilBallRadius - pupilExtraProtrude;
+const pupilBallL  = sdf.sphere(pupilBallRadius).translate(eyeAnchorLx, pupilBallCY, eyeZ);
+const pupilBallRn = sdf.sphere(pupilBallRadius).translate(eyeAnchorRx, pupilBallCY, eyeZ);
+const pupilClipL  = sdf.cylinder(pupilDiscR, pupilBallRadius * 3.0).rotate(90, 0, 0).translate(eyeAnchorLx, pupilBallCY, eyeZ);
+const pupilClipR  = sdf.cylinder(pupilDiscR, pupilBallRadius * 3.0).rotate(90, 0, 0).translate(eyeAnchorRx, pupilBallCY, eyeZ);
 const pupilCapL = pupilBallL.intersect(pupilClipL).label('pupil');
 const pupilCapR = pupilBallRn.intersect(pupilClipR).label('pupil');
 
-// Nose — protrudes 0.7 units PAST snout tip so the label surface is exposed
-// Snout tip at ~y=-12.8. Nose center at -12.1 (Y-radius 1.0 → nose tip at -13.1, overlap at -12.8)
-// Nose must be smoothUnioned into body FIRST so it's part of bodyMass, THEN labeled in final union
-const nose = sdf.ellipsoid(1.5, 1.0, 1.1).translate(0, -12.1, 21.8).label('nose');
+// ============================================================
+// EYELIDS (figure-API recipe — frames eyes, kills protrusion)
+// Lower UPPER_FRAC so the lid doesn't shadow the iris too much.
+// ============================================================
+const LID_SCALE    = 1.05;
+const LID_TILT_DEG = 14;
+const UPPER_FRAC   = 0.20;  // gentle upper-lid → soft, not startled
+const LOWER_FRAC   = 0.10;
+const lidR = eyeR * LID_SCALE;
+const big  = lidR * 4;
+function makeLidCap(dir, frac) {
+  const mz = dir * (1 - 2 * frac) * eyeR;
+  const halfSpace = sdf.box([big, big, big])
+    .translate([0, 0, dir * big / 2])
+    .rotate([dir * LID_TILT_DEG, 0, 0])
+    .translate([0, 0, mz]);
+  return sdf.sphere(lidR).intersect(halfSpace);
+}
+const lidsAtOrigin = sdf.union(makeLidCap(1, UPPER_FRAC), makeLidCap(-1, LOWER_FRAC));
+const lidsL = lidsAtOrigin.translate(eyeAnchorLx, eyeY, eyeZ).label('lids');
+const lidsR = lidsAtOrigin.translate(eyeAnchorRx, eyeY, eyeZ).label('lids');
 
 // ============================================================
-// ASSEMBLE
+// NOSE — rounded dog nose at the snout tip (dark in palette)
+// ============================================================
+const nY = fc.noseY + faceDY;
+const nZ = fc.noseZ + faceDZ;
+const noseMain   = sdf.ellipsoid(1.5, 1.0, 1.2).translate(0, nY, nZ);
+const noseNostrL = sdf.sphere(0.5).translate(-0.7, nY - 0.2, nZ - 0.5);
+const noseNostrR = sdf.sphere(0.5).translate( 0.7, nY - 0.2, nZ - 0.5);
+const noseFull   = noseMain.smoothUnion(noseNostrL, 0.4).smoothUnion(noseNostrR, 0.4).label('nose');
+
+// ============================================================
+// MOUTH — gentle smile below the nose
+// ============================================================
+const mY  = nY - 0.10;
+const mZ0 = nZ - 1.3;
+const philtrum = sdf.capsule([0, mY, nZ - 0.6], [0, mY, mZ0], 0.18);
+const arcL = sdf.capsule([0, mY, mZ0], [-1.3, mY + 0.1, mZ0 - 0.5], 0.18);
+const arcR = sdf.capsule([0, mY, mZ0], [ 1.3, mY + 0.1, mZ0 - 0.5], 0.18);
+const mouth = philtrum.smoothUnion(arcL, 0.15).smoothUnion(arcR, 0.15).label('mouth');
+
+// ============================================================
+// PATTERN MARKINGS (proud labeled blobs — muzzle recipe, clean flush color)
+// solid → none (baseline-safe). tuxedo → white bib/socks. tan-points → tan
+// brows, muzzle, chest, socks (Beagle/Doberman feel).
+// ============================================================
+function markAnchorsFor() {
+  if (p.pose === 'sitting') {
+    return {
+      pawPts: [[3.4, -4.6, 1.8], [-3.4, -4.6, 1.8]],
+      chest: [0, -4.8, 10.5], chestR: [3.4, 4.4, 4.8],
+      browPts: [[eyeAnchorLx, eyeY + 0.4, eyeZ + 2.2], [eyeAnchorRx, eyeY + 0.4, eyeZ + 2.2]],
+    };
+  }
+  const br = bodyResult;
+  return {
+    pawPts: [
+      [br.frontLegX, br.frontLegY, br.legBottom], [-br.frontLegX, br.frontLegY, br.legBottom],
+      [br.backLegX, br.backLegY, br.legBottom], [-br.backLegX, br.backLegY, br.legBottom],
+    ],
+    chest: [0, br.frontLegY - 1.2, br.legBottom + 3.5], chestR: [3.2, 3.0, 4.0],
+    browPts: [[eyeAnchorLx, eyeY + 0.4, eyeZ + 2.2], [eyeAnchorRx, eyeY + 0.4, eyeZ + 2.2]],
+  };
+}
+function buildMarkings() {
+  if (p.pattern === 'solid') return [];
+  const a = markAnchorsFor();
+  const out = [];
+  if (p.pattern === 'tuxedo') {
+    out.push(sdf.ellipsoid(a.chestR[0], a.chestR[1], a.chestR[2])
+      .translate(a.chest[0], a.chest[1], a.chest[2]).label('bib'));
+    for (const [x, y, z] of a.pawPts) out.push(sdf.ellipsoid(2.6, 2.3, 2.4).translate(x, y, z).label('socks'));
+  } else if (p.pattern === 'tan-points') {
+    for (const [x, y, z] of a.browPts) out.push(sdf.ellipsoid(1.0, 0.8, 0.9).translate(x, y, z).label('tan'));
+    out.push(sdf.ellipsoid(a.chestR[0] * 0.8, a.chestR[1], a.chestR[2])
+      .translate(a.chest[0], a.chest[1], a.chest[2]).label('tan'));
+    for (const [x, y, z] of a.pawPts) out.push(sdf.ellipsoid(2.6, 2.3, 2.4).translate(x, y, z).label('tan'));
+  }
+  return out;
+}
+const markings = buildMarkings();
+
+// ============================================================
+// DETAIL REGIONS
+// ============================================================
+const detailRegions = [
+  { center: headCenter,                         radius: 15,  edgeLength: 0.20 },
+  { center: [0, nY, nZ],                         radius: 5.0, edgeLength: 0.07 },
+  { center: [eyeAnchorLx, eyeY, eyeZ],           radius: 5.0, edgeLength: 0.05 },
+  { center: [eyeAnchorRx, eyeY, eyeZ],           radius: 5.0, edgeLength: 0.05 },
+  { center: [ielx, iely, ielz],                  radius: 6.0, edgeLength: 0.14 },
+  { center: [ierx, iery, ierz],                  radius: 6.0, edgeLength: 0.14 },
+];
+
+// ============================================================
+// ASSEMBLE & LIFT TO z≥0
 // ============================================================
 const dog = sdf.union(
   bodyLabeled,
+  muzzlePad,
   eyeballL, eyeballR,
   irisCapL, irisCapR,
   pupilCapL, pupilCapR,
-  nose
+  lidsL, lidsR,
+  noseFull,
+  mouth,
+  innerEarL, innerEarR,
+  ...markings
 );
 
-// Lift 0.75 to guarantee z≥0 base (smoothUnion blend dips ~0.7 below the disc)
-return dog.translate(0, 0, 0.75).build({
+const liftZ = p.pose === 'sitting' ? 0.9 : 0.25;
+
+return dog.translate(0, 0, liftZ).build({
   edgeLength: 0.45,
-  detail: [
-    { center: [0, -1.5, 23.0],        radius: 13,  edgeLength: 0.20  },
-    { center: [0, -10.0, 22.0],       radius: 5.0, edgeLength: 0.09  },
-    { center: [eyeAnchorLx, eyeAnchorY, eyeAnchorZ], radius: 2.5, edgeLength: 0.055 },
-    { center: [eyeAnchorRx, eyeAnchorY, eyeAnchorZ], radius: 2.5, edgeLength: 0.055 },
-  ]
+  detail: detailRegions,
 });

--- a/evals/cases/chibi-dog/palette.json
+++ b/evals/cases/chibi-dog/palette.json
@@ -1,0 +1,11 @@
+{
+  "body": "#D9A45B",
+  "lids": "#C8924B",
+  "muzzle": "#F5E5C0",
+  "eye": "#F8F8F8",
+  "iris": "#D4961E",
+  "pupil": "#1A1208",
+  "nose": "#2A2422",
+  "mouth": "#4A352F",
+  "innerEar": "#EEC0A0"
+}

--- a/evals/cases/chibi-dog/palettes/black.json
+++ b/evals/cases/chibi-dog/palettes/black.json
@@ -1,0 +1,1 @@
+{ "body":"#2E2A28","lids":"#262220","muzzle":"#4A433E","eye":"#F8F8F8","iris":"#8A5A2C","pupil":"#0E0B08","nose":"#141010","mouth":"#1A1410","innerEar":"#6A5048" }

--- a/evals/cases/chibi-dog/palettes/chocolate.json
+++ b/evals/cases/chibi-dog/palettes/chocolate.json
@@ -1,0 +1,1 @@
+{ "body":"#6B4427","lids":"#5C3A20","muzzle":"#8A6038","eye":"#F8F8F8","iris":"#C8861E","pupil":"#140E06","nose":"#2A1C10","mouth":"#2E2018","innerEar":"#A8704A" }

--- a/evals/cases/chibi-dog/palettes/cream.json
+++ b/evals/cases/chibi-dog/palettes/cream.json
@@ -1,0 +1,1 @@
+{ "body":"#EFE0C2","lids":"#E2D2B0","muzzle":"#F8F0DC","eye":"#F8F8F8","iris":"#7A4E28","pupil":"#1A1208","nose":"#3A322E","mouth":"#6A5048","innerEar":"#F0C8A8" }

--- a/evals/cases/chibi-dog/palettes/tan-points.json
+++ b/evals/cases/chibi-dog/palettes/tan-points.json
@@ -1,0 +1,1 @@
+{ "body":"#2A2624","lids":"#221E1C","muzzle":"#B5743A","eye":"#F8F8F8","iris":"#C8861E","pupil":"#0E0B08","nose":"#141010","mouth":"#1A1410","innerEar":"#9A6A48","tan":"#C8813A" }

--- a/evals/cases/chibi-dog/palettes/tuxedo.json
+++ b/evals/cases/chibi-dog/palettes/tuxedo.json
@@ -1,0 +1,1 @@
+{ "body":"#2E2A28","lids":"#262220","muzzle":"#F0F0EA","eye":"#F8F8F8","iris":"#8A5A2C","pupil":"#0E0B08","nose":"#141010","mouth":"#1A1410","innerEar":"#C99A8A","bib":"#F0F0EA","socks":"#F0F0EA" }

--- a/prompts/20260622-150000-dog-parity-and-patterns.md
+++ b/prompts/20260622-150000-dog-parity-and-patterns.md
@@ -1,0 +1,56 @@
+---
+session: "sharpbell"
+timestamp: "2026-06-22T15:00:00Z"
+sequence: 6
+---
+
+## Human
+
+bring the dog up to the cats quality level and also do the patterned colorways
+for both
+
+## Assistant
+
+## Key decisions
+
+Two deliverables in one branch.
+
+**1. Dog → cat parity.** Rewrote `evals/cases/chibi-dog/model.js` from a single
+hand-tuned spaniel into a **parametric `buildDog`** mirroring the merged chibi
+cat: same paramsSchema shape (pose sitting/standing, build
+puppy/slim/average/chonky, ears floppy/perky/long, tail curl/short/fluffy, face
+snouty/round) plus the cat's face machinery — figure-API **eyelids** (kills the
+bug-eye protrusion), ball-in-ball iris/pupil caps, a colored **muzzle** pad, a
+dark button **nose** at the snout tip, a **mouth** smile, and **innerEar** pads.
+Dog-specific anatomy vs the cat: a *projecting* snout ellipsoid (long in −Y) so
+it reads canine not flat-faced, and floppy ears as a two-segment capsule chain
+drooping down the head sides (perky = upright triangles, long = basset). Added a
+default golden palette + solid colorways (black/cream/chocolate) for parity with
+the cat's grey/black/white. The visual polish loop (hollow-eye fix, ear droop,
+snout projection) was delegated to the `model-sculpt` subagent so the render
+images stayed out of the main context; I finished the eyes by hand (iris disc
+0.62→0.80·eyeR + pupil 0.36→0.44 so the amber fills the eye instead of a
+startled ring of white).
+
+**2. Patterned colorways for both — proud-blob marking mechanism.** Added a
+`pattern` select to both models (cat: solid/tuxedo/points; dog:
+solid/tuxedo/tan-points). The mechanism: markings are **proud labeled blobs
+blended into the body** (the existing muzzle recipe), NOT `body.intersect(region)`.
+I tested the intersect approach first — a coincident patch *ties* with the
+`body` label in the nearest-centroid color remap and salt-and-peppers the
+boundary (verified in a render). A blob that sits slightly proud wins the
+nearest-centroid assignment cleanly, so the color is flush and solid. `solid`
+emits zero markings, so the default render (and the existing cat eval baseline)
+is byte-unchanged. Pattern colors live in per-pattern palette JSONs
+(`palettes/tuxedo.json`, `palettes/points.json` / `tan-points.json`).
+
+**Scope call — clean patterns only.** Tuxedo (bib + socks) and points/tan-points
+(siamese mask+ears+paws / Doberman muzzle+chest+paws) are clean with proud blobs.
+**Tabby stripes / calico were deferred**: stripes done as proud blobs would emboss
+as raised welts; doing them flush needs true per-triangle surface paint, not the
+blob trick. Filed as a follow-up rather than shipping a lower-quality version.
+
+All variants verified via `model:preview` (manifold, 1 component, genus ≤ 2, all
+of eye/iris/pupil/nose nonzero) across both poses and every pattern. No app/src
+code touched — these are standalone eval-corpus models, so `model:preview` colored
+renders are the verification surface (no browser spec needed).

--- a/retros/inbox/20260622-150500-dog-parity-and-colorway-patterns.md
+++ b/retros/inbox/20260622-150500-dog-parity-and-colorway-patterns.md
@@ -1,0 +1,38 @@
+---
+session: "sharpbell"
+date: "2026-06-22"
+task: "chibi dog → cat parity + tuxedo/points colorway patterns"
+---
+
+## Liked
+- Porting a *known-good* sibling (the merged chibi cat) into a new model was fast
+  and low-risk: same paramsSchema shape, same eye/lid/nose/mouth machinery, only
+  the anatomy deltas (projecting snout, drooping ears) were new. The cat was a
+  ready-made spec.
+- Delegating the dog's visual-polish loop to `model-sculpt` kept dozens of render
+  PNGs out of the main context; I only Read the final + one face close-up.
+
+## Lacked
+- No way to do **flush per-triangle surface paint** over an SDF `body` label.
+  Tabby stripes / calico are blocked on this — the only label mechanism is
+  whole-sub-SDF, so flush patterns need a blob that wins nearest-centroid. Stripes
+  via blobs would emboss as welts, so I had to defer them. A real surface-paint
+  region API would unlock the whole "patterned coat" axis.
+
+## Learned
+- **Proud blob, not `intersect`, for a flush color patch.** A `body.intersect(region)`
+  patch is *coincident* with the body surface, so it ties with the `body` label in
+  the nearest-centroid color remap and salt-and-peppers the boundary (verified in a
+  render). A blob that sits a hair *proud* (the existing muzzle recipe) wins the
+  assignment cleanly → solid flush color. This is the reusable trick for any
+  flat color zone (bib, socks, points, mask).
+- `model:preview` cleans old PNG stamps **per model**, so back-to-back renders of
+  the same file clobber each other — always pass an explicit `--png <path>` you
+  control and Read that, or the second render deletes the first.
+
+## Longed for
+- A headless **catalog-bake-and-register** one-liner. These polished models still
+  live only in the eval corpus; getting them into `/catalog` is a separate
+  dev-server + per-entry bake dance. A `model:preview`-style "bake this to a
+  catalog entry + thumbnail + manifest row" command would close the
+  eval-corpus → usable-in-app gap in one step.


### PR DESCRIPTION
## Summary

Two deliverables for the chibi-animal eval corpus:

### 1. Dog → cat quality parity
Rewrote `evals/cases/chibi-dog/model.js` from a single hand-tuned spaniel into a **parametric `buildDog`** mirroring the merged chibi cat:
- Same paramsSchema shape: `pose` (sitting/standing), `build` (puppy/slim/average/chonky), `ears` (floppy/perky/long), `tail` (curl/short/fluffy), `face` (snouty/round).
- Ported the cat's face machinery: **figure-API eyelids** (kills the bug-eye protrusion), ball-in-ball iris/pupil caps, and colored **muzzle / nose / mouth / innerEar** labels.
- Dog-specific anatomy: a **projecting canine snout** (reads as a muzzle, not a flat cat face) with a dark button nose at the tip, and **drooping floppy ears** (two-segment capsule chain; perky = upright triangles, long = basset).
- Default golden palette + **black / cream / chocolate** solid colorways (parity with the cat's grey/black/white).

### 2. Patterned colorways for both
New `pattern` param — cat `solid/tuxedo/points`, dog `solid/tuxedo/tan-points` — via **proud labeled marking blobs** (the existing muzzle recipe). A coincident `body.intersect(region)` patch *ties* with the `body` label in the nearest-centroid color remap and salt-and-peppers the boundary (verified); a slightly-proud blob wins cleanly, so the color is flush and solid. `solid` emits zero markings, so **default renders — and the existing cat eval baseline — are unchanged.** Pattern colors live in per-pattern palette JSONs.

**Scope note:** delivering the two *clean* patterns per animal. **Tabby stripes / calico are deferred** (tracked) — proud blobs would emboss stripes as raised welts; flush stripes need true per-triangle surface paint, not the blob trick.

## Test plan
- `model:preview` across **both poses × every pattern** for both animals: `isManifold:true`, `componentCount:1`, `genus ≤ 2`, and `eye/iris/pupil/nose` labels nonzero throughout.
- Default (`pattern:solid`) cat render is byte-identical to the merged cat → eval baseline safe.
- `npm run test:unit` green (no src/ touched — these are standalone eval-corpus models, so colored `model:preview` renders are the verification surface; no browser spec needed).

## Follow-ups (tracked separately)
- Tabby / calico / brindle patterns (need per-triangle surface paint).
- Bake colored `/catalog` entries so the cat & dog are usable in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017jjhM5YR9j3VYhtJRbyUeA)_