### PR TITLE
feat: algorithmic pattern colorways (api.paint.pattern) for chibi cat & dog

### DIFF
--- a/evals/cases/chibi-cat/model.js
+++ b/evals/cases/chibi-cat/model.js
@@ -24,7 +24,7 @@ const p = api.params({
            options: ['round', 'pointed'],
            label: 'Face' },
   pattern: { type: 'select', default: 'solid',
-           options: ['solid', 'tuxedo', 'points', 'tabby'],
+           options: ['solid', 'tuxedo', 'points', 'tabby', 'calico', 'spotted', 'siamese'],
            label: 'Pattern' },
 });
 
@@ -543,50 +543,42 @@ const result = cat.translate(0, 0, liftZ).build({
 });
 
 // ============================================================
-// TABBY STRIPES (flush surface paint — api.paint.*, not geometry)
-// Stripes are darker brown bands painted onto the finished mesh, so they
-// stay perfectly flush (no raised welt that a proud SDF blob would create).
-// Face features (eye/iris/pupil/nose/muzzle) are separate labeled solids
-// painted by the palette and survive — the stripe boxes are bounded away
-// from / behind them. Coords are POST-lift (the painted mesh is post-translate).
+// PROCEDURAL COLORWAYS (flush surface paint — api.paint.pattern, not geometry)
+// Algorithmic colour fields (the colour twin of api.surface.* textures) paint
+// each body triangle one palette colour, so the coat stays perfectly flush (no
+// raised welt). Scoped to the 'body' label so eyes/nose/muzzle (separate labeled
+// solids, palette-coloured) are never touched. Coords are POST-lift.
+//  - tabby   stripes  (warm-brown mackerel + fBm warp)
+//  - calico  patches  (cream / orange / dark-brown blotches)
+//  - spotted spots    (Worley leopard rosettes)
+//  - siamese gradient (dark points on the extremities via ear/paw/tail/face anchors)
 // ============================================================
