### PR TITLE
feat: grid plane on by default

### DIFF
--- a/prompts/grid-on-by-default.md
+++ b/prompts/grid-on-by-default.md
@@ -1,0 +1,35 @@
+---
+date: 2026-06-28
+branch: claude/nifty-cray-33fbbz
+files_changed:
+  - src/renderer/viewport.ts
+  - src/ui/layout.ts
+---
+
+## Human
+
+let's have grid mode on by default
+
+## Assistant
+
+The grid plane is a `THREE.GridHelper` built in `viewport.ts:makeGrid` and
+toggled by the `#grid-toggle` viewport pill. Two coupled places were forcing
+"off":
+
+1. `makeGrid` set `g.visible = false` so every fresh build (initial scene + every
+   theme rebuild path) hid the grid.
+2. The pill in `layout.ts` was constructed with the neutral inactive styling
+   and a "Show grid plane" tooltip, so even if step 1 were changed alone the
+   button would have lied about state on first paint.
+
+Both flipped. `makeGrid` now leaves `visible` at the `GridHelper` default
+(true), and the pill is built with the same active blue styling + "Hide grid
+plane" tooltip that the already-on-by-default `dimensions-toggle` uses one line
+below — keeping the visual convention consistent. `initGridToggle`'s click
+handler in `main.ts` already drives the active/inactive swap on click, so no
+change there.
+
+Comment "hidden by default" updated to "visible by default" to match. No
+existing test pinned the off-by-default state (`paint-controls-extended.spec.ts`
+and `viewport-toolbar-groups.spec.ts` both just check the button is present,
+not its title or initial visibility).

--- a/src/renderer/viewport.ts
+++ b/src/renderer/viewport.ts
@@ -26,7 +26,6 @@ function makeGrid(theme: Theme): THREE.GridHelper {
   const g = new THREE.GridHelper(div, div, c.major, c.minor);
   g.rotation.x = Math.PI / 2;
   g.scale.setScalar(lastGridScale);
-  g.visible = false;
   return g;
 }
 
@@ -395,7 +394,7 @@ export function initViewport(container: HTMLElement): {
   studioShadowCatcher.visible = false;
   scene.add(studioShadowCatcher);
 
-  // Grid on XY plane (hidden by default; user-toggleable). Theme-colored.
+  // Grid on XY plane (visible by default; user-toggleable). Theme-colored.
   grid = makeGrid(getTheme());
   scene.add(grid);
 

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -935,7 +935,11 @@ function createClipControls(): HTMLElement {
   // one-click pills (not collapsed into a menu): they're frequent, mutually
   // independent flips, and a menu round-trip per toggle was pure friction.
   container.appendChild(makeViewportPill('wireframe-toggle', '△ Edges', 'Show mesh edges'));
-  container.appendChild(makeViewportPill('grid-toggle', '▦ Grid', 'Show grid plane'));
+  // Grid defaults on — give it the active blue styling to match its state.
+  container.appendChild(makeViewportPill(
+    'grid-toggle', '▦ Grid', 'Hide grid plane',
+    'px-3 py-2 md:px-2 md:py-1 rounded text-sm md:text-xs bg-blue-500/20 backdrop-blur text-blue-400 [@media(hover:hover)]:hover:bg-blue-500/30 transition-colors border border-blue-500/30 text-left',
+  ));
   container.appendChild(makeViewportPill('light-toggle', '☀ Light', 'Studio lighting: reflections + soft shadow (on by default)'));
   // Dimensions defaults on — give it the active blue styling to match its state.
   container.appendChild(makeViewportPill(


### PR DESCRIPTION
## Summary

- Grid plane is now visible from first paint of the editor — previously you had to click the `▦ Grid` pill to show it.
- The Grid pill is now constructed in its active blue state with a "Hide grid plane" tooltip, matching the sibling `dimensions-toggle` (which is already on-by-default).

## Changes

- `src/renderer/viewport.ts` — `makeGrid` no longer forces `visible = false`; the `GridHelper` keeps its default-visible state. Updated the inline comment to "visible by default".
- `src/ui/layout.ts` — Grid pill built with the active-blue class string and "Hide grid plane" title (same pattern as the existing dimensions pill on the next line). `initGridToggle`'s click handler in `main.ts` already drives the flip on every click, so no change there.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:unit` — 1604 passed
- [x] Manual: `npm run snap -- /editor` shows the grid plane in the viewport and the Grid pill rendered in active blue.
- [ ] CI: build + unit + 3 e2e shards green on the draft.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TJkghegTVByrD7Wbr9kKMw)_