### PR TITLE
feat(paint): paintIsland for multi-part STLs + smooth edges on paintInBox

### DIFF
--- a/prompts/20260629-paint-by-crease-and-detect-regions.md
+++ b/prompts/20260629-paint-by-crease-and-detect-regions.md
@@ -1,0 +1,80 @@
+---
+date: 2026-06-29
+branch: claude/confident-carson-gpo63q
+files_changed:
+  - src/color/faceGroups.ts
+  - src/main.ts
+  - src/ai/tools.ts
+  - public/ai/colors.md
+  - tests/unit/detectRegionsExtension.test.ts
+  - tests/island-paint.spec.ts
+---
+
+## Human
+
+After the 4-agent Pomni validation pass produced a recognizable harlequin
+silhouette but **no face / eyes / mouth / blush**, the user pushed back hard
+("I've seen very little so far that would lead me to believe this is even
+worth merging") and shared past-AI-session feedback that named the actually-
+right primitive: **dihedral-angle (crease) watershed segmentation**. The user
+asked for a strategic recommendation, then green-lit folding the right tools
+into this branch and re-running the validation against the only success
+criterion that matters — "does the face come out white with red eyes."
+
+## Assistant
+
+**Audited before implementing.** The crease-watershed kernel was already in
+the codebase: `findCoplanarRegion` (src/color/adjacency.ts) does the right
+adjacent-pair bend gate, and `computeFaceGroups` (src/color/faceGroups.ts)
+already runs exhaustive multi-seed BFS on top of it. `paintRegion` already
+calls it. The gap was three things:
+
+1. **Wrong defaults.** `computeFaceGroups` defaulted to `tolerance = 0.9995`
+   (≈1.8°), which over-fragments organic sculpts. For sculpted features
+   (iris ring, mouth crease, pom-poms) the right threshold is ~20° crease
+   = `tolerance ≈ cos(20°) ≈ 0.94`.
+2. **No way to constrain to one mesh-island.** Pomni's body is a fused
+   205k-tri island; segmenting the whole mesh runs the BFS through other
+   islands too. Added `restrictTo: Set<number>` to `computeFaceGroups`
+   and a sibling `findCoplanarRegionConstrained` that won't walk outside it.
+3. **No region-adjacency graph.** The iris borders the sclera; the pupil
+   borders the iris. Added an opt-in `includeNeighborIds` post-pass: walk
+   each triangle's neighbours once, cross-reference the group assignment,
+   build per-group `neighborIds: number[]`.
+
+**New agent-facing APIs:**
+
+- `partwright.detectRegions({creaseAngleDeg=20, minTriangleCount=5,
+  maxRegions=64, withinIsland?, includeNeighbors=true})` — wraps
+  `computeFaceGroups` with sculpt-tuned defaults and the new `restrictTo`
+  filter (resolved from `meshIslands` + `trianglesInIsland`). Returns regions
+  sorted largest first with `{id, triangleCount, area, centroid, normal, bbox,
+  neighborIds, source: 'whole-mesh' | 'island'}`.
+- `partwright.paintByCrease({seedPoint, seedNormal?, creaseAngleDeg=20, color,
+  name?})` — wraps the existing `findCoplanarRegion` paint commit path, but
+  parameterised in DEGREES (sculpt-natural) instead of cosine. Snaps to
+  nearest triangle if normal not provided (forgiving of probePixel rounding
+  on iso views).
+
+Both are wired into `help()`, the AI-tools dispatcher, `PART_TARGETABLE_TOOLS`,
+and `PAINT_GATED`.
+
+**Workflow doc.** Added a "For SCULPTED FEATURES inside a fused mesh —
+`detectRegions` + `paintByCrease`" section to `public/ai/colors.md` with the
+listComponents → detectRegions({withinIsland}) → probePixel → paintByCrease
+recipe, plus a four-case decision tree: paintIsland (clearance-gap kits) vs
+detectRegions+paintByCrease (fused features) vs paintInBox/Slab (flat
+regions) vs paintByLabel (authored geometry).
+
+**Tests.** `tests/unit/detectRegionsExtension.test.ts` — 7 cases: cube splits
+to 6 faces at 20°, default 1.8° also gives 6 (coplanar faces); restrictTo
+filters correctly and returns empty when set is empty; cube faces have
+exactly 4 neighbours each; single-triangle has empty neighbours; two disjoint
+boxes never list each other's faces as neighbours. `tests/island-paint.spec.ts`
+got an e2e case: detectRegions on a Manifold cube returns 6 regions with 4
+neighbours each, and paintByCrease seeded at z=10 colours exactly the top
+face (2 triangles, stops at the 90° crease).
+
+**Pre-existing crease-watershed gate** in `findCoplanarRegion` was correct;
+no kernel changes needed. The whole new surface is wiring + defaults +
+documentation + one constrained-BFS helper for `restrictTo`.

--- a/prompts/20260629-paint-island-multi-part-stl.md
+++ b/prompts/20260629-paint-island-multi-part-stl.md
@@ -1,0 +1,92 @@
+---
+date: 2026-06-29
+branch: claude/confident-carson-gpo63q
+files_changed:
+  - src/color/meshIslands.ts
+  - src/main.ts
+  - src/ai/tools.ts
+  - public/ai/colors.md
+  - tests/unit/meshIslands.test.ts
+  - tests/island-paint.spec.ts
+---
+
+## Human
+
+The user shared an articulated 25-piece print-in-place Pomni STL plus a
+reference photo and asked an AI to paint it. The session failed: every paint
+selector picks triangles by spatial position, so on a tightly-packed kit where
+parts overlap in XYZ (hat over face, gloves touching pants) every box/sphere/
+cylinder selector bled across part boundaries. `listComponents()` errored
+because the import was render-only (non-manifold → no `Manifold.decompose()`).
+The chat AI's own retro nailed it: "a select-by-mesh-island paint tool" was
+the missing primitive. A follow-up note added "the box/slab edges are jagged
+because the selectors pick whole triangles by centroid."
+
+The user reviewed two rounds of design and chose: (1) per-triangle island IDs
++ render-only `listComponents` + `paintIsland`, and (2) smooth edges on
+`paintInBox` — noting that smooth-edge machinery already existed for the other
+selectors and `crispEdge` was likely just an alias.
+
+## Assistant
+
+**Re-verified before implementing.** The user was right: `paintInOrientedBox`,
+`paintSlab`, and `paintInCylinder` already accept `{smooth, resolution,
+maxEdge}` (default `smooth: true`) via `shapeRefineRegion` /
+`slabRefineRegion` / `cylinderRefineRegion` in `src/color/`, routed through
+`addRegion` with `withSyncReconcile`. The lone holdout is **`paintInBox`
+(AABB)** — which is the *first* selector an AI reaches for, which is why the
+session hit jaggedness. So the fix is "extend `paintInBox` with the existing
+smooth API," not "invent crispEdge."
+
+**Island detection on `buildAdjacency`.** `src/color/adjacency.ts` already
+welds vertices by exact position for the flood-fill primitives, so its neighbor
+graph IS the right substrate for face-connected island BFS. New
+`src/color/meshIslands.ts` runs the BFS, memoizes on a WeakMap keyed by
+MeshData (new engine run → fresh mesh → fresh entry), exports
+`meshIslands(mesh) → {triIslands, islands[{index, triangleCount, bbox,
+center}]}`, plus `trianglesInIsland(...)` and `islandAtPoint(point)`.
+Documented the known limitation (parts touching at a shared vertex merge into
+one island) — unavoidable without external part metadata and matches
+`Manifold.decompose()`'s behaviour.
+
+**`listComponents` fallback.** Kept the manifold path verbatim (still returns
+`volume`/`surfaceArea`); added a `mesh-island` branch when `currentManifold`
+is null but `currentMeshData` exists. Tagged the source as `'manifold'` or
+`'mesh-island'` so callers can tell which kind they got. Render-only STL
+imports now segment without needing a Manifold round-trip.
+
+**`paintIsland` + `paintIslandAt`.** New API methods on `partwrightAPI`,
+wired into `help()`, exposed as AI tools, added to `PART_TARGETABLE_TOOLS`
+and `PAINT_GATED`. `paintIsland({index, color})` collects the island's
+triangles via `trianglesInIsland` and commits through the existing
+`commitPaintFromSet` (same render/storage path as `paintFaces`).
+`paintIslandAt({point, color})` finds the nearest triangle, resolves its
+island, then delegates — for pairing with `probePixel` so the AI can say
+"paint the island under this pixel" without enumeration.
+
+**`paintInBox` smooth.** Added `{smooth, resolution, maxEdge}` to the schema.
+When smooth is on AND no `normalCone`/`topOnly`/`coverageMode`/
+`maxTriangleArea` filters are set, the AABB is converted to an
+identity-quaternion OBB and routed through the same `addRegion('box', ...)`
+descriptor path that already does boundary-subdivision for
+`paintInOrientedBox`. With filters present, smoothing is silently skipped
+(the filter combinatorics aren't worth extending the 'box' descriptor for
+now) and the legacy `commitPaintFromSet` branch handles it.
+
+**Tests.** `tests/unit/meshIslands.test.ts` covers single/multi-island BFS,
+the 25-disjoint-triangle scale, empty meshes, the WeakMap cache invariant,
+plus `trianglesInIsland` / `islandAtPoint`. `tests/island-paint.spec.ts`
+imports a three-cube binary STL via `importMeshData`, asserts
+`listComponents` returns 3 components and each `paintIsland` colors exactly
+12 triangles (no bleed) — and that `paintInBox` returns `smooth: true` by
+default on a plain AABB. The three-cube STL is watertight enough to land on
+the manifold path; the assertion accepts either source since both share
+`meshIslands(currentMeshData)` for island enumeration.
+
+**AI docs.** `public/ai/colors.md` got a new "Paint by part on multi-part STL
+imports — `paintIsland`" section above `paintComponent`, with the
+listComponents→paintIsland recipe and the touching-parts limitation.
+
+Preflight (typecheck + 1660 unit tests + lint:deps + lint:consistency) all
+green; the consistency warnings are pre-existing mousedown advisories
+unrelated to this diff.

--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -402,6 +402,63 @@ cleanly, one island per part. When islands fuse together, fall back
 to combining `paintIsland` with `paintInBox`/`paintConnected` to
 carve the touching boundary.
 
+**For SCULPTED FEATURES inside a fused mesh — `detectRegions` +
+`paintByCrease`.** When a character's head, body, buttons, eye
+sockets, etc. all welded into one big island, `paintIsland` can
+only colour the whole thing one shade. The sculpted FEATURES on
+that island — the iris ring around each eye, the pupil, the mouth
+crease, the blush dimples, each torso pom-pom, the bangs — are
+all bounded by *crease* edges (sharp angle changes between adjacent
+faces). The crease-watershed segmentation enumerates them, and a
+crease-stop flood paint colours each one cleanly:
+
+```js
+// Find the body island (the giant fused 200k-tri one).
+const { components } = partwright.listComponents();
+const body = components.reduce((a, b) => a.triangleCount > b.triangleCount ? a : b);
+
+// Segment ONLY that island into sculpted-feature regions.
+const { regions } = partwright.detectRegions({
+  withinIsland: body.index,
+  creaseAngleDeg: 20,         // default — good for sculpted features
+  minTriangleCount: 5,        // skip slivers
+});
+// regions: [{id, triangleCount, area, centroid, normal, bbox, neighborIds}, ...]
+// Sorted largest first. The face dome will be the biggest; the eye/mouth/
+// blush features will be smaller. neighborIds tells you what borders what
+// — the iris borders the sclera, the pupil borders the iris, etc.
+
+// Identify visually by rendering + probePixel, then paint each feature.
+const view = await partwright.renderView({ azimuth: 0, elevation: 0, size: 800 });
+const irisHit = await partwright.probePixel({ pixel: [pxX, pxY], view });
+partwright.paintByCrease({
+  seedPoint: irisHit.point,
+  seedNormal: irisHit.normal,
+  creaseAngleDeg: 20,          // raise to 30+ to capture larger neighbours
+  color: [0.85, 0.10, 0.10],
+  name: 'iris_left',
+});
+```
+
+For very tight nested features (pupil inside iris), lower
+`creaseAngleDeg` to 5–10° so the inner crease catches before the
+outer one. `detectRegions({creaseAngleDeg: 10})` exposes more
+fine-grained features; `detectRegions({creaseAngleDeg: 45})` collapses
+back to coarse part-level boundaries (useful for an overview pass
+before zooming in).
+
+> **Decision tree for paint on an imported character STL:**
+> 1. **Each anatomical part is its own mesh-island** (print-in-place kit
+>    with clearance gaps): `listComponents` → `paintIsland` per part.
+> 2. **Multiple parts fused into ONE mesh-island** (head+torso+features
+>    welded together): `listComponents` → `detectRegions({withinIsland})`
+>    → `paintByCrease` per sculpted feature.
+> 3. **Whole-region flat colour, not sculpt-feature** (top half of a vase,
+>    a stripe down the middle): `paintInBox` / `paintSlab` /
+>    `paintInCylinder` (now with smooth edges by default).
+> 4. **Authored geometry** (you wrote the model): `api.label` + `paintByLabel`
+>    — strongest primitive, no probing.
+
 **Avoiding over-paint.** When `paintInBox` / `paintNear` catches side
 walls or the bottom face by mistake, pass `topOnly: true` — restricts
 to upward-facing triangles (axis +Z within 30°). Equivalent to

--- a/public/ai/colors.md
+++ b/public/ai/colors.md
@@ -357,6 +357,51 @@ tweaks to the model, and skips the listComponents → paintInBox pair.
 Prefer `paintByLabel` when you control the code (whether manifold-js
 or SCAD); reach for `paintComponent` when you don't.
 
+**Paint by part on multi-part STL imports — `paintIsland`.** A user-
+uploaded multi-part STL (articulated print-in-place kit, separable
+mechanism, harlequin figure) usually imports as a render-only mesh
+(no Manifold), which means `paintComponent` and `Manifold.decompose()`
+both error with "No geometry loaded". The fix: `listComponents()`
+now falls back to face-connected island BFS in that case, and
+`paintIsland({index, color})` paints one island. **This is the right
+primitive whenever an import has multiple parts that overlap in 3D
+space** — a hat sitting over a head, gloves touching pants, puffs
+inside arms. Spatial selectors (`paintInBox`, `paintNear`,
+`paintInCylinder`) catch every triangle that's in the bounding
+volume regardless of which part it belongs to; `paintIsland` selects
+by topology and never bleeds across parts:
+
+```js
+const { count, components, source } = partwright.listComponents();
+// source: 'manifold' (decompose result) or 'mesh-island' (BFS fallback).
+// For a 25-piece articulated kit: count === 25, source === 'mesh-island'.
+// Each entry: {index, triangleCount, boundingBox, centroid}.
+
+// Identify which island is which by bbox/centroid (top-most → hat,
+// largest below it → torso, leftmost arm-like → left arm, etc.).
+// Then paint each part by its island index:
+partwright.paintIsland({ index: 7, color: [0.85, 0.10, 0.10], name: 'hat-left' });
+partwright.paintIsland({ index: 8, color: [0.10, 0.20, 0.85], name: 'hat-right' });
+```
+
+`paintIslandAt({point, color})` is the grounded sibling: pair with
+`probePixel` to "click the part in the iso render" and paint that
+island without enumerating first — handy when an island's index is
+ambiguous but its visible location isn't:
+
+```js
+const hit = await partwright.probePixel({ view: 'iso', u: 0.42, v: 0.31 });
+if (hit?.point) partwright.paintIslandAt({ point: hit.point, color: [1, 0, 0] });
+```
+
+**Limitation:** islands are detected by *welded* vertex adjacency —
+two parts that physically touch at a shared vertex (a hat brim
+resting on a head with no gap) appear as one island and will both
+get painted. Print-in-place kits with proper clearance gaps split
+cleanly, one island per part. When islands fuse together, fall back
+to combining `paintIsland` with `paintInBox`/`paintConnected` to
+carve the touching boundary.
+
 **Avoiding over-paint.** When `paintInBox` / `paintNear` catches side
 walls or the bottom face by mistake, pass `topOnly: true` — restricts
 to upward-facing triangles (axis +Z within 30°). Equivalent to

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -189,12 +189,12 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'listComponents',
-    description: 'Decompose the current manifold into its boolean-distinct components and return {index, centroid, boundingBox, volume, surfaceArea} for each. Use this for "paint each feature" workflows on unioned models — for a smiley built from head + 2 eyes + mouth, this returns 4 components with bboxes. Prefer paintComponent(index, color) if you intend to paint right after — it skips this query entirely.',
+    description: 'List the parts of the current geometry. Returns {count, components: [{index, centroid, boundingBox, ...}], source}. Two paths: (1) "manifold" — uses Manifold.decompose() on built geometry; entries include volume + surfaceArea. (2) "mesh-island" — face-connected BFS over the triangle adjacency graph; entries include triangleCount and works on render-only imports / non-manifold meshes (multi-part STL kits — articulated print-in-place figures, separable mechanism parts — finally segment without needing Manifold). Print-in-place kits with clearance gaps split cleanly into one island per part; parts that physically touch at a shared vertex appear as one island. Pair with paintIsland({index, color}) — topological, never bleeds across XYZ-overlapping parts.',
     input_schema: { type: 'object', properties: {} },
   },
   {
     name: 'paintComponent',
-    description: 'Paint a boolean-distinct component (from listComponents) in one call. Equivalent to listComponents → paintInBox(component.boundingBox) but a single round-trip. Use whenever the user wants "paint the Nth piece a color" — eyes, nose, mouth on a unioned smiley, arms of a robot, etc.',
+    description: 'Paint a boolean-distinct component (from listComponents on built geometry) in one call. Equivalent to listComponents → paintInBox(component.boundingBox) but a single round-trip. Use for "paint the Nth piece a color" — eyes, nose, mouth on a unioned smiley, arms of a robot, etc. REQUIRES a manifold — for render-only STL imports use paintIsland instead.',
     input_schema: {
       type: 'object',
       properties: {
@@ -204,6 +204,32 @@ const ALL_TOOLS: ToolDefinition[] = [
         topOnly: { type: 'boolean', description: 'If true, only paint upward-facing triangles (skip side walls + bottom). Same shortcut as paintInBox.topOnly.' },
       },
       required: ['index', 'color'],
+    },
+  },
+  {
+    name: 'paintIsland',
+    description: 'Paint a single face-connected mesh island by index from listComponents(). The right tool for painting one part of a multi-part STL kit (articulated figures, separable mechanism parts) — selects by topological connectivity, NOT XYZ position, so it never bleeds across parts that overlap in 3D space (the failure mode that defeats paintInBox/paintNear/paintInCylinder on tightly-packed prints). Works on ANY mesh including render-only imports; paintComponent requires Manifold but this does not. Use whenever a multi-part import is in play — call listComponents() first to see the island count, then loop one paintIsland call per part. Topological: print-in-place kits with clearance gaps split cleanly; two parts touching at a shared vertex appear as one island.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        index: { type: 'integer', description: 'Island index from listComponents() (0-based).' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[r, g, b] in 0..1.' },
+        name: { type: 'string', description: 'Optional region name. Defaults to "Island <index>".' },
+      },
+      required: ['index', 'color'],
+    },
+  },
+  {
+    name: 'paintIslandAt',
+    description: 'Paint the face-connected island containing the triangle closest to `point`. Use this when you have a 3D point on the part you want — e.g. from probePixel after raycasting a pixel in an iso render — and want to paint that whole part without enumerating islands first. The grounded equivalent of paintIsland.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        point: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[x, y, z] world-space point on the part you want to paint (from probePixel.point or any other source).' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[r, g, b] in 0..1.' },
+        name: { type: 'string', description: 'Optional region name.' },
+      },
+      required: ['point', 'color'],
     },
   },
   {
@@ -563,17 +589,20 @@ const ALL_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'paintInBox',
-    description: 'Paint every triangle whose centroid is inside the axis-aligned box (optionally constrained by a normal cone). One call. Use for "paint the top half / the right rim / everything below z=0". Pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause. On fan-topology meshes (cylinder/revolve/linear_extrude surfaces), pass `coverageMode: "fully_inside"` and/or `maxTriangleArea` to avoid long radial triangles bleeding paint outside the box. On BREP-engine solids (replicad language, or a manifold-js session whose return value came through `BREP.toManifold`), OCCT booleans can leave interior intersection-seam triangles inside the bounding volume — the centroid test then catches them and you get patchy paint on a surface that looks solid. Default to `coverageMode: "fully_inside"` on BREP, or use `paintConnected` from a probePixel seed instead.',
+    description: 'Paint every triangle inside the axis-aligned box. One call. Use for "paint the top half / the right rim / everything below z=0". The painted edge is SMOOTHED by default — the mesh is subdivided near the box faces so the colour boundary follows the box, not the coarse tessellation. Pass `smooth: false` for the raw blocky edge, or tune `resolution` / `maxEdge`. Smoothing is automatically skipped (silently) when `normalCone` / `topOnly` / `coverageMode` / `maxTriangleArea` are set — the filter path stays on the legacy centroid-collect branch. Filter options: pass `topOnly: true` to skip side walls and the bottom face — the most common over-paint cause. On fan-topology meshes (cylinder/revolve/linear_extrude surfaces), pass `coverageMode: "fully_inside"` and/or `maxTriangleArea` to avoid long radial triangles bleeding paint outside the box. On BREP-engine solids (replicad language, or a manifold-js session whose return value came through `BREP.toManifold`), OCCT booleans can leave interior intersection-seam triangles inside the bounding volume — default to `coverageMode: "fully_inside"` on BREP, or use `paintConnected` from a probePixel seed instead.',
     input_schema: {
       type: 'object',
       properties: {
         box: { type: 'object', description: '{min: [x,y,z], max: [x,y,z]}' },
-        normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n}.' },
-        topOnly: { type: 'boolean', description: 'Shortcut for normalCone: {axis: [0,0,1], angleDeg: 30}. Common case: paint the top face of a feature without catching its sides.' },
-        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'Triangle containment test. Default "centroid". "fully_inside" requires all 3 vertices inside the box — defangs fan-bleed.' },
-        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this. Use to filter out the long radial triangles that cylinder/revolve produce.' },
+        normalCone: { type: 'object', description: 'Optional {axis: [x,y,z], angleDeg: n}. Setting this disables smooth edges.' },
+        topOnly: { type: 'boolean', description: 'Shortcut for normalCone: {axis: [0,0,1], angleDeg: 30}. Common case: paint the top face of a feature without catching its sides. Disables smooth edges.' },
+        coverageMode: { type: 'string', enum: ['centroid', 'fully_inside', 'any_vertex_inside'], description: 'Triangle containment test. Default "centroid". "fully_inside" requires all 3 vertices inside the box — defangs fan-bleed. Disables smooth edges.' },
+        maxTriangleArea: { type: 'number', description: 'Skip triangles larger than this. Use to filter out the long radial triangles that cylinder/revolve produce. Disables smooth edges.' },
         color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
         name: { type: 'string' },
+        smooth: { type: 'boolean', description: 'Smooth the painted edge by subdividing the mesh near the box faces. Default true; pass false for the raw (blocky) tessellation. Ignored when any filter (normalCone/topOnly/coverageMode/maxTriangleArea) is set.' },
+        resolution: { type: 'number', description: 'Smoothing detail: target boundary edge = model bbox diagonal / resolution. Higher = smoother + more triangles. Default 256, range 2–1024.' },
+        maxEdge: { type: 'number', description: 'Optional absolute override for the target boundary edge length (mesh units). Takes precedence over resolution.' },
       },
       required: ['box', 'color'],
     },
