### PR TITLE
docs: changelog for Partwright 1.3 + version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "partwright-cad",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "LicenseRef-PolyForm-Noncommercial-1.0.0",
   "type": "module",
   "bin": {

--- a/prompts/release-2026-06-24-changelog-v1.3.md
+++ b/prompts/release-2026-06-24-changelog-v1.3.md
@@ -1,0 +1,62 @@
+---
+date: 2026-06-24
+branch: claude/funny-fermat-7zwulr
+files_changed:
+  - package.json
+  - src/content/data/whatsNew.ts
+---
+
+## Human
+
+Prepare another staging → production release. First make a PR to update the
+externally facing changelog and anything else that needs updating doc-wise.
+Then also make a PR to merge staging into production.
+
+## Assistant
+
+Same two-step shape as 1.2: docs/version bump goes in via `main` so the pipeline's
+pure-promotion invariant holds — a `staging` → `production` PR must carry zero
+content beyond `main`, and CLAUDE.md is explicit that
+changelog/version edits land on `main` first (never on the release branch). The
+promotion PR is cut *after* this one reaches staging via the gate.
+
+What's in this release (40 non-merge commits on `origin/staging` not on
+`origin/production`). Filtering to user-facing changes (the eval:models,
+headless-rasterizer, palette-preview, retro, and test-only commits stay out of
+the public changelog — those are agent-tooling internals):
+
+- **Catalog**: chibi cat and chibi dog as parametric figures with
+  paramsSchema-driven pose/build/colorway presets (siamese / calico / tabby
+  /tuxedo for cats; brindle / dalmatian and more for dogs). Cat face polish:
+  cream muzzle, ω mouth, flatter eyes framed by figure-API eyelids.
+- **New paint API — `api.paint.pattern`**: procedural stripes / spots /
+  patches / gradients with regional scope predicates, rendered live in the
+  editor (per-triangle colors now flow through the in-app render path).
+- **Performance**: SDF distance functions are now compiled to flat JS
+  (`src/geometry/sdfCompile.ts`), ~3× speed-up on figure evaluation.
+- **Painting bug fixes**: sliver streaks at smoothed brush edges, `api.label`
+  underlay coverage across incremental strokes, and concave-footprint regions
+  no longer leave buried triangles unpainted.
+
+Scope decisions:
+
+- **Version → 1.3.0 (minor).** All new capabilities are backward-compatible
+  `feat:` work (existing sessions/exports still load), so a minor bump per
+  CLAUDE.md's semver rules. The bump rides this `main`-bound PR so it flows
+  through the gate; `release-tag.yml` tags `v1.3.0` on promotion. Without the
+  bump the release would no-op the tag and ship the new features unversioned.
+- **Changelog** (`whatsNew.ts`) — added a new "June 24, 2026 — Partwright 1.3"
+  week entry at the top (Releases / Catalog / Painting / Performance groups),
+  above the unchanged 1.2 entry.
+- **Help** — no new section needed. `api.paint.pattern` is API-level surface
+  already covered in `public/ai/colors.md` (so AI agents see it); the
+  user-facing end-product of patterns is the colorway presets on the new
+  catalog figures, which the changelog already calls out. No new top-level
+  toolbar/panel/setting was added.
+- **No `llms.txt` change** — the file's API section doesn't enumerate
+  `api.paint.*` calls; agents reach pattern docs through the `colors` subdoc.
+- **Bambu printer churn** (drop-then-revert plus a test pin) is dev-internal
+  and excluded from the public changelog — no user-visible behavior change.
+
+Verified: `npm run typecheck` clean, `npm run test:unit` 1604/1604 pass. The
+draft PR's PR-checks workflow runs the full e2e shards on push.