-function applyTabbyStripes() {
-  const STRIPE = '#5A3A1F';   // classic warm brown mackerel stripe
-  if (p.pose === 'sitting') {
-    // Vertical mackerel stripes down the flanks/back (thin in X, tall in Z),
-    // bounded to the torso so they wrap the body but not the face.
-    const zLo = 1.0, zHi = 16.0;
-    for (let x = -6; x <= 6; x += 2.4) {
-      api.paint.box({ min: [x - 0.6, -3.0, zLo], max: [x + 0.6, 9.0, zHi], color: STRIPE });
+function applyColorway() {
+  const a = markAnchorsFor();
+  const lift = (pt) => [pt[0], pt[1], pt[2] + liftZ];
+  switch (p.pattern) {
+    case 'tabby':
+      api.paint.pattern({ pattern: 'stripes', colors: ['#D6913E', '#5A3A1F'],
+                          scope: 'body', axis: 'z', scale: 5, warp: 0.45 });
+      break;
+    case 'calico':
+      api.paint.pattern({ pattern: 'patches', colors: ['#F2EAD6', '#E0892F', '#3A2A22'],
+                          scope: 'body', scale: 5 });
+      break;
+    case 'spotted':
+      api.paint.pattern({ pattern: 'spots', colors: ['#E8C07A', '#5A3A1F'],
+                          scope: 'body', scale: 4, coverage: 0.4 });
+      break;
+    case 'siamese': {
+      const anchors = [
+        ...a.earPts.map(lift), ...a.pawPts.map(lift), ...a.tailPts.map(lift), lift(a.faceCenter),
+      ];
+      api.paint.pattern({ pattern: 'gradient', colors: ['#EDE2CE', '#4A3329'],
+                          scope: 'body', anchors, scale: 5.5, warp: 0.18 });
+      break;
     }
-    // Forehead "M" — three short stripes between the ears (the tabby signature).
-    api.paint.box({ min: [-1.0, -8, 27], max: [ 1.0, 2, 34], color: STRIPE });
-    api.paint.box({ min: [-3.4, -8, 26], max: [-2.0, 2, 33], color: STRIPE });
-    api.paint.box({ min: [ 2.0, -8, 26], max: [ 3.4, 2, 33], color: STRIPE });
-    // Tail rings (the curl sweeps out to +X around z 2–6).
-    api.paint.box({ min: [2.5, -8, 2.2], max: [9.0, 2, 3.4], color: STRIPE });
-    api.paint.box({ min: [2.5, -8, 4.4], max: [9.0, 2, 5.6], color: STRIPE });
-  } else {
-    // Standing: horizontal barrel — vertical flank stripes run across the back
-    // as thin bands along Y (front→rear), spanning the full width and up over
-    // the spine. Derive the span from the body result.
-    const br = bodyResult;
-    const yFront = br.frontLegY - 1.0;
-    const yRear  = br.rearY + 0.5;
-    const zMid   = br.bodyBaseZ;          // body ellipsoid center height
-    const zTop   = zMid + 9.0;            // over the back
-    const n = 5;
-    for (let i = 0; i < n; i++) {
-      const y = yFront + (yRear - yFront) * (i / (n - 1));
-      api.paint.box({ min: [-9, y - 0.55, zMid - 1.0], max: [9, y + 0.55, zTop], color: STRIPE });
-    }
-    // Forehead "M" over the head.
-    const hy = br.headY, hz = br.headZ;
-    api.paint.box({ min: [-1.0, hy - 7, hz + 4], max: [ 1.0, hy + 2, hz + 11], color: STRIPE });
-    api.paint.box({ min: [-3.4, hy - 7, hz + 3], max: [-2.0, hy + 2, hz + 10], color: STRIPE });
-    api.paint.box({ min: [ 2.0, hy - 7, hz + 3], max: [ 3.4, hy + 2, hz + 10], color: STRIPE });
   }
 }
-if (p.pattern === 'tabby') applyTabbyStripes();
+applyColorway();
 
 return result;

--- a/evals/cases/chibi-cat/model.js
+++ b/evals/cases/chibi-cat/model.js
@@ -24,7 +24,7 @@ const p = api.params({
            options: ['round', 'pointed'],
            label: 'Face' },
   pattern: { type: 'select', default: 'solid',
-           options: ['solid', 'tuxedo', 'points'],
+           options: ['solid', 'tuxedo', 'points', 'tabby'],
            label: 'Pattern' },
 });
 
@@ -537,7 +537,56 @@ const cat = sdf.union(
 // +0.25 for standing to clear paw sphere bottom (paw centers at z=lt, bottom at z≈lt-lt=0 but sdf smoothUnion bulges slightly below)
 const liftZ = p.pose === 'sitting' ? 0.9 : 0.25;
 
-return cat.translate(0, 0, liftZ).build({
+const result = cat.translate(0, 0, liftZ).build({
   edgeLength: 0.45,
   detail: detailRegions,
 });
+
+// ============================================================
+// TABBY STRIPES (flush surface paint — api.paint.*, not geometry)
+// Stripes are darker brown bands painted onto the finished mesh, so they
+// stay perfectly flush (no raised welt that a proud SDF blob would create).
+// Face features (eye/iris/pupil/nose/muzzle) are separate labeled solids
+// painted by the palette and survive — the stripe boxes are bounded away
+// from / behind them. Coords are POST-lift (the painted mesh is post-translate).
+// ============================================================
+function applyTabbyStripes() {
+  const STRIPE = '#5A3A1F';   // classic warm brown mackerel stripe
+  if (p.pose === 'sitting') {
+    // Vertical mackerel stripes down the flanks/back (thin in X, tall in Z),
+    // bounded to the torso so they wrap the body but not the face.
+    const zLo = 1.0, zHi = 16.0;
+    for (let x = -6; x <= 6; x += 2.4) {
+      api.paint.box({ min: [x - 0.6, -3.0, zLo], max: [x + 0.6, 9.0, zHi], color: STRIPE });
+    }
+    // Forehead "M" — three short stripes between the ears (the tabby signature).
+    api.paint.box({ min: [-1.0, -8, 27], max: [ 1.0, 2, 34], color: STRIPE });
+    api.paint.box({ min: [-3.4, -8, 26], max: [-2.0, 2, 33], color: STRIPE });
+    api.paint.box({ min: [ 2.0, -8, 26], max: [ 3.4, 2, 33], color: STRIPE });
+    // Tail rings (the curl sweeps out to +X around z 2–6).
+    api.paint.box({ min: [2.5, -8, 2.2], max: [9.0, 2, 3.4], color: STRIPE });
+    api.paint.box({ min: [2.5, -8, 4.4], max: [9.0, 2, 5.6], color: STRIPE });
+  } else {
+    // Standing: horizontal barrel — vertical flank stripes run across the back
+    // as thin bands along Y (front→rear), spanning the full width and up over
+    // the spine. Derive the span from the body result.
+    const br = bodyResult;
+    const yFront = br.frontLegY - 1.0;
+    const yRear  = br.rearY + 0.5;
+    const zMid   = br.bodyBaseZ;          // body ellipsoid center height
+    const zTop   = zMid + 9.0;            // over the back
+    const n = 5;
+    for (let i = 0; i < n; i++) {
+      const y = yFront + (yRear - yFront) * (i / (n - 1));
+      api.paint.box({ min: [-9, y - 0.55, zMid - 1.0], max: [9, y + 0.55, zTop], color: STRIPE });
+    }
+    // Forehead "M" over the head.
+    const hy = br.headY, hz = br.headZ;
+    api.paint.box({ min: [-1.0, hy - 7, hz + 4], max: [ 1.0, hy + 2, hz + 11], color: STRIPE });
+    api.paint.box({ min: [-3.4, hy - 7, hz + 3], max: [-2.0, hy + 2, hz + 10], color: STRIPE });
+    api.paint.box({ min: [ 2.0, hy - 7, hz + 3], max: [ 3.4, hy + 2, hz + 10], color: STRIPE });
+  }
+}
+if (p.pattern === 'tabby') applyTabbyStripes();
+
+return result;

--- a/evals/cases/chibi-cat/palettes/calico.json
+++ b/evals/cases/chibi-cat/palettes/calico.json
@@ -1,0 +1,2 @@
+{ "body": "#F2EAD6", "lids": "#D8B48C", "muzzle": "#F7EFE0", "eye": "#FAFAFA",
+  "iris": "#4F8E3F", "pupil": "#141414", "nose": "#D98C7A", "innerEar": "#E8A79A", "mouth": "#5A3A3A" }

--- a/evals/cases/chibi-cat/palettes/siamese.json
+++ b/evals/cases/chibi-cat/palettes/siamese.json
@@ -1,0 +1,2 @@
+{ "body": "#EDE2CE", "lids": "#C9B79A", "muzzle": "#EFE6D2", "eye": "#FAFAFA",
+  "iris": "#5B8FB0", "pupil": "#141414", "nose": "#9A6A60", "innerEar": "#C99C86", "mouth": "#5A3A3A" }

--- a/evals/cases/chibi-cat/palettes/spotted.json
+++ b/evals/cases/chibi-cat/palettes/spotted.json
@@ -1,0 +1,2 @@
+{ "body": "#E8C07A", "lids": "#C79A52", "muzzle": "#F3E6C8", "eye": "#FAFAFA",
+  "iris": "#C8881E", "pupil": "#141414", "nose": "#9A6A60", "innerEar": "#D9A87E", "mouth": "#5A3A3A" }

--- a/evals/cases/chibi-cat/palettes/tabby.json
+++ b/evals/cases/chibi-cat/palettes/tabby.json
@@ -1,0 +1,11 @@
+{
+  "body": "#D6913E",
+  "lids": "#B5712A",
+  "muzzle": "#F5E9D8",
+  "eye": "#FAFAFA",
+  "iris": "#4F8E3F",
+  "pupil": "#141414",
+  "nose": "#D98C7A",
+  "innerEar": "#E8A79A",
+  "mouth": "#5A3A3A"
+}

--- a/evals/cases/chibi-dog/model.js
+++ b/evals/cases/chibi-dog/model.js
@@ -26,7 +26,7 @@ const p = api.params({
            options: ['snouty', 'round'],
            label: 'Face' },
   pattern: { type: 'select', default: 'solid',
-           options: ['solid', 'tuxedo', 'tan-points', 'brindle'],
+           options: ['solid', 'tuxedo', 'tan-points', 'brindle', 'merle', 'spotted'],
            label: 'Pattern' },
 });
 
@@ -490,40 +490,30 @@ const result = dog.translate(0, 0, liftZ).build({
 });
 
 // ============================================================
-// BRINDLE STRIPES (flush surface paint — api.paint.*, not geometry)
-// The canine counterpart of the cat's tabby: darker tiger-stripe bands
-// painted flush onto the finished mesh (no raised welt). Face features are
-// separate labeled solids painted by the palette and survive — the stripe
-// boxes are bounded away from them. Coords are POST-lift.
+// PROCEDURAL COLORWAYS (flush surface paint — api.paint.pattern, not geometry)
+// Canine counterparts of the cat's procedural colourways: algorithmic colour
+// fields paint each body triangle one palette colour (no raised welt), scoped to
+// 'body' so the face features survive. Coords are POST-lift.
+//  - brindle  stripes  (dark tiger stripes over a fawn coat)
+//  - merle    patches  (mottled dark/base blotches — the Aussie/collie look)
+//  - spotted  spots    (Worley dalmatian/ticking spots)
 // ============================================================
-function applyBrindleStripes() {
-  const STRIPE = '#3A2A1C';   // dark brindle stripe over a tan/fawn coat
-  if (p.pose === 'sitting') {
-    const zLo = 1.0, zHi = 16.0;
-    for (let x = -6; x <= 6; x += 2.4) {
-      api.paint.box({ min: [x - 0.5, -3.0, zLo], max: [x + 0.5, 9.0, zHi], color: STRIPE });
-    }
-    // a few short stripes over the crown (between the ears)
-    api.paint.box({ min: [-1.0, -8, 27], max: [ 1.0, 2, 33], color: STRIPE });
-    api.paint.box({ min: [-3.2, -8, 26], max: [-1.9, 2, 32], color: STRIPE });
-    api.paint.box({ min: [ 1.9, -8, 26], max: [ 3.2, 2, 32], color: STRIPE });
-  } else {
-    const br = bodyResult;
-    const yFront = br.frontLegY - 1.0;
-    const yRear  = br.rearY + 0.5;
-    const zMid   = br.rearZ;              // body ellipsoid center height
-    const zTop   = zMid + 9.0;
-    const n = 5;
-    for (let i = 0; i < n; i++) {
-      const y = yFront + (yRear - yFront) * (i / (n - 1));
-      api.paint.box({ min: [-9, y - 0.5, zMid - 1.0], max: [9, y + 0.5, zTop], color: STRIPE });
-    }
-    const hy = br.headY, hz = br.headZ;
-    api.paint.box({ min: [-1.0, hy - 7, hz + 4], max: [ 1.0, hy + 2, hz + 10], color: STRIPE });
-    api.paint.box({ min: [-3.2, hy - 7, hz + 3], max: [-1.9, hy + 2, hz + 9], color: STRIPE });
-    api.paint.box({ min: [ 1.9, hy - 7, hz + 3], max: [ 3.2, hy + 2, hz + 9], color: STRIPE });
+function applyColorway() {
+  switch (p.pattern) {
+    case 'brindle':
+      api.paint.pattern({ pattern: 'stripes', colors: ['#B5793A', '#3A2A1C'],
+                          scope: 'body', axis: 'z', scale: 4.5, warp: 0.5 });
+      break;
+    case 'merle':
+      api.paint.pattern({ pattern: 'patches', colors: ['#9FA6A0', '#3A3A3C'],
+                          scope: 'body', scale: 4.5, coverage: 0.5 });
+      break;
+    case 'spotted':
+      api.paint.pattern({ pattern: 'spots', colors: ['#F2EEE6', '#2A2422'],
+                          scope: 'body', scale: 4, coverage: 0.32 });
+      break;
   }
 }
-if (p.pattern === 'brindle') applyBrindleStripes();
+applyColorway();
 
 return result;

--- a/evals/cases/chibi-dog/model.js
+++ b/evals/cases/chibi-dog/model.js
@@ -26,7 +26,7 @@ const p = api.params({
            options: ['snouty', 'round'],
            label: 'Face' },
   pattern: { type: 'select', default: 'solid',
-           options: ['solid', 'tuxedo', 'tan-points'],
+           options: ['solid', 'tuxedo', 'tan-points', 'brindle'],
            label: 'Pattern' },
 });
 
@@ -484,7 +484,46 @@ const dog = sdf.union(
 
 const liftZ = p.pose === 'sitting' ? 0.9 : 0.25;
 
-return dog.translate(0, 0, liftZ).build({
+const result = dog.translate(0, 0, liftZ).build({
   edgeLength: 0.45,
   detail: detailRegions,
 });
+
+// ============================================================
+// BRINDLE STRIPES (flush surface paint — api.paint.*, not geometry)
+// The canine counterpart of the cat's tabby: darker tiger-stripe bands
+// painted flush onto the finished mesh (no raised welt). Face features are
+// separate labeled solids painted by the palette and survive — the stripe
+// boxes are bounded away from them. Coords are POST-lift.
+// ============================================================
+function applyBrindleStripes() {
+  const STRIPE = '#3A2A1C';   // dark brindle stripe over a tan/fawn coat
+  if (p.pose === 'sitting') {
+    const zLo = 1.0, zHi = 16.0;
+    for (let x = -6; x <= 6; x += 2.4) {
+      api.paint.box({ min: [x - 0.5, -3.0, zLo], max: [x + 0.5, 9.0, zHi], color: STRIPE });
+    }
+    // a few short stripes over the crown (between the ears)
+    api.paint.box({ min: [-1.0, -8, 27], max: [ 1.0, 2, 33], color: STRIPE });
+    api.paint.box({ min: [-3.2, -8, 26], max: [-1.9, 2, 32], color: STRIPE });
+    api.paint.box({ min: [ 1.9, -8, 26], max: [ 3.2, 2, 32], color: STRIPE });
+  } else {
+    const br = bodyResult;
+    const yFront = br.frontLegY - 1.0;
+    const yRear  = br.rearY + 0.5;
+    const zMid   = br.rearZ;              // body ellipsoid center height
+    const zTop   = zMid + 9.0;
+    const n = 5;
+    for (let i = 0; i < n; i++) {
+      const y = yFront + (yRear - yFront) * (i / (n - 1));
+      api.paint.box({ min: [-9, y - 0.5, zMid - 1.0], max: [9, y + 0.5, zTop], color: STRIPE });
+    }
+    const hy = br.headY, hz = br.headZ;
+    api.paint.box({ min: [-1.0, hy - 7, hz + 4], max: [ 1.0, hy + 2, hz + 10], color: STRIPE });
+    api.paint.box({ min: [-3.2, hy - 7, hz + 3], max: [-1.9, hy + 2, hz + 9], color: STRIPE });
+    api.paint.box({ min: [ 1.9, hy - 7, hz + 3], max: [ 3.2, hy + 2, hz + 9], color: STRIPE });
+  }
+}
+if (p.pattern === 'brindle') applyBrindleStripes();
+
+return result;

--- a/evals/cases/chibi-dog/palettes/brindle.json
+++ b/evals/cases/chibi-dog/palettes/brindle.json
@@ -1,0 +1,11 @@
+{
+  "body": "#B5793A",
+  "lids": "#9A6430",
+  "muzzle": "#E9D2A6",
+  "eye": "#F8F8F8",
+  "iris": "#8A5A22",
+  "pupil": "#1A1208",
+  "nose": "#2A2422",
+  "mouth": "#4A352F",
+  "innerEar": "#D9A87E"
+}

--- a/evals/cases/chibi-dog/palettes/merle.json
+++ b/evals/cases/chibi-dog/palettes/merle.json
@@ -1,0 +1,2 @@
+{ "body": "#9FA6A0", "lids": "#8A908B", "muzzle": "#E2E0D6", "eye": "#F8F8F8",
+  "iris": "#7FA9C4", "pupil": "#1A1208", "nose": "#2A2422", "mouth": "#4A352F", "innerEar": "#CBB7A6" }

--- a/evals/cases/chibi-dog/palettes/spotted.json
+++ b/evals/cases/chibi-dog/palettes/spotted.json
@@ -1,0 +1,2 @@
+{ "body": "#F2EEE6", "lids": "#D8D2C4", "muzzle": "#FAF7F0", "eye": "#F8F8F8",
+  "iris": "#8A5A22", "pupil": "#1A1208", "nose": "#2A2422", "mouth": "#4A352F", "innerEar": "#E6C9B2" }

--- a/prompts/20260623-120000-tabby-brindle-stripes.md
+++ b/prompts/20260623-120000-tabby-brindle-stripes.md
@@ -1,0 +1,55 @@
+---
+session: "sharpbell"
+timestamp: "2026-06-23T12:00:00Z"
+sequence: 7
+---
+
+## Human
+
+I merged the recent work, but can we apply tabby patterns to the cats (or any
+animal I guess)?
+
+## Assistant
+
+## Key decisions
+
+**The earlier deferral was wrong — `api.paint.*` is the missing tool.** Tabby
+stripes were deferred on the previous PR because the proud-blob marking
+mechanism (used for tuxedo/points) would emboss stripes as raised welts, and
+the conclusion was "flush stripes need true per-triangle surface paint the SDF
+label system lacks." But Partwright *has* that: `api.paint.box` / `paint.slab`
+color surface triangles flush, changing zero geometry, and `model:preview`
+resolves them headlessly (`stats.paintOps`). I proved it on a scratch sphere
+first, then on the real cat — stripes resolve to nonzero triangle counts and
+every face label (eye/iris/pupil/nose/muzzle) survives.
+
+**Cat → `tabby`, dog → `brindle` (species-accurate striped colorways).** Added a
+new option to each model's `pattern` param. Tabby = warm-brown mackerel stripes;
+brindle = dark tiger stripes over a fawn coat (the canine term — "tabby" isn't a
+dog pattern, and the user's "or any animal" invited the equivalent). Both are
+**flush surface paint applied AFTER `.build()`** (paint resolves against the
+returned mesh), pose-aware:
+
+- *sitting:* vertical mackerel stripes down the flanks (thin boxes along X,
+  bounded to the torso Z so they wrap the body but not the face), a forehead
+  "M" of short crown stripes between the ears, and tail rings (cat).
+- *standing:* the body is a horizontal barrel, so flank stripes run as thin
+  bands along Y (front→rear) up over the spine, derived from `bodyResult`.
+
+The stripe boxes are bounded away from the eyes/nose, and those are separate
+labeled solids painted by the palette, so they're never clobbered (verified:
+all face labels nonzero in both poses).
+
+**Baseline-safe.** `solid` emits zero `api.paint.*` calls, so the default
+render (the only variant the eval case tests) is byte-identical — `paintOps:
+None`, genus/manifold unchanged. Paint never touches geometry, so the
+`maxGenus` gate is unaffected.
+
+**New palettes** `palettes/tabby.json` (cat) and `palettes/brindle.json` (dog)
+set the harmonizing base coat; the stripe color is a const in the model (paint
+takes a literal color, and a striped coat's stripe is intrinsically dark).
+
+**Scope.** Delivered the striped colorways asked for. **Calico is now unblocked
+by the same `api.paint.box` mechanism** (it's colored patches, not stripes) —
+noted as an easy follow-up rather than expanding this PR. Verified every variant
+via `model:preview --palette-file` across both poses; no app/src code touched.

--- a/prompts/20260623-140000-procedural-color-patterns.md
+++ b/prompts/20260623-140000-procedural-color-patterns.md
@@ -1,0 +1,57 @@
+---
+session: "sharpbell"
+timestamp: "2026-06-23T14:00:00Z"
+sequence: 8
+---
+
+## Human
+
+I don't like that particular attempt at producing tabby stripes. I was thinking
+maybe something algorithmic similar to how we produce textures only it would be
+for paint or color. [...] Build option 1 and show me previews of each effect.
+
+## Assistant
+
+## Key decisions
+
+Built **Option 1 from #850 — `api.paint.pattern`**, the colour twin of the
+`api.surface.*` procedural *texture* system: a field evaluated per-triangle
+assigns each triangle in a scope ONE palette colour, instead of displacing
+geometry. Replaces the disliked hand-placed `api.paint.box` stripe slabs with
+organic field-driven patterns.
+
+**Reused the existing substrate rather than new plumbing.** Per-triangle colour
+is already a persisted/exported path (`ColorRegion.perTriColors`, used by
+`imagePaint`), and `src/geometry/noise.ts` already ships Perlin/fBm + a seeded
+PRNG. So the only new pieces are a pure field module and a descriptor kind:
+
+- `src/color/colorPattern.ts` (new, pure) — `computePatternColors(mesh, scope,
+  spec)` → `Map<triId, rgb>`. Four fields: `stripes` (sin·axis + fBm
+  domain-warp → tabby/tiger/zebra/brindle), `spots` (Worley/cellular nearest-
+  feature distance → leopard/dalmatian, optional 3rd-colour rosette core),
+  `patches` (low-freq fBm split into 2–3 zones → calico/cow/tortie), `gradient`
+  (distance-from-centre, noise-jittered → siamese points).
+- New `{ kind: 'pattern', pattern, colors, scope?, scale?, axis?, warp?,
+  coverage?, seed? }` in `RegionDescriptor`, resolved in BOTH the headless
+  `paintOpsResolve.ts` (→ `model:preview`) and the browser
+  `resolveDescriptorTriangles` (`main.ts`), so it renders identically in CI and
+  in-app. `previewModel.ts` colours per-triangle when `perTriColors` is present.
+- `api.paint.pattern(...)` recorder in `manifoldJs.ts` (strict validation,
+  matching the other `api.paint.*` verbs).
+
+**`scope: 'body'` is the key ergonomic win** — it restricts the fill to an
+`api.label` region, so the pattern paints the whole body/head/tail but never the
+eyes/nose/muzzle (separate labels). That's the thing the box approach had to
+fight with hand-tuned bounds. Verified all face labels stay nonzero.
+
+**Printability preserved:** every triangle stays one flat palette colour (no
+blending), so a pattern still maps cleanly onto filament slots.
+
+Prototyped all four on the real cat geometry via `model:preview --palette-file`
+and showed the user; stripes/spots/patches look spot-on, gradient flagged for a
+possible "distance-from-nearest-extremity" refinement so the face mask darkens.
+
+**This commit is the engine only.** Wiring it into the eval cat/dog models
+(replacing the box tabby/brindle), the in-app AI tool, and `colors.md` docs
+(UI↔API parity) is the follow-up, pending the user's pick on named colorways +
+the gradient tweak. Tracked on #850. Typecheck + full unit tier (1588) green.

--- a/prompts/20260623-143000-pattern-region-scopes.md
+++ b/prompts/20260623-143000-pattern-region-scopes.md
@@ -1,0 +1,55 @@
+---
+session: "sharpbell"
+timestamp: "2026-06-23T14:30:00Z"
+sequence: 9
+---
+
+## Human
+
+Is it possible to separate patterns into regions? ... could we target just the
+head or maybe apply one pattern above an XY plane and another below? Could it
+have been labeled as a head and given its own pattern? ... Do both. I like the
+idea of having leg, tail, etc labels. Proceed and show previews.
+
+## Assistant
+
+## Key decisions
+
+**Geometric scope predicates over SDF sub-labels — because SDF labels seam.**
+The user wanted per-region patterns (head vs body, above/below a plane) and
+liked the idea of head/leg/tail *labels*. But `src/geometry/sdf.ts` partitions
+the tree at each `.label()` and meshes each labelled subtree independently —
+"smooth blends ACROSS labels degrade to a hard union" (sdf.ts header). So
+labeling head/legs/tail as separate SDF labels would put a **hard seam/pinch at
+every joint** (neck, hips, tail root) — exactly what the rubric forbids, and the
+reason the body is one fused `body` label today. Reported that finding and
+delivered the seam-free equivalent instead.
+
+**`PatternScope` geometric predicates.** Extended the pattern op's `scope` from
+`{ label }` to `{ label?, above?, below?, box?, sphere? }`. The geometric
+predicates AND together and narrow the base set by triangle centroid
+(`filterScopeTriangles` in `colorPattern.ts`, a pure helper shared by both the
+headless `paintOpsResolve` and the browser `resolveDescriptorTriangles`). This
+gives the full regional capability with **no relabel and no seam**:
+
+- `scope: { label:'body', sphere:{center, radius} }` → a head/paw blob (spotted
+  head + striped body verified on one continuous mesh, clean neck).
+- `scope: { label:'body', above:{axis:'z', at:zCut} }` + the matching `below` →
+  one pattern above an XY plane, another below (calico head / striped body).
+
+Multiple `api.paint.pattern` calls already composite (later wins), so regions
+layer. Scoping by `label` still keeps eyes/nose untouched; the geometric
+predicate further narrows within that.
+
+**Validation + tests.** Strict arg validation for the new scope keys in
+`manifoldJs.ts` (unknown-key rejection, axis/vec checks). Added
+`tests/unit/colorPattern.test.ts` (pure module → unit tier): palette
+quantization, stripes produce both tones, 3-color patches, and the
+above/below/box/sphere filters. Full unit tier green (1594).
+
+**On the user's "leg/tail labels" preference:** the seam-free way to give them
+*named* regions is named geometric scopes in the model (head sphere / leg boxes
+derived from the model's own anchors), not SDF labels — flagged as the wiring
+step. The pattern engine stays untouched; only the model declares the named
+scopes.
+</content>

--- a/prompts/20260623-151000-pattern-colorways-wired.md
+++ b/prompts/20260623-151000-pattern-colorways-wired.md
@@ -1,0 +1,45 @@
+---
+session: "sharpbell"
+timestamp: "2026-06-23T15:10:00Z"
+sequence: 10
+---
+
+## Human
+
+proceed to the next step  [wire the procedural colourways into the real
+cat & dog models; add the gradient face-darkening refinement; docs]
+
+## Assistant
+
+## Key decisions
+
+**Gradient (siamese) refinement — anchor-driven extremities.** Added an optional
+`anchors: [x,y,z][]` to the pattern spec. When present, `gradient` marks
+triangles within `scale` of the nearest anchor (so the *face mask* darkens, not
+just top/bottom); without anchors it keeps the distance-from-centre fallback.
+The cat passes its existing `markAnchorsFor()` ear/paw/tail/face points — no new
+anchor math, and the seal-point siamese now reads correctly (dark mask + ears +
+paws over a cream body, blue eyes from the palette).
+
+**Replaced the box-based tabby/brindle with `api.paint.pattern` colourways.** The
+hand-placed `paint.box` stripes (which the user disliked) are gone. The cat now
+has `tabby` (stripes), `calico` (patches), `spotted` (spots), `siamese`
+(gradient); the dog has `brindle` (stripes), `merle` (patches), `spotted`
+(dalmatian spots) — all scoped to the `body` label so the face features survive,
+all pose-aware, all verified headlessly (manifold, face labels nonzero). The
+proud-blob `tuxedo`/`points`/`tan-points` colourways are untouched, and `solid`
+still emits zero paint ops so the eval default case is byte-identical.
+
+**Coats live in code, faces in the palette.** Each colourway's coat colours are
+the in-code `api.paint.pattern` args; the per-colourway palette JSONs only set
+the face features (eye/iris/nose/muzzle/…) — e.g. blue eyes for siamese, amber
+for the dalmatian. Since the pattern paints the whole body, the palette's `body`
+value is cosmetic for patterned variants.
+
+**Docs/parity.** `api.paint.*`/`api.surface.*` are code-gen for the in-app AI
+(docs-only, no dedicated tool), so parity = documenting it: added the
+"Algorithmic colourways — api.paint.pattern" section to `public/ai/colors.md`,
+including the regional-scope predicates and the **why-not-SDF-labels** seam note.
+
+Engine remains pure + shared between the headless preview and the browser
+resolver; unit tier green; tsc clean.

--- a/prompts/20260623-153000-pattern-inapp-render-fix.md
+++ b/prompts/20260623-153000-pattern-inapp-render-fix.md
@@ -1,0 +1,30 @@
+---
+session: "sharpbell"
+timestamp: "2026-06-23T15:30:00Z"
+sequence: 11
+---
+
+## Human
+
+[PR #852 in-app verification + watch CI] proceed to the next step
+
+## Assistant
+
+## Key decisions
+
+**Browser check caught a real in-app render bug the headless path couldn't.** A
+striped sphere rendered SOLID amber in the editor while `model:preview` showed
+stripes. Root cause: the live-run path that turns `api.paint.*` ops into the
+model-colour underlay (`main.ts`, ~16693) destructured only `triangles` from
+`resolveDescriptorTriangles` and dropped `perTriColors`; `setModelColorRegions`
+didn't thread it either. So a `pattern` op fell back to its single swatch colour
+(base) on every triangle. The headless `paintOpsResolve` resolves `perTriColors`
+directly, which is why it was unaffected and the bug slipped through. Fix: thread
+`perTriColors` through both (the compositor already stamps it per triangle).
+
+**Added a permanent golden-path e2e** (`tests/pattern-colorway.spec.ts`): runs a
+striped colourway in the editor, screenshots the canvas, and asserts ≥2 distinct
+warm coat colours render. Deterministic (fixed seed), and it specifically guards
+the live-run `perTriColors` path — with the regression the coat collapses to one
+colour and the assertion fails. Uses a Playwright canvas screenshot + `sharp`
+(WebGL `readPixels` returns blank without `preserveDrawingBuffer`).

--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -218,6 +218,65 @@ Like the tools, these resolve **by triangle**, so paint a refined mesh (`refine(
 
 Because the code is the source of truth, these colors are **read-only at runtime**: `getModelColors()` lists them, but `getRegions()`/`listRegions()` stay empty, and `replaceColor` / palette operations / the paint panel's Clear button don't touch them — change a code-declared color by editing the `color` argument and re-running.
 
+### Algorithmic colourways — `api.paint.pattern`
+
+The colour twin of `api.surface.*` textures: instead of one flat region, a
+**procedural field** assigns each triangle in a scope ONE palette colour. Every
+triangle stays a single flat colour, so the result is multi-material printable
+(each colour maps to a filament slot). Use it for animal coats / camo / any
+repeating colour motif — it reads far better than hand-placed `paint.box` bands.
+
+```js
+api.paint.pattern({
+  pattern: 'stripes',                 // 'stripes' | 'spots' | 'patches' | 'gradient'
+  colors:  ['#D6913E', '#5A3A1F'],    // [base, mark, third?] — hex or [r,g,b]; ≥2
+  scope:   'body',                    // an api.label region (so it never touches eyes/nose); omit = whole model
+  axis:    'z',                       // stripes: band direction
+  scale:   5,                         // feature size (stripe period / spot spacing / blotch size)
+  warp:    0.45,                      // 0..1 organic wiggle of stripe lines / edges
+  coverage: 0.5,                      // duty cycle / spot radius / base-coat fraction / threshold
+  seed:    1,                         // reproducible noise
+});
+```
+
+- **`stripes`** — tabby / tiger / zebra / brindle. `sin(axis)` with an fBm
+  domain-warp so the bands wiggle organically and wrap the whole form.
+- **`spots`** — leopard / cheetah / dalmatian. Worley/cellular scatter; a 3rd
+  colour tints the spot core (rosettes).
+- **`patches`** — calico / cow / tortoiseshell. Low-frequency fBm split into 2–3
+  irregular colour zones.
+- **`gradient`** — siamese / colourpoint. Darkens the extremities; pass
+  `anchors: [[x,y,z], …]` (ear/paw/tail/face points) so the field marks triangles
+  within `scale` of the nearest one (the face mask darkens too) — without anchors
+  it falls back to distance-from-centre.
+
+**Regional scoping — different patterns on different parts, seam-free.** The
+`scope` accepts geometric predicates that AND with the label and narrow by
+triangle centroid: `above`/`below` a plane, inside a `box`, inside a `sphere`.
+Multiple `api.paint.pattern` calls composite (later wins), so you can layer them:
+
+```js
+// spotted head + striped body on ONE continuous mesh (no SDF label seam)
+api.paint.pattern({ pattern:'stripes', colors:['#D6913E','#5A3A1F'], scope:'body' });
+api.paint.pattern({ pattern:'spots',   colors:['#E8C07A','#3A241A'],
+                    scope:{ label:'body', sphere:{ center:[0,-1,23], radius:11 } } });
+
+// one pattern above an XY plane, another below
+api.paint.pattern({ pattern:'patches', colors:[...], scope:{ label:'body', above:{ axis:'z', at:16 } } });
+api.paint.pattern({ pattern:'stripes', colors:[...], scope:{ label:'body', below:{ axis:'z', at:16 } } });
+```
+
+> **Why a geometric scope and not separate SDF `.label()` regions?** In an
+> `api.sdf` model, `.label()` partitions the tree and meshes each labelled subtree
+> independently — a smooth blend *across* a label degrades to a hard union, i.e. a
+> visible **seam/pinch at the neck/hips/tail**. Keep the body one fused `label`
+> and target sub-regions by geometric scope instead — same per-region colour, no
+> seam.
+
+Like the other `api.paint.*` ops these resolve **by triangle** (refine for
+crisper field edges) and are validated strictly (unknown keys / bad colour /
+axis throw). manifold-js sandbox only.
+
 SCAD has the same `label()` pattern, but **without** the `{ color }`
 option — a SCAD `label()` is a passthrough wrapper for `paintByLabel`
 only, so color a SCAD model with an explicit `paintByLabel` call. Partwright pre-injects a

--- a/retros/inbox/pattern-colorway-engine-and-inapp-bug.md
+++ b/retros/inbox/pattern-colorway-engine-and-inapp-bug.md
@@ -1,0 +1,22 @@
+---
+date: 2026-06-23
+author: claude (opus-4-8)
+task: api.paint.pattern — algorithmic colour patterns + regional scopes (PR #852)
+---
+
+## Liked
+- The codebase already had every primitive the feature needed — `ColorRegion.perTriColors` (proven by `imagePaint`), a Perlin/fBm `noise.ts`, and a shared headless/browser resolver split (`paintOpsResolve` ↔ `resolveDescriptorTriangles`). Reading those first turned "build a colour-texture system" into "add one descriptor kind + a pure field function." Survey the existing substrate before designing.
+- `model:preview` colour renders made the four pattern fields self-correcting in ~2s each — stripes/spots/patches/gradient were dialed in headlessly without a browser round-trip, and the `model-sculpt`-style discipline (render→look→adjust) kept the loop tight.
+- Reusing the model's own `markAnchorsFor()` for the siamese gradient anchors — no new anchor math, and it stays pose-aware for free.
+
+## Lacked
+- A reason to distrust the headless preview. It rendered the patterns perfectly, so I nearly shipped without the in-app check — but the live editor path (`setModelColorRegions`) silently dropped `perTriColors`, so the real app rendered every coat FLAT. The headless `paintOpsResolve` resolves `perTriColors` directly, so the two paths diverged exactly where no headless test could see it. The browser screenshot was the only thing that caught it.
+- An SDF-label fact up front: `.label()` meshes each subtree independently, so labeling head/legs/tail would hard-seam every joint. I only found this by reading `sdf.ts` after the user asked for per-part labels. A one-line "labels seam smooth blends" note in the sdf docs would have saved a detour.
+
+## Learned
+- **For an app-facing engine change, the headless preview and the browser are DIFFERENT code paths — verify both.** A new `perTriColors`-bearing descriptor has to be threaded through *two* resolvers AND the underlay builder (`setModelColorRegions`); the headless one passing is no evidence the live one does. The eyes-on browser check is not ceremony here — it's the only coverage for the live path.
+- Per-region colour on a fused SDF body wants a **geometric scope** (sphere/box/plane by centroid), not SDF sub-labels — same result, no seam.
+
+## Longed for
+- A console/API readback of composed per-triangle colours (`getMesh()` carries none), so a regression test could assert "coat has ≥2 colours" structurally instead of via a canvas-screenshot + `sharp` pixel count. The pixel test works but is heavier and coarser than a direct assertion would be.
+- A typed link between "new `RegionDescriptor` kind" and "every site that resolves a descriptor," so dropping `perTriColors` in one of the three consumers would be a type error, not a silent flat render.

--- a/src/color/colorPattern.ts
+++ b/src/color/colorPattern.ts
@@ -41,8 +41,44 @@ export interface ColorPatternSpec {
 
 export const COLOR_PATTERN_KINDS: ReadonlyArray<ColorPatternKind> = ['stripes', 'spots', 'patches', 'gradient'];
 
+/** Where a pattern applies. A `label` restricts it to an `api.label` region; the
+ *  geometric predicates (`above`/`below` a plane, inside a `box`, inside a
+ *  `sphere`) further narrow it by triangle centroid. All provided predicates AND
+ *  together, so `{ label:'body', above:{axis:'z',at:14} }` = the upper body, and
+ *  `{ sphere:{center, radius} }` = a head/paw blob — no relabeling, no SDF seams. */
+export interface PatternScope {
+  label?: string;
+  above?: { axis: 'x' | 'y' | 'z'; at: number };
+  below?: { axis: 'x' | 'y' | 'z'; at: number };
+  box?: { min: [number, number, number]; max: [number, number, number] };
+  sphere?: { center: [number, number, number]; radius: number };
+}
+
 const AXIS_IDX: Record<'x' | 'y' | 'z', number> = { x: 0, y: 1, z: 2 };
 const clamp01 = (v: number): number => (v < 0 ? 0 : v > 1 ? 1 : v);
+
+/** Narrow a base triangle set by the scope's geometric predicates (centroid
+ *  test). Returns `base` unchanged when no geometric predicate is set. */
+export function filterScopeTriangles(mesh: MeshData, base: Set<number>, scope?: PatternScope): Set<number> {
+  if (!scope || (!scope.above && !scope.below && !scope.box && !scope.sphere)) return base;
+  const out = new Set<number>();
+  for (const t of base) {
+    const c = getTriangleCentroid(t, mesh);
+    if (scope.above && c[AXIS_IDX[scope.above.axis]] < scope.above.at) continue;
+    if (scope.below && c[AXIS_IDX[scope.below.axis]] > scope.below.at) continue;
+    if (scope.box) {
+      const { min, max } = scope.box;
+      if (c[0] < min[0] || c[0] > max[0] || c[1] < min[1] || c[1] > max[1] || c[2] < min[2] || c[2] > max[2]) continue;
+    }
+    if (scope.sphere) {
+      const { center, radius } = scope.sphere;
+      const dx = c[0] - center[0], dy = c[1] - center[1], dz = c[2] - center[2];
+      if (dx * dx + dy * dy + dz * dz > radius * radius) continue;
+    }
+    out.add(t);
+  }
+  return out;
+}
 
 /** Assign every triangle in `scope` a palette colour from the chosen field.
  *  Returns a `triId → rgb` map (the `perTriColors` substrate). */

--- a/src/color/colorPattern.ts
+++ b/src/color/colorPattern.ts
@@ -37,6 +37,10 @@ export interface ColorPatternSpec {
   coverage?: number;
   /** Seed for reproducible noise / feature scatter. Default 1. */
   seed?: number;
+  /** `gradient` only: extremity anchor points (ears/paws/tail/face). Triangles
+   *  within `scale` of the nearest anchor get the mark colour — the seam-free way
+   *  to darken a colourpoint's actual extremities (incl. the face mask). */
+  anchors?: [number, number, number][];
 }
 
 export const COLOR_PATTERN_KINDS: ReadonlyArray<ColorPatternKind> = ['stripes', 'spots', 'patches', 'gradient'];
@@ -163,17 +167,35 @@ export function computePatternColors(
       break;
     }
     case 'gradient': {
-      // Points/colourpoint (siamese): mark the extremities — triangles far from the
-      // model centre — with a noise-jittered threshold so the edge isn't a hard ring.
-      const lo = clamp01(spec.coverage ?? 0.58);
+      // Points/colourpoint (siamese): darken the extremities. With `anchors`
+      // (ear/paw/tail/face points the model supplies) it marks triangles within
+      // `scale` of the nearest anchor — so the face mask darkens too, not just the
+      // top/bottom. Without anchors it falls back to distance-from-centre. Both
+      // use a noise-jittered threshold so the edge reads soft, not a hard ring.
       const warp = spec.warp ?? 0.12;
-      const maxR = diag / 2;
       const jitter = makeNoise({ seed, frequency: 4 / diag, octaves: 2 });
-      pick = (c) => {
-        const dx = c[0] - center[0], dy = c[1] - center[1], dz = c[2] - center[2];
-        const d = Math.hypot(dx, dy, dz) / maxR + warp * jitter(c[0], c[1], c[2]);
-        return d > lo ? mark : base;
-      };
+      const anchors = spec.anchors;
+      if (anchors && anchors.length > 0) {
+        const pointR = spec.scale && spec.scale > 0 ? spec.scale : diag / 6;
+        pick = (c) => {
+          let dmin = Infinity;
+          for (let i = 0; i < anchors.length; i++) {
+            const dx = c[0] - anchors[i][0], dy = c[1] - anchors[i][1], dz = c[2] - anchors[i][2];
+            const dd = dx * dx + dy * dy + dz * dz;
+            if (dd < dmin) dmin = dd;
+          }
+          const d = Math.sqrt(dmin) + warp * pointR * jitter(c[0], c[1], c[2]);
+          return d < pointR ? mark : base;
+        };
+      } else {
+        const lo = clamp01(spec.coverage ?? 0.58);
+        const maxR = diag / 2;
+        pick = (c) => {
+          const dx = c[0] - center[0], dy = c[1] - center[1], dz = c[2] - center[2];
+          const d = Math.hypot(dx, dy, dz) / maxR + warp * jitter(c[0], c[1], c[2]);
+          return d > lo ? mark : base;
+        };
+      }
       break;
     }
     default:

--- a/src/color/colorPattern.ts
+++ b/src/color/colorPattern.ts
@@ -1,0 +1,149 @@
+// Algorithmic colour patterns — the colour twin of the `src/surface/` procedural
+// *texture* system. Instead of displacing geometry, a pattern assigns each
+// triangle in a scope ONE colour from a small palette, computed from a field
+// evaluated at the triangle's centroid. Because every triangle stays a single
+// flat colour, the result is multi-material printable (each colour maps to a
+// filament slot) and rides the existing per-triangle colour path
+// (`ColorRegion.perTriColors`, the same one `imagePaint` uses).
+//
+// Pure + dependency-free (mesh + noise only), so it resolves identically in the
+// browser underlay (`resolveDescriptorTriangles`) and the HEADLESS preview
+// (`paintOpsResolve` → `model:preview`).
+
+import type { MeshData } from '../geometry/types';
+import { getTriangleCentroid } from './adjacency';
+import { meshBounds } from './slabPaint';
+import { makeNoise, mulberry32 } from '../geometry/noise';
+
+export type RGB = [number, number, number];
+export type ColorPatternKind = 'stripes' | 'spots' | 'patches' | 'gradient';
+
+export interface ColorPatternSpec {
+  /** Which field to evaluate. */
+  pattern: ColorPatternKind;
+  /** Palette: colors[0] = base coat, colors[1] = primary marking, colors[2] =
+   *  optional third (calico third tone / leopard rosette centre). */
+  colors: RGB[];
+  /** Feature size in world units — stripe period / spot spacing / blotch size.
+   *  Omitted ⇒ ~1/8 of the model's bounding-box diagonal. */
+  scale?: number;
+  /** Stripe band direction (the axis the bands run *across*). Default 'z'. */
+  axis?: 'x' | 'y' | 'z';
+  /** Domain-warp amount 0..1 — how much fBm noise wiggles the stripe lines /
+   *  blotch and gradient edges so they read organic, not ruler-straight. */
+  warp?: number;
+  /** Pattern-specific fraction 0..1: stripe duty cycle, spot radius (× spacing),
+   *  base-coat fraction for patches, or the distance threshold for gradient. */
+  coverage?: number;
+  /** Seed for reproducible noise / feature scatter. Default 1. */
+  seed?: number;
+}
+
+export const COLOR_PATTERN_KINDS: ReadonlyArray<ColorPatternKind> = ['stripes', 'spots', 'patches', 'gradient'];
+
+const AXIS_IDX: Record<'x' | 'y' | 'z', number> = { x: 0, y: 1, z: 2 };
+const clamp01 = (v: number): number => (v < 0 ? 0 : v > 1 ? 1 : v);
+
+/** Assign every triangle in `scope` a palette colour from the chosen field.
+ *  Returns a `triId → rgb` map (the `perTriColors` substrate). */
+export function computePatternColors(
+  mesh: MeshData,
+  scope: Iterable<number>,
+  spec: ColorPatternSpec,
+): Map<number, RGB> {
+  const out = new Map<number, RGB>();
+  const ids = [...scope];
+  const colors = spec.colors;
+  if (ids.length === 0 || colors.length === 0) return out;
+  const base = colors[0];
+  const mark = colors[1] ?? colors[0];
+
+  const b = meshBounds(mesh);
+  const size: RGB = [b.max[0] - b.min[0], b.max[1] - b.min[1], b.max[2] - b.min[2]];
+  const center: RGB = [(b.max[0] + b.min[0]) / 2, (b.max[1] + b.min[1]) / 2, (b.max[2] + b.min[2]) / 2];
+  const diag = Math.hypot(size[0], size[1], size[2]) || 1;
+  const seed = spec.seed ?? 1;
+  const scale = spec.scale && spec.scale > 0 ? spec.scale : diag / 8;
+
+  let pick: (c: RGB) => RGB;
+
+  switch (spec.pattern) {
+    case 'stripes': {
+      const axis = AXIS_IDX[spec.axis ?? 'z'];
+      const warp = spec.warp ?? 0.35;
+      const duty = clamp01(spec.coverage ?? 0.5);     // fraction of each cycle in the mark colour
+      const period = Math.max(scale, 1e-3);
+      const warpNoise = makeNoise({ seed, frequency: 1.3 / period, octaves: 2 });
+      pick = (c) => {
+        const w = warp * period * warpNoise(c[0], c[1], c[2]);
+        const phase = (c[axis] + w) / period;
+        const frac = phase - Math.floor(phase);        // 0..1 sawtooth along the axis
+        return frac < duty ? mark : base;
+      };
+      break;
+    }
+    case 'spots': {
+      // Worley/cellular: scatter feature points, colour a triangle if it's within
+      // `spotR` of the nearest one. A third colour (if present) tints the spot core.
+      const spacing = Math.max(scale, 1e-3);
+      const vol = Math.max(size[0], 1e-3) * Math.max(size[1], 1e-3) * Math.max(size[2], 1e-3);
+      const n = Math.max(4, Math.min(500, Math.round((vol / (spacing * spacing * spacing)) * 0.5)));
+      const rng = mulberry32(seed || 1);
+      const pts: RGB[] = [];
+      for (let i = 0; i < n; i++) {
+        pts.push([b.min[0] + rng() * size[0], b.min[1] + rng() * size[1], b.min[2] + rng() * size[2]]);
+      }
+      const spotR = spacing * clamp01(spec.coverage ?? 0.38);
+      const core = colors[2];
+      pick = (c) => {
+        let dmin = Infinity;
+        for (let i = 0; i < pts.length; i++) {
+          const dx = c[0] - pts[i][0], dy = c[1] - pts[i][1], dz = c[2] - pts[i][2];
+          const dd = dx * dx + dy * dy + dz * dz;
+          if (dd < dmin) dmin = dd;
+        }
+        const dist = Math.sqrt(dmin);
+        if (dist >= spotR) return base;
+        if (core && dist < spotR * 0.55) return core;
+        return mark;
+      };
+      break;
+    }
+    case 'patches': {
+      // Irregular blotches (calico / cow / tortoiseshell): a low-frequency fBm
+      // split into 2 zones, or 3 via a second decorrelated field inside the marks.
+      const warp = spec.warp ?? 0;
+      const f1 = makeNoise({ seed, frequency: 1 / Math.max(scale, 1e-3), octaves: 2, gain: 0.6 });
+      const f2 = makeNoise({ seed: seed * 2 + 17, frequency: 1.0 / Math.max(scale, 1e-3), octaves: 2, gain: 0.6 });
+      const baseFrac = clamp01(spec.coverage ?? 0.5);
+      const third = colors[2];
+      pick = (c) => {
+        const wj = warp ? warp * (f2(c[0], c[1], c[2])) * scale * 0.3 : 0;
+        const v = (f1(c[0] + wj, c[1], c[2]) + 1) / 2;   // 0..1
+        if (v < baseFrac) return base;
+        if (third) return f2(c[0], c[1], c[2]) > 0 ? mark : third;
+        return mark;
+      };
+      break;
+    }
+    case 'gradient': {
+      // Points/colourpoint (siamese): mark the extremities — triangles far from the
+      // model centre — with a noise-jittered threshold so the edge isn't a hard ring.
+      const lo = clamp01(spec.coverage ?? 0.58);
+      const warp = spec.warp ?? 0.12;
+      const maxR = diag / 2;
+      const jitter = makeNoise({ seed, frequency: 4 / diag, octaves: 2 });
+      pick = (c) => {
+        const dx = c[0] - center[0], dy = c[1] - center[1], dz = c[2] - center[2];
+        const d = Math.hypot(dx, dy, dz) / maxR + warp * jitter(c[0], c[1], c[2]);
+        return d > lo ? mark : base;
+      };
+      break;
+    }
+    default:
+      pick = () => base;
+  }
+
+  for (const t of ids) out.set(t, pick(getTriangleCentroid(t, mesh)));
+  return out;
+}

--- a/src/color/paintOpsResolve.ts
+++ b/src/color/paintOpsResolve.ts
@@ -16,7 +16,7 @@ import type { RegionDescriptor } from './regions';
 import { findSlabTriangles } from './slabPaint';
 import { findShapeTriangles } from './boxPaint';
 import { findCylinderTriangles } from './cylinderPaint';
-import { computePatternColors } from './colorPattern';
+import { computePatternColors, filterScopeTriangles } from './colorPattern';
 
 export interface ResolvedPaintOp {
   name: string;
@@ -53,12 +53,17 @@ export function resolvePaintDescriptor(
     case 'byLabel':
       return labelMap?.get(descriptor.label) ?? new Set<number>();
     case 'pattern': {
-      // Scope: a label region (so it never touches eyes/nose) or the whole mesh.
+      // Scope: a label region (so it never touches eyes/nose) or the whole mesh,
+      // then narrowed by any geometric predicate (above/below/box/sphere).
       const label = descriptor.scope?.label;
-      if (label) return labelMap?.get(label) ?? new Set<number>();
-      const all = new Set<number>();
-      for (let t = 0; t < mesh.numTri; t++) all.add(t);
-      return all;
+      let base: Set<number>;
+      if (label) {
+        base = labelMap?.get(label) ?? new Set<number>();
+      } else {
+        base = new Set<number>();
+        for (let t = 0; t < mesh.numTri; t++) base.add(t);
+      }
+      return filterScopeTriangles(mesh, base, descriptor.scope);
     }
     default:
       return null;

--- a/src/color/paintOpsResolve.ts
+++ b/src/color/paintOpsResolve.ts
@@ -16,6 +16,7 @@ import type { RegionDescriptor } from './regions';
 import { findSlabTriangles } from './slabPaint';
 import { findShapeTriangles } from './boxPaint';
 import { findCylinderTriangles } from './cylinderPaint';
+import { computePatternColors } from './colorPattern';
 
 export interface ResolvedPaintOp {
   name: string;
@@ -23,6 +24,10 @@ export interface ResolvedPaintOp {
   /** RGB 0..1, as recorded by `api.paint.*`. */
   color: [number, number, number];
   triangles: Set<number>;
+  /** Per-triangle colours for the `pattern` op (algorithmic colourways) — each
+   *  triangle gets one palette colour from the field. Absent for the single-colour
+   *  box/slab/cylinder/byLabel ops, which paint every triangle `color`. */
+  perTriColors?: Map<number, [number, number, number]>;
 }
 
 /** Resolve one `api.paint.*` descriptor against an un-subdivided engine mesh.
@@ -47,6 +52,14 @@ export function resolvePaintDescriptor(
     }
     case 'byLabel':
       return labelMap?.get(descriptor.label) ?? new Set<number>();
+    case 'pattern': {
+      // Scope: a label region (so it never touches eyes/nose) or the whole mesh.
+      const label = descriptor.scope?.label;
+      if (label) return labelMap?.get(label) ?? new Set<number>();
+      const all = new Set<number>();
+      for (let t = 0; t < mesh.numTri; t++) all.add(t);
+      return all;
+    }
     default:
       return null;
   }
@@ -64,7 +77,10 @@ export function resolvePaintOps(
     const descriptor = op.descriptor as RegionDescriptor;
     const triangles = resolvePaintDescriptor(descriptor, mesh, labelMap);
     if (triangles === null) continue; // not an api.paint.* kind — shouldn't happen
-    out.push({ name: op.name, kind: descriptor.kind, color: op.color, triangles });
+    const perTriColors = descriptor.kind === 'pattern'
+      ? computePatternColors(mesh, triangles, descriptor)
+      : undefined;
+    out.push({ name: op.name, kind: descriptor.kind, color: op.color, triangles, perTriColors });
   }
   return out;
 }

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -3,7 +3,7 @@
 import type { MeshData } from '../geometry/types';
 import type { ShapeType } from './boxPaint';
 import type { BrushShape } from './subdivide';
-import type { ColorPatternKind } from './colorPattern';
+import type { ColorPatternKind, PatternScope } from './colorPattern';
 
 export interface ColorRegion {
   id: number;
@@ -108,7 +108,7 @@ export type RegionDescriptor =
   // produces a `perTriColors` map. `scope.label` restricts it to an `api.label`
   // region (e.g. the body) so it never touches eyes/nose; absent ⇒ whole mesh.
   | { kind: 'pattern'; pattern: ColorPatternKind; colors: [number, number, number][];
-      scope?: { label?: string };
+      scope?: PatternScope;
       scale?: number; axis?: 'x' | 'y' | 'z'; warp?: number; coverage?: number; seed?: number };
 
 export interface SerializedColorRegion {

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -3,6 +3,7 @@
 import type { MeshData } from '../geometry/types';
 import type { ShapeType } from './boxPaint';
 import type { BrushShape } from './subdivide';
+import type { ColorPatternKind } from './colorPattern';
 
 export interface ColorRegion {
   id: number;
@@ -100,7 +101,15 @@ export type RegionDescriptor =
       imageDataUrl?: string;
       removeBackground?: boolean;
       manualBgColor?: [number, number, number];
-      bgTolerance?: number };
+      bgTolerance?: number }
+  // Algorithmic colour pattern (the colour twin of `api.surface.*` textures):
+  // a field evaluated per-triangle assigns each triangle in `scope` one palette
+  // colour. Resolved by `computePatternColors` (src/color/colorPattern.ts), which
+  // produces a `perTriColors` map. `scope.label` restricts it to an `api.label`
+  // region (e.g. the body) so it never touches eyes/nose; absent ⇒ whole mesh.
+  | { kind: 'pattern'; pattern: ColorPatternKind; colors: [number, number, number][];
+      scope?: { label?: string };
+      scale?: number; axis?: 'x' | 'y' | 'z'; warp?: number; coverage?: number; seed?: number };
 
 export interface SerializedColorRegion {
   id: number;

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -518,7 +518,7 @@ export function clearRegionsBySource(source: ColorRegion['source']): void {
  *  `[]` (or run code that declares no colors) to clear the layer. Does NOT
  *  notify — the run path drives a single re-render after setting these. */
 export function setModelColorRegions(
-  decls: ReadonlyArray<{ name: string; color: [number, number, number]; triangles: Set<number>; descriptor?: RegionDescriptor }>,
+  decls: ReadonlyArray<{ name: string; color: [number, number, number]; triangles: Set<number>; descriptor?: RegionDescriptor; perTriColors?: Map<number, [number, number, number]> }>,
 ): void {
   modelRegions = decls.map((d, i) => ({
     id: -(i + 1), // negative ids never collide with the positive user-region ids
@@ -529,6 +529,7 @@ export function setModelColorRegions(
     order: i + 1, // order within the model band; the user paint layer sits above
     visible: true,
     triangles: d.triangles,
+    perTriColors: d.perTriColors, // pattern ops carry per-triangle colours
   }));
 }
 

--- a/src/color/regions.ts
+++ b/src/color/regions.ts
@@ -109,7 +109,8 @@ export type RegionDescriptor =
   // region (e.g. the body) so it never touches eyes/nose; absent ⇒ whole mesh.
   | { kind: 'pattern'; pattern: ColorPatternKind; colors: [number, number, number][];
       scope?: PatternScope;
-      scale?: number; axis?: 'x' | 'y' | 'z'; warp?: number; coverage?: number; seed?: number };
+      scale?: number; axis?: 'x' | 'y' | 'z'; warp?: number; coverage?: number; seed?: number;
+      anchors?: [number, number, number][] };
 
 export interface SerializedColorRegion {
   id: number;

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -477,8 +477,8 @@ export const manifoldJsEngine: Engine = {
        *   - colors:  [base, mark, third?] — hex or [r,g,b]; ≥2 required
        *   - scope:   'labelName' (e.g. 'body', so it never touches eyes/nose) — omit = whole model */
       pattern(opts: unknown): void {
-        const o = paintObj(opts, "api.paint.pattern({ pattern, colors, scope?, scale?, axis?, warp?, coverage?, seed? })");
-        const { pattern, colors, scope, scale, axis, warp, coverage, seed, ...rest } = o;
+        const o = paintObj(opts, "api.paint.pattern({ pattern, colors, scope?, scale?, axis?, warp?, coverage?, seed?, anchors? })");
+        const { pattern, colors, scope, scale, axis, warp, coverage, seed, anchors, ...rest } = o;
         paintRejectUnknown('api.paint.pattern', rest);
         if (typeof pattern !== 'string' || !COLOR_PATTERN_KINDS.includes(pattern as ColorPatternKind)) {
           throw new Error(`api.paint.pattern pattern: expected one of ${COLOR_PATTERN_KINDS.map(k => `'${k}'`).join(', ')}.`);
@@ -531,6 +531,11 @@ export const manifoldJsEngine: Engine = {
         if (axis !== undefined && (typeof axis !== 'string' || !(axis in AXIS_NORMAL))) {
           throw new Error("api.paint.pattern axis: expected 'x', 'y' or 'z'.");
         }
+        let anchorPts: [number, number, number][] | undefined;
+        if (anchors !== undefined) {
+          if (!Array.isArray(anchors)) throw new Error('api.paint.pattern anchors: expected an array of [x, y, z] points.');
+          anchorPts = anchors.map((a, i) => paintVec3(a, `api.paint.pattern anchors[${i}]`));
+        }
         const descriptor: RegionDescriptor = {
           kind: 'pattern',
           pattern: pattern as ColorPatternKind,
@@ -541,6 +546,7 @@ export const manifoldJsEngine: Engine = {
           ...(warp !== undefined ? { warp: paintNum(warp, 'api.paint.pattern warp') } : {}),
           ...(coverage !== undefined ? { coverage: paintNum(coverage, 'api.paint.pattern coverage') } : {}),
           ...(seed !== undefined ? { seed: paintNum(seed, 'api.paint.pattern seed') } : {}),
+          ...(anchorPts ? { anchors: anchorPts } : {}),
         };
         paintOps.push({ name: `paint·pattern ${pattern} ${++paintSeq}`, color: rgbColors[0], descriptor });
       },

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -17,6 +17,7 @@ import { createKnurlNamespace } from '../knurl';
 import { getBrepNamespace, consumeBrepAllocations, disposeBrepAllocationsExcept, consumeBrepToManifoldLabels, consumeBrepToManifoldLabelColors } from '../brepRuntime';
 import { parseLabelColor } from '../../color/labelColor';
 import type { RegionDescriptor } from '../../color/regions';
+import { COLOR_PATTERN_KINDS, type ColorPatternKind } from '../../color/colorPattern';
 import { SURFACE_OP_FIELDS, isSurfaceOpId, parseSurfaceOpts, type SurfaceOp, type SurfaceOpId } from '../../surface/surfaceOpSpec';
 import { wasmFaultHint } from '../workerFaults';
 import { assertNumber, assertNumberTuple, ValidationError } from '../../validation/apiValidation';
@@ -466,6 +467,55 @@ export const manifoldJsEngine: Engine = {
         if (typeof labelName !== 'string' || labelName.length === 0) throw new Error('api.paint.label: label must be a non-empty string naming an api.label(...) region.');
         const rgb = paintColor(col, 'api.paint.label');
         paintOps.push({ name: `paint·label ${labelName}`, color: rgb, descriptor: { kind: 'byLabel', label: labelName } });
+      },
+      /** Algorithmic colourway — fill a scope with a procedural pattern, the colour
+       *  twin of `api.surface.*` textures. Every triangle in `scope` gets ONE palette
+       *  colour from a field, so the result stays multi-material printable.
+       *  `api.paint.pattern({ pattern, colors, scope, scale, axis, warp, coverage, seed })`
+       *   - pattern: 'stripes' (tabby/tiger/zebra/brindle) | 'spots' (leopard/dalmatian)
+       *              | 'patches' (calico/cow/tortie) | 'gradient' (siamese points)
+       *   - colors:  [base, mark, third?] — hex or [r,g,b]; ≥2 required
+       *   - scope:   'labelName' (e.g. 'body', so it never touches eyes/nose) — omit = whole model */
+      pattern(opts: unknown): void {
+        const o = paintObj(opts, "api.paint.pattern({ pattern, colors, scope?, scale?, axis?, warp?, coverage?, seed? })");
+        const { pattern, colors, scope, scale, axis, warp, coverage, seed, ...rest } = o;
+        paintRejectUnknown('api.paint.pattern', rest);
+        if (typeof pattern !== 'string' || !COLOR_PATTERN_KINDS.includes(pattern as ColorPatternKind)) {
+          throw new Error(`api.paint.pattern pattern: expected one of ${COLOR_PATTERN_KINDS.map(k => `'${k}'`).join(', ')}.`);
+        }
+        if (!Array.isArray(colors) || colors.length < 2) {
+          throw new Error('api.paint.pattern colors: expected an array of at least 2 colors [base, mark, third?].');
+        }
+        const rgbColors = colors.map((c, i) => paintColor(c, `api.paint.pattern colors[${i}]`));
+        let scopeObj: { label?: string } | undefined;
+        if (scope !== undefined) {
+          if (typeof scope === 'string') {
+            if (scope.length === 0) throw new Error('api.paint.pattern scope: label name must be non-empty.');
+            scopeObj = { label: scope };
+          } else if (scope && typeof scope === 'object' && !Array.isArray(scope)) {
+            const { label: l, ...srest } = scope as { label?: unknown };
+            paintRejectUnknown('api.paint.pattern scope', srest as Record<string, unknown>);
+            if (l !== undefined && (typeof l !== 'string' || l.length === 0)) throw new Error('api.paint.pattern scope.label: must be a non-empty string.');
+            scopeObj = l !== undefined ? { label: l as string } : undefined;
+          } else {
+            throw new Error("api.paint.pattern scope: expected a label name string (e.g. 'body') or { label }.");
+          }
+        }
+        if (axis !== undefined && (typeof axis !== 'string' || !(axis in AXIS_NORMAL))) {
+          throw new Error("api.paint.pattern axis: expected 'x', 'y' or 'z'.");
+        }
+        const descriptor: RegionDescriptor = {
+          kind: 'pattern',
+          pattern: pattern as ColorPatternKind,
+          colors: rgbColors,
+          ...(scopeObj ? { scope: scopeObj } : {}),
+          ...(scale !== undefined ? { scale: paintNum(scale, 'api.paint.pattern scale') } : {}),
+          ...(axis !== undefined ? { axis: axis as 'x' | 'y' | 'z' } : {}),
+          ...(warp !== undefined ? { warp: paintNum(warp, 'api.paint.pattern warp') } : {}),
+          ...(coverage !== undefined ? { coverage: paintNum(coverage, 'api.paint.pattern coverage') } : {}),
+          ...(seed !== undefined ? { seed: paintNum(seed, 'api.paint.pattern seed') } : {}),
+        };
+        paintOps.push({ name: `paint·pattern ${pattern} ${++paintSeq}`, color: rgbColors[0], descriptor });
       },
     };
 

--- a/src/geometry/engines/manifoldJs.ts
+++ b/src/geometry/engines/manifoldJs.ts
@@ -17,7 +17,7 @@ import { createKnurlNamespace } from '../knurl';
 import { getBrepNamespace, consumeBrepAllocations, disposeBrepAllocationsExcept, consumeBrepToManifoldLabels, consumeBrepToManifoldLabelColors } from '../brepRuntime';
 import { parseLabelColor } from '../../color/labelColor';
 import type { RegionDescriptor } from '../../color/regions';
-import { COLOR_PATTERN_KINDS, type ColorPatternKind } from '../../color/colorPattern';
+import { COLOR_PATTERN_KINDS, type ColorPatternKind, type PatternScope } from '../../color/colorPattern';
 import { SURFACE_OP_FIELDS, isSurfaceOpId, parseSurfaceOpts, type SurfaceOp, type SurfaceOpId } from '../../surface/surfaceOpSpec';
 import { wasmFaultHint } from '../workerFaults';
 import { assertNumber, assertNumberTuple, ValidationError } from '../../validation/apiValidation';
@@ -487,18 +487,45 @@ export const manifoldJsEngine: Engine = {
           throw new Error('api.paint.pattern colors: expected an array of at least 2 colors [base, mark, third?].');
         }
         const rgbColors = colors.map((c, i) => paintColor(c, `api.paint.pattern colors[${i}]`));
-        let scopeObj: { label?: string } | undefined;
+        let scopeObj: PatternScope | undefined;
         if (scope !== undefined) {
           if (typeof scope === 'string') {
             if (scope.length === 0) throw new Error('api.paint.pattern scope: label name must be non-empty.');
             scopeObj = { label: scope };
           } else if (scope && typeof scope === 'object' && !Array.isArray(scope)) {
-            const { label: l, ...srest } = scope as { label?: unknown };
-            paintRejectUnknown('api.paint.pattern scope', srest as Record<string, unknown>);
-            if (l !== undefined && (typeof l !== 'string' || l.length === 0)) throw new Error('api.paint.pattern scope.label: must be a non-empty string.');
-            scopeObj = l !== undefined ? { label: l as string } : undefined;
+            const { label: l, above, below, box, sphere, ...srest } = scope as Record<string, unknown>;
+            paintRejectUnknown('api.paint.pattern scope', srest);
+            const s: PatternScope = {};
+            if (l !== undefined) {
+              if (typeof l !== 'string' || l.length === 0) throw new Error('api.paint.pattern scope.label: must be a non-empty string.');
+              s.label = l;
+            }
+            const parsePlane = (v: unknown, where: string): { axis: 'x' | 'y' | 'z'; at: number } => {
+              const o = paintObj(v, where);
+              const { axis: a, at, ...rest } = o;
+              paintRejectUnknown(where, rest);
+              if (typeof a !== 'string' || !(a in AXIS_NORMAL)) throw new Error(`${where}.axis: expected 'x', 'y' or 'z'.`);
+              return { axis: a as 'x' | 'y' | 'z', at: paintNum(at, `${where}.at`) };
+            };
+            if (above !== undefined) s.above = parsePlane(above, 'api.paint.pattern scope.above');
+            if (below !== undefined) s.below = parsePlane(below, 'api.paint.pattern scope.below');
+            if (box !== undefined) {
+              const o = paintObj(box, 'api.paint.pattern scope.box');
+              const { min, max, ...rest } = o;
+              paintRejectUnknown('api.paint.pattern scope.box', rest);
+              s.box = { min: paintVec3(min, 'api.paint.pattern scope.box.min'), max: paintVec3(max, 'api.paint.pattern scope.box.max') };
+            }
+            if (sphere !== undefined) {
+              const o = paintObj(sphere, 'api.paint.pattern scope.sphere');
+              const { center, radius, ...rest } = o;
+              paintRejectUnknown('api.paint.pattern scope.sphere', rest);
+              const rad = paintNum(radius, 'api.paint.pattern scope.sphere.radius');
+              if (rad <= 0) throw new Error('api.paint.pattern scope.sphere.radius: must be > 0.');
+              s.sphere = { center: paintVec3(center, 'api.paint.pattern scope.sphere.center'), radius: rad };
+            }
+            scopeObj = Object.keys(s).length > 0 ? s : undefined;
           } else {
-            throw new Error("api.paint.pattern scope: expected a label name string (e.g. 'body') or { label }.");
+            throw new Error("api.paint.pattern scope: expected a label name string (e.g. 'body') or { label, above, below, box, sphere }.");
           }
         }
         if (axis !== undefined && (typeof axis !== 'string' || !(axis in AXIS_NORMAL))) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16669,7 +16669,7 @@ async function main() {
       // — passing [] when nothing was declared clears any prior run's layer.
       // This layer never locks the editor and is never serialized; the user's
       // manual paint composites on top of it. See src/color/regions.ts.
-      const modelColorDecls: { name: string; color: [number, number, number]; triangles: Set<number>; descriptor?: RegionDescriptor }[] = [];
+      const modelColorDecls: { name: string; color: [number, number, number]; triangles: Set<number>; descriptor?: RegionDescriptor; perTriColors?: Map<number, [number, number, number]> }[] = [];
       if (result.labelColors && currentLabelMap) {
         for (const [name, color] of result.labelColors) {
           const triangles = currentLabelMap.get(name);
@@ -16690,8 +16690,8 @@ async function main() {
           if (!paintAdjacency && (d.kind === 'coplanar' || d.kind === 'connectedFromSeed' || d.kind === 'colorFlood')) {
             paintAdjacency = buildAdjacency(mesh);
           }
-          const { triangles } = resolveDescriptorTriangles(d, mesh, paintAdjacency, null);
-          if (triangles.size > 0) modelColorDecls.push({ name: op.name, color: op.color, triangles, descriptor: d });
+          const { triangles, perTriColors } = resolveDescriptorTriangles(d, mesh, paintAdjacency, null);
+          if (triangles.size > 0) modelColorDecls.push({ name: op.name, color: op.color, triangles, descriptor: d, perTriColors });
         }
       }
       setModelColorRegions(modelColorDecls);

--- a/src/main.ts
+++ b/src/main.ts
@@ -209,6 +209,7 @@ import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontS
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
 import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, setRegionTriangles, buildTriColors, createEmptyTriColors, overlayPainted, setModelColorRegions, setModelRegionTriangles, hasModelColorRegions, clearModelColorRegions, getModelRegions, getDistinctRegionColors, replaceRegionColors, composeTriColors, type ColorRegion, type SerializedColorRegion, type RegionDescriptor } from './color/regions';
 import { resolvePaintOps, resolvePaintDescriptor } from './color/paintOpsResolve';
+import { computePatternColors } from './color/colorPattern';
 import { setPaintLabels } from './color/labels';
 import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as getPaintBucketTolerance, setBucketColorTolerance as setPaintBucketColorTolerance, getBucketColorTolerance as getPaintBucketColorTolerance, setBucketMode as setPaintBucketMode, getBucketMode as getPaintBucketMode, setBrushRadius as setPaintBrushRadius, getBrushRadius as getPaintBrushRadius, setBrushSmooth as setPaintBrushSmooth, isBrushSmooth as isPaintBrushSmooth, setBrushSmoothDivisor as setPaintBrushSmoothDivisor, getBrushSmoothDivisor as getPaintBrushSmoothDivisor, setBrushSurface as setPaintBrushSurface, getBrushSurface as getPaintBrushSurface, setBrushPaintDepth as setPaintBrushDepth, getBrushPaintDepth as getPaintBrushDepth, setBrushWrapAngle as setPaintBrushWrapAngle, getBrushWrapAngle as getPaintBrushWrapAngle, SMOOTH_DIVISOR_MIN, SMOOTH_DIVISOR_MAX, WRAP_ANGLE_MIN, WRAP_ANGLE_MAX } from './color/paintMode';
 import { buildStrokeMesh, buildRefinedMesh, buildRefinedMeshFromSet, brushRefineRegion, strokeFootprintTriangles, deriveSampleNormals, buildGeodesicField, tangentBasis, wrapAngleGate, childrenByParent, type BrushStroke, type BrushShape, type RefineRegion } from './color/subdivide';
@@ -1136,6 +1137,21 @@ function resolveDescriptorTriangles(
       // Re-expand the stored [triIdx,r,g,b,…] entries through the subdivision
       // map (children inherit their parent's projected color).
       return entriesToPerTriColors(descriptor.entries, parentToChildren);
+    case 'pattern': {
+      // Algorithmic colourway: resolve the scope (an api.label region, remapped
+      // through subdivision, or the whole mesh), then assign each triangle one
+      // palette colour from the field (computePatternColors → perTriColors).
+      const label = descriptor.scope?.label;
+      let scope: Set<number>;
+      if (label) {
+        const ids = currentLabelMap?.get(label);
+        scope = ids ? remapTriangleIds(ids, parentToChildren) : new Set<number>();
+      } else {
+        scope = new Set<number>();
+        for (let t = 0; t < mesh.numTri; t++) scope.add(t);
+      }
+      return { triangles: scope, perTriColors: computePatternColors(mesh, scope, descriptor) };
+    }
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -209,7 +209,7 @@ import { addTextAnnotationAtAnchor, setFontSize as setAnnotateFontSize, getFontS
 import { restoreView as restoreAnnotationViewById } from './annotations/selectMode';
 import { applyTriColors, applyTriColorsIfVisible, hasRegions as hasColorRegions, onChange as onColorRegionsChange, onVisibilityChange as onPaintVisibilityChange, clearRegions, serialize as serializeRegions, addRegion, getRegions, removeRegion, removeLastRegion, redoLastRegion, setRegionVisibility, setRegionTriangles, buildTriColors, createEmptyTriColors, overlayPainted, setModelColorRegions, setModelRegionTriangles, hasModelColorRegions, clearModelColorRegions, getModelRegions, getDistinctRegionColors, replaceRegionColors, composeTriColors, type ColorRegion, type SerializedColorRegion, type RegionDescriptor } from './color/regions';
 import { resolvePaintOps, resolvePaintDescriptor } from './color/paintOpsResolve';
-import { computePatternColors } from './color/colorPattern';
+import { computePatternColors, filterScopeTriangles } from './color/colorPattern';
 import { setPaintLabels } from './color/labels';
 import { setBucketTolerance as setPaintBucketTolerance, getBucketTolerance as getPaintBucketTolerance, setBucketColorTolerance as setPaintBucketColorTolerance, getBucketColorTolerance as getPaintBucketColorTolerance, setBucketMode as setPaintBucketMode, getBucketMode as getPaintBucketMode, setBrushRadius as setPaintBrushRadius, getBrushRadius as getPaintBrushRadius, setBrushSmooth as setPaintBrushSmooth, isBrushSmooth as isPaintBrushSmooth, setBrushSmoothDivisor as setPaintBrushSmoothDivisor, getBrushSmoothDivisor as getPaintBrushSmoothDivisor, setBrushSurface as setPaintBrushSurface, getBrushSurface as getPaintBrushSurface, setBrushPaintDepth as setPaintBrushDepth, getBrushPaintDepth as getPaintBrushDepth, setBrushWrapAngle as setPaintBrushWrapAngle, getBrushWrapAngle as getPaintBrushWrapAngle, SMOOTH_DIVISOR_MIN, SMOOTH_DIVISOR_MAX, WRAP_ANGLE_MIN, WRAP_ANGLE_MAX } from './color/paintMode';
 import { buildStrokeMesh, buildRefinedMesh, buildRefinedMeshFromSet, brushRefineRegion, strokeFootprintTriangles, deriveSampleNormals, buildGeodesicField, tangentBasis, wrapAngleGate, childrenByParent, type BrushStroke, type BrushShape, type RefineRegion } from './color/subdivide';
@@ -1142,14 +1142,15 @@ function resolveDescriptorTriangles(
       // through subdivision, or the whole mesh), then assign each triangle one
       // palette colour from the field (computePatternColors → perTriColors).
       const label = descriptor.scope?.label;
-      let scope: Set<number>;
+      let base: Set<number>;
       if (label) {
         const ids = currentLabelMap?.get(label);
-        scope = ids ? remapTriangleIds(ids, parentToChildren) : new Set<number>();
+        base = ids ? remapTriangleIds(ids, parentToChildren) : new Set<number>();
       } else {
-        scope = new Set<number>();
-        for (let t = 0; t < mesh.numTri; t++) scope.add(t);
+        base = new Set<number>();
+        for (let t = 0; t < mesh.numTri; t++) base.add(t);
       }
+      const scope = filterScopeTriangles(mesh, base, descriptor.scope);
       return { triangles: scope, perTriColors: computePatternColors(mesh, scope, descriptor) };
     }
   }

--- a/src/tools/previewModel.ts
+++ b/src/tools/previewModel.ts
@@ -203,11 +203,16 @@ export async function previewModel(
   if (r.paintOps && r.paintOps.length > 0) {
     const resolved = resolvePaintOps(r.paintOps, mesh, r.labelMap);
     if (!triColors) triColors = new Uint8Array(numTri * 3).fill(170);
+    const to255 = (c: readonly number[]): [number, number, number] =>
+      [Math.round(Math.max(0, Math.min(1, c[0])) * 255), Math.round(Math.max(0, Math.min(1, c[1])) * 255), Math.round(Math.max(0, Math.min(1, c[2])) * 255)];
     for (const op of resolved) {
-      const [cr, cg, cb] = op.color.map((v) => Math.round(Math.max(0, Math.min(1, v)) * 255));
+      const [cr, cg, cb] = to255(op.color);
       for (const id of op.triangles) {
         if (id < 0 || id >= numTri) continue;
-        triColors[id * 3] = cr; triColors[id * 3 + 1] = cg; triColors[id * 3 + 2] = cb;
+        // Pattern ops carry a per-triangle colour; fall back to the flat colour.
+        const pc = op.perTriColors?.get(id);
+        const [r, g, b] = pc ? to255(pc) : [cr, cg, cb];
+        triColors[id * 3] = r; triColors[id * 3 + 1] = g; triColors[id * 3 + 2] = b;
       }
     }
     paintOpStats = resolved.map((op) => ({ name: op.name, kind: op.kind, triangleCount: op.triangles.size }));

--- a/tests/pattern-colorway.spec.ts
+++ b/tests/pattern-colorway.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from 'playwright/test';
+import sharp from 'sharp';
+
+// Golden path for api.paint.pattern: a striped colourway must render with at
+// least two distinct coat colours in the editor viewport. Guards the live-run
+// perTriColors path (a regression there renders the whole coat one flat colour —
+// the headless preview can't catch it because it resolves perTriColors directly).
+test('api.paint.pattern renders multiple coat colors in-app', async ({ page }) => {
+  await page.goto('/editor');
+  await page.waitForFunction(() => (window as any).partwright?.runAndSave, null, { timeout: 60000 });
+
+  const code = `
+    const body = api.label(api.Manifold.sphere(12, 64).refine(3), 'body', { color: '#D6913E' });
+    api.paint.pattern({ pattern: 'stripes', colors: ['#D6913E', '#5A3A1F'], scope: 'body', axis: 'z', scale: 5, warp: 0.45 });
+    return body;
+  `;
+  const run = await page.evaluate(async (src) => {
+    const r = await (window as any).partwright.runAndSave(src, 'pattern-spec', { isManifold: true });
+    return { passed: r?.passed, colorCount: (window as any).partwright.getModelColors?.()?.count ?? 0 };
+  }, code);
+  expect(run.passed).toBe(true);
+  expect(run.colorCount).toBeGreaterThanOrEqual(2); // base + pattern region both present
+
+  // dismiss onboarding so the viewport is unobstructed, let it settle
+  const skip = page.getByText('Skip', { exact: true });
+  if (await skip.count()) await skip.click().catch(() => {});
+  await page.waitForTimeout(2500);
+
+  // Screenshot the viewport canvas (Playwright captures the composited frame
+  // reliably, unlike readPixels on a non-preserved WebGL buffer), then count
+  // distinct WARM coat colours. The light base (#D6913E) and the dark stripe
+  // (#5A3A1F) must BOTH appear — with the bug they'd collapse to one.
+  const canvas = page.locator('canvas').first();
+  const png = await canvas.screenshot();
+  const { data, info } = await sharp(png).raw().toBuffer({ resolveWithObject: true });
+  const ch = info.channels;
+  const seen = new Set<string>();
+  for (let i = 0; i < data.length; i += ch) {
+    const r = data[i], g = data[i + 1], b = data[i + 2];
+    if (r < 45 && g < 45 && b < 45) continue;   // dark background
+    if (!(r > g && g >= b)) continue;            // keep warm coat tones only
+    seen.add(`${r >> 5}-${g >> 5}-${b >> 5}`);   // quantize to 8 levels/channel
+  }
+  expect(seen.size).toBeGreaterThanOrEqual(2);
+});

--- a/tests/unit/colorPattern.test.ts
+++ b/tests/unit/colorPattern.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import type { MeshData } from '../../src/geometry/types';
+import { computePatternColors, filterScopeTriangles, COLOR_PATTERN_KINDS, type RGB } from '../../src/color/colorPattern';
+
+/** Axis-aligned cube spanning [0,s]^3 (8 verts / 12 tris). */
+function cube(s = 10): MeshData {
+  const vertProperties = new Float32Array([
+    0, 0, 0, s, 0, 0, s, s, 0, 0, s, 0,
+    0, 0, s, s, 0, s, s, s, s, 0, s, s,
+  ]);
+  const triVerts = new Uint32Array([
+    0, 2, 1, 0, 3, 2, 4, 5, 6, 4, 6, 7,
+    0, 1, 5, 0, 5, 4, 2, 3, 7, 2, 7, 6,
+    1, 2, 6, 1, 6, 5, 0, 4, 7, 0, 7, 3,
+  ]);
+  return { vertProperties, triVerts, numVert: 8, numTri: 12, numProp: 3 };
+}
+
+const all = (m: MeshData): Set<number> => new Set(Array.from({ length: m.numTri }, (_, i) => i));
+const BASE: RGB = [1, 0, 0];
+const MARK: RGB = [0, 0, 1];
+
+describe('colorPattern', () => {
+  it('assigns every scoped triangle one of the palette colors', () => {
+    const m = cube();
+    for (const pattern of COLOR_PATTERN_KINDS) {
+      const colors = computePatternColors(m, all(m), { pattern, colors: [BASE, MARK] });
+      expect(colors.size).toBe(m.numTri);
+      for (const c of colors.values()) {
+        // each triangle is exactly the base or the mark colour (no blending)
+        const isBase = c[0] === BASE[0] && c[1] === BASE[1] && c[2] === BASE[2];
+        const isMark = c[0] === MARK[0] && c[1] === MARK[1] && c[2] === MARK[2];
+        expect(isBase || isMark).toBe(true);
+      }
+    }
+  });
+
+  it('stripes produce both colors over a span (not a single flat fill)', () => {
+    const m = cube(40);
+    const colors = computePatternColors(m, all(m), { pattern: 'stripes', colors: [BASE, MARK], axis: 'z', scale: 6, warp: 0 });
+    const distinct = new Set([...colors.values()].map((c) => c.join(',')));
+    expect(distinct.size).toBe(2);
+  });
+
+  it('patches can use a third color', () => {
+    const m = cube(60);
+    const THIRD: RGB = [0, 1, 0];
+    const colors = computePatternColors(m, all(m), { pattern: 'patches', colors: [BASE, MARK, THIRD], scale: 8 });
+    const used = new Set([...colors.values()].map((c) => c.join(',')));
+    // at least two of the three tones appear on a 12-tri cube; the third may or may not
+    expect(used.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('filterScopeTriangles narrows by an above/below plane', () => {
+    const m = cube(10);
+    const base = all(m);
+    const above = filterScopeTriangles(m, base, { above: { axis: 'z', at: 5 } });
+    const below = filterScopeTriangles(m, base, { below: { axis: 'z', at: 5 } });
+    // the split is disjoint and covers everything (no centroid sits exactly on z=5)
+    expect(above.size).toBeGreaterThan(0);
+    expect(below.size).toBeGreaterThan(0);
+    expect(above.size + below.size).toBe(m.numTri);
+    for (const t of above) expect(below.has(t)).toBe(false);
+  });
+
+  it('filterScopeTriangles narrows by a box and a sphere', () => {
+    const m = cube(10);
+    const base = all(m);
+    const boxed = filterScopeTriangles(m, base, { box: { min: [-1, -1, -1], max: [11, 11, 11] } });
+    expect(boxed.size).toBe(m.numTri); // box contains the whole cube
+    const tiny = filterScopeTriangles(m, base, { box: { min: [100, 100, 100], max: [101, 101, 101] } });
+    expect(tiny.size).toBe(0);
+    const sphere = filterScopeTriangles(m, base, { sphere: { center: [5, 5, 5], radius: 100 } });
+    expect(sphere.size).toBe(m.numTri);
+  });
+
+  it('returns the base set unchanged when no geometric predicate is present', () => {
+    const m = cube();
+    const base = all(m);
+    expect(filterScopeTriangles(m, base, { label: 'body' })).toBe(base);
+    expect(filterScopeTriangles(m, base, undefined)).toBe(base);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **`api.paint.pattern`** — the colour twin of `api.surface.*` textures: a procedural field assigns each triangle in a scope ONE palette colour (flat per triangle → multi-material printable). This replaces the earlier hand-placed `paint.box` stripes (which read as rigid welts) with organic, field-driven coats, and wires named colourways into the chibi cat & dog.

Four fields:
- **stripes** — tabby / tiger / zebra / brindle (`sin(axis)` + fBm domain-warp)
- **spots** — leopard / cheetah / dalmatian (Worley scatter; 3rd colour = rosette core)
- **patches** — calico / cow / tortoiseshell (low-freq fBm → 2–3 zones)
- **gradient** — siamese / colourpoint (darkens extremities via ear/paw/tail/face `anchors`)

**Regional scoping (seam-free).** The `scope` accepts an `api.label` region plus geometric predicates (`above`/`below` a plane, `box`, `sphere`) that AND together and narrow by triangle centroid; multiple calls composite (later wins). This gives "spotted head + striped body" or "pattern above/below a plane" on **one continuous mesh** — deliberately *not* via SDF `.label()` sub-regions, which would mesh each subtree independently and put a hard seam/pinch at the neck/hips/tail (`sdf.ts`).

## What's in it
- **Engine** (pure, shared by the headless preview and the browser resolver): `src/color/colorPattern.ts` (fields + `filterScopeTriangles`), new `pattern` `RegionDescriptor` kind resolved in `paintOpsResolve.ts` (→ `model:preview`) and `resolveDescriptorTriangles` (`main.ts`); rides the existing `perTriColors` rails (save/export already handle it). Strict arg validation in `manifoldJs.ts`.
- **Models**: cat gains `tabby`/`calico`/`spotted`/`siamese`; dog gains `brindle`/`merle`/`spotted`. Scoped to `body` so eyes/nose/muzzle survive; pose-aware; `tuxedo`/`points`/`tan-points` blob colourways untouched; `solid` emits zero paint ops (eval default byte-identical).
- **Palettes**: per-colourway face colours (blue siamese eyes, amber dalmatian); coats are in-code.
- **Docs**: `api.paint.pattern` section in `public/ai/colors.md` (in-app AI parity — `api.paint.*` is code-gen, docs-only).
- **Tests**: `tests/unit/colorPattern.test.ts` (palette quantization, stripe span, 3-colour patches, scope filters). Full unit tier green; `tsc` clean.

## Test plan
- [x] `npm run typecheck`, `npm run test:unit` (1594 pass)
- [x] Headless renders of all 7 colourways on both models — manifold, face labels nonzero
- [x] Defaults (`solid`) unchanged (`paintOps: None`), tuxedo blob path intact
- [ ] PR-checks shards (build + unit + e2e) green
- [ ] manual browser check of a pattern colourway

Scope manifest (tracking #850):
- [x] this PR — `api.paint.pattern` engine + regional scopes + cat/dog colourways + docs + tests
- [ ] follow-ups on #850: bake colored `/catalog` entries; in-app Surface-panel-style UI affordance if desired

Closes the pattern-colourway items on #850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017jjhM5YR9j3VYhtJRbyUeA)_