@@ -1387,7 +1416,7 @@ export const PART_TARGETABLE_TOOLS = new Set<string>([
   'modifyAndTest', 'query', 'findFaces', 'listComponents', 'listLabels', 'getModelColors',
   'listRegions', 'probePixel', 'probeRay', 'paintPreview', 'paintExplain',
   'paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintImage', 'paintInBox', 'paintInOrientedBox',
-  'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels',
+  'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintIsland', 'paintIslandAt', 'paintByLabel', 'paintByLabels',
   'paintConnected', 'paintInCylinder', 'undoLastPaint', 'redoLastPaint', 'removeRegion',
   'clearColors', 'assertPaint', 'sliceAtZVisual', 'checkPrintability',
   'renderView', 'renderViews',
@@ -1501,7 +1530,7 @@ export const RETRY_SAFE_TOOLS = new Set([
 
 const RUN_GATED = new Set(['runCode', 'setParams']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion', 'saveVersion', 'applySurfaceTexture', 'applyVoronoiLamp', 'engraveModel', 'voxelizeModel', 'scaleModel', 'placeModel', 'rotateModel', 'layFlatModel']);
-const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintImage', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintImage', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintIsland', 'paintIslandAt', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);
 /** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
  *  vision spend in one place — when off, the agent has to reason from
@@ -2013,6 +2042,10 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.listComponents();
     case 'paintComponent':
       return api.paintComponent(input);
+    case 'paintIsland':
+      return api.paintIsland(input);
+    case 'paintIslandAt':
+      return api.paintIslandAt(input);
     case 'listLabels':
       return api.listLabels();
     case 'getModelColors':

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -233,6 +233,36 @@ const ALL_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'detectRegions',
+    description: 'Auto-segment the mesh into SCULPTED FEATURE regions by crease (dihedral-angle) watershed. THE enumeration primitive for organic sculpts — the iris ring, pupil, eye outline, mouth crease, blush dimples, each torso pom-pom, bangs/hairline are all sculpted features whose boundaries are crease edges. With the default 20° threshold, the BFS walks freely across the gentle curvature of cheeks and a hat dome but stops cold at a 30°+ crease, so features pop out as distinct regions. Returns regions sorted largest first with {id, triangleCount, area, centroid, normal, bbox, neighborIds?}. Pass `withinIsland: <id>` (from listComponents) to segment ONE mesh-island (a fused body part) so the head\'s eyes/buttons stop being unreachable. Pair with paintByCrease (paint one region) or paintFaces (paint by triangleIds for surgical control). For coarse part-level segmentation, raise creaseAngleDeg to 45°; for fine detail, lower to 10°.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        creaseAngleDeg: { type: 'number', description: 'Dihedral angle threshold in DEGREES — BFS stops where adjacent face bend exceeds this. Default 20 (good for sculpted features). 10 = fine detail, 45 = coarse parts.' },
+        minTriangleCount: { type: 'integer', description: 'Skip regions with fewer than this many triangles. Default 5. Filters out single-triangle slivers.' },
+        maxRegions: { type: 'integer', description: 'Cap returned region count (largest first). Default 64. 0 = unlimited (use sparingly).' },
+        withinIsland: { type: 'integer', description: 'Optional index from listComponents() — segment ONLY this mesh-island, not the whole mesh. The fix for fused body islands (head+torso+buttons welded as one island) — pass the body island id and the eyes/mouth/buttons separate out as their own regions.' },
+        includeNeighbors: { type: 'boolean', description: 'Add neighborIds (regions sharing a crease boundary) to each region. Default true. Useful for "what borders the iris?" queries.' },
+        maxTrianglesPerGroup: { type: 'integer', description: 'Cap triangleIds per region. Default 0 (omit entirely — keeps response small). Set >0 only if you need raw ids for paintFaces.' },
+      },
+    },
+  },
+  {
+    name: 'paintByCrease',
+    description: 'Flood paint from a surface seed, stopping at the next crease edge. THE paint primitive for SCULPTED FEATURES on organic meshes (eyes, mouth, pom-poms). Clean edges by construction — no box guessing, no jaggies. Same math as paintRegion but parameterised in DEGREES (sculpt-natural) with a sculpt-tuned default of 20°. seedNormal optional; if omitted we snap to the nearest triangle and use its normal — forgiving of off-surface points from probePixel rounding. PAIR THIS WITH probePixel: render an iso, click the iris pixel, hand probePixel.point straight to paintByCrease. For very tight features (pupil inside iris) lower creaseAngleDeg to 5–10° so the inner crease catches.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        seedPoint: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[x, y, z] world-space point on the surface (e.g. probePixel.point).' },
+        seedNormal: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Optional surface normal at the seed (e.g. probePixel.normal). Omit to auto-snap to the nearest triangle\'s normal.' },
+        creaseAngleDeg: { type: 'number', description: 'Crease angle in degrees. Default 20. Lower for tighter features (5–10° for pupil inside iris), higher for coarser flood (45°+).' },
+        color: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[r, g, b] in 0..1.' },
+        name: { type: 'string', description: 'Optional region name.' },
+      },
+      required: ['seedPoint', 'color'],
+    },
+  },
+  {
     name: 'listLabels',
     description: 'Return labels registered in the current run via api.label(shape, name) — the cleanest paint primitive on agent-authored geometry, in both manifold-js and SCAD (where labels come from top-level `label("name") <expr>;` wrappers). Each entry: {name, triangleCount, bbox, centroid}. Empty when the code did not call api.label or `label("name")`. Use to confirm labels resolved correctly before paintByLabel; otherwise prefer calling paintByLabel directly to save a round-trip.',
     input_schema: { type: 'object', properties: {} },
@@ -1416,8 +1446,8 @@ export const PART_TARGETABLE_TOOLS = new Set<string>([
   'modifyAndTest', 'query', 'findFaces', 'listComponents', 'listLabels', 'getModelColors',
   'listRegions', 'probePixel', 'probeRay', 'paintPreview', 'paintExplain',
   'paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintImage', 'paintInBox', 'paintInOrientedBox',
-  'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintIsland', 'paintIslandAt', 'paintByLabel', 'paintByLabels',
-  'paintConnected', 'paintInCylinder', 'undoLastPaint', 'redoLastPaint', 'removeRegion',
+  'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintIsland', 'paintIslandAt', 'paintByCrease', 'paintByLabel', 'paintByLabels',
+  'paintConnected', 'paintInCylinder', 'detectRegions', 'undoLastPaint', 'redoLastPaint', 'removeRegion',
   'clearColors', 'assertPaint', 'sliceAtZVisual', 'checkPrintability',
   'renderView', 'renderViews',
   'applySurfaceTexture', 'applyVoronoiLamp', 'engraveModel', 'voxelizeModel',
@@ -1530,7 +1560,7 @@ export const RETRY_SAFE_TOOLS = new Set([
 
 const RUN_GATED = new Set(['runCode', 'setParams']);
 const SAVE_GATED = new Set(['runAndSave', 'loadVersion', 'saveVersion', 'applySurfaceTexture', 'applyVoronoiLamp', 'engraveModel', 'voxelizeModel', 'scaleModel', 'placeModel', 'rotateModel', 'layFlatModel']);
-const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintImage', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintIsland', 'paintIslandAt', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);
+const PAINT_GATED = new Set(['paintRegion', 'paintFaces', 'paintNear', 'paintStroke', 'paintImage', 'paintInBox', 'paintInOrientedBox', 'paintSlab', 'paintNearestRegion', 'paintComponent', 'paintIsland', 'paintIslandAt', 'paintByCrease', 'paintByLabel', 'paintByLabels', 'paintConnected', 'undoLastPaint', 'redoLastPaint', 'removeRegion', 'clearColors', 'copyColorsFromVersion']);
 /** Tools that ship a PNG back to the model via a multimodal content
  *  block. Gated by the Views vision toggle so the user can disable
  *  vision spend in one place — when off, the agent has to reason from
@@ -2046,6 +2076,10 @@ async function dispatch(api: PartwrightAPI, name: string, input: Record<string, 
       return api.paintIsland(input);
     case 'paintIslandAt':
       return api.paintIslandAt(input);
+    case 'detectRegions':
+      return api.detectRegions(input);
+    case 'paintByCrease':
+      return api.paintByCrease(input);
     case 'listLabels':
       return api.listLabels();
     case 'getModelColors':

--- a/src/color/faceGroups.ts
+++ b/src/color/faceGroups.ts
@@ -21,6 +21,9 @@ export interface FaceGroup {
   bbox: { min: [number, number, number]; max: [number, number, number] };
   /** Triangle indices belonging to this group. Capped by `maxTrianglesPerGroup`. */
   triangleIds: number[];
+  /** Ids of groups this group shares a crease boundary with. Present only
+   *  when `includeNeighborIds: true` was passed to `computeFaceGroups`. */
+  neighborIds?: number[];
 }
 
 export interface FaceGroupSummary {
@@ -32,7 +35,8 @@ export interface FaceGroupSummary {
 }
 
 interface FaceGroupOptions {
-  /** Cosine bend tolerance for the BFS that gathers each group. Default 0.9995 (≈1.8°). */
+  /** Cosine bend tolerance for the BFS that gathers each group. Default 0.9995 (≈1.8°).
+   *  Use `~0.94` (cos 20°) for sculpt-feature segmentation (iris ring, mouth crease, etc.). */
   tolerance?: number;
   /** Skip groups smaller than this many triangles. Default 1 (return everything). */
   minTriangles?: number;
@@ -42,6 +46,16 @@ interface FaceGroupOptions {
   /** Maximum number of groups to return (largest by triangle count first).
    *  Default 256 — large enough for typical models. Set 0 for unlimited. */
   maxGroups?: number;
+  /** Optional triangle-id restriction. Only seed triangles in this set are
+   *  considered, and the BFS won't walk into triangles outside it. Use to
+   *  segment a single mesh-island (fused body part) rather than the whole
+   *  mesh — e.g. pass the result of `trianglesInIsland(triIslands, idx)`. */
+  restrictTo?: Set<number>;
+  /** When true, each group gets a `neighborIds: number[]` field listing the
+   *  ids of every group it shares at least one crease boundary with. Computed
+   *  by walking each group's boundary triangles and cross-referencing the
+   *  group assignment of their cross-crease neighbours. ~30 lines, O(triangles). */
+  includeNeighborIds?: boolean;
 }
 
 export function computeFaceGroups(mesh: MeshData, options?: FaceGroupOptions): FaceGroupSummary {
@@ -49,23 +63,62 @@ export function computeFaceGroups(mesh: MeshData, options?: FaceGroupOptions): F
   const minTriangles = Math.max(1, options?.minTriangles ?? 1);
   const maxTrianglesPerGroup = options?.maxTrianglesPerGroup ?? 64;
   const maxGroups = options?.maxGroups ?? 256;
+  const restrictTo = options?.restrictTo;
+  const includeNeighborIds = options?.includeNeighborIds ?? false;
 
   const adjacency = buildAdjacency(mesh);
   const visited = new Uint8Array(mesh.numTri);
+  // Pre-mark every triangle OUTSIDE the restriction set as visited so the
+  // outer-loop seed scan skips them AND the per-triangle resolver below maps
+  // them to NO_GROUP (= no neighbour cross-reference into them).
+  if (restrictTo) {
+    for (let t = 0; t < mesh.numTri; t++) if (!restrictTo.has(t)) visited[t] = 1;
+  }
   const groups: FaceGroup[] = [];
+  const triToGroup = includeNeighborIds ? new Int32Array(mesh.numTri).fill(-1) : null;
 
   for (let seed = 0; seed < mesh.numTri; seed++) {
     if (visited[seed]) continue;
-    const triangles = findCoplanarRegion(seed, adjacency, tolerance);
+    const triangles = restrictTo
+      ? findCoplanarRegionConstrained(seed, adjacency, tolerance, restrictTo)
+      : findCoplanarRegion(seed, adjacency, tolerance);
     for (const t of triangles) visited[t] = 1;
     if (triangles.size < minTriangles) continue;
-    groups.push(buildGroup(groups.length, triangles, mesh, adjacency, maxTrianglesPerGroup));
+    const group = buildGroup(groups.length, triangles, mesh, adjacency, maxTrianglesPerGroup);
+    if (triToGroup) for (const t of triangles) triToGroup[t] = group.id;
+    groups.push(group);
   }
 
   // Largest groups first so an agent that only inspects the top N gets the
   // most structurally significant faces.
   groups.sort((a, b) => b.triangleCount - a.triangleCount);
+  // Rewrite ids to match the post-sort order, then re-key triToGroup so
+  // neighbour lookups still hit the right group.
+  if (triToGroup) {
+    const oldToNew = new Int32Array(groups.length);
+    for (let i = 0; i < groups.length; i++) oldToNew[groups[i].id] = i;
+    for (let t = 0; t < mesh.numTri; t++) {
+      if (triToGroup[t] >= 0) triToGroup[t] = oldToNew[triToGroup[t]];
+    }
+  }
   for (let i = 0; i < groups.length; i++) groups[i].id = i;
+
+  // Cross-crease neighbour graph: for each triangle in group G, any neighbour
+  // belonging to a different group H means G and H share a boundary. Cheap
+  // and exact over the adjacency we already built.
+  if (triToGroup) {
+    const seen: Set<number>[] = groups.map(() => new Set<number>());
+    for (let t = 0; t < mesh.numTri; t++) {
+      const g = triToGroup[t];
+      if (g < 0) continue;
+      const ns = adjacency.neighbors[t];
+      for (let i = 0; i < ns.length; i++) {
+        const h = triToGroup[ns[i]];
+        if (h >= 0 && h !== g) seen[g].add(h);
+      }
+    }
+    for (let i = 0; i < groups.length; i++) groups[i].neighborIds = [...seen[i]].sort((a, b) => a - b);
+  }
 
   const trimmed = maxGroups > 0 ? groups.slice(0, maxGroups) : groups;
 
@@ -74,6 +127,39 @@ export function computeFaceGroups(mesh: MeshData, options?: FaceGroupOptions): F
     totalTriangles: mesh.numTri,
     tolerance,
   };
+}
+
+/** BFS variant of `findCoplanarRegion` that won't walk outside `allowed`. The
+ *  adjacent-pair crease gate is unchanged; the constraint just prunes the
+ *  walk to one island's triangles. */
+function findCoplanarRegionConstrained(
+  seedTri: number,
+  adjacency: AdjacencyGraph,
+  normalTolerance: number,
+  allowed: Set<number>,
+): Set<number> {
+  const { neighbors, normals } = adjacency;
+  const result = new Set<number>();
+  if (!allowed.has(seedTri)) return result;
+  result.add(seedTri);
+  const stack = [seedTri];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const cnx = normals[current * 3];
+    const cny = normals[current * 3 + 1];
+    const cnz = normals[current * 3 + 2];
+    const adj = neighbors[current];
+    for (let i = 0; i < adj.length; i++) {
+      const nb = adj[i];
+      if (result.has(nb) || !allowed.has(nb)) continue;
+      const dot = cnx * normals[nb * 3] + cny * normals[nb * 3 + 1] + cnz * normals[nb * 3 + 2];
+      if (dot >= normalTolerance) {
+        result.add(nb);
+        stack.push(nb);
+      }
+    }
+  }
+  return result;
 }
 
 function buildGroup(

--- a/src/color/meshIslands.ts
+++ b/src/color/meshIslands.ts
@@ -1,0 +1,161 @@
+// Mesh islands — face-connected topological components of a triangle mesh.
+//
+// The voxel engine has `voxelPieceCount` (6-neighbour BFS over the grid); this
+// is the triangle-mesh analog. It runs on ANY MeshData regardless of manifold
+// status, so a render-only STL import (which can't use `Manifold.decompose()`)
+// can still be split into its constituent parts for painting and bbox queries.
+//
+// We reuse `buildAdjacency` for the underlying graph: it welds vertices by
+// exact position before walking, so coincident-but-split vertex copies (common
+// in STL triangle soups, where every facet stores its own three vertices) get
+// joined into a single island instead of fragmenting into 100k singletons.
+//
+// LIMITATION: parts that physically touch at a shared vertex (a hat brim
+// resting on a head) appear as one island because the welded adjacency can't
+// tell them apart. This matches `Manifold.decompose()`'s behaviour and is
+// unavoidable without external part metadata. For print-in-place / articulated
+// kits where parts have clearance gaps (the common case), island detection
+// matches each part exactly.
+//
+// Results are memoized on a WeakMap keyed by the MeshData reference. A new
+// engine run produces a fresh MeshData, so the cache invalidates implicitly.
+
+import { buildAdjacency } from './adjacency';
+import type { MeshData } from '../geometry/types';
+
+export interface MeshIsland {
+  /** Stable index 0..N-1 within this mesh's island list. */
+  index: number;
+  /** Number of triangles in this island. */
+  triangleCount: number;
+  /** Axis-aligned bounding box of the island's vertices. */
+  bbox: { min: [number, number, number]; max: [number, number, number] };
+  /** Bbox centre (not the centroid of triangles). Cheap and good enough for
+   *  "where is this island in space" — what the AI needs to label parts. */
+  center: [number, number, number];
+}
+
+export interface MeshIslandsResult {
+  /** Per-triangle island id, length = mesh.numTri. */
+  triIslands: Uint32Array;
+  /** Per-island metadata. */
+  islands: MeshIsland[];
+}
+
+const cache = new WeakMap<MeshData, MeshIslandsResult>();
+
+/** Compute (or fetch from cache) the face-connected island decomposition of
+ *  `mesh`. Triangle adjacency uses `buildAdjacency`'s welded-by-position
+ *  graph, so coincident vertex copies don't fragment a single island. */
+export function meshIslands(mesh: MeshData): MeshIslandsResult {
+  const cached = cache.get(mesh);
+  if (cached) return cached;
+  const result = compute(mesh);
+  cache.set(mesh, result);
+  return result;
+}
+
+/** Clear the WeakMap entry for a mesh — useful in tests; the WeakMap drops
+ *  entries automatically when the mesh is garbage-collected, so production
+ *  code doesn't need this. */
+export function clearMeshIslandsCache(mesh?: MeshData): void {
+  if (mesh) cache.delete(mesh);
+}
+
+function compute(mesh: MeshData): MeshIslandsResult {
+  const { numTri } = mesh;
+  const triIslands = new Uint32Array(numTri);
+  if (numTri === 0) return { triIslands, islands: [] };
+
+  // Sentinel: 0xFFFFFFFF = unvisited. (Real island ids start at 0 and we
+  // won't ever hit 2^32-1 islands.)
+  triIslands.fill(0xFFFFFFFF);
+
+  const adjacency = buildAdjacency(mesh);
+  const { neighbors } = adjacency;
+  const { triVerts, vertProperties, numProp } = mesh;
+
+  const islands: MeshIsland[] = [];
+  const stack: number[] = [];
+
+  for (let seed = 0; seed < numTri; seed++) {
+    if (triIslands[seed] !== 0xFFFFFFFF) continue;
+    const islandIdx = islands.length;
+    triIslands[seed] = islandIdx;
+    stack.push(seed);
+
+    let triCount = 0;
+    let minX = Infinity, minY = Infinity, minZ = Infinity;
+    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+
+    while (stack.length > 0) {
+      const t = stack.pop()!;
+      triCount++;
+      // Accumulate bbox from the triangle's three vertices.
+      for (let k = 0; k < 3; k++) {
+        const v = triVerts[t * 3 + k];
+        const x = vertProperties[v * numProp];
+        const y = vertProperties[v * numProp + 1];
+        const z = vertProperties[v * numProp + 2];
+        if (x < minX) minX = x;
+        if (y < minY) minY = y;
+        if (z < minZ) minZ = z;
+        if (x > maxX) maxX = x;
+        if (y > maxY) maxY = y;
+        if (z > maxZ) maxZ = z;
+      }
+      const ns = neighbors[t];
+      for (let i = 0; i < ns.length; i++) {
+        const nb = ns[i];
+        if (triIslands[nb] === 0xFFFFFFFF) {
+          triIslands[nb] = islandIdx;
+          stack.push(nb);
+        }
+      }
+    }
+
+    islands.push({
+      index: islandIdx,
+      triangleCount: triCount,
+      bbox: { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] },
+      center: [(minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2],
+    });
+  }
+
+  return { triIslands, islands };
+}
+
+/** Collect every triangle id belonging to the given island. */
+export function trianglesInIsland(triIslands: Uint32Array, islandIndex: number): Set<number> {
+  const out = new Set<number>();
+  for (let t = 0; t < triIslands.length; t++) {
+    if (triIslands[t] === islandIndex) out.add(t);
+  }
+  return out;
+}
+
+/** Find the island id that owns the triangle closest to `point` (linear scan
+ *  over triangle centroids). Returns -1 for an empty mesh. */
+export function islandAtPoint(
+  mesh: MeshData,
+  point: [number, number, number],
+): number {
+  const { triIslands } = meshIslands(mesh);
+  const { triVerts, vertProperties, numProp, numTri } = mesh;
+  if (numTri === 0) return -1;
+  const [px, py, pz] = point;
+  let bestT = -1;
+  let bestD2 = Infinity;
+  for (let t = 0; t < numTri; t++) {
+    const v0 = triVerts[t * 3];
+    const v1 = triVerts[t * 3 + 1];
+    const v2 = triVerts[t * 3 + 2];
+    const cx = (vertProperties[v0 * numProp] + vertProperties[v1 * numProp] + vertProperties[v2 * numProp]) / 3;
+    const cy = (vertProperties[v0 * numProp + 1] + vertProperties[v1 * numProp + 1] + vertProperties[v2 * numProp + 1]) / 3;
+    const cz = (vertProperties[v0 * numProp + 2] + vertProperties[v1 * numProp + 2] + vertProperties[v2 * numProp + 2]) / 3;
+    const dx = cx - px, dy = cy - py, dz = cz - pz;
+    const d2 = dx * dx + dy * dy + dz * dz;
+    if (d2 < bestD2) { bestD2 = d2; bestT = t; }
+  }
+  return bestT >= 0 ? triIslands[bestT] : -1;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14700,6 +14700,164 @@ async function main() {
       return partwrightAPI.paintIsland({ index: islandIdx, color: opts.color, name: opts.name ?? `Island ${islandIdx}` });
     },
 
+    /** Auto-segment the current mesh by **crease (dihedral-angle) watershed**
+     *  and return a region list. This is the right enumeration primitive for
+     *  ORGANIC SCULPTS — the iris ring, pupil, eye outline, mouth crease,
+     *  blush dimples, each torso pom-pom, the bangs/hairline are all sculpted
+     *  features whose boundaries are crease edges in the mesh. With the
+     *  default `creaseAngleDeg: 20`, the BFS walks freely across the gentle
+     *  curvature of cheeks and a hat dome but stops cold at a 30°+ crease.
+     *
+     *  Output is sorted largest first. With `includeNeighbors: true`, each
+     *  region also reports `neighborIds` — the regions it shares at least
+     *  one crease boundary with (the iris borders the sclera, etc.).
+     *
+     *  For mesh-island contexts (multi-part STL kits with fused body
+     *  islands), pass `withinIsland: <id>` to segment ONLY that island's
+     *  triangles — the body's face/eyes/buttons stop being unreachable. */
+    detectRegions(opts?: {
+      creaseAngleDeg?: number;
+      minTriangleCount?: number;
+      maxRegions?: number;
+      withinIsland?: number;
+      includeNeighbors?: boolean;
+      maxTrianglesPerGroup?: number;
+    }) {
+      if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
+      const o = opts ?? {};
+      const creaseAngleDeg = o.creaseAngleDeg ?? 20;
+      if (typeof creaseAngleDeg !== 'number' || !Number.isFinite(creaseAngleDeg) || creaseAngleDeg <= 0 || creaseAngleDeg >= 180) {
+        return { error: 'creaseAngleDeg must be a finite number in (0, 180). Default 20° — try 10° for fine sculpt features, 45° for coarse part-level segmentation.' };
+      }
+      const minTriangleCount = o.minTriangleCount ?? 5;
+      if (!Number.isInteger(minTriangleCount) || minTriangleCount < 1) {
+        return { error: 'minTriangleCount must be a positive integer (default 5 — filters out single-triangle slivers).' };
+      }
+      const maxRegions = o.maxRegions ?? 64;
+      if (!Number.isInteger(maxRegions) || maxRegions < 0) {
+        return { error: 'maxRegions must be a non-negative integer (0 = unlimited).' };
+      }
+      const maxTrianglesPerGroup = o.maxTrianglesPerGroup ?? 0;
+      if (!Number.isInteger(maxTrianglesPerGroup) || maxTrianglesPerGroup < 0) {
+        return { error: 'maxTrianglesPerGroup must be a non-negative integer (0 = omit triangleIds entirely; the default to keep responses small).' };
+      }
+
+      let restrictTo: Set<number> | undefined;
+      if (o.withinIsland !== undefined) {
+        if (!Number.isInteger(o.withinIsland) || o.withinIsland < 0) return { error: 'withinIsland must be a non-negative integer (an index from listComponents).' };
+        const { triIslands, islands } = meshIslands(currentMeshData);
+        if (o.withinIsland >= islands.length) return { error: `withinIsland ${o.withinIsland} out of range — listComponents has ${islands.length} island(s).` };
+        restrictTo = trianglesInIsland(triIslands, o.withinIsland);
+      }
+
+      // tolerance = cos(crease) — a neighbour at less than the crease bend
+      // passes (dot >= tolerance), past the crease stops.
+      const tolerance = Math.cos(creaseAngleDeg * Math.PI / 180);
+      const summary = computeFaceGroups(currentMeshData, {
+        tolerance,
+        minTriangles: minTriangleCount,
+        maxTrianglesPerGroup,
+        maxGroups: maxRegions,
+        restrictTo,
+        includeNeighborIds: o.includeNeighbors ?? true,
+      });
+
+      return {
+        count: summary.groups.length,
+        creaseAngleDeg,
+        tolerance,
+        source: o.withinIsland !== undefined ? 'island' as const : 'whole-mesh' as const,
+        ...(o.withinIsland !== undefined ? { withinIsland: o.withinIsland } : {}),
+        regions: summary.groups.map(g => ({
+          id: g.id,
+          triangleCount: g.triangleCount,
+          area: g.area,
+          centroid: g.centroid,
+          normal: g.normal,
+          bbox: g.bbox,
+          ...(g.neighborIds ? { neighborIds: g.neighborIds } : {}),
+          ...(g.triangleIds.length > 0 ? { triangleIds: g.triangleIds } : {}),
+        })),
+      };
+    },
+
+    /** Flood paint from a surface seed, stopping at the next crease edge.
+     *  This is the right paint primitive for SCULPTED FEATURES (irises,
+     *  pupils, mouth, blush, buttons, pom-poms) — clean edges by
+     *  construction, no box guessing.
+     *
+     *  Same math as `paintRegion` but parameterised in DEGREES (sculpt-
+     *  natural) instead of cosine tolerance, with a sculpt-tuned default
+     *  of 20°. `seedNormal` is optional; if omitted we snap to the nearest
+     *  triangle and use its normal (the `paintNearestRegion` style). Pair
+     *  with `probePixel`/`probeRay` to ground the seed in a visible point.
+     *
+     *  Returns `{id, name, triangles, ...}` or `{error}`. */
+    paintByCrease(opts: {
+      seedPoint: [number, number, number];
+      seedNormal?: [number, number, number];
+      creaseAngleDeg?: number;
+      color: [number, number, number];
+      name?: string;
+    }) {
+      if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintByCrease requires { seedPoint, color }' };
+      const { seedPoint, seedNormal, color, name } = opts;
+      if (!Array.isArray(seedPoint) || seedPoint.length !== 3) return { error: 'seedPoint must be [x,y,z]' };
+      for (let i = 0; i < 3; i++) {
+        if (typeof seedPoint[i] !== 'number' || !Number.isFinite(seedPoint[i])) return { error: 'seedPoint components must be finite numbers' };
+      }
+      if (!Array.isArray(color) || color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+      const creaseAngleDeg = opts.creaseAngleDeg ?? 20;
+      if (typeof creaseAngleDeg !== 'number' || !Number.isFinite(creaseAngleDeg) || creaseAngleDeg <= 0 || creaseAngleDeg >= 180) {
+        return { error: 'creaseAngleDeg must be a finite number in (0, 180). Default 20° — try 10° for fine sculpt features, 45° for coarse boundaries.' };
+      }
+      const tolerance = Math.cos(creaseAngleDeg * Math.PI / 180);
+      const adjacency = buildAdjacency(currentMeshData);
+
+      // Resolve seed: use supplied normal when present (paintRegion path);
+      // otherwise snap to nearest triangle and adopt its normal (the
+      // paintNearestRegion path). Snapping is forgiving — the probePixel
+      // round-trip can land slightly off-surface in iso views and we
+      // shouldn't punish that.
+      let seedTri = -1;
+      let resolvedPoint: [number, number, number] = seedPoint as [number, number, number];
+      let resolvedNormal: [number, number, number] | null = null;
+      if (Array.isArray(seedNormal) && seedNormal.length === 3 && seedNormal.every(v => typeof v === 'number' && Number.isFinite(v))) {
+        seedTri = resolveSeed(seedPoint as [number, number, number], seedNormal as [number, number, number], currentMeshData, adjacency, tolerance);
+        if (seedTri >= 0) resolvedNormal = seedNormal as [number, number, number];
+      }
+      if (seedTri < 0) {
+        const nearest = findNearestTriangle(seedPoint as [number, number, number], currentMeshData, adjacency);
+        if (nearest.triIndex < 0) return { error: 'paintByCrease: mesh has no triangles.' };
+        seedTri = nearest.triIndex;
+        resolvedPoint = nearest.closest;
+        resolvedNormal = nearest.normal;
+      }
+
+      const triangles = findCoplanarRegion(seedTri, adjacency, tolerance);
+      if (triangles.size === 0) return { error: `paintByCrease: BFS returned no triangles from seed ${seedTri} (should be impossible — please report).` };
+      const regionName = name ?? `Region ${getRegions().length + 1}`;
+      const region = addRegion(
+        regionName,
+        color as [number, number, number],
+        'face-pick',
+        { kind: 'coplanar', seedPoint: resolvedPoint, seedNormal: resolvedNormal ?? [0, 0, 1], normalTolerance: tolerance },
+        triangles,
+      );
+      scheduleColorRefresh();
+      syncLockState();
+      const stats = regionTriangleStats(triangles, currentMeshData);
+      return {
+        id: region.id,
+        name: region.name,
+        triangles: triangles.size,
+        creaseAngleDeg,
+        bbox: stats.bbox,
+        centroid: stats.centroid,
+      };
+    },
+
     /** Token-cheap planning aid for paint workflows: returns just the
      *  centroid + normal + bbox of each coplanar face group, no triangle
      *  IDs. Same as `getMeshSummary({maxTrianglesPerGroup: 0, maxGroups})`
@@ -15515,6 +15673,8 @@ async function main() {
         'paintComponent':  { signature: 'paintComponent({index, color, name?, topOnly?}) -- One-call shortcut: listComponents + paintInBox for the Nth piece. Requires a manifold (uses decompose). For render-only imports use paintIsland.', docs: '/ai/colors.md' },
         'paintIsland':     { signature: 'paintIsland({index, color, name?}) -- Paint a single face-connected mesh island by index from listComponents(). Works on ANY mesh including render-only STL imports — the right tool for painting one part of a multi-part STL kit by its component number. Topological, not spatial — never bleeds across XYZ-overlapping parts.', docs: '/ai/colors.md' },
         'paintIslandAt':   { signature: 'paintIslandAt({point, color, name?}) -- Paint the face-connected island containing the triangle closest to point. Pair with probePixel/probeRay to ground island selection in a visible point ("the hat in the iso render") without enumerating islands.', docs: '/ai/colors.md' },
+        'detectRegions':   { signature: 'detectRegions({creaseAngleDeg?=20, minTriangleCount?=5, maxRegions?=64, withinIsland?, includeNeighbors?=true, maxTrianglesPerGroup?=0}) -> {count, regions: [{id, triangleCount, area, centroid, normal, bbox, neighborIds?, triangleIds?}], source} -- Auto-segment by crease (dihedral) watershed. The right enumeration primitive for SCULPTED FEATURES — iris ring, pupil, mouth crease, blush dimples, pom-poms, bangs all separate naturally at the 20° default. Pass withinIsland to segment ONE mesh-island (fused body part) so the face/eyes/buttons stop being unreachable.', docs: '/ai/colors.md' },
+        'paintByCrease':   { signature: 'paintByCrease({seedPoint, seedNormal?, creaseAngleDeg?=20, color, name?}) -- Flood paint from a surface seed, stopping at the next crease edge. The right paint primitive for SCULPTED FEATURES on organic meshes. Clean edges by construction, no box guessing. Pair with probePixel to ground the seed. seedNormal optional (snaps to nearest triangle).', docs: '/ai/colors.md' },
         'listLabels':      { signature: 'listLabels() -> {count, labels: [{name, triangleCount, bbox, centroid}]} -- Labels registered in the current run via api.label(shape, name). Survives boolean ops; the cleanest paint primitive on agent-authored geometry.', docs: '/ai/colors.md' },
         'getModelColors':  { signature: 'getModelColors() -> {count, colors: [{name, color, triangleCount}]} -- Colors declared in code via api.label(shape, name, {color}) or api.paint.*. Render + export automatically; editor stays editable; manual paint overrides.', docs: '/ai/colors.md' },
         'paintByLabel':    { signature: 'paintByLabel({label, color, name?}) -- Paint a labelled feature by name. Pair with api.label/labeledUnion in your code. No coordinate guessing.', docs: '/ai/colors.md' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -250,6 +250,7 @@ import {
   apiRotateSelection,
 } from './ui/insertPalette';
 import { buildAdjacency, findCoplanarRegion, findConnectedFromSeed, findColorRegion, resolveSeed, findNearestTriangle, type AdjacencyGraph } from './color/adjacency';
+import { meshIslands, trianglesInIsland, islandAtPoint } from './color/meshIslands';
 import { findSlabTriangles, slabRefineRegion, smoothEdgeForResolution } from './color/slabPaint';
 import { findBoxTriangles, findShapeTriangles, shapeRefineRegion } from './color/boxPaint';
 import { cylinderRefineRegion, findCylinderTriangles, type CylinderAxis } from './color/cylinderPaint';
@@ -13201,6 +13202,23 @@ async function main() {
        *  isn't enough. Inspect `largestTriangleArea` from `paintPreview`
        *  to pick a sensible value. */
       maxTriangleArea?: number;
+      /** Smooth the painted edge by subdividing the mesh along the AABB
+       *  faces so the colour boundary follows the analytic box rather than
+       *  the coarse base tessellation. Defaults to `true`. Ignored (and
+       *  silently treated as `false`) when `normalCone` / `topOnly` /
+       *  `coverageMode` / `maxTriangleArea` are set — smoothing is the
+       *  centroid-test code path; those filters live on the unsmoothed
+       *  branch. Pass `smooth: false` to opt back into the raw tessellation
+       *  for the simple case (e.g. when you want byte-identical behaviour
+       *  to the pre-smooth release). */
+      smooth?: boolean;
+      /** Smoothing detail: target boundary edge = model bbox diagonal /
+       *  resolution. Higher = smoother + more triangles. Default 256,
+       *  range 2–1024. Ignored when `maxEdge` is set. */
+      resolution?: number;
+      /** Absolute target boundary edge length (mesh units); overrides
+       *  `resolution`. */
+      maxEdge?: number;
     }) {
       if (!currentMeshData) return { error: 'No geometry loaded' };
       if (!opts || typeof opts !== 'object') return { error: 'paintInBox requires { box, color }' };
@@ -13212,6 +13230,51 @@ async function main() {
       const areaErr = validateMaxTriangleArea(opts.maxTriangleArea);
       if (areaErr) return { error: areaErr };
       if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+      const smoothErr = validateSmoothParams(opts);
+      if (smoothErr) return { error: smoothErr };
+
+      // Smooth-edge fast path: an AABB with no extra filters is just an
+      // identity-quaternion OBB, and the OBB descriptor already does
+      // boundary-subdivision (paintInOrientedBox / paintSlab / paintInCylinder
+      // all share this machinery). Routing through it makes paintInBox edges
+      // crisp by default — the single biggest paint-quality win for the most-
+      // reached-for AABB selector. The filter path stays on the legacy
+      // centroid-collect branch (smoothing the filter combinatorics isn't worth
+      // the surface-area extension to the 'box' descriptor right now).
+      const hasFilters = cone !== undefined || opts.coverageMode !== undefined || opts.maxTriangleArea !== undefined;
+      const wantsSmooth = opts.smooth !== false && !hasFilters;
+      if (wantsSmooth) {
+        const { smooth, maxEdge } = resolveShapeSmoothFields(opts);
+        if (smooth) {
+          const center: [number, number, number] = [
+            (opts.box.min[0] + opts.box.max[0]) / 2,
+            (opts.box.min[1] + opts.box.max[1]) / 2,
+            (opts.box.min[2] + opts.box.max[2]) / 2,
+          ];
+          const size: [number, number, number] = [
+            opts.box.max[0] - opts.box.min[0],
+            opts.box.max[1] - opts.box.min[1],
+            opts.box.max[2] - opts.box.min[2],
+          ];
+          const obb = { center, size, quaternion: [0, 0, 0, 1] as [number, number, number, number] };
+          const seedTris = findBoxTriangles(currentMeshData, obb);
+          if (seedTris.size === 0) {
+            return { error: `paintInBox: no triangles matched the box. Try widening the box or call findFaces() to see what's around.` };
+          }
+          const regionName = opts.name ?? `Region ${getRegions().length + 1}`;
+          const region = withSyncReconcile(() => addRegion(
+            regionName,
+            opts.color as [number, number, number],
+            'slab',
+            { kind: 'box', center, size, quaternion: obb.quaternion, smooth: true, maxEdge },
+            seedTris,
+          ));
+          scheduleColorRefresh();
+          syncLockState();
+          const stats = currentMeshData ? regionTriangleStats(region.triangles, currentMeshData) : { bbox: null, centroid: null };
+          return { id: region.id, name: region.name, triangles: region.triangles.size, bbox: stats.bbox, centroid: stats.centroid, smooth: true, maxEdge };
+        }
+      }
 
       const triangles = collectTrianglesByFilter(currentMeshData, opts.box, cone, null, opts.coverageMode, opts.maxTriangleArea);
       if (triangles.size === 0) return { error: `paintInBox: no triangles matched the box${cone ? ' (with the normalCone' + (opts.topOnly ? '/topOnly' : '') + ' filter)' : ''}${opts.coverageMode === 'fully_inside' ? ' (with coverageMode: fully_inside — try widening the box or dropping the mode)' : ''}${opts.maxTriangleArea !== undefined ? ` (with maxTriangleArea: ${opts.maxTriangleArea} — try raising it)` : ''}. Try widening the box, dropping topOnly/normalCone, or call findFaces() to see what passes each filter individually.` };
@@ -14586,6 +14649,57 @@ async function main() {
       }
     },
 
+    /** Paint a single face-connected mesh island by index from
+     *  `listComponents()`. Works on render-only imports (STL multi-part kits
+     *  that can't go through `Manifold.decompose()`) AND on manifold meshes
+     *  — for manifold geometry, the resulting island ids match `listComponents`
+     *  exactly when each component is fully-disconnected from the others.
+     *
+     *  The island is selected by topological connectivity (welded by vertex
+     *  position), so two parts that physically touch at a shared vertex appear
+     *  as one island and will both get painted; print-in-place kits with
+     *  clearance gaps split cleanly. Returns `{id, name, triangles, ...}` or
+     *  `{error}`. Use `paintIslandAt({point, color})` if you have a 3D point
+     *  (e.g. from `probePixel`) instead of an index. */
+    paintIsland(opts: {
+      index: number;
+      color: [number, number, number];
+      name?: string;
+    }) {
+      if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintIsland requires { index, color }' };
+      if (!Number.isInteger(opts.index) || opts.index < 0) return { error: 'paintIsland.index must be a non-negative integer (from listComponents)' };
+      if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+      const { triIslands, islands } = meshIslands(currentMeshData);
+      if (opts.index >= islands.length) {
+        return { error: `paintIsland.index ${opts.index} out of range — listComponents has ${islands.length} island(s).` };
+      }
+      const triangles = trianglesInIsland(triIslands, opts.index);
+      if (triangles.size === 0) return { error: `paintIsland: island ${opts.index} has no triangles (should be impossible — please report).` };
+      return commitPaintFromSet(triangles, opts.color, opts.name ?? `Island ${opts.index}`, 'paintbrush');
+    },
+
+    /** Paint the face-connected mesh island containing the triangle closest to
+     *  `point`. Pair with `probePixel` / `probeRay` to ground island selection
+     *  in a visible point — "click the hat in the iso render, paint *that*
+     *  island red" — without having to enumerate islands first. */
+    paintIslandAt(opts: {
+      point: [number, number, number];
+      color: [number, number, number];
+      name?: string;
+    }) {
+      if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
+      if (!opts || typeof opts !== 'object') return { error: 'paintIslandAt requires { point, color }' };
+      if (!Array.isArray(opts.point) || opts.point.length !== 3) return { error: 'point must be [x,y,z]' };
+      for (let i = 0; i < 3; i++) {
+        if (typeof opts.point[i] !== 'number' || !Number.isFinite(opts.point[i])) return { error: 'point components must be finite numbers' };
+      }
+      if (!Array.isArray(opts.color) || opts.color.length !== 3) return { error: 'color must be [r,g,b] with values 0..1' };
+      const islandIdx = islandAtPoint(currentMeshData, opts.point as [number, number, number]);
+      if (islandIdx < 0) return { error: 'paintIslandAt: no triangle near point (mesh empty?)' };
+      return partwrightAPI.paintIsland({ index: islandIdx, color: opts.color, name: opts.name ?? `Island ${islandIdx}` });
+    },
+
     /** Token-cheap planning aid for paint workflows: returns just the
      *  centroid + normal + bbox of each coplanar face group, no triangle
      *  IDs. Same as `getMeshSummary({maxTrianglesPerGroup: 0, maxGroups})`
@@ -14603,29 +14717,47 @@ async function main() {
      *  the agent can then call `paintInBox({box: component.boundingBox,
      *  color})` for each, with no coordinate guessing. */
     listComponents() {
-      if (!currentManifold) return { error: 'No geometry loaded — run code first.' };
+      if (currentManifold) {
+        try {
+          const parts = currentManifold.decompose();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const components = parts.map((p: any, i: number) => {
+            const bb = getBoundingBox(p);
+            const vol = (() => { try { return p.volume(); } catch { return 0; } })();
+            const sa = (() => { try { return p.surfaceArea(); } catch { return 0; } })();
+            const centroid: [number, number, number] = bb
+              ? [(bb.min[0] + bb.max[0]) / 2, (bb.min[1] + bb.max[1]) / 2, (bb.min[2] + bb.max[2]) / 2]
+              : [0, 0, 0];
+            p.delete();
+            return {
+              index: i,
+              volume: Math.round(vol * 100) / 100,
+              surfaceArea: Math.round(sa * 100) / 100,
+              centroid,
+              boundingBox: bb ?? { min: [0, 0, 0], max: [0, 0, 0] },
+            };
+          });
+          return { count: components.length, components, source: 'manifold' as const };
+        } catch (err) {
+          return { error: `decompose failed: ${err instanceof Error ? err.message : String(err)}` };
+        }
+      }
+      // Render-only fallback (STL imports, non-manifold meshes): face-connected
+      // BFS over the triangle adjacency graph. No volume / surfaceArea (no
+      // closed-solid guarantee), but bbox + triangleCount + centroid land,
+      // which is what `paintIsland({index, color})` needs.
+      if (!currentMeshData) return { error: 'No geometry loaded — run code first.' };
       try {
-        const parts = currentManifold.decompose();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const components = parts.map((p: any, i: number) => {
-          const bb = getBoundingBox(p);
-          const vol = (() => { try { return p.volume(); } catch { return 0; } })();
-          const sa = (() => { try { return p.surfaceArea(); } catch { return 0; } })();
-          const centroid: [number, number, number] = bb
-            ? [(bb.min[0] + bb.max[0]) / 2, (bb.min[1] + bb.max[1]) / 2, (bb.min[2] + bb.max[2]) / 2]
-            : [0, 0, 0];
-          p.delete();
-          return {
-            index: i,
-            volume: Math.round(vol * 100) / 100,
-            surfaceArea: Math.round(sa * 100) / 100,
-            centroid,
-            boundingBox: bb ?? { min: [0, 0, 0], max: [0, 0, 0] },
-          };
-        });
-        return { count: components.length, components };
+        const { islands } = meshIslands(currentMeshData);
+        const components = islands.map(island => ({
+          index: island.index,
+          triangleCount: island.triangleCount,
+          centroid: island.center,
+          boundingBox: island.bbox,
+        }));
+        return { count: components.length, components, source: 'mesh-island' as const };
       } catch (err) {
-        return { error: `decompose failed: ${err instanceof Error ? err.message : String(err)}` };
+        return { error: `mesh-island BFS failed: ${err instanceof Error ? err.message : String(err)}` };
       }
     },
 
@@ -15379,8 +15511,10 @@ async function main() {
         'removeFilament':  { signature: 'removeFilament(id) -- Remove a slot from the active palette -> {ok} or {error}', docs: '/ai/colors.md' },
         'setPaletteCapacity': { signature: 'setPaletteCapacity(n) -- Set the AMS/MMU slot budget -> {ok, capacity}', docs: '/ai/colors.md' },
         'setPaletteConstrained': { signature: 'setPaletteConstrained(on) -- Constrain paint to palette slots (snap) vs free RGB -> {ok, constrained}', docs: '/ai/colors.md' },
-        'listComponents':  { signature: 'listComponents() -> {count, components: [{index, centroid, boundingBox, volume, surfaceArea}]} -- Decompose the manifold into boolean-distinct parts. For "paint each feature" workflows (e.g. unioned head + eyes + mouth).', docs: '/ai/colors.md' },
-        'paintComponent':  { signature: 'paintComponent({index, color, name?, topOnly?}) -- One-call shortcut: listComponents + paintInBox for the Nth piece.', docs: '/ai/colors.md' },
+        'listComponents':  { signature: 'listComponents() -> {count, components: [{index, centroid, boundingBox, volume?, surfaceArea?, triangleCount?}], source} -- Decompose into parts. Uses Manifold.decompose() for built geometry (gives volume/surfaceArea, source: "manifold"); falls back to face-connected BFS for render-only imports / non-manifold meshes (gives triangleCount, source: "mesh-island") — multi-part STL kits now segment without needing Manifold.', docs: '/ai/colors.md' },
+        'paintComponent':  { signature: 'paintComponent({index, color, name?, topOnly?}) -- One-call shortcut: listComponents + paintInBox for the Nth piece. Requires a manifold (uses decompose). For render-only imports use paintIsland.', docs: '/ai/colors.md' },
+        'paintIsland':     { signature: 'paintIsland({index, color, name?}) -- Paint a single face-connected mesh island by index from listComponents(). Works on ANY mesh including render-only STL imports — the right tool for painting one part of a multi-part STL kit by its component number. Topological, not spatial — never bleeds across XYZ-overlapping parts.', docs: '/ai/colors.md' },
+        'paintIslandAt':   { signature: 'paintIslandAt({point, color, name?}) -- Paint the face-connected island containing the triangle closest to point. Pair with probePixel/probeRay to ground island selection in a visible point ("the hat in the iso render") without enumerating islands.', docs: '/ai/colors.md' },
         'listLabels':      { signature: 'listLabels() -> {count, labels: [{name, triangleCount, bbox, centroid}]} -- Labels registered in the current run via api.label(shape, name). Survives boolean ops; the cleanest paint primitive on agent-authored geometry.', docs: '/ai/colors.md' },
         'getModelColors':  { signature: 'getModelColors() -> {count, colors: [{name, color, triangleCount}]} -- Colors declared in code via api.label(shape, name, {color}) or api.paint.*. Render + export automatically; editor stays editable; manual paint overrides.', docs: '/ai/colors.md' },
         'paintByLabel':    { signature: 'paintByLabel({label, color, name?}) -- Paint a labelled feature by name. Pair with api.label/labeledUnion in your code. No coordinate guessing.', docs: '/ai/colors.md' },

--- a/tests/island-paint.spec.ts
+++ b/tests/island-paint.spec.ts
@@ -145,4 +145,39 @@ test.describe('island painting on a multi-part STL', () => {
     expect(flat.smooth).toBeUndefined();
     expect(flat.triangles).toBeGreaterThan(0);
   });
+
+  test('detectRegions returns crease-bounded face groups; paintByCrease colours one', async ({ page }) => {
+    await waitForEngine(page);
+    // A plain cube has 6 faces meeting at 90° creases. detectRegions at the
+    // default 20° threshold should pop out 6 regions (2 triangles each),
+    // each with 4 neighbours (top/bottom/left/right faces of a cube).
+    await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { run: (code: string) => Promise<unknown> } }).partwright;
+      return pw.run('const { Manifold } = api; return Manifold.cube([20, 20, 20], true);');
+    });
+    await page.waitForTimeout(800);
+
+    const regions = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { detectRegions: (opts?: unknown) => unknown } }).partwright;
+      return pw.detectRegions({ creaseAngleDeg: 20, minTriangleCount: 1, includeNeighbors: true });
+    }) as { count: number; creaseAngleDeg: number; source: string; regions: Array<{ id: number; triangleCount: number; neighborIds?: number[]; centroid: [number, number, number]; normal: [number, number, number] }>; error?: string };
+    expect(regions.error).toBeUndefined();
+    expect(regions.source).toBe('whole-mesh');
+    expect(regions.creaseAngleDeg).toBe(20);
+    expect(regions.count).toBe(6);
+    for (const r of regions.regions) {
+      expect(r.triangleCount).toBe(2);
+      expect(r.neighborIds).toHaveLength(4);
+    }
+
+    // paintByCrease seeded at the top of the cube should colour exactly the
+    // top face (2 triangles), stopping at the 90° crease to the side faces.
+    const painted = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { paintByCrease: (opts: unknown) => unknown } }).partwright;
+      return pw.paintByCrease({ seedPoint: [0, 0, 10], color: [0.9, 0.1, 0.1], creaseAngleDeg: 20, name: 'top-face' });
+    }) as { id?: number; triangles?: number; creaseAngleDeg?: number; error?: string };
+    expect(painted.error).toBeUndefined();
+    expect(painted.triangles).toBe(2);
+    expect(painted.creaseAngleDeg).toBe(20);
+  });
 });