--- a/src/content/data/whatsNew.ts
+++ b/src/content/data/whatsNew.ts
@@ -26,6 +26,52 @@ export const WHATS_NEW_INTRO =
 // Most recent first. Each entry is a calendar week (Mon–Sun) of shipped work.
 export const WHATS_NEW_WEEKS: WeekEntry[] = [
   {
+    range: 'June 24, 2026',
+    headline: 'Partwright 1.3 — chibi pets, painted patterns, and ~3× faster figures',
+    groups: [
+      {
+        label: 'Releases',
+        items: [
+          {
+            title: 'Partwright 1.3',
+            body: 'A small, backward-compatible feature release — existing sessions and exported files all keep working, and the running version is shown in the About dialog. This update adds a parametric chibi cat and chibi dog with colorway presets, a new algorithmic-pattern paint API, and a roughly 3× speed-up on figure rendering.',
+          },
+        ],
+      },
+      {
+        label: 'Catalog',
+        items: [
+          {
+            title: 'Chibi cat & chibi dog — parametric, with colorway presets',
+            body: 'Two new figure catalog entries, built on the same paramsSchema system as the rest of the figure library. Pick a pose, build, and colorway — siamese, calico, tabby and tuxedo points for cats; brindle, dalmatian and more for dogs — and remix any preset by tweaking individual sliders. The cat\'s face also got a polish pass: cream muzzle, ω-shaped mouth, and flatter eyes framed by figure-API eyelids that no longer protrude.',
+          },
+        ],
+      },
+      {
+        label: 'Painting',
+        items: [
+          {
+            title: 'Algorithmic colorway patterns — stripes, spots, patches, gradients',
+            body: 'A new api.paint.pattern(...) call lets model code declare procedural colorways instead of painting them by hand: stripes, spots, patches, and gradients render at runtime, so tabby cats and brindle dogs stay crisp at any zoom. Patterns can be scoped to a label or to a regional predicate (above/below a Z height, inside a sphere, …), and they render live as you edit.',
+          },
+          {
+            title: 'Cleaner paint at edges, smoothed brushes, and concave regions',
+            body: 'Three fixes to the painting pipeline that mostly show up on smoothed and figure-shaped models: smoothed-edge brush strokes no longer leave bright sliver streaks along the seam, api.label underlays now stay covering the mesh across incremental strokes (no more peek-through), and concave-footprint paint regions no longer leave buried triangles unpainted.',
+          },
+        ],
+      },
+      {
+        label: 'Performance',
+        items: [
+          {
+            title: '~3× faster figure rendering',
+            body: 'The figure SDF compiler now flattens distance functions into straight-line JavaScript instead of walking a tree on every sample, cutting figure evaluation time to roughly a third. The Character Creator preview, model bakes, and live edits on figure models all feel noticeably snappier.',
+          },
+        ],
+      },
+    ],
+  },
+  {
     range: 'June 21, 2026',
     headline: 'Partwright 1.2 — the AI paints images onto your model, and a grid that scales to your room',
     groups: [


### PR DESCRIPTION
## Summary

Docs-side of the upcoming **Partwright 1.3** release. Per CLAUDE.md the changelog and version bump must flow `main` → gate → `staging` first; only after this lands and the gate advances `staging` can the `staging` → `production` promotion PR be cut without tripping the `production-promotion-guard`.

- **`src/content/data/whatsNew.ts`** — new "June 24, 2026 — Partwright 1.3 — chibi pets, painted patterns, and ~3× faster figures" entry at the top (Releases / Catalog / Painting / Performance), above the unchanged 1.2 entry.
- **`package.json`** — `1.2.0` → `1.3.0` (minor; all landed work is backward-compatible `feat:`/`fix:`). The `release-tag` Action will stamp `v1.3.0` on the promotion merge.
- **`prompts/release-2026-06-24-changelog-v1.3.md`** — scope decisions (what's in vs out of the public changelog, why minor not major).

## What's in this release

40 non-merge commits on `staging` not on `production`. Filtering to user-visible:

- **Catalog**: chibi cat & chibi dog as parametric figures with `paramsSchema` pose/build/colorway presets (siamese / calico / tabby / tuxedo for cats; brindle / dalmatian and more for dogs). Cat face polish: cream muzzle, ω mouth, flatter eyes framed by figure-API eyelids.
- **New API — `api.paint.pattern`**: procedural stripes / spots / patches / gradients with regional scope predicates, rendered live in the editor (per-triangle colors flow through the in-app render path).
- **Performance**: SDF distance functions are now compiled to flat JS (`src/geometry/sdfCompile.ts`), ~3× faster figure evaluation.
- **Painting fixes**: sliver streaks at smoothed brush edges, `api.label` underlay coverage across incremental strokes, and concave-footprint regions no longer leaving buried triangles unpainted.

Excluded from the public changelog (agent-tooling / dev-internal): `eval:models` generalization, in-container Claude judge, palette-colored `model:preview`, smooth-shaded headless rasterizer, retros, Bambu printer churn (drop-then-revert + test pin).

## Next steps

1. Watch PR-checks shards on this draft → green → mark ready → merge to `main`.
2. The staging-gate Action advances `staging`.
3. Open the `staging` → `production` promotion PR (no docs/version edits on that branch — it must be a pure promotion).
4. On merge, `release-tag.yml` stamps `v1.3.0` and creates the GitHub Release with auto-generated notes.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test:unit` — 1604/1604 pass
- [ ] PR-checks build + unit + 3 e2e shards green on this draft
- [ ] Visual check of `/whats-new` showing the new 1.3 entry above 1.2
- [ ] About dialog shows `1.3.0` on the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfD5KyVkK9owpTpSt55RVh)_