--- a/tests/island-paint.spec.ts
+++ b/tests/island-paint.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, type Page } from 'playwright/test';
+
+/** Three disjoint cubes laid out along X at z=0. Each cube has 12 triangles
+ *  (24 verts in triangle-soup form), 3 cubes → 36 triangles total, all
+ *  topologically disconnected (no shared vertex positions). After import,
+ *  `listComponents()` should report 3 islands, and `paintIsland({index})`
+ *  should colour exactly one cube per call. */
+function buildMultiCubeSTL(): Buffer {
+  const cubes = [
+    { center: [-20, 0, 0], size: 5 },
+    { center: [  0, 0, 0], size: 5 },
+    { center: [ 20, 0, 0], size: 5 },
+  ];
+  const faces: number[][][] = [];
+  for (const { center: [cx, cy, cz], size: s } of cubes) {
+    const v = [
+      [cx - s, cy - s, cz - s], [cx + s, cy - s, cz - s], [cx + s, cy + s, cz - s], [cx - s, cy + s, cz - s],
+      [cx - s, cy - s, cz + s], [cx + s, cy - s, cz + s], [cx + s, cy + s, cz + s], [cx - s, cy + s, cz + s],
+    ];
+    faces.push(
+      [v[0], v[2], v[1]], [v[0], v[3], v[2]],
+      [v[4], v[5], v[6]], [v[4], v[6], v[7]],
+      [v[0], v[1], v[5]], [v[0], v[5], v[4]],
+      [v[2], v[3], v[7]], [v[2], v[7], v[6]],
+      [v[0], v[4], v[7]], [v[0], v[7], v[3]],
+      [v[1], v[2], v[6]], [v[1], v[6], v[5]],
+    );
+  }
+  const buf = new ArrayBuffer(84 + faces.length * 50);
+  const view = new DataView(buf);
+  view.setUint32(80, faces.length, true);
+  let off = 84;
+  for (const tri of faces) {
+    off += 12;
+    for (const vert of tri) {
+      view.setFloat32(off, vert[0], true); off += 4;
+      view.setFloat32(off, vert[1], true); off += 4;
+      view.setFloat32(off, vert[2], true); off += 4;
+    }
+    view.setUint16(off, 0, true); off += 2;
+  }
+  return Buffer.from(new Uint8Array(buf));
+}
+
+async function waitForEngine(page: Page) {
+  await page.goto('/editor');
+  await page.waitForFunction(
+    () => !!(window as unknown as { partwright?: { run?: unknown } }).partwright?.run,
+    undefined,
+    { timeout: 30_000 },
+  );
+}
+
+test.describe('island painting on a multi-part STL', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('partwright-tour-completed', '1'));
+  });
+
+  test('listComponents falls back to mesh-island BFS and paintIsland colours one cube at a time', async ({ page }) => {
+    await waitForEngine(page);
+
+    const stl = buildMultiCubeSTL();
+    const base64 = stl.toString('base64');
+
+    // Import the multi-cube STL via the programmatic API (bypasses file picker).
+    const importResult = await page.evaluate(async (b64: string) => {
+      const pw = (window as unknown as { partwright: { importMeshData: (b64: string, name: string, opts?: { sessionName?: string }) => Promise<{ sessionId: string; error?: string }> } }).partwright;
+      return pw.importMeshData(b64, 'three-cubes.stl', { sessionName: 'three-cubes' });
+    }, base64);
+    expect(importResult.error).toBeUndefined();
+
+    // Give the import a beat to run the freshly-generated code.
+    await page.waitForTimeout(2000);
+
+    // listComponents should return 3 islands via the mesh-island fallback.
+    const list = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { listComponents: () => unknown } }).partwright;
+      return pw.listComponents();
+    }) as { count: number; components: Array<{ index: number; triangleCount?: number; centroid: [number, number, number] }>; source: string };
+    // Three-cube STL is watertight enough to round-trip through Manifold,
+    // so we land on source='manifold'. The Pomni STL the user uploaded is
+    // non-manifold and would land on 'mesh-island'. Both paths return 3
+    // components for 3 disjoint cubes — the assertion is the count + the
+    // ability to paint by index, not which code path enumerated them.
+    expect(['manifold', 'mesh-island']).toContain(list.source);
+    expect(list.count).toBe(3);
+    expect(list.components).toHaveLength(3);
+    // Centroids should line up at x ≈ -20, 0, +20 (in some order — the BFS
+    // enumeration order isn't a contract).
+    const xs = list.components.map(c => Math.round(c.centroid[0])).sort((a, b) => a - b);
+    expect(xs).toEqual([-20, 0, 20]);
+
+    // Paint each cube a distinct colour by island index.
+    const paintResults = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { paintIsland: (opts: unknown) => unknown } }).partwright;
+      return [
+        pw.paintIsland({ index: 0, color: [1.0, 0.1, 0.1], name: 'cube-0' }),
+        pw.paintIsland({ index: 1, color: [0.1, 1.0, 0.1], name: 'cube-1' }),
+        pw.paintIsland({ index: 2, color: [0.1, 0.1, 1.0], name: 'cube-2' }),
+      ];
+    }) as Array<{ id?: number; triangles?: number; error?: string }>;
+    for (const r of paintResults) {
+      expect(r.error).toBeUndefined();
+      expect(r.triangles).toBe(12);  // exactly one cube's worth — no bleed
+    }
+
+    // Smoke-test paintIslandAt — point near the centre cube should grab island 1.
+    const atResult = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { paintIslandAt: (opts: unknown) => unknown } }).partwright;
+      return pw.paintIslandAt({ point: [0, 0, 5.5], color: [0.5, 0.5, 0.5], name: 'centre-by-point' });
+    }) as { triangles?: number; error?: string };
+    expect(atResult.error).toBeUndefined();
+    expect(atResult.triangles).toBe(12);
+
+  });
+
+  test('paintInBox smooth: true is the default and accepted on AABB', async ({ page }) => {
+    await waitForEngine(page);
+    // Build a simple cube so we can paint half of it.
+    await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { run: (code: string) => Promise<unknown> } }).partwright;
+      return pw.run('const { Manifold } = api; return Manifold.cube([20, 20, 20], true);');
+    });
+    await page.waitForTimeout(800);
+
+    // Paint the top half with smooth: true (default) — should succeed and
+    // return smooth: true.
+    const smooth = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { paintInBox: (opts: unknown) => unknown } }).partwright;
+      return pw.paintInBox({ box: { min: [-10, -10, 0], max: [10, 10, 10] }, color: [0.9, 0.2, 0.2] });
+    }) as { smooth?: boolean; triangles?: number; error?: string };
+    expect(smooth.error).toBeUndefined();
+    expect(smooth.smooth).toBe(true);
+    expect(smooth.triangles).toBeGreaterThan(0);
+
+    // Paint the bottom half with smooth: false — should bypass the smooth
+    // path entirely.
+    const flat = await page.evaluate(() => {
+      const pw = (window as unknown as { partwright: { paintInBox: (opts: unknown) => unknown } }).partwright;
+      return pw.paintInBox({ box: { min: [-10, -10, -10], max: [10, 10, 0] }, color: [0.2, 0.2, 0.9], smooth: false });
+    }) as { smooth?: boolean; triangles?: number; error?: string };
+    expect(flat.error).toBeUndefined();
+    // commitPaintFromSet doesn't return a smooth field — its absence confirms
+    // we took the legacy path.
+    expect(flat.smooth).toBeUndefined();
+    expect(flat.triangles).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/detectRegionsExtension.test.ts
+++ b/tests/unit/detectRegionsExtension.test.ts
@@ -1,0 +1,150 @@
+// Tests for the computeFaceGroups extensions in PR #870:
+//   - tolerance tuned for sculpted-feature segmentation (cos 20°)
+//   - restrictTo (segment within a single mesh-island)
+//   - includeNeighborIds (region adjacency post-pass)
+//
+// These exercise the pure-logic core that backs partwright.detectRegions().
+// The window.partwright wrapper is e2e-tested elsewhere; this file pins the
+// math so a regression in the kernel can't sneak past the unit tier.
+
+import { describe, it, expect } from 'vitest';
+import { computeFaceGroups } from '../../src/color/faceGroups';
+import type { MeshData } from '../../src/geometry/types';
+
+/** Build a MeshData from a list of triangles, each defined by its three world-
+ *  space vertices (triangle-soup form). Adjacency layer welds by exact position. */
+function meshFromTriangles(triangles: [number, number, number][][]): MeshData {
+  const vertProperties: number[] = [];
+  const triVerts: number[] = [];
+  triangles.forEach((tri, t) => {
+    for (const [x, y, z] of tri) vertProperties.push(x, y, z);
+    triVerts.push(t * 3, t * 3 + 1, t * 3 + 2);
+  });
+  return {
+    vertProperties: new Float32Array(vertProperties),
+    triVerts: new Uint32Array(triVerts),
+    numProp: 3,
+    numVert: triangles.length * 3,
+    numTri: triangles.length,
+  } as MeshData;
+}
+
+/** A 6-face axis-aligned box at the origin with `s` half-extent. 12 triangles
+ *  (2 per face), all face-normals on ±X/±Y/±Z. Adjacent faces meet at 90°
+ *  creases that the watershed should never cross. */
+function boxMesh(s: number, offset: [number, number, number] = [0, 0, 0]): [number, number, number][][] {
+  const [ox, oy, oz] = offset;
+  const v = [
+    [ox - s, oy - s, oz - s], [ox + s, oy - s, oz - s], [ox + s, oy + s, oz - s], [ox - s, oy + s, oz - s],
+    [ox - s, oy - s, oz + s], [ox + s, oy - s, oz + s], [ox + s, oy + s, oz + s], [ox - s, oy + s, oz + s],
+  ] as [number, number, number][];
+  return [
+    [v[0], v[2], v[1]], [v[0], v[3], v[2]],   // -Z
+    [v[4], v[5], v[6]], [v[4], v[6], v[7]],   // +Z
+    [v[0], v[1], v[5]], [v[0], v[5], v[4]],   // -Y
+    [v[2], v[3], v[7]], [v[2], v[7], v[6]],   // +Y
+    [v[0], v[4], v[7]], [v[0], v[7], v[3]],   // -X
+    [v[1], v[2], v[6]], [v[1], v[6], v[5]],   // +X
+  ];
+}
+
+describe('computeFaceGroups — crease-watershed at sculpt-tuned tolerance', () => {
+  it('splits a box into its 6 faces at a 20° crease threshold', () => {
+    // Each face = 2 coplanar triangles. The 90° crease between faces is well
+    // above the 20° threshold, so the BFS stops at every face boundary and
+    // returns exactly 6 groups, 2 triangles each.
+    const mesh = meshFromTriangles(boxMesh(5));
+    const tol = Math.cos(20 * Math.PI / 180);  // ≈ 0.94
+    const summary = computeFaceGroups(mesh, { tolerance: tol, minTriangles: 1 });
+    expect(summary.groups).toHaveLength(6);
+    for (const g of summary.groups) expect(g.triangleCount).toBe(2);
+  });
+
+  it('default (1.8°) tolerance also splits a box into 6 faces (the faces ARE coplanar)', () => {
+    // The default crease test passes at adjacent-pair angle <= ~1.8°; box
+    // faces are perfectly coplanar (0°) so this still gives 6 faces.
+    const mesh = meshFromTriangles(boxMesh(5));
+    const summary = computeFaceGroups(mesh);
+    expect(summary.groups).toHaveLength(6);
+  });
+});
+
+describe('computeFaceGroups — restrictTo (withinIsland filter)', () => {
+  it('only segments triangles in the restriction set', () => {
+    // Two disjoint boxes; restrictTo the second box (triangles 12–23) and
+    // assert we get exactly its 6 faces back.
+    const all = [...boxMesh(5, [0, 0, 0]), ...boxMesh(5, [100, 0, 0])];
+    const mesh = meshFromTriangles(all);
+    const island2 = new Set<number>();
+    for (let t = 12; t < 24; t++) island2.add(t);
+    const tol = Math.cos(20 * Math.PI / 180);
+    const summary = computeFaceGroups(mesh, { tolerance: tol, minTriangles: 1, restrictTo: island2 });
+    expect(summary.groups).toHaveLength(6);
+    // Every reported triangle id should belong to the restriction.
+    for (const g of summary.groups) {
+      for (const t of g.triangleIds) expect(island2.has(t)).toBe(true);
+    }
+  });
+
+  it('returns no groups when the restriction set is empty', () => {
+    const mesh = meshFromTriangles(boxMesh(5));
+    const summary = computeFaceGroups(mesh, { restrictTo: new Set<number>() });
+    expect(summary.groups).toHaveLength(0);
+  });
+});
+
+describe('computeFaceGroups — includeNeighborIds (region adjacency)', () => {
+  it('reports each box face neighbouring exactly 4 other faces (top/bottom of cube)', () => {
+    // On a cube, every face touches the 4 adjacent faces (not the opposite
+    // one). So `neighborIds.length === 4` for every group.
+    const mesh = meshFromTriangles(boxMesh(5));
+    const tol = Math.cos(20 * Math.PI / 180);
+    const summary = computeFaceGroups(mesh, { tolerance: tol, minTriangles: 1, includeNeighborIds: true });
+    expect(summary.groups).toHaveLength(6);
+    for (const g of summary.groups) {
+      expect(g.neighborIds).toBeDefined();
+      expect(g.neighborIds).toHaveLength(4);
+      // No self-loops.
+      expect(g.neighborIds).not.toContain(g.id);
+    }
+  });
+
+  it('reports empty neighbours for a disconnected single face', () => {
+    // Single triangle has no neighbours of its own group OR another group.
+    const mesh = meshFromTriangles([
+      [[0, 0, 0], [1, 0, 0], [0, 1, 0]],
+    ]);
+    const summary = computeFaceGroups(mesh, { tolerance: 0.9995, minTriangles: 1, includeNeighborIds: true });
+    expect(summary.groups).toHaveLength(1);
+    expect(summary.groups[0].neighborIds).toEqual([]);
+  });
+
+  it('two disjoint boxes: each box face touches 4 of its OWN box, none of the other', () => {
+    // 12 faces total. Each face's neighborIds are the 4 adjacent faces ON
+    // THE SAME BOX. Crucially, faces on box A never list faces on box B
+    // (different topological components).
+    const all = [...boxMesh(5, [0, 0, 0]), ...boxMesh(5, [100, 0, 0])];
+    const mesh = meshFromTriangles(all);
+    const tol = Math.cos(20 * Math.PI / 180);
+    const summary = computeFaceGroups(mesh, { tolerance: tol, minTriangles: 1, includeNeighborIds: true });
+    expect(summary.groups).toHaveLength(12);
+
+    // Partition groups by box (which mesh-side their centroids live on).
+    const boxA: number[] = [];
+    const boxB: number[] = [];
+    for (const g of summary.groups) (g.centroid[0] < 50 ? boxA : boxB).push(g.id);
+    expect(boxA).toHaveLength(6);
+    expect(boxB).toHaveLength(6);
+
+    // No face on box A should list a face on box B as a neighbour.
+    for (const g of summary.groups) {
+      const sameSide = boxA.includes(g.id) ? boxA : boxB;
+      const otherSide = boxA.includes(g.id) ? boxB : boxA;
+      expect(g.neighborIds).toHaveLength(4);
+      for (const n of g.neighborIds!) {
+        expect(sameSide).toContain(n);
+        expect(otherSide).not.toContain(n);
+      }
+    }
+  });
+});

--- a/tests/unit/meshIslands.test.ts
+++ b/tests/unit/meshIslands.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { meshIslands, trianglesInIsland, islandAtPoint, clearMeshIslandsCache } from '../../src/color/meshIslands';
+import type { MeshData } from '../../src/geometry/types';
+
+/** Build a MeshData from a list of triangles, each defined by its three world-
+ *  space vertices. Vertices are stored per-triangle (triangle soup) — the
+ *  adjacency layer welds them by exact position, so two triangles sharing a
+ *  vertex coordinate are recognized as adjacent. */
+function meshFromTriangles(triangles: [number, number, number][][]): MeshData {
+  const vertProperties: number[] = [];
+  const triVerts: number[] = [];
+  triangles.forEach((tri, t) => {
+    for (const [x, y, z] of tri) vertProperties.push(x, y, z);
+    triVerts.push(t * 3, t * 3 + 1, t * 3 + 2);
+  });
+  return {
+    vertProperties: new Float32Array(vertProperties),
+    triVerts: new Uint32Array(triVerts),
+    numProp: 3,
+    numVert: triangles.length * 3,
+    numTri: triangles.length,
+  } as MeshData;
+}
+
+describe('meshIslands', () => {
+  it('returns one island for a single connected component', () => {
+    // Two triangles sharing an edge (vertices at the same position).
+    const mesh = meshFromTriangles([
+      [[0, 0, 0], [1, 0, 0], [0, 1, 0]],
+      [[1, 0, 0], [1, 1, 0], [0, 1, 0]],
+    ]);
+    const { triIslands, islands } = meshIslands(mesh);
+    expect(islands).toHaveLength(1);
+    expect(islands[0].triangleCount).toBe(2);
+    expect(triIslands[0]).toBe(0);
+    expect(triIslands[1]).toBe(0);
+  });
+
+  it('separates two disconnected triangle groups into two islands', () => {
+    // Triangle A at origin, triangle B at z=100 — no shared vertices.
+    const mesh = meshFromTriangles([
+      [[0, 0, 0], [1, 0, 0], [0, 1, 0]],
+      [[0, 0, 100], [1, 0, 100], [0, 1, 100]],
+    ]);
+    const { triIslands, islands } = meshIslands(mesh);
+    expect(islands).toHaveLength(2);
+    expect(triIslands[0]).not.toBe(triIslands[1]);
+    expect(islands[0].triangleCount).toBe(1);
+    expect(islands[1].triangleCount).toBe(1);
+  });
+
+  it('computes per-island bbox and center from the triangle vertices', () => {
+    const mesh = meshFromTriangles([
+      [[0, 0, 0], [10, 0, 0], [0, 10, 0]],
+      [[100, 100, 100], [110, 100, 100], [100, 110, 100]],
+    ]);
+    const { islands } = meshIslands(mesh);
+    expect(islands[0].bbox).toEqual({ min: [0, 0, 0], max: [10, 10, 0] });
+    expect(islands[0].center).toEqual([5, 5, 0]);
+    expect(islands[1].bbox).toEqual({ min: [100, 100, 100], max: [110, 110, 100] });
+    expect(islands[1].center).toEqual([105, 105, 100]);
+  });
+
+  it('handles 25 disjoint triangles (multi-part STL kit scale)', () => {
+    const tris: [number, number, number][][] = [];
+    for (let i = 0; i < 25; i++) {
+      const z = i * 50;
+      tris.push([[0, 0, z], [1, 0, z], [0, 1, z]]);
+    }
+    const mesh = meshFromTriangles(tris);
+    const { islands } = meshIslands(mesh);
+    expect(islands).toHaveLength(25);
+    for (let i = 0; i < 25; i++) expect(islands[i].triangleCount).toBe(1);
+  });
+
+  it('returns empty result for an empty mesh', () => {
+    const mesh: MeshData = {
+      vertProperties: new Float32Array(),
+      triVerts: new Uint32Array(),
+      numProp: 3,
+      numVert: 0,
+      numTri: 0,
+    } as MeshData;
+    const { triIslands, islands } = meshIslands(mesh);
+    expect(triIslands.length).toBe(0);
+    expect(islands).toEqual([]);
+  });
+
+  it('memoizes results on the same mesh reference (WeakMap cache)', () => {
+    const mesh = meshFromTriangles([
+      [[0, 0, 0], [1, 0, 0], [0, 1, 0]],
+    ]);
+    const a = meshIslands(mesh);
+    const b = meshIslands(mesh);
+    expect(b).toBe(a);
+    clearMeshIslandsCache(mesh);
+    const c = meshIslands(mesh);
+    expect(c).not.toBe(a);
+  });
+});
+
+describe('trianglesInIsland', () => {
+  it('returns the triangle indices belonging to one island', () => {
+    const mesh = meshFromTriangles([
+      [[0, 0, 0], [1, 0, 0], [0, 1, 0]],
+      [[1, 0, 0], [1, 1, 0], [0, 1, 0]],
+      [[0, 0, 100], [1, 0, 100], [0, 1, 100]],
+    ]);
+    const { triIslands } = meshIslands(mesh);
+    const island0Tris = trianglesInIsland(triIslands, triIslands[0]);
+    expect(island0Tris.size).toBe(2);
+    expect([...island0Tris].sort()).toEqual([0, 1]);
+    const island2Tris = trianglesInIsland(triIslands, triIslands[2]);
+    expect(island2Tris.size).toBe(1);
+    expect([...island2Tris]).toEqual([2]);
+  });
+});
+
+describe('islandAtPoint', () => {
+  it('returns the island index containing the triangle closest to a point', () => {
+    const mesh = meshFromTriangles([
+      [[0, 0, 0], [1, 0, 0], [0, 1, 0]],          // island 0 near origin
+      [[0, 0, 100], [1, 0, 100], [0, 1, 100]],    // island 1 at z=100
+    ]);
+    expect(islandAtPoint(mesh, [0.3, 0.3, 0])).toBe(0);
+    expect(islandAtPoint(mesh, [0.3, 0.3, 100])).toBe(1);
+    // A midway point still picks ONE island deterministically (whichever's
+    // centroid is closer); both are equidistant at z=50, so just check valid.
+    const mid = islandAtPoint(mesh, [0.3, 0.3, 50]);
+    expect([0, 1]).toContain(mid);
+  });
+
+  it('returns -1 for an empty mesh', () => {
+    const mesh: MeshData = {
+      vertProperties: new Float32Array(),
+      triVerts: new Uint32Array(),
+      numProp: 3,
+      numVert: 0,
+      numTri: 0,
+    } as MeshData;
+    expect(islandAtPoint(mesh, [0, 0, 0])).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Summary

Three paint primitives motivated by a session that failed at painting an articulated 25-piece Pomni STL to a reference photo. The first round (commit b79beef) shipped `paintIsland` + `paintInBox` smooth edges — necessary but insufficient: 4 validation agents produced a recognizable harlequin silhouette but **no face / eyes / mouth** because the figure's design fuses the head + torso + sculpted features into a single 205k-tri mesh-island that `paintIsland` can only colour one shade. The second commit (362221f) adds the actual unlock — **crease-watershed segmentation** — and a second 4-agent validation pass produced **two independent successes** with recognizable, face-painted Pomnis.

### Commit 1 — multi-part-STL primitives (b79beef)

1. **`paintIsland({index, color})` / `paintIslandAt({point, color})` + render-only `listComponents` fallback.** `src/color/meshIslands.ts` runs face-connected BFS over the existing welded triangle-adjacency graph (memoized on a `WeakMap`). `listComponents` falls back to it when no Manifold is available — tagging `source` as `'manifold'` or `'mesh-island'`. Topological selection, never bleeds across XYZ-overlapping parts. Works for print-in-place kits with clearance gaps.
2. **Smooth edges on `paintInBox` (AABB).** Brings the AABB selector in line with `paintInOrientedBox` / `paintSlab` / `paintInCylinder` via identity-quaternion OBB routing.

### Commit 2 — sculpted-feature primitives (362221f)

3. **`detectRegions({creaseAngleDeg=20, withinIsland?, includeNeighbors=true})`** — crease (dihedral-angle) watershed segmentation. Returns regions sorted largest first with `{id, triangleCount, area, centroid, normal, bbox, neighborIds, triangleIds?}`. `withinIsland` scopes segmentation to ONE mesh-island so the features INSIDE a fused body island (face dome, iris rings, pupils, mouth, blush, buttons, bangs) stop being unreachable.
4. **`paintByCrease({seedPoint, seedNormal?, creaseAngleDeg=20, color})`** — flood paint stopping at the next crease edge. Same math as `paintRegion` but parameterised in degrees (sculpt-natural) instead of cosine, with nearest-triangle snapping when normal omitted (forgiving of `probePixel` rounding on iso views).

The crease primitives extend `computeFaceGroups` (which was already adjacent-pair gated) with `restrictTo` + `includeNeighborIds` — the kernel was already correct; the gap was defaults + agent-friendly surfaces + the within-island filter. Documented in `public/ai/colors.md` with a 4-case decision tree (paintIsland / detectRegions+paintByCrease / paintInBox-Slab-Cylinder / paintByLabel).

## Test plan

- [x] `npm run preflight` — typecheck + 1667 unit tests + lint:deps + lint:consistency, all green
- [x] `tests/unit/meshIslands.test.ts` — 9 cases (BFS, WeakMap cache, island helpers)
- [x] `tests/unit/detectRegionsExtension.test.ts` — 7 cases (crease BFS at 20°; restrictTo; neighborIds; two disjoint boxes never cross-list as neighbours)
- [x] `tests/island-paint.spec.ts` — 3 e2e cases (3-cube STL paintIsland no-bleed; paintInBox smooth-default; detectRegions returns 6 box faces and paintByCrease colours 1)
- [x] **Two 4-agent validation passes on the original Pomni STL** — see below
- [ ] CI shards (build + unit + 3 e2e shards)

## Validation pass v1 (commit b79beef — `paintIsland` only)

4 agents, 0 face-painted results. Recognizable harlequin body/limbs but no face, no eyes, no mouth — the sculpted features were unreachable inside the fused 205k-tri body island. Bug surfaced: `importMeshData` on a 25 MB STL crashes `page.evaluate` with "Execution context destroyed". → **#873**.

## Validation pass v2 (commit 362221f — adds crease tools)

| Agent | Face | Hat | Body | Limbs | Outcome |
|---|---|---|---|---|---|
| **Opus D** | ✅ white + concentric red/blue/black eyes + bangs + mouth + yellow band | ✅ harlequin lobes | ✅ harlequin split | partial | "Recognizable Pomni from across a room" |
| **Opus C** | ✅ same + concentric eye layers cleanly painted via triangleIds | ✅ correctly mirrored | ✅ split | ✅ all coloured | Most complete result |
| Sonnet A | partial (white face + pupils + blue rings + mouth + collar; outer red ring under-covered at 10°) | ❌ gray | ❌ gray | ❌ gray | Session race during paint loop silently dropped most calls |
| Sonnet B | partial (eyes painted as one ring; couldn't isolate inner from outer at integer crease angles) | partial | partial | partial | 10° too tight, 15° too loose for concentric isolation |

**`detectRegions({withinIsland: <body>, creaseAngleDeg: 20})` returned 18–20 regions on Pomni's fused body island** (both Opus agents confirmed independently). Each eye splits into 4 concentric layers (outer iris ~2890 tris → middle ~770 → inner iris ~360 → pupil ~210). Bangs/ear cups as their own regions. **Mouth + buttons + collar do NOT show up as crease regions** — they're flush sculpts; the watershed merges them. Successful agents fell back to `paintInBox` for those.

**Key technique both successful agents discovered independently**: bypass `paintByCrease`'s re-flood — pull `triangleIds` directly off each `detectRegions` region (set `maxTrianglesPerGroup > 0`) and pass to `paintFaces({triangleIds})`. Exact per-region control, no crease-angle re-tuning per feature.

**Net verdict**: the new APIs unlock a real result on a real-world model. With agents that use them correctly, recognizable character paint is reproducible.

## Follow-ups filed (not blockers)

- **#871** — Per-region shape metadata (principalAxis / surfaceArea / normalHistogram + top-level modelUpAxis). Would have helped the v1 agents avoid the wrong-axis spiral.
- **#872** — `renderRegion({id})` / per-region thumbnails. Vision is still the missing modality for visually-similar peer regions.
- **#873** (broadened) — Session-navigation race silently drops paint calls at BOTH import AND mid-paint-loop autosave. The dominant failure mode for the 2 of 4 v2 agents that didn't ship a face. Specific fix candidates inside the issue.

## Notes

- AI-tool surface added: `paintIsland`, `paintIslandAt`, `detectRegions`, `paintByCrease` (all in `PART_TARGETABLE_TOOLS` + `PAINT_GATED`); `paintInBox` schema gained `smooth` / `resolution` / `maxEdge`.
- The crease-watershed kernel (`findCoplanarRegion`) and exhaustive enumerator (`computeFaceGroups`) were already in the codebase; the gap was the wrong defaults (1.8° vs 20° for sculpts), no `withinIsland` filter, no `neighborIds`, and no agent-friendly surface.
- Islands are detected by *welded* vertex adjacency: two parts touching at a shared vertex appear as one island (matches `Manifold.decompose()` semantics, documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHXyPCqtDwQ8aD5HWAq5Qq